### PR TITLE
Improve the types for the gecko profile format

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -50,6 +50,7 @@ import type {
 import type { Milliseconds } from '../types/units';
 import type {
   GeckoProfile,
+  GeckoSubprocessProfile,
   GeckoThread,
   GeckoMarkerStruct,
   GeckoFrameStruct,
@@ -680,7 +681,7 @@ function _processSamples(geckoSamples: GeckoSampleStruct): SamplesTable {
  * Converts the Gecko list of counters into the processed format.
  */
 function _processCounters(
-  geckoProfile: GeckoProfile,
+  geckoProfile: GeckoProfile | GeckoSubprocessProfile,
   // The counters are listed independently from the threads, so we need an index that
   // references back into a stable list of threads. The threads list in the processing
   // step is built dynamically, so the "stableThreadList" variable is a hint that this
@@ -737,7 +738,7 @@ function _processCounters(
  */
 function _processThread(
   thread: GeckoThread,
-  processProfile: GeckoProfile,
+  processProfile: GeckoProfile | GeckoSubprocessProfile,
   extensions: ExtensionTable
 ): Thread {
   const geckoFrameStruct: GeckoFrameStruct = _toStructOfArrays(
@@ -1028,7 +1029,7 @@ export function processProfile(
     oscpu: geckoProfile.meta.oscpu,
     platform: geckoProfile.meta.platform,
     processType: geckoProfile.meta.processType,
-    product: geckoProfile.meta.product,
+    product: geckoProfile.meta.product || '',
     stackwalk: geckoProfile.meta.stackwalk,
     debug: !!geckoProfile.meta.debug,
     toolkit: geckoProfile.meta.toolkit,


### PR DESCRIPTION
When working on a test to check a bug in https://github.com/firefox-devtools/profiler/pull/1883 I realized that our types and fixtures weren't perfect around subprocesses in the gecko profile format. This PR fixes that.

I used https://searchfox.org/mozilla-central/rev/7556a400affa9eb99e522d2d17c40689fa23a729/tools/profiler/core/platform.cpp#1829 as source of truth for the properties that are in `profile.meta`. As a result I added some new properties, and I also made some properties optional, even if that doesn't generally happen.

But the biggest change is that the `meta` object for subprocesses is now much smaller, and as a result we won't be able to make mistake trying to use inexistant properties.

I should note that I checked this was true by adding logs to `processProfile` and capturing a proifle.