### PR TITLE
Fix #2008: Changes contrast of the time ruler

### DIFF
--- a/src/components/timeline/Ruler.css
+++ b/src/components/timeline/Ruler.css
@@ -31,7 +31,7 @@
   height: 20px;
   padding: 0;
   margin: 0;
-  color: #888;
+  color: var(--grey-50);
   cursor: default;
   font-size: 9px;
   line-height: 20px;


### PR DESCRIPTION
## Issue number

#2008 

## Description

This PR changes contrast of the time ruler.
I changed contrast from `#888` to `var(--grey-50)` as @julienw suggested in #2008.
I feel the time ruler became blacker than the current.

## Screenshot

### Currently

![currently](https://user-images.githubusercontent.com/11808736/57634343-18c1f800-75e0-11e9-89f5-66eab2bc46f5.jpg)

### After

![after](https://user-images.githubusercontent.com/11808736/57634384-2b3c3180-75e0-11e9-8875-776ed56d9aea.jpg)

