### PR TITLE
Add relevantForJS label frame support for js implementation filter

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -87,12 +87,12 @@ export function setHasZoomedViaMousewheel() {
  */
 export function setupInitialUrlState(
   location: Location,
-  _profile: Profile
+  profile: Profile
 ): ThunkAction<void> {
   return dispatch => {
     let urlState;
     try {
-      urlState = stateFromLocation(location); // TODO: pass the profile here.
+      urlState = stateFromLocation(location, profile);
     } catch (e) {
       // The location could not be parsed, show a 404 instead.
       console.error(e);

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -83,21 +83,23 @@ export function updateUrlState(newUrlState: UrlState | null): Action {
   return { type: 'UPDATE_URL_STATE', newUrlState };
 }
 
-export const reportTrackThreadHeight = (
+export function reportTrackThreadHeight(
   threadIndex: ThreadIndex,
   height: CssPixels
-): ThunkAction<void> => (dispatch, getState) => {
-  const trackThreadHeights = getTrackThreadHeights(getState());
-  const previousHeight = trackThreadHeights[threadIndex];
-  if (previousHeight !== height) {
-    // Guard against unnecessary dispatches. This could happen frequently.
-    dispatch({
-      type: 'UPDATE_TRACK_THREAD_HEIGHT',
-      height,
-      threadIndex,
-    });
-  }
-};
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const trackThreadHeights = getTrackThreadHeights(getState());
+    const previousHeight = trackThreadHeights[threadIndex];
+    if (previousHeight !== height) {
+      // Guard against unnecessary dispatches. This could happen frequently.
+      dispatch({
+        type: 'UPDATE_TRACK_THREAD_HEIGHT',
+        height,
+        threadIndex,
+      });
+    }
+  };
+}
 
 /**
  * This action dismisses the newly published state. This happens when a user first

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -105,6 +105,12 @@ export function setupInitialUrlState(
       urlState = null;
     }
 
+    // Normally having multiple dispatches is an anti pattern, but here it's
+    // necessary because we are doing different things inside those actions and
+    // they can't be merged because we are also calling those seperately on
+    // other parts of the code.
+    // The first dispatch here updates the url state, then changes state as the url
+    // setup is done, and lastly finalizes the profile view since everything is set up now.
     dispatch(updateUrlState(urlState));
     dispatch(urlSetupDone());
     dispatch(finalizeProfileView());

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -7,7 +7,7 @@ import { getSelectedTab, getDataSource } from '../selectors/url-state';
 import { getTrackThreadHeights } from '../selectors/app';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
-import { finalizeView } from './receive-profile';
+import { finalizeProfileView } from './receive-profile';
 import type { Profile, ThreadIndex } from '../types/profile';
 import type { CssPixels } from '../types/units';
 import type { Action, ThunkAction } from '../types/store';
@@ -107,7 +107,7 @@ export function setupInitialUrlState(
 
     dispatch(updateUrlState(urlState));
     dispatch(urlSetupDone());
-    dispatch(finalizeView());
+    dispatch(finalizeProfileView());
   };
 }
 

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -42,6 +42,7 @@ import type {
   ImplementationFilter,
   TrackReference,
   TimelineType,
+  DataSource,
 } from '../types/actions';
 import type { State } from '../types/state';
 import type { Action, ThunkAction } from '../types/store';
@@ -1064,5 +1065,12 @@ export function changeProfileName(profileName: string): Action {
   return {
     type: 'CHANGE_PROFILE_NAME',
     profileName,
+  };
+}
+
+export function setDataSource(dataSource: DataSource): Action {
+  return {
+    type: 'SET_DATA_SOURCE',
+    dataSource,
   };
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -17,7 +17,6 @@ import { expandUrl } from '../utils/shorten-url';
 import { TemporaryError } from '../utils/errors';
 import JSZip from 'jszip';
 import {
-  getDataSource,
   getSelectedThreadIndexOrNull,
   getGlobalTrackOrder,
   getHiddenGlobalTracks,
@@ -173,7 +172,6 @@ export function viewProfile(
       pathInZipFile: config.pathInZipFile,
       implementationFilter: config.implementationFilter,
       transformStacks: config.transformStacks,
-      dataSource: getDataSource(getState()),
     });
 
     // Note we kick off symbolication only for the profiles we know for sure

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -103,6 +103,13 @@ export function loadProfile(
       return;
     }
 
+    // We have a 'PROFILE_LOADED' dispatch here and a second dispatch for
+    // `finalizeProfileView`. Normally this is an anti-pattern but that was
+    // necessary for initial load url handling. We are not dispatching
+    // `finalizeProfileView` here if it's initial load, instead are getting the
+    // url, upgrading the url and then creating a UrlState that we can use
+    // first. That is necessary because we need a UrlState inside `finalizeProfileView`.
+    // If this is not the initial load, we are dispatching both of them.
     dispatch({
       type: 'PROFILE_LOADED',
       profile,

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -217,6 +217,12 @@ export function finalizeProfileView(
   };
 }
 
+// Previously `loadProfile` and `finalizeProfileView` functions were a single
+// function called `viewProfile`. Then we had to split it because of the changes
+// of url/profile loading mechanism. We kept the `viewProfile` function with the
+// same functionality as previous `viewProfile` because many of the tests use this.
+// This function will simply call `loadProfile` (and `finalizeProfileView` inside
+// `loadProfile`) and wait until symbolication finishes.
 export function viewProfile(
   profile: Profile,
   config: $Shape<{|
@@ -980,6 +986,10 @@ export function retrieveProfilesToCompare(
   };
 }
 
+// This function takes location(most probably `window.location`) as parameter
+// and loads the profile in that given location, then returns the profile data.
+// This function is being used to get the initial profile data before upgrading
+// the url and processing the UrlState.
 export function getProfilesFromRawUrl(
   location: Location
 ): ThunkAction<Promise<Profile>> {
@@ -987,8 +997,8 @@ export function getProfilesFromRawUrl(
     const pathParts = location.pathname.split('/').filter(d => d);
     let dataSource = getDataSourceFromPathParts(pathParts);
     if (dataSource === 'from-file') {
-      // Redirect to 'none' if dataSource is 'from-file' since initial url can't
-      // be from-file and needs to be redirected to home
+      // Redirect to 'none' if `dataSource` is 'from-file' since initial urls can't
+      // be 'from-file' and needs to be redirected to home page.
       dataSource = 'none';
     }
     dispatch(setDataSource(dataSource));

--- a/src/actions/zipped-profiles.js
+++ b/src/actions/zipped-profiles.js
@@ -5,7 +5,7 @@
 // @flow
 import { getZipFileTable, getZipFileState } from '../selectors/zipped-profiles';
 import { unserializeProfileOfArbitraryFormat } from '../profile-logic/process-profile';
-import { viewProfile } from './receive-profile';
+import { loadProfile, finalizeView } from './receive-profile';
 
 import type { Action, ThunkAction } from '../types/store';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
@@ -38,7 +38,8 @@ export function changeExpandedZipFile(
  * can change the ZipFileState, and not have any race conditions.
  */
 export function viewProfileFromZip(
-  zipFileIndex: IndexIntoZipFileTable
+  zipFileIndex: IndexIntoZipFileTable,
+  initialLoad: boolean = false
 ): ThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
     const zipFileTable = getZipFileTable(getState());
@@ -66,7 +67,10 @@ export function viewProfileFromZip(
         zipFileState.pathInZipFile === pathInZipFile &&
         zipFileState.phase === 'PROCESS_PROFILE_FROM_ZIP_FILE'
       ) {
-        dispatch(viewProfile(profile, { pathInZipFile }));
+        dispatch(loadProfile(profile, { pathInZipFile }));
+        if (initialLoad === false) {
+          dispatch(finalizeView());
+        }
       }
     } catch (error) {
       console.error(

--- a/src/actions/zipped-profiles.js
+++ b/src/actions/zipped-profiles.js
@@ -5,7 +5,7 @@
 // @flow
 import { getZipFileTable, getZipFileState } from '../selectors/zipped-profiles';
 import { unserializeProfileOfArbitraryFormat } from '../profile-logic/process-profile';
-import { loadProfile, finalizeView } from './receive-profile';
+import { loadProfile } from './receive-profile';
 
 import type { Action, ThunkAction } from '../types/store';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
@@ -67,10 +67,7 @@ export function viewProfileFromZip(
         zipFileState.pathInZipFile === pathInZipFile &&
         zipFileState.phase === 'PROCESS_PROFILE_FROM_ZIP_FILE'
       ) {
-        dispatch(loadProfile(profile, { pathInZipFile }));
-        if (initialLoad === false) {
-          dispatch(finalizeView());
-        }
+        await dispatch(loadProfile(profile, { pathInZipFile }, initialLoad));
       }
     } catch (error) {
       console.error(

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -271,7 +271,7 @@ export function urlFromState(urlState: UrlState): string {
   return pathname + (qString ? '?' + qString : '');
 }
 
-function getDataSourceFromPathParts(pathParts: string[]): DataSource {
+export function getDataSourceFromPathParts(pathParts: string[]): DataSource {
   const str = pathParts[0] || 'none';
   // With this switch, flow is able to understand that we return a valid value
   switch (str) {

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -12,14 +12,23 @@ import {
   stringifyTransforms,
   parseTransforms,
 } from '../profile-logic/transforms';
-import { assertExhaustiveCheck, toValidTabSlug } from '../utils/flow';
+import {
+  assertExhaustiveCheck,
+  toValidTabSlug,
+  ensureExists,
+} from '../utils/flow';
 import { oneLine } from 'common-tags';
 import type { UrlState } from '../types/state';
 import type { DataSource } from '../types/actions';
-import type { Pid } from '../types/profile';
-import type { TrackIndex } from '../types/profile-derived';
+import type {
+  Pid,
+  Profile,
+  Thread,
+  IndexIntoStackTable,
+} from '../types/profile';
+import type { TrackIndex, CallNodePath } from '../types/profile-derived';
 
-export const CURRENT_URL_VERSION = 3;
+export const CURRENT_URL_VERSION = 4;
 
 /**
  * This static piece of state might look like an anti-pattern, but it's a relatively
@@ -298,14 +307,20 @@ type Location = {
   hash: string,
 };
 
-export function stateFromLocation(location: Location): UrlState {
-  const { pathname, query } = upgradeLocationToCurrentVersion({
-    pathname: location.pathname,
-    hash: location.hash,
-    query: queryString.parse(location.search.substr(1), {
-      arrayFormat: 'bracket', // This uses parameters with brackets for arrays.
-    }),
-  });
+export function stateFromLocation(
+  location: Location,
+  profile?: Profile
+): UrlState {
+  const { pathname, query } = upgradeLocationToCurrentVersion(
+    {
+      pathname: location.pathname,
+      hash: location.hash,
+      query: queryString.parse(location.search.substr(1), {
+        arrayFormat: 'bracket', // This uses parameters with brackets for arrays.
+      }),
+    },
+    profile
+  );
 
   const pathParts = pathname.split('/').filter(d => d);
   const dataSource = getDataSourceFromPathParts(pathParts);
@@ -438,7 +453,8 @@ type ProcessedLocationBeforeUpgrade = {|
 |};
 
 export function upgradeLocationToCurrentVersion(
-  processedLocation: ProcessedLocationBeforeUpgrade
+  processedLocation: ProcessedLocationBeforeUpgrade,
+  profile?: Profile
 ): ProcessedLocation {
   const urlVersion = +processedLocation.query.v || 0;
   if (urlVersion === CURRENT_URL_VERSION) {
@@ -459,7 +475,7 @@ export function upgradeLocationToCurrentVersion(
     destVersion++
   ) {
     if (destVersion in _upgraders) {
-      _upgraders[destVersion](processedLocation);
+      _upgraders[destVersion](processedLocation, profile);
     }
   }
 
@@ -471,7 +487,7 @@ export function upgradeLocationToCurrentVersion(
 // Every "upgrader" takes the processedLocation as its single argument and mutates it.
 /* eslint-disable no-useless-computed-key */
 const _upgraders = {
-  [0]: (processedLocation: ProcessedLocationBeforeUpgrade) => {
+  [0]: (processedLocation: ProcessedLocationBeforeUpgrade, _: Profile) => {
     // Version 1 is the first versioned url.
 
     // If the pathname is '/', this could be a very old URL that has its information
@@ -497,7 +513,7 @@ const _upgraders = {
       processedLocation.query.implementation = 'js';
     }
   },
-  [1]: (processedLocation: ProcessedLocationBeforeUpgrade) => {
+  [1]: (processedLocation: ProcessedLocationBeforeUpgrade, _: Profile) => {
     // The transform stack was added. Convert the callTreeFilters into the new
     // transforms format.
     if (processedLocation.query.callTreeFilters) {
@@ -525,7 +541,7 @@ const _upgraders = {
       delete processedLocation.query.callTreeFilters;
     }
   },
-  [2]: (processedLocation: ProcessedLocationBeforeUpgrade) => {
+  [2]: (processedLocation: ProcessedLocationBeforeUpgrade, _: Profile) => {
     // Map the tab "timeline" to "stack-chart".
     // Map the tab "markers" to "marker-table".
     processedLocation.pathname = processedLocation.pathname
@@ -536,13 +552,65 @@ const _upgraders = {
       // Matches:  $1^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       .replace(/^(\/[^/]+\/[^/]+)\/markers\/?/, '$1/marker-table/');
   },
-  [3]: (processedLocation: ProcessedLocationBeforeUpgrade) => {
+  [3]: (processedLocation: ProcessedLocationBeforeUpgrade, _: Profile) => {
     const { query } = processedLocation;
     // Removed "Hide platform details" checkbox from the stack chart.
     if ('hidePlatformDetails' in query) {
       delete query.hidePlatformDetails;
       query.implementation = 'js';
     }
+  },
+  [4]: (
+    processedLocation: ProcessedLocationBeforeUpgrade,
+    profile: Profile
+  ) => {
+    // 'js' implementation filter has been changed to include 'relevantForJS' label frames.
+    // Iterate through all transforms and upgrade the ones that has callNodePath with JS
+    // implementation filter, so they also include 'relevantForJS' label frames in their
+    // callNodePaths. For example,  in a call stack like this: 'C++->JS->relevantForJS->JS'
+    // Previous callNodePath was 'JS,JS'. But now it has to be 'JS,relevantForJS,JS'.
+    const query = processedLocation.query;
+    const selectedThread = query.thread !== undefined ? +query.thread : null;
+    const transforms = query.transforms
+      ? parseTransforms(query.transforms)
+      : [];
+
+    if (transforms.length === 0) {
+      // We don't have any transforms to upgrade.
+      return;
+    }
+
+    if (selectedThread === null || profile === undefined) {
+      return;
+    }
+
+    const thread = profile.threads[selectedThread];
+    for (let i = 0; i < transforms.length; i++) {
+      const transform = transforms[i];
+      if (
+        !transform.implementation ||
+        transform.implementation !== 'js' ||
+        !transform.callNodePath
+      ) {
+        // Only transforms with JS implementation filters that have callNodePaths
+        // need to be upgraded.
+        continue;
+      }
+
+      const callNodeStackIndex = getStackIndexFromVersion3JSCallNodePath(
+        thread,
+        transform.callNodePath
+      );
+      if (callNodeStackIndex === null) {
+        // If we can't find the stack index of given call node path, just abort.
+        continue;
+      }
+      transform.callNodePath = getVersion4JSCallNodePathFromStackIndex(
+        thread,
+        callNodeStackIndex
+      );
+    }
+    processedLocation.query.transforms = stringifyTransforms(transforms);
   },
 };
 

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -53,6 +53,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
     }
     switch (phase) {
       case 'INITIALIZING':
+      case 'PROFILE_LOADED':
         return <ProfileLoaderAnimation />;
       case 'FATAL_ERROR': {
         const message =
@@ -84,7 +85,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
       default:
         // Assert with Flow that we've handled all the cases, as the only thing left
         // should be 'ROUTE_NOT_FOUND' or 'PROFILE_LOADED'.
-        (phase: 'ROUTE_NOT_FOUND' | 'PROFILE_LOADED');
+        (phase: 'ROUTE_NOT_FOUND');
         return (
           <Home specialMessage="The URL you came in on was not recognized." />
         );

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -16,19 +16,11 @@ import { getView } from '../../selectors/app';
 import { getHasZipFile } from '../../selectors/zipped-profiles';
 import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
 import ServiceWorkerManager from './ServiceWorkerManager';
+import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 
 import type { AppViewState, State } from '../../types/state';
 import type { DataSource } from '../../types/actions';
 import type { ConnectedProps } from '../../utils/connect';
-
-const LOADING_MESSAGES: { [string]: string } = Object.freeze({
-  'from-addon': 'Grabbing the profile from the Gecko Profiler Addon...',
-  'from-file': 'Reading the file and processing the profile...',
-  local: 'Not implemented yet.',
-  public: 'Downloading and processing the profile...',
-  'from-url': 'Downloading and processing the profile...',
-  compare: 'Reading and processing profiles...',
-});
 
 const ERROR_MESSAGES: { [string]: string } = Object.freeze({
   'from-addon': "Couldn't retrieve the profile from the Gecko Profiler Addon.",
@@ -38,18 +30,6 @@ const ERROR_MESSAGES: { [string]: string } = Object.freeze({
   'from-url': 'Could not download the profile.',
   compare: 'Could not retrieve the profile',
 });
-
-// TODO Switch to a proper i18n library
-function fewTimes(count: number) {
-  switch (count) {
-    case 1:
-      return 'once';
-    case 2:
-      return 'twice';
-    default:
-      return `${count} times`;
-  }
-}
 
 type AppViewRouterStateProps = {|
   +view: AppViewState,
@@ -72,33 +52,8 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
       return <CompareHome />;
     }
     switch (phase) {
-      case 'INITIALIZING': {
-        const loadingMessage = LOADING_MESSAGES[dataSource];
-        const message = loadingMessage ? loadingMessage : 'View not found';
-        const showLoader = Boolean(loadingMessage);
-
-        let additionalMessage = '';
-        if (view.additionalData) {
-          if (view.additionalData.message) {
-            additionalMessage = view.additionalData.message;
-          }
-
-          if (view.additionalData.attempt) {
-            const attempt = view.additionalData.attempt;
-            additionalMessage += `\nTried ${fewTimes(attempt.count)} out of ${
-              attempt.total
-            }.`;
-          }
-        }
-
-        return (
-          <ProfileRootMessage
-            message={message}
-            additionalMessage={additionalMessage}
-            showLoader={showLoader}
-          />
-        );
-      }
+      case 'INITIALIZING':
+        return <ProfileLoaderAnimation />;
       case 'FATAL_ERROR': {
         const message =
           ERROR_MESSAGES[dataSource] || "Couldn't retrieve the profile.";

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -128,8 +128,8 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
       case 'ROUTE_NOT_FOUND':
       default:
         // Assert with Flow that we've handled all the cases, as the only thing left
-        // should be 'ROUTE_NOT_FOUND'.
-        (phase: 'ROUTE_NOT_FOUND');
+        // should be 'ROUTE_NOT_FOUND' or 'PROFILE_LOADED'.
+        (phase: 'ROUTE_NOT_FOUND' | 'PROFILE_LOADED');
         return (
           <Home specialMessage="The URL you came in on was not recognized." />
         );

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { Fragment, PureComponent } from 'react';
+import explicitConnect from '../../utils/connect';
+
+import ProfileViewer from './ProfileViewer';
+import ZipFileViewer from './ZipFileViewer';
+import Home from './Home';
+import CompareHome from './CompareHome';
+import { ProfileRootMessage } from './ProfileRootMessage';
+import { getView } from '../../selectors/app';
+import { getHasZipFile } from '../../selectors/zipped-profiles';
+import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
+import ServiceWorkerManager from './ServiceWorkerManager';
+
+import type { AppViewState, State } from '../../types/state';
+import type { DataSource } from '../../types/actions';
+import type { ConnectedProps } from '../../utils/connect';
+
+const LOADING_MESSAGES: { [string]: string } = Object.freeze({
+  'from-addon': 'Grabbing the profile from the Gecko Profiler Addon...',
+  'from-file': 'Reading the file and processing the profile...',
+  local: 'Not implemented yet.',
+  public: 'Downloading and processing the profile...',
+  'from-url': 'Downloading and processing the profile...',
+  compare: 'Reading and processing profiles...',
+});
+
+const ERROR_MESSAGES: { [string]: string } = Object.freeze({
+  'from-addon': "Couldn't retrieve the profile from the Gecko Profiler Addon.",
+  'from-file': "Couldn't read the file or parse the profile in it.",
+  local: 'Not implemented yet.',
+  public: 'Could not download the profile.',
+  'from-url': 'Could not download the profile.',
+  compare: 'Could not retrieve the profile',
+});
+
+// TODO Switch to a proper i18n library
+function fewTimes(count: number) {
+  switch (count) {
+    case 1:
+      return 'once';
+    case 2:
+      return 'twice';
+    default:
+      return `${count} times`;
+  }
+}
+
+type AppViewRouterStateProps = {|
+  +view: AppViewState,
+  +dataSource: DataSource,
+  +profilesToCompare: string[] | null,
+  +hasZipFile: boolean,
+|};
+
+type AppViewRouterProps = ConnectedProps<{||}, AppViewRouterStateProps, {||}>;
+
+class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
+  renderCurrentRoute() {
+    const { view, dataSource, profilesToCompare, hasZipFile } = this.props;
+    const phase = view.phase;
+    if (dataSource === 'none') {
+      return <Home />;
+    }
+
+    if (dataSource === 'compare' && profilesToCompare === null) {
+      return <CompareHome />;
+    }
+    switch (phase) {
+      case 'INITIALIZING': {
+        const loadingMessage = LOADING_MESSAGES[dataSource];
+        const message = loadingMessage ? loadingMessage : 'View not found';
+        const showLoader = Boolean(loadingMessage);
+
+        let additionalMessage = '';
+        if (view.additionalData) {
+          if (view.additionalData.message) {
+            additionalMessage = view.additionalData.message;
+          }
+
+          if (view.additionalData.attempt) {
+            const attempt = view.additionalData.attempt;
+            additionalMessage += `\nTried ${fewTimes(attempt.count)} out of ${
+              attempt.total
+            }.`;
+          }
+        }
+
+        return (
+          <ProfileRootMessage
+            message={message}
+            additionalMessage={additionalMessage}
+            showLoader={showLoader}
+          />
+        );
+      }
+      case 'FATAL_ERROR': {
+        const message =
+          ERROR_MESSAGES[dataSource] || "Couldn't retrieve the profile.";
+        let additionalMessage = null;
+        if (view.error) {
+          console.error(view.error);
+          additionalMessage =
+            `${view.error.toString()}\n` +
+            'The full stack has been written to the Web Console.';
+        }
+
+        return (
+          <ProfileRootMessage
+            message={message}
+            additionalMessage={additionalMessage}
+            showLoader={false}
+          />
+        );
+      }
+      case 'DATA_LOADED':
+        // The data is now loaded. This could be either a single profile, or a zip file
+        // with multiple profiles. Only show the ZipFileViewer if the data loaded is a
+        // Zip file, and there is no stored path into the zip file.
+        return hasZipFile ? <ZipFileViewer /> : <ProfileViewer />;
+      case 'TRANSITIONING_FROM_STALE_PROFILE':
+        return null;
+      case 'ROUTE_NOT_FOUND':
+      default:
+        // Assert with Flow that we've handled all the cases, as the only thing left
+        // should be 'ROUTE_NOT_FOUND'.
+        (phase: 'ROUTE_NOT_FOUND');
+        return (
+          <Home specialMessage="The URL you came in on was not recognized." />
+        );
+    }
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <ServiceWorkerManager />
+        {this.renderCurrentRoute()}
+      </Fragment>
+    );
+  }
+}
+
+export const AppViewRouter = explicitConnect<
+  {||},
+  AppViewRouterStateProps,
+  {||}
+>({
+  mapStateToProps: (state: State) => ({
+    view: getView(state),
+    dataSource: getDataSource(state),
+    profilesToCompare: getProfilesToCompare(state),
+    hasZipFile: getHasZipFile(state),
+  }),
+  component: AppViewRouterImpl,
+});

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -79,10 +79,6 @@ class ProfileLoaderImpl extends PureComponent<Props> {
     }
   };
 
-  componentDidMount() {
-    this._retrieveProfileFromDataSource();
-  }
-
   componentDidUpdate(prevProps) {
     if (prevProps.dataSource === 'none' && this.props.dataSource !== 'none') {
       this._retrieveProfileFromDataSource();

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import explicitConnect from '../../utils/connect';
+
+import { ProfileRootMessage } from './ProfileRootMessage';
+import { getView } from '../../selectors/app';
+import { getDataSource } from '../../selectors/url-state';
+
+import type { AppViewState, State } from '../../types/state';
+import type { DataSource } from '../../types/actions';
+import type { ConnectedProps } from '../../utils/connect';
+
+const LOADING_MESSAGES: { [string]: string } = Object.freeze({
+  'from-addon': 'Grabbing the profile from the Gecko Profiler Addon...',
+  'from-file': 'Reading the file and processing the profile...',
+  local: 'Not implemented yet.',
+  public: 'Downloading and processing the profile...',
+  'from-url': 'Downloading and processing the profile...',
+  compare: 'Reading and processing profiles...',
+});
+
+// TODO Switch to a proper i18n library
+function fewTimes(count: number) {
+  switch (count) {
+    case 1:
+      return 'once';
+    case 2:
+      return 'twice';
+    default:
+      return `${count} times`;
+  }
+}
+
+type ProfileLoaderAnimationStateProps = {|
+  +view: AppViewState,
+  +dataSource: DataSource,
+|};
+
+type ProfileLoaderAnimationProps = ConnectedProps<
+  {||},
+  ProfileLoaderAnimationStateProps,
+  {||}
+>;
+
+class ProfileLoaderAnimationImpl extends PureComponent<ProfileLoaderAnimationProps> {
+  render() {
+    const { view, dataSource } = this.props;
+    const loadingMessage = LOADING_MESSAGES[dataSource];
+    const message = loadingMessage ? loadingMessage : 'View not found';
+    const showLoader = Boolean(loadingMessage);
+
+    let additionalMessage = '';
+    if (view.additionalData) {
+      if (view.additionalData.message) {
+        additionalMessage = view.additionalData.message;
+      }
+
+      if (view.additionalData.attempt) {
+        const attempt = view.additionalData.attempt;
+        additionalMessage += `\nTried ${fewTimes(attempt.count)} out of ${
+          attempt.total
+        }.`;
+      }
+    }
+
+    return (
+      <ProfileRootMessage
+        message={message}
+        additionalMessage={additionalMessage}
+        showLoader={showLoader}
+      />
+    );
+  }
+}
+
+export const ProfileLoaderAnimation = explicitConnect<
+  {||},
+  ProfileLoaderAnimationStateProps,
+  {||}
+>({
+  mapStateToProps: (state: State) => ({
+    view: getView(state),
+    dataSource: getDataSource(state),
+  }),
+  component: ProfileLoaderAnimationImpl,
+});

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -3,167 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import React, { Fragment, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { Provider } from 'react-redux';
-import explicitConnect from '../../utils/connect';
-
-import ProfileViewer from './ProfileViewer';
-import ZipFileViewer from './ZipFileViewer';
-import Home from './Home';
-import CompareHome from './CompareHome';
-import { ProfileRootMessage } from './ProfileRootMessage';
-import { getView } from '../../selectors/app';
-import { getHasZipFile } from '../../selectors/zipped-profiles';
-import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
 import UrlManager from './UrlManager';
-import ServiceWorkerManager from './ServiceWorkerManager';
 import FooterLinks from './FooterLinks';
 import { ErrorBoundary } from './ErrorBoundary';
 import { ProfileLoader } from './ProfileLoader';
+import { AppViewRouter } from './AppViewRouter';
 
 import type { Store } from '../../types/store';
-import type { AppViewState, State } from '../../types/state';
-import type { DataSource } from '../../types/actions';
-import type { ConnectedProps } from '../../utils/connect';
-
-const LOADING_MESSAGES: { [string]: string } = Object.freeze({
-  'from-addon': 'Grabbing the profile from the Gecko Profiler Addon...',
-  'from-file': 'Reading the file and processing the profile...',
-  local: 'Not implemented yet.',
-  public: 'Downloading and processing the profile...',
-  'from-url': 'Downloading and processing the profile...',
-  compare: 'Reading and processing profiles...',
-});
-
-const ERROR_MESSAGES: { [string]: string } = Object.freeze({
-  'from-addon': "Couldn't retrieve the profile from the Gecko Profiler Addon.",
-  'from-file': "Couldn't read the file or parse the profile in it.",
-  local: 'Not implemented yet.',
-  public: 'Could not download the profile.',
-  'from-url': 'Could not download the profile.',
-  compare: 'Could not retrieve the profile',
-});
-
-// TODO Switch to a proper i18n library
-function fewTimes(count: number) {
-  switch (count) {
-    case 1:
-      return 'once';
-    case 2:
-      return 'twice';
-    default:
-      return `${count} times`;
-  }
-}
-
-type ProfileViewStateProps = {|
-  +view: AppViewState,
-  +dataSource: DataSource,
-  +profilesToCompare: string[] | null,
-  +hasZipFile: boolean,
-|};
-
-type ProfileViewProps = ConnectedProps<{||}, ProfileViewStateProps, {||}>;
-
-class ProfileViewWhenReadyImpl extends PureComponent<ProfileViewProps> {
-  renderAppropriateComponents() {
-    const { view, dataSource, profilesToCompare, hasZipFile } = this.props;
-    const phase = view.phase;
-    if (dataSource === 'none') {
-      return <Home />;
-    }
-
-    if (dataSource === 'compare' && profilesToCompare === null) {
-      return <CompareHome />;
-    }
-    switch (phase) {
-      case 'INITIALIZING': {
-        const loadingMessage = LOADING_MESSAGES[dataSource];
-        const message = loadingMessage ? loadingMessage : 'View not found';
-        const showLoader = Boolean(loadingMessage);
-
-        let additionalMessage = '';
-        if (view.additionalData) {
-          if (view.additionalData.message) {
-            additionalMessage = view.additionalData.message;
-          }
-
-          if (view.additionalData.attempt) {
-            const attempt = view.additionalData.attempt;
-            additionalMessage += `\nTried ${fewTimes(attempt.count)} out of ${
-              attempt.total
-            }.`;
-          }
-        }
-
-        return (
-          <ProfileRootMessage
-            message={message}
-            additionalMessage={additionalMessage}
-            showLoader={showLoader}
-          />
-        );
-      }
-      case 'FATAL_ERROR': {
-        const message =
-          ERROR_MESSAGES[dataSource] || "Couldn't retrieve the profile.";
-        let additionalMessage = null;
-        if (view.error) {
-          console.error(view.error);
-          additionalMessage =
-            `${view.error.toString()}\n` +
-            'The full stack has been written to the Web Console.';
-        }
-
-        return (
-          <ProfileRootMessage
-            message={message}
-            additionalMessage={additionalMessage}
-            showLoader={false}
-          />
-        );
-      }
-      case 'DATA_LOADED':
-        // The data is now loaded. This could be either a single profile, or a zip file
-        // with multiple profiles. Only show the ZipFileViewer if the data loaded is a
-        // Zip file, and there is no stored path into the zip file.
-        return hasZipFile ? <ZipFileViewer /> : <ProfileViewer />;
-      case 'TRANSITIONING_FROM_STALE_PROFILE':
-        return null;
-      case 'ROUTE_NOT_FOUND':
-      default:
-        // Assert with Flow that we've handled all the cases, as the only thing left
-        // should be 'ROUTE_NOT_FOUND'.
-        (phase: 'ROUTE_NOT_FOUND');
-        return (
-          <Home specialMessage="The URL you came in on was not recognized." />
-        );
-    }
-  }
-
-  render() {
-    return (
-      <Fragment>
-        <ServiceWorkerManager />
-        {this.renderAppropriateComponents()}
-      </Fragment>
-    );
-  }
-}
-
-export const ProfileViewWhenReady = explicitConnect<
-  {||},
-  ProfileViewStateProps,
-  {||}
->({
-  mapStateToProps: (state: State) => ({
-    view: getView(state),
-    dataSource: getDataSource(state),
-    profilesToCompare: getProfilesToCompare(state),
-    hasZipFile: getHasZipFile(state),
-  }),
-  component: ProfileViewWhenReadyImpl,
-});
 
 type RootProps = {
   store: Store,
@@ -177,7 +25,7 @@ export default class Root extends PureComponent<RootProps> {
         <Provider store={store}>
           <UrlManager>
             <ProfileLoader />
-            <ProfileViewWhenReady />
+            <AppViewRouter />
             <FooterLinks />
           </UrlManager>
         </Provider>

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -8,8 +8,8 @@ import { Provider } from 'react-redux';
 import UrlManager from './UrlManager';
 import FooterLinks from './FooterLinks';
 import { ErrorBoundary } from './ErrorBoundary';
-import { ProfileLoader } from './ProfileLoader';
 import { AppViewRouter } from './AppViewRouter';
+import { ProfileLoader } from './ProfileLoader';
 
 import type { Store } from '../../types/store';
 

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -49,6 +49,32 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 /**
  * This component manages the interaction with the window.history browser API.
+ *
+ * There are two different profile loading paths currently:
+ * 1. Initial URL processing:
+ *    This happens when user loads a URL with a profile hash or URL.
+ *    In the first load, we have the URL but we don't have the `UrlState` to get the
+ *    information from it and download the profile. So we have these steps in the
+ *    initial URL processsing:
+ *    1. Get the intial raw url, set the `urlSetupPhase` as 'initial-load'.
+ *    2. Extract the `dataSource` from the raw url.
+ *    3. Extract the profile hash or URL from it if it's in the store and download
+ *       it, or retrieve from Firefox. Set the `urlSetupPhase` as 'loading-profile'.
+ *    4. Upgrade the URL with downloaded profile data and setup initial `UrlState`.
+ *    5. Finalize the profile view with the `UrlState` information. (we couldn't
+ *       finalize the profile view immediately after the download because we need
+ *       `UrlState` for this step.)
+ *    6. Set the `urlSetupPhase` as 'done' and display the profile view.
+ *
+ * 2. State changes after some user interactions (e.g. drag and drop):
+ *    In this path, the initial URL processing is already done, and this path is
+ *    being used if `dataSource` changes after some user interaction. This is
+ *    handled by `ProfileLoader` component. This path has these steps:
+ *    1. Get the `dataSource` and `hash/profileUrl` information from the store.
+ *    2. Download the profile.
+ *    3. Update the `UrlState` to reflect the changes and finalize the profile
+ *       view with the `UrlState` information.
+ *    4. Display the profile view.
  */
 class UrlManager extends React.PureComponent<Props> {
   async _processInitialUrls() {

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -6,26 +6,39 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getIsUrlSetupDone } from '../../selectors/app';
-import { updateUrlState, urlSetupDone, show404 } from '../../actions/app';
+import { getUrlSetupPhase } from '../../selectors/app';
+import {
+  updateUrlState,
+  startFetchingProfiles,
+  urlSetupDone,
+  show404,
+  setupInitialUrlState,
+} from '../../actions/app';
 import {
   urlFromState,
   stateFromLocation,
   getIsHistoryReplaceState,
 } from '../../app-logic/url-handling';
+import { getProfilesFromRawUrl } from '../../actions/receive-profile';
+import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
+import { assertExhaustiveCheck } from '../../utils/flow';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { UrlState } from '../../types/state';
+import type { UrlState, UrlSetupPhase } from '../../types/state';
+import type { Profile } from '../../types/profile';
 
 type StateProps = {|
   +urlState: UrlState,
-  +isUrlSetupDone: boolean,
+  +urlSetupPhase: UrlSetupPhase,
 |};
 
 type DispatchProps = {|
   +updateUrlState: typeof updateUrlState,
+  +startFetchingProfiles: typeof startFetchingProfiles,
   +urlSetupDone: typeof urlSetupDone,
   +show404: typeof show404,
+  +getProfilesFromRawUrl: typeof getProfilesFromRawUrl,
+  +setupInitialUrlState: typeof setupInitialUrlState,
 |};
 
 type OwnProps = {|
@@ -38,7 +51,39 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
  * This component manages the interaction with the window.history browser API.
  */
 class UrlManager extends React.PureComponent<Props> {
-  _updateState(firstRun: boolean) {
+  async _processInitialUrls() {
+    const {
+      startFetchingProfiles,
+      getProfilesFromRawUrl,
+      setupInitialUrlState,
+      urlSetupDone,
+    } = this.props;
+    let profile: Profile | null = null;
+    let error;
+
+    startFetchingProfiles();
+
+    try {
+      // Process the raw url and fetch the profile.
+      // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
+      profile = await getProfilesFromRawUrl(window.location);
+    } catch (err) {
+      error = err;
+    }
+
+    if (profile) {
+      setupInitialUrlState(window.location, profile);
+    } else if (error) {
+      // Just silently finish the url setup and return to home.
+      urlSetupDone();
+    } else {
+      throw new Error(
+        'An unhandled case was reached during the initial processing of URLs'
+      );
+    }
+  }
+
+  _updateState() {
     const { updateUrlState, show404, urlState: previousUrlState } = this.props;
     let newUrlState;
     if (window.history.state) {
@@ -58,12 +103,7 @@ class UrlManager extends React.PureComponent<Props> {
       }
     }
 
-    if (firstRun) {
-      // Validate the initial URL state. We can't refresh on a from-file URL.
-      if (newUrlState.dataSource === 'from-file') {
-        newUrlState = null;
-      }
-    } else if (
+    if (
       previousUrlState.dataSource !== newUrlState.dataSource ||
       previousUrlState.hash !== newUrlState.hash
     ) {
@@ -83,16 +123,18 @@ class UrlManager extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    this._updateState(true);
-    window.addEventListener('popstate', () => this._updateState(false));
-    this.props.urlSetupDone();
+    this._processInitialUrls();
+    window.addEventListener('popstate', () => this._updateState());
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { isUrlSetupDone } = this.props;
+    const { urlSetupPhase } = this.props;
+    if (urlSetupPhase !== 'done') {
+      return;
+    }
     const newUrl = urlFromState(nextProps.urlState);
     if (newUrl !== window.location.pathname + window.location.search) {
-      if (isUrlSetupDone && !getIsHistoryReplaceState()) {
+      if (!getIsHistoryReplaceState()) {
         // Push the URL state only when the url setup is done, and we haven't set
         // a flag to only replace the state.
         window.history.pushState(nextProps.urlState, document.title, newUrl);
@@ -105,24 +147,33 @@ class UrlManager extends React.PureComponent<Props> {
   }
 
   render() {
-    const { isUrlSetupDone } = this.props;
-    return isUrlSetupDone ? (
-      this.props.children
-    ) : (
-      <div className="processingUrl" />
-    );
+    const { urlSetupPhase, children } = this.props;
+    switch (urlSetupPhase) {
+      case 'initial-load':
+        return null;
+      case 'loading-profile':
+        return <ProfileLoaderAnimation />;
+      case 'done':
+        return children;
+      default:
+        assertExhaustiveCheck(urlSetupPhase, `Unhandled URL setup phase.`);
+        return null;
+    }
   }
 }
 
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     urlState: state.urlState,
-    isUrlSetupDone: getIsUrlSetupDone(state),
+    urlSetupPhase: getUrlSetupPhase(state),
   }),
   mapDispatchToProps: {
     updateUrlState,
+    startFetchingProfiles,
     urlSetupDone,
     show404,
+    setupInitialUrlState,
+    getProfilesFromRawUrl,
   },
   component: UrlManager,
 });

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -673,7 +673,11 @@ export function filterThreadByImplementation(
     case 'js':
       return _filterThreadByFunc(
         thread,
-        funcIndex => funcTable.isJS[funcIndex],
+        funcIndex => {
+          return (
+            funcTable.isJS[funcIndex] || funcTable.relevantForJS[funcIndex]
+          );
+        },
         defaultCategory
       );
     default:

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -996,7 +996,10 @@ const FUNC_MATCHES = {
     return !isProbablyJitCode;
   },
   js: (thread: Thread, funcIndex: IndexIntoFuncTable): boolean => {
-    return thread.funcTable.isJS[funcIndex];
+    return (
+      thread.funcTable.isJS[funcIndex] ||
+      thread.funcTable.relevantForJS[funcIndex]
+    );
   },
 };
 

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -12,6 +12,7 @@ import type {
   AppViewState,
   IsSidebarOpenPerPanelState,
   Reducer,
+  UrlSetupPhase,
 } from '../types/state';
 import type { ThreadIndex } from '../types/profile';
 
@@ -48,10 +49,15 @@ const view: Reducer<AppViewState> = (
   }
 };
 
-const isUrlSetupDone: Reducer<boolean> = (state = false, action) => {
+const urlSetupPhase: Reducer<UrlSetupPhase> = (
+  state = 'initial-load',
+  action
+) => {
   switch (action.type) {
+    case 'START_FETCHING_PROFILES':
+      return 'loading-profile';
     case 'URL_SETUP_DONE':
-      return true;
+      return 'done';
     default:
       return state;
   }
@@ -179,7 +185,7 @@ const isNewlyPublished: Reducer<boolean> = (state = false, action) => {
 
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,
-  isUrlSetupDone,
+  urlSetupPhase,
   hasZoomedViaMousewheel,
   isSidebarOpenPerPanel,
   panelLayoutGeneration,

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -38,6 +38,8 @@ const view: Reducer<AppViewState> = (
     case 'REVERT_TO_ORIGINAL_PROFILE':
     case 'SANITIZED_PROFILE_PUBLISHED':
       return { phase: 'TRANSITIONING_FROM_STALE_PROFILE' };
+    case 'PROFILE_LOADED':
+      return { phase: 'PROFILE_LOADED' };
     case 'RECEIVE_ZIP_FILE':
     case 'VIEW_PROFILE':
       return { phase: 'DATA_LOADED' };

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -29,7 +29,7 @@ import type {
 
 const profile: Reducer<Profile | null> = (state = null, action) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'PROFILE_LOADED':
       return action.profile;
     case 'COALESCED_FUNCTIONS_UPDATE': {
       if (state === null) {
@@ -127,7 +127,7 @@ const viewOptionsPerThread: Reducer<ThreadViewOptions[]> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'PROFILE_LOADED':
       return action.profile.threads.map(() => ({
         selectedCallNodePath: [],
         rightClickedCallNodePath: null,
@@ -480,7 +480,7 @@ const rootRange: Reducer<StartEndRange> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'PROFILE_LOADED':
       return ProfileData.getTimeRangeIncludingAllThreads(action.profile);
     default:
       return state;

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -31,7 +31,7 @@ const checkedSharingOptions: Reducer<CheckedSharingOptions> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE': {
+    case 'PROFILE_LOADED': {
       const newState = _getDefaultSharingOptions();
       if (!getShouldSanitizeByDefault(action.profile)) {
         // Flip the sharing options.
@@ -194,7 +194,7 @@ const isHidingStaleProfile: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'HIDE_STALE_PROFILE':
       return true;
-    case 'VIEW_PROFILE':
+    case 'VIEW_PROFILE': // TODO: should this be PROFILE_LOADED?
       return false;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -162,7 +162,7 @@ const networkSearchString: Reducer<string> = (state = '', action) => {
 
 const transforms: Reducer<TransformStacksPerThread> = (state = {}, action) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'PROFILE_LOADED':
       return action.transformStacks || state;
     case 'ADD_TRANSFORM_TO_STACK': {
       const { threadIndex, transform } = action;
@@ -217,7 +217,7 @@ const implementation: Reducer<ImplementationFilter> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'PROFILE_LOADED':
       return action.implementationFilter || state;
     case 'CHANGE_IMPLEMENTATION_FILTER':
       return action.implementation;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -41,6 +41,8 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
       return 'public';
     case 'TRIGGER_LOADING_FROM_URL':
       return 'from-url';
+    case 'SET_DATA_SOURCE':
+      return action.dataSource;
     default:
       return state;
   }

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -24,7 +24,7 @@ import {
 } from '../app-logic/constants';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { AppState, AppViewState } from '../types/state';
+import type { AppState, AppViewState, UrlSetupPhase } from '../types/state';
 import type { Selector } from '../types/store';
 import type { CssPixels } from '../types/units';
 import type { ThreadIndex } from '../types/profile';
@@ -34,8 +34,8 @@ import type { ThreadIndex } from '../types/profile';
  */
 export const getApp: Selector<AppState> = state => state.app;
 export const getView: Selector<AppViewState> = state => getApp(state).view;
-export const getIsUrlSetupDone: Selector<boolean> = state =>
-  getApp(state).isUrlSetupDone;
+export const getUrlSetupPhase: Selector<UrlSetupPhase> = state =>
+  getApp(state).urlSetupPhase;
 export const getHasZoomedViaMousewheel: Selector<boolean> = state => {
   return getApp(state).hasZoomedViaMousewheel;
 };

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -29,7 +29,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
 
-import { ProfileViewWhenReady } from '../../components/app/Root';
+import { AppViewRouter } from '../../components/app/AppViewRouter';
 import { ProfileLoader } from '../../components/app/ProfileLoader';
 import { updateUrlState, changeProfilesToCompare } from '../../actions/app';
 // Because this module is mocked but we want the real actions in the test, we
@@ -53,7 +53,7 @@ import { TemporaryError } from '../../utils/errors';
 import { blankStore } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
-describe('app/ProfileViewWhenReady', function() {
+describe('app/AppViewRouter', function() {
   it('renders an initial home', function() {
     const { container } = setup();
 
@@ -164,7 +164,7 @@ function setup() {
     <Provider store={store}>
       <>
         <ProfileLoader />
-        <ProfileViewWhenReady />
+        <AppViewRouter />
       </>
     </Provider>
   );

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
 
-import { getIsUrlSetupDone } from '../../selectors/app';
+import { getUrlSetupPhase } from '../../selectors/app';
 import UrlManager from '../../components/app/UrlManager';
 import { blankStore } from '../fixtures/stores';
 import { getDataSource } from '../../selectors/url-state';
@@ -33,9 +33,9 @@ describe('UrlManager', function() {
 
   it('sets up the URL', function() {
     const { getState, createUrlManager } = setup();
-    expect(getIsUrlSetupDone(getState())).toBe(false);
+    expect(getUrlSetupPhase(getState())).toBe('initial-load');
     createUrlManager();
-    expect(getIsUrlSetupDone(getState())).toBe(true);
+    expect(getUrlSetupPhase(getState())).toBe('loading-profile');
   });
 
   it('has no data source by default', function() {

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/ProfileViewWhenReady does not try to retrieve a profile when moving from from-addon to public 1`] = `<profile-viewer />`;
+exports[`app/AppViewRouter does not try to retrieve a profile when moving from from-addon to public 1`] = `<profile-viewer />`;
 
-exports[`app/ProfileViewWhenReady renders an home when the user pressed back after an error 1`] = `
+exports[`app/AppViewRouter renders an home when the user pressed back after an error 1`] = `
 <div
   class="rootMessageContainer"
 >
@@ -38,11 +38,11 @@ exports[`app/ProfileViewWhenReady renders an home when the user pressed back aft
 </div>
 `;
 
-exports[`app/ProfileViewWhenReady renders an home when the user pressed back after an error 2`] = `<home />`;
+exports[`app/AppViewRouter renders an home when the user pressed back after an error 2`] = `<home />`;
 
-exports[`app/ProfileViewWhenReady renders an initial home 1`] = `<home />`;
+exports[`app/AppViewRouter renders an initial home 1`] = `<home />`;
 
-exports[`app/ProfileViewWhenReady renders temporary errors 1`] = `
+exports[`app/AppViewRouter renders temporary errors 1`] = `
 <div
   class="rootMessageContainer"
 >
@@ -112,7 +112,7 @@ exports[`app/ProfileViewWhenReady renders temporary errors 1`] = `
 </div>
 `;
 
-exports[`app/ProfileViewWhenReady renders the addon loading page, and the profile view after capturing 1`] = `
+exports[`app/AppViewRouter renders the addon loading page, and the profile view after capturing 1`] = `
 <div
   class="rootMessageContainer"
 >
@@ -167,9 +167,9 @@ exports[`app/ProfileViewWhenReady renders the addon loading page, and the profil
 </div>
 `;
 
-exports[`app/ProfileViewWhenReady renders the addon loading page, and the profile view after capturing 2`] = `<profile-viewer />`;
+exports[`app/AppViewRouter renders the addon loading page, and the profile view after capturing 2`] = `<profile-viewer />`;
 
-exports[`app/ProfileViewWhenReady renders the profile view 1`] = `
+exports[`app/AppViewRouter renders the profile view 1`] = `
 <div
   class="rootMessageContainer"
 >
@@ -224,4 +224,4 @@ exports[`app/ProfileViewWhenReady renders the profile view 1`] = `
 </div>
 `;
 
-exports[`app/ProfileViewWhenReady renders the profile view 2`] = `<profile-viewer />`;
+exports[`app/AppViewRouter renders the profile view 2`] = `<profile-viewer />`;

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -90,9 +90,9 @@ describe('app actions', function() {
   describe('urlSetupDone', function() {
     it('will remember when url setup is done', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
-      expect(AppSelectors.getIsUrlSetupDone(getState())).toEqual(false);
+      expect(AppSelectors.getUrlSetupPhase(getState())).toEqual('initial-load');
       dispatch(AppActions.urlSetupDone());
-      expect(AppSelectors.getIsUrlSetupDone(getState())).toEqual(true);
+      expect(AppSelectors.getUrlSetupPhase(getState())).toEqual('done');
     });
 
     it('records analytics events for pageview and datasource', function() {

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -392,7 +392,7 @@ describe('actions/receive-profile', function() {
           additionalData: { attempt: null, message: errorMessage },
         }, // when the error happens
         { phase: 'INITIALIZING' }, // when we could connect to the addon but waiting for the profile
-        { phase: 'DATA_LOADED' }, // yay, we got a profile!
+        { phase: 'PROFILE_LOADED' }, // yay, we got a profile!
       ]);
 
       const state = store.getState();
@@ -501,6 +501,7 @@ describe('actions/receive-profile', function() {
             message: errorMessage,
           },
         },
+        { phase: 'PROFILE_LOADED' },
         { phase: 'DATA_LOADED' },
       ]);
 
@@ -615,6 +616,7 @@ describe('actions/receive-profile', function() {
             message: errorMessage,
           },
         },
+        { phase: 'PROFILE_LOADED' },
         { phase: 'DATA_LOADED' },
       ]);
 

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -18,6 +18,7 @@ import {
   urlStateToUrlObject,
   urlFromState,
   CURRENT_URL_VERSION,
+  upgradeLocationToCurrentVersion,
 } from '../app-logic/url-handling';
 import { blankStore } from './fixtures/stores';
 import { viewProfile } from '../actions/receive-profile';
@@ -30,6 +31,7 @@ import {
 } from './fixtures/profiles/tracks';
 import { getProfileFromTextSamples } from './fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../selectors/per-thread';
+import { uintArrayToString } from '../utils/uintarray-encoding';
 
 function _getStoreWithURL(
   settings: {
@@ -435,6 +437,263 @@ describe('url upgrading', function() {
         v: 2,
       });
       expect(urlStateReducers.getImplementationFilter(getState())).toBe('js');
+    });
+  });
+
+  describe('version 4: Add relevantForJs frames to JS callNodePaths', function() {
+    it('can upgrade a simple stack with one relevantForJs frame in the middle', function() {
+      const {
+        profile,
+        funcNamesDictPerThread: [funcNamesDictPerThread],
+      } = getProfileFromTextSamples(`
+        A
+        B.js
+        C.js
+        DrelevantForJs
+        E
+        F
+        G.js
+      `);
+
+      profile.threads[0].funcTable.relevantForJS[
+        funcNamesDictPerThread.DrelevantForJs
+      ] = true;
+
+      const callNodePathBefore = [
+        funcNamesDictPerThread['B.js'],
+        funcNamesDictPerThread['C.js'],
+        funcNamesDictPerThread['G.js'],
+      ];
+
+      // Upgrader
+      const callNodeString = uintArrayToString(callNodePathBefore);
+      // focus-subtree transform with js implementation filter.
+      const transformString = 'f-js-' + callNodeString;
+      const { query } = upgradeLocationToCurrentVersion(
+        {
+          pathname: '',
+          hash: '',
+          query: {
+            thread: '0',
+            implementation: 'js',
+            transforms: transformString,
+            v: '3',
+          },
+        },
+        profile
+      );
+
+      const callNodePathAfter = [
+        funcNamesDictPerThread['B.js'],
+        funcNamesDictPerThread['C.js'],
+        funcNamesDictPerThread.DrelevantForJs,
+        funcNamesDictPerThread['G.js'],
+      ];
+
+      const newTransformNodeString =
+        'f-js-' + uintArrayToString(callNodePathAfter);
+      expect(query.transforms).toEqual(newTransformNodeString);
+    });
+
+    it('can upgrade a simple stack with one relevantForJs frame in the front', function() {
+      const {
+        profile,
+        funcNamesDictPerThread: [funcNamesDictPerThread],
+      } = getProfileFromTextSamples(`
+        A
+        BrelevantForJs
+        C.js
+        D
+        E.js
+      `);
+
+      profile.threads[0].funcTable.relevantForJS[
+        funcNamesDictPerThread.BrelevantForJs
+      ] = true;
+
+      const callNodePathBefore = [
+        funcNamesDictPerThread['C.js'],
+        funcNamesDictPerThread['E.js'],
+      ];
+
+      // Upgrader
+      const callNodeString = uintArrayToString(callNodePathBefore);
+      // focus-subtree transform with js implementation filter.
+      const transformString = 'f-js-' + callNodeString;
+      const { query } = upgradeLocationToCurrentVersion(
+        {
+          pathname: '',
+          hash: '',
+          query: {
+            thread: '0',
+            implementation: 'js',
+            transforms: transformString,
+            v: '3',
+          },
+        },
+        profile
+      );
+
+      const callNodePathAfter = [
+        funcNamesDictPerThread.BrelevantForJs,
+        funcNamesDictPerThread['C.js'],
+        funcNamesDictPerThread['E.js'],
+      ];
+
+      const newTransformNodeString =
+        'f-js-' + uintArrayToString(callNodePathAfter);
+      expect(query.transforms).toEqual(newTransformNodeString);
+    });
+
+    it('can upgrade a simple stack with relevantForJs and native frames in the middle', function() {
+      const {
+        profile,
+        funcNamesDictPerThread: [funcNamesDictPerThread],
+      } = getProfileFromTextSamples(`
+        A
+        BrelevantForJs
+        C
+        D.js
+        E
+        F.js
+      `);
+
+      profile.threads[0].funcTable.relevantForJS[
+        funcNamesDictPerThread.BrelevantForJs
+      ] = true;
+
+      const callNodePathBefore = [
+        funcNamesDictPerThread['D.js'],
+        funcNamesDictPerThread['F.js'],
+      ];
+
+      // Upgrader
+      const callNodeString = uintArrayToString(callNodePathBefore);
+      // focus-subtree transform with js implementation filter.
+      const transformString = 'f-js-' + callNodeString;
+      const { query } = upgradeLocationToCurrentVersion(
+        {
+          pathname: '',
+          hash: '',
+          query: {
+            thread: '0',
+            implementation: 'js',
+            transforms: transformString,
+            v: '3',
+          },
+        },
+        profile
+      );
+
+      const callNodePathAfter = [
+        funcNamesDictPerThread.BrelevantForJs,
+        funcNamesDictPerThread['D.js'],
+        funcNamesDictPerThread['F.js'],
+      ];
+
+      const newTransformNodeString =
+        'f-js-' + uintArrayToString(callNodePathAfter);
+      expect(query.transforms).toEqual(newTransformNodeString);
+    });
+
+    it('can upgrade the callNodePath in the second branch of the call tree', function() {
+      const {
+        profile,
+        funcNamesDictPerThread: [funcNamesDictPerThread],
+      } = getProfileFromTextSamples(`
+        A               A
+        B.js            B.js
+        H               CrelevantForJs
+        D               D
+        G.js            E.js
+      `);
+
+      profile.threads[0].funcTable.relevantForJS[
+        funcNamesDictPerThread.CrelevantForJs
+      ] = true;
+
+      const callNodePathBefore = [
+        funcNamesDictPerThread['B.js'],
+        funcNamesDictPerThread['E.js'],
+      ];
+
+      // Upgrader
+      const callNodeString = uintArrayToString(callNodePathBefore);
+      // focus-subtree transform with js implementation filter.
+      const transformString = 'f-js-' + callNodeString;
+      const { query } = upgradeLocationToCurrentVersion(
+        {
+          pathname: '',
+          hash: '',
+          query: {
+            thread: '0',
+            implementation: 'js',
+            transforms: transformString,
+            v: '3',
+          },
+        },
+        profile
+      );
+
+      const callNodePathAfter = [
+        funcNamesDictPerThread['B.js'],
+        funcNamesDictPerThread.CrelevantForJs,
+        funcNamesDictPerThread['E.js'],
+      ];
+
+      const newTransformNodeString =
+        'f-js-' + uintArrayToString(callNodePathAfter);
+      expect(query.transforms).toEqual(newTransformNodeString);
+    });
+
+    it('can upgrade the callNodePath in the second branch of the call tree with relevantForJs frame first', function() {
+      const {
+        profile,
+        funcNamesDictPerThread: [funcNamesDictPerThread],
+      } = getProfileFromTextSamples(`
+        A               A
+        BrelevantForJs  BrelevantForJs
+        H               C.js
+        D               D
+        G.js            E.js
+      `);
+
+      profile.threads[0].funcTable.relevantForJS[
+        funcNamesDictPerThread.BrelevantForJs
+      ] = true;
+
+      const callNodePathBefore = [
+        funcNamesDictPerThread['C.js'],
+        funcNamesDictPerThread['E.js'],
+      ];
+
+      // Upgrader
+      const callNodeString = uintArrayToString(callNodePathBefore);
+      // focus-subtree transform with js implementation filter.
+      const transformString = 'f-js-' + callNodeString;
+      const { query } = upgradeLocationToCurrentVersion(
+        {
+          pathname: '',
+          hash: '',
+          query: {
+            thread: '0',
+            implementation: 'js',
+            transforms: transformString,
+            v: '3',
+          },
+        },
+        profile
+      );
+
+      const callNodePathAfter = [
+        funcNamesDictPerThread.BrelevantForJs,
+        funcNamesDictPerThread['C.js'],
+        funcNamesDictPerThread['E.js'],
+      ];
+
+      const newTransformNodeString =
+        'f-js-' + uintArrayToString(callNodePathAfter);
+      expect(query.transforms).toEqual(newTransformNodeString);
     });
   });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -231,8 +231,14 @@ type ReceiveProfileAction =
       +error: Error,
     |}
   | {|
-      +type: 'VIEW_PROFILE',
+      +type: 'PROFILE_LOADED',
       +profile: Profile,
+      +pathInZipFile: ?string,
+      +implementationFilter: ?ImplementationFilter,
+      +transformStacks: ?TransformStacksPerThread,
+    |}
+  | {|
+      +type: 'VIEW_PROFILE',
       +selectedThreadIndex: ThreadIndex,
       +globalTracks: GlobalTrack[],
       +globalTrackOrder: TrackIndex[],
@@ -240,9 +246,6 @@ type ReceiveProfileAction =
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
-      +pathInZipFile: ?string,
-      +implementationFilter: ?ImplementationFilter,
-      +transformStacks: ?TransformStacksPerThread,
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -262,6 +262,7 @@ type ReceiveProfileAction =
   | {| +type: 'TRIGGER_LOADING_FROM_URL', +profileUrl: string |};
 
 type UrlEnhancerAction =
+  | {| +type: 'START_FETCHING_PROFILES' |}
   | {| +type: 'URL_SETUP_DONE' |}
   | {| +type: 'UPDATE_URL_STATE', +newUrlState: UrlState | null |};
 
@@ -327,6 +328,10 @@ type UrlStateAction =
       +oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex> | null,
       +originalProfile: Profile,
       +originalUrlState: UrlState,
+    |}
+  | {|
+      +type: 'SET_DATA_SOURCE',
+      +dataSource: DataSource,
     |};
 
 type IconsAction =

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -243,7 +243,6 @@ type ReceiveProfileAction =
       +pathInZipFile: ?string,
       +implementationFilter: ?ImplementationFilter,
       +transformStacks: ?TransformStacksPerThread,
-      +dataSource: DataSource,
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -61,6 +61,7 @@ export type ProfileViewState = {|
 export type AppViewState =
   | {| +phase: 'ROUTE_NOT_FOUND' |}
   | {| +phase: 'TRANSITIONING_FROM_STALE_PROFILE' |}
+  | {| +phase: 'PROFILE_LOADED' |}
   | {| +phase: 'DATA_LOADED' |}
   | {| +phase: 'FATAL_ERROR', +error: Error |}
   | {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -109,9 +109,11 @@ export type ZipFileState =
 
 export type IsSidebarOpenPerPanelState = { [TabSlug]: boolean };
 
+export type UrlSetupPhase = 'initial-load' | 'loading-profile' | 'done';
+
 export type AppState = {|
   +view: AppViewState,
-  +isUrlSetupDone: boolean,
+  +urlSetupPhase: UrlSetupPhase,
   +hasZoomedViaMousewheel: boolean,
   +isSidebarOpenPerPanel: IsSidebarOpenPerPanelState,
   +panelLayoutGeneration: number,


### PR DESCRIPTION
Well, I was looking from another perspective for the whole thing and after talking with Greg, I understood that it's actually pretty easy to implement because we have one mechanism that all transforms use(`FUNC_MATCHES`).
For this PR, the remaining part is handling URL serialized call tree transforms with URL upgraders.