### PR TITLE
Add prettier as a stylelint rule and update CSS to fix errors

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,16 @@
 {
+  "plugins": [
+    "stylelint-prettier"
+  ],
   "extends": [
     "stylelint-config-standard",
     "stylelint-config-idiomatic-order",
     "stylelint-config-prettier"
-  ]
+  ],
+  "rules": {
+    "prettier/prettier": [
+      true,
+      { "parser": "css" }
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "lint-js": "eslint *.js bin src",
     "lint-fix-js": "yarn lint-js --fix",
     "lint-css": "stylelint 'src/**/*.css' 'res/css/**/*.css'",
-    "lint-fix-css-stylelint": "yarn lint-css --fix",
-    "lint-fix-css-prettier": "prettier 'src/**/*.css' 'res/css/**/*.css' --write",
-    "lint-fix-css": "run-s lint-fix-css-prettier lint-fix-css-stylelint",
+    "lint-fix-css": "yarn lint-css --fix",
     "prettier-json": "prettier --write src/**/*.json",
     "flow": "flow --max-warnings 0",
     "flow-stop": "flow stop",
@@ -132,6 +130,7 @@
     "stylelint-config-idiomatic-order": "^6.2.0",
     "stylelint-config-prettier": "^4.0.0",
     "stylelint-config-standard": "^18.2.0",
+    "stylelint-prettier": "^1.0.6",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.1"

--- a/res/css/photon/checkbox.css
+++ b/res/css/photon/checkbox.css
@@ -15,7 +15,7 @@
 
 /* Remove the border, as it compets with box-shadow styles applied with focus.css */
 .photon-checkbox:focus {
-  border: none
+  border: none;
 }
 
 /* Use this class with the photon-checkbox for the canonical photon styling. */

--- a/res/css/photon/index.css
+++ b/res/css/photon/index.css
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- @import "./button.css";
- @import "./checkbox.css";
- @import "./input.css";
- @import "./label.css";
- @import "./message-bar.css";
- @import "./radio-button.css";
+@import './button.css';
+@import './checkbox.css';
+@import './input.css';
+@import './label.css';
+@import './message-bar.css';
+@import './radio-button.css';

--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -120,4 +120,3 @@
   max-width: unset;
   color: unset;
 }
-

--- a/src/components/shared/NetworkSettings.css
+++ b/src/components/shared/NetworkSettings.css
@@ -3,31 +3,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .networkSettings {
-    display: flex;
-    height: 25px;
-    flex-flow: row nowrap;
-    padding: 0;
-    line-height: 25px;
-  }
-  
+  display: flex;
+  height: 25px;
+  flex-flow: row nowrap;
+  padding: 0;
+  line-height: 25px;
+}
+
 .networkSettingsSpacer {
-    flex: 1;
-  }
-  
+  flex: 1;
+}
+
 .networkSettingsLabel {
-    display: inline-flex;
-    height: 25px;
-    flex-flow: row nowrap;
-    align-items: center;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    user-select: none;
-  }
-  
+  display: inline-flex;
+  height: 25px;
+  flex-flow: row nowrap;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+
 .networkSettingsSearchbar {
-    padding: 0 5px;
-  }
-  
+  padding: 0 5px;
+}
+
 .networkSettingsSearchField {
-    width: 250px;
-  }
+  width: 250px;
+}

--- a/src/components/timeline/VerticalIndicators.css
+++ b/src/components/timeline/VerticalIndicators.css
@@ -27,13 +27,11 @@
 .timelineVerticalIndicatorsLine::after {
   position: absolute;
   top: 0;
-  left: calc(
-    var(--active-area-width) * 0.5 - var(--visible-width) * 0.5
-  );
+  left: calc(var(--active-area-width) * 0.5 - var(--visible-width) * 0.5);
   width: var(--visible-width);
   height: 100%;
   background-color: var(--vertical-indicator-color);
-  content: "";
+  content: '';
   opacity: 0.6;
   pointer-events: none;
 }

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -33,7 +33,7 @@
 .timelineSettings {
   display: flex;
   height: var(--timeline-settings-height);
-  
+
   /* Ensure the --timeline-settings-height defines the outer height of the component. */
   box-sizing: border-box;
   flex: none;
@@ -96,7 +96,7 @@
   border-right: 4px solid transparent;
   border-bottom: 0 solid transparent;
   border-left: 4px solid transparent;
-  content: "";
+  content: '';
 }
 
 .timelineSettingsHiddenTracksNumber {

--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -57,7 +57,7 @@
   height: 9px;
   box-sizing: border-box;
   margin-right: 3px;
-  border: .5px solid rgba(0,0,0,.1);
+  border: 0.5px solid rgba(0, 0, 0, 0.1);
 }
 
 .tooltipCallNodeImplementationHeaderSwatchRunning {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4655,6 +4655,11 @@ fast-diff@^1.1.1:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
   integrity sha1-CuoOTmBbaiGJ8Ok21Lf7rxt8/Zs=
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.6.tgz#a5d5b697ec8deda468d85a74035290a025a95295"
@@ -9764,6 +9769,13 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 prettier@^1.16.4:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
@@ -11690,6 +11702,13 @@ stylelint-order@^1.0.0:
     lodash "^4.17.10"
     postcss "^7.0.2"
     postcss-sorting "^4.0.0"
+
+stylelint-prettier@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.6.tgz#479b76336751cb617c5beb7545d05a791f945e1e"
+  integrity sha512-XKlTyJHJYiyXs9JXRMt2FQxMJoBSjz4I6+4+/R3o8/ePof19v9naC4d0zsMKUJ88by81+qHfqXBLfmAalu46cg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 stylelint@^9.10.1, stylelint@^9.6.0:
   version "9.10.1"


### PR DESCRIPTION
Added some additional rules to css linting. These are actually the style rules we follow instinctively, that's why I had to change only one line. But I think this is a good addition to have since some new contributors may not know and this will save them/us some time because people will be able to see the errors before pushing the commit instead of comments during review.
(Generally the rules I added related to spacing {before,after} {brace,comma,colon} because I'm a bit obsessed with spacing 😄 )
Rules can be seen here: https://stylelint.io/user-guide/rules/