### PR TITLE
[WIP] Uncouple the selected node from the right click action

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -190,6 +190,9 @@ body,
   background-color: var(--grey-30);
   color: black;
 }
+.treeViewRow.rightClicked:not(.selected) {
+  background-color: var(--blue-50-a30);
+}
 .treeViewRow.dim > .treeViewMainColumn {
   opacity: 0.7;
 }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -98,6 +98,22 @@ export function changeSelectedCallNode(
 }
 
 /**
+ * This action is used when the user right clicks on a call node (in panels such
+ * as the call tree, the flame chart, or the stack chart). It's especially used
+ * to display the context menu.
+ */
+export function changeRightClickedCallNode(
+  threadIndex: ThreadIndex,
+  callNodePath: CallNodePath | null
+) {
+  return {
+    type: 'CHANGE_RIGHT_CLICKED_CALL_NODE',
+    threadIndex,
+    callNodePath,
+  };
+}
+
+/**
  * Given a threadIndex and a sampleIndex, select the call node at the top ("leaf")
  * of that sample's stack.
  */
@@ -313,10 +329,16 @@ export function changeRightClickedTrack(
   };
 }
 
-export function setCallNodeContextMenuVisibility(isVisible: boolean): Action {
-  return {
-    type: 'SET_CALL_NODE_CONTEXT_MENU_VISIBILITY',
-    isVisible,
+export function setCallNodeContextMenuVisibility(
+  isVisible: boolean
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const selectedThreadIndex = getSelectedThreadIndex(getState());
+    dispatch({
+      type: 'SET_CALL_NODE_CONTEXT_MENU_VISIBILITY',
+      threadIndex: selectedThreadIndex,
+      isVisible,
+    });
   };
 }
 

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -24,6 +24,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { getIconsWithClassNames } from '../../selectors/icons';
 import {
   changeSelectedCallNode,
+  changeRightClickedCallNode,
   changeExpandedCallNodes,
   addTransformToStack,
 } from '../../actions/profile-view';
@@ -50,6 +51,7 @@ type StateProps = {|
   +tree: CallTree,
   +callNodeInfo: CallNodeInfo,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
+  +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +expandedCallNodeIndexes: Array<IndexIntoCallNodeTable | null>,
   +searchStringsRegExp: RegExp | null,
   +disableOverscan: boolean,
@@ -61,6 +63,7 @@ type StateProps = {|
 
 type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
+  +changeRightClickedCallNode: typeof changeRightClickedCallNode,
   +changeExpandedCallNodes: typeof changeExpandedCallNodes,
   +addTransformToStack: typeof addTransformToStack,
 |};
@@ -119,6 +122,18 @@ class CallTreeComponent extends PureComponent<Props> {
     );
   };
 
+  _onRightClickSelection = (newSelectedCallNode: IndexIntoCallNodeTable) => {
+    const {
+      callNodeInfo,
+      threadIndex,
+      changeRightClickedCallNode,
+    } = this.props;
+    changeRightClickedCallNode(
+      threadIndex,
+      getCallNodePathFromIndex(newSelectedCallNode, callNodeInfo.callNodeTable)
+    );
+  };
+
   _onExpandedCallNodesChange = (
     newExpandedCallNodeIndexes: Array<IndexIntoCallNodeTable | null>
   ) => {
@@ -159,6 +174,7 @@ class CallTreeComponent extends PureComponent<Props> {
     const {
       tree,
       selectedCallNodeIndex,
+      rightClickedCallNodeIndex,
       expandedCallNodeIndexes,
       searchStringsRegExp,
       disableOverscan,
@@ -174,8 +190,10 @@ class CallTreeComponent extends PureComponent<Props> {
         mainColumn={this._mainColumn}
         appendageColumn={this._appendageColumn}
         onSelectionChange={this._onSelectedCallNodeChange}
+        onRightClickSelection={this._onRightClickSelection}
         onExpandedNodesChange={this._onExpandedCallNodesChange}
         selectedNodeId={selectedCallNodeIndex}
+        rightClickedNodeId={rightClickedCallNodeIndex}
         expandedNodeIds={expandedCallNodeIndexes}
         highlightRegExp={searchStringsRegExp}
         disableOverscan={disableOverscan}
@@ -200,6 +218,9 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
     selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
       state
     ),
+    rightClickedCallNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(
+      state
+    ),
     expandedCallNodeIndexes: selectedThreadSelectors.getExpandedCallNodeIndexes(
       state
     ),
@@ -212,6 +233,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   }),
   mapDispatchToProps: {
     changeSelectedCallNode,
+    changeRightClickedCallNode,
     changeExpandedCallNodes,
     addTransformToStack,
   },

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -38,6 +38,7 @@ export type OwnProps = {|
   +stackFrameHeight: CssPixels,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +onSelectionChange: (IndexIntoCallNodeTable | null) => void,
+  +onRightClick: (IndexIntoCallNodeTable | null) => void,
   +disableTooltips: boolean,
   +scrollToSelectionGeneration: number,
   +categories: CategoryList,
@@ -265,17 +266,32 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
     );
   };
 
+  getCallNodeIndexFromHoveredItem(
+    hoveredItem: HoveredStackTiming | null
+  ): IndexIntoCallNodeTable | null {
+    if (hoveredItem === null) {
+      return null;
+    }
+
+    const { depth, flameGraphTimingIndex } = hoveredItem;
+    const { flameGraphTiming } = this.props;
+    const stackTiming = flameGraphTiming[depth];
+    const callNodeIndex = stackTiming.callNode[flameGraphTimingIndex];
+    return callNodeIndex;
+  }
+
   _onSelectItem = (hoveredItem: HoveredStackTiming | null) => {
     // Change our selection to the hovered item, or deselect (with
     // null) if there's nothing hovered.
-    let callNodeIndex = null;
-    if (hoveredItem !== null) {
-      const { depth, flameGraphTimingIndex } = hoveredItem;
-      const { flameGraphTiming } = this.props;
-      const stackTiming = flameGraphTiming[depth];
-      callNodeIndex = stackTiming.callNode[flameGraphTimingIndex];
-    }
+    const callNodeIndex = this.getCallNodeIndexFromHoveredItem(hoveredItem);
     this.props.onSelectionChange(callNodeIndex);
+  };
+
+  _onRightClick = (hoveredItem: HoveredStackTiming | null) => {
+    // Change our selection to the hovered item, or deselect (with
+    // null) if there's nothing hovered.
+    const callNodeIndex = this.getCallNodeIndexFromHoveredItem(hoveredItem);
+    this.props.onRightClick(callNodeIndex);
   };
 
   _hitTest = (x: CssPixels, y: CssPixels): HoveredStackTiming | null => {
@@ -320,6 +336,7 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
         drawCanvas={this._drawCanvas}
         hitTest={this._hitTest}
         onSelectItem={this._onSelectItem}
+        onRightClick={this._onRightClick}
       />
     );
   }

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -17,7 +17,10 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { getSelectedThreadIndex } from '../../selectors/url-state';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
-import { changeSelectedCallNode } from '../../actions/profile-view';
+import {
+  changeSelectedCallNode,
+  changeRightClickedCallNode,
+} from '../../actions/profile-view';
 import { getIconsWithClassNames } from '../../selectors/icons';
 import { BackgroundImageStyleDef } from '../shared/StyleDef';
 
