### PR TITLE
Fix the index for the location pathname check in redirect

### DIFF
--- a/res/before-load.js
+++ b/res/before-load.js
@@ -14,7 +14,7 @@
           registration.unregister();
         }
       }
-      if (window.location.pathname.split('/')[0] !== 'from-addon') {
+      if (window.location.pathname.split('/')[1] !== 'from-addon') {
         // This "from-addon" check can be removed after Bug 1525358 lands, and there has
         // been a reasonable amount of time for folks to upgrade their Gecko Profiler
         // Add-on.


### PR DESCRIPTION
I'm using my administrative powers to merge this in without review. It's a one-line "off by one error" hotfix for the deploy I just did.