### PR TITLE
[deploy-preview] use a gradient to draw markers in the timeline

### DIFF
--- a/src/components/timeline/TracingMarkers.js
+++ b/src/components/timeline/TracingMarkers.js
@@ -288,7 +288,14 @@ class TimelineTracingMarkersImplementation extends React.PureComponent<
         ? dur / (rangeEnd - rangeStart) * width
         : Number.MAX_SAFE_INTEGER;
       const style = name in styles ? styles[name] : styles.default;
-      ctx.fillStyle = style.background;
+      const gradient = ctx.createLinearGradient(0, 0, width, 0);
+      gradient.addColorStop(0, '#000000');
+      gradient.addColorStop(1, '#ffffff');
+      if (name in styles) {
+        ctx.fillStyle = style.background;
+      } else {
+        ctx.fillStyle = gradient;
+      }
       if (style.squareCorners) {
         ctx.fillRect(pos, style.top, itemWidth, style.height);
       } else {

--- a/src/test/components/__snapshots__/TimelineTracingMarkersOverview.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineTracingMarkersOverview.test.js.snap
@@ -29,8 +29,48 @@ Array [
     1,
   ],
   Array [
+    "createLinearGradient",
+    0,
+    0,
+    200,
+    0,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#000000",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "#ffffff",
+  ],
+  Array [
     "set fillStyle",
-    "black",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#000000",
+          ],
+          Array [
+            1,
+            "#ffffff",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    },
   ],
   Array [
     "fillRect",
@@ -54,8 +94,48 @@ Array [
     1,
   ],
   Array [
+    "createLinearGradient",
+    0,
+    0,
+    200,
+    0,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#000000",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "#ffffff",
+  ],
+  Array [
     "set fillStyle",
-    "black",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#000000",
+          ],
+          Array [
+            1,
+            "#ffffff",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    },
   ],
   Array [
     "fillRect",
@@ -79,8 +159,48 @@ Array [
     1,
   ],
   Array [
+    "createLinearGradient",
+    0,
+    0,
+    200,
+    0,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#000000",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "#ffffff",
+  ],
+  Array [
     "set fillStyle",
-    "black",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#000000",
+          ],
+          Array [
+            1,
+            "#ffffff",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    },
   ],
   Array [
     "fillRect",


### PR DESCRIPTION
This is the code to experiment with linear-gradient for markers, as suggested in #687. 