### PR TITLE
Make contributions easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,6 @@ ports:
 tasks:
 - before: nvm install 10
   init: yarn install
-  command: PERFHTML_HOST="0.0.0.0" yarn start
+  command: FX_PROFILER_HOST="0.0.0.0" yarn start
 - openMode: split-right
   command: printf "\nFirefox Profiler ❤ Gitpod\nWelcome to this virtual environment.\nYou can type your commands in this terminal.\n\n"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+ports:
+- port: 4242
+tasks:
+- before: nvm install 10
+  init: yarn install
+  command: PERFHTML_HOST="0.0.0.0" yarn start
+- openMode: split-right
+  command: printf "\nFirefox Profiler ❤ Gitpod\nWelcome to this virtual environment.\nYou can type your commands in this terminal.\n\n"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ To get started clone the repo and get the web application started.
 
 Alternatively, you can also develop the Firefox Profiler online in a pre-configured development environment:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/devtools-html/profiler)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/firefox-devtools/profiler)
 
 Gitpod will automatically install all dependencies; start the webpack server for you; and open the web app in a new browser tab.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ To get started clone the repo and get the web application started.
  5. Point your browser to [http://localhost:4242](http://localhost:4242).
  6. If port `4242` is taken, then you can run the web app on a different port: `FX_PROFILER_PORT=1234 yarn start`
 
+## Using Gitpod
+
+Alternatively, you can also develop the Firefox Profiler online in a pre-configured development environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/devtools-html/profiler)
+
+Gitpod will automatically install all dependencies; start the webpack server for you; and open the web app in a new browser tab.
+
 ## Loading in profiles for development
 
 The web app doesn't include any performance profiles by default, so you'll need to load some in. Make sure the local Webpack web server is running, and then try one of the following:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ yarn start
 
 You can also develop the Firefox Profiler online in a pre-configured development environment:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/devtools-html/profiler)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/firefox-devtools/profiler)
 
 For more detailed information on getting started contributing. We have plenty of docs available to get you started.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ yarn install
 yarn start
 ```
 
+You can also develop the Firefox Profiler online in a pre-configured development environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/devtools-html/profiler)
+
 For more detailed information on getting started contributing. We have plenty of docs available to get you started.
 
 | | |

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const localConfigExists = fs.existsSync(
 );
 
 const serverConfig = {
-  allowedHosts: ['localhost'],
+  allowedHosts: ['localhost', '.gitpod.io'],
   contentBase: config.output.path,
   publicPath: config.output.publicPath,
   hot: process.env.NODE_ENV === 'development' ? true : false,


### PR DESCRIPTION
This pull request configures Gitpod for perf.html development, so that anyone can get started easily with a pre-configured environment.

Workspaces are prepared with `yarn install`, then the perf.html server will start automatically with `PERFHTML_HOST="0.0.0.0" yarn start`. Please let me know if that fits your workflow.

(Hint: When prompted, open the running app in a new Browser tab -- the default Preview won't work because your CSP rules forbid cross-domain iframes. We can make this the default action by adding `onOpen: open-browser` to port 4242 in `.gitpod.yml`.)

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/jankeromnes/perf.html)

<img width="1440" alt="screenshot 2019-01-23 at 18 56 39" src="https://user-images.githubusercontent.com/599268/51626799-a6e67580-1f40-11e9-8d97-0e5e81e0876b.png">

@julienw Sorry for incrementing your review pile again! :innocent: Please take your time and review this whenever is convenient for you.