### PR TITLE
added width limit to context menu using css

### DIFF
--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -29,8 +29,9 @@
 }
 
 .callNodeContextMenuLabel {
+  display: block;
   overflow: hidden;
-  min-width: 250px;
+  width: 250px;
   color: #555;
   font-weight: bold;
   text-overflow: ellipsis;

--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -29,8 +29,12 @@
 }
 
 .callNodeContextMenuLabel {
+  overflow: hidden;
+  min-width: 250px;
   color: #555;
   font-weight: bold;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .react-contextmenu-item--selected > .callNodeContextMenuLabel {

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -11,20 +11,7 @@ import * as icons from './icons';
 import * as publish from './publish';
 import * as zippedProfiles from './zipped-profiles';
 
-// Normally we don't need that type because flow can infer types, but on that
-// object, it gives weird flow errors that say missing type annotation for X.
-// Only adding a type like that seems to solve it.
-type Selectors = {
-  app: typeof app,
-  profile: typeof profile,
-  urlState: typeof urlState,
-  icons: typeof icons,
-  publish: typeof publish,
-  zippedProfiles: typeof zippedProfiles,
-  selectedThread: typeof selectedThread,
-};
-
-export default ({
+const allSelectors = {
   app,
   profile,
   urlState,
@@ -32,4 +19,7 @@ export default ({
   publish,
   zippedProfiles,
   selectedThread,
-}: Selectors);
+};
+
+// Flow requires that all exported object is explicitely typed.
+export default (allSelectors: typeof allSelectors);


### PR DESCRIPTION
added width limit to context menu collapse function as it was overflowing outside of screen . CSS fix.
Fixes #2006