### PR TITLE
[wip] Call Tree Comparison

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -41,6 +41,16 @@ export function setProfileSharingStatus(
   };
 }
 
+export function changeProfilesToCompare(
+  profileUrl1: string,
+  profileUrl2: string
+): Action {
+  return {
+    type: 'CHANGE_PROFILES',
+    profiles: [profileUrl1, profileUrl2],
+  };
+}
+
 export function urlSetupDone(): ThunkAction<void> {
   return (dispatch, getState) => {
     dispatch({ type: 'URL_SETUP_DONE' });

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -899,12 +899,14 @@ export function retrieveProfilesToCompare(
         resultProfile.threads.push(filteredThread);
       }
 
+      /*
       resultProfile.threads.push(
         getComparisonThread(
           translationMapsForCategories,
           ...resultProfile.threads
         )
       );
+      */
 
       dispatch(viewProfile(resultProfile));
     } catch (error) {

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -21,7 +21,9 @@ import type { TrackIndex } from '../types/profile-derived';
 
 export const CURRENT_URL_VERSION = 3;
 
-function dataSourceDirs(urlState: UrlState) {
+function getDataSourceDirs(
+  urlState: UrlState
+): [] | [DataSource] | [DataSource, string] {
   const { dataSource } = urlState;
   switch (dataSource) {
     case 'from-addon':
@@ -34,8 +36,21 @@ function dataSourceDirs(urlState: UrlState) {
       return ['public', urlState.hash];
     case 'from-url':
       return ['from-url', encodeURIComponent(urlState.profileUrl)];
-    default:
+    case 'compare':
+      if (urlState.profiles) {
+        const { profiles } = urlState;
+        if (profiles.length >= 2) {
+          return [
+            'compare',
+            encodeURIComponent(`${profiles[0]}...${profiles[1]}`),
+          ];
+        }
+      }
+      return ['compare'];
+    case 'none':
       return [];
+    default:
+      throw assertExhaustiveCheck(dataSource);
   }
 }
 
@@ -104,7 +119,15 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
       query: {},
     };
   }
-  const pathParts = [...dataSourceDirs(urlState), urlState.selectedTab];
+  const dataSourceDirs = getDataSourceDirs(urlState);
+  if (dataSource === 'compare' && dataSourceDirs.length < 2) {
+    return {
+      pathParts: [...dataSourceDirs],
+      query: {},
+    };
+  }
+
+  const pathParts = [...dataSourceDirs, urlState.selectedTab];
 
   // Start with the query parameters that are shown regardless of the active tab.
   const query: Object = {
@@ -215,6 +238,7 @@ function getDataSourceFromPathParts(pathParts: string[]): DataSource {
     case 'local':
     case 'public':
     case 'from-url':
+    case 'compare':
       return str;
     default:
       throw new Error(`Unexpected data source ${str}`);
@@ -248,8 +272,11 @@ export function stateFromLocation(location: Location): UrlState {
   // https://perf-html.io/from-url/{url}/calltree/
   const hasProfileUrl = ['from-url'].includes(dataSource);
 
+  const hasProfilesToCompare = dataSource === 'compare';
+
   // The selected tab is the last path part in the URL.
-  const selectedTabPathPart = hasProfileHash || hasProfileUrl ? 2 : 1;
+  const selectedTabPathPart =
+    hasProfileHash || hasProfileUrl || hasProfilesToCompare ? 2 : 1;
 
   let implementation = 'combined';
   // Don't trust the implementation values from the user. Make sure it conforms
@@ -265,10 +292,21 @@ export function stateFromLocation(location: Location): UrlState {
       : [];
   }
 
+  let profilesToCompare = null;
+  if (hasProfilesToCompare && pathParts[1]) {
+    profilesToCompare = decodeURIComponent(pathParts[1]).split('...');
+    if (profilesToCompare.length >= 2) {
+      profilesToCompare = [profilesToCompare[0], profilesToCompare[1]];
+    } else {
+      profilesToCompare = null;
+    }
+  }
+
   return {
     dataSource,
     hash: hasProfileHash ? pathParts[1] : '',
     profileUrl: hasProfileUrl ? decodeURIComponent(pathParts[1]) : '',
+    profiles: profilesToCompare,
     selectedTab: toValidTabSlug(pathParts[selectedTabPathPart]) || 'calltree',
     pathInZipFile: query.file || null,
     profileSpecific: {

--- a/src/components/app/CompareHome.css
+++ b/src/components/app/CompareHome.css
@@ -1,0 +1,20 @@
+.compareHome {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: .5em;
+  align-items: center;
+
+  width: 75%;
+  margin: auto;
+  padding: 8em;
+
+  border: 1px solid #CCC;
+  border-radius: 3px;
+  box-shadow: 0 5px 25px #0b1f50;
+  background: #fff;
+}
+
+.compareHome h1,
+.compareHome input[type=submit] {
+  grid-column-start: span 2
+}

--- a/src/components/app/CompareHome.js
+++ b/src/components/app/CompareHome.js
@@ -36,8 +36,14 @@ class CompareHome extends PureComponent<Props, State> {
 
   handleFormSubmit = (e: SyntheticEvent<>) => {
     e.preventDefault();
-    const { profile1, profile2 } = this.state;
+    let { profile1, profile2 } = this.state;
     const { changeProfilesToCompare } = this.props;
+    if (!profile1.startsWith('http')) {
+      profile1 = 'http://' + profile1;
+    }
+    if (!profile2.startsWith('http')) {
+      profile2 = 'http://' + profile2;
+    }
     changeProfilesToCompare(profile1, profile2);
   };
 

--- a/src/components/app/CompareHome.js
+++ b/src/components/app/CompareHome.js
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import { changeProfilesToCompare } from '../../actions/app';
+
+import explicitConnect from '../../utils/connect';
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../utils/connect';
+
+import './CompareHome.css';
+
+type DispatchProps = {|
+  +changeProfilesToCompare: typeof changeProfilesToCompare,
+|};
+
+type Props = ConnectedProps<{||}, {||}, DispatchProps>;
+
+type State = {
+  profile1: string,
+  profile2: string,
+};
+
+class CompareHome extends PureComponent<Props, State> {
+  state = { profile1: '', profile2: '' };
+
+  handleInputChange = (event: SyntheticInputEvent<>) => {
+    const { name, value } = event.target;
+    this.setState({ [name]: value });
+  };
+
+  handleFormSubmit = (e: SyntheticEvent<>) => {
+    e.preventDefault();
+    const { profile1, profile2 } = this.state;
+    const { changeProfilesToCompare } = this.props;
+    changeProfilesToCompare(profile1, profile2);
+  };
+
+  render() {
+    const { profile1, profile2 } = this.state;
+
+    return (
+      <form className="compareHome" onSubmit={this.handleFormSubmit}>
+        <h1>Enter the 2 profile URLs that you’d like to compare</h1>
+        <label htmlFor="profile1">Profile 1:</label>
+        <input
+          name="profile1"
+          className="compareHome-input"
+          onChange={this.handleInputChange}
+          value={profile1}
+        />
+        <label htmlFor="profile2">Profile 2:</label>
+        <input
+          name="profile2"
+          className="compareHome-input"
+          onChange={this.handleInputChange}
+          value={profile2}
+        />
+        <input
+          className="compareHome-submit-button"
+          type="submit"
+          value="Retrieve profiles"
+        />
+      </form>
+    );
+  }
+}
+
+const options: ExplicitConnectOptions<{||}, {||}, Props> = {
+  mapDispatchToProps: { changeProfilesToCompare },
+  component: CompareHome,
+};
+
+export default explicitConnect(options);

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -11,6 +11,7 @@ import {
   retrieveProfileFromAddon,
   retrieveProfileFromStore,
   retrieveProfileOrZipFromUrl,
+  retrieveProfilesToCompare,
 } from '../../actions/receive-profile';
 import ProfileViewer from './ProfileViewer';
 import ZipFileViewer from './ZipFileViewer';
@@ -86,6 +87,7 @@ type ProfileViewDispatchProps = {|
   +retrieveProfileFromAddon: typeof retrieveProfileFromAddon,
   +retrieveProfileFromStore: typeof retrieveProfileFromStore,
   +retrieveProfileOrZipFromUrl: typeof retrieveProfileOrZipFromUrl,
+  +retrieveProfilesToCompare: typeof retrieveProfilesToCompare,
 |};
 
 type ProfileViewProps = ConnectedProps<
@@ -104,6 +106,7 @@ class ProfileViewWhenReadyImpl extends PureComponent<ProfileViewProps> {
       retrieveProfileFromAddon,
       retrieveProfileFromStore,
       retrieveProfileOrZipFromUrl,
+      retrieveProfilesToCompare,
     } = this.props;
     switch (dataSource) {
       case 'from-addon':
@@ -256,6 +259,7 @@ const options: ExplicitConnectOptions<
     retrieveProfileFromStore,
     retrieveProfileOrZipFromUrl,
     retrieveProfileFromAddon,
+    retrieveProfilesToCompare,
   },
   component: ProfileViewWhenReadyImpl,
 };

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -136,6 +136,12 @@ class ProfileViewWhenReadyImpl extends PureComponent<ProfileViewProps> {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (!prevProps.profiles && this.props.profiles) {
+      this.props.retrieveProfilesToCompare(this.props.profiles);
+    }
+  }
+
   renderMessage(
     message: string,
     additionalMessage: string | null,

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -1,0 +1,325 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import { UniqueStringArray } from '../utils/unique-string-array';
+
+import type {
+  IndexIntoCategoryList,
+  IndexIntoFrameTable,
+  IndexIntoFuncTable,
+  IndexIntoResourceTable,
+  IndexIntoLibs,
+  CategoryList,
+  FuncTable,
+  FrameTable,
+  Lib,
+  SamplesTable,
+  ResourceTable,
+  Thread,
+} from '../types/profile';
+
+type TranslationMapForCategories = Map<
+  IndexIntoCategoryList,
+  IndexIntoCategoryList
+>;
+export function mergeCategories(
+  categories1: CategoryList,
+  categories2: CategoryList
+): {
+  categories: CategoryList,
+  translationMaps: TranslationMapForCategories[],
+} {
+  const newCategories = [];
+  const translationMaps = [];
+
+  [categories1, categories2].forEach(categories => {
+    const translationMap = new Map();
+    const insertedCategories: Map<string, IndexIntoCategoryList> = new Map();
+
+    categories.forEach((category, i) => {
+      const { name } = category;
+      const insertedCategoryIndex = insertedCategories.get(name);
+      if (insertedCategoryIndex !== undefined) {
+        translationMap.set(i, insertedCategoryIndex);
+        return;
+      }
+
+      translationMap.set(i, newCategories.length);
+      insertedCategories.set(name, newCategories.length);
+      newCategories.push(category);
+    });
+  });
+
+  return { categories: newCategories, translationMaps };
+}
+
+export function getComparisonThread(
+  translationMapForCategories: TranslationMapForCategories[],
+  thread1: Thread,
+  thread2: Thread
+): Thread {
+  const newStringTable = new UniqueStringArray();
+  const newSamples: SamplesTable = {
+    responsiveness: [],
+    stack: [],
+    time: [],
+    interval: [],
+    rss: [],
+    uss: [],
+    length: 0,
+  };
+
+  type FuncTableTranslationMap = Map<IndexIntoFuncTable, IndexIntoFuncTable>;
+  type ResourceTableTranslationMap = Map<
+    IndexIntoResourceTable,
+    IndexIntoResourceTable
+  >;
+  type FrameTableTranslationMap = Map<IndexIntoFrameTable, IndexIntoFrameTable>;
+  type LibTranslationMap = Map<IndexIntoLibs, IndexIntoLibs>;
+
+  function computeNewLibTable(
+    ...threads: Thread[]
+  ): { libs: Lib[], translationMaps: LibTranslationMap[] } {
+    const mapOfInsertedLibs: Map<string, IndexIntoLibs> = new Map();
+
+    const translationMaps = [];
+    const newLibTable = [];
+
+    threads.forEach(thread => {
+      const translationMap = new Map();
+      const { libs } = thread;
+
+      libs.forEach((lib, i) => {
+        const insertedLibKey = [lib.name, lib.debugName].join('#');
+        const insertedLibIndex = mapOfInsertedLibs.get(insertedLibKey);
+        if (insertedLibIndex !== undefined) {
+          translationMap.set(i, insertedLibIndex);
+          return;
+        }
+
+        translationMap.set(i, newLibTable.length);
+        mapOfInsertedLibs.set(insertedLibKey, newLibTable.length);
+
+        newLibTable.push({
+          start: lib.start,
+          end: lib.end,
+          offset: lib.offset,
+          arch: lib.arch,
+          name: lib.name,
+          path: lib.path,
+          debugName: lib.debugName,
+          debugPath: lib.debugPath,
+          breakpadId: lib.breakpadId,
+        });
+      });
+
+      translationMaps.push(translationMap);
+    });
+
+    return { libs: newLibTable, translationMaps };
+  }
+
+  function computeNewResourceTable(
+    translationMapsForLibs: LibTranslationMap[],
+    ...threads: Thread[]
+  ): {
+    resourceTable: ResourceTable,
+    translationMaps: ResourceTableTranslationMap[],
+  } {
+    const translationMaps = [];
+    const newResourceTable: ResourceTable = {
+      lib: [],
+      name: [],
+      host: [],
+      type: [],
+      length: 0,
+    };
+
+    threads.forEach((thread, threadIndex) => {
+      const translationMap = new Map();
+      const { resourceTable, stringTable } = thread;
+      const libTranslationMap = translationMapsForLibs[threadIndex];
+
+      for (let i = 0; i < resourceTable.length; i++) {
+        const libIndex = resourceTable.lib[i];
+        const newLibIndex =
+          typeof libIndex === 'number' && libIndex >= 0
+            ? libTranslationMap.get(libIndex)
+            : null;
+
+        const nameIndex = resourceTable.name[i];
+        const newName =
+          nameIndex >= 0 ? stringTable.getString(nameIndex) : null;
+
+        const hostIndex = resourceTable.host[i];
+        const newHost =
+          hostIndex !== undefined && hostIndex >= 0
+            ? stringTable.getString(hostIndex)
+            : undefined;
+
+        translationMap.set(i, newResourceTable.length);
+
+        newResourceTable.lib.push(newLibIndex);
+        newResourceTable.name.push(
+          newName === null ? -1 : newStringTable.indexForString(newName)
+        );
+        newResourceTable.host.push(
+          newHost === undefined
+            ? undefined
+            : newStringTable.indexForString(newHost)
+        );
+        newResourceTable.type.push(resourceTable.type[i]);
+        newResourceTable.length++;
+      }
+
+      translationMaps.push(translationMap);
+    });
+
+    return { resourceTable: newResourceTable, translationMaps };
+  }
+
+  function computeNewFuncTable(
+    translationMapsForResourceTable: ResourceTableTranslationMap[],
+    ...threads: Thread[]
+  ): { funcTable: FuncTable, translationMaps: FuncTableTranslationMap[] } {
+    const translationMaps = [];
+    const newFuncTable: FuncTable = {
+      address: [],
+      isJS: [],
+      length: 0,
+      name: [],
+      resource: [],
+      fileName: [],
+      lineNumber: [],
+    };
+
+    threads.forEach((thread, threadIndex) => {
+      const { funcTable, stringTable } = thread;
+      const translationMap = new Map();
+      const resourceTranslationMap =
+        translationMapsForResourceTable[threadIndex];
+
+      for (let i = 0; i < funcTable.length; i++) {
+        const fileNameIndex = funcTable.fileName[i];
+        const fileName =
+          fileNameIndex === null ? null : stringTable.getString(fileNameIndex);
+        const lineNumber = funcTable.lineNumber[i];
+
+        newFuncTable.address.push(funcTable.address[i]);
+        newFuncTable.isJS.push(funcTable.isJS[i]);
+        newFuncTable.name.push(
+          newStringTable.indexForString(
+            stringTable.getString(funcTable.name[i])
+          )
+        );
+        const newResourceIndex = resourceTranslationMap.get(
+          funcTable.resource[i]
+        );
+        newFuncTable.resource.push(
+          newResourceIndex === undefined ? -1 : newResourceIndex
+        );
+        newFuncTable.fileName.push(
+          fileName === null ? null : newStringTable.indexForString(fileName)
+        );
+        newFuncTable.lineNumber.push(lineNumber === null ? null : lineNumber);
+        translationMap.set(i, newFuncTable.length);
+        newFuncTable.length++;
+      }
+
+      translationMaps.push(translationMap);
+    });
+
+    return { funcTable: newFuncTable, translationMaps };
+  }
+
+  function computeNewFrameTable(
+    translationMapsForFuncTable: FuncTableTranslationMap[],
+    ...threads: Thread[]
+  ): { frameTable: FrameTable, translationMaps: FrameTableTranslationMap[] } {
+    const translationMaps = [];
+    const newFrameTable: FrameTable = {
+      address: [],
+      category: [],
+      func: [],
+      implementation: [],
+      line: [],
+      column: [],
+      optimizations: [],
+      length: 0,
+    };
+
+    threads.forEach((thread, threadIndex) => {
+      const { frameTable, stringTable } = thread;
+
+      for (let i = 0; i < frameTable.length; i++) {
+        const translationMap = new Map();
+        const funcTranslationMap = translationMapsForFuncTable[threadIndex];
+      }
+    });
+
+    return { frameTable: newFrameTable, translationMaps };
+  }
+
+  const {
+    libs: newLibTable,
+    translationMaps: translationMapsForLibs,
+  } = computeNewLibTable(thread1, thread2);
+  const {
+    resourceTable: newResourceTable,
+    translationMaps: translationMapsForResourceTable,
+  } = computeNewResourceTable(translationMapsForLibs, thread1, thread2);
+  const {
+    funcTable: newFuncTable,
+    translationMaps: translationMapsForFuncTable,
+  } = computeNewFuncTable(translationMapsForResourceTable, thread1, thread2);
+  const {
+    frameTable: newFrameTable,
+    translationMaps: translationMapsForFrameTable,
+  } = computeNewFrameTable(translationMapsForFuncTable, thread1, thread2);
+
+  const mergedThread = {
+    processType: 'comparison',
+    processStartupTime: Math.min(
+      thread1.processStartupTime,
+      thread2.processStartupTime
+    ),
+    processShutdownTime:
+      Math.max(
+        thread1.processShutdownTime || 0,
+        thread2.processShutdownTime || 0
+      ) || null,
+    registerTime: Math.min(thread1.registerTime, thread2.registerTime),
+    unregisterTime:
+      Math.max(thread1.unregisterTime || 0, thread2.unregisterTime || 0) ||
+      null,
+    pausedRanges: [],
+    name: 'Diff between 1 and 2',
+    pid: 'Diff between 1 and 2',
+    tid: undefined,
+    samples: newSamples,
+    markers: {
+      data: [],
+      name: [],
+      time: [],
+      length: 0,
+    },
+    stackTable: {
+      frame: [],
+      category: [],
+      prefix: [],
+      length: 0,
+    },
+    frameTable: newFrameTable,
+    // Strings for profiles are collected into a single table, and are referred to by
+    // their index by other tables.
+    stringTable: newStringTable,
+    libs: newLibTable,
+    funcTable: newFuncTable,
+
+    resourceTable: newResourceTable,
+  };
+
+  return mergedThread;
+}

--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -171,7 +171,6 @@ export function getRootsAndChildren(
  */
 export function getFlameGraphTiming(
   thread: Thread,
-  interval: Milliseconds,
   callNodeInfo: CallNodeInfo,
   invertCallstack: boolean
 ): FlameGraphTiming {
@@ -179,12 +178,7 @@ export function getFlameGraphTiming(
     callNodeChildCount,
     callNodeTimes,
     rootTotalTime,
-  } = computeCallTreeCountsAndTimings(
-    thread,
-    callNodeInfo,
-    interval,
-    invertCallstack
-  );
+  } = computeCallTreeCountsAndTimings(thread, callNodeInfo, invertCallstack);
   const { roots, children } = getRootsAndChildren(
     thread,
     callNodeInfo.callNodeTable,

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -773,7 +773,7 @@ function _processThread(
  * has its own timebase, and we don't want to keep converting timestamps when
  * we deal with the integrated profile.
  */
-function _adjustSampleTimestamps(
+export function _adjustSampleTimestamps(
   samples: SamplesTable,
   delta: Milliseconds
 ): SamplesTable {
@@ -788,7 +788,7 @@ function _adjustSampleTimestamps(
  * profile's process has its own timebase, and we don't want to keep
  * converting timestamps when we deal with the integrated profile.
  */
-function _adjustMarkerTimestamps(
+export function _adjustMarkerTimestamps(
   markers: MarkersTable,
   delta: Milliseconds
 ): MarkersTable {

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -685,13 +685,17 @@ function _processMarkers(geckoMarkers: GeckoMarkerStruct): MarkersTable {
 /**
  * Explicitly recreate the markers here to help enforce our assumptions about types.
  */
-function _processSamples(geckoSamples: GeckoSampleStruct): SamplesTable {
+function _processSamples(
+  geckoSamples: GeckoSampleStruct,
+  interval: number
+): SamplesTable {
   return {
     responsiveness: geckoSamples.responsiveness,
     stack: geckoSamples.stack,
     time: geckoSamples.time,
     rss: geckoSamples.rss,
     uss: geckoSamples.uss,
+    interval: Array(geckoSamples.length).fill(interval),
     length: geckoSamples.length,
   };
 }
@@ -742,7 +746,7 @@ function _processThread(
     categories
   );
   const markers = _processMarkers(geckoMarkers);
-  const samples = _processSamples(geckoSamples);
+  const samples = _processSamples(geckoSamples, processProfile.meta.interval);
 
   return {
     name: thread.name,
@@ -911,8 +915,8 @@ export function processProfile(
   }
 
   const meta = {
-    interval: geckoProfile.meta.interval,
     startTime: geckoProfile.meta.startTime,
+    interval: geckoProfile.meta.interval,
     abi: geckoProfile.meta.abi,
     extensions: extensions,
     misc: geckoProfile.meta.misc,

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -22,7 +22,7 @@ import {
 import { UniqueStringArray } from '../utils/unique-string-array';
 import { timeCode } from '../utils/time-code';
 
-export const CURRENT_VERSION = 19; // The current version of the "processed" profile format.
+export const CURRENT_VERSION = 20; // The current version of the "processed" profile format.
 
 // Processed profiles before version 1 did not have a profile.meta.preprocessedProfileVersion
 // field. Treat those as version zero.
@@ -898,6 +898,14 @@ const _upgraders = {
           }
         }
       }
+    }
+  },
+  [20]: profile => {
+    // The interval is now define in samples
+    for (const thread of profile.threads) {
+      thread.samples.interval = Array(thread.samples.length).fill(
+        profile.meta.interval
+      );
     }
   },
 };

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -67,6 +67,7 @@ export const defaultCategories: CategoryList = Object.freeze([
   { name: 'Network', color: 'lightblue' },
   { name: 'Graphics', color: 'green' },
   { name: 'DOM', color: 'blue' },
+  { name: 'Idle', color: 'transparent' },
 ]);
 
 /**

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -68,14 +68,12 @@ type LastSeen = {
  * @param {object} thread - The profile thread.
  * @param {object} callNodeInfo - from the callNodeInfo selector.
  * @param {integer} maxDepth - The max depth of the all the stacks.
- * @param {number} interval - The sampling interval that the profile was recorded with.
  * @return {array} stackTimingByDepth
  */
 export function getStackTimingByDepth(
   thread: Thread,
   callNodeInfo: CallNodeInfo,
-  maxDepth: number,
-  interval: number
+  maxDepth: number
 ): StackTimingByDepth {
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
   const stackTimingByDepth = Array.from({ length: maxDepth }, () => ({
@@ -126,8 +124,9 @@ export function getStackTimingByDepth(
   }
 
   // Pop the remaining stacks
+  const lastIndex = thread.samples.length - 1;
   const endingTime =
-    thread.samples.time[thread.samples.time.length - 1] + interval;
+    thread.samples.time[lastIndex] + thread.samples.interval[lastIndex];
   _popStacks(stackTimingByDepth, lastSeen, -1, previousDepth, endingTime);
 
   return stackTimingByDepth;
@@ -200,7 +199,6 @@ type GetRelevantFrame = (Thread, IndexIntoStackTable) => IndexIntoFrameTable;
 
 export function getLeafCategoryStackTiming(
   thread: Thread,
-  interval: number,
   getCategory: GetCategory,
   getRelevantLeafStack: GetRelevantFrame = getNearestJSFrame
 ) {
@@ -241,8 +239,9 @@ export function getLeafCategoryStackTiming(
 
   if (stackTiming.end.length !== stackTiming.start.length) {
     // Calculate the final end time.
+    const lastIndex = thread.samples.length - 1;
     stackTiming.end.push(
-      thread.samples.time[thread.samples.length - 1] + interval
+      thread.samples.time[lastIndex] + thread.samples.interval[lastIndex]
     );
   }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -1181,7 +1181,6 @@ export const selectorsForThread = (
     );
     const getCallTree = createSelector(
       getPreviewFilteredThread,
-      getProfileInterval,
       getCallNodeInfo,
       getCategories,
       UrlState.getImplementationFilter,
@@ -1192,7 +1191,6 @@ export const selectorsForThread = (
       getFilteredThread,
       getCallNodeInfo,
       getCallNodeMaxDepth,
-      getProfileInterval,
       StackTiming.getStackTimingByDepth
     );
     const getCallNodeMaxDepthForFlameGraph = createSelector(
@@ -1202,7 +1200,6 @@ export const selectorsForThread = (
     );
     const getFlameGraphTiming = createSelector(
       getPreviewFilteredThread,
-      getProfileInterval,
       getCallNodeInfo,
       UrlState.getInvertCallstack,
       FlameGraph.getFlameGraphTiming
@@ -1211,17 +1208,14 @@ export const selectorsForThread = (
      * The buffers of the samples can be cleared out. This function lets us know the
      * absolute range of samples that we have collected.
      */
-    const unfilteredSamplesRange = createSelector(
-      getThread,
-      getProfileInterval,
-      (thread, interval) => {
-        const { time } = thread.samples;
-        if (time.length === 0) {
-          return null;
-        }
-        return { start: time[0], end: time[time.length - 1] + interval };
+    const unfilteredSamplesRange = createSelector(getThread, thread => {
+      const { time, interval } = thread.samples;
+      if (time.length === 0) {
+        return null;
       }
-    );
+      const lastIndex = time.length - 1;
+      return { start: time[0], end: time[lastIndex] + interval[lastIndex] };
+    });
     const getSelectedMarkerIndex = (state: State) =>
       getViewOptions(state).selectedMarker;
 
@@ -1337,24 +1331,9 @@ export const selectedNodeSelectors: SelectorsForNode = (() => {
   const getTimingsForSidebar = createSelector(
     selectedThreadSelectors.getSelectedCallNodePath,
     selectedThreadSelectors.getCallNodeInfo,
-    getProfileInterval,
     UrlState.getInvertCallstack,
     selectedThreadSelectors.getPreviewFilteredThread,
-    (
-      selectedPath,
-      callNodeInfo,
-      interval,
-      isInvertedTree,
-      thread
-    ): TimingsForPath => {
-      return ProfileData.getTimingsForPath(
-        selectedPath,
-        callNodeInfo,
-        interval,
-        isInvertedTree,
-        thread
-      );
-    }
+    ProfileData.getTimingsForPath
   );
 
   return {

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -454,15 +454,6 @@ function rootRange(
   }
 }
 
-function zeroAt(state: Milliseconds = 0, action: Action) {
-  switch (action.type) {
-    case 'VIEW_PROFILE':
-      return ProfileData.getTimeRangeIncludingAllThreads(action.profile).start;
-    default:
-      return state;
-  }
-}
-
 function rightClickedTrack(
   // Make the initial value the first global track, which is assumed to exists.
   // This makes the track reference always exist, which in turn makes it so that
@@ -545,7 +536,6 @@ export default wrapReducerInResetter(
       scrollToSelectionGeneration,
       focusCallTreeGeneration,
       rootRange,
-      zeroAt,
       rightClickedTrack,
       isCallNodeContextMenuVisible,
       profileSharingStatus,
@@ -574,20 +564,13 @@ export const getScrollToSelectionGeneration = createSelector(
   getProfileViewOptions,
   viewOptions => viewOptions.scrollToSelectionGeneration
 );
-
-export const getFocusCallTreeGeneration = createSelector(
-  getProfileViewOptions,
-  viewOptions => viewOptions.focusCallTreeGeneration
-);
-
-export const getZeroAt = createSelector(
-  getProfileViewOptions,
-  viewOptions => viewOptions.zeroAt
-);
+export const getFocusCallTreeGeneration = (state: State) =>
+  getProfileViewOptions(state).focusCallTreeGeneration;
+export const getZeroAt = (state: State) => getProfileRootRange(state).start;
 
 export const getCommittedRange = createSelector(
-  (state: State) => getProfileViewOptions(state).rootRange,
-  (state: State) => getProfileViewOptions(state).zeroAt,
+  getProfileRootRange,
+  getZeroAt,
   UrlState.getAllCommittedRanges,
   (rootRange, zeroAt, committedRanges): StartEndRange => {
     if (committedRanges.length > 0) {

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -49,9 +49,17 @@ function hash(state: string = '', action: Action) {
   }
 }
 
-function profileUrl(state: string = '', action: Action) {
+function profileUrl(state: string = '') {
+  // This will be set by UPDATE_URL_STATE
+  return state;
+}
+
+function profiles(state: [string, string] | null = null, action: Action) {
   switch (action.type) {
+    case 'CHANGE_PROFILES':
+      return action.profiles;
     default:
+      // This will also be set by UPDATE_URL_STATE
       return state;
   }
 }
@@ -333,6 +341,7 @@ const urlStateReducer = wrapReducerInResetter(
     dataSource,
     hash,
     profileUrl,
+    profiles,
     selectedTab,
     pathInZipFile,
     profileSpecific,
@@ -348,6 +357,7 @@ export const getProfileSpecificState = (state: State) =>
 export const getDataSource = (state: State) => getUrlState(state).dataSource;
 export const getHash = (state: State) => getUrlState(state).hash;
 export const getProfileUrl = (state: State) => getUrlState(state).profileUrl;
+export const getProfiles = (state: State) => getUrlState(state).profiles;
 export const getAllCommittedRanges = (state: State) =>
   getProfileSpecificState(state).committedRanges;
 export const getImplementationFilter = (state: State) =>

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -54,7 +54,10 @@ function profileUrl(state: string = '') {
   return state;
 }
 
-function profiles(state: [string, string] | null = null, action: Action) {
+function profiles(
+  state: [string, string] | null = null,
+  action: Action
+): [string, string] | null {
   switch (action.type) {
     case 'CHANGE_PROFILES':
       return action.profiles;

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -34,7 +34,8 @@ export type DataSource =
   | 'from-addon'
   | 'local'
   | 'public'
-  | 'from-url';
+  | 'from-url'
+| 'compare';
 export type TimelineType = 'stack' | 'category';
 export type PreviewSelection =
   | {| +hasSelection: false, +isModifying: false |}
@@ -267,7 +268,8 @@ type UrlStateAction =
       +callNodeTable: CallNodeTable,
       +selectedThreadIndex: ThreadIndex,
     |}
-  | {| +type: 'CHANGE_MARKER_SEARCH_STRING', +searchString: string |};
+  | {| +type: 'CHANGE_MARKER_SEARCH_STRING', +searchString: string |}
+  | {| +type: 'CHANGE_PROFILES', +profiles: [string, string] |};
 
 type IconsAction =
   | {| +type: 'ICON_HAS_LOADED', +icon: string |}

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -250,8 +250,6 @@ export type Thread = {
   pausedRanges: PausedRange[],
   name: string,
   processName?: string,
-  // An undefined pid is a valid value. An undefined value will key
-  // properly on Map<pid, T>.
   pid: Pid,
   tid: number | void,
   samples: SamplesTable,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -88,6 +88,7 @@ export type SamplesTable = {
   responsiveness: Array<?Milliseconds>,
   stack: Array<IndexIntoStackTable | null>,
   time: Milliseconds[],
+  interval: Milliseconds[],
   rss: Array<null | number>,
   uss: Array<null | number>,
   length: number,

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -59,7 +59,6 @@ export type ProfileViewState = {|
     scrollToSelectionGeneration: number,
     focusCallTreeGeneration: number,
     rootRange: StartEndRange,
-    zeroAt: Milliseconds,
     rightClickedTrack: TrackReference,
     isCallNodeContextMenuVisible: boolean,
     profileSharingStatus: ProfileSharingStatus,

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -138,8 +138,12 @@ export type ZippedProfilesState = {
 
 export type UrlState = {|
   +dataSource: DataSource,
+  // This is used for the "public" dataSource".
   +hash: string,
+  // This is used for the "from-url" dataSource.
   +profileUrl: string,
+  // This is used for the "compare" dataSource, to compare 2 profiles.
+  +profiles: [string, string] | null,
   +selectedTab: TabSlug,
   +pathInZipFile: string | null,
   +profileSpecific: {|


### PR DESCRIPTION
Fixes #470 

[deploy preview: form](https://deploy-preview-1249--perf-html.netlify.com/compare/)
[deploy preview: with profiles](https://deploy-preview-1249--perf-html.netlify.com/compare/http%3A%2F%2Flocalhost%3A4242%2Fpublic%2F47f7a1c0329931070db1ddd14a23360ed1a5dae9%2Fmarker-table%2F%3FglobalTrackOrder%3D0-1-2-3%26hiddenGlobalTracks%3D2%26localTrackOrderByPid%3D1011-1-0~1042-0~%26markerSearch%3Dcomplicated%26range%3D4.7031_10.1588%26react_perf%26thread%3D0%26v%3D3...http%3A%2F%2Flocalhost%3A4242%2Fpublic%2Fdfc1b84f9982b4d67e0c1079bad2c582cde1f32f%2Fmarker-table%2F%3FglobalTrackOrder%3D0-1-2-3%26hiddenGlobalTracks%3D1%26localTrackOrderByPid%3D2399-0-1~2422-0~%26markerSearch%3Ddamp%26range%3D4.9060_11.1083%26react_perf%26thread%3D0%26v%3D3/calltree/?globalTrackOrder=0-1&localTrackOrderByPid=1011-1-0~2399-1-0~&thread=0&v=3)

TODO:
* [x] import profiles
* [x] filter the imported profiles using the selected thread and the range
* [x] add a mechanism to make it possible to substract timings instead of just adding them
* [ ] merge 2 threads into 1
* [x] arrange the threads in a better way in the timeline
* [x] display markers in the timeline
* [x] apply transforms
* [ ] support minified URLs