### PR TITLE
[WIP] Defer the rendering of the arrow panel content until it is open

### DIFF
--- a/src/components/app/MenuButtons/Download.js
+++ b/src/components/app/MenuButtons/Download.js
@@ -69,7 +69,7 @@ export class ProfileDownloadButton extends React.PureComponent<Props, State> {
     });
   };
 
-  render() {
+  _renderPanelContent = () => {
     const {
       filename,
       uncompressedBlobUrl,
@@ -77,6 +77,36 @@ export class ProfileDownloadButton extends React.PureComponent<Props, State> {
       uncompressedSize,
       compressedSize,
     } = this.state;
+
+    return (
+      <section>
+        {uncompressedBlobUrl ? (
+          <p>
+            <a
+              className="menuButtonsDownloadLink"
+              href={uncompressedBlobUrl}
+              download={filename}
+            >
+              {`${filename} (${prettyBytes(uncompressedSize)})`}
+            </a>
+          </p>
+        ) : null}
+        {compressedBlobUrl ? (
+          <p>
+            <a
+              className="menuButtonsDownloadLink"
+              href={compressedBlobUrl}
+              download={`${filename}.gz`}
+            >
+              {`${filename}.gz (${prettyBytes(compressedSize)})`}
+            </a>
+          </p>
+        ) : null}
+      </section>
+    );
+  };
+
+  render() {
     return (
       <ButtonWithPanel
         className="menuButtonsProfileDownloadButton"
@@ -86,32 +116,8 @@ export class ProfileDownloadButton extends React.PureComponent<Props, State> {
             className="menuButtonsProfileDownloadPanel"
             title="Save Profile to a Local File"
             onOpen={this._onPanelOpen}
-          >
-            <section>
-              {uncompressedBlobUrl ? (
-                <p>
-                  <a
-                    className="menuButtonsDownloadLink"
-                    href={uncompressedBlobUrl}
-                    download={filename}
-                  >
-                    {`${filename} (${prettyBytes(uncompressedSize)})`}
-                  </a>
-                </p>
-              ) : null}
-              {compressedBlobUrl ? (
-                <p>
-                  <a
-                    className="menuButtonsDownloadLink"
-                    href={compressedBlobUrl}
-                    download={`${filename}.gz`}
-                  >
-                    {`${filename}.gz (${prettyBytes(compressedSize)})`}
-                  </a>
-                </p>
-              ) : null}
-            </section>
-          </ArrowPanel>
+            content={this._renderPanelContent}
+          />
         }
       />
     );

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -19,111 +19,114 @@ type Props = {
  * This component formats the profile's meta information into a dropdown panel.
  */
 export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
-  render() {
-    const { profile } = this.props;
-    const meta = profile.meta;
+  _renderPanelContent = () => {
+    const meta = this.props.profile.meta;
 
-    if (meta !== undefined && meta !== null) {
-      return (
-        <div className="menuButtonsMetaInfoButtonBox">
-          <div className="menuButtonsMetaInfoButtonLabel">
-            <span className="menuButtonsMetaInfoButtonLabelOverflow">
-              {_formatLabel(meta)}
-            </span>
-          </div>
-          <ButtonWithPanel
-            className="menuButtonsMetaInfoButtonButton"
-            label="&nbsp;"
-            panel={
-              <ArrowPanel className="arrowPanelOpenMetaInfo">
-                <h2 className="arrowPanelSubTitle">Timing</h2>
-                <div className="arrowPanelSection">
-                  {meta.startTime ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Recording started:</span>
-                      {_formatDate(meta.startTime)}
-                    </div>
-                  ) : null}
-                  {meta.interval ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Interval:</span>
-                      {meta.interval}ms
-                    </div>
-                  ) : null}
-                  {meta.preprocessedProfileVersion ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Profile Version:</span>
-                      {meta.preprocessedProfileVersion}
-                    </div>
-                  ) : null}
-                </div>
-                <h2 className="arrowPanelSubTitle">Application</h2>
-                <div className="arrowPanelSection">
-                  {meta.product ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Name:</span>
-                      {meta.product}
-                    </div>
-                  ) : null}
-                  {meta.misc ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Version:</span>
-                      {_formatVersionNumber(meta.misc)}
-                    </div>
-                  ) : null}
-                  {meta.appBuildID ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Build ID:</span>
-                      {meta.sourceURL ? (
-                        <a
-                          href={meta.sourceURL}
-                          title={meta.sourceURL}
-                          target="_blank"
-                        >
-                          {meta.appBuildID}
-                        </a>
-                      ) : (
-                        meta.appBuildID
-                      )}
-                    </div>
-                  ) : null}
-                  {meta.extensions ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Extensions:</span>
-                      <ul className="metaInfoList">
-                        {_mapMetaInfoExtensionNames(meta.extensions.name)}
-                      </ul>
-                    </div>
-                  ) : null}
-                </div>
-                <h2 className="arrowPanelSubTitle">Platform</h2>
-                <div className="arrowPanelSection">
-                  {meta.platform ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">Platform:</span>
-                      {meta.platform}
-                    </div>
-                  ) : null}
-                  {meta.oscpu ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">OS:</span>
-                      {meta.oscpu}
-                    </div>
-                  ) : null}
-                  {meta.abi ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoLabel">ABI:</span>
-                      {meta.abi}
-                    </div>
-                  ) : null}
-                </div>
-              </ArrowPanel>
-            }
-          />
+    return (
+      <>
+        <h2 className="arrowPanelSubTitle">Timing</h2>
+        <div className="arrowPanelSection">
+          {meta.startTime ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Recording started:</span>
+              {_formatDate(meta.startTime)}
+            </div>
+          ) : null}
+          {meta.interval ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Interval:</span>
+              {meta.interval}ms
+            </div>
+          ) : null}
+          {meta.preprocessedProfileVersion ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Profile Version:</span>
+              {meta.preprocessedProfileVersion}
+            </div>
+          ) : null}
         </div>
