### PR TITLE
#1543 Clicking on the meatball button should toggle the state of the dialog 

### DIFF
--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -64,14 +64,12 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
   }
 
   _onPanelOpen = () => {
-    this.setState({ open: true });
     if (this.props.panel.props.onOpen) {
       this.props.panel.props.onOpen();
     }
   };
 
   _onPanelClose = () => {
-    this.setState({ open: false });
     if (this.props.panel.props.onClose) {
       this.props.panel.props.onClose();
     }
@@ -84,16 +82,22 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
   openPanel() {
     if (this._panel) {
       this._panel.open();
+      this.setState({ open: true });
     }
   }
   closePanel() {
     if (this._panel && this.state.open) {
       this._panel.close();
+      this.setState({ open: false });
     }
   }
 
   _onButtonClick = () => {
-    this.openPanel();
+    if (this._panel && this.state.open) {
+      this.closePanel();
+    } else {
+      this.openPanel();
+    }
   };
 
   _onKeyDown = (e: KeyboardEvent) => {


### PR DESCRIPTION
[#1543
![ezgif com-gif-maker 2](https://user-images.githubusercontent.com/25532570/53754071-da6dd580-3ed8-11e9-9a2f-beaedb9b8028.gif)
](https://github.com/firefox-devtools/profiler/issues/1543 )
The button now shows a toggling behaviour