### PR TITLE
Rename `clone*` function names to `shallowClone*`

### DIFF
--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -68,7 +68,7 @@ export function getEmptyFrameTable(): FrameTable {
   };
 }
 
-export function cloneFrameTable(frameTable: FrameTable): FrameTable {
+export function shallowCloneFrameTable(frameTable: FrameTable): FrameTable {
   return {
     // Important!
     // If modifying this structure, please update all callers of this function to ensure
@@ -103,7 +103,7 @@ export function getEmptyFuncTable(): FuncTable {
   };
 }
 
-export function cloneFuncTable(funcTable: FuncTable): FuncTable {
+export function shallowCloneFuncTable(funcTable: FuncTable): FuncTable {
   return {
     // Important!
     // If modifying this structure, please update all callers of this function to ensure
@@ -148,7 +148,7 @@ export function getEmptyRawMarkerTable(): RawMarkerTable {
   };
 }
 
-export function cloneRawMarkerTable(
+export function shallowCloneRawMarkerTable(
   markerTable: RawMarkerTable
 ): RawMarkerTable {
   return {

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -11,7 +11,7 @@ import {
   getEmptyExtensions,
   getEmptyFuncTable,
   getEmptyResourceTable,
-  cloneRawMarkerTable,
+  shallowCloneRawMarkerTable,
 } from './data-structures';
 import { immutableUpdate } from '../utils/flow';
 import { removeURLs } from '../utils/string';
@@ -1188,7 +1188,7 @@ function sanitizeThreadPII(
   // current thread.
   // We need to update the stringTable. It's not possible with UniqueStringArray.
   const stringArray = thread.stringTable.serializeToArray();
-  let markerTable = cloneRawMarkerTable(thread.markers);
+  let markerTable = shallowCloneRawMarkerTable(thread.markers);
 
   // We iterate all the markers and remove/change data depending on the PII
   // status.

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -29,8 +29,8 @@ import type {
 } from '../types/profile-derived';
 import {
   getEmptyStackTable,
-  cloneFrameTable,
-  cloneFuncTable,
+  shallowCloneFrameTable,
+  shallowCloneFuncTable,
 } from './data-structures';
 import { assertExhaustiveCheck } from '../utils/flow';
 
@@ -774,8 +774,8 @@ export function collapsePlatformStackFrames(thread: Thread): Thread {
 
     // Create new tables for the data.
     const newStackTable = getEmptyStackTable();
-    const newFrameTable = cloneFrameTable(frameTable);
-    const newFuncTable = cloneFuncTable(funcTable);
+    const newFrameTable = shallowCloneFrameTable(frameTable);
+    const newFuncTable = shallowCloneFuncTable(funcTable);
 
     // Create a Map that takes a prefix and frame as input, and maps it to the new stack
     // index. Since Maps can't be keyed off of two values, do a little math to key off

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -15,8 +15,8 @@ import { timeCode } from '../utils/time-code';
 import { assertExhaustiveCheck, convertToTransformType } from '../utils/flow';
 import { CallTree } from '../profile-logic/call-tree';
 import {
-  cloneFrameTable,
-  cloneFuncTable,
+  shallowCloneFrameTable,
+  shallowCloneFuncTable,
   getEmptyStackTable,
 } from './data-structures';
 import { getFunctionName } from './function-info';
@@ -754,8 +754,8 @@ export function collapseResource(
 ): Thread {
   const { stackTable, funcTable, frameTable, resourceTable, samples } = thread;
   const resourceNameIndex = resourceTable.name[resourceIndexToCollapse];
-  const newFrameTable = cloneFrameTable(frameTable);
-  const newFuncTable = cloneFuncTable(funcTable);
+  const newFrameTable = shallowCloneFrameTable(frameTable);
+  const newFuncTable = shallowCloneFuncTable(funcTable);
   const newStackTable = getEmptyStackTable();
   const oldStackToNewStack: Map<
     IndexIntoStackTable | null,


### PR DESCRIPTION
As Greg mentioned in https://github.com/firefox-devtools/profiler/pull/1790#discussion_r267472788, they can easily be confused with deep cloning, so it's better to be more explicit.