### PR TITLE
Fix the hash for the injected script content-home.js

### DIFF
--- a/res/_headers
+++ b/res/_headers
@@ -29,7 +29,7 @@
   # 6. `frame-ancestors` is the same purpose as `X-Frame-Options` above.
   # 7. `form-action`prevents forms, we don't need this.`
   # 8. `frame-src` allows the embedding of YouTube videos in the docs.
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src http: https: data:; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; frame-src www.youtube-nocookie.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-vY1KJ1dyP9vvnuERKMiQAcoKKtMUXZUEWJ/dT1XqpKM=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src http: https: data:; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; frame-src www.youtube-nocookie.com
 
 # Set the correct MIME type for WebAssembly modules.
 /*.wasm

--- a/server.js
+++ b/server.js
@@ -31,7 +31,7 @@ const serverConfig = {
       script-src
         'self'
         'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw='
-        'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E='
+        'sha256-vY1KJ1dyP9vvnuERKMiQAcoKKtMUXZUEWJ/dT1XqpKM='
         https://www.google-analytics.com;
       style-src 'self' 'unsafe-inline';
       img-src http: https: data:;


### PR DESCRIPTION
The content changed because we changed some comments when we rebranded to Firefox Profiler. As a result, the sha needs to be changed too.

I checked the SHA is correct by locally changing the profiler add-on's manifest file so that it tries to inject the script in localhost and in this deploy preview.

The error is that in the home we don't see the "how to profile" page, we always see the "install add-on" page.