-      );
-    }
-    return null;
+        <h2 className="arrowPanelSubTitle">Application</h2>
+        <div className="arrowPanelSection">
+          {meta.product ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Name:</span>
+              {meta.product}
+            </div>
+          ) : null}
+          {meta.misc ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Version:</span>
+              {_formatVersionNumber(meta.misc)}
+            </div>
+          ) : null}
+          {meta.appBuildID ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Build ID:</span>
+              {meta.sourceURL ? (
+                <a href={meta.sourceURL} title={meta.sourceURL} target="_blank">
+                  {meta.appBuildID}
+                </a>
+              ) : (
+                meta.appBuildID
+              )}
+            </div>
+          ) : null}
+          {meta.extensions ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Extensions:</span>
+              <ul className="metaInfoList">
+                {_mapMetaInfoExtensionNames(meta.extensions.name)}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+        <h2 className="arrowPanelSubTitle">Platform</h2>
+        <div className="arrowPanelSection">
+          {meta.platform ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Platform:</span>
+              {meta.platform}
+            </div>
+          ) : null}
+          {meta.oscpu ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">OS:</span>
+              {meta.oscpu}
+            </div>
+          ) : null}
+          {meta.abi ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">ABI:</span>
+              {meta.abi}
+            </div>
+          ) : null}
+        </div>
+      </>
+    );
+  };
+
+  render() {
+    const meta = this.props.profile.meta;
+
+    return (
+      <div className="menuButtonsMetaInfoButtonBox">
+        <div className="menuButtonsMetaInfoButtonLabel">
+          <span className="menuButtonsMetaInfoButtonLabelOverflow">
+            {_formatLabel(meta)}
+          </span>
+        </div>
+        <ButtonWithPanel
+          className="menuButtonsMetaInfoButtonButton"
+          label="&nbsp;"
+          panel={
+            <ArrowPanel
+              className="arrowPanelOpenMetaInfo"
+              content={this._renderPanelContent}
+            />
+          }
+        />
+      </div>
+    );
   }
 }
 

--- a/src/components/app/MenuButtons/ProfileSharing.js
+++ b/src/components/app/MenuButtons/ProfileSharing.js
@@ -242,8 +242,32 @@ export class MenuButtonsProfileSharing extends React.PureComponent<
     });
   };
 
