### PR TITLE
Remove perf-html service workers, and redirect to the new website

### DIFF
--- a/res/_headers
+++ b/res/_headers
@@ -1,7 +1,3 @@
-# Clear out old service workers for renaming to profiler.firefox.com
-https://perf-html.io/*
-  Clear-Site-Data: "*"
-
 # Headers for the entire site. The /* represents matching all routes, NOT a comment.
 /*
   # Do not try to guess the content-type for JS and CSS files served with a wrong mime-type.

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -71,10 +71,29 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
     });
   }
 
+  async _removePerfHtmlServiceWorkers() {
+    if (window.location.host === 'perf-html.io') {
+      const { serviceWorker } = navigator;
+      if (!serviceWorker) {
+        return;
+      }
+      const registrations = await serviceWorker.getRegistrations();
+      for (const registration of registrations) {
+        registration.unregister();
+      }
+      window.location.replace(
+        'https://profiler.firefox.com' +
+          window.location.pathname +
+          window.location.search
+      );
+    }
+  }
+
   componentWillMount() {
     if (process.env.NODE_ENV === 'production') {
       this._installServiceWorker();
     }
+    this._removePerfHtmlServiceWorkers();
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
The redirects don't seem to be working, so I think we may need to do this. @julienw what are your thoughts?