@@ -58,6 +61,7 @@ type StateProps = {|
 |};
 type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
+  +changeRightClickedCallNode: typeof changeRightClickedCallNode,
 |};
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
@@ -87,6 +91,20 @@ class FlameGraph extends React.PureComponent<Props> {
   componentDidMount() {
     this._focusViewport();
   }
+
+  _onRightClickedCallNodeChange = (
+    callNodeIndex: IndexIntoCallNodeTable | null
+  ) => {
+    const {
+      callNodeInfo,
+      threadIndex,
+      changeRightClickedCallNode,
+    } = this.props;
+    changeRightClickedCallNode(
+      threadIndex,
+      getCallNodePathFromIndex(callNodeIndex, callNodeInfo.callNodeTable)
+    );
+  };
 
   render() {
     const {
@@ -149,6 +167,7 @@ class FlameGraph extends React.PureComponent<Props> {
               scrollToSelectionGeneration,
               stackFrameHeight: STACK_FRAME_HEIGHT,
               onSelectionChange: this._onSelectedCallNodeChange,
+              onRightClick: this._onRightClickedCallNodeChange,
               disableTooltips: isCallNodeContextMenuVisible,
             }}
           />
@@ -191,6 +210,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   },
   mapDispatchToProps: {
     changeSelectedCallNode,
+    changeRightClickedCallNode,
   },
   component: FlameGraph,
 };

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -15,6 +15,7 @@ type Props<HoveredItem> = {|
   +containerHeight: CssPixels,
   +className: string,
   +onSelectItem?: (HoveredItem | null) => void,
+  +onRightClick?: (HoveredItem | null) => void,
   +onDoubleClickItem: (HoveredItem | null) => void,
   +getHoveredItemInfo: HoveredItem => React.Node,
   +drawCanvas: (CanvasRenderingContext2D, HoveredItem | null) => void,
@@ -128,18 +129,28 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
     }
   }
 
