### PR TITLE
Fix Flow and locale-dependent tests errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start-examples": "ws -d examples/ -s index.html -p 4242",
     "start-docs": "docsify serve ./docs-user",
     "start-photon": "node res/photon/server",
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-worker jest",
+    "test": "cross-env LC_ALL=C NODE_ENV=test NODE_OPTIONS=--experimental-worker jest",
     "test-all": "run-p flow license-check lint test",
     "test-build-coverage": "jest --coverage --coverageReporters=html",
     "test-serve-coverage": "ws -d coverage/ -p 4343",

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -99,7 +99,7 @@ function _formatDateTime(timestamp: number): string {
   return dateTimeLabel;
 }
 
-export default explicitConnect({
+export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: state => ({
     profileName: getProfileName(state),
     profile: getProfile(state),


### PR DESCRIPTION
Regression from #1926

The Flow error were because I didn't take the time to update the tree.
The tests error may happen only on my french locale PC, but this is still a problem for me.