### PR TITLE
Add a track to compute a diff of 2 profiles

### DIFF
--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -117,13 +117,18 @@ class CategoryBreakdown extends React.PureComponent<CategoryBreakdownProps> {
       .sort(({ value: valueA }, { value: valueB }) => valueB - valueA)
       .filter(({ value }) => value);
 
-    const totalTime = data.reduce((accum, { value }) => accum + value, 0);
+    // Values can be negative for diffing tracks, that's why we use the absolute
+    // value to compute the total time. Indeed even if all values average out,
+    // we want to display a sensible percentage.
+    const totalTime = data.reduce(
+      (accum, { value }) => accum + Math.abs(value),
+      0
+    );
     const maxFractionalDigits = isIntervalInteger ? 0 : 1;
 
     return (
       <div className="sidebar-categorylist">
         {data.map(({ category, value, subcategories }) => {
-          const percentage = Math.round((value / totalTime) * 100);
           return (
             <React.Fragment key={category.name}>
               <div className="sidebar-categoryname">
@@ -137,7 +142,7 @@ class CategoryBreakdown extends React.PureComponent<CategoryBreakdownProps> {
               </div>
               <div className="sidebar-categorytiming">
                 {formatMilliseconds(value, 3, maxFractionalDigits)} (
-                {percentage}%)
+                {formatPercent(value / totalTime)})
               </div>
               {shouldDisplaySubcategoryInfoForCategory(category)
                 ? subcategories.map(({ name, value }) => (
@@ -252,8 +257,13 @@ class CallTreeSidebar extends React.PureComponent<Props> {
           </header>
           <h3 className="sidebar-title2">This selected call node</h3>
           <SidebarDetail label="Running Time">
-            {formatMilliseconds(totalTime.value, 3, maxFractionalDigits)} (
-            {totalTimePercent}%)
+            {totalTime.value
+              ? `${formatMilliseconds(
+                  totalTime.value,
+                  3,
+                  maxFractionalDigits
+                )} (${totalTimePercent}%)`
+              : '—'}
           </SidebarDetail>
           <SidebarDetail label="Self Time">
             {selfTime.value
@@ -296,8 +306,13 @@ class CallTreeSidebar extends React.PureComponent<Props> {
             This function across the entire tree
           </h3>
           <SidebarDetail label="Running Time">
-            {formatMilliseconds(totalTimeForFunc.value, 3, maxFractionalDigits)}{' '}
-            ({totalTimeForFuncPercent}%)
+            {totalTimeForFunc.value
+              ? `${formatMilliseconds(
+                  totalTimeForFunc.value,
+                  3,
+                  maxFractionalDigits
+                )} (${totalTimeForFuncPercent}%)`
+              : '—'}
           </SidebarDetail>
           <SidebarDetail label="Self Time">
             {selfTimeForFunc.value

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -122,9 +122,15 @@ export class CallTree {
         children.length < childCount;
         childCallNodeIndex++
       ) {
+        const childPrefixIndex = this._callNodeTable.prefix[childCallNodeIndex];
+        const childTotalTime = this._callNodeTimes.totalTime[
+          childCallNodeIndex
+        ];
+        const childChildCount = this._callNodeChildCount[childCallNodeIndex];
+
         if (
-          this._callNodeTable.prefix[childCallNodeIndex] === callNodeIndex &&
-          this._callNodeTimes.totalTime[childCallNodeIndex] !== 0
+          childPrefixIndex === callNodeIndex &&
+          (childTotalTime !== 0 || childChildCount !== 0)
         ) {
           children.push(childCallNodeIndex);
         }
@@ -381,16 +387,21 @@ export function computeCallTreeCountsAndTimings(
   let rootCount = 0;
 
   // We loop the call node table in reverse, so that we find the children
-  // before their parents.
+  // before their parents, and the total time is known at the time we reach a
+  // node.
   for (
     let callNodeIndex = callNodeTable.length - 1;
     callNodeIndex >= 0;
     callNodeIndex--
   ) {
     callNodeTotalTime[callNodeIndex] += callNodeLeafTime[callNodeIndex];
-    if (callNodeTotalTime[callNodeIndex] === 0) {
+    const hasChildren = callNodeChildCount[callNodeIndex] !== 0;
+    const hasTotalTime = callNodeTotalTime[callNodeIndex] !== 0;
+
+    if (!hasChildren && !hasTotalTime) {
       continue;
     }
+
     const prefixCallNode = callNodeTable.prefix[callNodeIndex];
     if (prefixCallNode === -1) {
       rootTotalTime += callNodeTotalTime[callNodeIndex];

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -395,6 +395,7 @@ export function computeCallTreeCountsAndTimings(
     callNodeIndex--
   ) {
     callNodeTotalTime[callNodeIndex] += callNodeLeafTime[callNodeIndex];
+    rootTotalTime += Math.abs(callNodeLeafTime[callNodeIndex]);
     const hasChildren = callNodeChildCount[callNodeIndex] !== 0;
     const hasTotalTime = callNodeTotalTime[callNodeIndex] !== 0;
 
@@ -404,7 +405,6 @@ export function computeCallTreeCountsAndTimings(
 
     const prefixCallNode = callNodeTable.prefix[callNodeIndex];
     if (prefixCallNode === -1) {
-      rootTotalTime += callNodeTotalTime[callNodeIndex];
       rootCount++;
     } else {
       callNodeTotalTime[prefixCallNode] += callNodeTotalTime[callNodeIndex];

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -234,8 +234,8 @@ export class CallTree {
       );
 
       displayData = {
-        totalTime: formattedTotalTime,
-        totalTimeWithUnit: formattedTotalTime + 'ms',
+        totalTime: totalTime === 0 ? '—' : formattedTotalTime,
+        totalTimeWithUnit: totalTime === 0 ? '—' : formattedTotalTime + 'ms',
         selfTime: selfTime === 0 ? '—' : formattedSelfTime,
         selfTimeWithUnit: selfTime === 0 ? '—' : formattedSelfTime + 'ms',
         totalTimePercent: `${formatPercent(totalTimeRelative)}`,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -131,7 +131,8 @@ export class CallTree {
       }
       children.sort(
         (a, b) =>
-          this._callNodeTimes.totalTime[b] - this._callNodeTimes.totalTime[a]
+          Math.abs(this._callNodeTimes.totalTime[b]) -
+          Math.abs(this._callNodeTimes.totalTime[a])
       );
       this._children[callNodeIndex] = children;
     }

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -14,24 +14,53 @@ import {
   adjustSampleTimestamps,
   adjustMarkerTimestamps,
 } from './process-profile';
-import { getEmptyProfile } from './data-structures';
+import {
+  getEmptyProfile,
+  getEmptyResourceTable,
+  getEmptySamplesTable,
+  getEmptyFrameTable,
+  getEmptyFuncTable,
+  getEmptyStackTable,
+  getEmptyRawMarkerTable,
+} from './data-structures';
 import {
   filterThreadSamplesToRange,
   getTimeRangeForThread,
   getTimeRangeIncludingAllThreads,
 } from './profile-data';
 import { filterRawMarkerTableToRange } from './marker-data';
+import { UniqueStringArray } from '../utils/unique-string-array';
 
 import type {
   Profile,
   Thread,
   IndexIntoCategoryList,
   CategoryList,
+  IndexIntoFrameTable,
+  IndexIntoFuncTable,
+  IndexIntoResourceTable,
+  IndexIntoLibs,
+  IndexIntoStackTable,
+  IndexIntoSamplesTable,
+  FuncTable,
+  FrameTable,
+  Lib,
+  ResourceTable,
+  StackTable,
+  SamplesTable,
 } from '../types/profile';
 import type { UrlState } from '../types/state';
 import type { ImplementationFilter } from '../types/actions';
 import type { TransformStacksPerThread } from '../types/transforms';
 
+/**
+ * This function is the entry point for this file. From a list of profile
+ * sources and a list of states coming from URLs, it computes a new profile
+ * that's composed of parts of the 2 source profiles.
+ * It also computes a diffed profile as a last thread.
+ * It returns this merged profile along the transforms and implementation
+ * filters as decided by the source states.
+ */
 export function mergeProfiles(
   profiles: Profile[],
   profileStates: UrlState[]
@@ -40,6 +69,15 @@ export function mergeProfiles(
   transformStacks: TransformStacksPerThread,
   implementationFilters: ImplementationFilter[],
 |} {
+  if (profiles.length !== profileStates.length) {
+    throw new Error(
+      'Passed arrays do not have the same length. This should not happen.'
+    );
+  }
+  if (!profiles.length) {
+    throw new Error('There is no profiles to merge.');
+  }
+
   const resultProfile = getEmptyProfile();
   resultProfile.meta.interval = Math.min(
     ...profiles.map(profile => profile.meta.interval)
@@ -146,9 +184,22 @@ export function mergeProfiles(
     resultProfile.threads.push(thread);
   }
 
+  if (resultProfile.threads.length === 2) {
+    resultProfile.threads.push(
+      getComparisonThread(
+        translationMapsForCategories,
+        ...resultProfile.threads
+      )
+    );
+  }
+
   return { profile: resultProfile, implementationFilters, transformStacks };
 }
 
+/**
+ * This is a small utility function that makes it easier to filter a thread
+ * completely (both markers and samples).
+ */
 function filterThreadToRange(
   thread: Thread,
   rangeStart: number,
@@ -166,6 +217,18 @@ function filterThreadToRange(
 type TranslationMapForCategories = Map<
   IndexIntoCategoryList,
   IndexIntoCategoryList
+>;
+type TranslationMapForFuncs = Map<IndexIntoFuncTable, IndexIntoFuncTable>;
+type TranslationMapForResources = Map<
+  IndexIntoResourceTable,
+  IndexIntoResourceTable
+>;
+type TranslationMapForFrames = Map<IndexIntoFrameTable, IndexIntoFrameTable>;
+type TranslationMapForStacks = Map<IndexIntoStackTable, IndexIntoStackTable>;
+type TranslationMapForLibs = Map<IndexIntoLibs, IndexIntoLibs>;
+type TranslationMapForSamples = Map<
+  IndexIntoSamplesTable,
+  IndexIntoSamplesTable
 >;
 
 /**
@@ -252,4 +315,499 @@ function adjustNullableCategories(
     }
     return result;
   });
+}
+
+/**
+ * This combines the library tables for a list of threads. It returns a merged
+ * Lib array, along with a translation maps that can be used in other functions
+ * when merging lib references in other tables.
+ */
+function combineLibTables(
+  ...threads: Thread[]
+): { libs: Lib[], translationMaps: TranslationMapForLibs[] } {
+  const mapOfInsertedLibs: Map<string, IndexIntoLibs> = new Map();
+
+  const translationMaps = [];
+  const newLibTable = [];
+
+  threads.forEach(thread => {
+    const translationMap = new Map();
+    const { libs } = thread;
+
+    libs.forEach((lib, i) => {
+      const insertedLibKey = [lib.name, lib.debugName].join('#');
+      const insertedLibIndex = mapOfInsertedLibs.get(insertedLibKey);
+      if (insertedLibIndex !== undefined) {
+        translationMap.set(i, insertedLibIndex);
+        return;
+      }
+
+      translationMap.set(i, newLibTable.length);
+      mapOfInsertedLibs.set(insertedLibKey, newLibTable.length);
+
+      newLibTable.push({
+        start: lib.start,
+        end: lib.end,
+        offset: lib.offset,
+        arch: lib.arch,
+        name: lib.name,
+        path: lib.path,
+        debugName: lib.debugName,
+        debugPath: lib.debugPath,
+        breakpadId: lib.breakpadId,
+      });
+    });
+
+    translationMaps.push(translationMap);
+  });
+
+  return { libs: newLibTable, translationMaps };
+}
+
+/**
+ * This combines the resource tables for a list of threads. It returns the new
+ * resource table with the translation maps to be used in subsequent merging
+ * functions.
+ */
+function combineResourceTables(
+  translationMapsForLibs: TranslationMapForLibs[],
+  newStringTable: UniqueStringArray,
+  ...threads: Thread[]
+): {
+  resourceTable: ResourceTable,
+  translationMaps: TranslationMapForResources[],
+} {
+  const mapOfInsertedResources: Map<string, IndexIntoResourceTable> = new Map();
+  const translationMaps = [];
+  const newResourceTable = getEmptyResourceTable();
+
+  threads.forEach((thread, threadIndex) => {
+    const translationMap = new Map();
+    const { resourceTable, stringTable } = thread;
+    const libTranslationMap = translationMapsForLibs[threadIndex];
+
+    for (let i = 0; i < resourceTable.length; i++) {
+      const libIndex = resourceTable.lib[i];
+      const newLibIndex =
+        typeof libIndex === 'number' && libIndex >= 0
+          ? libTranslationMap.get(libIndex)
+          : null;
+      if (newLibIndex === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the lib of resource ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+
+      const nameIndex = resourceTable.name[i];
+      const newName = nameIndex >= 0 ? stringTable.getString(nameIndex) : null;
+
+      const hostIndex = resourceTable.host[i];
+      const newHost =
+        typeof hostIndex === 'number' && hostIndex >= 0
+          ? stringTable.getString(hostIndex)
+          : undefined;
+
+      const type = resourceTable.type[i];
+
+      // Duplicate search.
+      const resourceKey = [newLibIndex, newName || '', type].join('#');
+      const insertedResourceIndex = mapOfInsertedResources.get(resourceKey);
+      if (insertedResourceIndex !== undefined) {
+        translationMap.set(i, insertedResourceIndex);
+        continue;
+      }
+
+      translationMap.set(i, newResourceTable.length);
+      mapOfInsertedResources.set(resourceKey, newResourceTable.length);
+
+      newResourceTable.lib.push(newLibIndex);
+      newResourceTable.name.push(
+        newName === null ? -1 : newStringTable.indexForString(newName)
+      );
+      newResourceTable.host.push(
+        newHost === undefined
+          ? undefined
+          : newStringTable.indexForString(newHost)
+      );
+      newResourceTable.type.push(type);
+
+      newResourceTable.length++;
+    }
+
+    translationMaps.push(translationMap);
+  });
+
+  return { resourceTable: newResourceTable, translationMaps };
+}
+
+/**
+ * This combines the function tables for a list of threads. It returns the new
+ * function table with the translation maps to be used in subsequent merging
+ * functions.
+ */
+function combineFuncTables(
+  translationMapsForResources: TranslationMapForResources[],
+  newStringTable: UniqueStringArray,
+  ...threads: Thread[]
+): { funcTable: FuncTable, translationMaps: TranslationMapForFuncs[] } {
+  const mapOfInsertedFuncs: Map<string, IndexIntoFuncTable> = new Map();
+  const translationMaps = [];
+  const newFuncTable = getEmptyFuncTable();
+
+  threads.forEach((thread, threadIndex) => {
+    const { funcTable, stringTable } = thread;
+    const translationMap = new Map();
+    const resourceTranslationMap = translationMapsForResources[threadIndex];
+
+    for (let i = 0; i < funcTable.length; i++) {
+      const fileNameIndex = funcTable.fileName[i];
+      const fileName =
+        typeof fileNameIndex === 'number'
+          ? stringTable.getString(fileNameIndex)
+          : null;
+      const resourceIndex = funcTable.resource[i];
+      const newResourceIndex =
+        resourceIndex >= 0
+          ? resourceTranslationMap.get(funcTable.resource[i])
+          : -1;
+      if (newResourceIndex === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the resource of func ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+      const name = stringTable.getString(funcTable.name[i]);
+
+      const funcKey = [name, newResourceIndex].join('#');
+      const insertedFuncIndex = mapOfInsertedFuncs.get(funcKey);
+      if (insertedFuncIndex !== undefined) {
+        translationMap.set(i, insertedFuncIndex);
+        continue;
+      }
+      mapOfInsertedFuncs.set(funcKey, newFuncTable.length);
+      translationMap.set(i, newFuncTable.length);
+
+      newFuncTable.address.push(funcTable.address[i]);
+      newFuncTable.isJS.push(funcTable.isJS[i]);
+      newFuncTable.name.push(newStringTable.indexForString(name));
+      newFuncTable.resource.push(newResourceIndex);
+      newFuncTable.relevantForJS.push(funcTable.relevantForJS[i]);
+      newFuncTable.fileName.push(
+        fileName === null ? null : newStringTable.indexForString(fileName)
+      );
+      newFuncTable.lineNumber.push(funcTable.lineNumber[i]);
+      newFuncTable.columnNumber.push(funcTable.columnNumber[i]);
+
+      newFuncTable.length++;
+    }
+
+    translationMaps.push(translationMap);
+  });
+
+  return { funcTable: newFuncTable, translationMaps };
+}
+
+/**
+ * This combines the frame tables for a list of threads. It returns the new
+ * frame table with the translation maps to be used in subsequent merging
+ * functions.
+ */
+function combineFrameTables(
+  translationMapsForCategories: TranslationMapForCategories[],
+  translationMapsForFuncs: TranslationMapForFuncs[],
+  newStringTable: UniqueStringArray,
+  ...threads: Thread[]
+): { frameTable: FrameTable, translationMaps: TranslationMapForFrames[] } {
+  const translationMaps = [];
+  const newFrameTable = getEmptyFrameTable();
+
+  threads.forEach((thread, threadIndex) => {
+    const { frameTable, stringTable } = thread;
+    const translationMap = new Map();
+    const funcTranslationMap = translationMapsForFuncs[threadIndex];
+    const categoryTranslationMap = translationMapsForCategories[threadIndex];
+
+    for (let i = 0; i < frameTable.length; i++) {
+      const addressIndex = frameTable.address[i];
+      const address =
+        typeof addressIndex === 'number' && addressIndex >= 0
+          ? stringTable.getString(addressIndex)
+          : null;
+      const category = frameTable.category[i];
+      const newCategory =
+        category === null ? null : categoryTranslationMap.get(category);
+      if (newCategory === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the category of frame ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+
+      const newFunc = funcTranslationMap.get(frameTable.func[i]);
+      if (newFunc === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the function of frame ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+
+      const implementationIndex = frameTable.implementation[i];
+      const implementation =
+        typeof implementationIndex === 'number'
+          ? stringTable.getString(implementationIndex)
+          : null;
+
+      newFrameTable.address.push(
+        address === null ? -1 : newStringTable.indexForString(address)
+      );
+      newFrameTable.category.push(newCategory);
+      newFrameTable.func.push(newFunc);
+      newFrameTable.implementation.push(
+        implementation === null
+          ? null
+          : newStringTable.indexForString(implementation)
+      );
+      newFrameTable.line.push(frameTable.line[i]);
+      newFrameTable.column.push(frameTable.column[i]);
+      newFrameTable.optimizations.push(frameTable.optimizations[i]);
+
+      translationMap.set(i, newFrameTable.length);
+      newFrameTable.length++;
+    }
+
+    translationMaps.push(translationMap);
+  });
+
+  return { frameTable: newFrameTable, translationMaps };
+}
+
+/**
+ * This combines the stack tables for a list of threads. It returns the new
+ * stack table with the translation maps to be used in subsequent merging
+ * functions.
+ */
+function combineStackTables(
+  translationMapsForCategories: TranslationMapForCategories[],
+  translationMapsForFrames: TranslationMapForFrames[],
+  ...threads: Thread[]
+): { stackTable: StackTable, translationMaps: TranslationMapForStacks[] } {
+  const translationMaps = [];
+  const newStackTable = getEmptyStackTable();
+
+  threads.forEach((thread, threadIndex) => {
+    const { stackTable } = thread;
+    const translationMap = new Map();
+    const frameTranslationMap = translationMapsForFrames[threadIndex];
+    const categoryTranslationMap = translationMapsForCategories[threadIndex];
+
+    for (let i = 0; i < stackTable.length; i++) {
+      const newFrameIndex = frameTranslationMap.get(stackTable.frame[i]);
+      if (newFrameIndex === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the frame of stack ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+      const newCategory = categoryTranslationMap.get(stackTable.category[i]);
+      if (newCategory === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the category of stack ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+
+      const prefix = stackTable.prefix[i];
+      const newPrefix = prefix === null ? null : translationMap.get(prefix);
+      if (newPrefix === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the prefix of stack ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+
+      newStackTable.frame.push(newFrameIndex);
+      newStackTable.category.push(newCategory);
+      newStackTable.prefix.push(newPrefix);
+
+      translationMap.set(i, newStackTable.length);
+      newStackTable.length++;
+    }
+
+    translationMaps.push(translationMap);
+  });
+
+  return { stackTable: newStackTable, translationMaps };
+}
+
+/**
+ * This combines the sample tables for 2 threads. The samples for the first
+ * thread are added in a negative way while the samples for the second thread
+ * are added in a positive way, so that they will be diffed when computing the
+ * call tree and the various other timings in the app.
+ * It returns the new sample table with the translation maps to be used in
+ * subsequent merging functions, if necessary.
+ */
+function combineSamplesDiffing(
+  translationMapsForStacks: TranslationMapForStacks[],
+  { samples: samples1 }: Thread,
+  { samples: samples2 }: Thread
+): { samples: SamplesTable, translationMaps: TranslationMapForSamples[] } {
+  const translationMaps = [new Map(), new Map()];
+  const newSamples = getEmptySamplesTable();
+
+  let i = 0;
+  let j = 0;
+  while (i < samples1.length || j < samples2.length) {
+    // We take the next sample from thread 1 if:
+    // - We still have samples in thread 1 AND
+    // - EITHER:
+    //   + there's no samples left in thread 2
+    //   + looking at the next samples for each thread, the earliest is from thread 1.
+    // Otherwise we take the next samples from thread 2 until we run out of samples.
+    const nextSampleIsFromThread1 =
+      i < samples1.length &&
+      (j >= samples2.length || samples1.time[i] < samples2.time[j]);
+
+    if (nextSampleIsFromThread1) {
+      // Next sample is from thread 1.
+      const stackIndex = samples1.stack[i];
+      const newStackIndex =
+        stackIndex === null
+          ? null
+          : translationMapsForStacks[0].get(stackIndex);
+      if (newStackIndex === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the stack of sample ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+      newSamples.stack.push(newStackIndex);
+      newSamples.responsiveness.push(samples1.responsiveness[i]);
+      newSamples.time.push(samples1.time[i]);
+      // We add the first thread with a negative duration, because this is the
+      // base profile.
+      newSamples.duration.push(-samples1.duration[i]);
+
+      translationMaps[0].set(i, newSamples.length);
+      newSamples.length++;
+      i++;
+    } else {
+      // Next sample is from thread 2.
+      const stackIndex = samples2.stack[j];
+      const newStackIndex =
+        stackIndex === null
+          ? null
+          : translationMapsForStacks[1].get(stackIndex);
+      if (newStackIndex === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the stack of sample ${j} in the translation map.
+          This is a programming error.
+        `);
+      }
+      newSamples.stack.push(newStackIndex);
+      newSamples.responsiveness.push(samples2.responsiveness[j]);
+      newSamples.time.push(samples2.time[j]);
+      newSamples.duration.push(samples2.duration[j]);
+
+      translationMaps[1].set(j, newSamples.length);
+      newSamples.length++;
+      j++;
+    }
+  }
+
+  return {
+    samples: newSamples,
+    translationMaps,
+  };
+}
+
+/**
+ * This function will compute a diffing thread from 2 different threads, using
+ * all the previous functions.
+ */
+function getComparisonThread(
+  translationMapsForCategories: TranslationMapForCategories[],
+  thread1: Thread,
+  thread2: Thread
+): Thread {
+  const newStringTable = new UniqueStringArray();
+
+  const {
+    libs: newLibTable,
+    translationMaps: translationMapsForLibs,
+  } = combineLibTables(thread1, thread2);
+  const {
+    resourceTable: newResourceTable,
+    translationMaps: translationMapsForResources,
+  } = combineResourceTables(
+    translationMapsForLibs,
+    newStringTable,
+    thread1,
+    thread2
+  );
+  const {
+    funcTable: newFuncTable,
+    translationMaps: translationMapsForFuncs,
+  } = combineFuncTables(
+    translationMapsForResources,
+    newStringTable,
+    thread1,
+    thread2
+  );
+  const {
+    frameTable: newFrameTable,
+    translationMaps: translationMapsForFrames,
+  } = combineFrameTables(
+    translationMapsForCategories,
+    translationMapsForFuncs,
+    newStringTable,
+    thread1,
+    thread2
+  );
+  const {
+    stackTable: newStackTable,
+    translationMaps: translationMapsForStacks,
+  } = combineStackTables(
+    translationMapsForCategories,
+    translationMapsForFrames,
+    thread1,
+    thread2
+  );
+  const { samples: newSamples } = combineSamplesDiffing(
+    translationMapsForStacks,
+    thread1,
+    thread2
+  );
+
+  const mergedThread = {
+    processType: 'comparison',
+    processStartupTime: Math.min(
+      thread1.processStartupTime,
+      thread2.processStartupTime
+    ),
+    processShutdownTime:
+      Math.max(
+        thread1.processShutdownTime || 0,
+        thread2.processShutdownTime || 0
+      ) || null,
+    registerTime: Math.min(thread1.registerTime, thread2.registerTime),
+    unregisterTime:
+      Math.max(thread1.unregisterTime || 0, thread2.unregisterTime || 0) ||
+      null,
+    pausedRanges: [],
+    name: 'Diff between 1 and 2',
+    pid: 'Diff between 1 and 2',
+    tid: undefined,
+    samples: newSamples,
+    markers: getEmptyRawMarkerTable(),
+    stackTable: newStackTable,
+    frameTable: newFrameTable,
+    stringTable: newStringTable,
+    libs: newLibTable,
+    funcTable: newFuncTable,
+    resourceTable: newResourceTable,
+  };
+
+  return mergedThread;
 }

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -539,11 +539,6 @@ function combineFrameTables(
     const categoryTranslationMap = translationMapsForCategories[threadIndex];
 
     for (let i = 0; i < frameTable.length; i++) {
-      const addressIndex = frameTable.address[i];
-      const address =
-        typeof addressIndex === 'number' && addressIndex >= 0
-          ? stringTable.getString(addressIndex)
-          : null;
       const category = frameTable.category[i];
       const newCategory =
         category === null ? null : categoryTranslationMap.get(category);
@@ -568,9 +563,7 @@ function combineFrameTables(
           ? stringTable.getString(implementationIndex)
           : null;
 
-      newFrameTable.address.push(
-        address === null ? -1 : newStringTable.indexForString(address)
-      );
+      newFrameTable.address.push(frameTable.address[i]);
       newFrameTable.category.push(newCategory);
       newFrameTable.func.push(newFunc);
       newFrameTable.implementation.push(

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -477,8 +477,17 @@ function combineFuncTables(
         `);
       }
       const name = stringTable.getString(funcTable.name[i]);
+      const lineNumber = funcTable.lineNumber[i];
 
-      const funcKey = [name, newResourceIndex].join('#');
+      // Entries in this table can be either:
+      // 1. native: in that case they'll have a resource index and a name. The
+      //    name should be unique in a specific resource.
+      // 2. JS: they'll have a resource index and a name too, but the name is
+      //    not garanteed to be unique in a resource. That's why we use the line
+      //    number as well.
+      // 3. Label frames: they have no resource, only a name. So we can't do
+      //    better than this.
+      const funcKey = [name, newResourceIndex, lineNumber].join('#');
       const insertedFuncIndex = mapOfInsertedFuncs.get(funcKey);
       if (insertedFuncIndex !== undefined) {
         translationMap.set(i, insertedFuncIndex);
@@ -495,7 +504,7 @@ function combineFuncTables(
       newFuncTable.fileName.push(
         fileName === null ? null : newStringTable.indexForString(fileName)
       );
-      newFuncTable.lineNumber.push(funcTable.lineNumber[i]);
+      newFuncTable.lineNumber.push(lineNumber);
       newFuncTable.columnNumber.push(funcTable.columnNumber[i]);
 
       newFuncTable.length++;
@@ -511,6 +520,8 @@ function combineFuncTables(
  * This combines the frame tables for a list of threads. It returns the new
  * frame table with the translation maps to be used in subsequent merging
  * functions.
+ * Note that we don't try to merge the frames of the source threads, because
+ * that's not needed to get a diffing call tree.
  */
 function combineFrameTables(
   translationMapsForCategories: TranslationMapForCategories[],
@@ -585,6 +596,8 @@ function combineFrameTables(
  * This combines the stack tables for a list of threads. It returns the new
  * stack table with the translation maps to be used in subsequent merging
  * functions.
+ * Note that we don't try to merge the stacks of the source threads, because
+ * that's not needed to get a diffing call tree.
  */
 function combineStackTables(
   translationMapsForCategories: TranslationMapForCategories[],

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -121,7 +121,7 @@ export function mergeProfiles(
     implementationFilters.push(profileSpecific.implementation);
 
     // We adjust the categories using the maps computed above.
-    // TODO: Also adjust subcategories.
+    // TODO issue #2151: Also adjust subcategories.
     thread.stackTable.category = adjustCategories(
       thread.stackTable.category,
       translationMapsForCategories[i]
@@ -268,8 +268,8 @@ function mergeCategories(
       } else {
         // We're assuming that newCategories[newCategoryIndex].subcategories
         // is the same list of strings as category.subcategories.
-        // TODO: merge the subcategories too, and make a translationMap for
-        // those (per category), too.
+        // TODO issue #2151: merge the subcategories too, and make a
+        // translationMap for those (per category), too.
       }
       translationMap.set(i, newCategoryIndex);
     });
@@ -565,9 +565,9 @@ function combineFrameTables(
 
       newFrameTable.address.push(frameTable.address[i]);
       newFrameTable.category.push(newCategory);
-      // TODO we assume that subcategory strings are the same if the category is
-      // the same, and have no translation maps. But we should really implement
-      // one.
+      // TODO issue #2151: we assume that subcategory strings are the same if
+      // the category is the same, and have no translation maps. But we should
+      // really implement one.
       newFrameTable.subcategory.push(frameTable.subcategory[i]);
       newFrameTable.func.push(newFunc);
       newFrameTable.implementation.push(
@@ -637,9 +637,9 @@ function combineStackTables(
 
       newStackTable.frame.push(newFrameIndex);
       newStackTable.category.push(newCategory);
-      // TODO we assume that subcategory strings are the same if the category is
-      // the same, and have no translation maps. But we should really implement
-      // one.
+      // TODO issue #2151: we assume that subcategory strings are the same if
+      // the category is the same, and have no translation maps. But we should
+      // really implement one.
       newStackTable.subcategory.push(stackTable.subcategory[i]);
       newStackTable.prefix.push(newPrefix);
 

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -565,6 +565,10 @@ function combineFrameTables(
 
       newFrameTable.address.push(frameTable.address[i]);
       newFrameTable.category.push(newCategory);
+      // TODO we assume that subcategory strings are the same if the category is
+      // the same, and have no translation maps. But we should really implement
+      // one.
+      newFrameTable.subcategory.push(frameTable.subcategory[i]);
       newFrameTable.func.push(newFunc);
       newFrameTable.implementation.push(
         implementation === null
@@ -633,6 +637,10 @@ function combineStackTables(
 
       newStackTable.frame.push(newFrameIndex);
       newStackTable.category.push(newCategory);
+      // TODO we assume that subcategory strings are the same if the category is
+      // the same, and have no translation maps. But we should really implement
+      // one.
+      newStackTable.subcategory.push(stackTable.subcategory[i]);
       newStackTable.prefix.push(newPrefix);
 
       translationMap.set(i, newStackTable.length);

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -468,7 +468,7 @@ export function getTimingsForCallNodeIndex(
       ? samples.duration[sampleIndex]
       : interval;
 
-    rootTime += duration;
+    rootTime += Math.abs(duration);
 
     const thisNodeIndex = stackIndexToCallNodeIndex[thisStackIndex];
     const thisFunc = callNodeTable.func[thisNodeIndex];

--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -43,9 +43,16 @@ export function getComposedSelectorsPerThread(
    * when it's absurd.
    */
   const getUsefulTabs: Selector<$ReadOnlyArray<TabSlug>> = createSelector(
+    threadSelectors.getThread,
     threadSelectors.getIsNetworkChartEmptyInFullRange,
     threadSelectors.getJsTracerTable,
-    (isNetworkChartEmpty, jsTracerTable) => {
+    ({ processType }, isNetworkChartEmpty, jsTracerTable) => {
+      if (processType === 'comparison') {
+        // For a diffing tracks, we display only the calltree tab for now, because
+        // other views make no or not much sense.
+        return ['calltree'];
+      }
+
       let visibleTabs = tabSlugs;
       if (isNetworkChartEmpty) {
         visibleTabs = visibleTabs.filter(

--- a/src/test/components/__snapshots__/CallTreeSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/CallTreeSidebar.test.js.snap
@@ -44,10 +44,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -82,8 +79,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         2ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -119,11 +116,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       
-      (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -195,10 +188,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      1ms
-       (
-      25
-      %)
+      1ms (25%)
     </div>
     <div
       class="sidebar-label"
@@ -233,8 +223,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -270,11 +260,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      1ms
-       
-      (
-      25
-      %)
+      1ms (25%)
     </div>
     <div
       class="sidebar-label"
@@ -346,10 +332,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -384,8 +367,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        50
-        %)
+        50%
+        )
       </div>
       <div
         class="sidebar-categoryname"
@@ -401,8 +384,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        50
-        %)
+        50%
+        )
       </div>
     </div>
     <h4
@@ -457,11 +440,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       
-      (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -552,10 +531,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      1ms
-       (
-      25
-      %)
+      1ms (25%)
     </div>
     <div
       class="sidebar-label"
@@ -590,8 +566,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -646,11 +622,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       
-      (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -749,10 +721,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -787,8 +756,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         2ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -824,11 +793,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       
-      (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -919,10 +884,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      1ms
-       (
-      25
-      %)
+      1ms (25%)
     </div>
     <div
       class="sidebar-label"
@@ -957,8 +919,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -994,11 +956,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       
-      (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -1089,10 +1047,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      1ms
-       (
-      25
-      %)
+      1ms (25%)
     </div>
     <div
       class="sidebar-label"
@@ -1127,8 +1082,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -1164,11 +1119,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      2ms
-       
-      (
-      50
-      %)
+      2ms (50%)
     </div>
     <div
       class="sidebar-label"
@@ -1259,10 +1210,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      1ms
-       (
-      25
-      %)
+      1ms (25%)
     </div>
     <div
       class="sidebar-label"
@@ -1297,8 +1245,8 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       >
         1ms
          (
-        100
-        %)
+        100%
+        )
       </div>
     </div>
     <h4
@@ -1334,11 +1282,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
     <div
       class="sidebar-value"
     >
-      4ms
-       
-      (
-      100
-      %)
+      4ms (100%)
     </div>
     <div
       class="sidebar-label"

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -9,6 +9,8 @@ import {
   getEmptyJsTracerTable,
   resourceTypes,
 } from '../../../profile-logic/data-structures';
+import { mergeProfiles } from '../../../profile-logic/comparison';
+import { stateFromLocation } from '../../../app-logic/url-handling';
 import { UniqueStringArray } from '../../../utils/unique-string-array';
 
 import type {
@@ -529,6 +531,22 @@ function _buildThreadFromTextOnlyStacks(
     samples.time.push(columnIndex);
   });
   return thread;
+}
+
+/**
+ * This returns a merged profile from a number of profile strings.
+ */
+export function getMergedProfileFromTextSamples(...profileStrings: string[]) {
+  const profiles = profileStrings.map(
+    str => getProfileFromTextSamples(str).profile
+  );
+  const profileState = stateFromLocation({
+    pathname: '/public/fakehash1/',
+    search: '?thread=0&v=3',
+    hash: '',
+  });
+  const { profile } = mergeProfiles(profiles, profiles.map(() => profileState));
+  return profile;
 }
 
 type NetworkMarkersOptions = {|

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -536,17 +536,32 @@ function _buildThreadFromTextOnlyStacks(
 /**
  * This returns a merged profile from a number of profile strings.
  */
-export function getMergedProfileFromTextSamples(...profileStrings: string[]) {
-  const profiles = profileStrings.map(
-    str => getProfileFromTextSamples(str).profile
+export function getMergedProfileFromTextSamples(
+  ...profileStrings: string[]
+): {
+  profile: Profile,
+  funcNamesPerThread: Array<string[]>,
+  funcNamesDictPerThread: Array<{ [funcName: string]: number }>,
+} {
+  const profilesAndFuncNames = profileStrings.map(str =>
+    getProfileFromTextSamples(str)
   );
+  const profiles = profilesAndFuncNames.map(({ profile }) => profile);
   const profileState = stateFromLocation({
     pathname: '/public/fakehash1/',
     search: '?thread=0&v=3',
     hash: '',
   });
   const { profile } = mergeProfiles(profiles, profiles.map(() => profileState));
-  return profile;
+  return {
+    profile,
+    funcNamesPerThread: profilesAndFuncNames.map(
+      ({ funcNamesPerThread }) => funcNamesPerThread[0]
+    ),
+    funcNamesDictPerThread: profilesAndFuncNames.map(
+      ({ funcNamesDictPerThread }) => funcNamesDictPerThread[0]
+    ),
+  };
 }
 
 type NetworkMarkersOptions = {|

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -8,6 +8,7 @@ import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import {
   getProfileFromTextSamples,
+  getMergedProfileFromTextSamples,
   getProfileWithMarkers,
   getNetworkTrackProfile,
   getScreenshotTrackProfile,
@@ -437,6 +438,30 @@ describe('actions/ProfileView', function() {
           'calltree'
         );
         dispatch(ProfileView.selectTrack(memoryTrackReference));
+        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
+          'calltree'
+        );
+      });
+    });
+
+    describe('with a comparison profile', function() {
+      it('selects the calltree tab when selecting the diffing track', function() {
+        const diffingTrackReference = {
+          type: 'global',
+          trackIndex: 2,
+        };
+
+        const profile = getMergedProfileFromTextSamples('A  B  C', 'A  B  B');
+        const { getState, dispatch } = storeWithProfile(profile);
+
+        dispatch(App.changeSelectedTab('flame-graph'));
+        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
+          'flame-graph'
+        );
+
+        dispatch(ProfileView.selectTrack(diffingTrackReference));
+        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(2);
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'calltree'
         );

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -451,7 +451,10 @@ describe('actions/ProfileView', function() {
           trackIndex: 2,
         };
 
-        const profile = getMergedProfileFromTextSamples('A  B  C', 'A  B  B');
+        const { profile } = getMergedProfileFromTextSamples(
+          'A  B  C',
+          'A  B  B'
+        );
         const { getState, dispatch } = storeWithProfile(profile);
 
         dispatch(App.changeSelectedTab('flame-graph'));

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1229,8 +1229,17 @@ describe('actions/receive-profile', function() {
           unregisterTime: thread.samples.length,
         })
       );
+
+      // comparison thread
+      expectedThreads.push(
+        expect.objectContaining({
+          processType: 'comparison',
+          pid: 'Diff between 1 and 2',
+          name: 'Diff between 1 and 2',
+        })
+      );
       expect(resultProfile.threads).toEqual(expectedThreads);
-      expect(globalTracks).toHaveLength(2);
+      expect(globalTracks).toHaveLength(3); // each thread + comparison track
       expect(rootRange).toEqual({ start: 0, end: 9 });
     });
 
@@ -1243,7 +1252,7 @@ describe('actions/receive-profile', function() {
       } = await setupWithShortUrl('thread=0', 'thread=1');
 
       // Reuse some expectations from the previous test
-      expect(globalTracks).toHaveLength(2);
+      expect(globalTracks).toHaveLength(3); // each thread + comparison track
       expect(rootRange).toEqual({ start: 0, end: 9 });
 
       // Check that expandUrl has been called

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -11,6 +11,7 @@ import {
   getProfileWithMarkers,
   getNetworkMarkers,
   getProfileWithJsTracerEvents,
+  getMergedProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
 
 describe('getUsefulTabs', function() {
@@ -49,6 +50,27 @@ describe('getUsefulTabs', function() {
       'marker-chart',
       'marker-table',
       'js-tracer',
+    ]);
+  });
+
+  it('shows only the call tree when a diffing track is selected', function() {
+    const profile = getMergedProfileFromTextSamples('A  B  C', 'A  B  B');
+    const { getState, dispatch } = storeWithProfile(profile);
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'calltree',
+      'flame-graph',
+      'stack-chart',
+      'marker-chart',
+      'marker-table',
+    ]);
+
+    dispatch({
+      type: 'SELECT_TRACK',
+      selectedThreadIndex: 2,
+      selectedTab: 'calltree',
+    });
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'calltree',
     ]);
   });
 });

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -54,7 +54,7 @@ describe('getUsefulTabs', function() {
   });
 
   it('shows only the call tree when a diffing track is selected', function() {
-    const profile = getMergedProfileFromTextSamples('A  B  C', 'A  B  B');
+    const { profile } = getMergedProfileFromTextSamples('A  B  C', 'A  B  B');
     const { getState, dispatch } = storeWithProfile(profile);
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -36,6 +36,7 @@ import { ensureExists } from '../../utils/flow';
 import getCallNodeProfile from '../fixtures/profiles/call-nodes';
 import {
   getProfileFromTextSamples,
+  getMergedProfileFromTextSamples,
   getJsTracerTable,
 } from '../fixtures/profiles/processed-profile';
 import { funcHasRecursiveCall } from '../../profile-logic/transforms';
@@ -1172,6 +1173,70 @@ describe('getTimingsForPath for an inverted tree', function() {
         },
       },
       rootTime: 5,
+    });
+  });
+});
+
+describe('getTimingsForPath for a diffing track', function() {
+  function setup() {
+    const { profile, funcNamesDictPerThread } = getMergedProfileFromTextSamples(
+      `
+      A              A  A
+      B              B  C
+      D[cat:Layout]  E  F
+    `,
+      `
+      A                  A  A
+      B                  B  B
+      G[cat:JavaScript]  I  E
+    `
+    );
+    const defaultCategory = profile.meta.categories.findIndex(
+      c => c.name === 'Other'
+    );
+    const thread = profile.threads[2];
+
+    const callNodeInfo = getCallNodeInfo(
+      thread.stackTable,
+      thread.frameTable,
+      thread.funcTable,
+      defaultCategory
+    );
+    const curriedGetTimingsForPath = path =>
+      getTimingsForPath(
+        path,
+        callNodeInfo,
+        profile.meta.interval,
+        false /* inverted tree */,
+        thread,
+        profile.meta.categories
+      );
+
+    return {
+      getTimingsForPath: curriedGetTimingsForPath,
+      funcNamesDictPerThread,
+    };
+  }
+
+  it('computes the right breakdowns', () => {
+    const {
+      getTimingsForPath,
+      funcNamesDictPerThread: [{ A }],
+    } = setup();
+    const timings = getTimingsForPath([A]);
+    expect(timings.forPath).toEqual({
+      selfTime: {
+        breakdownByCategory: null,
+        breakdownByImplementation: null,
+        value: 0,
+      },
+      totalTime: {
+        breakdownByCategory: withSingleSubcategory([0, 0, -1, 1, 0, 0, 0, 0]), // Idle, Other, Layout, JavaScript, etc.
+        breakdownByImplementation: {
+          native: 0,
+        },
+        value: 0,
+      },
     });
   });
 });

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -555,7 +555,7 @@ describe('diffing trees', function() {
     const callTree = callTreeFromProfile(profile, /* threadIndex */ 2);
     const formattedTree = formatTree(callTree);
     expect(formattedTree).toEqual([
-      '- A (total: 0, self: —)',
+      '- A (total: —, self: —)',
       '  - B (total: 1, self: —)',
       '    - D (total: -1, self: -1)',
       '    - G (total: 1, self: 1)',
@@ -579,7 +579,7 @@ describe('diffing trees', function() {
     const formattedTree = formatTree(callTree);
     expect(formattedTree).toEqual([
       // A -> B -> D and A -> B -> G should be filtered out by the range filtering.
-      '- A (total: 0, self: —)',
+      '- A (total: —, self: —)',
       '  - B (total: 1, self: —)',
       '    - I (total: 1, self: 1)',
       '  - C (total: -1, self: —)',

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import {
+  getProfileFromTextSamples,
+  getMergedProfileFromTextSamples,
+} from '../fixtures/profiles/processed-profile';
 import {
   getCallTree,
   computeCallTreeCountsAndTimings,
@@ -14,11 +17,41 @@ import {
   invertCallstack,
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
+  filterThreadSamplesToRange,
 } from '../../profile-logic/profile-data';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { formatTree, formatTreeIncludeCategories } from '../fixtures/utils';
 
 import type { Profile } from '../../types/profile';
+
+function callTreeFromProfile(
+  profile: Profile,
+  threadIndex: number = 0
+): CallTree {
+  const thread = profile.threads[threadIndex];
+  const { interval, categories } = profile.meta;
+  const defaultCategory = categories.findIndex(c => c.name === 'Other');
+  const callNodeInfo = getCallNodeInfo(
+    thread.stackTable,
+    thread.frameTable,
+    thread.funcTable,
+    defaultCategory
+  );
+  const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
+    thread,
+    callNodeInfo,
+    interval,
+    false
+  );
+  return getCallTree(
+    thread,
+    interval,
+    callNodeInfo,
+    categories,
+    'combined',
+    callTreeCountsAndTimings
+  );
+}
 
 describe('unfiltered call tree', function() {
   // These values are hoisted at the top for the ease of access. In the profile fixture
@@ -42,32 +75,6 @@ describe('unfiltered call tree', function() {
       D  F  I
       E  G
     `).profile;
-  }
-
-  function callTreeFromProfile(profile: Profile): CallTree {
-    const [thread] = profile.threads;
-    const { interval, categories } = profile.meta;
-    const defaultCategory = categories.findIndex(c => c.name === 'Other');
-    const callNodeInfo = getCallNodeInfo(
-      thread.stackTable,
-      thread.frameTable,
-      thread.funcTable,
-      defaultCategory
-    );
-    const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
-      thread,
-      callNodeInfo,
-      interval,
-      false
-    );
-    return getCallTree(
-      thread,
-      interval,
-      callNodeInfo,
-      categories,
-      'combined',
-      callTreeCountsAndTimings
-    );
   }
 
   /**
@@ -523,6 +530,82 @@ describe('inverted call tree', function() {
         '        - A [Other] (total: 1, self: —)',
       ]);
     });
+  });
+});
+
+describe('diffing trees', function() {
+  function getProfile() {
+    const profile = getMergedProfileFromTextSamples(
+      `
+      A  A  A
+      B  B  C
+      D  E  F
+    `,
+      `
+      A  A  A
+      B  B  B
+      G  I  E
+    `
+    );
+    return profile;
+  }
+
+  it('displays a proper call tree, including nodes with totalTime = 0', () => {
+    const profile = getProfile();
+    const callTree = callTreeFromProfile(profile, /* threadIndex */ 2);
+    const formattedTree = formatTree(callTree);
+    expect(formattedTree).toEqual([
+      '- A (total: 0, self: —)',
+      '  - B (total: 1, self: —)',
+      '    - D (total: -1, self: -1)',
+      '    - G (total: 1, self: 1)',
+      '    - I (total: 1, self: 1)',
+      '  - C (total: -1, self: —)',
+      '    - F (total: -1, self: -1)',
+    ]);
+
+    // There's no A -> B -> E node because the diff makes it completely disappear.
+    expect(formattedTree).not.toContainEqual(expect.stringMatching(/^\s*- E/));
+  });
+
+  it('displays a proper call tree, even for range-filtered threads', () => {
+    const profile = getProfile();
+    const rangeStart = 1;
+    const rangeEnd = 3;
+    profile.threads = profile.threads.map(thread =>
+      filterThreadSamplesToRange(thread, rangeStart, rangeEnd)
+    );
+    const callTree = callTreeFromProfile(profile, /* threadIndex */ 2);
+    const formattedTree = formatTree(callTree);
+    expect(formattedTree).toEqual([
+      // A -> B -> D and A -> B -> G should be filtered out by the range filtering.
+      '- A (total: 0, self: —)',
+      '  - B (total: 1, self: —)',
+      '    - I (total: 1, self: 1)',
+      '  - C (total: -1, self: —)',
+      '    - F (total: -1, self: -1)',
+    ]);
+  });
+
+  it('computes a rootTotalTime that is the absolute count of all intervals', () => {
+    const profile = getProfile();
+
+    const thread = profile.threads[2];
+    const { interval, categories } = profile.meta;
+    const defaultCategory = categories.findIndex(c => c.name === 'Other');
+    const callNodeInfo = getCallNodeInfo(
+      thread.stackTable,
+      thread.frameTable,
+      thread.funcTable,
+      defaultCategory
+    );
+    const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
+      thread,
+      callNodeInfo,
+      interval,
+      false
+    );
+    expect(callTreeCountsAndTimings.rootTotalTime).toBe(4);
   });
 });
 

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -535,7 +535,7 @@ describe('inverted call tree', function() {
 
 describe('diffing trees', function() {
   function getProfile() {
-    const profile = getMergedProfileFromTextSamples(
+    const { profile } = getMergedProfileFromTextSamples(
       `
       A  A  A
       B  B  C

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -177,7 +177,7 @@ export type ResourceTable = {|
   // See https://github.com/firefox-devtools/profiler/issues/652
   lib: Array<IndexIntoLibs | void | null | -1>,
   name: Array<IndexIntoStringTable | -1>,
-  host: Array<IndexIntoStringTable | void>,
+  host: Array<IndexIntoStringTable | void | null>,
   type: resourceTypeEnum[],
 |};
 


### PR DESCRIPTION
This patch adds a new track to the compare view, that's built by computing a diff between 2 profiles.

This builds on the changes of #2143 to use this new `duration` array property. Indeed the "base" profile gets negative intervals in this duration array.

Some other changes are about how to display call nodes with a total time of `0`.

Compared to your previous review, I only added new commits: the ones with `review comments` are fixes from comments in your previous review, and the ones with `post-review commit` are new code coming from problems I found afterwards.

[master](https://profiler.firefox.com/compare/calltree/?globalTrackOrder=0-1-2&implementation=js&invertCallstack&localTrackOrderByPid=1011%20from%20profile%201-0~2399%20from%20profile%202-0~&profiles[]=http%3A%2F%2Flocalhost%3A4242%2Fpublic%2F42b39ea3f82cb8cba896324b8bc9854dfddde598%2Fmarker-chart%2F%3FglobalTrackOrder%3D0-1-2-3%26hiddenGlobalTracks%3D1-2%26localTrackOrderByPid%3D1011-1-0~1042-0~%26range%3D4.7031_10.1588%26thread%3D0%26v%3D3&profiles[]=http%3A%2F%2Flocalhost%3A4242%2Fpublic%2Fd83c1d4bc152257ad9da9b774e59bc6ea49ee225%2Fcalltree%2F%3FglobalTrackOrder%3D0-1-2-3%26hiddenGlobalTracks%3D1-2%26invertCallstack%26localTrackOrderByPid%3D2399-1-0~2422-0~%26range%3D4.9060_11.1083%26thread%3D0%26v%3D3&thread=2&v=3)
[deploy preview](https://deploy-preview-1883--perf-html.netlify.com/compare/calltree/?globalTrackOrder=0-1-2&localTrackOrderByPid=1011%20from%20profile%201-0~2399%20from%20profile%202-0~&profiles[]=https%3A%2F%2Fperfht.ml%2F2XLxFPG&profiles[]=https%3A%2F%2Fperfht.ml%2F2XGDKgw&thread=0&v=4) from [profile 1](https://perfht.ml/2XLxFPG) and [profile 2](https://perfht.ml/2XGDKgw) (they were given to me by @codehag who was working on a perf regression in devtools)
[another deploy preview](https://deploy-preview-1883--perf-html.netlify.com/compare/calltree/?globalTrackOrder=0-1&implementation=js&localTrackOrderByPid=24165%20from%20profile%201-0~24165%20from%20profile%202-0~&profiles[]=http%3A%2F%2Flocalhost%3A4242%2Fpublic%2Ffffb33f4e03e1845335485f84e9658dfeb4bc269%2Fmarker-chart%2F%3FglobalTrackOrder%3D5-0-1-2-3-4%26hiddenGlobalTracks%3D1-2-3%26localTrackOrderByPid%3D3823-1-2-0~31204-0~24100-0~24180-0~24165-0-1~%26range%3D1.9912_3.8980~2.0324_3.2938%26thread%3D5%26v%3D4&profiles[]=http%3A%2F%2Flocalhost%3A4242%2Fpublic%2F678e2fb8470def25c160625d578e719839a0b091%2Fmarker-chart%2F%3FglobalTrackOrder%3D6-0-1-2-3-4-5%26hiddenGlobalTracks%3D1-2-3-4%26localTrackOrderByPid%3D3823-1-2-0~31277-0~24180-0~31204-0~24100-0~24165-0-1~%26range%3D1.4855_2.9697%26thread%3D6%26v%3D4&thread=0&v=4) coming from capturing 2 profiles of the same profile with the same Firefox: [profile1](https://profiler.firefox.com/public/fffb33f4e03e1845335485f84e9658dfeb4bc269/marker-chart/?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3823-1-2-0~31204-0~24100-0~24180-0~24165-0-1~&range=1.9912_3.8980~2.0324_3.2938&thread=5&v=4) [profile2](https://profiler.firefox.com/public/678e2fb8470def25c160625d578e719839a0b091/marker-chart/?globalTrackOrder=6-0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=3823-1-2-0~31277-0~24180-0~31204-0~24100-0~24165-0-1~&range=1.4855_2.9697&thread=6&v=4)

#470