### PR TITLE
[deploy-preview] Timeline toolbar and filter markers by docshell

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -47,6 +47,7 @@ import type {
   IndexIntoMarkersTable,
   Pid,
   IndexIntoSamplesTable,
+  IndexIntoPageList,
 } from '../types/profile';
 import type {
   CallNodePath,
@@ -874,6 +875,23 @@ export function changeImplementationFilter(
       threadIndex,
       transformedThread,
       previousImplementation,
+    });
+  };
+}
+
+export function changePageFilter(
+  pageIndex: IndexIntoPageList | null
+): ThunkAction<void> {
+  return dispatch => {
+    sendAnalytics({
+      hitType: 'event',
+      eventCategory: 'profile',
+      eventAction: 'change page filter',
+    });
+
+    dispatch({
+      type: 'CHANGE_PAGE_FILTER',
+      pageIndex,
     });
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -57,6 +57,8 @@ type BaseQuery = {|
   // must be fetched to compute the tracks.
   threadOrder?: string, // "3-2-0-1"
   hiddenThreads?: string, // "0-1"
+  // The current PageList filter.
+  page?: string,
 |};
 
 type CallTreeQuery = {|
@@ -155,6 +157,10 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     /* eslint-disable camelcase */
     query.react_perf = null;
     /* eslint-enable camelcase */
+  }
+
+  if (urlState.profileSpecific.page !== null) {
+    query.page = urlState.profileSpecific.page;
   }
 
   // Depending on which tab is active, also show tab-specific query parameters.
@@ -265,6 +271,12 @@ export function stateFromLocation(location: Location): UrlState {
       : [];
   }
 
+  // Perform some basic sanitization on the page index.
+  let page = parseInt(Number(query.page), 10);
+  if (isNaN(page) || page < 0) {
+    page = null;
+  }
+
   return {
     dataSource,
     hash: hasProfileHash ? pathParts[1] : '',
@@ -294,6 +306,7 @@ export function stateFromLocation(location: Location): UrlState {
       markersSearchString: query.markerSearch || '',
       transforms,
       timelineType: query.timelineType === 'stack' ? 'stack' : 'category',
+      page,
       legacyThreadOrder: query.threadOrder
         ? query.threadOrder.split('-').map(index => Number(index))
         : null,

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -22,24 +22,38 @@
   background-color: var(--grey-20);
 }
 
-.timelineToggle {
-  position: absolute;
-  top: 0;
-  left: -150px;
-  width: 150px;
-  height: 22px;
+.timelineSettings {
+  height: 25px;
+  padding: 0;
+  line-height: 25px;
   display: flex;
-  font-size: 9px;
+  flex-flow: row nowrap;
+  color: var(--ink-70);
+  border-bottom: 1px solid var(--grey-30);
+  justify-content: space-between;
+  white-space: nowrap;
 }
 
-.timelineToggleInput {
-  height: 12px;
-  width: 12px;
-  margin: 0 3px;
+.timelineSettingsToggle {
+  display: flex;
+  border-right: 1px solid var(--grey-30);
+  padding: 0 8px;
+}
+
+.timelineSettingsToggleInput {
+  margin: 0 5px;
   vertical-align: middle;
 }
 
-.timelineToggleLabel {
+.timelineSettingsToggleLabel {
   display: flex;
   align-items: center;
+}
+
+.timelineSettingsPages {
+  padding: 0 8px;
+}
+
+.timelineSettingsPagesSelect {
+  max-width: 350px;
 }

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -1,432 +1,457 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Timeline renders the header 1`] = `
-<div
-  className="timelineSelection"
-  onMouseDown={[Function]}
-  onMouseMove={[Function]}
->
-  <form>
+Array [
+  <div
+    className="timelineSettings"
+  >
+    <form>
+      <div
+        className="timelineSettingsToggle"
+      >
+        Graph type:
+         
+        <label
+          className="timelineSettingsToggleLabel"
+        >
+          <input
+            checked={true}
+            className="timelineSettingsToggleInput"
+            name="timelineSettingsToggle"
+            onChange={[Function]}
+            type="radio"
+          />
+          Categories
+        </label>
+        <label
+          className="timelineSettingsToggleLabel"
+        >
+          <input
+            checked={false}
+            className="timelineSettingsToggleInput"
+            name="timelineSettingsToggle"
+            onChange={[Function]}
+            type="radio"
+          />
+          Stack height
+        </label>
+      </div>
+    </form>
     <div
-      className="timelineToggle"
+      className="timelineSettingsPages"
     >
-      <label
-        className="timelineToggleLabel"
+      Filter by page:
+       
+      <select
+        className="timelineSettingsPagesSelect"
+        onChange={[Function]}
+        value="all"
       >
-        <input
-          checked={true}
-          className="timelineToggleInput"
-          name="timelineToggle"
-          onChange={[Function]}
-          type="radio"
-        />
-        Categories
-      </label>
-      <label
-        className="timelineToggleLabel"
-      >
-        <input
-          checked={false}
-          className="timelineToggleInput"
-          name="timelineToggle"
-          onChange={[Function]}
-          type="radio"
-        />
-        Stack height
-      </label>
+        <option
+          value="all"
+        >
+          Show all pages
+        </option>
+      </select>
     </div>
-  </form>
+  </div>,
   <div
-    className="timelineRuler"
+    className="timelineSelection"
+    onMouseDown={[Function]}
+    onMouseMove={[Function]}
   >
-    <ol
-      className="timelineRulerContainer"
+    <div
+      className="timelineRuler"
     >
-      <li
-        className="timelineRulerNotch"
-        style={
-          Object {
-            "left": "0px",
-          }
-        }
+      <ol
+        className="timelineRulerContainer"
       >
-        <span
-          className="timelineRulerNotchText"
-        >
-          0.000s
-        </span>
-      </li>
-      <li
-        className="timelineRulerNotch"
-        style={
-          Object {
-            "left": "66.66666666666667px",
+        <li
+          className="timelineRulerNotch"
+          style={
+            Object {
+              "left": "0px",
+            }
           }
-        }
-      >
-        <span
-          className="timelineRulerNotchText"
         >
-          0.002s
-        </span>
-      </li>
-      <li
-        className="timelineRulerNotch"
-        style={
-          Object {
-            "left": "133.33333333333334px",
+          <span
+            className="timelineRulerNotchText"
+          >
+            0.000s
+          </span>
+        </li>
+        <li
+          className="timelineRulerNotch"
+          style={
+            Object {
+              "left": "66.66666666666667px",
+            }
           }
-        }
-      >
-        <span
-          className="timelineRulerNotchText"
         >
-          0.004s
-        </span>
-      </li>
-      <li
-        className="timelineRulerNotch"
-        style={
-          Object {
-            "left": "200px",
+          <span
+            className="timelineRulerNotchText"
+          >
+            0.002s
+          </span>
+        </li>
+        <li
+          className="timelineRulerNotch"
+          style={
+            Object {
+              "left": "133.33333333333334px",
+            }
           }
-        }
-      >
-        <span
-          className="timelineRulerNotchText"
         >
-          0.006s
-        </span>
-      </li>
-      <li
-        className="timelineRulerNotch"
-        style={
-          Object {
-            "left": "266.6666666666667px",
+          <span
+            className="timelineRulerNotchText"
+          >
+            0.004s
+          </span>
+        </li>
+        <li
+          className="timelineRulerNotch"
+          style={
+            Object {
+              "left": "200px",
+            }
           }
-        }
-      >
-        <span
-          className="timelineRulerNotchText"
         >
-          0.008s
-        </span>
-      </li>
-    </ol>
-  </div>
-  <div
-    className="overflowEdgeIndicator timelineOverflowEdgeIndicator"
-  >
+          <span
+            className="timelineRulerNotchText"
+          >
+            0.006s
+          </span>
+        </li>
+        <li
+          className="timelineRulerNotch"
+          style={
+            Object {
+              "left": "266.6666666666667px",
+            }
+          }
+        >
+          <span
+            className="timelineRulerNotchText"
+          >
+            0.008s
+          </span>
+        </li>
+      </ol>
+    </div>
     <div
-      className="overflowEdgeIndicatorEdge topEdge"
-    />
-    <div
-      className="overflowEdgeIndicatorEdge rightEdge"
-    />
-    <div
-      className="overflowEdgeIndicatorEdge bottomEdge"
-    />
-    <div
-      className="overflowEdgeIndicatorEdge leftEdge"
-    />
-    <div
-      className="overflowEdgeIndicatorScrollbox timelineOverflowEdgeIndicatorScrollbox"
-      onScroll={[Function]}
+      className="overflowEdgeIndicator timelineOverflowEdgeIndicator"
     >
       <div
-        className="overflowEdgeIndicatorContentsWrapper"
+        className="overflowEdgeIndicatorEdge topEdge"
+      />
+      <div
+        className="overflowEdgeIndicatorEdge rightEdge"
+      />
+      <div
+        className="overflowEdgeIndicatorEdge bottomEdge"
+      />
+      <div
+        className="overflowEdgeIndicatorEdge leftEdge"
+      />
+      <div
+        className="overflowEdgeIndicatorScrollbox timelineOverflowEdgeIndicatorScrollbox"
+        onScroll={[Function]}
       >
-        <ol
-          className="timelineThreadList"
-          onMouseDown={[Function]}
+        <div
+          className="overflowEdgeIndicatorContentsWrapper"
         >
-          <li
-            className="timelineTrack"
+          <ol
+            className="timelineThreadList"
+            onMouseDown={[Function]}
           >
-            <div
-              className="timelineTrackRow timelineTrackGlobalRow"
-              onClick={[Function]}
+            <li
+              className="timelineTrack"
             >
               <div
-                className="react-contextmenu-wrapper timelineTrackLabel timelineTrackGlobalGrippy"
-                onContextMenu={[Function]}
+                className="timelineTrackRow timelineTrackGlobalRow"
+                onClick={[Function]}
+              >
+                <div
+                  className="react-contextmenu-wrapper timelineTrackLabel timelineTrackGlobalGrippy"
+                  onContextMenu={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                  title={null}
+                >
+                  <h1
+                    className="timelineTrackName"
+                  >
+                    Process 0
+                  </h1>
+                </div>
+                <div
+                  className="timelineTrackTrack"
+                >
+                  <div
+                    className="timelineTrackThreadBlank"
+                  />
+                </div>
+              </div>
+              <ol
+                className="timelineTrackLocalTracks"
                 onMouseDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchStart={[Function]}
-                title={null}
               >
-                <h1
-                  className="timelineTrackName"
-                >
-                  Process 0
-                </h1>
-              </div>
-              <div
-                className="timelineTrackTrack"
-              >
-                <div
-                  className="timelineTrackThreadBlank"
-                />
-              </div>
-            </div>
-            <ol
-              className="timelineTrackLocalTracks"
-              onMouseDown={[Function]}
-            >
-              <li
-                className="timelineTrack timelineTrackLocal"
-              >
-                <div
-                  className="timelineTrackRow timelineTrackLocalRow selected"
-                  onClick={[Function]}
+                <li
+                  className="timelineTrack timelineTrackLocal"
                 >
                   <div
-                    className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-                    onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    title="thread: \\"Main Thread\\" (0)
-process: \\"default\\" (0)"
-                  >
-                    <h1
-                      className="timelineTrackName"
-                    >
-                      Main Thread
-                    </h1>
-                  </div>
-                  <div
-                    className="timelineTrackTrack"
+                    className="timelineTrackRow timelineTrackLocalRow selected"
+                    onClick={[Function]}
                   >
                     <div
-                      className="timelineTrackThread"
+                      className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
+                      onContextMenu={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                      title="thread: \\"Main Thread\\" (0)
+process: \\"default\\" (0)"
                     >
-                      <div
-                        className="timelineTrackThreadIntervalMarkerOverview selected"
+                      <h1
+                        className="timelineTrackName"
                       >
-                        <canvas
-                          className="timelineTracingMarkersCanvas"
-                          onMouseDown={[Function]}
-                          onMouseMove={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseUp={[Function]}
-                        />
-                      </div>
-                      <div
-                        className="threadActivityGraph"
-                      >
-                        <canvas
-                          className="threadActivityGraphCanvas threadActivityGraphCanvas"
-                          onMouseUp={[Function]}
-                        />
-                      </div>
-                      <div
-                        className="timelineEmptyThreadIndicator"
-                      />
+                        Main Thread
+                      </h1>
                     </div>
-                  </div>
-                </div>
-              </li>
-              <li
-                className="timelineTrack timelineTrackLocal"
-              >
-                <div
-                  className="timelineTrackRow timelineTrackLocalRow"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-                    onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    title="thread: \\"Thread with dropped samples\\" (0)
-process: \\"default\\" (0)"
-                  >
-                    <h1
-                      className="timelineTrackName"
-                    >
-                      Thread with dropped samples
-                    </h1>
-                  </div>
-                  <div
-                    className="timelineTrackTrack"
-                  >
                     <div
-                      className="timelineTrackThread"
+                      className="timelineTrackTrack"
                     >
                       <div
-                        className="timelineTrackThreadIntervalMarkerOverview"
-                      >
-                        <canvas
-                          className="timelineTracingMarkersCanvas"
-                          onMouseDown={[Function]}
-                          onMouseMove={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseUp={[Function]}
-                        />
-                      </div>
-                      <div
-                        className="threadActivityGraph"
-                      >
-                        <canvas
-                          className="threadActivityGraphCanvas threadActivityGraphCanvas"
-                          onMouseUp={[Function]}
-                        />
-                      </div>
-                      <div
-                        className="timelineEmptyThreadIndicator"
+                        className="timelineTrackThread"
                       >
                         <div
-                          className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorStartup"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "left": 0,
-                              "width": 66.66666666666667,
-                            }
-                          }
-                        />
+                          className="timelineTrackThreadIntervalMarkerOverview selected"
+                        >
+                          <canvas
+                            className="timelineTracingMarkersCanvas"
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseUp={[Function]}
+                          />
+                        </div>
                         <div
-                          className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorShutdown"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "right": 0,
-                              "width": 66.66666666666667,
-                            }
-                          }
-                        />
+                          className="threadActivityGraph"
+                        >
+                          <canvas
+                            className="threadActivityGraphCanvas threadActivityGraphCanvas"
+                            onMouseUp={[Function]}
+                          />
+                        </div>
                         <div
-                          className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorEmptyBuffer"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "left": 66.66666666666667,
-                              "width": 66.66666666666667,
-                            }
-                          }
+                          className="timelineEmptyThreadIndicator"
                         />
                       </div>
                     </div>
                   </div>
-                </div>
-              </li>
-              <li
-                className="timelineTrack timelineTrackLocal"
-              >
-                <div
-                  className="timelineTrackRow timelineTrackLocalRow"
-                  onClick={[Function]}
+                </li>
+                <li
+                  className="timelineTrack timelineTrackLocal"
                 >
                   <div
-                    className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-                    onContextMenu={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchStart={[Function]}
-                    title="thread: \\"Thread with dropped samples\\" (0)
-process: \\"default\\" (0)"
-                  >
-                    <h1
-                      className="timelineTrackName"
-                    >
-                      Thread with dropped samples
-                    </h1>
-                  </div>
-                  <div
-                    className="timelineTrackTrack"
+                    className="timelineTrackRow timelineTrackLocalRow"
+                    onClick={[Function]}
                   >
                     <div
-                      className="timelineTrackThread"
+                      className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
+                      onContextMenu={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                      title="thread: \\"Thread with dropped samples\\" (0)
+process: \\"default\\" (0)"
+                    >
+                      <h1
+                        className="timelineTrackName"
+                      >
+                        Thread with dropped samples
+                      </h1>
+                    </div>
+                    <div
+                      className="timelineTrackTrack"
                     >
                       <div
-                        className="timelineTrackThreadIntervalMarkerOverview"
-                      >
-                        <canvas
-                          className="timelineTracingMarkersCanvas"
-                          onMouseDown={[Function]}
-                          onMouseMove={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseUp={[Function]}
-                        />
-                      </div>
-                      <div
-                        className="threadActivityGraph"
-                      >
-                        <canvas
-                          className="threadActivityGraphCanvas threadActivityGraphCanvas"
-                          onMouseUp={[Function]}
-                        />
-                      </div>
-                      <div
-                        className="timelineEmptyThreadIndicator"
+                        className="timelineTrackThread"
                       >
                         <div
-                          className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorStartup"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "left": 0,
-                              "width": 66.66666666666667,
-                            }
-                          }
-                        />
+                          className="timelineTrackThreadIntervalMarkerOverview"
+                        >
+                          <canvas
+                            className="timelineTracingMarkersCanvas"
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseUp={[Function]}
+                          />
+                        </div>
                         <div
-                          className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorShutdown"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "right": 0,
-                              "width": 66.66666666666667,
-                            }
-                          }
-                        />
+                          className="threadActivityGraph"
+                        >
+                          <canvas
+                            className="threadActivityGraphCanvas threadActivityGraphCanvas"
+                            onMouseUp={[Function]}
+                          />
+                        </div>
                         <div
-                          className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorEmptyBuffer"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "left": 66.66666666666667,
-                              "width": 66.66666666666667,
+                          className="timelineEmptyThreadIndicator"
+                        >
+                          <div
+                            className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorStartup"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "left": 0,
+                                "width": 66.66666666666667,
+                              }
                             }
-                          }
-                        />
+                          />
+                          <div
+                            className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorShutdown"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "right": 0,
+                                "width": 66.66666666666667,
+                              }
+                            }
+                          />
+                          <div
+                            className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorEmptyBuffer"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "left": 66.66666666666667,
+                                "width": 66.66666666666667,
+                              }
+                            }
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              </li>
-            </ol>
-          </li>
-        </ol>
+                </li>
+                <li
+                  className="timelineTrack timelineTrackLocal"
+                >
+                  <div
+                    className="timelineTrackRow timelineTrackLocalRow"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
+                      onContextMenu={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                      title="thread: \\"Thread with dropped samples\\" (0)
+process: \\"default\\" (0)"
+                    >
+                      <h1
+                        className="timelineTrackName"
+                      >
+                        Thread with dropped samples
+                      </h1>
+                    </div>
+                    <div
+                      className="timelineTrackTrack"
+                    >
+                      <div
+                        className="timelineTrackThread"
+                      >
+                        <div
+                          className="timelineTrackThreadIntervalMarkerOverview"
+                        >
+                          <canvas
+                            className="timelineTracingMarkersCanvas"
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseUp={[Function]}
+                          />
+                        </div>
+                        <div
+                          className="threadActivityGraph"
+                        >
+                          <canvas
+                            className="threadActivityGraphCanvas threadActivityGraphCanvas"
+                            onMouseUp={[Function]}
+                          />
+                        </div>
+                        <div
+                          className="timelineEmptyThreadIndicator"
+                        >
+                          <div
+                            className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorStartup"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "left": 0,
+                                "width": 66.66666666666667,
+                              }
+                            }
+                          />
+                          <div
+                            className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorShutdown"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "right": 0,
+                                "width": 66.66666666666667,
+                              }
+                            }
+                          />
+                          <div
+                            className="timelineEmptyThreadIndicatorBlock timelineEmptyThreadIndicatorEmptyBuffer"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "left": 66.66666666666667,
+                                "width": 66.66666666666667,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    className="timelineSelectionHoverLine"
-    style={
-      Object {
-        "left": "0",
-        "visibility": "hidden",
+    <div
+      className="timelineSelectionHoverLine"
+      style={
+        Object {
+          "left": "0",
+          "visibility": "hidden",
+        }
       }
-    }
-  />
-</div>
+    />
+  </div>,
+]
 `;
 
 exports[`Timeline renders the header 2`] = `

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -12,6 +12,7 @@ import type {
   IndexIntoMarkersTable,
   IndexIntoFuncTable,
   Pid,
+  IndexIntoPageList,
 } from './profile';
 import type {
   CallNodePath,
@@ -259,6 +260,10 @@ type UrlStateAction =
       +transformedThread: Thread,
       +previousImplementation: ImplementationFilter,
       +implementation: ImplementationFilter,
+    |}
+  | {|
+      +type: 'CHANGE_PAGE_FILTER',
+      +pageIndex: IndexIntoPageList | null,
     |}
   | {|
       +type: 'CHANGE_INVERT_CALLSTACK',

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -16,6 +16,7 @@ export type IndexIntoFuncTable = number;
 export type IndexIntoResourceTable = number;
 export type IndexIntoLibs = number;
 export type IndexIntoCategoryList = number;
+export type IndexIntoPageList = number;
 export type resourceTypeEnum = number;
 export type ThreadIndex = number;
 

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -20,6 +20,7 @@ import type {
   Profile,
   ThreadIndex,
   Pid,
+  IndexIntoPageList,
 } from './profile';
 
 import type {
@@ -147,6 +148,7 @@ export type UrlState = {|
     hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
     localTrackOrderByPid: Map<Pid, TrackIndex[]>,
     implementation: ImplementationFilter,
+    page: IndexIntoPageList | null,
     invertCallstack: boolean,
     committedRanges: StartEndRange[],
     callTreeSearchString: string,

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -158,3 +158,16 @@ export function getNumberPropertyOrNull<T: Object>(
   const maybeNumber = (data: Object)[property];
   return typeof maybeNumber === 'number' ? maybeNumber : null;
 }
+
+/**
+ * Flow doesn't want us to access potentitally non-existent properties on unions of
+ * of objects. This function creates a safe interface to access number properties
+ * if they might exist.
+ */
+export function getStringPropertyOrNull<T: Object>(
+  data: T,
+  property: string
+): string | null {
+  const maybeString = (data: Object)[property];
+  return typeof maybeString === 'string' ? maybeString : null;
+}


### PR DESCRIPTION
This deploy preview adds a timeline toolbar, and a first pass at filtering data by site. See issue #1511.

[Deploy preview](https://deploy-preview-1510--perf-html.netlify.com/public/d9f19838ff07d9baff2aba03f1ca4d6830a05703/marker-chart/?globalTrackOrder=6-1-2-0-3-4-5&hiddenGlobalTracks=1-2&hiddenLocalTracksByPid=60074-1-2-3-4-5-6&localTrackOrderByPid=60074-7-0-1-2-3-4-5-6~73137-0~63732-0~&markerSearch=&thread=0&v=3)

<img width="447" alt="image" src="https://user-images.githubusercontent.com/1588648/48736695-8f71d000-ec11-11e8-8105-7a40c72e9a16.png">
