### PR TITLE
Update marker-timing.js to include 'Text' case

### DIFF
--- a/src/profile-logic/marker-timing.js
+++ b/src/profile-logic/marker-timing.js
@@ -119,6 +119,8 @@ function computeMarkerLabel(data: MarkerPayload): string {
           return (data: DOMEventMarkerPayload).eventType;
         }
         break;
+      case 'Text':
+        return (data: TextMarkerPayload).name;
       default:
     }
   }


### PR DESCRIPTION
fixing #1827 