### PR TITLE
Update copy-to-clipboard to prevent the "copy" event from bubbling up

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "clamp": "^1.0.1",
     "classnames": "^2.2.6",
     "common-tags": "^1.8.0",
-    "copy-to-clipboard": "^3.0.8",
+    "copy-to-clipboard": "^3.1.0",
     "escape-string-regexp": "^1.0.5",
     "gecko-profiler-demangle": "^0.2.0",
     "jszip": "^3.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3113,12 +3113,12 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
-  integrity sha512-c3GdeY8qxCHGezVb1EFQfHYK/8NZRemgcTIzPq7PuxjHAf/raKibn2QdhHPb/y6q74PMgH6yizaDZlRmw6QyKw==
+copy-to-clipboard@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.1.0.tgz#0a28141899e6bd217b9dc13fd1689b3b38820b44"
+  integrity sha512-+RNyDq266tv5aGhfRsL6lxgj8Y6sCvTrVJnFUVvuxuqkcSMaLISt1wd4JkdQSphbcLTIQ9kEpTULNnoCXAFdng==
   dependencies:
-    toggle-selection "^1.0.3"
+    toggle-selection "^1.0.6"
 
 copy-to@^2.0.1:
   version "2.0.1"
@@ -12080,10 +12080,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toggle-selection@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.5.tgz#726c703de607193a73c32c7df49cd24950fc574f"
-  integrity sha1-cmxwPeYHGTpzwyx99JzSSVD8V08=
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #1903
[deploy preview](https://deploy-preview-1922--perf-html.netlify.com/public/4e94b58771488bd7fc0c7c9423ef4faa864b3ba8/calltree/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&thread=5&v=3)