### PR TITLE
Added WindowTitle component to improve searchability of tabs

### DIFF
--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -9,6 +9,7 @@ import explicitConnect from '../../utils/connect';
 import DetailsContainer from './DetailsContainer';
 import ProfileFilterNavigator from './ProfileFilterNavigator';
 import MenuButtons from './MenuButtons';
+import WindowTitle from '../shared/WindowTitle';
 import SymbolicationStatusOverlay from './SymbolicationStatusOverlay';
 import { returnToZipFileList } from '../../actions/zipped-profiles';
 import { getProfileName } from '../../selectors/url-state';
@@ -94,6 +95,7 @@ class ProfileViewer extends PureComponent<Props> {
           <Timeline />
           <DetailsContainer />
         </SplitterLayout>
+        <WindowTitle />
         <SymbolicationStatusOverlay />
       </div>
     );

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -11,10 +11,7 @@ import { getProfileName, getDataSource } from '../../selectors/url-state';
 import { getProfile } from '../../selectors/profile';
 
 import type { Profile, ProfileMeta } from '../../types/profile';
-import type {
-  ExplicitConnectOptions,
-  ConnectedProps,
-} from '../../utils/connect';
+import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|
   +profile: Profile,
@@ -27,7 +24,7 @@ type Props = ConnectedProps<{||}, StateProps, {||}>;
 class WindowTitle extends PureComponent<Props> {
   // This component updates window title in the form of:
   // profile name - version - platform - date time - data source - 'Firefox profiler'
-  componentDidUpdate() {
+  _updateTitle() {
     const { profile, profileName, dataSource } = this.props;
     const { meta } = profile;
     let title = '';
@@ -45,6 +42,14 @@ class WindowTitle extends PureComponent<Props> {
     }
     title = title.concat(' - ', 'Firefox profiler');
     document.title = title;
+  }
+
+  componentDidMount() {
+    this._updateTitle();
+  }
+
+  componentDidUpdate() {
+    this._updateTitle();
   }
 
   render() {
@@ -94,13 +99,11 @@ function _formatDateTime(timestamp: number): string {
   return dateTimeLabel;
 }
 
-const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
+export default explicitConnect({
   mapStateToProps: state => ({
     profileName: getProfileName(state),
     profile: getProfile(state),
     dataSource: getDataSource(state),
   }),
   component: WindowTitle,
-};
-
-export default explicitConnect(options);
+});

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import { PureComponent } from 'react';
+import explicitConnect from '../../utils/connect';
+
+import { getProfileName } from '../../selectors/url-state';
+import { getProfile } from '../../selectors/profile';
+
+import type { Profile, ProfileMeta } from '../../types/profile';
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../utils/connect';
+
+type StateProps = {|
+  +profile: Profile,
+  +profileName: string | null,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, {||}>;
+
+class WindowTitle extends PureComponent<Props> {
+  // This component updates window title in the form of:
+  // profile name - version - platform - date time - 'perf.html'
+  componentDidUpdate() {
+    const { profile, profileName } = this.props;
+    const { meta } = profile;
+    let title = '';
+
+    if (profileName) {
+      title = title.concat(profileName, ' - ');
+    }
+    if (meta) {
+      title = title.concat(_formatVersion(meta), ' - ');
+    }
+    if (meta && meta.oscpu) {
+      title = title.concat(_formatPlatform(meta), ' - ');
+    }
+    if (meta && meta.startTime) {
+      title = title.concat(_formatDateTime(meta.startTime), ' - ');
+    }
+    title = title.concat('perf.html');
+    document.title = title;
+  }
+
+  render() {
+    return null;
+  }
+}
+
+function _formatVersionNumber(version?: string): string | null {
+  const regex = /[0-9]+.+[0-9]/gi;
+
+  if (version) {
+    const match = version.match(regex);
+    if (match) {
+      return match.toString();
+    }
+  }
+  return null;
+}
+
+function _formatVersion(meta: ProfileMeta): string {
+  const product = meta.product || '';
+  const version = _formatVersionNumber(meta.misc) || '';
+  const versionLabel = product + ' ' + version + ' ';
+
+  return versionLabel;
+}
+
+function _formatPlatform(meta: ProfileMeta): string {
+  let os;
+  // To display Android Version instead of Linux for Android developers.
+  if (meta.platform !== undefined && meta.platform.match(/android/i)) {
+    os = meta.platform;
+  } else {
+    os = meta.oscpu || '';
+  }
+
+  return os;
+}
+
+function _formatDateTime(timestamp: number): string {
+  const timestampDate = new Date(timestamp);
+  let month = timestampDate.getUTCMonth() + 1 + '';
+  let date = timestampDate.getUTCDate() + '';
+  const year = timestampDate.getUTCFullYear();
+
+  if (month.length === 1) month = '0' + month;
+  if (date.length === 1) date = '0' + date;
+
+  const dateLabel = [year, month, date].join('-');
+  const time = _formatTime(timestamp);
+
+  return [dateLabel, time].join(' ');
+}
+
+function _formatTime(timestamp: number): string {
+  const timestampDate = new Date(timestamp);
+  let hours = timestampDate.getUTCHours() + '';
+  let minutes = timestampDate.getUTCMinutes() + '';
+
+  if (hours.length === 1) hours = '0' + hours;
+  if (minutes.length === 1) minutes = '0' + minutes;
+
+  return [hours, minutes].join(':');
+}
+
+const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
+  mapStateToProps: state => ({
+    profileName: getProfileName(state),
+    profile: getProfile(state),
+  }),
+  component: WindowTitle,
+};
+
+export default explicitConnect(options);

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -26,7 +26,7 @@ type Props = ConnectedProps<{||}, StateProps, {||}>;
 
 class WindowTitle extends PureComponent<Props> {
   // This component updates window title in the form of:
-  // profile name - version - platform - date time - 'perf.html'
+  // profile name - version - platform - date time - data source - 'Firefox profiler'
   componentDidUpdate() {
     const { profile, profileName, dataSource } = this.props;
     const { meta } = profile;
@@ -43,8 +43,7 @@ class WindowTitle extends PureComponent<Props> {
     if (dataSource === 'public') {
       title = title.concat(' (', dataSource, ')');
     }
-    title = title.concat(' - ');
-    title = title.concat('Firefox profiler');
+    title = title.concat(' - ', 'Firefox profiler');
     document.title = title;
   }
 
@@ -62,6 +61,7 @@ function _formatVersionNumber(version?: string): string | null {
       return match.toString();
     }
   }
+
   return null;
 }
 
@@ -86,27 +86,12 @@ function _formatPlatform(meta: ProfileMeta): string {
 }
 
 function _formatDateTime(timestamp: number): string {
-  const dateOptions = {
+  const dateTimeLabel = new Date(timestamp).toLocaleString(undefined, {
     timeZone: 'UTC',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  };
-  const timeOptions = {
-    timeZone: 'UTC',
-    hourCycle: 'h24',
-    hour: '2-digit',
-    minute: '2-digit',
-  };
-  const date = new Date(timestamp);
-  const dateLabel = date
-    .toLocaleString('en-GB', dateOptions)
-    .split('/')
-    .reverse()
-    .join('-');
-  const timeLabel = date.toLocaleString('en-GB', timeOptions);
+    timeZoneName: 'short',
+  });
 
-  return [dateLabel, timeLabel].join(' ');
+  return dateTimeLabel;
 }
 
 const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {

--- a/src/test/components/WindowTitle.test.js
+++ b/src/test/components/WindowTitle.test.js
@@ -63,5 +63,10 @@ describe('WindowTitle', () => {
     expect(document.title).toBe(
       'good profile - Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
     );
+
+    store.dispatch(changeProfileName('awesome profile'));
+    expect(document.title).toBe(
+      'awesome profile - Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+    );
   });
 });

--- a/src/test/components/WindowTitle.test.js
+++ b/src/test/components/WindowTitle.test.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from 'react-testing-library';
+
+import WindowTitle from '../../components/shared/WindowTitle';
+import {
+  getEmptyProfile,
+  getEmptyThread,
+} from '../../profile-logic/data-structures';
+import { storeWithProfile } from '../fixtures/stores';
+import { changeProfileName } from '../../actions/profile-view';
+
+describe('WindowTitle', () => {
+  it('shows basic window title', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    const store = storeWithProfile(profile);
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe(
+      'Firefox - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+    );
+  });
+
+  it('shows platform details in the window title if it is available', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    profile.meta.oscpu = 'Intel Mac OS X 10.14';
+    const store = storeWithProfile(profile);
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe(
+      'Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+    );
+  });
+
+  it('shows profile name in the window title if it is available', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    profile.meta.oscpu = 'Intel Mac OS X 10.14';
+    const store = storeWithProfile(profile);
+    store.dispatch(changeProfileName('good profile'));
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe(
+      'good profile - Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+    );
+  });
+});


### PR DESCRIPTION
This is PR solves issue #1055 and also solves 3rd part of issue #448.
After merging this PR we would be able to see window title in form of:
``profile name - version - platform - date time - 'perf.html'``

Here is the preview:
(kindly look at the hover on tab)
<img width="1440" alt="Screenshot 2019-04-08 at 11 58 07 PM" src="https://user-images.githubusercontent.com/16744065/55747591-325ca680-5a5a-11e9-90af-92c13b79b74e.png">

