### PR TITLE
[deploy-preview] Prototype JIT optimizations for the sidebar

### DIFF
--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -70,10 +70,57 @@
 .sidebar-label {
   color: var(--grey-50);
   white-space: nowrap;
-  text-align: right;
 }
 
 .sidebar-value {
   white-space: nowrap;
-  text-align: right;
+}
+
+.sidebarOptimizations {
+  border: 1px solid #aaf;
+  padding: 10px;
+}
+
+.sidebarOptimizationsTitle {
+  grid-column-start: span 2;
+}
+
+.sidebarOptimizations {
+  padding: 1em;
+  margin-bottom: 1em;
+
+  font-size: 11px;
+  background: #fff;
+  border: 1px solid var(--grey-30);
+
+  display: grid;
+  grid-column-start: span 2;
+  grid-template-columns: 75px 1fr;
+  grid-gap: 2px 5px;
+  align-content: start; /* the grid isn't vertically stretched */
+
+  line-height: 1.5;
+}
+
+.sidebarOptimizations h1,
+.sidebarOptimizations h2,
+.sidebarOptimizations h3,
+.sidebarOptimizations h4,
+.sidebarOptimizations h5 {
+  grid-column-start: span 2;
+}
+
+.sidebarOptimizationsTitle:first-child {
+  margin-top: 0;
+}
+
+.sidebarOptimizations h3 {
+  margin-bottom: 0;
+  margin-top: 0.3em;
+}
+
+.sidebarOptimizations .sidebar-label,
+.sidebarOptimizations .sidebar-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -79,7 +79,7 @@ function isSidebarOpenPerPanel(
 ): IsSidebarOpenPerPanelState {
   if (state === undefined) {
     state = {};
-    tabSlugs.forEach(tabSlug => (state[tabSlug] = false));
+    tabSlugs.forEach(tabSlug => (state[tabSlug] = true));
   }
 
   switch (action.type) {

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -32,6 +32,7 @@ import type {
   SamplesTable,
   MarkersTable,
   Pid,
+  ProcessedOptimization,
 } from '../types/profile';
 import type {
   TracingMarker,
@@ -1113,6 +1114,11 @@ export type SelectorsForNode = {
   getIsJS: State => boolean,
   getLib: State => string,
   getTimingsForSidebar: State => TimingsForPath,
+  getJitOptimizationsForSidebar: State => Array<{
+    selfTime: number,
+    runningTime: number,
+    optimizations: ProcessedOptimization,
+  }>,
 };
 
 export const selectedNodeSelectors: SelectorsForNode = (() => {
@@ -1182,10 +1188,19 @@ export const selectedNodeSelectors: SelectorsForNode = (() => {
     }
   );
 
+  const getJitOptimizationsForSidebar = createSelector(
+    selectedThreadSelectors.getPreviewFilteredThread,
+    selectedThreadSelectors.getSelectedCallNodeIndex,
+    getProfileInterval,
+    selectedThreadSelectors.getCallNodeInfo,
+    ProfileData.getJitOptimizationsAtCallNode
+  );
+
   return {
     getName,
     getIsJS,
     getLib,
     getTimingsForSidebar,
+    getJitOptimizationsForSidebar,
   };
 })();

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -118,18 +118,63 @@ export type MarkersTable = {
   length: number,
 };
 
+// TODO - Put in processing step
+export type UnprocessedOptimization = {
+  types: Array<{
+    site: IndexIntoStringTable,
+    mirType: IndexIntoStringTable,
+    typeset?: [
+      {
+        keyedBy: IndexIntoStringTable,
+        name?: IndexIntoStringTable,
+        location?: IndexIntoStringTable,
+        line?: IndexIntoStringTable,
+      },
+    ],
+  }>,
+  attempts: {
+    schema: {
+      strategy: 0,
+      outcome: 1,
+    },
+    data: [[IndexIntoStringTable, IndexIntoStringTable]],
+  },
+  line: number,
+  column: number,
+};
+
+// TODO - Put in processing step
+export type ProcessedOptimization = {
+  types: Array<{
+    site: string,
+    mirType: string,
+    typeset: Array<{
+      keyedBy: string,
+      name: string,
+      location: string,
+      line: number | void,
+    }>,
+  }>,
+  attempts: Array<{
+    strategy: string,
+    outcome: string,
+  }>,
+  line: number,
+  column: number,
+};
+
 /**
  * Frames contain the context information about the function execution at the moment in
  * time. The relationship between frames is defined by the StackTable.
  */
 export type FrameTable = {
   address: IndexIntoStringTable[],
-  category: (IndexIntoCategoryList | null)[],
+  category: Array<IndexIntoCategoryList | null>,
   func: IndexIntoFuncTable[],
-  implementation: (IndexIntoStringTable | null)[],
-  line: (number | null)[],
-  column: (number | null)[],
-  optimizations: ({} | null)[],
+  implementation: Array<IndexIntoStringTable | null>,
+  line: Array<number | null>,
+  optimizations: Array<{} | null>,
+  column: Array<number | null>,
   length: number,
 };
 


### PR DESCRIPTION
This is a deploy preview of surfacing the JIT optimizations information.

[Deploy preview, with some JIT code](https://deploy-preview-1202--perf-html.netlify.com/public/a0a0c25e3e896b8033ea165bf292c777ee59887f/calltree/?globalTrackOrder=0-1-2-3&hiddenGlobalTracks=0-1-2&hiddenLocalTracksByPid=12435-0-1-2~12437-0&implementation=js&localTrackOrderByPid=12435-0-1-2~12437-0~&range=5.1544_9.1862&thread=6&v=3) - This profile was created from zooming in on the stack chart.

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/1588648/44277088-27c17880-a20f-11e8-9885-8d287dd003a1.png">

To record your own profile, make sure "Track JIT Optimizations" is checked in the addon:
<img width="332" alt="image" src="https://user-images.githubusercontent.com/1588648/44277036-03659c00-a20f-11e8-97d3-60c63f456a75.png">

Record the profile, share it, then replace the domain in the URL with `deploy-preview-1202--perf-html.netlify.com`