+  _renderPermalinkTextField = () => {
+    const { shortUrl } = this.state;
+
+    return (
+      <input
+        type="text"
+        className="menuButtonsPermalinkTextField photon-input"
+        value={shortUrl}
+        readOnly="readOnly"
+        ref={this._takePermalinkTextFieldRef}
+      />
+    );
+  };
+
+  _renderUploadError = () => {
+    const { error } = this.state;
+    return (
+      <>
+        <p>An error occurred during upload:</p>
+        <pre>{error && error.toString()}</pre>
+      </>
+    );
+  };
+
   render() {
-    const { state, uploadProgress, error, shortUrl } = this.state;
+    const { state, uploadProgress } = this.state;
     const { profile, profileSharingStatus } = this.props;
 
     // We don't show the secondary button if any of these conditions is true:
@@ -310,15 +334,8 @@ export class MenuButtonsProfileSharing extends React.PureComponent<
                   className="menuButtonsPermalinkPanel"
                   onOpen={this._onPermalinkPanelOpen}
                   onClose={this._onPermalinkPanelClose}
-                >
-                  <input
-                    type="text"
-                    className="menuButtonsPermalinkTextField photon-input"
-                    value={shortUrl}
-                    readOnly="readOnly"
-                    ref={this._takePermalinkTextFieldRef}
-                  />
-                </ArrowPanel>
+                  content={this._renderPermalinkTextField}
+                />
               }
             />
           </AnimateUpTransition>
@@ -337,10 +354,8 @@ export class MenuButtonsProfileSharing extends React.PureComponent<
                   okButtonText="Try Again"
                   cancelButtonText="Cancel"
                   onOkButtonClick={this._attemptToShare}
-                >
-                  <p>An error occurred during upload:</p>
-                  <pre>{error && error.toString()}</pre>
-                </ArrowPanel>
+                  content={this._renderUploadError}
+                />
               }
             />
           </AnimateUpTransition>
@@ -418,27 +433,17 @@ type ProfileSharingButtonProps = {|
   +checkboxDisabled: boolean,
 |};
 
