### PR TITLE
[deploy-preview] Convert JS Tracer data to the Profile format

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -8,6 +8,8 @@ import {
   processProfile,
   unserializeProfileOfArbitraryFormat,
 } from '../profile-logic/process-profile';
+import { convertJsTracerToThread } from '../profile-logic/js-tracer';
+import { getFriendlyThreadName } from '../profile-logic/profile-data';
 import { SymbolStore } from '../profile-logic/symbol-store';
 import { symbolicateProfile } from '../profile-logic/symbolication';
 import * as MozillaSymbolicationAPI from '../profile-logic/mozilla-symbolication-api';
@@ -90,6 +92,27 @@ export function viewProfile(
       );
       return;
     }
+
+    // This is NOT the right place for this code. This is just an easy hack to
+    // show off this feature.
+    const jsTracerThreads = [];
+    for (const thread of profile.threads) {
+      const { jsTracer } = thread;
+      if (jsTracer) {
+        const friendlyThreadName = getFriendlyThreadName(
+          profile.threads,
+          thread
+        );
+        const jsTracerThread = convertJsTracerToThread(
+          thread,
+          jsTracer,
+          profile.meta.categories
+        );
+        jsTracerThread.name = `JS Tracer of ${friendlyThreadName}`;
+        jsTracerThreads.push(jsTracerThread);
+      }
+    }
+    profile.threads = [...profile.threads, ...jsTracerThreads];
 
     // The selectedThreadIndex is only null for new profiles that haven't
     // been seen before. If it's non-null, then there is profile view information

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -108,6 +108,7 @@ export function viewProfile(
           jsTracer,
           profile.meta.categories
         );
+        jsTracerThread.isJsTracer = true;
         jsTracerThread.name = `JS Tracer of ${friendlyThreadName}`;
         jsTracerThreads.push(jsTracerThread);
       }

