### PR TITLE
Consolidate URL fields in RemoveProfileInformation object

### DIFF
--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -31,10 +31,7 @@ export function sanitizePII(
   const oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex | null> = new Map();
   let pages;
   if (profile.pages) {
-    if (
-      PIIToBeRemoved.shouldRemoveNetworkUrls ||
-      PIIToBeRemoved.shouldRemoveAllUrls
-    ) {
+    if (PIIToBeRemoved.shouldRemoveUrls) {
       pages = profile.pages.map(page =>
         Object.assign({}, page, {
           url: 'Page #' + urlCounter++,
@@ -137,7 +134,7 @@ function sanitizeThreadPII(
   // status.
   const markersToDelete = new Set();
   if (
-    PIIToBeRemoved.shouldRemoveNetworkUrls ||
+    PIIToBeRemoved.shouldRemoveUrls ||
     PIIToBeRemoved.shouldRemoveThreadsWithScreenshots.size > 0
   ) {
     for (let i = 0; i < markerTable.length; i++) {
@@ -145,7 +142,7 @@ function sanitizeThreadPII(
 
       // Remove the all network URLs if user wants to remove them.
       if (
-        PIIToBeRemoved.shouldRemoveNetworkUrls &&
+        PIIToBeRemoved.shouldRemoveUrls &&
         currentMarker &&
         currentMarker.type &&
         currentMarker.type === 'Network'
@@ -210,7 +207,7 @@ function sanitizeThreadPII(
 
   // This is expensive but needs to be done somehow.
   // Maybe we can find something better here.
-  if (PIIToBeRemoved.shouldRemoveAllUrls) {
+  if (PIIToBeRemoved.shouldRemoveUrls) {
     for (let i = 0; i < stringArray.length; i++) {
       stringArray[i] = removeURLs(stringArray[i]);
     }

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -125,8 +125,7 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
       shouldFilterToCommittedRange: checkedSharingOptions.includeFullTimeRange
         ? null
         : committedRange,
-      shouldRemoveNetworkUrls: !checkedSharingOptions.includeUrls,
-      shouldRemoveAllUrls: !checkedSharingOptions.includeUrls,
+      shouldRemoveUrls: !checkedSharingOptions.includeUrls,
       shouldRemoveThreadsWithScreenshots: new Set(
         checkedSharingOptions.includeScreenshots
           ? []

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -264,8 +264,7 @@ describe('sanitizePII', function() {
     return {
       shouldRemoveThreads: new Set(),
       shouldRemoveThreadsWithScreenshots: new Set(),
-      shouldRemoveNetworkUrls: false,
-      shouldRemoveAllUrls: false,
+      shouldRemoveUrls: false,
       shouldFilterToCommittedRange: null,
       shouldRemoveExtensions: false,
       ...customFields,
@@ -369,7 +368,7 @@ describe('sanitizePII', function() {
     }
 
     const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveNetworkUrls: true,
+      shouldRemoveUrls: true,
     });
 
     const sanitizedProfile = sanitizePII(profile, PIIToRemove);
@@ -378,10 +377,10 @@ describe('sanitizePII', function() {
     }
   });
 
-  it('should sanitize the network URLS', function() {
+  it('should sanitize all the URLs inside network markers', function() {
     const profile = processProfile(createGeckoProfile());
     const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveNetworkUrls: true,
+      shouldRemoveUrls: true,
     });
 
     const sanitizedProfile = sanitizePII(profile, PIIToRemove);
@@ -403,10 +402,10 @@ describe('sanitizePII', function() {
     }
   });
 
-  it('should sanitize all the URLS', function() {
+  it('should sanitize all the URLs inside string table', function() {
     const profile = processProfile(createGeckoProfile());
     const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveAllUrls: true,
+      shouldRemoveUrls: true,
     });
 
     const sanitizedProfile = sanitizePII(profile, PIIToRemove);

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -170,10 +170,8 @@ export type RemoveProfileInformation = {
   shouldRemoveThreadsWithScreenshots: Set<ThreadIndex>,
   // Remove the full time range if StartEndRange is provided.
   shouldFilterToCommittedRange: StartEndRange | null,
-  // Remove all the network URLs if it's true.
-  shouldRemoveNetworkUrls: boolean,
-  // Remove all the URLs inside string table if it's true.
-  shouldRemoveAllUrls: boolean,
+  // Remove all the URLs if it's true.
+  shouldRemoveUrls: boolean,
   // Remove the extension list if it's true.
   shouldRemoveExtensions: boolean,
 };


### PR DESCRIPTION
We no longer expose two different fields in the publish panel. Consolidated them to reflect the panel.
Fixes #1941.