### PR TITLE
Update CallNode.css to remove the second horizontal line on stack chart tooltip

### DIFF
--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -6,6 +6,8 @@
   display: grid;
   grid-gap: 2px;
   grid-template-columns: repeat(4, min-content);
+  border-bottom: 1px solid var(--grey-30);
+  padding-bottom: 5px;
 }
 
 .tooltipCallNodeImplementationHeader {
@@ -70,5 +72,4 @@
   padding: 10px;
   padding-bottom: 5px;
   margin-top: 10px;
-  border-top: 1px solid var(--grey-30);
 }


### PR DESCRIPTION
[#1799 The stack chart tooltip has 2 horizontal lines](https://github.com/firefox-devtools/profiler/issues/1799) @julienw 
Also added a padding for a neater border-bottom 