### PR TITLE
 #1804 The meta panel has a too low contrast for accessibility

### DIFF
--- a/src/components/shared/ArrowPanel.css
+++ b/src/components/shared/ArrowPanel.css
@@ -188,7 +188,7 @@
 .metaInfoLabel {
   display: inline-block;
   width: 120px;
-  color: var(--grey-40);
+  color: var(--grey-50);
 }
 
 .metaInfoList {


### PR DESCRIPTION
changed the metaInfoLabel 
[#1804](https://github.com/firefox-devtools/profiler/issues/1804)