### PR TITLE
Remove the note that says shutdown profiles are not symbolicated in the doc

### DIFF
--- a/docs-user/guide-startup-shutdown.md
+++ b/docs-user/guide-startup-shutdown.md
@@ -14,13 +14,6 @@ Startup profiling does not use the settings that you configured in the add-on's 
 
 ## Shutdown
 
----
-**NOTE**
-
-A recorded Firefox shutdown profile won't be symbolicated, so when loading it into [profiler.firefox.com](https://profiler.firefox.com) it will be of limited use. [Issue #1458](https://github.com/firefox-devtools/profiler/issues/1458) addresses this.
-
----
-
 1. Start your Firefox with the environment variable `MOZ_PROFILER_SHUTDOWN=<filename>` set, where `<filename>` is the name of the file where the recorded profile should be saved.
 
 2. Start the profiler using the add-on, then close Firefox.


### PR DESCRIPTION
This message is not valid anymore since #1458 is closed.