### PR TITLE
Fix a regression for the timeline selection

### DIFF
--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -25,6 +25,11 @@ import {
   getGlobalTrackOrder,
   getTimelineType,
 } from '../../selectors/url-state';
+import {
+  TIMELINE_MARGIN_LEFT,
+  TIMELINE_MARGIN_RIGHT,
+} from '../../app-logic/constants';
+
 import './index.css';
 
 import type { SizeProps } from '../shared/WithSize';
@@ -166,6 +171,9 @@ class Timeline extends React.PureComponent<Props> {
       changeRightClickedTrack,
     } = this.props;
 
+    // Do not include the left and right margins when computing the timeline width.
+    const timelineWidth = width - TIMELINE_MARGIN_LEFT - TIMELINE_MARGIN_RIGHT;
+
     return (
       <>
         <div className="timelineSettings">
@@ -178,12 +186,12 @@ class Timeline extends React.PureComponent<Props> {
             changeRightClickedTrack={changeRightClickedTrack}
           />
         </div>
-        <TimelineSelection width={width}>
+        <TimelineSelection width={timelineWidth}>
           <TimelineRuler
             zeroAt={zeroAt}
             rangeStart={committedRange.start}
             rangeEnd={committedRange.end}
-            width={width}
+            width={timelineWidth}
           />
           <OverflowEdgeIndicator
             className="timelineOverflowEdgeIndicator"


### PR DESCRIPTION
Steps to reproduce:
 * Go to [the master branch deploy preview](https://master--perf-html.netlify.com/public/62a6d6feb3d1d4fe6d0dd48d9ec4e1fb62a73998/calltree/?v=3)
 * Create a range selection by dragging in the timeline.

Expected result:
 * The selection correctly aligns to the mouse.

Actual result:
 * The selection is misaligned.

This was introduced by PR #1803.

I also am filing a follow-up to create a test for the range selection. (edit: this is #1846)