### PR TITLE
Display the tooltip as soon as we hover the line

### DIFF
--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -268,15 +268,17 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
     );
 
     return (
-      <section className={itemClassName}>
+      <section
+        className={itemClassName}
+        onMouseEnter={this._hoverIn}
+        onMouseLeave={this._hoverOut}
+      >
         <div className="networkChartRowItemLabel">
           {this._splitsURI(marker.name)}
         </div>
         <div
           className="networkChartRowItemBar"
           style={{ width: markerWidth, left: startPosition }}
-          onMouseEnter={this._hoverIn}
-          onMouseLeave={this._hoverOut}
         >
           <NetworkChartRowBar
             marker={marker}

--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -48,12 +48,6 @@
   white-space: nowrap;
 }
 
-/* This rule is useful to make the label more visible on hover. */
-.networkChartRowItem:hover .networkChartRowItemLabel {
-  position: relative;
-  z-index: 1;
-}
-
 .networkChartRowItemBar {
   position: absolute; /* The bar will be positioned in JS. */
   display: inline-block;
@@ -66,10 +60,6 @@
   border-radius: 2px;
   box-shadow: 0 0 0 1px inset var(--marker-color);
   opacity: 0.7;
-}
-
-.networkChartRowItem:hover .networkChartRowItemBar {
-  opacity: 0.4;
 }
 
 .networkChartRowItemBarPhase {
@@ -90,14 +80,11 @@
 .networkChartRowItemUriRequired {
   display: inline-block;
   overflow: hidden;
+  max-width: 600px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.networkChartRowItemUriRequired:nth-child(1) {
-  padding-right: 8px;
-}
-
-/* This makes the URI completely visible on hover */
 .networkChartRowItem:hover .networkChartRowItemUriOptional {
-  max-width: unset;
   color: unset;
 }


### PR DESCRIPTION
[master](https://master--perf-html.netlify.com/public/2a5d34be5f5f662438b765cdd3796fbad8d8b051/network-chart/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4-5&localTrackOrderByPid=5569-1-2-0~6172-0~6295-0~6403-0~5755-0~5696-0~6351-0-1~&thread=7&v=3)
[deploy preview](https://deploy-preview-1967--perf-html.netlify.com/public/2a5d34be5f5f662438b765cdd3796fbad8d8b051/network-chart/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4-5&localTrackOrderByPid=5569-1-2-0~6172-0~6295-0~6403-0~5755-0~5696-0~6351-0-1~&thread=7&v=3)

Note: I tried various strategies for the tooltip positioning:
* depending on the marker position
* always at the left

but in the end I kept the current strategy (using the mouse position) as I thought it was the most usable.