### PR TITLE
PII UX work

### DIFF
--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -173,14 +173,10 @@
   margin: 4px 0;
 }
 
-.menuButtonsPublishDataChoicesLabel.disabled {
-  opacity: 0.4;
-}
-
 .menuButtonsPublishDataSummary {
-  margin: 20px 0;
+  margin: 13px 8px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: bold;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -240,12 +236,10 @@
   background: url(../../../../res/img/svg/download.svg) center center no-repeat;
 }
 
-.menuButtonsDownloadButton {
-  transition: color 100ms;
-}
-
-.menuButtonsDownloadButtonIsLoading {
-  color: var(--grey-40);
+.menuButtonsDownloadSize {
+  display: inline-block;
+  margin: 0 4px;
+  font-size: 11px;
 }
 
 .menuButtonsPublishUpload {

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -73,12 +73,15 @@ class MenuButtonsPublishImpl extends React.PureComponent<
       this.setState({ isFilteringToggledOnce: true });
       this.props.toggleCheckedSharingOptions('isFiltering');
     },
-    hiddenThreads: () =>
-      this.props.toggleCheckedSharingOptions('hiddenThreads'),
-    timeRange: () => this.props.toggleCheckedSharingOptions('timeRange'),
-    screenshots: () => this.props.toggleCheckedSharingOptions('screenshots'),
-    urls: () => this.props.toggleCheckedSharingOptions('urls'),
-    extension: () => this.props.toggleCheckedSharingOptions('extension'),
+    includeHiddenThreads: () =>
+      this.props.toggleCheckedSharingOptions('includeHiddenThreads'),
+    includeFullTimeRange: () =>
+      this.props.toggleCheckedSharingOptions('includeFullTimeRange'),
+    includeScreenshots: () =>
+      this.props.toggleCheckedSharingOptions('includeScreenshots'),
+    includeUrls: () => this.props.toggleCheckedSharingOptions('includeUrls'),
+    includeExtension: () =>
+      this.props.toggleCheckedSharingOptions('includeExtension'),
   };
 
   state = {
@@ -95,7 +98,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
           className="photon-checkbox photon-checkbox-default"
           name={slug}
           onChange={toggle}
-          checked={!checkedSharingOptions[slug]}
+          checked={checkedSharingOptions[slug]}
         />
         {label}
       </label>
@@ -152,11 +155,17 @@ class MenuButtonsPublishImpl extends React.PureComponent<
                 Include additional data
               </summary>
               <div className="menuButtonsPublishDataChoices">
-                {this._renderCheckbox('hiddenThreads', 'Hidden threads')}
-                {this._renderCheckbox('timeRange', 'Hidden time range')}
-                {this._renderCheckbox('screenshots', 'Screenshots')}
-                {this._renderCheckbox('urls', 'Resource URLs')}
-                {this._renderCheckbox('extension', 'Extension information')}
+                {this._renderCheckbox('includeHiddenThreads', 'Hidden threads')}
+                {this._renderCheckbox(
+                  'includeFullTimeRange',
+                  'Hidden time range'
+                )}
+                {this._renderCheckbox('includeScreenshots', 'Screenshots')}
+                {this._renderCheckbox('includeUrls', 'Resource URLs')}
+                {this._renderCheckbox(
+                  'includeExtension',
+                  'Extension information'
+                )}
               </div>
             </details>
           ) : null}

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -17,11 +17,11 @@ import type {
 function _getDefaultSharingOptions(): CheckedSharingOptions {
   return {
     isFiltering: true,
-    hiddenThreads: true,
-    timeRange: true,
-    screenshots: true,
-    urls: true,
-    extension: true,
+    includeHiddenThreads: false,
+    includeFullTimeRange: false,
+    includeScreenshots: false,
+    includeUrls: false,
+    includeExtension: false,
   };
 }
 

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -77,7 +77,7 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
 
     // Find all of the thread indexes that are hidden.
     const shouldRemoveThreads = new Set();
-    if (checkedSharingOptions.hiddenThreads) {
+    if (!checkedSharingOptions.includeHiddenThreads) {
       for (const globalTrackIndex of hiddenGlobalTracks) {
         const globalTrack = globalTracks[globalTrackIndex];
         if (
@@ -116,18 +116,18 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
     }
 
     return {
-      shouldFilterToCommittedRange: checkedSharingOptions.timeRange
-        ? committedRange
-        : null,
-      shouldRemoveNetworkUrls: checkedSharingOptions.urls,
-      shouldRemoveAllUrls: checkedSharingOptions.urls,
+      shouldFilterToCommittedRange: checkedSharingOptions.includeFullTimeRange
+        ? null
+        : committedRange,
+      shouldRemoveNetworkUrls: !checkedSharingOptions.includeUrls,
+      shouldRemoveAllUrls: !checkedSharingOptions.includeUrls,
       shouldRemoveThreadsWithScreenshots: new Set(
-        checkedSharingOptions.screenshots
-          ? profile.threads.map((_, threadIndex) => threadIndex)
-          : []
+        checkedSharingOptions.includeScreenshots
+          ? []
+          : profile.threads.map((_, threadIndex) => threadIndex)
       ),
       shouldRemoveThreads,
-      shouldRemoveExtensions: checkedSharingOptions.extension,
+      shouldRemoveExtensions: !checkedSharingOptions.includeExtension,
     };
   }
 );

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -11,7 +11,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { TextEncoder } from 'util';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import { ensureExists } from '../../utils/flow';
-import { getProfile } from '../../selectors/profile';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
 // Mocking SymbolStoreDB
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';
@@ -52,9 +52,9 @@ describe('app/MenuButtons', function() {
   }
 
   function setup(updateChannel = 'release') {
-    const store = storeWithProfile();
-    const profile = getProfile(store.getState());
+    const { profile } = getProfileFromTextSamples('A');
     profile.meta.updateChannel = updateChannel;
+    const store = storeWithProfile(profile);
     const { resolveUpload, rejectUpload } = mockUpload();
 
     store.dispatch({
@@ -132,7 +132,7 @@ describe('app/MenuButtons', function() {
       expect(getPanel()).toMatchSnapshot();
     });
 
-    it('matches the snapshot for the opened panel for a release profile', () => {
+    fit('matches the snapshot for the opened panel for a release profile', () => {
       const { getPanel, getPublishButton } = setup('release');
       fireEvent.click(getPublishButton());
       expect(getPanel()).toMatchSnapshot();

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -132,7 +132,7 @@ describe('app/MenuButtons', function() {
       expect(getPanel()).toMatchSnapshot();
     });
 
-    fit('matches the snapshot for the opened panel for a release profile', () => {
+    it('matches the snapshot for the opened panel for a release profile', () => {
       const { getPanel, getPublishButton } = setup('release');
       fireEvent.click(getPublishButton());
       expect(getPanel()).toMatchSnapshot();

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -314,6 +314,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         class="photon-label"
       >
         <input
+          checked=""
           class="photon-checkbox photon-checkbox-default"
           name="isFiltering"
           type="checkbox"
@@ -324,60 +325,55 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         class="menuButtonsPublishDataChoices"
       >
         <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
+          class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
             checked=""
             class="photon-checkbox photon-checkbox-default"
-            disabled=""
             name="hiddenThreads"
             type="checkbox"
           />
           Remove hidden threads
         </label>
         <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
+          class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
             checked=""
             class="photon-checkbox photon-checkbox-default"
-            disabled=""
             name="timeRange"
             type="checkbox"
           />
           Remove information out of the time range
         </label>
         <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
+          class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
             checked=""
             class="photon-checkbox photon-checkbox-default"
-            disabled=""
             name="screenshots"
             type="checkbox"
           />
           Remove screenshots
         </label>
         <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
+          class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
             checked=""
             class="photon-checkbox photon-checkbox-default"
-            disabled=""
             name="urls"
             type="checkbox"
           />
           Remove all URLs
         </label>
         <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
+          class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
             checked=""
             class="photon-checkbox photon-checkbox-default"
-            disabled=""
             name="extension"
             type="checkbox"
           />

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -297,30 +297,27 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     <p
       class="menuButtonsPublishInfoDescription"
     >
-      You’re about to share your profile potentially where others have public access to it. 
-      By default, the profile is stripped of much of the personally identifiable information.
+      You’re about to publicly share your profile, which can potentially contain personally identifiable information.
     </p>
+    <label
+      class="photon-label"
+    >
+      <input
+        checked=""
+        class="photon-checkbox photon-checkbox-default"
+        name="isFiltering"
+        type="checkbox"
+      />
+      Filter out potentially identifying information
+    </label>
     <details
       class="menuButtonsPublishData"
-      open=""
     >
       <summary
         class="menuButtonsPublishDataSummary"
       >
-        Adjust how much is shared
-         
+        Include additional data
       </summary>
-      <label
-        class="photon-label"
-      >
-        <input
-          checked=""
-          class="photon-checkbox photon-checkbox-default"
-          name="isFiltering"
-          type="checkbox"
-        />
-        Filter out potentially identifying information
-      </label>
       <div
         class="menuButtonsPublishDataChoices"
       >
@@ -328,56 +325,51 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
-            checked=""
             class="photon-checkbox photon-checkbox-default"
             name="hiddenThreads"
             type="checkbox"
           />
-          Remove hidden threads
+          Hidden threads
         </label>
         <label
           class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
-            checked=""
             class="photon-checkbox photon-checkbox-default"
             name="timeRange"
             type="checkbox"
           />
-          Remove information out of the time range
+          Hidden time range
         </label>
         <label
           class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
-            checked=""
             class="photon-checkbox photon-checkbox-default"
             name="screenshots"
             type="checkbox"
           />
-          Remove screenshots
+          Screenshots
         </label>
         <label
           class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
-            checked=""
             class="photon-checkbox photon-checkbox-default"
             name="urls"
             type="checkbox"
           />
-          Remove all URLs
+          Resource URLs
         </label>
         <label
           class="photon-label menuButtonsPublishDataChoicesLabel"
         >
           <input
-            checked=""
             class="photon-checkbox photon-checkbox-default"
             name="extension"
             type="checkbox"
           />
-          Remove extensions
+          Extension information
         </label>
       </div>
     </details>

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -57,7 +57,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the closed state 1`]
       <input
         class="buttonWithPanelButton menuButtonsMetaInfoButtonButton"
         type="button"
-        value="Firefox (48.0) Intel Mac OS X 10.11"
+        value="Firefox () "
       />
     </div>
     <div
@@ -173,94 +173,18 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     <p
       class="menuButtonsPublishInfoDescription"
     >
-      You’re about to share your profile potentially where others have public access to it. 
-      In Nightly and custom builds, no information is stripped by default.
+      You’re about to publicly share your profile, which can potentially contain personally identifiable information.
     </p>
-    <details
-      class="menuButtonsPublishData"
-      open=""
+    <label
+      class="photon-label"
     >
-      <summary
-        class="menuButtonsPublishDataSummary"
-      >
-        Adjust how much is shared
-         
-      </summary>
-      <label
-        class="photon-label"
-      >
-        <input
-          class="photon-checkbox photon-checkbox-default"
-          name="isFiltering"
-          type="checkbox"
-        />
-        Filter out potentially identifying information
-      </label>
-      <div
-        class="menuButtonsPublishDataChoices"
-      >
-        <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
-        >
-          <input
-            checked=""
-            class="photon-checkbox photon-checkbox-default"
-            disabled=""
-            name="hiddenThreads"
-            type="checkbox"
-          />
-          Remove hidden threads
-        </label>
-        <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
-        >
-          <input
-            checked=""
-            class="photon-checkbox photon-checkbox-default"
-            disabled=""
-            name="timeRange"
-            type="checkbox"
-          />
-          Remove information out of the time range
-        </label>
-        <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
-        >
-          <input
-            checked=""
-            class="photon-checkbox photon-checkbox-default"
-            disabled=""
-            name="screenshots"
-            type="checkbox"
-          />
-          Remove screenshots
-        </label>
-        <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
-        >
-          <input
-            checked=""
-            class="photon-checkbox photon-checkbox-default"
-            disabled=""
-            name="urls"
-            type="checkbox"
-          />
-          Remove all URLs
-        </label>
-        <label
-          class="photon-label menuButtonsPublishDataChoicesLabel disabled"
-        >
-          <input
-            checked=""
-            class="photon-checkbox photon-checkbox-default"
-            disabled=""
-            name="extension"
-            type="checkbox"
-          />
-          Remove extensions
-        </label>
-      </div>
-    </details>
+      <input
+        class="photon-checkbox photon-checkbox-default"
+        name="isFiltering"
+        type="checkbox"
+      />
+      Filter out potentially identifying information
+    </label>
     <div
       class="menuButtonsPublishButtons"
     >

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -326,7 +326,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         >
           <input
             class="photon-checkbox photon-checkbox-default"
-            name="hiddenThreads"
+            name="includeHiddenThreads"
             type="checkbox"
           />
           Hidden threads
@@ -336,7 +336,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         >
           <input
             class="photon-checkbox photon-checkbox-default"
-            name="timeRange"
+            name="includeFullTimeRange"
             type="checkbox"
           />
           Hidden time range
@@ -346,7 +346,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         >
           <input
             class="photon-checkbox photon-checkbox-default"
-            name="screenshots"
+            name="includeScreenshots"
             type="checkbox"
           />
           Screenshots
@@ -356,7 +356,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         >
           <input
             class="photon-checkbox photon-checkbox-default"
-            name="urls"
+            name="includeUrls"
             type="checkbox"
           />
           Resource URLs
@@ -366,7 +366,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         >
           <input
             class="photon-checkbox photon-checkbox-default"
-            name="extension"
+            name="includeExtension"
             type="checkbox"
           />
           Extension information

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -87,12 +87,14 @@ export type ImplementationFilter = 'combined' | 'js' | 'cpp';
  * This type determines what kind of information gets sanitized from published profiles.
  */
 export type CheckedSharingOptions = {|
+  // This first values determines if we are filtering at all.
   isFiltering: boolean,
-  hiddenThreads: boolean,
-  timeRange: boolean,
-  screenshots: boolean,
-  urls: boolean,
-  extension: boolean,
+  // The following values are for including more information in a sanitized profile.
+  includeHiddenThreads: boolean,
+  includeFullTimeRange: boolean,
+  includeScreenshots: boolean,
+  includeUrls: boolean,
+  includeExtension: boolean,
 |};
 
 type ProfileAction =


### PR DESCRIPTION
This PR incorporates the feedback from: https://github.com/firefox-devtools/ux/issues/54

I didn't 100% follow everything on it, but tried to incorporate much of it. I felt confused by some of the original wording on nightly vs. release. I tried to make the user flow feel better on each release. I kept the "checked to filter" option, but then moved around the individuals items and made it so that it would be "checked to include the information".

The commits should be in logical order, and help show the steps involved in this PR.

> Nightly default state:
>
> <img width="547" alt="image" src="https://user-images.githubusercontent.com/1588648/55826682-26aac780-5ace-11e9-9714-37fd84b3d664.png">

> Nightly filtering checked:
> 
> <img width="549" alt="image" src="https://user-images.githubusercontent.com/1588648/55826734-4641f000-5ace-11e9-89d5-51b8c393343d.png">

> Release default state:
>
> <img width="537" alt="image" src="https://user-images.githubusercontent.com/1588648/55826778-5c4fb080-5ace-11e9-8713-049d5b35b602.png">

