### PR TITLE
Checked the value of marker.dur and called formatMilliseconds accordingly

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -861,7 +861,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
             <div className="tooltipTiming">
               {/* we don't know the duration if the marker is incomplete */}
               {!marker.incomplete
-                ? formatMilliseconds(marker.dur)
+                ? marker.dur ? formatMilliseconds(marker.dur) : '—'
                 : 'unknown duration'}
             </div>
             <div className="tooltipTitle">{marker.title || marker.name}</div>

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -13,7 +13,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: Bailout-10 
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -449,7 +449,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: GCMajor-16.
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -607,7 +607,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: GCMinor-15.
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -730,7 +730,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: GCSlice-17.
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -804,7 +804,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: Invalidate-
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -1132,7 +1132,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: Log-21.7 1`
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -1743,7 +1743,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: TTFI-21.4 1
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"
@@ -1789,7 +1789,7 @@ exports[`MarkerTooltipContents renders tooltips for various markers: UserTiming-
       <div
         class="tooltipTiming"
       >
-        0.000ms
+        —
       </div>
       <div
         class="tooltipTitle"


### PR DESCRIPTION
This PR solves issue : #1858 

Here is the screenshot of how it looks:

<img width="426" alt="Screenshot 2019-03-16 at 5 55 56 PM" src="https://user-images.githubusercontent.com/16744065/54475683-40802400-481a-11e9-8178-d2c13084afad.png">
