### PR TITLE
Split up publish actions, and add test coverage

### DIFF
--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -324,6 +324,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
       case 'local':
         return this._renderPublishPanel();
       case 'uploading':
+      case 'compressing':
         return this._renderUploadPanel();
       case 'uploaded':
         return this._renderUploadedPanel();

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -47,8 +47,15 @@ const checkedSharingOptions: Reducer<CheckedSharingOptions> = (
 
 const phase: Reducer<UploadPhase> = (state = 'local', action) => {
   switch (action.type) {
-    case 'CHANGE_UPLOAD_STATE':
-      return 'phase' in action.changes ? action.changes.phase : state;
+    case 'UPLOAD_STARTED':
+      return 'uploading';
+    case 'UPLOAD_FINISHED':
+      return 'uploaded';
+    case 'UPLOAD_FAILED':
+      return 'error';
+    case 'UPLOAD_ABORTED':
+    case 'UPLOAD_RESET':
+      return 'local';
     default:
       return state;
   }
@@ -56,10 +63,13 @@ const phase: Reducer<UploadPhase> = (state = 'local', action) => {
 
 const uploadProgress: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
-    case 'CHANGE_UPLOAD_STATE':
-      return 'uploadProgress' in action.changes
-        ? action.changes.uploadProgress
-        : state;
+    case 'UPDATE_UPLOAD_PROGRESS':
+      return action.uploadProgress;
+    case 'UPLOAD_STARTED':
+    case 'UPLOAD_ABORTED':
+    case 'UPLOAD_RESET':
+    case 'UPLOAD_FINISHED':
+      return 0;
     default:
       return state;
   }
@@ -67,8 +77,8 @@ const uploadProgress: Reducer<number> = (state = 0, action) => {
 
 const error: Reducer<Error | mixed> = (state = null, action) => {
   switch (action.type) {
-    case 'CHANGE_UPLOAD_STATE':
-      return 'error' in action.changes ? action.changes.error : state;
+    case 'UPLOAD_FAILED':
+      return action.error;
     default:
       return state;
   }
@@ -76,8 +86,8 @@ const error: Reducer<Error | mixed> = (state = null, action) => {
 
 const url: Reducer<string> = (state = '', action) => {
   switch (action.type) {
-    case 'CHANGE_UPLOAD_STATE':
-      return 'url' in action.changes ? action.changes.url : state;
+    case 'UPLOAD_FINISHED':
+      return action.url;
     default:
       return state;
   }
@@ -85,10 +95,8 @@ const url: Reducer<string> = (state = '', action) => {
 
 const abortFunction: Reducer<() => void> = (state = () => {}, action) => {
   switch (action.type) {
-    case 'CHANGE_UPLOAD_STATE':
-      return 'abortFunction' in action.changes
-        ? action.changes.abortFunction
-        : state;
+    case 'UPLOAD_STARTED':
+      return action.abortFunction;
     default:
       return state;
   }
@@ -99,9 +107,9 @@ const abortFunction: Reducer<() => void> = (state = () => {}, action) => {
  */
 const generation: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
-    case 'CHANGE_UPLOAD_STATE':
+    case 'UPLOAD_STARTED':
       // Increment the generation value if starting to upload.
-      return action.changes.phase === 'uploading' ? state + 1 : state;
+      return state + 1;
     default:
       return state;
   }

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -8,6 +8,7 @@ import {
   attemptToPublish,
   resetUploadState,
   abortUpload,
+  toggleCheckedSharingOptions,
 } from '../../actions/publish';
 import {
   getCheckedSharingOptions,
@@ -62,6 +63,27 @@ describe('getCheckedSharingOptions', function() {
     it('does filter with release', function() {
       expect(getDefaultsWith('release')).toMatchObject({
         isFiltering: true,
+      });
+    });
+  });
+  describe('toggleCheckedSharingOptions', function() {
+    it('can toggle options', function() {
+      const { profile } = getProfileFromTextSamples('A');
+      const { getState, dispatch } = storeWithProfile(profile);
+      expect(getCheckedSharingOptions(getState())).toMatchObject({
+        includeHiddenThreads: false,
+      });
+
+      dispatch(toggleCheckedSharingOptions('includeHiddenThreads'));
+
+      expect(getCheckedSharingOptions(getState())).toMatchObject({
+        includeHiddenThreads: true,
+      });
+
+      dispatch(toggleCheckedSharingOptions('includeHiddenThreads'));
+
+      expect(getCheckedSharingOptions(getState())).toMatchObject({
+        includeHiddenThreads: false,
       });
     });
   });

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -4,9 +4,27 @@
 
 // @flow
 
-import { getCheckedSharingOptions } from '../../selectors/publish';
+import {
+  attemptToPublish,
+  resetUploadState,
+  abortUpload,
+} from '../../actions/publish';
+import {
+  getCheckedSharingOptions,
+  getUploadPhase,
+  getUploadError,
+  getUploadProgress,
+  getUploadGeneration,
+} from '../../selectors/publish';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
+import { TextEncoder } from 'util';
+import { ensureExists } from '../../utils/flow';
+import { waitUntilState } from '../fixtures/utils';
+
+// Mocks:
+import { uploadBinaryProfileData } from '../../profile-logic/profile-store';
+jest.mock('../../profile-logic/profile-store');
 
 describe('getCheckedSharingOptions', function() {
   describe('default filtering by channel', function() {
@@ -46,5 +64,178 @@ describe('getCheckedSharingOptions', function() {
         isFiltering: true,
       });
     });
+  });
+});
+
+describe('attemptToPublish', function() {
+  beforeEach(function() {
+    if ((window: any).TextEncoder) {
+      throw new Error('A TextEncoder was already on the window object.');
+    }
+    (window: any).TextEncoder = TextEncoder;
+  });
+
+  afterEach(async function() {
+    delete (window: any).TextEncoder;
+  });
+
+  function setup() {
+    const { profile } = getProfileFromTextSamples('A');
+    const store = storeWithProfile(profile);
+
+    let updateUploadProgress;
+    let resolveUpload;
+    let rejectUpload;
+    const abortFunction = jest.fn();
+    const promise = new Promise((resolve, reject) => {
+      resolveUpload = resolve;
+      rejectUpload = reject;
+    });
+
+    promise.catch(() => {
+      // Node complains if we don't handle a promise/catch, and this one rejects
+      // before it's properly handled. Catch it here so that Node doesn't complain.
+    });
+
+    const initUploadProcess: typeof uploadBinaryProfileData = () => ({
+      abortFunction,
+      startUpload: (data, callback) => {
+        updateUploadProgress = callback;
+        return promise;
+      },
+    });
+    (uploadBinaryProfileData: any).mockImplementation(initUploadProcess);
+
+    jest.spyOn(window, 'open').mockImplementation(() => {});
+
+    function getUpdateUploadProgress() {
+      return ensureExists(
+        updateUploadProgress,
+        'Expected to get a reference to the callback to update the upload progress.'
+      );
+    }
+
+    function waitUntilPhase(phase) {
+      return waitUntilState(store, state => getUploadPhase(state) === phase);
+    }
+
+    return {
+      ...store,
+      resolveUpload,
+      rejectUpload,
+      getUpdateUploadProgress,
+      waitUntilPhase,
+      abortFunction,
+    };
+  }
+
+  it('cycles through the upload phases on a successful upload', async function() {
+    const { dispatch, getState, resolveUpload } = setup();
+    expect(getUploadPhase(getState())).toEqual('local');
+    const publishAttempt = dispatch(attemptToPublish());
+    expect(getUploadPhase(getState())).toEqual('compressing');
+    resolveUpload('FAKEHASH');
+    await publishAttempt;
+    expect(getUploadPhase(getState())).toEqual('uploaded');
+  });
+
+  it('can handle upload errors', async function() {
+    const { dispatch, getState, rejectUpload } = setup();
+    const publishAttempt = dispatch(attemptToPublish());
+    // Reject with a simple string since it's easy to test equality.
+    rejectUpload('fake error');
+    await publishAttempt;
+    expect(getUploadPhase(getState())).toEqual('error');
+    expect(getUploadError(getState())).toEqual('fake error');
+  });
+
+  it('calls window.open after publishing a profile', async function() {
+    const { dispatch, resolveUpload } = setup();
+    const publishAttempt = dispatch(attemptToPublish());
+    resolveUpload('FAKEHASH');
+    await publishAttempt;
+    expect(window.open).toHaveBeenCalledWith(
+      'http://localhost/public/FAKEHASH/calltree/?profileName=&published&v=3',
+      '_blank'
+    );
+  });
+
+  it('updates with upload progress', async function() {
+    const {
+      waitUntilPhase,
+      dispatch,
+      getState,
+      resolveUpload,
+      getUpdateUploadProgress,
+    } = setup();
+    const publishAttempt = dispatch(attemptToPublish());
+    await waitUntilPhase('uploading');
+    const updateUploadProgress = getUpdateUploadProgress();
+
+    expect(getUploadProgress(getState())).toEqual(0);
+
+    updateUploadProgress(0.2);
+    expect(getUploadProgress(getState())).toEqual(0.2);
+
+    updateUploadProgress(0.5);
+    expect(getUploadProgress(getState())).toEqual(0.5);
+
+    resolveUpload('FAKEHASH');
+    await publishAttempt;
+    expect(getUploadProgress(getState())).toEqual(0);
+  });
+
+  it('can reset after a successful upload', async function() {
+    const { dispatch, getState, resolveUpload } = setup();
+    const publishAttempt = dispatch(attemptToPublish());
+    resolveUpload('FAKEHASH');
+    expect(getUploadGeneration(getState())).toEqual(0);
+    await publishAttempt;
+    expect(getUploadPhase(getState())).toEqual('uploaded');
+    expect(getUploadGeneration(getState())).toEqual(1);
+    dispatch(resetUploadState());
+    expect(getUploadPhase(getState())).toEqual('local');
+  });
+
+  it('can abort an upload', async function() {
+    const { dispatch, getState } = setup();
+    const publishAttempt = dispatch(attemptToPublish());
+    expect(getUploadGeneration(getState())).toEqual(0);
+    dispatch(abortUpload());
+    expect(getUploadGeneration(getState())).toEqual(1);
+
+    // Returning the publish attempt will ensure the that generation check gets hit.
+    return publishAttempt;
+  });
+
+  it('obeys the generational value, and ignores stale uploads', async function() {
+    const {
+      dispatch,
+      getState,
+      resolveUpload,
+      waitUntilPhase,
+      abortFunction,
+    } = setup();
+    // Kick off a download.
+    const promise = dispatch(attemptToPublish());
+    expect(getUploadGeneration(getState())).toEqual(0);
+
+    // Wait until it finishes compressing, and starts uploading.
+    await waitUntilPhase('uploading');
+
+    // Abort the download.
+    dispatch(abortUpload());
+
+    // Make sure the abort function was called.
+    expect(abortFunction).toHaveBeenCalled();
+    expect(getUploadGeneration(getState())).toEqual(1);
+
+    // Resolve the previous upload.
+    resolveUpload('FAKEHASH');
+    await promise;
+
+    // Make sure that the attemptToPublish workflow doesn't continue to the
+    // uploaded state.
+    expect(getUploadPhase(getState())).toEqual('local');
   });
 });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -348,6 +348,9 @@ type PublishAction =
       +type: 'UPLOAD_RESET',
     |}
   | {|
+      +type: 'UPLOAD_COMPRESSION_STARTED',
+    |}
+  | {|
       +type: 'CHANGE_UPLOAD_STATE',
       +changes: $Shape<UploadState>,
     |};

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -326,12 +326,30 @@ type PublishAction =
       +slug: $Keys<CheckedSharingOptions>,
     |}
   | {|
-      +type: 'CHANGE_UPLOAD_STATE',
-      +changes: $Shape<UploadState>,
+      +type: 'UPLOAD_STARTED',
+      +abortFunction: () => void,
     |}
   | {|
-      +type: 'SAVE_ABORT_UPLOAD_FUNCTION',
-      +abort: () => void,
+      +type: 'UPDATE_UPLOAD_PROGRESS',
+      +uploadProgress: number,
+    |}
+  | {|
+      +type: 'UPLOAD_FINISHED',
+      +url: string,
+    |}
+  | {|
+      +type: 'UPLOAD_FAILED',
+      +error: mixed,
+    |}
+  | {|
+      +type: 'UPLOAD_ABORTED',
+    |}
+  | {|
+      +type: 'UPLOAD_RESET',
+    |}
+  | {|
+      +type: 'CHANGE_UPLOAD_STATE',
+      +changes: $Shape<UploadState>,
     |};
 
 export type Action =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -120,7 +120,12 @@ export type AppState = {|
   +trackThreadHeights: Array<ThreadIndex | void>,
 |};
 
-export type UploadPhase = 'local' | 'uploading' | 'uploaded' | 'error';
+export type UploadPhase =
+  | 'local'
+  | 'compressing'
+  | 'uploading'
+  | 'uploaded'
+  | 'error';
 
 export type UploadState = {|
   phase: UploadPhase,


### PR DESCRIPTION
Resolves #1895
Resolves #1894

Originally I only wanted to split up the publish actions, but I didn't feel confidant in not breaking things, so I also wrote the tests. I would appreciate some manual testing here, as this codifies some of the behaviors for uploading in tests.