### PR TITLE
Implement FileIO search in marker table

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -94,6 +94,10 @@ export function getSearchFilteredMarkers(
       continue;
     }
     if (data && typeof data === 'object') {
+      if (data.type === 'FileIO') {
+        newMarkers.push(marker);
+        continue;
+      }
       if (
         typeof data.eventType === 'string' &&
         data.eventType.toLowerCase().includes(lowerCaseSearchString)

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -95,8 +95,15 @@ export function getSearchFilteredMarkers(
     }
     if (data && typeof data === 'object') {
       if (data.type === 'FileIO') {
-        newMarkers.push(marker);
-        continue;
+        const { filename, operation, source } = data;
+        if (
+          filename.toLowerCase().includes(lowerCaseSearchString) ||
+          operation.toLowerCase().includes(lowerCaseSearchString) ||
+          source.toLowerCase().includes(lowerCaseSearchString)
+        ) {
+          newMarkers.push(marker);
+          continue;
+        }
       }
       if (
         typeof data.eventType === 'string' &&


### PR DESCRIPTION
Fixes #1741

Allows the user to search for FileIO markers in a profile, which are then displayed in the Marker Table.

You can search for terms like `Poison`, `create`, `open`, `stat`, `widevine` , and even the file name, and it is case insensitive. 

Tested locally with [this profile](https://perf-html.io/public/35026af1053a9b674dcabc52f94580942ff40e9d/marker-table/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1&hiddenLocalTracksByPid=10084-1-2-3&markerSearch=diskio&range=2.5201_5.0874&thread=0&v=3). 

This is the current behavior (no markers displayed) - 

![prf-1](https://user-images.githubusercontent.com/11348778/53943262-b9e57d00-408a-11e9-84c2-c9bcb6ef3812.png)

This is the new behavior after including the changes from this PR - 

![prf-2](https://user-images.githubusercontent.com/11348778/53943337-df728680-408a-11e9-8b67-fb463763420e.png)

Here is a sample search for a file name (case insensitive ) -

![prf-3](https://user-images.githubusercontent.com/11348778/53943375-f74a0a80-408a-11e9-97ef-e6fba454ca47.png)

Tested locally that these changes don't break anything by running `yarn test-all` - 

![prf-test](https://user-images.githubusercontent.com/11348778/53943500-3c6e3c80-408b-11e9-93a9-b1b3ce94b46a.png)

Closes #1741 
