### PR TITLE
Rewrite marker selectors to return references instead of marker objects

### DIFF
--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -24,7 +24,7 @@ import type { ThreadIndex } from '../../types/profile';
 import type {
   Marker,
   MarkerTimingRows,
-  IndexIntoMarkerTiming,
+  MarkerIndex,
 } from '../../types/profile-derived';
 import type { Viewport } from '../shared/chart/Viewport';
 import type { WrapFunctionInDispatch } from '../../utils/connect';
@@ -43,7 +43,7 @@ type OwnProps = {|
   +rangeEnd: Milliseconds,
   +markerTimingRows: MarkerTimingRows,
   +rowHeight: CssPixels,
-  +markers: Marker[],
+  +getMarker: MarkerIndex => Marker,
   +threadIndex: ThreadIndex,
   +updatePreviewSelection: WrapFunctionInDispatch<
     typeof updatePreviewSelection
@@ -72,7 +72,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
 
   drawCanvas = (
     ctx: CanvasRenderingContext2D,
-    hoveredItem: IndexIntoMarkerTiming | null
+    hoveredItem: MarkerIndex | null
   ) => {
     const {
       rowHeight,
@@ -148,7 +148,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
 
   drawMarkers(
     ctx: CanvasRenderingContext2D,
-    hoveredItem: IndexIntoMarkerTiming | null,
+    hoveredItem: MarkerIndex | null,
     startRow: number,
     endRow: number
   ) {
@@ -302,7 +302,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     }
   }
 
-  hitTest = (x: CssPixels, y: CssPixels): IndexIntoMarkerTiming | null => {
+  hitTest = (x: CssPixels, y: CssPixels): MarkerIndex | null => {
     const {
       rangeStart,
       rangeEnd,
@@ -345,12 +345,12 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     return null;
   };
 
-  onDoubleClickMarker = (markerIndex: IndexIntoMarkerTiming | null) => {
+  onDoubleClickMarker = (markerIndex: MarkerIndex | null) => {
     if (markerIndex === null) {
       return;
     }
-    const { markers, updatePreviewSelection } = this.props;
-    const marker = markers[markerIndex];
+    const { getMarker, updatePreviewSelection } = this.props;
+    const marker = getMarker(markerIndex);
     updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
@@ -375,8 +375,8 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     ctx.fillRect(x + c, bottom - c, width - 2 * c, c);
   }
 
-  getHoveredMarkerInfo = (hoveredItem: IndexIntoMarkerTiming): React.Node => {
-    const marker = this.props.markers[hoveredItem];
+  getHoveredMarkerInfo = (markerIndex: MarkerIndex): React.Node => {
+    const marker = this.props.getMarker(markerIndex);
     return (
       <TooltipMarker marker={marker} threadIndex={this.props.threadIndex} />
     );

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -22,7 +22,11 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { getSelectedThreadIndex } from '../../selectors/url-state';
 import { updatePreviewSelection } from '../../actions/profile-view';
 
-import type { Marker, MarkerTimingRows } from '../../types/profile-derived';
+import type {
+  Marker,
+  MarkerIndex,
+  MarkerTimingRows,
+} from '../../types/profile-derived';
 import type {
   Milliseconds,
   UnitIntervalOfProfileRange,
@@ -39,7 +43,7 @@ type DispatchProps = {|
 |};
 
 type StateProps = {|
-  +markers: Marker[],
+  +getMarker: MarkerIndex => Marker,
   +markerTimingRows: MarkerTimingRows,
   +maxMarkerRows: number,
   +timeRange: { start: Milliseconds, end: Milliseconds },
@@ -83,7 +87,7 @@ class MarkerChart extends React.PureComponent<Props> {
       timeRange,
       threadIndex,
       markerTimingRows,
-      markers,
+      getMarker,
       previewSelection,
       updatePreviewSelection,
     } = this.props;
@@ -100,7 +104,7 @@ class MarkerChart extends React.PureComponent<Props> {
         aria-labelledby="marker-chart-tab-button"
       >
         <MarkerSettings />
-        {markers.length === 0 ? (
+        {maxMarkerRows === 0 ? (
           <MarkerChartEmptyReasons />
         ) : (
           <MarkerChartCanvas
@@ -117,7 +121,7 @@ class MarkerChart extends React.PureComponent<Props> {
             }}
             chartProps={{
               markerTimingRows,
-              markers,
+              getMarker,
               // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
               updatePreviewSelection,
               rangeStart: timeRange.start,
@@ -148,9 +152,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
       state
     );
     return {
-      markers: selectedThreadSelectors.getSearchFilteredMarkerChartMarkers(
-        state
-      ),
+      getMarker: selectedThreadSelectors.getMarkerGetter(state),
       markerTimingRows,
       maxMarkerRows: markerTimingRows.length,
       timeRange: getCommittedRange(state),

--- a/src/components/marker-table/ContextMenu.js
+++ b/src/components/marker-table/ContextMenu.js
@@ -200,22 +200,13 @@ class MarkersContextMenu extends PureComponent<Props> {
 }
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
-  mapStateToProps: state => {
-    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
-    const selectedMarkerIndex = selectedThreadSelectors.getSelectedMarkerIndex(
-      state
-    );
-    const selectedMarker =
-      selectedMarkerIndex === null ? null : getMarker(selectedMarkerIndex);
-
-    return {
-      previewSelection: getPreviewSelection(state),
-      committedRange: getCommittedRange(state),
-      thread: selectedThreadSelectors.getThread(state),
-      implementationFilter: getImplementationFilter(state),
-      selectedMarker,
-    };
-  },
+  mapStateToProps: state => ({
+    previewSelection: getPreviewSelection(state),
+    committedRange: getCommittedRange(state),
+    thread: selectedThreadSelectors.getThread(state),
+    implementationFilter: getImplementationFilter(state),
+    selectedMarker: selectedThreadSelectors.getSelectedMarker(state),
+  }),
   mapDispatchToProps: { updatePreviewSelection },
   component: MarkersContextMenu,
 });

--- a/src/components/marker-table/ContextMenu.js
+++ b/src/components/marker-table/ContextMenu.js
@@ -15,7 +15,7 @@ import {
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import copy from 'copy-to-clipboard';
 
-import type { Marker, IndexIntoMarkers } from '../../types/profile-derived';
+import type { Marker } from '../../types/profile-derived';
 import type { StartEndRange } from '../../types/units';
 import type {
   PreviewSelection,
@@ -32,10 +32,9 @@ import {
 import { getMarkerFullDescription } from '../../profile-logic/marker-data';
 
 type StateProps = {|
-  +markers: Marker[],
   +previewSelection: PreviewSelection,
   +committedRange: StartEndRange,
-  +selectedMarker: IndexIntoMarkers | null,
+  +selectedMarker: Marker | null,
   +thread: Thread,
   +implementationFilter: ImplementationFilter,
 |};
@@ -50,7 +49,6 @@ class MarkersContextMenu extends PureComponent<Props> {
   setStartRange = () => {
     const {
       selectedMarker,
-      markers,
       updatePreviewSelection,
       previewSelection,
       committedRange,
@@ -67,7 +65,7 @@ class MarkersContextMenu extends PureComponent<Props> {
     updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
-      selectionStart: markers[selectedMarker].start,
+      selectionStart: selectedMarker.start,
       selectionEnd,
     });
   };
@@ -75,7 +73,6 @@ class MarkersContextMenu extends PureComponent<Props> {
   setEndRange = () => {
     const {
       selectedMarker,
-      markers,
       updatePreviewSelection,
       committedRange,
       previewSelection,
@@ -89,34 +86,32 @@ class MarkersContextMenu extends PureComponent<Props> {
       ? previewSelection.selectionStart
       : committedRange.start;
 
-    const marker = markers[selectedMarker];
     updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart,
       // For markers without a duration, add an arbitrarily small bit of time at
       // the end to make sure the selected marker doesn't disappear from view.
-      selectionEnd: marker.start + (marker.dur || 0.0001),
+      selectionEnd: selectedMarker.start + (selectedMarker.dur || 0.0001),
     });
   };
 
   setRangeByDuration = () => {
-    const { selectedMarker, markers, updatePreviewSelection } = this.props;
+    const { selectedMarker, updatePreviewSelection } = this.props;
 
     if (selectedMarker === null) {
       return;
     }
 
-    const marker = markers[selectedMarker];
-    if (this._isZeroDurationMarker(marker)) {
+    if (this._isZeroDurationMarker(selectedMarker)) {
       return;
     }
 
     updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
-      selectionStart: marker.start,
-      selectionEnd: marker.start + marker.dur,
+      selectionStart: selectedMarker.start,
+      selectionEnd: selectedMarker.start + selectedMarker.dur,
     });
   };
 
@@ -143,47 +138,40 @@ class MarkersContextMenu extends PureComponent<Props> {
   }
 
   copyMarkerJSON = () => {
-    const { selectedMarker, markers } = this.props;
+    const { selectedMarker } = this.props;
 
     if (selectedMarker === null) {
       return;
     }
 
-    copy(JSON.stringify(markers[selectedMarker], null, 2));
+    copy(JSON.stringify(selectedMarker, null, 2));
   };
 
   copyMarkerDescription = () => {
-    const { selectedMarker, markers } = this.props;
+    const { selectedMarker } = this.props;
 
     if (selectedMarker === null) {
       return;
     }
-    const marker = markers[selectedMarker];
-    copy(getMarkerFullDescription(marker));
+
+    copy(getMarkerFullDescription(selectedMarker));
   };
 
   copyMarkerCause = () => {
-    const { markers, selectedMarker } = this.props;
+    const { selectedMarker } = this.props;
 
-    if (selectedMarker === null) {
-      return;
-    }
-
-    const marker = markers[selectedMarker];
-    if (marker && marker.data && marker.data.cause) {
-      const stack = this._convertStackToString(marker.data.cause.stack);
+    if (selectedMarker && selectedMarker.data && selectedMarker.data.cause) {
+      const stack = this._convertStackToString(selectedMarker.data.cause.stack);
       copy(stack);
     }
   };
 
   render() {
-    const { markers, selectedMarker } = this.props;
+    const { selectedMarker } = this.props;
 
     if (selectedMarker === null) {
       return null;
     }
-
-    const marker = markers[selectedMarker];
 
     return (
       <ContextMenu id="MarkersContextMenu">
@@ -195,7 +183,7 @@ class MarkersContextMenu extends PureComponent<Props> {
         </MenuItem>
         <MenuItem
           onClick={this.setRangeByDuration}
-          disabled={this._isZeroDurationMarker(marker)}
+          disabled={this._isZeroDurationMarker(selectedMarker)}
         >
           Set selection from duration
         </MenuItem>
@@ -203,7 +191,7 @@ class MarkersContextMenu extends PureComponent<Props> {
         <MenuItem onClick={this.copyMarkerDescription}>
           Copy marker description
         </MenuItem>
-        {marker && marker.data && marker.data.cause ? (
+        {selectedMarker.data && selectedMarker.data.cause ? (
           <MenuItem onClick={this.copyMarkerCause}>Copy marker cause</MenuItem>
         ) : null}
       </ContextMenu>
@@ -212,14 +200,22 @@ class MarkersContextMenu extends PureComponent<Props> {
 }
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
-  mapStateToProps: state => ({
-    markers: selectedThreadSelectors.getPreviewFilteredMarkers(state),
-    previewSelection: getPreviewSelection(state),
-    committedRange: getCommittedRange(state),
-    thread: selectedThreadSelectors.getThread(state),
-    implementationFilter: getImplementationFilter(state),
-    selectedMarker: selectedThreadSelectors.getSelectedMarkerIndex(state),
-  }),
+  mapStateToProps: state => {
+    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+    const selectedMarkerIndex = selectedThreadSelectors.getSelectedMarkerIndex(
+      state
+    );
+    const selectedMarker =
+      selectedMarkerIndex === null ? null : getMarker(selectedMarkerIndex);
+
+    return {
+      previewSelection: getPreviewSelection(state),
+      committedRange: getCommittedRange(state),
+      thread: selectedThreadSelectors.getThread(state),
+      implementationFilter: getImplementationFilter(state),
+      selectedMarker,
+    };
+  },
   mapDispatchToProps: { updatePreviewSelection },
   component: MarkersContextMenu,
 });

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -168,7 +168,7 @@ class NetworkChart extends React.PureComponent<Props> {
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
-      markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkChartMarkerIndexes(
+      markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
         state
       ),
       getMarker: selectedThreadSelectors.getMarkerGetter(state),

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -26,7 +26,7 @@ import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type { SizeProps } from '../shared/WithSize';
 import type { NetworkPayload } from '../../types/markers';
-import type { Marker } from '../../types/profile-derived';
+import type { Marker, MarkerIndex } from '../../types/profile-derived';
 import type { Milliseconds, CssPixels, StartEndRange } from '../../types/units';
 import type { ConnectedProps } from '../../utils/connect';
 
@@ -40,7 +40,8 @@ type DispatchProps = {|
 |};
 
 type StateProps = {|
-  +markers: Marker[],
+  +markerIndexes: MarkerIndex[],
+  +getMarker: MarkerIndex => Marker,
   +disableOverscan: boolean,
   +timeRange: StartEndRange,
   +threadIndex: number,
@@ -82,8 +83,9 @@ class NetworkChart extends React.PureComponent<Props> {
     return markerPosition;
   }
 
-  _renderRow = (marker: Marker, index: number): React.Node => {
-    const { threadIndex } = this.props;
+  _renderRow = (markerIndex: MarkerIndex, index: number): React.Node => {
+    const { threadIndex, getMarker } = this.props;
+    const marker = getMarker(markerIndex);
 
     // Since our type definition for Marker can't refine to just Network
     // markers, extract the payload using an utility function.
@@ -119,7 +121,7 @@ class NetworkChart extends React.PureComponent<Props> {
   };
 
   render() {
-    const { markers, width, timeRange, disableOverscan } = this.props;
+    const { markerIndexes, width, timeRange, disableOverscan } = this.props;
 
     // We want to force a full rerender whenever the width or the range changes.
     // We compute a string using these values, so that when one of the value
@@ -136,12 +138,12 @@ class NetworkChart extends React.PureComponent<Props> {
         aria-labelledby="network-chart-tab-button"
       >
         <NetworkSettings />
-        {markers.length === 0 ? (
+        {markerIndexes.length === 0 ? (
           <NetworkChartEmptyReasons />
         ) : (
           <VirtualList
             className="treeViewBody"
-            items={markers}
+            items={markerIndexes}
             renderItem={this._renderRow}
             itemHeight={ROW_HEIGHT}
             columnCount={1}
@@ -166,9 +168,10 @@ class NetworkChart extends React.PureComponent<Props> {
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
-      markers: selectedThreadSelectors.getSearchFilteredNetworkChartMarkers(
+      markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkChartMarkerIndexes(
         state
       ),
+      getMarker: selectedThreadSelectors.getMarkerGetter(state),
       timeRange: getPreviewSelectionRange(state),
       disableOverscan: getPreviewSelection(state).isModifying,
       threadIndex: getSelectedThreadIndex(state),

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -45,16 +45,9 @@ class MarkerSidebar extends React.PureComponent<Props> {
 }
 
 export default explicitConnect<{||}, StateProps, {||}>({
-  mapStateToProps: state => {
-    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
-    const selectedMarkerIndex = selectedThreadSelectors.getSelectedMarkerIndex(
-      state
-    );
-    return {
-      marker:
-        selectedMarkerIndex === null ? null : getMarker(selectedMarkerIndex),
-      selectedThreadIndex: getSelectedThreadIndex(state),
-    };
-  },
+  mapStateToProps: state => ({
+    marker: selectedThreadSelectors.getSelectedMarker(state),
+    selectedThreadIndex: getSelectedThreadIndex(state),
+  }),
   component: MarkerSidebar,
 });

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -46,17 +46,13 @@ class MarkerSidebar extends React.PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: state => {
-    const filteredMarkers = selectedThreadSelectors.getPreviewFilteredMarkers(
-      state
-    );
+    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
     const selectedMarkerIndex = selectedThreadSelectors.getSelectedMarkerIndex(
       state
     );
     return {
       marker:
-        selectedMarkerIndex === null
-          ? null
-          : filteredMarkers[selectedMarkerIndex] || null,
+        selectedMarkerIndex === null ? null : getMarker(selectedMarkerIndex),
       selectedThreadIndex: getSelectedThreadIndex(state),
     };
   },

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -16,11 +16,14 @@ import { getThreadSelectors } from '../../selectors/per-thread';
 import { VerticalIndicators } from './VerticalIndicators';
 
 import type { ThreadIndex, PageList } from '../../types/profile';
-import type {} from '../../types/markers';
+import type {
+  Marker,
+  MarkerIndex,
+  MarkerTiming,
+} from '../../types/profile-derived';
 import type { Milliseconds } from '../../types/units';
 import type { SizeProps } from '../shared/WithSize';
 import type { ConnectedProps } from '../../utils/connect';
-import type { Marker } from '../../types/profile-derived';
 
 import './TrackNetwork.css';
 
@@ -33,9 +36,9 @@ type StateProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +zeroAt: Milliseconds,
-  +networkMarkers: *,
-  +networkTiming: *,
-  +verticalMarkers: Marker[],
+  +getMarker: MarkerIndex => Marker,
+  +networkTiming: MarkerTiming[],
+  +verticalMarkerIndexes: MarkerIndex[],
 |};
 type DispatchProps = {||};
 type Props = {|
@@ -120,7 +123,14 @@ class Network extends PureComponent<Props, State> {
   }
 
   render() {
-    const { pages, rangeStart, rangeEnd, verticalMarkers, zeroAt } = this.props;
+    const {
+      pages,
+      rangeStart,
+      rangeEnd,
+      getMarker,
+      verticalMarkerIndexes,
+      zeroAt,
+    } = this.props;
     this._scheduleDraw();
 
     return (
@@ -135,7 +145,8 @@ class Network extends PureComponent<Props, State> {
           ref={this._takeCanvasRef}
         />
         <VerticalIndicators
-          verticalMarkers={verticalMarkers}
+          verticalMarkerIndexes={verticalMarkerIndexes}
+          getMarker={getMarker}
           pages={pages}
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
@@ -153,13 +164,13 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     const { start, end } = getCommittedRange(state);
     const networkTiming = selectors.getNetworkTrackTiming(state);
     return {
-      networkMarkers: selectors.getNetworkMarkers(state),
+      getMarker: selectors.getMarkerGetter(state),
       pages: getPageList(state),
       networkTiming: networkTiming,
       rangeStart: start,
       rangeEnd: end,
       zeroAt: getZeroAt(state),
-      verticalMarkers: selectors.getTimelineVerticalMarkers(state),
+      verticalMarkerIndexes: selectors.getTimelineVerticalMarkerIndexes(state),
     };
   },
   component: withSize<Props>(Network),

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -231,7 +231,7 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
       rangeEnd: committedRange.end,
       categories: getCategories(state),
       timelineType: getTimelineType(state),
-      hasFileIoMarkers: selectors.getFileIoMarkers(state).length !== 0,
+      hasFileIoMarkers: selectors.getFileIoMarkerIndexes(state).length !== 0,
     };
   },
   mapDispatchToProps: {

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -11,13 +11,14 @@ import { formatSeconds } from '../../utils/format-numbers';
 
 import type { SizeProps } from '../shared/WithSize';
 import type { PageList } from '../../types/profile';
-import type { Marker } from '../../types/profile-derived';
+import type { Marker, MarkerIndex } from '../../types/profile-derived';
 import type { Milliseconds } from '../../types/units';
 
 import './VerticalIndicators.css';
 
 type Props = {|
-  +verticalMarkers: Marker[],
+  +getMarker: MarkerIndex => Marker,
+  +verticalMarkerIndexes: MarkerIndex[],
   +pages: PageList | null,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -32,7 +33,8 @@ type Props = {|
 class VerticalIndicatorsImpl extends React.PureComponent<Props> {
   render() {
     const {
-      verticalMarkers,
+      getMarker,
+      verticalMarkerIndexes,
       pages,
       rangeStart,
       rangeEnd,
@@ -44,7 +46,8 @@ class VerticalIndicatorsImpl extends React.PureComponent<Props> {
         data-testid="vertical-indicators"
         className="timelineVerticalIndicators"
       >
-        {verticalMarkers.map((marker, markerIndex) => {
+        {verticalMarkerIndexes.map(markerIndex => {
+          const marker = getMarker(markerIndex);
           // Decide on the indicator color.
           let color = '#000';
           switch (marker.name) {

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -836,6 +836,10 @@ export function filterRawMarkerTableToRangeWithMarkersToDelete(
   };
 }
 
+/**
+ * This utility function makes it easier to implement functions filtering
+ * markers, with marker indexes both as input and output.
+ */
 export function filterMarkerIndexes(
   getMarker: MarkerIndex => Marker,
   markerIndexes: MarkerIndex[],

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -11,7 +11,7 @@ import type {
   IndexIntoStringTable,
   IndexIntoRawMarkerTable,
 } from '../types/profile';
-import type { Marker, IndexIntoMarkers } from '../types/profile-derived';
+import type { Marker, MarkerIndex } from '../types/profile-derived';
 import type { BailoutPayload, NetworkPayload } from '../types/markers';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { StartEndRange } from '../types/units';
@@ -76,20 +76,21 @@ export function deriveJankMarkers(
   return jankInstances;
 }
 
-export function getSearchFilteredMarkers(
-  markers: Marker[],
+export function getSearchFilteredMarkerIndexes(
+  getMarker: MarkerIndex => Marker,
+  markerIndexes: MarkerIndex[],
   searchString: string
-): Marker[] {
+): MarkerIndex[] {
   if (!searchString) {
-    return markers;
+    return markerIndexes;
   }
   const lowerCaseSearchString = searchString.toLowerCase();
-  const newMarkers: Marker[] = [];
-  for (const marker of markers) {
-    const { data, name } = marker;
+  const newMarkers: MarkerIndex[] = [];
+  for (const markerIndex of markerIndexes) {
+    const { data, name } = getMarker(markerIndex);
     const lowerCaseName = name.toLowerCase();
     if (lowerCaseName.includes(lowerCaseSearchString)) {
-      newMarkers.push(marker);
+      newMarkers.push(markerIndex);
       continue;
     }
     if (data && typeof data === 'object') {
@@ -100,7 +101,7 @@ export function getSearchFilteredMarkers(
           operation.toLowerCase().includes(lowerCaseSearchString) ||
           source.toLowerCase().includes(lowerCaseSearchString)
         ) {
-          newMarkers.push(marker);
+          newMarkers.push(markerIndex);
           continue;
         }
       }
@@ -109,7 +110,7 @@ export function getSearchFilteredMarkers(
         data.eventType.toLowerCase().includes(lowerCaseSearchString)
       ) {
         // Match DOMevents data.eventType
-        newMarkers.push(marker);
+        newMarkers.push(markerIndex);
         continue;
       }
       if (
@@ -117,7 +118,7 @@ export function getSearchFilteredMarkers(
         data.name.toLowerCase().includes(lowerCaseSearchString)
       ) {
         // Match UserTiming's name.
-        newMarkers.push(marker);
+        newMarkers.push(markerIndex);
         continue;
       }
       if (
@@ -125,7 +126,7 @@ export function getSearchFilteredMarkers(
         data.category.toLowerCase().includes(lowerCaseSearchString)
       ) {
         // Match UserTiming's name.
-        newMarkers.push(marker);
+        newMarkers.push(markerIndex);
         continue;
       }
     }
@@ -244,22 +245,19 @@ export function deriveMarkersFromRawMarkerTable(
   // nested and that's why we use an array structure as value.
   const openTracingMarkers: Map<
     IndexIntoStringTable,
-    IndexIntoMarkers[]
+    MarkerIndex[]
   > = new Map();
 
   // The second map contains the start markers for network markers.
   // Note that we don't have more than 2 network markers with the same name as
   // the name contains an incremented index. Therefore we don't need to use an
   // array as value like for tracing markers.
-  const openNetworkMarkers: Map<
-    IndexIntoStringTable,
-    IndexIntoMarkers
-  > = new Map();
+  const openNetworkMarkers: Map<IndexIntoStringTable, MarkerIndex> = new Map();
 
   // We don't add a screenshot marker as we find it, because to know its
   // duration we need to wait until the next one or the end of the profile. So
   // we keep it here.
-  let previousScreenshotMarker: IndexIntoMarkers | null = null;
+  let previousScreenshotMarker: MarkerIndex | null = null;
 
   for (let i = 0; i < rawMarkers.length; i++) {
     const name = rawMarkers.name[i];
@@ -577,7 +575,7 @@ export function* filterRawMarkerTableToRangeIndexGenerator(
   markers: RawMarkerTable,
   rangeStart: number,
   rangeEnd: number
-): Generator<IndexIntoMarkers, void, void> {
+): Generator<MarkerIndex, void, void> {
   const isTimeInRange = (time: number): boolean =>
     time < rangeEnd && time >= rangeStart;
   const intersectsRange = (start: number, end: number): boolean =>
@@ -589,7 +587,7 @@ export function* filterRawMarkerTableToRangeIndexGenerator(
   // nested and that's why we use an array structure as value.
   const openTracingMarkers: Map<
     IndexIntoStringTable,
-    IndexIntoMarkers[]
+    IndexIntoRawMarkerTable[]
   > = new Map();
 
   // The second map contains the start markers for network markers.
@@ -598,7 +596,7 @@ export function* filterRawMarkerTableToRangeIndexGenerator(
   // array as value like for tracing markers.
   const openNetworkMarkers: Map<
     IndexIntoStringTable,
-    IndexIntoMarkers
+    IndexIntoRawMarkerTable
   > = new Map();
 
   let previousScreenshotMarker = null;
@@ -838,13 +836,26 @@ export function filterRawMarkerTableToRangeWithMarkersToDelete(
   };
 }
 
-export function filterMarkersToRange(
-  markers: Marker[],
+export function filterMarkerIndexes(
+  getMarker: MarkerIndex => Marker,
+  markerIndexes: MarkerIndex[],
+  filterFunc: Marker => boolean
+): MarkerIndex[] {
+  return markerIndexes.filter(markerIndex => {
+    return filterFunc(getMarker(markerIndex));
+  });
+}
+
+export function filterMarkerIndexesToRange(
+  getMarker: MarkerIndex => Marker,
+  markerIndexes: MarkerIndex[],
   rangeStart: number,
   rangeEnd: number
-): Marker[] {
-  return markers.filter(
-    tm => tm.start < rangeEnd && tm.start + tm.dur >= rangeStart
+): MarkerIndex[] {
+  return filterMarkerIndexes(
+    getMarker,
+    markerIndexes,
+    marker => marker.start < rangeEnd && marker.start + marker.dur >= rangeStart
   );
 }
 
@@ -899,8 +910,15 @@ export function filterForNetworkChart(markers: Marker[]): Marker[] {
   return markers.filter(marker => isNetworkMarker(marker));
 }
 
-export function filterForMarkerChart(markers: Marker[]): Marker[] {
-  return markers.filter(marker => !isNetworkMarker(marker));
+export function filterForMarkerChart(
+  getMarker: MarkerIndex => Marker,
+  markerIndexes: MarkerIndex[]
+): MarkerIndex[] {
+  return filterMarkerIndexes(
+    getMarker,
+    markerIndexes,
+    marker => !isNetworkMarker(marker)
+  );
 }
 
 // Identifies mime type of a network request.
@@ -973,10 +991,13 @@ export function getColorClassNameForMimeType(
   }
 }
 
-export function groupScreenshotsById(markers: Marker[]): Map<string, Marker[]> {
+export function groupScreenshotsById(
+  getMarker: MarkerIndex => Marker,
+  markerIndexes: MarkerIndex[]
+): Map<string, Marker[]> {
   const idToScreenshotMarkers = new Map();
-  for (let i = 0; i < markers.length; i++) {
-    const marker = markers[i];
+  for (const markerIndex of markerIndexes) {
+    const marker = getMarker(markerIndex);
     const { data } = marker;
     if (data && data.type === 'CompositorScreenshot') {
       let markers = idToScreenshotMarkers.get(data.windowID);

--- a/src/profile-logic/marker-timing.js
+++ b/src/profile-logic/marker-timing.js
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import type {
   DOMEventMarkerPayload,
@@ -7,6 +10,7 @@ import type {
 } from '../types/markers';
 import type {
   Marker,
+  MarkerIndex,
   MarkerTiming,
   MarkerTimingRows,
 } from '../types/profile-derived';
@@ -60,14 +64,17 @@ const MAX_STACKING_DEPTH = 300;
  *   | User Timings |       *--*     *---*        |
  *   |______________|_____________________________|
  */
-export function getMarkerTiming(markers: Marker[]): MarkerTimingRows {
+export function getMarkerTiming(
+  getMarker: MarkerIndex => Marker,
+  markerIndexes: MarkerIndex[]
+): MarkerTimingRows {
   // Each marker type will have it's own timing information, later collapse these into
   // a single array.
   const markerTimingsMap: Map<string, MarkerTiming[]> = new Map();
 
   // Go through all of the markers.
-  for (let markerIndex = 0; markerIndex < markers.length; markerIndex++) {
-    const marker = markers[markerIndex];
+  for (const markerIndex of markerIndexes) {
+    const marker = getMarker(markerIndex);
     let markerTimingsByName = markerTimingsMap.get(marker.name);
     if (markerTimingsByName === undefined) {
       markerTimingsByName = [];

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -116,6 +116,28 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     markers => markers.map((_, i) => i)
   );
 
+  /* This utility function makes it easy to write selectors that deal with list
+   * of marker indexes.
+   * It takes a filtering function as parameter. This filtering function takes a
+   * marker as parameter and returns a boolean deciding whether this marker
+   * should be kept.
+   * This function returns a function that does the actual filtering.
+   *
+   * It is typically used this way:
+   *  const filteredMarkerIndexes = createSelector(
+   *    getMarkerGetter,
+   *    getSourceMarkerIndexesSelector,
+   *    filterMarkerIndexesCreator(
+   *      marker => MarkerData.isNetworkMarker(marker)
+   *    )
+   *  );
+   */
+  const filterMarkerIndexesCreator = (filterFunc: Marker => boolean) => (
+    getMarker: MarkerIndex => Marker,
+    markerIndexes: MarkerIndex[]
+  ): MarkerIndex[] =>
+    MarkerData.filterMarkerIndexes(getMarker, markerIndexes, filterFunc);
+
   const getCommittedRangeFilteredMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -138,20 +160,17 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   > = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes): MarkerIndex[] =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        marker =>
-          marker.name !== 'BHR-detected hang' &&
-          marker.name !== 'LongTask' &&
-          marker.name !== 'LongIdleTask' &&
-          marker.name !== 'Jank' &&
-          !MarkerData.isNetworkMarker(marker) &&
-          !MarkerData.isFileIoMarker(marker) &&
-          !MarkerData.isNavigationMarker(marker) &&
-          !MarkerData.isMemoryMarker(marker)
-      )
+    filterMarkerIndexesCreator(
+      marker =>
+        marker.name !== 'BHR-detected hang' &&
+        marker.name !== 'LongTask' &&
+        marker.name !== 'LongIdleTask' &&
+        marker.name !== 'Jank' &&
+        !MarkerData.isNetworkMarker(marker) &&
+        !MarkerData.isFileIoMarker(marker) &&
+        !MarkerData.isNavigationMarker(marker) &&
+        !MarkerData.isMemoryMarker(marker)
+    )
   );
 
   const getTimelineVerticalMarkerIndexes: Selector<
@@ -159,23 +178,13 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   > = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes): MarkerIndex[] =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        MarkerData.isNavigationMarker
-      )
+    filterMarkerIndexesCreator(MarkerData.isNavigationMarker)
   );
 
   const getJankMarkerIndexesForHeader: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes) =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        marker => marker.name === 'Jank'
-      )
+    filterMarkerIndexesCreator(marker => marker.name === 'Jank')
   );
 
   const getSearchFilteredMarkerIndexes: Selector<
@@ -215,12 +224,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   const getNetworkChartMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes) =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        MarkerData.isNetworkMarker
-      )
+    filterMarkerIndexesCreator(MarkerData.isNetworkMarker)
   );
 
   const getSearchFilteredNetworkChartMarkerIndexes: Selector<
@@ -261,34 +265,19 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   const getNetworkMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes) =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        MarkerData.isNetworkMarker
-      )
+    filterMarkerIndexesCreator(MarkerData.isNetworkMarker)
   );
 
   const getFileIoMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes) =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        MarkerData.isFileIoMarker
-      )
+    filterMarkerIndexesCreator(MarkerData.isFileIoMarker)
   );
 
   const getMemoryMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    (markerList, markerIndexes) =>
-      MarkerData.filterMarkerIndexes(
-        markerList,
-        markerIndexes,
-        MarkerData.isMemoryMarker
-      )
+    filterMarkerIndexesCreator(MarkerData.isMemoryMarker)
   );
 
   const getNetworkTrackTiming: Selector<MarkerTimingRows> = createSelector(

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -51,8 +51,8 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
    * 3b. _getDerivedJankMarkers - Jank markers come from our samples data, and
    *                              this selector returns Marker structures out of
    *                              the samples structure.
-   * 4. getReferenceMarkerTable - Concatenates and sorts all markers coming from
-   *                              different origin structures.
+   * 4. getFullMarkerList - Concatenates and sorts all markers coming from
+   *                        different origin structures.
    * 5. getCommittedRangeFilteredMarkers - Apply the committed range.
    * 6. getSearchFilteredMarkers - Apply the search string
    * 7. getPreviewFilteredMarkers - Apply the preview range
@@ -85,7 +85,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     samples => MarkerData.deriveJankMarkers(samples, 50)
   );
 
-  const getReferenceMarkerTable: Selector<Marker[]> = createSelector(
+  const getFullMarkerList: Selector<Marker[]> = createSelector(
     _getDerivedMarkers,
     _getDerivedJankMarkers,
     (derivedMarkers, derivedJankMarkers) =>
@@ -95,7 +95,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   );
 
   const getCommittedRangeFilteredMarkers: Selector<Marker[]> = createSelector(
-    getReferenceMarkerTable,
+    getFullMarkerList,
     ProfileSelectors.getCommittedRange,
     (markers, range): Marker[] => {
       const { start, end } = range;
@@ -154,7 +154,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   );
 
   const getIsNetworkChartEmptyInFullRange: Selector<boolean> = createSelector(
-    getReferenceMarkerTable,
+    getFullMarkerList,
     markers => markers.filter(MarkerData.isNetworkMarker).length === 0
   );
 
@@ -172,7 +172,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   );
 
   const getIsMarkerChartEmptyInFullRange: Selector<boolean> = createSelector(
-    getReferenceMarkerTable,
+    getFullMarkerList,
     markers => MarkerData.filterForMarkerChart(markers).length === 0
   );
 
@@ -227,7 +227,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   return {
     getJankMarkersForHeader,
     getProcessedRawMarkerTable,
-    getReferenceMarkerTable,
+    getFullMarkerList,
     getNetworkChartMarkers,
     getSearchFilteredNetworkChartMarkers,
     getIsMarkerChartEmptyInFullRange,

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -46,19 +46,24 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
    * omitted, but the ordered steps below give the general picture.
    *
    * 1. _getRawMarkerTable - Get the RawMarkerTable from the current thread.
-   * 2. getProcessedRawMarkerTable - Process marker payloads out of raw strings, and other
-   *                                 future processing needs. This returns a
+   * 2. getProcessedRawMarkerTable - Process marker payloads out of raw strings, and
+   *                                 other future processing needs. This returns a
    *                                 RawMarkerTable still.
-   * 3a. _getDerivedMarkers - Match up start/end markers, and start returning
-   *                          the Marker[] type.
-   * 3b. _getDerivedJankMarkers - Jank markers come from our samples data, and
-   *                              this selector returns Marker structures out of
-   *                              the samples structure.
-   * 4. getFullMarkerList - Concatenates and sorts all markers coming from
-   *                        different origin structures.
-   * 5. getCommittedRangeFilteredMarkers - Apply the committed range.
-   * 6. getSearchFilteredMarkers - Apply the search string
-   * 7. getPreviewFilteredMarkers - Apply the preview range
+   * 3a. _getDerivedMarkers        - Match up start/end markers, and start
+   *                                 returning the Marker[] type.
+   * 3b. _getDerivedJankMarkers    - Jank markers come from our samples data, and
+   *                                 this selector returns Marker structures out of
+   *                                 the samples structure.
+   * 4. getFullMarkerList          - Concatenates and sorts all markers coming from
+   *                                 different origin structures.
+   * 5. getFullMarkerListIndexes   - From the full marker list, generates an array
+   *                                 containing the sequence of indexes for all markers.
+   * 5. getCommittedRangeFilteredMarkerIndexes - Apply the committed range.
+   * 6. getSearchFilteredMarkerIndexes         - Apply the search string
+   * 7. getPreviewFilteredMarkerIndexes        - Apply the preview range
+   *
+   * Selectors are commonly written using the utility filterMarkerIndexesCreator
+   * (see below for more information about this function).
    */
   const getProcessedRawMarkerTable: Selector<RawMarkerTable> = createSelector(
     _getRawMarkerTable,
@@ -83,11 +88,18 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     MarkerData.deriveMarkersFromRawMarkerTable
   );
 
+  /**
+   * This selector constructs jank markers from the responsiveness data.
+   */
   const _getDerivedJankMarkers: Selector<Marker[]> = createSelector(
     threadSelectors.getSamplesTable,
     samples => MarkerData.deriveJankMarkers(samples, 50)
   );
 
+  /**
+   * This selector returns the list of all markers, this is our reference list
+   * that MarkerIndex values refer to.
+   */
   const getFullMarkerList: Selector<Marker[]> = createSelector(
     _getDerivedMarkers,
     _getDerivedJankMarkers,
@@ -97,6 +109,17 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
       )
   );
 
+  /**
+   * This selector returns a function that's used to retrieve a marker object
+   * from its MarkerIndex:
+   *
+   *   const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+   *   const marker = getMarker(markerIndex);
+   *
+   * This is essentially the same as using the full marker list, but it's more
+   * encapsulated and handles the case where a marker object isn't found (which
+   * means the marker index is incorrect).
+   */
   const getMarkerGetter: Selector<(MarkerIndex) => Marker> = createSelector(
     getFullMarkerList,
     markerList => (markerIndex: MarkerIndex): Marker => {
@@ -111,12 +134,17 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     }
   );
 
+  /**
+   * This returns the list of all marker indexes. This is simply a sequence
+   * built from the full marker list.
+   */
   const getFullMarkerListIndexes: Selector<MarkerIndex[]> = createSelector(
     getFullMarkerList,
     markers => markers.map((_, i) => i)
   );
 
-  /* This utility function makes it easy to write selectors that deal with list
+  /**
+   * This utility function makes it easy to write selectors that deal with list
    * of marker indexes.
    * It takes a filtering function as parameter. This filtering function takes a
    * marker as parameter and returns a boolean deciding whether this marker
@@ -138,6 +166,9 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   ): MarkerIndex[] =>
     MarkerData.filterMarkerIndexes(getMarker, markerIndexes, filterFunc);
 
+  /**
+   * This selector applies the committed range to the full list of markers.
+   */
   const getCommittedRangeFilteredMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -155,6 +186,11 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     }
   );
 
+  /**
+   * This selector filters out markers that are usually too long to be displayed
+   * in the header, because they would obscure the header, or that are displayed
+   * in other tracks already.
+   */
   const getCommittedRangeFilteredMarkerIndexesForHeader: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -173,6 +209,9 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     )
   );
 
+  /**
+   * This selector selects only navigation markers.
+   */
   const getTimelineVerticalMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -181,12 +220,18 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     filterMarkerIndexesCreator(MarkerData.isNavigationMarker)
   );
 
+  /**
+   * This selector selects only jank markers.
+   */
   const getJankMarkerIndexesForHeader: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
     filterMarkerIndexesCreator(marker => marker.name === 'Jank')
   );
 
+  /**
+   * This selector filters markers matching a search string.
+   */
   const getSearchFilteredMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -196,6 +241,9 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     MarkerData.getSearchFilteredMarkerIndexes
   );
 
+  /**
+   * This further filters markers using the preview selection range.
+   */
   const getPreviewFilteredMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -216,37 +264,56 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     }
   );
 
+  /**
+   * This selector finds out whether there's any network marker in this thread.
+   */
   const getIsNetworkChartEmptyInFullRange: Selector<boolean> = createSelector(
     getFullMarkerList,
     markers => markers.every(marker => !MarkerData.isNetworkMarker(marker))
   );
 
-  const getNetworkChartMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
+  /**
+   * This selector filters network markers from the range filtered markers.
+   */
+  const getNetworkMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
     filterMarkerIndexesCreator(MarkerData.isNetworkMarker)
   );
 
-  const getSearchFilteredNetworkChartMarkerIndexes: Selector<
+  /**
+   * This filters network markers using a search string.
+   */
+  const getSearchFilteredNetworkMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
     getMarkerGetter,
-    getNetworkChartMarkerIndexes,
+    getNetworkMarkerIndexes,
     UrlState.getNetworkSearchString,
     MarkerData.getSearchFilteredMarkerIndexes
   );
 
+  /**
+   * Returns whether there's any marker besides network markers.
+   */
   const getIsMarkerChartEmptyInFullRange: Selector<boolean> = createSelector(
     getFullMarkerList,
     markers => markers.every(marker => MarkerData.isNetworkMarker(marker))
   );
 
+  /**
+   * This filters out network markers from the list of all markers, so that
+   * they'll be displayed in the marker chart.
+   */
   const getMarkerChartMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
     MarkerData.filterForMarkerChart
   );
 
+  /**
+   * This filters the previous result using a search string.
+   */
   const getSearchFilteredMarkerChartMarkerIndexes: Selector<
     MarkerIndex[]
   > = createSelector(
@@ -256,36 +323,47 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     MarkerData.getSearchFilteredMarkerIndexes
   );
 
+  /**
+   * This organizes the result of the previous selector in rows to be nicely
+   * displayed in the marker chart.
+   */
   const getMarkerChartTiming: Selector<MarkerTimingRows> = createSelector(
     getMarkerGetter,
     getSearchFilteredMarkerChartMarkerIndexes,
     MarkerTiming.getMarkerTiming
   );
 
-  const getNetworkMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
-    getMarkerGetter,
-    getCommittedRangeFilteredMarkerIndexes,
-    filterMarkerIndexesCreator(MarkerData.isNetworkMarker)
-  );
-
+  /**
+   * This returns only FileIO markers.
+   */
   const getFileIoMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
     filterMarkerIndexesCreator(MarkerData.isFileIoMarker)
   );
 
+  /**
+   * This returns only memory markers.
+   */
   const getMemoryMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
     filterMarkerIndexesCreator(MarkerData.isMemoryMarker)
   );
 
+  /**
+   * This organizes the network markers in rows so that they're nicely displayed
+   * in the header.
+   */
   const getNetworkTrackTiming: Selector<MarkerTimingRows> = createSelector(
     getMarkerGetter,
     getNetworkMarkerIndexes,
     MarkerTiming.getMarkerTiming
   );
 
+  /**
+   * This groups screenshot markers by their window ID.
+   */
   const getRangeFilteredScreenshotsById: Selector<
     Map<string, Marker[]>
   > = createSelector(
@@ -294,9 +372,16 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     MarkerData.groupScreenshotsById
   );
 
+  /**
+   * This returns the marker index for the currently selected marker.
+   */
   const getSelectedMarkerIndex: Selector<MarkerIndex | null> = state =>
     threadSelectors.getViewOptions(state).selectedMarker;
 
+  /**
+   * From the previous value, this returns the full marker object for the
+   * selected marker.
+   */
   const getSelectedMarker: Selector<Marker | null> = state => {
     const getMarker = getMarkerGetter(state);
     const selectedMarkerIndex = getSelectedMarkerIndex(state);
@@ -305,17 +390,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
       return null;
     }
 
-    const marker = getMarker(selectedMarkerIndex);
-    if (!marker) {
-      console.error(stripIndent`
-        Couldn't find the selected marker index ${selectedMarkerIndex} in the full marker list.
-        This shouldn't normally happen and is likely a programming error.
-      `);
-
-      return null;
-    }
-
-    return marker;
+    return getMarker(selectedMarkerIndex);
   };
 
   return {
@@ -323,8 +398,8 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getJankMarkerIndexesForHeader,
     getProcessedRawMarkerTable,
     getFullMarkerListIndexes,
-    getNetworkChartMarkerIndexes,
-    getSearchFilteredNetworkChartMarkerIndexes,
+    getNetworkMarkerIndexes,
+    getSearchFilteredNetworkMarkerIndexes,
     getIsMarkerChartEmptyInFullRange,
     getMarkerChartMarkerIndexes,
     getSearchFilteredMarkerChartMarkerIndexes,
@@ -334,7 +409,6 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getTimelineVerticalMarkerIndexes,
     getFileIoMarkerIndexes,
     getMemoryMarkerIndexes,
-    getNetworkMarkerIndexes,
     getNetworkTrackTiming,
     getRangeFilteredScreenshotsById,
     getSearchFilteredMarkerIndexes,

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -297,6 +297,27 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   const getSelectedMarkerIndex: Selector<MarkerIndex | null> = state =>
     threadSelectors.getViewOptions(state).selectedMarker;
 
+  const getSelectedMarker: Selector<Marker | null> = state => {
+    const getMarker = getMarkerGetter(state);
+    const selectedMarkerIndex = getSelectedMarkerIndex(state);
+
+    if (selectedMarkerIndex === null) {
+      return null;
+    }
+
+    const marker = getMarker(selectedMarkerIndex);
+    if (!marker) {
+      console.error(stripIndent`
+        Couldn't find the selected marker index ${selectedMarkerIndex} in the full marker list.
+        This shouldn't normally happen and is likely a programming error.
+      `);
+
+      return null;
+    }
+
+    return marker;
+  };
+
   return {
     getMarkerGetter,
     getJankMarkerIndexesForHeader,
@@ -319,6 +340,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getSearchFilteredMarkerIndexes,
     getPreviewFilteredMarkerIndexes,
     getSelectedMarkerIndex,
+    getSelectedMarker,
     getIsNetworkChartEmptyInFullRange,
   };
 }

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -435,9 +435,13 @@ describe('TooltipMarker', function() {
     const store = storeWithProfile(profile);
     const state = store.getState();
     const threadIndex = getSelectedThreadIndex(state);
-    const markers = selectedThreadSelectors.getFullMarkerList(state);
+    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+    const markerIndexes = selectedThreadSelectors.getFullMarkerListIndexes(
+      state
+    );
 
-    markers.forEach(marker => {
+    markerIndexes.forEach(markerIndex => {
+      const marker = getMarker(markerIndex);
       const { container } = render(
         <Provider store={store}>
           <TooltipMarker

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -435,7 +435,7 @@ describe('TooltipMarker', function() {
     const store = storeWithProfile(profile);
     const state = store.getState();
     const threadIndex = getSelectedThreadIndex(state);
-    const markers = selectedThreadSelectors.getReferenceMarkerTable(state);
+    const markers = selectedThreadSelectors.getFullMarkerList(state);
 
     markers.forEach(marker => {
       const { container } = render(

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -62,11 +62,11 @@ describe('VerticalIndicators', function() {
 
   it('creates the vertical indicators', function() {
     const { getIndicatorLines, getState } = setup();
-    const markers = selectedThreadSelectors.getTimelineVerticalMarkers(
+    const markerIndexes = selectedThreadSelectors.getTimelineVerticalMarkerIndexes(
       getState()
     );
     const markerCount = 5;
-    expect(markers).toHaveLength(markerCount);
+    expect(markerIndexes).toHaveLength(markerCount);
     expect(getIndicatorLines()).toHaveLength(markerCount);
   });
 

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -494,6 +494,8 @@ Object {
           "F",
           "Load 6: https://mozilla.org",
           "Load 7: https://mozilla.org",
+          "Bailout",
+          "Invalidate",
         ],
         "_stringToIndex": Map {
           "A" => 0,
@@ -504,6 +506,8 @@ Object {
           "F" => 5,
           "Load 6: https://mozilla.org" => 6,
           "Load 7: https://mozilla.org" => 7,
+          "Bailout" => 8,
+          "Invalidate" => 9,
         },
       },
       "tid": 0,
@@ -946,6 +950,8 @@ Array [
         "F",
         "Load 6: https://mozilla.org",
         "Load 7: https://mozilla.org",
+        "Bailout",
+        "Invalidate",
       ],
       "_stringToIndex": Map {
         "A" => 0,
@@ -956,6 +962,8 @@ Array [
         "F" => 5,
         "Load 6: https://mozilla.org" => 6,
         "Load 7: https://mozilla.org" => 7,
+        "Bailout" => 8,
+        "Invalidate" => 9,
       },
     },
     "tid": 0,
@@ -964,7 +972,7 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkers 1`] = `
+exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkerIndexes 1`] = `
 Array [
   Object {
     "data": null,
@@ -1006,7 +1014,7 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkersForHeader 1`] = `
+exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkerIndexesForHeader 1`] = `
 Array [
   Object {
     "data": null,
@@ -1032,6 +1040,85 @@ Array [
 ]
 `;
 
+exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getFullMarkerListIndexes 1`] = `
+Array [
+  Object {
+    "data": null,
+    "dur": 0,
+    "name": "A",
+    "start": 0,
+    "title": null,
+  },
+  Object {
+    "data": null,
+    "dur": 0,
+    "name": "B",
+    "start": 1,
+    "title": null,
+  },
+  Object {
+    "data": null,
+    "dur": 0,
+    "name": "C",
+    "start": 2,
+    "title": null,
+  },
+  Object {
+    "data": null,
+    "dur": 0,
+    "name": "D",
+    "start": 3,
+    "title": null,
+  },
+  Object {
+    "data": null,
+    "dur": 0,
+    "name": "E",
+    "start": 4,
+    "title": null,
+  },
+  Object {
+    "data": null,
+    "dur": 0,
+    "name": "F",
+    "start": 5,
+    "title": null,
+  },
+  Object {
+    "data": Object {
+      "URI": "https://mozilla.org",
+      "endTime": 7,
+      "fetchStart": 6.5,
+      "id": 6,
+      "pri": 0,
+      "startTime": 6,
+      "status": "STATUS_STOP",
+      "type": "Network",
+    },
+    "dur": 1,
+    "name": "Load 6: https://mozilla.org",
+    "start": 6,
+    "title": null,
+  },
+  Object {
+    "data": Object {
+      "URI": "https://mozilla.org",
+      "endTime": 8,
+      "fetchStart": 7.5,
+      "id": 7,
+      "pri": 0,
+      "startTime": 7,
+      "status": "STATUS_STOP",
+      "type": "Network",
+    },
+    "dur": 1,
+    "name": "Load 7: https://mozilla.org",
+    "start": 7,
+    "title": null,
+  },
+]
+`;
+
 exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getMarkerChartTiming 1`] = `
 Array [
   Object {
@@ -1039,7 +1126,7 @@ Array [
       3,
     ],
     "index": Array [
-      0,
+      3,
     ],
     "label": Array [
       "",
@@ -1055,7 +1142,7 @@ Array [
       4,
     ],
     "index": Array [
-      1,
+      4,
     ],
     "label": Array [
       "",
@@ -1071,7 +1158,7 @@ Array [
       5,
     ],
     "index": Array [
-      2,
+      5,
     ],
     "label": Array [
       "",
@@ -1159,86 +1246,7 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getFullMarkerList 1`] = `
-Array [
-  Object {
-    "data": null,
-    "dur": 0,
-    "name": "A",
-    "start": 0,
-    "title": null,
-  },
-  Object {
-    "data": null,
-    "dur": 0,
-    "name": "B",
-    "start": 1,
-    "title": null,
-  },
-  Object {
-    "data": null,
-    "dur": 0,
-    "name": "C",
-    "start": 2,
-    "title": null,
-  },
-  Object {
-    "data": null,
-    "dur": 0,
-    "name": "D",
-    "start": 3,
-    "title": null,
-  },
-  Object {
-    "data": null,
-    "dur": 0,
-    "name": "E",
-    "start": 4,
-    "title": null,
-  },
-  Object {
-    "data": null,
-    "dur": 0,
-    "name": "F",
-    "start": 5,
-    "title": null,
-  },
-  Object {
-    "data": Object {
-      "URI": "https://mozilla.org",
-      "endTime": 7,
-      "fetchStart": 6.5,
-      "id": 6,
-      "pri": 0,
-      "startTime": 6,
-      "status": "STATUS_STOP",
-      "type": "Network",
-    },
-    "dur": 1,
-    "name": "Load 6: https://mozilla.org",
-    "start": 6,
-    "title": null,
-  },
-  Object {
-    "data": Object {
-      "URI": "https://mozilla.org",
-      "endTime": 8,
-      "fetchStart": 7.5,
-      "id": 7,
-      "pri": 0,
-      "startTime": 7,
-      "status": "STATUS_STOP",
-      "type": "Network",
-    },
-    "dur": 1,
-    "name": "Load 7: https://mozilla.org",
-    "start": 7,
-    "title": null,
-  },
-]
-`;
-
-exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getSearchFilteredMarkers 1`] = `
+exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getSearchFilteredMarkerIndexes 1`] = `
 Array [
   Object {
     "data": null,

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1159,7 +1159,7 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getReferenceMarkerTable 1`] = `
+exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getFullMarkerList 1`] = `
 Array [
   Object {
     "data": null,

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -209,9 +209,7 @@ describe('getTimelineVerticalMarkers', function() {
     const markers = selectedThreadSelectors.getTimelineVerticalMarkers(
       getState()
     );
-    const allMarkers = selectedThreadSelectors.getReferenceMarkerTable(
-      getState()
-    );
+    const allMarkers = selectedThreadSelectors.getFullMarkerList(getState());
 
     expect(allMarkers.length).toBeGreaterThan(markers.length);
     expect(markers).toHaveLength(5);

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -206,14 +206,17 @@ describe('getProcessedRawMarkerTable', function() {
 describe('getTimelineVerticalMarkers', function() {
   it('gets the appropriate markers', function() {
     const { getState } = storeWithProfile(getNetworkTrackProfile());
-    const markers = selectedThreadSelectors.getTimelineVerticalMarkers(
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+    const markerIndexes = selectedThreadSelectors.getTimelineVerticalMarkerIndexes(
       getState()
     );
-    const allMarkers = selectedThreadSelectors.getFullMarkerList(getState());
+    const allMarkers = selectedThreadSelectors.getFullMarkerListIndexes(
+      getState()
+    );
 
-    expect(allMarkers.length).toBeGreaterThan(markers.length);
-    expect(markers).toHaveLength(5);
-    expect(markers).toMatchSnapshot();
+    expect(allMarkers.length).toBeGreaterThan(markerIndexes.length);
+    expect(markerIndexes).toHaveLength(5);
+    expect(markerIndexes.map(getMarker)).toMatchSnapshot();
   });
 });
 
@@ -259,20 +262,23 @@ describe('memory markers', function() {
 
   it('can get memory markers using getMemoryMarkers', function() {
     const { getState } = setup();
-    const markers = selectedThreadSelectors.getMemoryMarkers(getState());
-    expect(markers.map(marker => marker.name)).toEqual([
-      'IdleForgetSkippable',
-      'GCMinor',
-      'GCMajor',
-      'GCSlice',
-    ]);
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+    const markerIndexes = selectedThreadSelectors.getMemoryMarkerIndexes(
+      getState()
+    );
+    expect(
+      markerIndexes.map(markerIndex => getMarker(markerIndex).name)
+    ).toEqual(['IdleForgetSkippable', 'GCMinor', 'GCMajor', 'GCSlice']);
   });
 
   it('ignores memory markers in getCommittedRangeFilteredMarkersForHeader', function() {
     const { getState } = setup();
-    const markers = selectedThreadSelectors.getCommittedRangeFilteredMarkersForHeader(
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+    const markerIndexes = selectedThreadSelectors.getCommittedRangeFilteredMarkerIndexesForHeader(
       getState()
     );
-    expect(markers.map(marker => marker.name)).toEqual(['A', 'B', 'C']);
+    expect(
+      markerIndexes.map(markerIndex => getMarker(markerIndex).name)
+    ).toEqual(['A', 'B', 'C']);
   });
 });

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -157,7 +157,10 @@ describe('getJankMarkersForHeader', function() {
     );
     profile.threads[0].samples.responsiveness = responsiveness;
     const { getState } = storeWithProfile(profile);
-    return selectedThreadSelectors.getJankMarkersForHeader(getState());
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+    return selectedThreadSelectors
+      .getJankMarkerIndexesForHeader(getState())
+      .map(getMarker);
   }
 
   it('will not create any jank markers for undefined responsiveness', function() {
@@ -681,18 +684,19 @@ describe('actions/ProfileView', function() {
       const networkSearchString = '3';
 
       expect(
-        selectedThreadSelectors.getSearchFilteredNetworkChartMarkers(getState())
-          .length
-      ).toBe(10);
+        selectedThreadSelectors.getSearchFilteredNetworkChartMarkerIndexes(
+          getState()
+        )
+      ).toHaveLength(10);
       dispatch(ProfileView.changeNetworkSearchString(networkSearchString));
+
+      const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+      const markerIndexes = selectedThreadSelectors.getSearchFilteredNetworkChartMarkerIndexes(
+        getState()
+      );
+      expect(markerIndexes).toHaveLength(1);
       expect(
-        selectedThreadSelectors.getSearchFilteredNetworkChartMarkers(getState())
-          .length
-      ).toBe(1);
-      expect(
-        selectedThreadSelectors
-          .getSearchFilteredNetworkChartMarkers(getState())[0]
-          .name.includes(networkSearchString)
+        getMarker(markerIndexes[0]).name.includes(networkSearchString)
       ).toBeTruthy();
     });
   });
@@ -1093,6 +1097,7 @@ describe('snapshots of selectors/profile', function() {
       samplesThread,
       mergeFunction,
       markerThreadSelectors: getThreadSelectors(1),
+      getMarker: getThreadSelectors(1).getMarkerGetter(getState()),
       A,
       B,
       C,
@@ -1160,8 +1165,11 @@ describe('snapshots of selectors/profile', function() {
   });
   it('matches the last stored run of selectedThreadSelector.getJankMarkersForHeader', function() {
     const { getState } = setupStore();
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
     expect(
-      selectedThreadSelectors.getJankMarkersForHeader(getState())
+      selectedThreadSelectors
+        .getJankMarkerIndexesForHeader(getState())
+        .map(getMarker)
     ).toMatchSnapshot();
   });
   it('matches the last stored run of markerThreadSelectors.getProcessedRawMarkerTable', function() {
@@ -1170,10 +1178,10 @@ describe('snapshots of selectors/profile', function() {
       markerThreadSelectors.getProcessedRawMarkerTable(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of markerThreadSelectors.getFullMarkerList', function() {
-    const { getState, markerThreadSelectors } = setupStore();
+  it('matches the last stored run of markerThreadSelectors.getFullMarkerListIndexes', function() {
+    const { getState, markerThreadSelectors, getMarker } = setupStore();
     expect(
-      markerThreadSelectors.getFullMarkerList(getState())
+      markerThreadSelectors.getFullMarkerListIndexes(getState()).map(getMarker)
     ).toMatchSnapshot();
   });
   it('matches the last stored run of markerThreadSelectors.getMarkerChartTiming', function() {
@@ -1182,18 +1190,20 @@ describe('snapshots of selectors/profile', function() {
       markerThreadSelectors.getMarkerChartTiming(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkers', function() {
-    const { getState, markerThreadSelectors } = setupStore();
+  it('matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkerIndexes', function() {
+    const { getState, markerThreadSelectors, getMarker } = setupStore();
     expect(
-      markerThreadSelectors.getCommittedRangeFilteredMarkers(getState())
+      markerThreadSelectors
+        .getCommittedRangeFilteredMarkerIndexes(getState())
+        .map(getMarker)
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkersForHeader', function() {
-    const { getState, markerThreadSelectors } = setupStore();
+  it('matches the last stored run of markerThreadSelectors.getCommittedRangeFilteredMarkerIndexesForHeader', function() {
+    const { getState, markerThreadSelectors, getMarker } = setupStore();
     expect(
-      markerThreadSelectors.getCommittedRangeFilteredMarkersForHeader(
-        getState()
-      )
+      markerThreadSelectors
+        .getCommittedRangeFilteredMarkerIndexesForHeader(getState())
+        .map(getMarker)
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getFilteredThread', function() {
@@ -1265,10 +1275,12 @@ describe('snapshots of selectors/profile', function() {
       selectedThreadSelectors.getThreadProcessDetails(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of markerThreadSelectors.getSearchFilteredMarkers', function() {
-    const { getState, markerThreadSelectors } = setupStore();
+  it('matches the last stored run of markerThreadSelectors.getSearchFilteredMarkerIndexes', function() {
+    const { getState, markerThreadSelectors, getMarker } = setupStore();
     expect(
-      markerThreadSelectors.getSearchFilteredMarkers(getState())
+      markerThreadSelectors
+        .getSearchFilteredMarkerIndexes(getState())
+        .map(getMarker)
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.unfilteredSamplesRange', function() {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1170,10 +1170,10 @@ describe('snapshots of selectors/profile', function() {
       markerThreadSelectors.getProcessedRawMarkerTable(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of markerThreadSelectors.getReferenceMarkerTable', function() {
+  it('matches the last stored run of markerThreadSelectors.getFullMarkerList', function() {
     const { getState, markerThreadSelectors } = setupStore();
     expect(
-      markerThreadSelectors.getReferenceMarkerTable(getState())
+      markerThreadSelectors.getFullMarkerList(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of markerThreadSelectors.getMarkerChartTiming', function() {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -684,14 +684,14 @@ describe('actions/ProfileView', function() {
       const networkSearchString = '3';
 
       expect(
-        selectedThreadSelectors.getSearchFilteredNetworkChartMarkerIndexes(
+        selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
           getState()
         )
       ).toHaveLength(10);
       dispatch(ProfileView.changeNetworkSearchString(networkSearchString));
 
       const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-      const markerIndexes = selectedThreadSelectors.getSearchFilteredNetworkChartMarkerIndexes(
+      const markerIndexes = selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
         getState()
       );
       expect(markerIndexes).toHaveLength(1);

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -33,12 +33,21 @@ describe('deriveMarkersFromRawMarkerTable', function() {
     const store = storeWithProfile(profile);
     const state = store.getState();
 
+    const mainThreadSelectors = getThreadSelectors(0);
+    const contentThreadSelectors = getThreadSelectors(2);
+    const mainGetMarker = mainThreadSelectors.getMarkerGetter(state);
+    const contentGetMarker = contentThreadSelectors.getMarkerGetter(state);
+
     return {
       profile,
-      markers: getThreadSelectors(0).getFullMarkerList(state),
+      markers: mainThreadSelectors
+        .getFullMarkerListIndexes(state)
+        .map(mainGetMarker),
       thread,
       contentThread,
-      contentMarkers: getThreadSelectors(2).getFullMarkerList(state),
+      contentMarkers: contentThreadSelectors
+        .getFullMarkerListIndexes(state)
+        .map(contentGetMarker),
     };
   }
 

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -35,10 +35,10 @@ describe('deriveMarkersFromRawMarkerTable', function() {
 
     return {
       profile,
-      markers: getThreadSelectors(0).getReferenceMarkerTable(state),
+      markers: getThreadSelectors(0).getFullMarkerList(state),
       thread,
       contentThread,
-      contentMarkers: getThreadSelectors(2).getReferenceMarkerTable(state),
+      contentMarkers: getThreadSelectors(2).getFullMarkerList(state),
     };
   }
 

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -80,6 +80,15 @@ export type Marker = {|
   incomplete?: boolean,
 |};
 
+/**
+ * A value with this type uniquely identifies a marker. This is the index of a
+ * marker in the full marker list (as returned by the selector `getFullMarkerList`),
+ * and the marker object is returned using the function `getMarker` as returned
+ * by the selector `getMarkerGetter`:
+ *
+ *   const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+ *   const marker = getMarker(markerIndex);
+ */
 export type MarkerIndex = number;
 
 export type CallNodeData = {

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -80,7 +80,7 @@ export type Marker = {|
   incomplete?: boolean,
 |};
 
-export type IndexIntoMarkers = number;
+export type MarkerIndex = number;
 
 export type CallNodeData = {
   funcName: string,
@@ -106,14 +106,12 @@ export type CallNodeDisplayData = $Exact<
   }>
 >;
 
-export type IndexIntoMarkerTiming = number;
-
 export type MarkerTiming = {
   // Start time in milliseconds.
   start: number[],
   // End time in milliseconds.
   end: number[],
-  index: IndexIntoMarkers[],
+  index: MarkerIndex[],
   label: string[],
   name: string,
   length: number,

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -16,18 +16,14 @@ import type {
 } from './actions';
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type { StartEndRange } from './units';
-import type {
-  IndexIntoRawMarkerTable,
-  Profile,
-  ThreadIndex,
-  Pid,
-} from './profile';
+import type { Profile, ThreadIndex, Pid } from './profile';
 
 import type {
   CallNodePath,
   GlobalTrack,
   LocalTrack,
   TrackIndex,
+  MarkerIndex,
 } from './profile-derived';
 import type { Attempt } from '../utils/errors';
 import type { TransformStacksPerThread } from './transforms';
@@ -41,7 +37,7 @@ export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {|
   +selectedCallNodePath: CallNodePath,
   +expandedCallNodePaths: PathSet,
-  +selectedMarker: IndexIntoRawMarkerTable | null,
+  +selectedMarker: MarkerIndex | null,
 |};
 
 export type ProfileViewState = {|

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -46,7 +46,12 @@ export function addDataToWindowObject(
   defineProperty(target, 'filteredMarkers', {
     enumerable: true,
     get() {
-      return selectors.selectedThread.getPreviewFilteredMarkers(getState());
+      const state = getState();
+      const getMarker = selectors.selectedThread.getMarkerGetter(state);
+      const markerIndexes = selectors.selectedThread.getPreviewFilteredMarkerIndexes(
+        state
+      );
+      return markerIndexes.map(getMarker);
     },
   });
 


### PR DESCRIPTION
[deploy preview](https://deploy-preview-1812--perf-html.netlify.com/public/2a5d34be5f5f662438b765cdd3796fbad8d8b051/marker-table/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4-5&localTrackOrderByPid=5569-1-2-0~6172-0~6295-0~6403-0~5755-0~5696-0~6351-0-1~&thread=7&v=3)

With this PR there should be no behavior change at all. The goal of this PR is that a `MarkerIndex` refers to the marker at the index in the full list. This makes it possible to share indexes across views and components.
The logic change is that instead of filtering lists of markers we filter lists of marker indexes, and we have access to a function (returned by the `getMarkerGetter` selector) that gets the full object.

Things to especially test: behavior around search / range filter / preview filter, with context menus, sidebar, tooltips. I checked most of the cases already but please double check, also with other profiles maybe.

About tests: because this doesn't add new behavior but mostly change existing functions, I updated the existing tests but didn't add more. I couldn't think of new tests (except maybe covering utils/window-console ?).

Tell me what you think!