-  _onMouseDown = (
-    event: { nativeEvent: MouseEvent } & SyntheticMouseEvent<>
-  ) => {
-    // Remember where the mouse was positioned. Move too far and it
-    // won't be registered as a selecting click on mouse up.
-    this._mouseDownOffsetX = event.nativeEvent.offsetX;
-    this._mouseDownOffsetY = event.nativeEvent.offsetY;
-    this._mouseMovedWhileClicked = false;
+  _onMouseDown = (e: { nativeEvent: MouseEvent } & SyntheticMouseEvent<>) => {
+    if (e.button === 0) {
+      // Remember where the mouse was positioned. Move too far and it
+      // won't be registered as a selecting click on mouse up.
+      this._mouseDownOffsetX = e.nativeEvent.offsetX;
+      this._mouseDownOffsetY = e.nativeEvent.offsetY;
+      this._mouseMovedWhileClicked = false;
+    }
+
+    if (e.button === 2 && this.props.onRightClick) {
+      // Right button is a contextual action
+      this.props.onRightClick(this.state.hoveredItem);
+    }
   };
 
-  _onMouseUp = () => {
-    if (!this._mouseMovedWhileClicked && this.props.onSelectItem) {
+  _onMouseUp = (e: SyntheticMouseEvent<>) => {
+    if (this._mouseMovedWhileClicked) {
+      return;
+    }
+
+    if (e.button === 0 && this.props.onSelectItem) {
+      // Left button is a selection action
       this.props.onSelectItem(this.state.hoveredItem);
     }
   };
@@ -155,12 +166,12 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
     this._offsetY = event.nativeEvent.offsetY;
     const maybeHoveredItem = this.props.hitTest(this._offsetX, this._offsetY);
 
-    // If the mouse moves too far while a button down, flag this as
-    // drag event only. Then it won't select anything when the button
-    // is released.
+    // If the mouse moves too far while the primary button is down, flag this as
+    // drag event only. Then it won't select anything when the button is
+    // released.
     if (
       !this._mouseMovedWhileClicked &&
-      event.buttons !== 0 &&
+      (event.buttons & 1) !== 0 &&
       (Math.abs(this._offsetX - this._mouseDownOffsetX) >
         MOUSE_CLICK_MAX_MOVEMENT_DELTA ||
         Math.abs(this._offsetY - this._mouseDownOffsetY) >

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -97,6 +97,21 @@ export function getStackAndSampleSelectorsPerThread(
     }
   );
 
+  const getRightClickedCallNodePath: Selector<CallNodePath | null> = state =>
+    threadSelectors.getViewOptions(state).rightClickedCallNodePath;
+
+  const getRightClickedCallNodeIndex: Selector<IndexIntoCallNodeTable | null> = createSelector(
+    getCallNodeInfo,
+    getRightClickedCallNodePath,
+    ({ callNodeTable }, callNodePath): IndexIntoCallNodeTable | null => {
+      if (callNodePath === null) {
+        return null;
+      }
+
+      return ProfileData.getCallNodeIndexFromPath(callNodePath, callNodeTable);
+    }
+  );
+
   const getExpandedCallNodePaths: Selector<PathSet> = createSelector(
     threadSelectors.getViewOptions,
     threadViewOptions => threadViewOptions.expandedCallNodePaths
@@ -202,6 +217,8 @@ export function getStackAndSampleSelectorsPerThread(
     getCallNodeMaxDepth,
     getSelectedCallNodePath,
     getSelectedCallNodeIndex,
+    getRightClickedCallNodePath,
+    getRightClickedCallNodeIndex,
     getExpandedCallNodePaths,
     getExpandedCallNodeIndexes,
     getSamplesSelectedStatesInFilteredThread,

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -8,7 +8,10 @@ import CallNodeContextMenu from '../../components/shared/CallNodeContextMenu';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { render, fireEvent } from 'react-testing-library';
-import { changeSelectedCallNode } from '../../actions/profile-view';
+import {
+  changeRightClickedCallNode,
+  changeExpandedCallNodes,
+} from '../../actions/profile-view';
 import { Provider } from 'react-redux';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
@@ -31,12 +34,11 @@ describe('calltree/CallNodeContextMenu', function() {
       E          E
     `);
     const store = storeWithProfile(profile);
-    store.dispatch(
-      changeSelectedCallNode(0, [
-        funcNames.indexOf('A'),
-        funcNames.indexOf('B:library'),
-      ])
-    );
+    const A = funcNames.indexOf('A');
+    const B = funcNames.indexOf('B:library');
+
+    store.dispatch(changeExpandedCallNodes(0, [[A]]));
+    store.dispatch(changeRightClickedCallNode(0, [A, B]));
     return store;
   }
 
@@ -147,7 +149,7 @@ describe('calltree/CallNodeContextMenu', function() {
       );
 
       const store = storeWithProfile(profile);
-      store.dispatch(changeSelectedCallNode(0, [funcIndex]));
+      store.dispatch(changeRightClickedCallNode(0, [funcIndex]));
       const { getByText } = setup(store);
 
       // Copy is a mocked module, clear it both before and after.
@@ -159,7 +161,7 @@ describe('calltree/CallNodeContextMenu', function() {
       const { getByText } = setup();
       // Copy is a mocked module, clear it both before and after.
       fireEvent.click(getByText('Copy stack'));
-      expect(copy).toBeCalledWith(`B:library\nA\n`);
+      expect(copy).toBeCalledWith(`B:library\nA`);
     });
   });
 });

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -87,7 +87,7 @@ exports[`MarkerTable renders some basic markers 1`] = `
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -110,7 +110,7 @@ exports[`MarkerTable renders some basic markers 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -146,7 +146,7 @@ exports[`MarkerTable renders some basic markers 1`] = `
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -163,7 +163,7 @@ exports[`MarkerTable renders some basic markers 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -559,7 +559,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -590,7 +590,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -621,7 +621,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -652,7 +652,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -683,7 +683,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -714,7 +714,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -745,7 +745,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -776,7 +776,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -807,7 +807,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -838,7 +838,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -869,7 +869,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -900,7 +900,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -931,7 +931,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -962,7 +962,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -993,7 +993,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1024,7 +1024,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1059,7 +1059,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1121,7 +1121,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1165,7 +1165,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1189,7 +1189,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1213,7 +1213,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1237,7 +1237,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1261,7 +1261,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1285,7 +1285,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1309,7 +1309,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1333,7 +1333,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1357,7 +1357,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1381,7 +1381,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1405,7 +1405,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1429,7 +1429,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1453,7 +1453,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1477,7 +1477,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1501,7 +1501,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1525,7 +1525,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1553,7 +1553,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1577,7 +1577,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd selected "
+                class="treeViewRow treeViewRowScrolledColumns odd selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1601,7 +1601,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1796,7 +1796,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1827,38 +1827,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
-                  title="67%"
-                >
-                  67%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalTime"
-                  title="2"
-                >
-                  2
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn selfTime"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1889,7 +1858,38 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="67%"
+                >
+                  67%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="2"
+                >
+                  2
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1951,7 +1951,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -1982,7 +1982,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2026,7 +2026,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2050,7 +2050,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2074,7 +2074,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2098,7 +2098,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2122,7 +2122,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even selected "
+                class="treeViewRow treeViewRowScrolledColumns even selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2146,7 +2146,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2170,7 +2170,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2365,7 +2365,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2396,7 +2396,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2427,7 +2427,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2458,7 +2458,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2520,7 +2520,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2551,7 +2551,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2595,7 +2595,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2619,7 +2619,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2643,7 +2643,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2667,7 +2667,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2691,7 +2691,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even selected "
+                class="treeViewRow treeViewRowScrolledColumns even selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2715,7 +2715,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2739,7 +2739,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2934,7 +2934,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2965,7 +2965,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -2996,7 +2996,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3027,7 +3027,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3089,7 +3089,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3120,7 +3120,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3164,7 +3164,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3188,7 +3188,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3212,7 +3212,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3236,7 +3236,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3260,7 +3260,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even selected "
+                class="treeViewRow treeViewRowScrolledColumns even selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3284,7 +3284,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3308,7 +3308,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 />
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3503,7 +3503,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3534,7 +3534,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3565,7 +3565,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3596,7 +3596,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3658,7 +3658,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3702,7 +3702,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3728,7 +3728,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3754,7 +3754,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3786,7 +3786,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3812,7 +3812,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even selected "
+                class="treeViewRow treeViewRowScrolledColumns even selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -3838,7 +3838,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4035,7 +4035,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4066,7 +4066,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4097,7 +4097,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4128,7 +4128,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4190,7 +4190,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4234,7 +4234,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4260,7 +4260,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4286,7 +4286,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4318,7 +4318,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4344,7 +4344,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even selected "
+                class="treeViewRow treeViewRowScrolledColumns even selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4370,7 +4370,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4567,7 +4567,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4598,7 +4598,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4629,7 +4629,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4660,7 +4660,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4704,7 +4704,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4730,7 +4730,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4756,7 +4756,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4788,7 +4788,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4991,7 +4991,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5022,7 +5022,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5053,7 +5053,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5084,7 +5084,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5128,7 +5128,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5154,7 +5154,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5180,7 +5180,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5212,7 +5212,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5415,7 +5415,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5446,7 +5446,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5477,7 +5477,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even "
+                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5508,7 +5508,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5570,7 +5570,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd "
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5614,7 +5614,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5640,7 +5640,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5666,7 +5666,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even  "
+                class="treeViewRow treeViewRowScrolledColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5698,7 +5698,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5724,7 +5724,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns even selected "
+                class="treeViewRow treeViewRowScrolledColumns even selected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -5756,7 +5756,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowScrolledColumns odd  "
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span

--- a/src/test/components/__snapshots__/ZipFileTree.test.js.snap
+++ b/src/test/components/__snapshots__/ZipFileTree.test.js.snap
@@ -44,27 +44,27 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                 class="treeViewBodyInner treeViewBodyInner0InnerChunk"
               >
                 <div
-                  class="treeViewRow treeViewRowFixedColumns even "
+                  class="treeViewRow treeViewRowFixedColumns even"
                   style="height: 30px; line-height: 30px;"
                 />
                 <div
-                  class="treeViewRow treeViewRowFixedColumns odd "
+                  class="treeViewRow treeViewRowFixedColumns odd"
                   style="height: 30px; line-height: 30px;"
                 />
                 <div
-                  class="treeViewRow treeViewRowFixedColumns even "
+                  class="treeViewRow treeViewRowFixedColumns even"
                   style="height: 30px; line-height: 30px;"
                 />
                 <div
-                  class="treeViewRow treeViewRowFixedColumns odd "
+                  class="treeViewRow treeViewRowFixedColumns odd"
                   style="height: 30px; line-height: 30px;"
                 />
                 <div
-                  class="treeViewRow treeViewRowFixedColumns even "
+                  class="treeViewRow treeViewRowFixedColumns even"
                   style="height: 30px; line-height: 30px;"
                 />
                 <div
-                  class="treeViewRow treeViewRowFixedColumns odd "
+                  class="treeViewRow treeViewRowFixedColumns odd"
                   style="height: 30px; line-height: 30px;"
                 />
               </div>
@@ -81,7 +81,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                 class="treeViewBodyInner treeViewBodyInner1InnerChunk"
               >
                 <div
-                  class="treeViewRow treeViewRowScrolledColumns even  "
+                  class="treeViewRow treeViewRowScrolledColumns even"
                   style="height: 30px; line-height: 30px;"
                 >
                   <span
@@ -98,7 +98,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                   </span>
                 </div>
                 <div
-                  class="treeViewRow treeViewRowScrolledColumns odd  "
+                  class="treeViewRow treeViewRowScrolledColumns odd"
                   style="height: 30px; line-height: 30px;"
                 >
                   <span
@@ -115,7 +115,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                   </span>
                 </div>
                 <div
-                  class="treeViewRow treeViewRowScrolledColumns even  "
+                  class="treeViewRow treeViewRowScrolledColumns even"
                   style="height: 30px; line-height: 30px;"
                 >
                   <span
@@ -136,7 +136,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                   </span>
                 </div>
                 <div
-                  class="treeViewRow treeViewRowScrolledColumns odd  "
+                  class="treeViewRow treeViewRowScrolledColumns odd"
                   style="height: 30px; line-height: 30px;"
                 >
                   <span
@@ -157,7 +157,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                   </span>
                 </div>
                 <div
-                  class="treeViewRow treeViewRowScrolledColumns even  "
+                  class="treeViewRow treeViewRowScrolledColumns even"
                   style="height: 30px; line-height: 30px;"
                 >
                   <span
@@ -174,7 +174,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                   </span>
                 </div>
                 <div
-                  class="treeViewRow treeViewRowScrolledColumns odd  "
+                  class="treeViewRow treeViewRowScrolledColumns odd"
                   style="height: 30px; line-height: 30px;"
                 >
                   <span

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -3100,6 +3100,7 @@ Object {
       ],
     },
   },
+  "rightClickedCallNodePath": null,
   "selectedCallNodePath": Array [
     0,
     1,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -91,6 +91,11 @@ type ProfileAction =
       +optionalExpandedToCallNodePath: ?CallNodePath,
     |}
   | {|
+      +type: 'CHANGE_RIGHT_CLICKED_CALL_NODE',
+      +threadIndex: ThreadIndex,
+      +callNodePath: CallNodePath | null,
+    |}
+  | {|
       +type: 'FOCUS_CALL_TREE',
     |}
   | {|
@@ -170,6 +175,7 @@ type ProfileAction =
   | {|
       +type: 'SET_CALL_NODE_CONTEXT_MENU_VISIBILITY',
       +isVisible: boolean,
+      +threadIndex: ThreadIndex,
     |}
   | {|
       +type: 'SET_PROFILE_SHARING_STATUS',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -41,6 +41,7 @@ export type ThreadViewOptions = {|
   +selectedCallNodePath: CallNodePath,
   +expandedCallNodePaths: PathSet,
   +selectedMarker: IndexIntoRawMarkerTable | -1,
+  +rightClickedCallNodePath: CallNodePath | null,
 |};
 
 export type ProfileSharingStatus = {|


### PR DESCRIPTION
Until now a right click selects a node in the same time as showing the context menu. This PR uncouples these 2 actions.

This is now working properly but I'd like to check if I should add some tests around this new behavior.