### PR TITLE
Add a getBoundingClientRect mock to some files to avoid an intermittent

### DIFF
--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -25,6 +25,18 @@ import {
   addTransformToStack,
 } from '../../actions/profile-view';
 
+beforeEach(() => {
+  // Mock out the 2d canvas for the loupe view.
+  jest
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation(() => mockCanvasContext());
+  // This makes the bounding box large enough so that we don't trigger
+  // VirtualList's virtualization. We assert this above.
+  jest
+    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => getBoundingBox(1000, 2000));
+});
+
 describe('calltree/ProfileCallTreeView', function() {
   const { profile } = getProfileFromTextSamples(`
     A  A  A
@@ -33,13 +45,6 @@ describe('calltree/ProfileCallTreeView', function() {
     D  F  I
     E  E
   `);
-
-  beforeEach(() => {
-    // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
-  });
 
   it('renders an unfiltered call tree', () => {
     const { container } = render(
@@ -116,13 +121,6 @@ describe('calltree/ProfileCallTreeView', function() {
 });
 
 describe('calltree/ProfileCallTreeView EmptyReasons', function() {
-  beforeEach(() => {
-    // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
-  });
-
   const { profile } = getProfileFromTextSamples(`
     A  A  A
     B  B  B
@@ -164,20 +162,7 @@ describe('calltree/ProfileCallTreeView EmptyReasons', function() {
 });
 
 describe('calltree/ProfileCallTreeView navigation keys', () => {
-  beforeEach(() => {
-    // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
-  });
-
   function setup(profileString: string, expectedRowsLength: number) {
-    // This makes the bounding box large enough so that we don't trigger
-    // VirtualList's virtualization. We assert this above.
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(1000, 2000));
-
     const { profile } = getProfileFromTextSamples(profileString);
     const store = storeWithProfile(profile);
     const { container } = render(
@@ -254,19 +239,6 @@ describe('calltree/ProfileCallTreeView navigation keys', () => {
 });
 
 describe('calltree/ProfileCallTreeView TransformNavigator', () => {
-  beforeEach(() => {
-    // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
-
-    // This makes the bounding box large enough so that we don't trigger
-    // VirtualList's virtualization. We assert this above.
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(1000, 2000));
-  });
-
   it('renders with multiple transforms applied', () => {
     const {
       profile,

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -13,7 +13,7 @@ import * as ZippedProfileSelectors from '../../selectors/zipped-profiles';
 
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
-import { waitUntilState } from '../fixtures/utils';
+import { getBoundingBox, waitUntilState } from '../fixtures/utils';
 
 describe('calltree/ZipFileTree', function() {
   async function setup() {
@@ -27,6 +27,12 @@ describe('calltree/ZipFileTree', function() {
     jest
       .spyOn(HTMLCanvasElement.prototype, 'getContext')
       .mockImplementation(() => mockCanvasContext());
+
+    // This makes the bounding box large enough so that we don't trigger
+    // VirtualList's virtualization.
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(() => getBoundingBox(1000, 2000));
 
     const renderResult = render(
       <Provider store={store}>


### PR DESCRIPTION
This might fix some occurrences of #1767 and #1669.

Locally, this always triggered the error in ZipFileTree, and with this patch it doesn't anymore:
```
yarn test --no-cache TimelineMarkers ZipFileTree GlobalTrack TrackScreenshots LocalTrack 
```