### PR TITLE
Fix a marker mutation problem during sanitization

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -850,9 +850,10 @@ export function groupScreenshotsById(markers: Marker[]): Map<string, Marker[]> {
   return idToScreenshotMarkers;
 }
 
-export function removeNetworkMarkerURLs(payload: NetworkPayload) {
-  payload.URI = '';
-  payload.RedirectURI = '';
+export function removeNetworkMarkerURLs(
+  payload: NetworkPayload
+): NetworkPayload {
+  return { ...payload, URI: '', RedirectURI: '' };
 }
 
 export function getMarkerFullDescription(marker: Marker) {

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1220,9 +1220,7 @@ function sanitizeThreadPII(
         currentMarker.type === 'Network'
       ) {
         // Remove the URI fields from marker payload.
-        // Mutating the payload here but it's safe because we copied the
-        // markerTable already.
-        removeNetworkMarkerURLs(currentMarker);
+        markerTable.data[i] = removeNetworkMarkerURLs(currentMarker);
 
         // Strip the URL from the marker name
         const stringIndex = markerTable.name[i];


### PR DESCRIPTION
Problem STR:
1. Download this profile for example(it includes network markers): [Firefox 2019-04-17 19.39 profile.json.gz](https://github.com/firefox-devtools/profiler/files/3090846/Firefox.2019-04-17.19.39.profile.json.gz)
2. Open https://profiler.firefox.com and load this profile.
3. Open console and write `profile.threads[0].markers.data.filter(m => m && m.type == 'Network');` and see that `URI` fields are there.
4. Click "Share" button and check filter out checkbox.
5. Write `profile.threads[0].markers.data.filter(m => m && m.type == 'Network');` again and see that URIs are stripped from original profile but shouldn't.

And you can test use the same STR with https://deploy-preview-1955--perf-html.netlify.com/ to see that it doesn't mutate anymore.