### PR TITLE
Update our code of conduct to point to Mozilla's policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,37 +1,18 @@
-# Contributor Covenant Code of Conduct
+## Mozilla Community Participation Guidelines
 
-## Our Pledge
+This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+## How to Report
+For more information on how to report violations of the CPG, please read our '[How to Report](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/)' page.
 
-## Our Standards
+If you prefer you may also (but you're not obliged to) contact our team member
+[Greg Tatum \<gtatum@mozilla.com\>](mailto:gtatum@mozilla.com).
 
-Examples of behavior that contributes to creating a positive environment
-include:
+## Project Specific Etiquette
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-  * Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-## Our Responsibilities
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -43,36 +24,5 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting one of the following addresses:
-* [inclusion@mozilla.com](mailto:inclusion@mozilla.com) is a generic email
-  that's not directly tied to this project team. Use this if you don't feel safe in contacting
-  a team member.
-* [gtatum@mozilla.com](mailto:gtatum@mozilla.com) is a member of this project.
-All complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+Project maintainers who do not follow or enforce Mozilla's Participation Guidelines in good
+faith may face temporary or permanent repercussions.


### PR DESCRIPTION
Following a Slash discussion with @squelart, I updated the code of conduct to point to Mozilla's policy. I mostly imported the one from the debugger, and just added Greg's email to it to have a more direct point of contact in case the reporter prefers.

[preview](https://github.com/julienw/perf.html/blob/update-code-of-conduct/CODE_OF_CONDUCT.md)