### PR TITLE
Always show a tooltip when hovering small timeline markers

### DIFF
--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -111,7 +111,9 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
     const { width, rangeStart, rangeEnd, markers } = this.props;
     const x = e.pageX - r.left;
     const y = e.pageY - r.top;
-    const time = rangeStart + x / width * (rangeEnd - rangeStart);
+    const rangeLength = rangeEnd - rangeStart;
+    const time = rangeStart + x / width * rangeLength;
+    const onePixelTime = rangeLength / width * window.devicePixelRatio;
 
     // Markers are drawn in array order; the one drawn last is on top. So if
     // there are multiple markers under the mouse, we want to find the one
@@ -119,7 +121,8 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
     // from high index to low index, which is front to back in z-order.
     for (let i = markers.length - 1; i >= 0; i--) {
       const { start, dur, name } = markers[i];
-      if (time < start || time >= start + dur) {
+      const duration = Math.max(dur, onePixelTime);
+      if (time < start || time >= start + duration) {
         continue;
       }
       const markerStyle =

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -25,6 +25,9 @@ import type {
 } from '../../utils/connect';
 import type { ThreadIndex } from '../../types/profile';
 
+// Exported for tests.
+export const MIN_MARKER_WIDTH = 0.3;
+
 type MarkerState = 'PRESSED' | 'HOVERED' | 'NONE';
 
 /**
@@ -289,7 +292,10 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
       }
       previousPos = pos;
       const itemWidth = Number.isFinite(dur)
-        ? Math.max(dur / (rangeEnd - rangeStart) * width, 1 / devicePixelRatio)
+        ? Math.max(
+            dur / (rangeEnd - rangeStart) * width,
+            MIN_MARKER_WIDTH / devicePixelRatio
+          )
         : Number.MAX_SAFE_INTEGER;
       const markerStyle =
         name in markerStyles ? markerStyles[name] : markerStyles.default;

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -4,7 +4,10 @@
 
 // @flow
 import * as React from 'react';
-import { TimelineMarkersOverview } from '../../components/timeline/Markers';
+import {
+  TimelineMarkersOverview,
+  MIN_MARKER_WIDTH,
+} from '../../components/timeline/Markers';
 import { render } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -140,7 +143,7 @@ describe('TimelineMarkers', function() {
     expect(fillRectOperations).toHaveLength(2);
     expect(
       fillRectOperations.every(
-        ([, , , width]) => width >= 1 / window.devicePixelRatio
+        ([, , , width]) => width >= MIN_MARKER_WIDTH / window.devicePixelRatio
       )
     ).toBe(true);
 


### PR DESCRIPTION
Also, this makes it so that markers will be drawn as slightly transparent when they are are < 1 pixel wide to help differentiate them.

Resolves #1737 