### PR TITLE
Handle 'profile.meta.updateChannel' field and display it in the meta panel

### DIFF
--- a/docs-developer/gecko-profile-format.md
+++ b/docs-developer/gecko-profile-format.md
@@ -58,6 +58,7 @@ The source data format is de-duplicated to make it quicker to transfer in the JS
     abi: "x86_64-gcc3",
     toolkit: "cocoa",
     product: "Firefox",
+    updateChannel: "nightly",
     extensions: {
       schema: {
         id: 0,

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -65,6 +65,12 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                     {_formatVersionNumber(meta.misc)}
                   </div>
                 ) : null}
+                {meta.updateChannel ? (
+                  <div className="metaInfoRow">
+                    <span className="metaInfoLabel">Update Channel:</span>
+                    {meta.updateChannel}
+                  </div>
+                ) : null}
                 {meta.appBuildID ? (
                   <div className="metaInfoRow">
                     <span className="metaInfoLabel">Build ID:</span>

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1055,6 +1055,7 @@ export function processProfile(
     // perf). If it's present and true, then we indicate that the process is
     // already symbolicated, otherwise we indicate it needs to be symbolicated.
     symbolicated: !!geckoProfile.meta.presymbolicated,
+    updateChannel: geckoProfile.meta.updateChannel,
   };
 
   const result = {

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -100,6 +100,16 @@ Array [
               <span
                 class="metaInfoLabel"
               >
+                Update Channel:
+              </span>
+              nightly
+            </div>
+            <div
+              class="metaInfoRow"
+            >
+              <span
+                class="metaInfoLabel"
+              >
                 Build ID:
               </span>
               20181126165837

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -88,6 +88,7 @@ export function createGeckoProfile(): GeckoProfile {
     logicalCPUs: 8,
     physicalCPUs: 4,
     sourceURL: '',
+    updateChannel: 'nightly',
     categories: [
       {
         name: 'Other',

--- a/src/test/unit/__snapshots__/profile-conversion.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.js.snap
@@ -3839,6 +3839,7 @@ Object {
     "startTime": 2574592839.818,
     "symbolicated": true,
     "toolkit": undefined,
+    "updateChannel": undefined,
     "version": 15,
   },
   "pages": Array [],

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -61,6 +61,7 @@ Object {
     "startTime": 2574592839.818,
     "symbolicated": true,
     "toolkit": undefined,
+    "updateChannel": undefined,
     "version": 15,
   },
   "pages": Array [],

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -206,6 +206,18 @@ export type GeckoProfileMeta = {|
   // (which indicates that they'll need to be symbolicated) but may be specified
   // for profiles imported from other formats (eg: linux perf).
   presymbolicated?: boolean,
+  // The Update channel for this build of the application.
+  // This property is landed in Firefox 67, and is optional because older
+  // Firefox versions may not have them. No upgrader was necessary.
+  updateChannel?:
+    | 'default' // Local builds
+    | 'nightly'
+    | 'nightly-try' // Nightly try builds for QA
+    | 'aurora' // Developer Edition channel
+    | 'beta'
+    | 'release'
+    | 'esr' // Extended Support Release channel
+    | string,
 |};
 
 export type GeckoProfile = {|

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -381,6 +381,18 @@ export type ProfileMeta = {|
   // "unknown" state.  For now we don't do much with it but we may want to
   // propose a manual symbolication in the future.
   symbolicated?: boolean,
+  // The Update channel for this build of the application.
+  // This property is landed in Firefox 67, and is optional because older
+  // processed profile versions may not have them. No upgrader was necessary.
+  updateChannel?:
+    | 'default' // Local builds
+    | 'nightly'
+    | 'nightly-try' // Nightly try builds for QA
+    | 'aurora' // Developer Edition channel
+    | 'beta'
+    | 'release'
+    | 'esr' // Extended Support Release channel
+    | string,
 |};
 
 /**


### PR DESCRIPTION
This field is landed in [Bug 1535575](https://bugzilla.mozilla.org/show_bug.cgi?id=1535575) and will be available shortly in nightly. This will also help us to figure out the default values of PII share checkboxes. (ie, should share by default for local and nightly builds but not in others.)