### PR TITLE
Only show the PID if it is a number

### DIFF
--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -185,9 +185,14 @@ class GlobalTrackComponent extends PureComponent<Props> {
           >
             <button type="button" className="timelineTrackNameButton">
               {trackName}
-              <div className="timelineTrackNameButtonAdditionalDetails">
-                PID: {pid}
-              </div>
+              {/* Only show the PID if it is a real number. A string PID is an
+                * artificially generated value that is not useful, and a null
+                * value does not exist. */}
+              {typeof pid === 'number' ? (
+                <div className="timelineTrackNameButtonAdditionalDetails">
+                  PID: {pid}
+                </div>
+              ) : null}
             </button>
           </ContextMenuTrigger>
           <div className="timelineTrackTrack">{this.renderTrack()}</div>


### PR DESCRIPTION
This stops the PID from showing when it is a screenshot, or an older profile where this value is made up.

<img width="149" alt="image" src="https://user-images.githubusercontent.com/1588648/55033691-b7b77400-4fe1-11e9-90de-eec7be1eef81.png">
