### PR TITLE
Fix network marker rendering when it's on the edge of the chart

### DIFF
--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import clamp from 'clamp';
 import { oneLine } from 'common-tags';
 import * as React from 'react';
 import {
@@ -164,8 +163,7 @@ function _timeToCssPixels(props: Props, time: Milliseconds): CssPixels {
     ((time - timeRange.start) / timeRangeTotal) * innerContainerWidth +
     TIMELINE_MARGIN_LEFT;
 
-  // Keep the value bounded to the available viewport area.
-  return clamp(markerPosition, 0, width);
+  return markerPosition;
 }
 
 /**

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -69,6 +69,9 @@ function setupWithProfile(profile) {
       <NetworkChart />
     </Provider>
   );
+
+  flushRafCalls();
+
   const { container } = renderResult;
 
   function getUrlShorteningParts(): Array<[string, string]> {
@@ -92,8 +95,8 @@ function setupWithProfile(profile) {
 
   return {
     ...renderResult,
+    ...store,
     flushRafCalls,
-    dispatch: store.dispatch,
     flushDrawLog: () => ctx.__flushDrawLog(),
     getUrlShorteningParts,
     getPhaseElements,
@@ -102,30 +105,14 @@ function setupWithProfile(profile) {
   };
 }
 
-// create new function to get ProfileWithNetworkMarkers
 function setupWithPayload(markers: TestDefinedMarkers) {
   const profile = getProfileWithMarkers(markers);
-  const setupResult = setupWithProfile(profile);
-  const { flushRafCalls, dispatch } = setupResult;
-
-  dispatch(changeSelectedTab('network-chart'));
-  flushRafCalls();
-
-  return setupResult;
+  return setupWithProfile(profile);
 }
 
 describe('NetworkChart', function() {
   it('renders NetworkChart correctly', () => {
-    const profile = getProfileWithMarkers([...NETWORK_MARKERS]);
-    const {
-      flushRafCalls,
-      dispatch,
-      flushDrawLog,
-      container,
-    } = setupWithProfile(profile);
-
-    dispatch(changeSelectedTab('network-chart'));
-    flushRafCalls();
+    const { flushDrawLog, container } = setupWithPayload([...NETWORK_MARKERS]);
 
     const drawCalls = flushDrawLog();
     expect(container.firstChild).toMatchSnapshot();
@@ -413,10 +400,8 @@ describe('NetworkChartRowBar MIME-type filter', function() {
 
 describe('EmptyReasons', () => {
   it("shows a reason when a profile's network markers have been filtered out", () => {
-    const profile = getProfileWithMarkers(NETWORK_MARKERS);
-    const { dispatch, container } = setupWithProfile(profile);
+    const { dispatch, container } = setupWithPayload([...NETWORK_MARKERS]);
 
-    dispatch(changeSelectedTab('network-chart'));
     dispatch(changeNetworkSearchString('MATCH_NOTHING'));
     expect(container.querySelector('.EmptyReasons')).toMatchSnapshot();
   });


### PR DESCRIPTION
Fixes #1976

Notice that the phases are now hidden on the marker:
[master](https://profiler.firefox.com/public/8b2e92d6b9d9a506737fbed3d0fa5424e3b34a0c/network-chart/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3164-1-2-0~12558-0-1~&networkSearch=adnxs&range=5.7806_7.2783~5.8327_6.1186~5.8535_5.9234~5.8885_5.9013&thread=5&v=3)
[deploy preview](https://deploy-preview-1985--perf-html.netlify.com/public/8b2e92d6b9d9a506737fbed3d0fa5424e3b34a0c/network-chart/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3164-1-2-0~12558-0-1~&networkSearch=adnxs&range=5.7806_7.2783~5.8327_6.1186~5.8535_5.9234~5.8885_5.9013&thread=5&v=3)

You can look at the individual commits, they're meaningful when seen separately.