--- a/src/components/calltree/ProfileCallTreeView.js
+++ b/src/components/calltree/ProfileCallTreeView.js
@@ -25,7 +25,7 @@ const ProfileCallTreeView = (props: Props) => (
     <StackSettings />
     <TransformNavigator />
     {props && props.hideThreadActivityGraph ? null : (
-      <SelectedThreadActivityGraph />
+      <SelectedThreadActivityGraph viewport={(null: any)} />
     )}
     <CallTree />
   </div>

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -23,6 +23,7 @@ import type {
   CategoryDrawStyles,
   ActivityFillGraphQuerier,
 } from './ActivityGraphFills';
+import type { SelectedState } from '../../../profile-logic/profile-data';
 
 export type Props = {|
   +className: string,
@@ -32,7 +33,7 @@ export type Props = {|
   +rangeEnd: Milliseconds,
   +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
   +categories: CategoryList,
-  +samplesSelectedStates?: boolean[],
+  +samplesSelectedStates?: void | null | SelectedState[],
   +treeOrderSampleComparator?: (
     IndexIntoSamplesTable,
     IndexIntoSamplesTable

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -8,6 +8,7 @@ import clamp from 'clamp';
 
 import './ActivityGraph.css';
 
+import type { SelectedState } from '../../../profile-logic/profile-data';
 import type {
   IndexIntoSamplesTable,
   IndexIntoCategoryList,
@@ -42,7 +43,7 @@ type RenderedComponentSettings = {|
     IndexIntoSamplesTable
   ) => number,
   +greyCategoryIndex: IndexIntoCategoryList,
-  +samplesSelectedStates: ?Array<boolean>,
+  +samplesSelectedStates: ?Array<SelectedState>,
   +categoryDrawStyles: CategoryDrawStyles,
 |};
 

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -91,11 +91,13 @@ class StackGraph extends PureComponent<Props> {
       thread.samples,
       stackIndexToCallNodeIndex
     );
-    const samplesSelectedStates = getSamplesSelectedStates(
-      callNodeTable,
-      sampleCallNodes,
-      selectedCallNodeIndex
-    );
+    const samplesSelectedStates = thread.isJsTracer
+      ? null
+      : getSamplesSelectedStates(
+          callNodeTable,
+          sampleCallNodes,
+          selectedCallNodeIndex
+        );
     for (let i = 0; i < callNodeTable.depth.length; i++) {
       if (callNodeTable.depth[i] > maxDepth) {
         maxDepth = callNodeTable.depth[i];
@@ -154,7 +156,10 @@ class StackGraph extends PureComponent<Props> {
       const height = callNodeTable.depth[callNodeIndex] * yPixelsPerDepth;
       const xPos = (sampleTime - range[0]) * xPixelsPerMs;
       let samplesBucket;
-      if (samplesSelectedStates[i] === 'SELECTED') {
+      if (
+        samplesSelectedStates !== null &&
+        samplesSelectedStates[i] === 'SELECTED'
+      ) {
         samplesBucket = highlightedSamples;
       } else {
         const stackIndex = ensureExists(

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -288,6 +288,7 @@ function _getInvertedStackSelfTimes(
   // Calculate the timing information by going through each sample.
   const callNodeSelfTime = new Float32Array(callNodeTable.length);
   const callNodeLeafTime = new Float32Array(callNodeTable.length);
+  const weights = thread.samples.weight;
   for (
     let sampleIndex = 0;
     sampleIndex < sampleCallNodes.length;
@@ -296,8 +297,9 @@ function _getInvertedStackSelfTimes(
     const callNodeIndex = sampleCallNodes[sampleIndex];
     if (callNodeIndex !== null) {
       const rootIndex = callNodeToRoot[callNodeIndex];
-      callNodeSelfTime[rootIndex] += interval;
-      callNodeLeafTime[callNodeIndex] += interval;
+      const weight = weights ? weights[sampleIndex] : interval;
+      callNodeSelfTime[rootIndex] += weight;
+      callNodeLeafTime[callNodeIndex] += weight;
     }
   }
 
@@ -317,7 +319,7 @@ function _getStackSelfTimes(
   callNodeLeafTime: Float32Array, // Milliseconds[]
 } {
   const callNodeSelfTime = new Float32Array(callNodeTable.length);
-
+  const weights = thread.samples.weight;
   for (
     let sampleIndex = 0;
     sampleIndex < sampleCallNodes.length;
@@ -325,7 +327,9 @@ function _getStackSelfTimes(
   ) {
     const callNodeIndex = sampleCallNodes[sampleIndex];
     if (callNodeIndex !== null) {
-      callNodeSelfTime[callNodeIndex] += interval;
+      callNodeSelfTime[callNodeIndex] += weights
+        ? weights[sampleIndex]
+        : interval;
     }
   }
 

--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -10,12 +10,15 @@ import {
   getEmptySamplesTable,
   getEmptyRawMarkerTable,
 } from './data-structures';
+import { ensureExists } from '../utils/flow';
 
 import type {
   JsTracerTable,
   IndexIntoStringTable,
   IndexIntoJsTracerEvents,
+  IndexIntoStackTable,
   IndexIntoFuncTable,
+  SamplesTable,
   Thread,
   CategoryList,
 } from '../types/profile';
@@ -119,16 +122,22 @@ export function getJsTracerTiming(
  *     weight: [3,  3,  4,  3,  4,  10, 3,  3 ]
  *   }
  */
-export function convertJsTracerToThread(
+export function convertJsTracerToThreadWithoutSamples(
   fromThread: Thread,
   jsTracer: JsTracerTable,
   categories: CategoryList
-): Thread {
+): {
+  thread: Thread,
+  stackMap: Map<IndexIntoJsTracerEvents, IndexIntoStackTable>,
+} {
+  // Create a new thread, with empty information, but preserve some of the existing
+  // thread information.
   const funcTable = getEmptyFuncTable();
   const frameTable = getEmptyFrameTable();
   const stackTable = getEmptyStackTable();
   const samples = getEmptySamplesTable();
   const markers = getEmptyRawMarkerTable();
+  const { stringTable } = fromThread;
 
   const sampleWeights = [];
   samples.weight = sampleWeights;
@@ -143,27 +152,39 @@ export function convertJsTracerToThread(
     samples,
   };
 
+  // Keep a stack of js tracer events, and end timings, that will be used to find
+  // the stack prefixes. Once a JS tracer event starts past another event end, the
+  // stack will be "popped" but decrementing the unmatchedIndex.
   let unmatchedIndex = 0;
-  // Start with a -1 value, which signals no prefix.
   const unmatchedEventIndexes = [null];
   const unmatchedEventEnds = [0];
 
-  const { stringTable } = fromThread;
+  // Build up maps between index values.
   const funcMap: Map<IndexIntoStringTable, IndexIntoFuncTable> = new Map();
+  const stackMap: Map<IndexIntoJsTracerEvents, IndexIntoStackTable> = new Map();
+
+  // Get some computed values before entering the loop.
   const blankStringIndex = stringTable.indexForString('');
   const otherCategory = categories.findIndex(c => c.name === 'Other');
   if (otherCategory === -1) {
     throw new Error("Expected to find an 'Other' category.");
   }
 
+  // Go through all of the JS tracer events, and build up the func, stack, and
+  // frame tables.
   for (
     let tracerEventIndex = 0;
     tracerEventIndex < jsTracer.length;
     tracerEventIndex++
   ) {
+    // Look up various values for this event.
     const stringIndex = jsTracer.events[tracerEventIndex];
-    let funcIndex = funcMap.get(stringIndex);
+    const start = jsTracer.timestamps[tracerEventIndex];
+    const durationRaw = jsTracer.durations[tracerEventIndex];
+    const duration = durationRaw === null ? 0 : durationRaw;
+    const end = start + duration;
 
+    let funcIndex = funcMap.get(stringIndex);
     if (funcIndex === undefined) {
       // Create a new function only if the event string is different.
       funcIndex = funcTable.length++;
@@ -179,6 +200,7 @@ export function convertJsTracerToThread(
       funcMap.set(stringIndex, funcIndex);
     }
 
+    // Every event gets a unique frame entry.
     const frameIndex = frameTable.length++;
     frameTable.address.push(blankStringIndex);
     frameTable.category.push(otherCategory);
@@ -189,12 +211,7 @@ export function convertJsTracerToThread(
     frameTable.column.push(null);
     frameTable.optimizations.push(null);
 
-    const start = jsTracer.timestamps[tracerEventIndex];
-    const durationRaw = jsTracer.durations[tracerEventIndex];
-    const duration = durationRaw === null ? 0 : durationRaw;
-    const end = start + duration;
-
-    // Try to find the current prefix.
+    // Try to find the prefix stack for this event.
     let prefixIndex = unmatchedEventIndexes[unmatchedIndex];
     while (prefixIndex !== null) {
       const otherEnd = unmatchedEventEnds[unmatchedIndex];
@@ -206,25 +223,37 @@ export function convertJsTracerToThread(
       unmatchedIndex--;
     }
 
+    // Each event gets a stack table entry.
     const stackIndex = stackTable.length++;
     stackTable.frame.push(frameIndex);
     stackTable.category.push(otherCategory);
     stackTable.prefix.push(prefixIndex);
+    stackMap.set(tracerEventIndex, stackIndex);
 
-    // samples.responsiveness.push();
-    samples.stack.push(stackIndex);
-    samples.time.push(start);
-    samples.rss.push(null);
-    samples.uss.push(null);
-    sampleWeights.push(duration);
-    samples.length++;
-
-    // All done, keep going
+    // Add this stack to the unmatched stacks of events.
     unmatchedIndex++;
+    if (unmatchedIndex === 0) {
+      // Reached a new root, reset the index to 1.
+      unmatchedIndex = 1;
+    }
     unmatchedEventIndexes[unmatchedIndex] = tracerEventIndex;
     unmatchedEventEnds[unmatchedIndex] = end;
   }
 
+  return { thread, stackMap };
+}
+
+export function convertJsTracerToThread(
+  fromThread: Thread,
+  jsTracer: JsTracerTable,
+  categories: CategoryList
+): Thread {
+  const { thread, stackMap } = convertJsTracerToThreadWithoutSamples(
+    fromThread,
+    jsTracer,
+    categories
+  );
+  thread.samples = getSelfTimeSamplesFromJsTracer(thread, jsTracer, stackMap);
   return thread;
 }
 
@@ -511,4 +540,224 @@ export function getJsTracerLeafTiming(
 
     return 0;
   });
+}
+
+export function getSelfTimeSamplesFromJsTracer(
+  thread: Thread,
+  jsTracer: JsTracerTable,
+  stackMap: Map<IndexIntoJsTracerEvents, IndexIntoStackTable>
+): SamplesTable {
+  // Each event type will have it's own timing information, later collapse these into
+  // a single array.
+  const { stringTable } = thread;
+  const samples = getEmptySamplesTable();
+  const sampleWeights = [];
+  samples.weight = sampleWeights;
+  samples.weightType = 'microseconds';
+
+  function addSelfTimeAsASample(
+    eventIndex: IndexIntoJsTracerEvents,
+    start: Microseconds,
+    end: Microseconds
+  ): void {
+    if (start === end) {
+      // If this self time is 0, do not report it.
+      return;
+    }
+    const stackIndex = ensureExists(
+      stackMap.get(eventIndex),
+      'The JS tracer event did not exist in the stack map.'
+    );
+    samples.stack.push(stackIndex);
+    samples.time.push(
+      // Convert from microseconds.
+      start / 1000
+    );
+    samples.rss.push(null);
+    samples.uss.push(null);
+    sampleWeights.push(
+      // The weight of the sample is in microseconds.
+      end - start
+    );
+    samples.length++;
+  }
+  // Determine the self time of the various events.
+
+  // These arrays implement the stack of "prefix" events. This is implemented as 3
+  // arrays instead of an array of objects to reduce the GC pressure in this tight
+  // loop, but conceptually this is just one stack, not 3 stacks. At any given time,
+  // the stack represents the prefixes, aka the parents, of the current event.
+  const prefixesStarts: Microseconds[] = [];
+  const prefixesEnds: Microseconds[] = [];
+  const prefixesEventIndexes: IndexIntoJsTracerEvents[] = [];
+
+  // If there is no prefix, set it to -1. This simplifies some of the real-time
+  // type checks that would be required by Flow for this mutable variable.
+  let prefixesTip = -1;
+
+  // Go through all of the events. Each `if` branch is documented with a small diagram
+  // that includes a little bit of ascii art to help explain the step.
+  //
+  // Legend:
+  // xxxxxxxx - Already reported information, not part of the prefix stack.
+  // [======] - Some event on the stack that has not been reported.
+  // [prefix] - The prefix event to consider, the top of the prefix stack. This
+  //            could also be only part of an event, that has been split into multiple
+  //            pieces.
+  // [current] - The current event to add.
+
+  for (
+    let currentEventIndex = 0;
+    currentEventIndex < jsTracer.length;
+    currentEventIndex++
+  ) {
+    const currentStart = jsTracer.timestamps[currentEventIndex];
+    const durationRaw = jsTracer.durations[currentEventIndex];
+    const duration = durationRaw === null ? 0 : durationRaw;
+    const currentEnd = currentStart + duration;
+
+    if (prefixesTip === -1) {
+      // Nothing has been added yet, add this "current" event to the stack of prefixes.
+      prefixesTip = 0;
+      prefixesStarts[prefixesTip] = currentStart;
+      prefixesEnds[prefixesTip] = currentEnd;
+      prefixesEventIndexes[prefixesTip] = currentEventIndex;
+      continue;
+    }
+
+    while (true) {
+      const prefixStart = prefixesStarts[prefixesTip];
+      const prefixEnd = prefixesEnds[prefixesTip];
+      const prefixEventIndex = prefixesEventIndexes[prefixesTip];
+
+      // The following if/else blocks go through every potential case of timing for the
+      // the data, and finally throw if those cases weren't handled. Each block should
+      // have a diagram explaining the various states the timing can be in. Inside the
+      // if checks, the loop is either continued or broken.
+
+      if (prefixEnd <= currentStart) {
+        // In this case, the "current" event has passed the other "prefix" event.
+        //
+        //    xxxxxxxxxxxxxxxx[================]
+        //    xxxxxxxx[======]     [current]
+        //    [prefix]
+        //
+        // This next step would match too:
+        //
+        //    xxxxxxxxxxxxxxxx[================]
+        //    xxxxxxxx[prefix]     [current]
+        //    xxxxxxxx
+
+        // Commit the previous "prefix" event, then continue on with this loop.
+        addSelfTimeAsASample(prefixEventIndex, prefixStart, prefixEnd);
+
+        // Move the tip towards the prefix.
+        prefixesTip--;
+
+        if (prefixesTip === -1) {
+          // This next step would match too:
+          //
+          //   [prefix]     [current]
+
+          // There are no more "prefix" events to commit. Add the "current" event on, and
+          // break out of this loop.
+          prefixesTip = 0;
+          prefixesEventIndexes[prefixesTip] = currentEventIndex;
+          prefixesStarts[prefixesTip] = currentStart;
+          prefixesEnds[prefixesTip] = currentEnd;
+          break;
+        }
+
+        // Move up the prefix stack to report more self times. This is the only branch
+        // that has a `continue`, and not a `break`.
+        continue;
+      } else if (prefixEnd > currentEnd) {
+        // The current event occludes the prefix event.
+        //
+        //   [prefix=================]
+        //           [current]
+        //
+        // Split the reported self time of the prefix.
+        //
+        //   [prefix]xxxxxxxxx[prefix]
+        //           [current]
+        //
+        //                    ^leave the second prefix piece on the "prefixes" stack
+        //   ^report the first prefix piece
+        //
+        //   After reporting we are left with:
+        //
+        //   xxxxxxxxxxxxxxxxx[======]
+        //           [current]
+
+        // Report the first part of the prefix's self time.
+        addSelfTimeAsASample(prefixEventIndex, prefixStart, currentStart);
+
+        // Shorten the prefix's start time.
+        prefixesStarts[prefixesTip] = currentEnd;
+
+        // Now add on the "current" event to the stack of prefixes.
+        prefixesTip++;
+        prefixesStarts[prefixesTip] = currentStart;
+        prefixesEnds[prefixesTip] = currentEnd;
+        prefixesEventIndexes[prefixesTip] = currentEventIndex;
+        break;
+      } else if (prefixEnd === currentEnd) {
+        if (prefixStart !== currentStart) {
+          // The current event splits the event above it, so split the reported self
+          // time of the prefix.
+          //
+          //   [prefix]xxxxxxxxx
+          //           [current]
+
+          // Report the prefix's self time.
+          addSelfTimeAsASample(prefixEventIndex, prefixStart, currentStart);
+
+          // Update both the index and the start time.
+          prefixesStarts[prefixesTip] = currentStart;
+          prefixesEventIndexes[prefixesTip] = currentEventIndex;
+        } else {
+          // The prefix and current events completely match, so don't report any
+          // self time from the prefix. Replace the prefix's index.
+          prefixesEventIndexes[prefixesTip] = currentEventIndex;
+        }
+        break;
+      } else {
+        // There is some error in the data structure or this functions logic. Throw
+        // and error, and report some nice information to the console.
+        const prefixName = stringTable.getString(
+          jsTracer.events[prefixEventIndex]
+        );
+        const currentName = stringTable.getString(
+          jsTracer.events[currentEventIndex]
+        );
+        console.error('Current JS Tracer information:', {
+          jsTracer,
+          stringTable,
+          prefixEventIndex,
+          currentEventIndex,
+        });
+        console.error(
+          `Prefix (parent) times for "${prefixName}": ${prefixStart}ms to ${prefixEnd}ms`
+        );
+        console.error(
+          `Current (child) times for "${currentName}": ${currentStart}ms to ${currentEnd}ms`
+        );
+        throw new Error(
+          'The JS Tracer information was malformed. Some event lasted longer than its parent event.'
+        );
+      }
+    }
+  }
+
+  // Drain off the remaining "prefixes" from the stack, and report the self time.
+  for (; prefixesTip >= 0; prefixesTip--) {
+    addSelfTimeAsASample(
+      prefixesEventIndexes[prefixesTip],
+      prefixesStarts[prefixesTip],
+      prefixesEnds[prefixesTip]
+    );
+  }
+
+  return samples;
 }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -953,7 +953,7 @@ export function filterThreadSamplesToRange(
     rangeStart,
     rangeEnd
   );
-  const newSamples = {
+  const newSamples: SamplesTable = {
     length: sEnd - sBegin,
     time: samples.time.slice(sBegin, sEnd),
     stack: samples.stack.slice(sBegin, sEnd),
@@ -961,9 +961,17 @@ export function filterThreadSamplesToRange(
     rss: samples.rss.slice(sBegin, sEnd),
     uss: samples.uss.slice(sBegin, sEnd),
   };
-  return Object.assign({}, thread, {
+  const { weight, weightType } = samples;
+  if (weight) {
+    newSamples.weight = weight.slice(sBegin, sEnd);
+  }
+  if (weightType) {
+    newSamples.weightType = weightType;
+  }
+  return {
+    ...thread,
     samples: newSamples,
-  });
+  };
 }
 
 // --------------- CallNodePath and CallNodeIndex manipulations ---------------

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -18,10 +18,7 @@ import {
 
 describe('convertJsTracerToThread', function() {
   it('can generate stacks correctly', function() {
-    const {
-      meta: { categories },
-      threads: [thread],
-    } = getProfileWithJsTracerEvents([
+    const existingProfile = getProfileWithJsTracerEvents([
       // [mozilla                  ]
       //  [int   ][ion          ]
       //   [int]    [ion      ]
@@ -31,19 +28,23 @@ describe('convertJsTracerToThread', function() {
       ['IonMonkey', 5, 19],
       ['IonMonkey', 6, 18],
     ]);
+    const existingThread = existingProfile.threads[0];
+    const categories = existingProfile.meta.categories;
 
     const profile = getEmptyProfile();
-    const jsTracer = ensureExists(thread.jsTracer);
-    profile.threads.push(convertJsTracerToThread(thread, jsTracer, categories));
+    const jsTracer = ensureExists(existingThread.jsTracer);
+    profile.threads = [
+      convertJsTracerToThread(existingThread, jsTracer, categories),
+    ];
     const { getState } = storeWithProfile(profile);
     const callTree = selectedThreadSelectors.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
-      '- https://mozilla.org (total: 5, self: 1)',
-      '  - Interpreter (total: 4, self: 1)',
-      '    - IonMonkey (total: 2, self: 1)',
-      '      - IonMonkey (total: 1, self: 1)',
-      '    - Interpreter (total: 1, self: 1)',
+      '- https://mozilla.org (total: 20,000, self: 2,000)',
+      '  - Interpreter (total: 18,000, self: 2,000)',
+      '    - IonMonkey (total: 14,000, self: 2,000)',
+      '      - IonMonkey (total: 12,000, self: 12,000)',
+      '    - Interpreter (total: 2,000, self: 2,000)',
     ]);
   });
 });

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -266,6 +266,7 @@ export type Thread = {
   pausedRanges: PausedRange[],
   name: string,
   processName?: string,
+  isJsTracer?: boolean,
   // An undefined pid is a valid value. An undefined value will key
   // properly on Map<pid, T>.
   pid: Pid,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -89,6 +89,8 @@ export type SamplesTable = {
   responsiveness: Array<?Milliseconds>,
   stack: Array<IndexIntoStackTable | null>,
   time: Milliseconds[],
+  weight?: Array<number>,
+  weightType?: 'microseconds' | 'compare' | 'milliseconds',
   rss: Array<null | number>,
   uss: Array<null | number>,
   length: number,


### PR DESCRIPTION
This deploy preview takes the JS Tracer data source, and converts it into our usual Profile format.

[deploy preview](https://deploy-preview-1612--perf-html.netlify.com/public/a1cc1b91c3a23e8d16df3ee817ff98fdfc53f997/flame-graph/?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=0-1-2-3&hiddenLocalTracksByPid=11270-0~11339-0&localTrackOrderByPid=11251-0-1~11253-0~11270-0~11339-0~11271-0~&thread=10&timelineType=stack&v=3)