### PR TITLE
Handle preconnect phases properly

### DIFF
--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -47,6 +47,10 @@ const PATH_SPLIT_RE = /(.*)(\/[^/]+\/?)$/;
 //   connection is reused.
 // - Between `domainLookupStart` and `requestStart`, both the DNS request and
 //   the connection happens.
+//   Note that we never have connection-related properties without
+//   domainLookup-related properties, but we do have domainLookup-related
+//   properties without connection-related properties. So we only consider
+//   `domainLookupStart` to represent this whole connection phase.
 // - `responseStart` represents the first received information from the server.
 // - At last `responseEnd` represents the last received information from the
 //   server.
@@ -61,6 +65,16 @@ const PROPERTIES_IN_ORDER = [
   'responseEnd',
 ];
 
+// When the DNS request and the connection happen in a preconnect phase, the
+// timestamps for these properties will happen before `startTime`.
+// These properties represent respectively two possible ends of a preconnect
+// session. They're specified in their reverse order because we'll want to find
+// the latest one first.
+// It could theorically happen that a preconnect session starts before
+// `startTime` but ends after `startTime`; in that case we'll still draw only
+// one bar.
+const PRECONNECT_END_PROPERTIES = ['connectEnd', 'domainLookupEnd'];
+
 const PHASE_OPACITIES = PROPERTIES_IN_ORDER.reduce(
   (result, property, i, { length }) => {
     result[property] = length > 1 ? i / (length - 1) : 0;
@@ -69,22 +83,21 @@ const PHASE_OPACITIES = PROPERTIES_IN_ORDER.reduce(
   {}
 );
 
-type NetworkChartRowProps = {
-  +index: number,
-  +marker: Marker,
-  // Pass the payload in as well, since our types can't express a Marker with
-  // a specific payload.
-  +networkPayload: NetworkPayload,
-  +timeRange: StartEndRange,
-  +width: CssPixels,
-  +threadIndex: ThreadIndex,
-};
-
-type State = {|
-  pageX: CssPixels,
-  pageY: CssPixels,
-  hovered: ?boolean,
-|};
+function NetworkPhase({ name, previousName, value, duration, ...style }) {
+  // Specifying data attributes makes it easier to debug.
+  return (
+    <div
+      className="networkChartRowItemBarPhase"
+      key={name}
+      data-name={name}
+      data-value={value}
+      style={style}
+      aria-label={`${previousName} to ${name}: ${formatNumber(
+        duration
+      )} milliseconds`}
+    />
+  );
+}
 
 export type NetworkChartRowBarProps = {
   +marker: Marker,
@@ -116,6 +129,63 @@ class NetworkChartRowBar extends React.PureComponent<NetworkChartRowBarProps> {
     return markerPosition;
   }
 
+  _preconnectComponent(): React.Node {
+    const { networkPayload, marker } = this.props;
+
+    const preconnectStart = networkPayload.domainLookupStart;
+    if (typeof preconnectStart !== 'number') {
+      // All preconnect operations include a domain lookup part.
+      return null;
+    }
+
+    // The preconnect bar goes from the start to the end of the whole preconnect
+    // operation, that includes both the domain lookup and the connection
+    // process. Therefore we want the property that represents the latest phase.
+    const latestPreconnectEndProperty = PRECONNECT_END_PROPERTIES.find(
+      property => typeof networkPayload[property] === 'number'
+    );
+
+    if (!latestPreconnectEndProperty) {
+      return null;
+    }
+
+    // We force-coerce the value into a number just to appease Flow. Indeed
+    // the previous find operation ensures that all values are numbers but
+    // Flow can't know that.
+    const preconnectEnd = +networkPayload[latestPreconnectEndProperty];
+
+    // If the latest phase ends before the start of the marker, we'll display a
+    // separate preconnect bar.
+    const hasPreconnect = preconnectEnd < marker.start;
+    if (!hasPreconnect) {
+      return null;
+    }
+
+    const preconnectDuration = preconnectEnd - preconnectStart;
+    const preconnectStartPosition = this._timeToCssPixels(preconnectStart);
+    const preconnectEndPosition = this._timeToCssPixels(preconnectEnd);
+    const preconnectWidth = preconnectEndPosition - preconnectStartPosition;
+
+    const preconnectPhase = {
+      left: 0,
+      width: '100%',
+      opacity: PHASE_OPACITIES.requestStart,
+      name: latestPreconnectEndProperty,
+      previousName: 'domainLookupStart',
+      value: preconnectEnd,
+      duration: preconnectDuration,
+    };
+
+    return (
+      <div
+        className="networkChartRowItemBar"
+        style={{ width: preconnectWidth, left: preconnectStartPosition }}
+      >
+        {NetworkPhase(preconnectPhase)}
+      </div>
+    );
+  }
+
   render() {
     const {
       marker: { start, dur },
@@ -132,23 +202,35 @@ class NetworkChartRowBar extends React.PureComponent<NetworkChartRowBarProps> {
       markerWidth = 2.5;
     }
 
+    const preconnectComponent = this._preconnectComponent();
+
     // Compute the phases for this marker.
-    const barPhases = [];
+
+    // If there's a preconnect phase, we remove `domainLookupStart` from the
+    // main bar, but we'll draw a separate bar to represent it.
+    const mainBarProperties = preconnectComponent
+      ? PROPERTIES_IN_ORDER.slice(1)
+      : PROPERTIES_IN_ORDER;
+
+    // Not all properties are always present.
+    const availableProperties = mainBarProperties.filter(
+      property => typeof networkPayload[property] === 'number'
+    );
+
+    const mainBarPhases = [];
     let previousValue = start;
     let previousName = 'startTime';
 
     // In this loop we add the various phases to the array.
-    // Not all properties are always present.
-    PROPERTIES_IN_ORDER.filter(
-      property => typeof networkPayload[property] === 'number'
-    ).forEach((property, i) => {
+    availableProperties.forEach((property, i) => {
       // We force-coerce the value into a number just to appease Flow. Indeed the
       // previous filter ensures that all values are numbers but Flow can't know
       // that.
       const value = +networkPayload[property];
-      barPhases.push({
+      mainBarPhases.push({
         left: ((previousValue - start) / dur) * markerWidth,
         width: Math.max(((value - previousValue) / dur) * markerWidth, 1),
+        // The first phase is always transparent because this represents the wait time.
         opacity: i === 0 ? 0 : PHASE_OPACITIES[property],
         name: property,
         previousName,
@@ -161,10 +243,10 @@ class NetworkChartRowBar extends React.PureComponent<NetworkChartRowBarProps> {
 
     // The last part isn't generally colored (opacity is 0) unless it's the only
     // one, and in that case it covers the whole duration.
-    barPhases.push({
+    mainBarPhases.push({
       left: ((previousValue - start) / dur) * markerWidth,
       width: ((start + dur - previousValue) / dur) * markerWidth,
-      opacity: barPhases.length ? 0 : 1,
+      opacity: mainBarPhases.length ? 0 : 1,
       name: 'endTime',
       previousName,
       value: start + dur,
@@ -172,27 +254,35 @@ class NetworkChartRowBar extends React.PureComponent<NetworkChartRowBarProps> {
     });
 
     return (
-      <div
-        className="networkChartRowItemBar"
-        style={{ width: markerWidth, left: startPosition }}
-      >
-        {barPhases.map(({ name, previousName, value, duration, ...style }) => (
-          // Specifying data attributes makes it easier to debug.
-          <div
-            className="networkChartRowItemBarPhase"
-            key={name}
-            data-name={name}
-            data-value={value}
-            style={style}
-            aria-label={`${previousName} to ${name}: ${formatNumber(
-              duration
-            )} milliseconds`}
-          />
-        ))}
-      </div>
+      <>
+        {preconnectComponent}
+        <div
+          className="networkChartRowItemBar"
+          style={{ width: markerWidth, left: startPosition }}
+        >
+          {mainBarPhases.map(NetworkPhase)}
+        </div>
+      </>
     );
   }
 }
+
+type NetworkChartRowProps = {
+  +index: number,
+  +marker: Marker,
+  // Pass the payload in as well, since our types can't express a Marker with
+  // a specific payload.
+  +networkPayload: NetworkPayload,
+  +timeRange: StartEndRange,
+  +width: CssPixels,
+  +threadIndex: ThreadIndex,
+};
+
+type State = {|
+  pageX: CssPixels,
+  pageY: CssPixels,
+  hovered: ?boolean,
+|};
 
 class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
   state = {

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -85,6 +85,7 @@ type State = {|
 export type NetworkChartRowBarProps = {
   +marker: Marker,
   +markerWidth: CssPixels,
+  +startPosition: CssPixels,
   // Pass the payload in as well, since our types can't express a Marker with
   // a specific payload.
   +networkPayload: NetworkPayload,
@@ -93,7 +94,7 @@ export type NetworkChartRowBarProps = {
 // This component splits a network marker duration in different phases,
 // and renders each phase as a differently colored bar.
 const NetworkChartRowBar = (props: NetworkChartRowBarProps) => {
-  const { marker, networkPayload, markerWidth } = props;
+  const { marker, networkPayload, markerWidth, startPosition } = props;
   const { start, dur } = marker;
 
   const barPhases = [];
@@ -134,7 +135,10 @@ const NetworkChartRowBar = (props: NetworkChartRowBarProps) => {
   });
 
   return (
-    <>
+    <div
+      className="networkChartRowItemBar"
+      style={{ width: markerWidth, left: startPosition }}
+    >
       {barPhases.map(({ name, previousName, value, duration, ...style }) => (
         // Specifying data attributes makes it easier to debug.
         <div
@@ -148,7 +152,7 @@ const NetworkChartRowBar = (props: NetworkChartRowBarProps) => {
           )} milliseconds`}
         />
       ))}
-    </>
+    </div>
   );
 };
 
@@ -276,16 +280,12 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
         <div className="networkChartRowItemLabel">
           {this._splitsURI(marker.name)}
         </div>
-        <div
-          className="networkChartRowItemBar"
-          style={{ width: markerWidth, left: startPosition }}
-        >
-          <NetworkChartRowBar
-            marker={marker}
-            networkPayload={networkPayload}
-            markerWidth={markerWidth}
-          />
-        </div>
+        <NetworkChartRowBar
+          marker={marker}
+          networkPayload={networkPayload}
+          startPosition={startPosition}
+          markerWidth={markerWidth}
+        />
         {this.state.hovered ? (
           // This magic value "5" avoids the tooltip of being too close of the
           // row, especially when we mouseEnter the row from the top edge.

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -47,10 +47,9 @@ type StateProps = {|
   +threadIndex: number,
 |};
 
-type Props = {|
-  ...SizeProps,
-  ...ConnectedProps<{||}, StateProps, DispatchProps>,
-|};
+type OwnProps = {| ...SizeProps |};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class NetworkChart extends React.PureComponent<Props> {
   // This isn't used at the moment, but we need a fixed instance so that a
@@ -165,20 +164,24 @@ class NetworkChart extends React.PureComponent<Props> {
  * Wrap the component in the WithSize higher order component, as well as the redux
  * connected component.
  */
-export default explicitConnect<{||}, StateProps, DispatchProps>({
-  mapStateToProps: state => {
-    return {
-      markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
-        state
-      ),
-      getMarker: selectedThreadSelectors.getMarkerGetter(state),
-      timeRange: getPreviewSelectionRange(state),
-      disableOverscan: getPreviewSelection(state).isModifying,
-      threadIndex: getSelectedThreadIndex(state),
-    };
-  },
-  component: withSize<Props>(NetworkChart),
-});
+const ConnectedComponent = explicitConnect<OwnProps, StateProps, DispatchProps>(
+  {
+    mapStateToProps: state => {
+      return {
+        markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+          state
+        ),
+        getMarker: selectedThreadSelectors.getMarkerGetter(state),
+        timeRange: getPreviewSelectionRange(state),
+        disableOverscan: getPreviewSelection(state).isModifying,
+        threadIndex: getSelectedThreadIndex(state),
+      };
+    },
+    component: NetworkChart,
+  }
+);
+
+export default withSize<OwnProps>(ConnectedComponent);
 
 /**
  * Our definition of markers does not currently have the ability to refine

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -5,10 +5,6 @@
 // @flow
 import { oneLine } from 'common-tags';
 import * as React from 'react';
-import {
-  TIMELINE_MARGIN_LEFT,
-  TIMELINE_MARGIN_RIGHT,
-} from '../../app-logic/constants';
 import explicitConnect from '../../utils/connect';
 import NetworkSettings from '../shared/NetworkSettings';
 import VirtualList from '../shared/VirtualList';
@@ -27,7 +23,7 @@ import { updatePreviewSelection } from '../../actions/profile-view';
 import type { SizeProps } from '../shared/WithSize';
 import type { NetworkPayload } from '../../types/markers';
 import type { Marker, MarkerIndex } from '../../types/profile-derived';
-import type { Milliseconds, CssPixels, StartEndRange } from '../../types/units';
+import type { StartEndRange } from '../../types/units';
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');
@@ -64,26 +60,8 @@ class NetworkChart extends React.PureComponent<Props> {
     // Not implemented.
   };
 
-  /**
-   * Convert the time for a network marker into the CssPixels to be used on the screen.
-   * This function takes into account the range used, as well as the container sizing
-   * as passed in by the WithSize component.
-   */
-  _timeToCssPixels(time: Milliseconds): CssPixels {
-    const { timeRange, width } = this.props;
-    const timeRangeTotal = timeRange.end - timeRange.start;
-    const innerContainerWidth =
-      width - TIMELINE_MARGIN_LEFT - TIMELINE_MARGIN_RIGHT;
-
-    const markerPosition =
-      ((time - timeRange.start) / timeRangeTotal) * innerContainerWidth +
-      TIMELINE_MARGIN_LEFT;
-
-    return markerPosition;
-  }
-
   _renderRow = (markerIndex: MarkerIndex, index: number): React.Node => {
-    const { threadIndex, getMarker } = this.props;
+    const { threadIndex, getMarker, timeRange, width } = this.props;
     const marker = getMarker(markerIndex);
 
     // Since our type definition for Marker can't refine to just Network
@@ -97,15 +75,6 @@ class NetworkChart extends React.PureComponent<Props> {
         `
       );
     }
-    // Compute the positioning of the network markers.
-    const startPosition = this._timeToCssPixels(marker.start);
-    const endPosition = this._timeToCssPixels(marker.start + marker.dur);
-
-    // Set min-width for marker bar.
-    let markerWidth = endPosition - startPosition;
-    if (markerWidth < 1) {
-      markerWidth = 2.5;
-    }
 
     return (
       <NetworkChartRow
@@ -113,8 +82,8 @@ class NetworkChart extends React.PureComponent<Props> {
         marker={marker}
         networkPayload={networkPayload}
         threadIndex={threadIndex}
-        startPosition={startPosition}
-        markerWidth={markerWidth}
+        timeRange={timeRange}
+        width={width}
       />
     );
   };

--- a/src/components/tooltip/NetworkMarker.css
+++ b/src/components/tooltip/NetworkMarker.css
@@ -12,7 +12,24 @@
   margin-top: 4px;
   border-top: 1px solid var(--grey-40);
   grid-gap: 2px 5px;
+
+  /* When changing the number of columns, don't forget to change the span values
+   * in grid-column-start properties. */
   grid-template-columns: min-content min-content auto;
+}
+
+.tooltipNetworkTitle3 {
+  /* Reset most default properties of h3. */
+  padding: 0;
+  margin: 5px 0 3px 0;
+  font: inherit;
+
+  /* Make the title take the 2 columns. */
+  grid-column-start: span 3;
+}
+
+.tooltipNetworkTitle3:first-child {
+  margin-top: 3px;
 }
 
 .tooltipNetworkPhase {

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -378,6 +378,72 @@ describe('NetworkChartRowBar phase calculations', function() {
       'left: 140px; width: 58px; opacity: 0;',
     ]);
   });
+
+  it('renders 2 bars for a network marker with a preconnect part', () => {
+    const { getBarElementStyles } = setupWithPayload(
+      getNetworkMarkers({
+        startTime: 10010,
+        fetchStart: 10011,
+        // endTime is 99ms after startTime, so that the profile's end time is
+        // 10110ms, which makes the length 100ms, and we get nice rounded values
+        // as a result.
+        endTime: 10109,
+        id: 1235,
+        uri:
+          'https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*',
+        payload: {
+          count: 47027,
+          domainLookupStart: 500,
+          domainLookupEnd: 510,
+          connectStart: 511,
+          tcpConnectEnd: 515,
+          secureConnectionStart: 516,
+          connectEnd: 520,
+          requestStart: 10030,
+          responseStart: 10060,
+          responseEnd: 10080,
+        },
+      })
+    );
+
+    const barStyles = getBarElementStyles();
+    expect(barStyles).toHaveLength(2);
+    expect(barStyles).toEqual([
+      'width: 40px; left: -18870px;',
+      'width: 198px; left: 150px;',
+    ]);
+  });
+
+  it('renders 2 bars for a network markers with a preconnect part containing only the domain lookup', () => {
+    const { getBarElementStyles } = setupWithPayload(
+      getNetworkMarkers({
+        startTime: 10010,
+        fetchStart: 10011,
+        // endTime is 99ms after startTime, so that the profile's end time is
+        // 10110ms, which makes the length 100ms, and we get nice rounded values
+        // as a result.
+        endTime: 10109,
+        id: 1235,
+        uri:
+          'https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*',
+        payload: {
+          count: 47027,
+          domainLookupStart: 500,
+          domainLookupEnd: 520,
+          requestStart: 10030,
+          responseStart: 10060,
+          responseEnd: 10080,
+        },
+      })
+    );
+
+    const barStyles = getBarElementStyles();
+    expect(barStyles).toHaveLength(2);
+    expect(barStyles).toEqual([
+      'width: 40px; left: -18870px;',
+      'width: 198px; left: 150px;',
+    ]);
+  });
 });
 
 describe('NetworkChartRowBar URL split', function() {

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -464,4 +464,64 @@ describe('TooltipMarker', function() {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('renders properly network markers with a preconnect part', () => {
+    const { container, getByText } = setupWithPayload(
+      getNetworkMarkers({
+        startTime: 19000,
+        fetchStart: 19201,
+        endTime: 20433,
+        id: 1235,
+        uri:
+          'https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*',
+        payload: {
+          cache: 'Hit',
+          pri: 8,
+          count: 47027,
+          domainLookupStart: 10000,
+          domainLookupEnd: 10100,
+          connectStart: 10200,
+          tcpConnectEnd: 10210,
+          secureConnectionStart: 10211,
+          connectEnd: 10220,
+          requestStart: 19300,
+          responseStart: 19400,
+          responseEnd: 20200,
+        },
+      })
+    );
+
+    const preconnectTitle = getByText(/preconnect/i);
+    expect(preconnectTitle).toBeTruthy();
+    expect(preconnectTitle).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders properly network markers with a preconnect part containing only the domain lookup', () => {
+    const { container, getByText } = setupWithPayload(
+      getNetworkMarkers({
+        startTime: 19000,
+        fetchStart: 19201,
+        endTime: 20433,
+        id: 1235,
+        uri:
+          'https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*',
+        payload: {
+          cache: 'Hit',
+          pri: 8,
+          count: 47027,
+          domainLookupStart: 10000,
+          domainLookupEnd: 10100,
+          requestStart: 19300,
+          responseStart: 19400,
+          responseEnd: 20200,
+        },
+      })
+    );
+
+    const preconnectTitle = getByText(/preconnect/i);
+    expect(preconnectTitle).toBeTruthy();
+    expect(preconnectTitle).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { NetworkPayload } from '../../types/markers';
-
 import React from 'react';
 import { Provider } from 'react-redux';
 import { TooltipMarker } from '../../components/tooltip/Marker';
@@ -13,6 +11,8 @@ import { storeWithProfile } from '../fixtures/stores';
 import {
   addMarkersToThreadWithCorrespondingSamples,
   getProfileFromTextSamples,
+  getNetworkMarkers,
+  getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { getSelectedThreadIndex } from '../../selectors/url-state';
@@ -326,78 +326,6 @@ describe('TooltipMarker', function() {
         },
       ],
       [
-        'Load 31: http://wikia.com/',
-        10.5,
-        ({
-          type: 'Network',
-          startTime: 10.5,
-          endTime: 111.0,
-          id: 1234,
-          pri: 8,
-          status: 'STATUS_START',
-          URI: 'http://wikia.com/',
-          RedirectURI: '',
-        }: NetworkPayload),
-      ],
-      [
-        'Load 31: http://wikia.com/',
-        111.0,
-        // Coerce all of the Network payload objects to the NetworkPayload type to help
-        // surface helpful Flow error messages.
-        ({
-          type: 'Network',
-          startTime: 111.0,
-          endTime: 18736.6,
-          id: 1234,
-          status: 'STATUS_REDIRECT',
-          cache: 'any string could be here',
-          pri: -20,
-          count: 0,
-          URI: 'http://www.wikia.com/',
-          RedirectURI:
-            'http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625',
-        }: NetworkPayload),
-      ],
-      [
-        'Load 1234: http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625',
-        19000,
-        ({
-          type: 'Network',
-          startTime: 19000,
-          endTime: 19200.2,
-          id: 1235,
-          pri: 8,
-          status: 'STATUS_START',
-          RedirectURI: '',
-          URI: '',
-        }: NetworkPayload),
-      ],
-      [
-        'Load 1234: http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625',
-        19200.2,
-        ({
-          type: 'Network',
-          startTime: 19200.2,
-          endTime: 20433.8,
-          id: 1235,
-          status: 'STATUS_STOP',
-          cache: 'Hit',
-          pri: 8,
-          count: 47027,
-          URI:
-            'https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*',
-          domainLookupStart: 19050,
-          domainLookupEnd: 19060,
-          connectStart: 19200,
-          tcpConnectEnd: 19205,
-          secureConnectionStart: 19250,
-          connectEnd: 19290,
-          requestStart: 19300.8,
-          responseStart: 19400.2,
-          responseEnd: 20200,
-        }: NetworkPayload),
-      ],
-      [
         'ConstructRootFrame',
         112.5,
         {
@@ -460,5 +388,80 @@ describe('TooltipMarker', function() {
         `${marker.name}-${marker.start}`
       );
     });
+  });
+
+  // In this setup function, we'll render only the first derived marker. But
+  // there can be several raw markers as sources, that will be merged in our
+  // processing pipeline.
+  function setupWithPayload(markers) {
+    const profile = getProfileWithMarkers(markers);
+
+    const store = storeWithProfile(profile);
+    const state = store.getState();
+
+    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+    const markerIndexes = selectedThreadSelectors.getFullMarkerListIndexes(
+      state
+    );
+
+    // We render the first marker.
+    const marker = getMarker(markerIndexes[0]);
+
+    return render(
+      <Provider store={store}>
+        <TooltipMarker marker={marker} threadIndex={0} className="propClass" />
+      </Provider>
+    );
+  }
+
+  it('renders properly redirect network markers', () => {
+    const { container } = setupWithPayload(
+      getNetworkMarkers({
+        id: 1234,
+        startTime: 10.5,
+        fetchStart: 111.0,
+        endTime: 18736.6,
+        uri: 'http://www.wikia.com/',
+        payload: {
+          status: 'STATUS_REDIRECT',
+          cache: 'any string could be here',
+          pri: -20,
+          count: 0,
+          RedirectURI:
+            'http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625',
+        },
+      })
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders properly normal network markers', () => {
+    const { container } = setupWithPayload(
+      getNetworkMarkers({
+        id: 1235,
+        startTime: 19000,
+        fetchStart: 19200.2,
+        endTime: 20433.8,
+        uri:
+          'https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*',
+        payload: {
+          cache: 'Hit',
+          pri: 8,
+          count: 47027,
+          domainLookupStart: 19050,
+          domainLookupEnd: 19060,
+          connectStart: 19200,
+          tcpConnectEnd: 19205,
+          secureConnectionStart: 19250,
+          connectEnd: 19290,
+          requestStart: 19300.8,
+          responseStart: 19400.2,
+          responseEnd: 20200,
+        },
+      })
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1,5 +1,469 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipMarker renders properly network markers with a preconnect part 1`] = `
+<h3
+  class="tooltipNetworkTitle3"
+>
+  Preconnect (starting at 
+  -9,000ms
+  )
+</h3>
+`;
+
+exports[`TooltipMarker renders properly network markers with a preconnect part 2`] = `
+<div
+  class="tooltipMarker propClass"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1,433ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1235: https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Response received
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    Hit
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Low(8)
+    <div
+      class="tooltipLabel"
+    >
+      Guessed MIME type
+      :
+    </div>
+    <div
+      class="tooltipNetworkMimeType"
+    >
+      <span
+        class="tooltipNetworkMimeTypeSwatch colored-square network-color-img"
+        title="image/jpeg"
+      />
+      image/jpeg
+    </div>
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    45.9KB
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-img"
+  >
+    <h3
+      class="tooltipNetworkTitle3"
+    >
+      Preconnect (starting at 
+      -9,000ms
+      )
+    </h3>
+    <div
+      class="tooltipLabel"
+    >
+      DNS request
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 100 milliseconds"
+    >
+      100ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 54.54545454545455%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      After DNS request
+      :
+    </div>
+    <div
+      aria-label="Starting at 100 milliseconds, duration is 100 milliseconds"
+    >
+      100ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 45.45454545454545%; margin-right: 9.090909090909093%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      TCP connection
+      :
+    </div>
+    <div
+      aria-label="Starting at 200 milliseconds, duration is 10 milliseconds"
+    >
+      10ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 90.9090909090909%; margin-right: 4.545454545454548%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      After TCP connection
+      :
+    </div>
+    <div
+      aria-label="Starting at 210 milliseconds, duration is 1.0 milliseconds"
+    >
+      1.0ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 95.45454545454545%; margin-right: 4.090909090909093%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Establishing TLS session
+      :
+    </div>
+    <div
+      aria-label="Starting at 211 milliseconds, duration is 9.0 milliseconds"
+    >
+      9.0ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 95.9090909090909%; opacity: 0.5;"
+    />
+    <h3
+      class="tooltipNetworkTitle3"
+    >
+      Actual request
+    </h3>
+    <div
+      class="tooltipLabel"
+    >
+      Waiting for socket thread
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 300 milliseconds"
+    >
+      300ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
+      style="margin-left: 0%; margin-right: 79.0648988136776%;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      HTTP request and waiting for response
+      :
+    </div>
+    <div
+      aria-label="Starting at 300 milliseconds, duration is 100 milliseconds"
+    >
+      100ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 20.9351011863224%; margin-right: 72.08653175157013%; opacity: 0.75;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 400 milliseconds, duration is 800 milliseconds"
+    >
+      800ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 27.91346824842987%; margin-right: 16.259595254710398%; opacity: 1;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Waiting to transmit the response
+      :
+    </div>
+    <div
+      aria-label="Starting at 1,200 milliseconds, duration is 233 milliseconds"
+    >
+      233ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
+      style="margin-left: 83.7404047452896%;"
+    />
+  </div>
+</div>
+`;
+
+exports[`TooltipMarker renders properly network markers with a preconnect part containing only the domain lookup 1`] = `
+<h3
+  class="tooltipNetworkTitle3"
+>
+  Preconnect (starting at 
+  -9,000ms
+  )
+</h3>
+`;
+
+exports[`TooltipMarker renders properly network markers with a preconnect part containing only the domain lookup 2`] = `
+<div
+  class="tooltipMarker propClass"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1,433ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1235: https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Response received
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    Hit
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Low(8)
+    <div
+      class="tooltipLabel"
+    >
+      Guessed MIME type
+      :
+    </div>
+    <div
+      class="tooltipNetworkMimeType"
+    >
+      <span
+        class="tooltipNetworkMimeTypeSwatch colored-square network-color-img"
+        title="image/jpeg"
+      />
+      image/jpeg
+    </div>
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    45.9KB
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-img"
+  >
+    <h3
+      class="tooltipNetworkTitle3"
+    >
+      Preconnect (starting at 
+      -9,000ms
+      )
+    </h3>
+    <div
+      class="tooltipLabel"
+    >
+      DNS request
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 100 milliseconds"
+    >
+      100ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 0.5;"
+    />
+    <h3
+      class="tooltipNetworkTitle3"
+    >
+      Actual request
+    </h3>
+    <div
+      class="tooltipLabel"
+    >
+      Waiting for socket thread
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 300 milliseconds"
+    >
+      300ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
+      style="margin-left: 0%; margin-right: 79.0648988136776%;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      HTTP request and waiting for response
+      :
+    </div>
+    <div
+      aria-label="Starting at 300 milliseconds, duration is 100 milliseconds"
+    >
+      100ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 20.9351011863224%; margin-right: 72.08653175157013%; opacity: 0.75;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 400 milliseconds, duration is 800 milliseconds"
+    >
+      800ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 27.91346824842987%; margin-right: 16.259595254710398%; opacity: 1;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Waiting to transmit the response
+      :
+    </div>
+    <div
+      aria-label="Starting at 1,200 milliseconds, duration is 233 milliseconds"
+    >
+      233ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
+      style="margin-left: 83.7404047452896%;"
+    />
+  </div>
+</div>
+`;
+
 exports[`TooltipMarker renders properly normal network markers 1`] = `
 <div
   class="tooltipMarker propClass"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1,5 +1,373 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipMarker renders properly normal network markers 1`] = `
+<div
+  class="tooltipMarker propClass"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1,434ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1235: https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Response received
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    Hit
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Low(8)
+    <div
+      class="tooltipLabel"
+    >
+      Guessed MIME type
+      :
+    </div>
+    <div
+      class="tooltipNetworkMimeType"
+    >
+      <span
+        class="tooltipNetworkMimeTypeSwatch colored-square network-color-img"
+        title="image/jpeg"
+      />
+      image/jpeg
+    </div>
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    45.9KB
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-img"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Waiting for socket thread
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 50 milliseconds"
+    >
+      50ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
+      style="margin-left: 0%; margin-right: 96.51276328637188%;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      DNS request
+      :
+    </div>
+    <div
+      aria-label="Starting at 50 milliseconds, duration is 10 milliseconds"
+    >
+      10ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 3.487236713628123%; margin-right: 95.81531594364625%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      After DNS request
+      :
+    </div>
+    <div
+      aria-label="Starting at 60 milliseconds, duration is 140 milliseconds"
+    >
+      140ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 4.184684056353747%; margin-right: 86.05105314548751%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      TCP connection
+      :
+    </div>
+    <div
+      aria-label="Starting at 200 milliseconds, duration is 5.0 milliseconds"
+    >
+      5.0ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 13.948946854512492%; margin-right: 85.7023294741247%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      After TCP connection
+      :
+    </div>
+    <div
+      aria-label="Starting at 205 milliseconds, duration is 45 milliseconds"
+    >
+      45ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 14.297670525875303%; margin-right: 82.56381643185938%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Establishing TLS session
+      :
+    </div>
+    <div
+      aria-label="Starting at 250 milliseconds, duration is 40 milliseconds"
+    >
+      40ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 17.436183568140613%; margin-right: 79.77402706095688%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Waiting for HTTP request
+      :
+    </div>
+    <div
+      aria-label="Starting at 290 milliseconds, duration is 11 milliseconds"
+    >
+      11ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 20.225972939043114%; margin-right: 79.02078393081325%; opacity: 0.5;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      HTTP request and waiting for response
+      :
+    </div>
+    <div
+      aria-label="Starting at 301 milliseconds, duration is 99 milliseconds"
+    >
+      99ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 20.979216069186737%; margin-right: 72.08815734412046%; opacity: 0.75;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 400 milliseconds, duration is 800 milliseconds"
+    >
+      800ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 27.91184265587955%; margin-right: 16.306318872925047%; opacity: 1;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Waiting to transmit the response
+      :
+    </div>
+    <div
+      aria-label="Starting at 1,200 milliseconds, duration is 234 milliseconds"
+    >
+      234ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
+      style="margin-left: 83.69368112707495%;"
+    />
+  </div>
+</div>
+`;
+
+exports[`TooltipMarker renders properly redirect network markers 1`] = `
+<div
+  class="tooltipMarker propClass"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        18,726ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1234: http://www.wikia.com/
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Redirecting request
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    any string could be here
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://www.wikia.com/
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Redirect URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Highest(-20)
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    0.000B
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-other"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 18,726 milliseconds"
+    >
+      18,726ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+    />
+  </div>
+</div>
+`;
+
 exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
 <div
   class="tooltipMarker propClass"
@@ -856,374 +1224,6 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
       :
     </div>
     1234
-  </div>
-</div>
-`;
-
-exports[`TooltipMarker renders tooltips for various markers: Load 31: http://wikia.com/-10.5 1`] = `
-<div
-  class="tooltipMarker propClass"
->
-  <div
-    class="tooltipHeader"
-  >
-    <div
-      class="tooltipOneLine"
-    >
-      <div
-        class="tooltipTiming"
-      >
-        18,726ms
-      </div>
-      <div
-        class="tooltipTitle"
-      >
-        Load 31: http://wikia.com/
-      </div>
-    </div>
-    <div
-      class="tooltipDetails"
-    >
-      <div
-        class="tooltipLabel"
-      >
-        Thread
-        :
-      </div>
-      Main Thread
-    </div>
-  </div>
-  <div
-    class="tooltipDetails"
-  >
-    <div
-      class="tooltipLabel"
-    >
-      Status
-      :
-    </div>
-    Redirecting request
-    <div
-      class="tooltipLabel"
-    >
-      Cache
-      :
-    </div>
-    any string could be here
-    <div
-      class="tooltipLabel"
-    >
-      URL
-      :
-    </div>
-    <span
-      class="tooltipNetworkUrl"
-    >
-      http://www.wikia.com/
-    </span>
-    <div
-      class="tooltipLabel"
-    >
-      Redirect URL
-      :
-    </div>
-    <span
-      class="tooltipNetworkUrl"
-    >
-      http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
-    </span>
-    <div
-      class="tooltipLabel"
-    >
-      Priority
-      :
-    </div>
-    Highest(-20)
-    <div
-      class="tooltipLabel"
-    >
-      Requested bytes
-      :
-    </div>
-    0.000B
-  </div>
-  <div
-    class="tooltipNetworkPhases network-color-other"
-  >
-    <div
-      class="tooltipLabel"
-    >
-      HTTP response
-      :
-    </div>
-    <div
-      aria-label="Starting at 0.000 milliseconds, duration is 18,726 milliseconds"
-    >
-      18,726ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
-    />
-  </div>
-</div>
-`;
-
-exports[`TooltipMarker renders tooltips for various markers: Load 1234: http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625-19000 1`] = `
-<div
-  class="tooltipMarker propClass"
->
-  <div
-    class="tooltipHeader"
-  >
-    <div
-      class="tooltipOneLine"
-    >
-      <div
-        class="tooltipTiming"
-      >
-        1,434ms
-      </div>
-      <div
-        class="tooltipTitle"
-      >
-        Load 1234: http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
-      </div>
-    </div>
-    <div
-      class="tooltipDetails"
-    >
-      <div
-        class="tooltipLabel"
-      >
-        Thread
-        :
-      </div>
-      Main Thread
-    </div>
-  </div>
-  <div
-    class="tooltipDetails"
-  >
-    <div
-      class="tooltipLabel"
-    >
-      Status
-      :
-    </div>
-    Response received
-    <div
-      class="tooltipLabel"
-    >
-      Cache
-      :
-    </div>
-    Hit
-    <div
-      class="tooltipLabel"
-    >
-      URL
-      :
-    </div>
-    <span
-      class="tooltipNetworkUrl"
-    >
-      https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
-    </span>
-    <div
-      class="tooltipLabel"
-    >
-      Priority
-      :
-    </div>
-    Low(8)
-    <div
-      class="tooltipLabel"
-    >
-      Guessed MIME type
-      :
-    </div>
-    <div
-      class="tooltipNetworkMimeType"
-    >
-      <span
-        class="tooltipNetworkMimeTypeSwatch colored-square network-color-img"
-        title="image/jpeg"
-      />
-      image/jpeg
-    </div>
-    <div
-      class="tooltipLabel"
-    >
-      Requested bytes
-      :
-    </div>
-    45.9KB
-  </div>
-  <div
-    class="tooltipNetworkPhases network-color-img"
-  >
-    <div
-      class="tooltipLabel"
-    >
-      Waiting for socket thread
-      :
-    </div>
-    <div
-      aria-label="Starting at 0.000 milliseconds, duration is 50 milliseconds"
-    >
-      50ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
-      style="margin-left: 0%; margin-right: 96.51276328637188%;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      DNS request
-      :
-    </div>
-    <div
-      aria-label="Starting at 50 milliseconds, duration is 10 milliseconds"
-    >
-      10ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 3.487236713628123%; margin-right: 95.81531594364625%; opacity: 0.5;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      After DNS request
-      :
-    </div>
-    <div
-      aria-label="Starting at 60 milliseconds, duration is 140 milliseconds"
-    >
-      140ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 4.184684056353747%; margin-right: 86.05105314548751%; opacity: 0.5;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      TCP connection
-      :
-    </div>
-    <div
-      aria-label="Starting at 200 milliseconds, duration is 5.0 milliseconds"
-    >
-      5.0ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 13.948946854512492%; margin-right: 85.7023294741247%; opacity: 0.5;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      After TCP connection
-      :
-    </div>
-    <div
-      aria-label="Starting at 205 milliseconds, duration is 45 milliseconds"
-    >
-      45ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 14.297670525875303%; margin-right: 82.56381643185938%; opacity: 0.5;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      Establishing TLS session
-      :
-    </div>
-    <div
-      aria-label="Starting at 250 milliseconds, duration is 40 milliseconds"
-    >
-      40ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 17.436183568140613%; margin-right: 79.77402706095688%; opacity: 0.5;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      Waiting for HTTP request
-      :
-    </div>
-    <div
-      aria-label="Starting at 290 milliseconds, duration is 11 milliseconds"
-    >
-      11ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 20.225972939043114%; margin-right: 79.02078393081325%; opacity: 0.5;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      HTTP request and waiting for response
-      :
-    </div>
-    <div
-      aria-label="Starting at 301 milliseconds, duration is 99 milliseconds"
-    >
-      99ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 20.979216069186737%; margin-right: 72.08815734412046%; opacity: 0.75;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      HTTP response
-      :
-    </div>
-    <div
-      aria-label="Starting at 400 milliseconds, duration is 800 milliseconds"
-    >
-      800ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase"
-      style="margin-left: 27.91184265587955%; margin-right: 16.306318872925047%; opacity: 1;"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      Waiting to transmit the response
-      :
-    </div>
-    <div
-      aria-label="Starting at 1,200 milliseconds, duration is 234 milliseconds"
-    >
-      234ms
-    </div>
-    <div
-      aria-hidden="true"
-      class="tooltipNetworkPhase tooltipNetworkPhaseEmpty"
-      style="margin-left: 83.69368112707495%;"
-    />
   </div>
 </div>
 `;


### PR DESCRIPTION
Fixes #1965

In some cases (still a bit unclear), we can have the domain lookup and connection properties have timestamp that happen before the marker's start time. As I understand, this happens when Firefox decides to trigger a preconnect at a page load, when it thinks we'll have this connection happen. I couldn't really reproduce it reliably, but I could reproduce at least once.

See especially these links, and hover:
[before](https://profiler.firefox.com/public/8b2e92d6b9d9a506737fbed3d0fa5424e3b34a0c/network-chart/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3164-1-2-0~12671-0~12665-0~12605-0~12558-0-1~&networkSearch=sdk&range=10.7576_11.6252&thread=0&v=3)
[after](https://deploy-preview-2009--perf-html.netlify.com/public/8b2e92d6b9d9a506737fbed3d0fa5424e3b34a0c/network-chart/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3164-1-2-0~12671-0~12665-0~12605-0~12558-0-1~&networkSearch=sdk&range=10.7576_11.6252&thread=0&v=3)

See also the color which the marker itself is painted with.

It should be easier to look at the commits individually.