-const ProfileSharingButton = ({
-  buttonClassName,
-  shareLabel,
-  okButtonClickEvent,
-  panelOpenEvent,
-  shareNetworkUrlCheckboxChecked,
-  shareNetworkUrlCheckboxOnChange,
-  checkboxDisabled,
-}: ProfileSharingButtonProps) => (
-  <ButtonWithPanel
-    className={buttonClassName}
-    label={shareLabel}
-    panel={
-      <ArrowPanel
-        className="menuButtonsPrivacyPanel"
-        title="Upload Profile – Privacy Notice"
-        okButtonText="Share"
-        cancelButtonText="Cancel"
-        onOkButtonClick={okButtonClickEvent}
-        onOpen={panelOpenEvent ? panelOpenEvent : undefined}
-      >
+class ProfileSharingButton extends React.PureComponent<
+  ProfileSharingButtonProps
+> {
+  _renderPanelContent = () => {
+    const {
+      shareNetworkUrlCheckboxChecked,
+      shareNetworkUrlCheckboxOnChange,
+      checkboxDisabled,
+    } = this.props;
+    return (
+      <>
         <PrivacyNotice />
         <p className="menuButtonsShareNetworkUrlsContainer">
           <label>
@@ -452,7 +457,34 @@ const ProfileSharingButton = ({
             Share the URLs of all network requests
           </label>
         </p>
-      </ArrowPanel>
-    }
-  />
-);
+      </>
+    );
+  };
+
+  render() {
+    const {
+      buttonClassName,
+      shareLabel,
+      okButtonClickEvent,
+      panelOpenEvent,
+    } = this.props;
+
+    return (
+      <ButtonWithPanel
+        className={buttonClassName}
+        label={shareLabel}
+        panel={
+          <ArrowPanel
+            className="menuButtonsPrivacyPanel"
+            title="Upload Profile – Privacy Notice"
+            okButtonText="Share"
+            cancelButtonText="Cancel"
+            onOkButtonClick={okButtonClickEvent}
+            onOpen={panelOpenEvent ? panelOpenEvent : undefined}
+            content={this._renderPanelContent}
+          />
+        }
+      />
+    );
+  }
+}

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -12,15 +12,12 @@ import { ensureExists } from '../../utils/flow';
 describe('shared/ButtonWithPanel', () => {
   // renders the button in its default state
   function setup() {
+    const content = () => <div>Panel content</div>;
     return render(
       <ButtonWithPanel
         className="button"
         label="My Button"
-        panel={
-          <ArrowPanel className="panel">
-            <div>Panel content</div>
-          </ArrowPanel>
-        }
+        panel={<ArrowPanel className="panel" content={content} />}
       />
     );
   }
@@ -31,19 +28,48 @@ describe('shared/ButtonWithPanel', () => {
   });
 
   it('renders a button with a panel', () => {
+    const content = () => <div>Panel content</div>;
     const { container } = render(
       <ButtonWithPanel
         className="button"
         label="My Button"
         open={true}
-        panel={
-          <ArrowPanel className="panel">
-            <div>Panel content</div>
-          </ArrowPanel>
-        }
+        panel={<ArrowPanel className="panel" content={content} />}
       />
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('protecting against expensive panel contents', function() {
+    it('does not render the contents when closed', function() {
+      const content = jest.fn(() => <div>Panel content</div>);
+      render(
+        <ButtonWithPanel
+          className="button"
+          label="My Button"
+          panel={<ArrowPanel className="panel" content={content} />}
+        />
+      );
+      expect(content).not.toHaveBeenCalled();
+    });
+
+    /**
+     * This test asserts that we don't try and render the contents of a panel, which
+     * would run the selector. This protects us from running expensive selectors
+     * when they are not needed.
+     */
+    it('only renders the contents when open', function() {
+      const content = jest.fn(() => <div>Panel content</div>);
+      render(
+        <ButtonWithPanel
+          className="button"
+          label="My Button"
+          open={true}
+          panel={<ArrowPanel className="panel" content={content} />}
+        />
+      );
+      expect(content).toHaveBeenCalled();
+    });
   });
 
   it('opens the panel when the button is clicked and closes the panel when the escape key is pressed', () => {

--- a/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
+++ b/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
@@ -192,13 +192,6 @@ exports[`shared/ButtonWithPanel renders the ButtonWithPanel with a closed panel 
       <div
         class="arrowPanelArrow"
       />
-      <div
-        class="arrowPanelContent"
-      >
-        <div>
-          Panel content
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -35,140 +35,6 @@ Array [
           <div
             class="arrowPanelArrow"
           />
-          <div
-            class="arrowPanelContent"
-          >
-            <h2
-              class="arrowPanelSubTitle"
-            >
-              Timing
-            </h2>
-            <div
-              class="arrowPanelSection"
-            >
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Recording started:
-                </span>
-                Sat, 09 Apr 2016 17:02:32 GMT
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Interval:
-                </span>
-                1
-                ms
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Profile Version:
-                </span>
-                22
-              </div>
-            </div>
-            <h2
-              class="arrowPanelSubTitle"
-            >
-              Application
-            </h2>
-            <div
-              class="arrowPanelSection"
-            >
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Name:
-                </span>
-                Firefox
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Version:
-                </span>
-                48.0
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Build ID:
-                </span>
-                20181126165837
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Extensions:
-                </span>
-                <ul
-                  class="metaInfoList"
-                />
-              </div>
-            </div>
-            <h2
-              class="arrowPanelSubTitle"
-            >
-              Platform
-            </h2>
-            <div
-              class="arrowPanelSection"
-            >
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  Platform:
-                </span>
-                Macintosh
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  OS:
-                </span>
-                Intel Mac OS X 10.11
-              </div>
-              <div
-                class="metaInfoRow"
-              >
-                <span
-                  class="metaInfoLabel"
-                >
-                  ABI:
-                </span>
-                x86_64-gcc3
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
@@ -206,46 +72,6 @@ Array [
             >
               Upload Profile – Privacy Notice
             </h1>
-            <div
-              class="arrowPanelContent"
-            >
-              <section
-                class="privacyNotice"
-              >
-                <p>
-                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-                </p>
-                <ul>
-                  <li>
-                    The URLs of all painted tabs, and running scripts.
-                  </li>
-                  <li>
-                    The metadata of all your add-ons to identify slow add-ons.
-                  </li>
-                  <li>
-                    Firefox build and runtime configuration.
-                  </li>
-                </ul>
-                <p>
-                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
-                </p>
-                <p>
-                  By default, the URLs of all network requests will be removed while sharing the profile but keeping the URLs may help to identify the problems. Please select the checkbox below to share the URLs of the network requests:
-                </p>
-              </section>
-              <p
-                class="menuButtonsShareNetworkUrlsContainer"
-              >
-                <label>
-                  <input
-                    class="menuButtonsShareNetworkUrlsCheckbox"
-                    type="checkbox"
-                    value="on"
-                  />
-                  Share the URLs of all network requests
-                </label>
-              </p>
-            </div>
             <div
               class="arrowPanelButtons"
             >
@@ -290,11 +116,6 @@ Array [
           >
             Save Profile to a Local File
           </h1>
-          <div
-            class="arrowPanelContent"
-          >
-            <section />
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This is work to help solve a performance problem with the new sharing
panel I am working on, which expensively computes the profile size from
a selector.

Resolves #1851, and is part of the work of #1852.