### PR TITLE
Redraw ThreadActivityGraph canvas even when no samples are in range

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -132,12 +132,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
       treeOrderSampleComparator,
       categories,
     } = this.props;
-    const { samples } = fullThread;
 
-    if (samples.length === 0) {
-      // Do not attempt to render when there are no samples.
-      return;
-    }
     const rect = canvas.getBoundingClientRect();
     const ctx = canvas.getContext('2d');
     const canvasPixelWidth = Math.round(rect.width * window.devicePixelRatio);

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -197,6 +197,11 @@ export class ActivityGraphFillComputer {
       greyCategoryIndex,
     } = this.renderedComponentSettings;
 
+    if (samples.length === 0) {
+      // If we have no samples, there's nothing to do.
+      return;
+    }
+
     let prevSampleTime = samples.time[0] - interval;
     let sampleTime = samples.time[0];
 

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -23,6 +23,8 @@ import { getBoundingBox, getMouseEvent } from '../fixtures/utils';
 
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
+import { commitRange } from '../../actions/profile-view';
+
 // The following constants determine the size of the drawn graph.
 const SAMPLE_COUNT = 8;
 const PIXELS_PER_SAMPLE = 10;
@@ -152,7 +154,7 @@ describe('SelectedThreadActivityGraph', function() {
    * as once it's connected to the Redux store in the SelectedActivityGraph.
    */
   describe('ThreadActivityGraph', function() {
-    it('can click a a best ancestor call node', function() {
+    it('can click a best ancestor call node', function() {
       const { clickActivityGraph, getCallNodePath } = setup();
 
       // The full call node at this sample is:
@@ -170,6 +172,20 @@ describe('SelectedThreadActivityGraph', function() {
       // As this is the most common ancestor with the same category.
       clickActivityGraph(1, 0.8);
       expect(getCallNodePath()).toEqual(['A', 'B', 'H']);
+    });
+
+    it('will redraw even when there are no samples in range', function() {
+      const { dispatch, ctx } = setup();
+      ctx.__flushDrawLog();
+
+      // Commit a thin range which contains no samples
+      dispatch(commitRange(0.5, 0.6));
+      const drawCalls = ctx.__flushDrawLog();
+      // We use the presence of 'globalCompositeOperation' to know
+      // whether the canvas was redrawn or not.
+      expect(drawCalls.map(([fn]) => fn)).toContain(
+        'set globalCompositeOperation'
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #1453, fixes #1690