### PR TITLE
Network design refresh

### DIFF
--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -122,7 +122,10 @@ const NetworkChartRowBar = (props: NetworkChartRowBarProps) => {
       </span>
       <span
         className="networkChartRowItemBarInner networkChartRowItemBarResponse"
-        style={{ left: `${requestQueueWidth + requestWidth}%`, width: `${responseWidth}%` }}
+        style={{
+          left: `${requestQueueWidth + requestWidth}%`,
+          width: `${responseWidth}%`,
+        }}
       >
         &nbsp;
       </span>
@@ -261,7 +264,6 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
 
   render() {
     const { index, marker, markerStyle, networkPayload } = this.props;
-    console.log(markerStyle);
 
     const evenOddClassName = index % 2 === 0 ? 'even' : 'odd';
 
@@ -277,7 +279,10 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
         <div
           className="networkChartRowItemLabel"
           style={{
-            width: markerStyle.left > 0 ? (markerStyle.left - 8) : null,
+            width:
+              parseFloat(markerStyle.left) > 0
+                ? parseFloat(markerStyle.left) - 8
+                : null,
           }}
         >
           {this._splitsURI(marker.name)}

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 import Tooltip from '../shared/Tooltip';
+import { formatMilliseconds } from '../../utils/format-numbers';
 
 import type { CssPixels } from '../../types/units';
 import type { ThreadIndex } from '../../types/profile';
@@ -101,26 +102,38 @@ const NetworkChartRowBar = (props: NetworkChartRowBarProps) => {
   const requestQueueWidth = requestQueue;
   const requestWidth = request;
   const responseWidth = response;
+  const responseQueueWidth = 100 - requestQueue - request - response;
 
   return (
     <React.Fragment>
       <span
-        className="networkChartRowItemBarInner networkChartRowItemBarRequestQueue"
-        style={{ width: `${requestQueueWidth}%` }}
+        className="networkChartRowItemBarOuter networkChartRowItemBarRequestQueue"
+        style={{
+          width: `${requestQueueWidth}%`,
+        }}
       >
         &nbsp;
       </span>
       <span
         className="networkChartRowItemBarInner networkChartRowItemBarRequest"
-        style={{ width: `${requestWidth}%` }}
+        style={{ left: `${requestQueueWidth}%`, width: `${requestWidth}%` }}
       >
         &nbsp;
       </span>
       <span
         className="networkChartRowItemBarInner networkChartRowItemBarResponse"
-        style={{ width: `${responseWidth}%` }}
+        style={{ left: `${requestQueueWidth + requestWidth}%`, width: `${responseWidth}%` }}
       >
         &nbsp;
+      </span>
+      <span
+        className="networkChartRowItemBarOuter networkChartRowItemBarResponseQueue"
+        style={{ width: `${responseQueueWidth}%` }}
+      >
+        &nbsp;
+      </span>
+      <span className="networkChartRowItemBarDuration">
+        {formatMilliseconds(dur)}
       </span>
     </React.Fragment>
   );
@@ -186,22 +199,32 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
       const uriPath = uri.pathname.replace(uriFilename, '');
 
       return (
-        <span>
-          <span className="networkChartRowItemUriOptional">
+        <React.Fragment>
+          <span key="protocol" className="networkChartRowItemUriOptional">
             {uri.protocol + '//'}
           </span>
-          <span className="networkChartRowItemUriRequired">{uri.hostname}</span>
+          <span key="hostname" className="networkChartRowItemUriRequired">
+            {uri.hostname}
+          </span>
           {uriPath !== uriFilename && uriPath.length > 0 ? (
-            <span className="networkChartRowItemUriOptional">{uriPath}</span>
+            <span key="path" className="networkChartRowItemUriOptional">
+              {uriPath}
+            </span>
           ) : null}
-          <span className="networkChartRowItemUriRequired">{uriFilename}</span>
+          <span key="name" className="networkChartRowItemUriRequired">
+            {uriFilename}
+          </span>
           {uri.search ? (
-            <span className="networkChartRowItemUriOptional">{uri.search}</span>
+            <span key="search" className="networkChartRowItemUriOptional">
+              {uri.search}
+            </span>
           ) : null}
           {uri.hash ? (
-            <span className="networkChartRowItemUriOptional">{uri.hash}</span>
+            <span key="hash" className="networkChartRowItemUriOptional">
+              {uri.hash}
+            </span>
           ) : null}
-        </span>
+        </React.Fragment>
       );
     }
     return name;
@@ -238,6 +261,7 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
 
   render() {
     const { index, marker, markerStyle, networkPayload } = this.props;
+    console.log(markerStyle);
 
     const evenOddClassName = index % 2 === 0 ? 'even' : 'odd';
 
@@ -250,7 +274,12 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
       this._identifyType(marker.name);
     return (
       <section className={itemClassName}>
-        <div className="networkChartRowItemLabel">
+        <div
+          className="networkChartRowItemLabel"
+          style={{
+            width: markerStyle.left > 0 ? (markerStyle.left - 8) : null,
+          }}
+        >
           {this._splitsURI(marker.name)}
         </div>
         <div

--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -20,117 +20,111 @@
 
 .networkChartRowItem {
   display: block;
+  position: relative;
   width: 100%;
   height: 16px;
 }
 
 .networkChartRowItemLabel {
-  z-index: 2;
-  display: inline-block;
+  z-index: 3;
+  display: flex;
+  flex-direction: row;
   overflow: hidden;
-  width: 100%;
   max-height: 16px;
   flex-basis: 0;
   flex-shrink: 0;
+  position: absolute;
   margin-left: 4px;
+  min-width: 150px;
+  top: 0;
   white-space: nowrap;
+  mix-blend-mode: multiply;
 }
 
 .networkChartRowItemBar {
   position: absolute;
-  z-index: 3;
-  display: inline-block;
-  height: 12px;
+  top: 0.5px;
+  z-index: 2;
+  height: 15px;
   flex-grow: 1;
-  margin-top: 2px;
-  border: 1px solid var(--grey-40);
-  background-color: white;
-  border-radius: 2px;
-  opacity: 0.7;
 }
 
 .networkChartRowItemBarInner {
-  display: inline-block;
-  height: 12px;
+  position: absolute;
+  height: 15px;
   background-color: var(--grey-40);
+  box-sizing: border-box;
+  box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.5);
+  /* border: 0.5px solid rgba(0, 0, 0, 0.1); */
+  z-index: 2;
 }
-
-.networkChartRowItemCss .networkChartRowItemBar {
-  border-color: var(--purple-50);
-  opacity: 0.6;
+.networkChartRowItemBarOuter {
+  position: absolute;
+  box-sizing: border-box;
+  height: 7px;
+  margin-top: 4px;
+  border: 1px solid var(--grey-30);
+}
+.networkChartRowItemBarRequestQueue {
+  border-right: 0;
+}
+.networkChartRowItemBarResponseQueue {
+  right: 0;
+  border-left: 0;
+}
+.networkChartRowItemBarDuration {
+  position: absolute;
+  left: 100%;
+  width: 100%;
+  margin-left: 4px;
+  height: 15px;
+  color: var(--grey-40);
 }
 
 .networkChartRowItemCss .networkChartRowItemBarInner {
   background-color: var(--purple-50);
 }
 
-.networkChartRowItemJs .networkChartRowItemBar {
-  border-color: var(--yellow-50);
-  opacity: 0.6;
-}
-
 .networkChartRowItemJs .networkChartRowItemBarInner {
   background-color: var(--yellow-50);
-}
-
-.networkChartRowItemHtml .networkChartRowItemBar {
-  border-color: var(--blue-60);
-  opacity: 0.6;
 }
 
 .networkChartRowItemHtml .networkChartRowItemBarInner {
   background-color: var(--blue-60);
 }
 
-.networkChartRowItemImg .networkChartRowItemBar {
-  border-color: var(--green-60);
-  opacity: 0.6;
-}
-
 .networkChartRowItemImg .networkChartRowItemBarInner {
   background-color: var(--green-60);
 }
-
-.networkChartRowItemBarRequestQueue {
-  opacity: 0;
-}
 .networkChartRowItemBarRequest {
-  opacity: 0.5;
-}
-.networkChartRowItemBarResponse {
-  opacity: 1;
+  opacity: 0.6;
 }
 
 .networkChartRowItemUriOptional {
-  display: inline-block;
-  overflow: hidden;
-  max-width: 90px;
-  color: var(--grey-40);
-  text-overflow: ellipsis;
+  color: var(--grey-50);
   white-space: nowrap;
+}
+.networkChartRowItemUriOptional:first-child {
+  display: none;
+}
+.networkChartRowItemUriOptional:not(:first-child) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 15px;
+  flex: 0 1 auto;
 }
 
 .networkChartRowItemUriRequired {
-  display: inline-block;
-  overflow: hidden;
+  white-space: nowrap;
 }
 
 .networkChartRowItemUriRequired:nth-child(1) {
   padding-right: 8px;
 }
 
-.networkChartRowItem.odd {
-  background-color: #f5f5f5;
+.networkChartRowItemLabel:hover {
+  width: auto !important;
 }
-
-.networkChartRowItem:hover {
-  background-color: #bbe0f6;
-}
-
-.networkChartRowItem:hover .networkChartRowItemBar {
-  opacity: 1;
-}
-
-.networkChartRowItem:hover .networkChartRowItemLabel {
-  opacity: 0.4;
+.networkChartRowItemLabel:hover .networkChartRowItemUriOptional:first-child {
+  display: block;
 }

--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -19,49 +19,50 @@
 }
 
 .networkChartRowItem {
-  display: block;
   position: relative;
+  display: block;
   width: 100%;
   height: 16px;
 }
 
 .networkChartRowItemLabel {
+  position: absolute;
   z-index: 3;
+  top: 0;
   display: flex;
-  flex-direction: row;
   overflow: hidden;
+  min-width: 150px;
   max-height: 16px;
   flex-basis: 0;
+  flex-direction: row;
   flex-shrink: 0;
-  position: absolute;
   margin-left: 4px;
-  min-width: 150px;
-  top: 0;
-  white-space: nowrap;
   mix-blend-mode: multiply;
+  white-space: nowrap;
 }
 
 .networkChartRowItemBar {
   position: absolute;
-  top: 0.5px;
   z-index: 2;
+  top: 0.5px;
   height: 15px;
   flex-grow: 1;
 }
 
 .networkChartRowItemBarInner {
   position: absolute;
-  height: 15px;
-  background-color: var(--grey-40);
-  box-sizing: border-box;
-  box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.5);
+
   /* border: 0.5px solid rgba(0, 0, 0, 0.1); */
   z-index: 2;
+  height: 15px;
+  box-sizing: border-box;
+  background-color: var(--grey-40);
+  box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.5);
 }
 .networkChartRowItemBarOuter {
   position: absolute;
-  box-sizing: border-box;
   height: 7px;
+  box-sizing: border-box;
   margin-top: 4px;
   border: 1px solid var(--grey-30);
 }
@@ -76,8 +77,8 @@
   position: absolute;
   left: 100%;
   width: 100%;
-  margin-left: 4px;
   height: 15px;
+  margin-left: 4px;
   color: var(--grey-40);
 }
 
@@ -109,9 +110,9 @@
 }
 .networkChartRowItemUriOptional:not(:first-child) {
   overflow: hidden;
-  text-overflow: ellipsis;
   min-width: 15px;
   flex: 0 1 auto;
+  text-overflow: ellipsis;
 }
 
 .networkChartRowItemUriRequired {

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -150,7 +150,7 @@ function _makePriorityHumanReadable(
     return null;
   }
 
-  prioLabel = prioLabel + '(' + priority + ')';
+  prioLabel = prioLabel + ' (' + priority + ')';
   return _markerDetail(key, label, prioLabel);
 }
 


### PR DESCRIPTION
Design draft for network panel polish:

- Resource segments easier to read and with better contrast  inspired by Chrome's design to 
- Dynamic length for URLs, between timeline and resource bar
- Colors aligned with recent panel adjusted for better
- With longer rows, zebra pattern isn't needed

<img width="963" alt="image" src="https://user-images.githubusercontent.com/8599/51783408-26fe0e00-20ee-11e9-8a4f-4a81b1dd1c9f.png">

[Deploy preview](https://deploy-preview-1692--perf-html.netlify.com/public/fc3ba5c62c5fba6a593322069a7723f280da11b4/network-chart/?globalTrackOrder=4-0-1-2-3&hiddenGlobalTracks=1-2&thread=4&v=3)