### PR TITLE
Remove `networkURLsRemoved` field from metadata

### DIFF
--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -12,8 +12,7 @@
 .menuButtonsShareButton,
 .menuButtonsUploadingButton,
 .menuButtonsPermalinkButton,
-.menuButtonsUploadErrorButton,
-.menuButtonsSecondaryShareButton {
+.menuButtonsUploadErrorButton {
   height: 24px;
   margin-bottom: -24px;
 }
@@ -45,12 +44,9 @@
 }
 
 /* The button width needs to be large enough so that the text "Share Without URLs" fits */
-.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton
-  .menuButtonsPermalinkButton,
 .menuButtonsUploadingButtonInner,
 .menuButtonsPermalinkButtonButton,
-.menuButtonsUploadErrorButtonButton,
-.menuButtonsSecondaryShareButtonButton {
+.menuButtonsUploadErrorButtonButton {
   width: 115px;
 }
 
@@ -58,6 +54,8 @@
 "Sharing will be enabled once symbolication is complete" */
 .menuButtonsShareButtonButton {
   min-width: 115px;
+  background-color: #0d8730;
+  color: white;
 }
 
 .menuButtonsUploadingButtonProgress {
@@ -71,12 +69,6 @@
 
 .menuButtonsUploadingButtonProgress::-moz-progress-bar {
   background: var(--internal-uploading-progress-fill-color);
-}
-
-.menuButtonsShareButtonButton,
-.menuButtonsSecondaryShareButtonButton {
-  background-color: #0d8730;
-  color: white;
 }
 
 /* CSSTransition */
@@ -116,11 +108,6 @@
 .currentButtonIsUploadingButton .menuButtonsPermalinkButtonButton {
   opacity: 0;
   transform: translateY(100%);
-}
-
-.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton
-  .menuButtonsSecondaryShareButton {
-  margin-left: 115px;
 }
 
 .menuButtonsPublishPanel,

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1048,8 +1048,6 @@ export function processProfile(
     sourceURL: geckoProfile.meta.sourceURL,
     physicalCPUs: geckoProfile.meta.physicalCPUs,
     logicalCPUs: geckoProfile.meta.logicalCPUs,
-    // Gecko always sends the profile with URLs.
-    networkURLsRemoved: false,
     // `presymbolicated` indicates whether this gecko profile includes already
     // symbolicated frames. This will be missing for profiles coming from Gecko
     // but may be specified for profiles imported from other formats (eg: linux
@@ -1122,9 +1120,6 @@ export function sanitizePII(
     ...profile,
     meta: {
       ...profile.meta,
-      // FIXME: We won't be needing this after PII frontend changes.
-      // See: https://github.com/firefox-devtools/profiler/issues/1863
-      networkURLsRemoved: PIIToBeRemoved.shouldRemoveNetworkUrls,
       extensions: PIIToBeRemoved.shouldRemoveExtensions
         ? getEmptyExtensions()
         : profile.meta.extensions,

--- a/src/test/unit/__snapshots__/profile-conversion.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.js.snap
@@ -3828,7 +3828,6 @@ Object {
     "interval": 1,
     "logicalCPUs": undefined,
     "misc": undefined,
-    "networkURLsRemoved": false,
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -50,7 +50,6 @@ Object {
     "interval": 1,
     "logicalCPUs": undefined,
     "misc": undefined,
-    "networkURLsRemoved": false,
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -379,8 +379,6 @@ export type ProfileMeta = {|
   physicalCPUs?: number,
   // The amount of logically available CPU cores for the program.
   logicalCPUs?: number,
-  // A boolean flag for whether or not the network URLs were stripped from the profile.
-  networkURLsRemoved?: boolean,
   // A boolean flag indicating whether we symbolicated this profile. If this is
   // false we'll start a symbolication process when the profile is loaded.
   // A missing property means that it's an older profile, it stands for an


### PR DESCRIPTION
We don't need it anymore after the PII frontend changes.
Fixes #1863.