### PR TITLE
Fix rendering when pressing a marker in the timeline

### DIFF
--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -195,7 +195,8 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
   componentDidUpdate(prevProps: Props, prevState: State) {
     if (
       prevProps !== this.props ||
-      prevState.hoveredItem !== this.state.hoveredItem
+      prevState.hoveredItem !== this.state.hoveredItem ||
+      prevState.mouseDownItem !== this.state.mouseDownItem
     ) {
       this._scheduleDraw();
     }


### PR DESCRIPTION
STR:
1. click on a marker in the timeline.

=> notice its color doesn't change.