### PR TITLE
Open permalink menu when publishing a profile

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -105,3 +105,11 @@ export const reportTrackThreadHeight = (
     });
   }
 };
+
+/**
+ * This action dismisses the newly published state. This happens when a user first
+ * uploads a profile. We only want to remember this when we fist open the profile.
+ */
+export function dismissNewlyPublished(): Action {
+  return { type: 'DISMISS_NEWLY_PUBLISHED' };
+}

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -83,7 +83,7 @@ export function attemptToPublish(): ThunkAction<Promise<void>> {
       // Generate a url, and completely drop any of the existing URL state. In
       // a future patch, we should handle this gracefully.
       const url =
-        'https://profiler.firefox.com' +
+        window.location.origin +
         urlFromState(
           urlStateReducer(getUrlState(getState()), profilePublished(hash))
         );

--- a/src/components/app/MenuButtons/Permalink.js
+++ b/src/components/app/MenuButtons/Permalink.js
@@ -11,6 +11,10 @@ import * as UrlUtils from '../../../utils/shorten-url';
 
 type Props = {|
   +isNewlyPublished: boolean,
+  // This is for injecting a URL shortener for tests. Normally we would use a Jest mock
+  // that would mock out a local module, but I was having trouble getting it working
+  // correctly (perhaps due to ES6 modules), so I just went with dependency injection
+  // instead.
   +injectedUrlShortener?: typeof UrlUtils.shortenUrl | void,
 |};
 

--- a/src/components/app/MenuButtons/Permalink.js
+++ b/src/components/app/MenuButtons/Permalink.js
@@ -7,14 +7,19 @@
 import * as React from 'react';
 import ArrowPanel from '../../shared/ArrowPanel';
 import ButtonWithPanel from '../../shared/ButtonWithPanel';
-import { shortenUrl } from '../../../utils/shorten-url';
+import * as UrlUtils from '../../../utils/shorten-url';
+
+type Props = {|
+  +isNewlyPublished: boolean,
+  +injectedUrlShortener?: typeof UrlUtils.shortenUrl | void,
+|};
 
 type State = {|
   fullUrl: string,
   shortUrl: string,
 |};
 
-export class MenuButtonsPermalink extends React.PureComponent<*, State> {
+export class MenuButtonsPermalink extends React.PureComponent<Props, State> {
   _permalinkButton: ButtonWithPanel | null;
   _permalinkTextField: HTMLInputElement | null;
   _takePermalinkButtonRef = (elem: any) => {
@@ -33,6 +38,7 @@ export class MenuButtonsPermalink extends React.PureComponent<*, State> {
     const { fullUrl } = this.state;
     const currentFullUrl = window.location.href;
     if (fullUrl !== currentFullUrl) {
+      const shortenUrl = this.props.injectedUrlShortener || UrlUtils.shortenUrl;
       try {
         const shortUrl = await shortenUrl(currentFullUrl);
         this.setState({ shortUrl, fullUrl: currentFullUrl });
@@ -63,6 +69,7 @@ export class MenuButtonsPermalink extends React.PureComponent<*, State> {
         className="menuButtonsPermalinkButton"
         ref={this._takePermalinkButtonRef}
         label="Permalink"
+        defaultOpen={this.props.isNewlyPublished}
         panel={
           <ArrowPanel
             className="menuButtonsPermalinkPanel"
@@ -70,6 +77,7 @@ export class MenuButtonsPermalink extends React.PureComponent<*, State> {
             onClose={this._onPermalinkPanelClose}
           >
             <input
+              data-testid="MenuButtonsPermalink-input"
               type="text"
               className="menuButtonsPermalinkTextField photon-input"
               value={this.state.shortUrl}

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -30,7 +30,10 @@ import type {
 require('./index.css');
 
 type OwnProps = {|
-  // This is for injecting a URL shortener for tests.
+  // This is for injecting a URL shortener for tests. Normally we would use a Jest mock
+  // that would mock out a local module, but I was having trouble getting it working
+  // correctly (perhaps due to ES6 modules), so I just went with dependency injection
+  // instead.
   injectedUrlShortener?: string => Promise<string>,
 |};
 

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -7,13 +7,17 @@
 import * as React from 'react';
 import explicitConnect from '../../../utils/connect';
 import { getProfile, getProfileRootRange } from '../../../selectors/profile';
-import { getDataSource } from '../../../selectors/url-state';
+import {
+  getDataSource,
+  getIsNewlyPublished,
+} from '../../../selectors/url-state';
 import { MenuButtonsMetaInfo } from './MetaInfo';
 import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';
 import { assertExhaustiveCheck } from '../../../utils/flow';
 import ArrowPanel from '../../shared/ArrowPanel';
 import ButtonWithPanel from '../../shared/ButtonWithPanel';
+import { dismissNewlyPublished } from '../../../actions/app';
 
 import type { StartEndRange } from '../../../types/units';
 import type { Profile } from '../../../types/profile';
@@ -25,33 +29,67 @@ import type {
 
 require('./index.css');
 
+type OwnProps = {|
+  // This is for injecting a URL shortener for tests.
+  injectedUrlShortener?: string => Promise<string>,
+|};
+
 type StateProps = {|
   +profile: Profile,
   +rootRange: StartEndRange,
   +dataSource: DataSource,
+  +isNewlyPublished: boolean,
 |};
 
-type Props = ConnectedProps<{||}, StateProps, {||}>;
+type DispatchProps = {|
+  +dismissNewlyPublished: typeof dismissNewlyPublished,
+|};
 
-const MenuButtons = ({ profile, dataSource }: Props) => (
-  <>
-    {/* Place the info button outside of the menu buttons to allow it to shrink. */}
-    <MenuButtonsMetaInfo profile={profile} />
-    <div className="menuButtons">
-      <PublishOrPermalinkButtons dataSource={dataSource} />
-      <a
-        href="/docs/"
-        target="_blank"
-        className="menuButtonsLink"
-        title="Open the documentation in a new window"
-      >
-        Docs<i className="open-in-new" />
-      </a>
-    </div>
-  </>
-);
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
-const PublishOrPermalinkButtons = ({ dataSource }) => {
+class MenuButtons extends React.PureComponent<Props> {
+  componentDidMount() {
+    // Clear out the newly published notice from the URL.
+    this.props.dismissNewlyPublished();
+  }
+
+  render() {
+    const {
+      profile,
+      dataSource,
+      isNewlyPublished,
+      injectedUrlShortener,
+    } = this.props;
+    return (
+      <>
+        {/* Place the info button outside of the menu buttons to allow it to shrink. */}
+        <MenuButtonsMetaInfo profile={profile} />
+        <div className="menuButtons">
+          <PublishOrPermalinkButtons
+            dataSource={dataSource}
+            isNewlyPublished={isNewlyPublished}
+            injectedUrlShortener={injectedUrlShortener}
+          />
+          <a
+            href="/docs/"
+            target="_blank"
+            className="menuButtonsLink"
+            title="Open the documentation in a new window"
+          >
+            Docs
+            <i className="open-in-new" />
+          </a>
+        </div>
+      </>
+    );
+  }
+}
+
+const PublishOrPermalinkButtons = ({
+  dataSource,
+  isNewlyPublished,
+  injectedUrlShortener,
+}) => {
   switch (dataSource) {
     case 'from-addon':
     case 'from-file':
@@ -70,7 +108,12 @@ const PublishOrPermalinkButtons = ({ dataSource }) => {
     case 'public':
     case 'from-url':
     case 'compare':
-      return <MenuButtonsPermalink />;
+      return (
+        <MenuButtonsPermalink
+          isNewlyPublished={isNewlyPublished}
+          injectedUrlShortener={injectedUrlShortener}
+        />
+      );
     case 'none':
       return null;
     default:
@@ -78,12 +121,16 @@ const PublishOrPermalinkButtons = ({ dataSource }) => {
   }
 };
 
-const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
+const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
   mapStateToProps: state => ({
     profile: getProfile(state),
     rootRange: getProfileRootRange(state),
     dataSource: getDataSource(state),
+    isNewlyPublished: getIsNewlyPublished(state),
   }),
+  mapDispatchToProps: {
+    dismissNewlyPublished,
+  },
   component: MenuButtons,
 };
 export default explicitConnect(options);

--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -30,6 +30,9 @@ type Props = {
     Class<Panel & React.Component<$Subtype<PanelProps>, any>>
   >,
   open?: boolean,
+  // This prop tells the panel to be open by default, but the open/close state is fully
+  // managed by the ButtonWithPanel component.
+  defaultOpen?: boolean,
 };
 
 type State = {|
@@ -47,7 +50,7 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
   componentDidMount() {
     // the panel can be closed by pressing the Esc key
     window.addEventListener('keydown', this._onKeyDown);
-    if (this.props.open) {
+    if (this.props.open || this.props.defaultOpen) {
       this.openPanel();
     }
   }

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -337,6 +337,21 @@ const profileName: Reducer<string> = (state = '', action) => {
 };
 
 /**
+ * This reducer holds the state for whether or not a profile was newly uploaded
+ * or not. This way we can show a friendly message to the user.
+ */
+const isNewlyPublished: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'PROFILE_PUBLISHED':
+      return true;
+    case 'DISMISS_NEWLY_PUBLISHED':
+      return false;
+    default:
+      return state;
+  }
+};
+
+/**
  * These values are specific to an individual profile.
  */
 const profileSpecific = combineReducers({
@@ -401,6 +416,7 @@ const urlStateReducer: Reducer<UrlState> = wrapReducerInResetter(
     pathInZipFile,
     profileSpecific,
     profileName,
+    isNewlyPublished,
   })
 );
 

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -41,6 +41,8 @@ export const getProfilesToCompare: Selector<string[] | null> = state =>
   getUrlState(state).profilesToCompare;
 export const getProfileNameFromUrl: Selector<string> = state =>
   getUrlState(state).profileName;
+export const getIsNewlyPublished: Selector<boolean> = state =>
+  getUrlState(state).isNewlyPublished;
 export const getAllCommittedRanges: Selector<StartEndRange[]> = state =>
   getProfileSpecificState(state).committedRanges;
 export const getImplementationFilter: Selector<ImplementationFilter> = state =>

--- a/src/test/components/MenuButtonsPermalinks.test.js
+++ b/src/test/components/MenuButtonsPermalinks.test.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import MenuButtons from '../../components/app/MenuButtons';
+import { render, fireEvent } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import { storeWithProfile } from '../fixtures/stores';
+import { stateFromLocation } from '../../app-logic/url-handling';
+import { ensureExists } from '../../utils/flow';
+import { getIsNewlyPublished } from '../../selectors/url-state';
+
+describe('<Permalink>', function() {
+  function setup(search = '', injectedUrlShortener) {
+    const store = storeWithProfile();
+    const shortUrl = 'http://example.com/fake-short-url';
+    const shortUrlPromise = Promise.resolve(shortUrl);
+
+    if (!injectedUrlShortener) {
+      injectedUrlShortener = () => shortUrlPromise;
+    }
+    store.dispatch({
+      type: 'UPDATE_URL_STATE',
+      newUrlState: stateFromLocation({
+        pathname: '/public/fakehash',
+        search,
+        hash: '',
+      }),
+    });
+
+    const originalState = store.getState();
+
+    const renderResult = render(
+      <Provider store={store}>
+        <MenuButtons injectedUrlShortener={injectedUrlShortener} />
+      </Provider>
+    );
+
+    const { queryByTestId, getByText } = renderResult;
+    const getPermalinkButton = () => getByText('Permalink');
+    const queryInput = () => queryByTestId('MenuButtonsPermalink-input');
+
+    return {
+      ...store,
+      ...renderResult,
+      getPermalinkButton,
+      shortUrl,
+      shortUrlPromise,
+      queryInput,
+      originalState,
+    };
+  }
+
+  it('can render the permalink button', function() {
+    const { getPermalinkButton, queryInput } = setup();
+    getPermalinkButton();
+    expect(queryInput()).toBeFalsy();
+  });
+
+  it('can click the permalink button', async function() {
+    const {
+      getPermalinkButton,
+      queryInput,
+      shortUrl,
+      shortUrlPromise,
+    } = setup();
+    fireEvent.click(getPermalinkButton());
+    await shortUrlPromise;
+    const input = ensureExists(
+      queryInput(),
+      'Unable to find the permalink input text field'
+    );
+    expect(input.getAttribute('value')).toBe(shortUrl);
+  });
+
+  it('shows the permalink when visiting a published profile', async function() {
+    const { queryInput, shortUrl, shortUrlPromise } = setup('?published');
+    await shortUrlPromise;
+    const input = ensureExists(
+      queryInput(),
+      'Unable to find the permalink input text field'
+    );
+    expect(input.getAttribute('value')).toBe(shortUrl);
+  });
+
+  it('resets the isNewlyPublishedState in the URL when mounted', async function() {
+    const { originalState, getState } = setup('?published');
+    expect(getIsNewlyPublished(originalState)).toBe(true);
+    expect(getIsNewlyPublished(getState())).toBe(false);
+  });
+});

--- a/src/test/unit/shorten-url.test.js
+++ b/src/test/unit/shorten-url.test.js
@@ -78,7 +78,7 @@ describe('shortenUrl', () => {
   });
 });
 
-describe('shortenUrl', () => {
+describe('expandUrl', () => {
   function mockFetchWith(returnedLongUrl) {
     window.fetch.mockImplementation(async urlString => {
       const url = new URL(urlString);

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -200,7 +200,8 @@ type ProfileAction =
   | {|
       +type: 'INCREMENT_PANEL_LAYOUT_GENERATION',
     |}
-  | {| +type: 'HAS_ZOOMED_VIA_MOUSEWHEEL' |};
+  | {| +type: 'HAS_ZOOMED_VIA_MOUSEWHEEL' |}
+  | {| +type: 'DISMISS_NEWLY_PUBLISHED' |};
 
 type ReceiveProfileAction =
   | {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -156,6 +156,7 @@ export type UrlState = {|
   +selectedTab: TabSlug,
   +pathInZipFile: string | null,
   +profileName: string,
+  +isNewlyPublished: boolean,
   +profileSpecific: {|
     selectedThread: ThreadIndex | null,
     globalTrackOrder: TrackIndex[],


### PR DESCRIPTION
This resolves #1897.

Right now when a new profile is uploaded, there is no indication that it was successfully uploaded. This PR opens up the permalink menu, like before. I think it's enough for now to show that the profile was successfully opened. We can still add another message if that seems better, and if users are confused.