### PR TITLE
Publish on page

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -28,13 +28,6 @@ export function changeSelectedTab(selectedTab: TabSlug): ThunkAction<void> {
   };
 }
 
-export function profilePublished(hash: string): Action {
-  return {
-    type: 'PROFILE_PUBLISHED',
-    hash,
-  };
-}
-
 export function changeProfilesToCompare(profiles: string[]): Action {
   return {
     type: 'CHANGE_PROFILES_TO_COMPARE',

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -210,7 +210,7 @@ export function profileSanitized(
   originalUrlState: UrlState
 ): Action {
   return {
-    type: 'SANITIZE_PROFILE_PUBLISHED',
+    type: 'SANITIZED_PROFILE_PUBLISHED',
     hash,
     committedRanges,
     oldThreadIndexToNew,

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -89,9 +89,6 @@ type BaseQuery = {|
   hiddenThreads: string, // "0-1"
   profiles: string[],
   profileName: string,
-  // This value tracks whether a profile was newly published. Which in that case
-  // we will want to show a friendly message.
-  published: null | void,
 |};
 
 type CallTreeQuery = {|
@@ -180,7 +177,6 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     profiles: urlState.profilesToCompare || undefined,
     v: CURRENT_URL_VERSION,
     profileName: urlState.profileName || undefined,
-    published: urlState.isNewlyPublished === true ? null : undefined,
   };
 
   // Add the parameter hiddenGlobalTracks only when needed.
@@ -346,7 +342,6 @@ export function stateFromLocation(location: Location): UrlState {
     selectedTab: toValidTabSlug(pathParts[selectedTabPathPart]) || 'calltree',
     pathInZipFile: query.file || null,
     profileName: query.profileName,
-    isNewlyPublished: query.published !== undefined,
     profileSpecific: {
       implementation,
       invertCallstack: query.invertCallstack !== undefined,

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -21,6 +21,30 @@ import type { TrackIndex } from '../types/profile-derived';
 
 export const CURRENT_URL_VERSION = 3;
 
+/**
+ * This static piece of state might look like an anti-pattern, but it's a relatively
+ * simple way to adjust whether we are pushing or replacing onto the history API.
+ * The history API is a singleton, and so here we're also using a singleton pattern
+ * to manage this bit of state.
+ */
+let _isReplaceState: boolean = false;
+
+/**
+ * This function can be called from thunk actions or other components to change the
+ * history API's behavior.
+ */
+export function setHistoryReplaceState(value: boolean): void {
+  _isReplaceState = value;
+}
+
+/**
+ * This function is consumed by the UrlManager so it knows how to interact with the
+ * history API. It's embedded here to avoid cyclical dependencies when importing files.
+ */
+export function getIsHistoryReplaceState(): boolean {
+  return _isReplaceState;
+}
+
 function getDataSourceDirs(
   urlState: UrlState
 ): [] | [DataSource] | [DataSource, string] {

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -25,6 +25,7 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
     return (
       <ButtonWithPanel
         className="menuButtonsMetaInfoButton"
+        buttonClassName="menuButtonsMetaInfoButtonButton"
         label={_formatLabel(meta) || 'Profile information'}
         panel={
           <ArrowPanel className="arrowPanelOpenMetaInfo">

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -2,13 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.menuButtonsCompositeButtonContainer {
-  display: flex;
-  flex-flow: column nowrap;
-  border-right: 1px solid var(--grey-30);
-  border-left: 1px solid var(--grey-30);
-}
-
 .menuButtonsShareButton,
 .menuButtonsUploadingButton,
 .menuButtonsPermalinkButton,
@@ -21,95 +14,6 @@
   border-left: 1px solid var(--grey-30);
 }
 
-.menuButtonsUploadingButton {
-  overflow: hidden;
-}
-
-.menuButtonsUploadingButtonInner {
-  display: flex;
-  overflow: hidden;
-  height: 100%;
-  flex-flow: column nowrap;
-  align-items: stretch;
-}
-
-.menuButtonsUploadingButtonLabel {
-  position: relative;
-  padding: 0 10px;
-  color: hsla(0, 0%, 100%, 0.7);
-  cursor: default;
-  line-height: 24px;
-  text-align: center;
-  -moz-user-select: none;
-}
-
-/* The button width needs to be large enough so that the text "Share Without URLs" fits */
-.menuButtonsUploadingButtonInner,
-.menuButtonsPermalinkButtonButton,
-.menuButtonsUploadErrorButtonButton {
-  width: 115px;
-}
-
-/* The button will be larger during symbolication to fit the text:
-"Sharing will be enabled once symbolication is complete" */
-.menuButtonsShareButtonButton {
-  min-width: 115px;
-  background-color: #0d8730;
-  color: white;
-}
-
-.menuButtonsUploadingButtonProgress {
-  width: 100%;
-  height: 24px;
-  margin-bottom: -24px;
-  border: 0;
-  background: var(--internal-uploading-button-background-color);
-  transform-origin: bottom left;
-}
-
-.menuButtonsUploadingButtonProgress::-moz-progress-bar {
-  background: var(--internal-uploading-progress-fill-color);
-}
-
-/* CSSTransition */
-.buttonWithPanelButton,
-.menuButtonsUploadingButtonInner {
-  transition: opacity 200ms ease-in-out, transform 200ms ease-in-out;
-}
-
-.menuButtonsTransitionUp-enter .buttonWithPanelButton,
-.menuButtonsTransitionUp-enter .menuButtonsUploadingButtonInner {
-  opacity: 0;
-  transform: translateY(100%);
-}
-
-.menuButtonsTransitionUp-enter-active .buttonWithPanelButton,
-.menuButtonsTransitionUp-enter-active .menuButtonsUploadingButtonInner {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.menuButtonsTransitionUp-exit .buttonWithPanelButton,
-.menuButtonsTransitionUp-exit .menuButtonsUploadingButtonInner {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.menuButtonsTransitionUp-exit-active .buttonWithPanelButton,
-.menuButtonsTransitionUp-exit-active .menuButtonsUploadingButtonInner {
-  opacity: 0;
-  transform: translateY(-100%);
-}
-
-/* end of CSSTransition */
-
-/* permalink button is hidden whenever uploading is in progress, but is
- * moved up when uploading is finished. */
-.currentButtonIsUploadingButton .menuButtonsPermalinkButtonButton {
-  opacity: 0;
-  transform: translateY(100%);
-}
-
 .menuButtonsPublishPanel,
 .menuButtonsUploadErrorPanel {
   --width: 500px;
@@ -120,27 +24,6 @@
   height: 19px;
   padding: 0 4px;
   margin: 5px -5px;
-}
-
-.menuButtonsShareNetworkUrlsContainer {
-  margin: 20px 0;
-  -moz-user-select: none;
-  user-select: none;
-}
-
-.menuButtonsShareNetworkUrlsCheckbox {
-  position: relative;
-  bottom: 1px;
-  vertical-align: middle;
-}
-
-.menuButtonsProfileDownloadPanel {
-  --offset-from-right: 25px;
-  --width: 30em;
-}
-
-.menuButtonsDownloadLink {
-  white-space: nowrap;
 }
 
 .menuButtonsPublishContent {
@@ -287,30 +170,6 @@
   100% {
     background-position: -21px 0;
   }
-}
-
-.menuButtonsPublishUrl {
-  padding: 10px;
-  margin: 10px 0 35px;
-  border: 1px solid var(--grey-30);
-  background: #fff;
-  border-radius: 3px;
-}
-
-.menuButtonsPublishMessage {
-  margin: 14px 0;
-  font-size: 13px;
-}
-
-.menuButtonsPublishPreviousUrl {
-  margin: 17px 5px -15px;
-}
-
-.menuButtonsPublishPreviousUrlTitle {
-  margin-bottom: 10px;
-  color: var(--grey-70);
-  font-size: 14px;
-  font-weight: bold;
 }
 
 .menuButtonsPublishError {

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -3,19 +3,40 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .menuButtonsShareButton,
-.menuButtonsUploadingButton,
 .menuButtonsPermalinkButton,
-.menuButtonsUploadErrorButton {
+.menuButtonsRevertButton,
+.menuButtonsAbortUploadButton {
   height: 24px;
   margin-bottom: -24px;
-}
-
-.menuButtonsPermalinkButton {
   border-left: 1px solid var(--grey-30);
 }
 
-.menuButtonsPublishPanel,
-.menuButtonsUploadErrorPanel {
+.menuButtonsAbortUploadButton {
+  background-color: var(--green-70);
+  color: #fff;
+}
+
+.menuButtonsUploadingButtonLabel {
+  position: relative;
+  padding: 0 10px;
+  color: hsla(0, 0%, 100%, 0.7);
+  cursor: default;
+  line-height: 24px;
+  text-align: center;
+  -moz-user-select: none;
+}
+
+.menuButtonsShareButtonOriginal {
+  background-color: var(--green-70);
+  color: white;
+}
+
+.menuButtonsShareButtonError {
+  background-color: var(--red-60);
+  color: white;
+}
+
+.menuButtonsPublishPanel {
   --width: 500px;
 }
 
@@ -148,7 +169,9 @@
 }
 
 .menuButtonsPublishUploadBarInner {
-  height: 5px;
+  position: absolute;
+  top: 0;
+  height: 3px;
   animation: animate-stripes 1s linear infinite;
   background-color: var(--blue-50);
   background-image: linear-gradient(
@@ -163,7 +186,7 @@
     transparent 80%
   );
   background-size: 21px 20px, 100% 100%, 100% 100%;
-  border-radius: 2px;
+  border-radius: 0 2px 2px 0;
 }
 
 @keyframes animate-stripes {

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -20,7 +20,6 @@ import {
   getCompressedProfileBlob,
   getUploadPhase,
   getUploadProgressString,
-  getUploadUrl,
   getUploadError,
   getShouldSanitizeByDefault,
 } from '../../../selectors/publish';
@@ -36,7 +35,9 @@ import type { UploadPhase } from '../../../types/state';
 
 require('./Publish.css');
 
-type OwnProps = {||};
+type OwnProps = {|
+  +isRepublish?: boolean,
+|};
 
 type StateProps = {|
   +profile: Profile,
@@ -47,7 +48,6 @@ type StateProps = {|
   +downloadFileName: string,
   +uploadPhase: UploadPhase,
   +uploadProgress: string,
-  +uploadUrl: string,
   +shouldSanitizeByDefault: boolean,
   +error: mixed,
 |};
@@ -97,27 +97,19 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
       attemptToPublish,
       downloadFileName,
       compressedProfileBlobPromise,
-      uploadUrl,
       shouldSanitizeByDefault,
+      isRepublish,
     } = this.props;
 
     return (
       <div data-testid="MenuButtonsPublish-container">
-        {uploadUrl ? (
-          <div className="menuButtonsPublishPreviousUrl">
-            <div className="menuButtonsPublishPreviousUrlTitle">
-              Previously published profile:
-            </div>
-            <div className="menuButtonsPublishUrl">
-              <a href={uploadUrl} target="_blank" rel="noopener noreferrer">
-                {uploadUrl}
-              </a>
-            </div>
-          </div>
-        ) : null}
         <form className="menuButtonsPublishContent" onSubmit={attemptToPublish}>
           <div className="menuButtonsPublishIcon" />
-          <h1 className="menuButtonsPublishTitle">Share Performance Profile</h1>
+          <h1 className="menuButtonsPublishTitle">
+            {isRepublish
+              ? 'Re-publish Performance Profile'
+              : 'Share Performance Profile'}
+          </h1>
           <p className="menuButtonsPublishInfoDescription">
             Upload your profile and make it accessible to anyone with the link.
             {shouldSanitizeByDefault
@@ -221,37 +213,6 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
     );
   }
 
-  _renderUploadedPanel() {
-    const { uploadUrl } = this.props;
-    return (
-      <div
-        className="menuButtonsPublishUpload"
-        data-testid="MenuButtonsPublish-container"
-      >
-        <div className="menuButtonsPublishUploadTop">
-          <div className="menuButtonsPublishUploadTitle">Profile published</div>
-          <div className="menuButtonsPublishMessage">
-            Your profile was published, it is now safe to close this window.
-          </div>
-          <div className="menuButtonsPublishUrl">
-            <a href={uploadUrl} target="_blank" rel="noopener noreferrer">
-              {uploadUrl}
-            </a>
-          </div>
-        </div>
-        <div className="menuButtonsPublishButtons">
-          <button
-            type="button"
-            className="photon-button photon-button-primary menuButtonsPublishButton"
-            onClick={this._closePanelAfterUpload}
-          >
-            Ok
-          </button>
-        </div>
-      </div>
-    );
-  }
-
   _renderErrorPanel() {
     const { error, resetUploadState } = this.props;
     let message: string =
@@ -294,12 +255,11 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
       case 'error':
         return this._renderErrorPanel();
       case 'local':
+      case 'uploaded':
         return this._renderPublishPanel();
       case 'uploading':
       case 'compressing':
         return this._renderUploadPanel();
-      case 'uploaded':
-        return this._renderUploadedPanel();
       default:
         throw assertExhaustiveCheck(uploadPhase);
     }
@@ -320,7 +280,6 @@ export const MenuButtonsPublish = explicitConnect<
     compressedProfileBlobPromise: getCompressedProfileBlob(state),
     uploadPhase: getUploadPhase(state),
     uploadProgress: getUploadProgressString(state),
-    uploadUrl: getUploadUrl(state),
     error: getUploadError(state),
     shouldSanitizeByDefault: getShouldSanitizeByDefault(state),
   }),

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -11,7 +11,7 @@
 .menuButtonsLink {
   position: relative;
   height: 24px;
-  padding: 0 10px;
+  padding: 0 20px;
   border-left: 1px solid var(--grey-30);
   color: var(--grey-90);
   cursor: default;

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -3,19 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .menuButtons {
-  --internal-share-button-background-color: var(
-    --share-button-background-color,
-    hsl(137, 81%, 44%)
-  );
-  --internal-uploading-button-background-color: var(
-    --uploading-button-background-color,
-    #38445f
-  );
-  --internal-uploading-progress-fill-color: var(
-    --uploading-progress-fill-color,
-    #7990c8
-  );
-
   display: flex;
   height: 100%;
   flex-flow: row nowrap;

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -7,10 +7,8 @@
 import * as React from 'react';
 import explicitConnect from '../../../utils/connect';
 import { getProfile, getProfileRootRange } from '../../../selectors/profile';
-import {
-  getDataSource,
-  getIsNewlyPublished,
-} from '../../../selectors/url-state';
+import { getDataSource } from '../../../selectors/url-state';
+import { getIsNewlyPublished } from '../../../selectors/app';
 import { MenuButtonsMetaInfo } from './MetaInfo';
 import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -5,6 +5,7 @@
 // @flow
 
 import * as React from 'react';
+import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
 import { getProfile, getProfileRootRange } from '../../../selectors/profile';
 import { getDataSource } from '../../../selectors/url-state';
@@ -12,15 +13,17 @@ import { getIsNewlyPublished } from '../../../selectors/app';
 import { MenuButtonsMetaInfo } from './MetaInfo';
 import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';
-import { assertExhaustiveCheck } from '../../../utils/flow';
 import ArrowPanel from '../../shared/ArrowPanel';
 import ButtonWithPanel from '../../shared/ButtonWithPanel';
+import { revertToOriginalProfile, abortUpload } from '../../../actions/publish';
 import { dismissNewlyPublished } from '../../../actions/app';
+import { getUploadPhase, getOriginalProfile } from '../../../selectors/publish';
 
 import type { StartEndRange } from '../../../types/units';
 import type { Profile } from '../../../types/profile';
 import type { DataSource } from '../../../types/actions';
 import type { ConnectedProps } from '../../../utils/connect';
+import type { UploadPhase } from '../../../types/state';
 
 require('./index.css');
 
@@ -37,10 +40,14 @@ type StateProps = {|
   +rootRange: StartEndRange,
   +dataSource: DataSource,
   +isNewlyPublished: boolean,
+  +uploadPhase: UploadPhase,
+  +originalProfile: null | Profile,
 |};
 
 type DispatchProps = {|
   +dismissNewlyPublished: typeof dismissNewlyPublished,
+  +revertToOriginalProfile: typeof revertToOriginalProfile,
+  +abortUpload: typeof abortUpload,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -51,23 +58,97 @@ class MenuButtons extends React.PureComponent<Props> {
     this.props.dismissNewlyPublished();
   }
 
+  _renderPublishPanel() {
+    const { uploadPhase, dataSource, abortUpload } = this.props;
+
+    const isUploading =
+      uploadPhase === 'uploading' || uploadPhase === 'compressing';
+
+    if (isUploading) {
+      return (
+        <button
+          type="button"
+          className="buttonWithPanelButton menuButtonsAbortUploadButton"
+          onClick={abortUpload}
+        >
+          Cancel Upload
+        </button>
+      );
+    }
+
+    const isRepublish =
+      dataSource === 'public' ||
+      dataSource === 'from-url' ||
+      dataSource === 'compare';
+    const isError = uploadPhase === 'error';
+
+    let label = 'Publish…';
+    if (isRepublish) {
+      label = 'Re-publish…';
+    }
+    if (isError) {
+      label = 'Error publishing…';
+    }
+
+    return (
+      <ButtonWithPanel
+        className={classNames({
+          menuButtonsShareButton: true,
+          menuButtonsShareButtonOriginal: !isRepublish && !isError,
+          menuButtonsShareButtonError: isError,
+        })}
+        label={label}
+        panel={
+          <ArrowPanel className="menuButtonsPublishPanel">
+            <MenuButtonsPublish isRepublish={isRepublish} />
+          </ArrowPanel>
+        }
+      />
+    );
+  }
+
+  _renderPermalink() {
+    const { dataSource, isNewlyPublished, injectedUrlShortener } = this.props;
+
+    const showPermalink =
+      dataSource === 'public' ||
+      dataSource === 'from-url' ||
+      dataSource === 'compare';
+
+    return showPermalink ? (
+      <MenuButtonsPermalink
+        isNewlyPublished={isNewlyPublished}
+        injectedUrlShortener={injectedUrlShortener}
+      />
+    ) : null;
+  }
+
+  _renderRevertProfile() {
+    const { originalProfile, revertToOriginalProfile } = this.props;
+    if (!originalProfile) {
+      return null;
+    }
+    return (
+      <button
+        type="button"
+        className="buttonWithPanelButton menuButtonsRevertButton"
+        onClick={revertToOriginalProfile}
+      >
+        Revert to Original Profile
+      </button>
+    );
+  }
+
   render() {
-    const {
-      profile,
-      dataSource,
-      isNewlyPublished,
-      injectedUrlShortener,
-    } = this.props;
+    const { profile } = this.props;
     return (
       <>
         {/* Place the info button outside of the menu buttons to allow it to shrink. */}
         <MenuButtonsMetaInfo profile={profile} />
         <div className="menuButtons">
-          <PublishOrPermalinkButtons
-            dataSource={dataSource}
-            isNewlyPublished={isNewlyPublished}
-            injectedUrlShortener={injectedUrlShortener}
-          />
+          {this._renderRevertProfile()}
+          {this._renderPublishPanel()}
+          {this._renderPermalink()}
           <a
             href="/docs/"
             target="_blank"
@@ -83,51 +164,19 @@ class MenuButtons extends React.PureComponent<Props> {
   }
 }
 
-const PublishOrPermalinkButtons = ({
-  dataSource,
-  isNewlyPublished,
-  injectedUrlShortener,
-}) => {
-  switch (dataSource) {
-    case 'from-addon':
-    case 'from-file':
-    case 'local':
-      return (
-        <ButtonWithPanel
-          className="menuButtonsShareButton"
-          label="Publish…"
-          panel={
-            <ArrowPanel className="menuButtonsPublishPanel">
-              <MenuButtonsPublish />
-            </ArrowPanel>
-          }
-        />
-      );
-    case 'public':
-    case 'from-url':
-    case 'compare':
-      return (
-        <MenuButtonsPermalink
-          isNewlyPublished={isNewlyPublished}
-          injectedUrlShortener={injectedUrlShortener}
-        />
-      );
-    case 'none':
-      return null;
-    default:
-      throw assertExhaustiveCheck(dataSource);
-  }
-};
-
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     profile: getProfile(state),
     rootRange: getProfileRootRange(state),
     dataSource: getDataSource(state),
     isNewlyPublished: getIsNewlyPublished(state),
+    uploadPhase: getUploadPhase(state),
+    originalProfile: getOriginalProfile(state),
   }),
   mapDispatchToProps: {
     dismissNewlyPublished,
+    revertToOriginalProfile,
+    abortUpload,
   },
   component: MenuButtons,
 });

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -7,10 +7,53 @@
   }
 }
 
+@keyframes profileViewerFadeInSanitized {
+  0% {
+    opacity: 0;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes profileViewerFadeOut {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+.profileViewerWrapper {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+}
+
+.profileViewerWrapperBackground {
+  background-color: var(--grey-40);
+}
+
 .profileViewer {
   animation-duration: 200ms;
   animation-name: profileViewerFadeIn;
   background-color: #fff;
+}
+
+.profileViewerFadeOut {
+  /* Keep this duration in sync with the value in hideStaleProfile() */
+  animation-duration: 300ms;
+  animation-name: profileViewerFadeOut;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.profileViewerFadeInSanitized {
+  animation-duration: 500ms;
+  animation-name: profileViewerFadeInSanitized;
 }
 
 .profileViewerName {

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -18,6 +18,13 @@ import { getHasZipFile } from '../../selectors/zipped-profiles';
 import SplitterLayout from 'react-splitter-layout';
 import { invalidatePanelLayout } from '../../actions/app';
 import { getTimelineHeight } from '../../selectors/app';
+import {
+  getUploadProgressString,
+  getUploadPhase,
+  getIsHidingStaleProfile,
+  getHasSanitizedProfile,
+} from '../../selectors/publish';
+import classNames from 'classnames';
 
 import type { CssPixels } from '../../types/units';
 import type { ConnectedProps } from '../../utils/connect';
@@ -28,6 +35,10 @@ type StateProps = {|
   +profileName: string | null,
   +hasZipFile: boolean,
   +timelineHeight: CssPixels | null,
+  +uploadProgress: string,
+  +isUploading: boolean,
+  +isHidingStaleProfile: boolean,
+  +hasSanitizedProfile: boolean,
 |};
 
 type DispatchProps = {|
@@ -45,55 +56,77 @@ class ProfileViewer extends PureComponent<Props> {
       returnToZipFileList,
       invalidatePanelLayout,
       timelineHeight,
+      isUploading,
+      uploadProgress,
+      isHidingStaleProfile,
+      hasSanitizedProfile,
     } = this.props;
 
     return (
       <div
-        className="profileViewer"
-        style={
-          timelineHeight === null
-            ? {}
-            : {
-                '--profile-viewer-splitter-max-height': `${timelineHeight}px`,
-              }
-        }
+        className={classNames({
+          profileViewerWrapper: true,
+          profileViewerWrapperBackground: hasSanitizedProfile,
+        })}
       >
-        <div className="profileViewerTopBar">
-          {hasZipFile ? (
-            <button
-              type="button"
-              className="profileViewerZipButton"
-              title="View all files in the zip file"
-              onClick={returnToZipFileList}
-            />
-          ) : null}
-          {profileName ? (
-            <div className="profileViewerName">{profileName}</div>
-          ) : null}
-          <ProfileFilterNavigator />
-          {
-            // Define a spacer in the middle that will shrink based on the availability
-            // of space in the top bar. It will shrink away before any of the items
-            // with actual content in them do.
+        <div
+          className={classNames({
+            profileViewer: true,
+            profileViewerFadeInSanitized:
+              hasSanitizedProfile && !isHidingStaleProfile,
+            profileViewerFadeOut: isHidingStaleProfile,
+          })}
+          style={
+            timelineHeight === null
+              ? {}
+              : {
+                  '--profile-viewer-splitter-max-height': `${timelineHeight}px`,
+                }
           }
-          <div className="profileViewerSpacer" />
-          <MenuButtons />
-        </div>
-        <SplitterLayout
-          customClassName="profileViewerSplitter"
-          vertical
-          percentage={false}
-          // The DetailsContainer is primary.
-          primaryIndex={1}
-          // The Timeline is secondary.
-          secondaryInitialSize={270}
-          onDragEnd={invalidatePanelLayout}
         >
-          <Timeline />
-          <DetailsContainer />
-        </SplitterLayout>
-        <WindowTitle />
-        <SymbolicationStatusOverlay />
+          <div className="profileViewerTopBar">
+            {hasZipFile ? (
+              <button
+                type="button"
+                className="profileViewerZipButton"
+                title="View all files in the zip file"
+                onClick={returnToZipFileList}
+              />
+            ) : null}
+            {profileName ? (
+              <div className="profileViewerName">{profileName}</div>
+            ) : null}
+            <ProfileFilterNavigator />
+            {
+              // Define a spacer in the middle that will shrink based on the availability
+              // of space in the top bar. It will shrink away before any of the items
+              // with actual content in them do.
+            }
+            <div className="profileViewerSpacer" />
+            <MenuButtons />
+            {isUploading ? (
+              <div
+                className="menuButtonsPublishUploadBarInner"
+                style={{ width: uploadProgress }}
+              />
+            ) : null}
+          </div>
+          <SplitterLayout
+            customClassName="profileViewerSplitter"
+            vertical
+            percentage={false}
+            // The DetailsContainer is primary.
+            primaryIndex={1}
+            // The Timeline is secondary.
+            secondaryInitialSize={270}
+            onDragEnd={invalidatePanelLayout}
+          >
+            <Timeline />
+            <DetailsContainer />
+          </SplitterLayout>
+          <WindowTitle />
+          <SymbolicationStatusOverlay />
+        </div>
       </div>
     );
   }
@@ -104,6 +137,10 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     profileName: getProfileName(state),
     hasZipFile: getHasZipFile(state),
     timelineHeight: getTimelineHeight(state),
+    uploadProgress: getUploadProgressString(state),
+    isUploading: getUploadPhase(state) === 'uploading',
+    isHidingStaleProfile: getIsHidingStaleProfile(state),
+    hasSanitizedProfile: getHasSanitizedProfile(state),
   }),
   mapDispatchToProps: {
     returnToZipFileList,

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -128,6 +128,8 @@ class ProfileViewWhenReadyImpl extends PureComponent<ProfileViewProps> {
         // with multiple profiles. Only show the ZipFileViewer if the data loaded is a
         // Zip file, and there is no stored path into the zip file.
         return hasZipFile ? <ZipFileViewer /> : <ProfileViewer />;
+      case 'TRANSITIONING_FROM_STALE_PROFILE':
+        return null;
       case 'ROUTE_NOT_FOUND':
       default:
         // Assert with Flow that we've handled all the cases, as the only thing left

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -47,7 +47,7 @@ class UrlManager extends React.PureComponent<Props> {
       newUrlState = (window.history.state: UrlState);
     } else {
       // There is no state serialized and stored by the browser, attempt to create
-      // A UrlState object by parsin gthe window.location.
+      // a UrlState object by parsing the window.location.
       try {
         newUrlState = stateFromLocation(window.location);
       } catch (e) {
@@ -68,9 +68,8 @@ class UrlManager extends React.PureComponent<Props> {
       previousUrlState.hash !== newUrlState.hash
     ) {
       // Profile sanitization and publishing can do weird things for the history API.
-      // Rather than write lots of complicated interactions, just bail out of allowing
-      // the back button to work when going between a published profile, and one
-      // that is not.
+      // Rather than write lots of complicated interactions, just prevent the back button
+      // from working when going between a published profile, and one that is not.
       window.history.replaceState(
         previousUrlState,
         document.title,

--- a/src/components/shared/ButtonWithPanel.css
+++ b/src/components/shared/ButtonWithPanel.css
@@ -29,11 +29,15 @@
 
 .buttonWithPanelButton {
   height: 100%;
-  padding: 0 10px;
+  padding: 0 20px;
   margin: 0;
   border: 0;
   background: none;
+
+  /* Inherit the color rather than using the browser's */
+  color: inherit;
   font-size: 100%;
+  white-space: nowrap;
 }
 
 .buttonWithPanelButton:hover {

--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -33,6 +33,8 @@ type Props = {
   // This prop tells the panel to be open by default, but the open/close state is fully
   // managed by the ButtonWithPanel component.
   defaultOpen?: boolean,
+  // The class name of the button input element.
+  buttonClassName?: string,
 };
 
 type State = {|
@@ -105,17 +107,14 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { className, label, panel } = this.props;
+    const { className, label, panel, buttonClassName } = this.props;
     const { open } = this.state;
     return (
       <div className={classNames('buttonWithPanel', className, { open })}>
         <div className="buttonWithPanelButtonWrapper">
           <input
             type="button"
-            className={classNames(
-              'buttonWithPanelButton',
-              `${className}Button`
-            )}
+            className={classNames('buttonWithPanelButton', buttonClassName)}
             value={label}
             onClick={this._onButtonClick}
           />

--- a/src/profile-logic/profile-store.js
+++ b/src/profile-logic/profile-store.js
@@ -38,6 +38,7 @@ export function uploadBinaryProfileData(): * {
         };
 
         xhr.onerror = () => {
+          console.error('XHR error', xhr);
           reject(
             new Error(
               // The profile store does not give useful responses.

--- a/src/profile-logic/profile-store.js
+++ b/src/profile-logic/profile-store.js
@@ -38,7 +38,10 @@ export function uploadBinaryProfileData(): * {
         };
 
         xhr.onerror = () => {
-          console.error('XHR error', xhr);
+          console.error(
+            'There was an XHR error in uploadBinaryProfileData()',
+            xhr
+          );
           reject(
             new Error(
               // The profile store does not give useful responses.

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -19,11 +19,6 @@ const view: Reducer<AppViewState> = (
   state = { phase: 'INITIALIZING' },
   action
 ) => {
-  if (state.phase === 'DATA_LOADED') {
-    // Let's not come back at another phase if we're already displaying a profile
-    return state;
-  }
-
   switch (action.type) {
     case 'TEMPORARY_ERROR':
       return {
@@ -40,6 +35,9 @@ const view: Reducer<AppViewState> = (
       return { phase: 'INITIALIZING' };
     case 'ROUTE_NOT_FOUND':
       return { phase: 'ROUTE_NOT_FOUND' };
+    case 'REVERT_TO_ORIGINAL_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
+      return { phase: 'TRANSITIONING_FROM_STALE_PROFILE' };
     case 'RECEIVE_ZIP_FILE':
     case 'VIEW_PROFILE':
       return { phase: 'DATA_LOADED' };

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -161,6 +161,22 @@ const trackThreadHeights: Reducer<Array<ThreadIndex | void>> = (
   }
 };
 
+/**
+ * This reducer holds the state for whether or not a profile was newly uploaded
+ * or not. This way we can show the permalink to the user.
+ */
+const isNewlyPublished: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'PROFILE_PUBLISHED':
+    case 'SANITIZE_PROFILE_PUBLISHED':
+      return true;
+    case 'DISMISS_NEWLY_PUBLISHED':
+      return false;
+    default:
+      return state;
+  }
+};
+
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,
   isUrlSetupDone,
@@ -169,6 +185,7 @@ const appStateReducer: Reducer<AppState> = combineReducers({
   panelLayoutGeneration,
   lastVisibleThreadTabSlug,
   trackThreadHeights,
+  isNewlyPublished,
 });
 
 export default appStateReducer;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -36,7 +36,7 @@ const view: Reducer<AppViewState> = (
     case 'ROUTE_NOT_FOUND':
       return { phase: 'ROUTE_NOT_FOUND' };
     case 'REVERT_TO_ORIGINAL_PROFILE':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return { phase: 'TRANSITIONING_FROM_STALE_PROFILE' };
     case 'RECEIVE_ZIP_FILE':
     case 'VIEW_PROFILE':
@@ -166,7 +166,7 @@ const trackThreadHeights: Reducer<Array<ThreadIndex | void>> = (
 const isNewlyPublished: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return true;
     case 'DISMISS_NEWLY_PUBLISHED':
       return false;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -518,7 +518,7 @@ const wrapReducerInResetter = (
 ): Reducer<ProfileViewState> => {
   return (state, action) => {
     switch (action.type) {
-      case 'SANITIZE_PROFILE_PUBLISHED':
+      case 'SANITIZED_PROFILE_PUBLISHED':
       case 'REVERT_TO_ORIGINAL_PROFILE':
       case 'RETURN_TO_ZIP_FILE_LIST':
         // Provide a mechanism to wipe the state clean when changing out profiles.

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -518,9 +518,11 @@ const wrapReducerInResetter = (
 ): Reducer<ProfileViewState> => {
   return (state, action) => {
     switch (action.type) {
+      case 'SANITIZE_PROFILE_PUBLISHED':
+      case 'REVERT_TO_ORIGINAL_PROFILE':
       case 'RETURN_TO_ZIP_FILE_LIST':
-        // Provide a mechanism to wipe this state clean when returning to the zip file
-        // list, as it invalidates all of the profile view state.
+        // Provide a mechanism to wipe the state clean when changing out profiles.
+        // All of the profile view information is invalidated.
         return regularReducer(undefined, action);
       default:
         // Run the normal reducer.

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -71,7 +71,7 @@ const phase: Reducer<UploadPhase> = (state = 'local', action) => {
     case 'UPLOAD_STARTED':
       return 'uploading';
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return 'uploaded';
     case 'UPLOAD_FAILED':
       return 'error';
@@ -93,7 +93,7 @@ const uploadProgress: Reducer<number> = (state = 0, action) => {
     case 'UPLOAD_ABORTED':
     case 'UPLOAD_RESET':
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
     case 'UPLOAD_COMPRESSION_STARTED':
     case 'UPLOAD_FAILED':
       return 0;
@@ -119,7 +119,7 @@ const abortFunction: Reducer<() => void> = (state = noop, action) => {
   switch (action.type) {
     case 'UPLOAD_ABORTED':
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
     case 'UPLOAD_FAILED':
       return noop;
     case 'UPLOAD_STARTED':
@@ -135,7 +135,7 @@ const abortFunction: Reducer<() => void> = (state = noop, action) => {
 const generation: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
     case 'UPLOAD_ABORTED':
     case 'UPLOAD_FAILED':
       // Increment the generation value when exiting out of the profile uploading.
@@ -159,7 +159,7 @@ const upload: Reducer<UploadState> = combineReducers({
  */
 const originalProfile: Reducer<null | Profile> = (state = null, action) => {
   switch (action.type) {
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return action.originalProfile;
     case 'REVERT_TO_ORIGINAL_PROFILE':
       return null;
@@ -174,7 +174,7 @@ const originalProfile: Reducer<null | Profile> = (state = null, action) => {
  */
 const originalUrlState: Reducer<null | UrlState> = (state = null, action) => {
   switch (action.type) {
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return action.originalUrlState;
     case 'REVERT_TO_ORIGINAL_PROFILE':
       return null;
@@ -185,6 +185,10 @@ const originalUrlState: Reducer<null | UrlState> = (state = null, action) => {
 
 /**
  * This piece of state controls the animation of hiding the profile when it's stale.
+ * Stale profiles are ones that have been mutated in some way. This happens when
+ * the user goes from an original profile to a sanitized profile, or when they revert
+ * to the original. We want to display a helpful animation when this happens, and so
+ * this piece of state controls it.
  */
 const isHidingStaleProfile: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -37,7 +37,7 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
     case 'WAITING_FOR_PROFILE_FROM_FILE':
       return 'from-file';
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       return 'public';
     case 'TRIGGER_LOADING_FROM_URL':
       return 'from-url';
@@ -49,7 +49,7 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
 const hash: Reducer<string> = (state = '', action) => {
   switch (action.type) {
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       return action.hash;
     default:
       return state;
@@ -92,7 +92,7 @@ const committedRanges: Reducer<StartEndRange[]> = (state = [], action) => {
     }
     case 'POP_COMMITTED_RANGES':
       return state.slice(0, action.firstPoppedFilterIndex);
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       // This value may be updated due to profile sanitization.
       return action.committedRanges ? action.committedRanges : state;
     default:
@@ -112,7 +112,7 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
     case 'ISOLATE_LOCAL_TRACK':
       // Only switch to non-null selected threads.
       return (action.selectedThreadIndex: ThreadIndex);
-    case 'SANITIZE_PROFILE': {
+    case 'SANITIZE_PROFILE_PUBLISHED': {
       const { oldThreadIndexToNew } = action;
       if (state === null || !oldThreadIndexToNew) {
         // Either there was no selected thread, or the thread indexes were not modified.
@@ -178,7 +178,7 @@ const transforms: Reducer<TransformStacksPerThread> = (state = {}, action) => {
         [threadIndex]: transforms.slice(0, firstPoppedFilterIndex),
       });
     }
-    case 'SANITIZE_PROFILE': {
+    case 'SANITIZE_PROFILE_PUBLISHED': {
       const { oldThreadIndexToNew } = action;
       if (!oldThreadIndexToNew) {
         // The thread indexes weren't modified, just return the old value here.
@@ -253,7 +253,7 @@ const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
     case 'VIEW_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
       return action.globalTrackOrder;
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       // If some threads were removed, do not even attempt to figure this out. It's
       // complicated, and not many people use this feature.
       return action.oldThreadIndexToNew ? [] : state;
@@ -282,7 +282,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
       hiddenGlobalTracks.delete(action.trackIndex);
       return hiddenGlobalTracks;
     }
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       // If any threads were removed, this was because they were hidden.
       // Reset this state.
       return action.oldThreadIndexToNew ? new Set() : state;
@@ -318,7 +318,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
       hiddenLocalTracksByPid.set(action.pid, action.hiddenLocalTracks);
       return hiddenLocalTracksByPid;
     }
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       // If any threads were removed then this information is no longer valid.
       return action.oldThreadIndexToNew ? new Map() : state;
     default:
@@ -338,7 +338,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
       localTrackOrderByPid.set(action.pid, action.localTrackOrder);
       return localTrackOrderByPid;
     }
-    case 'SANITIZE_PROFILE':
+    case 'SANITIZE_PROFILE_PUBLISHED':
       // If any threads were removed then remove this information. It's complicated
       // to compute, and not many people use it.
       return action.oldThreadIndexToNew ? new Map() : state;
@@ -405,6 +405,8 @@ const wrapReducerInResetter = (
 ): Reducer<UrlState> => {
   return (state, action) => {
     switch (action.type) {
+      case 'REVERT_TO_ORIGINAL_PROFILE':
+        return action.originalUrlState;
       case 'UPDATE_URL_STATE':
         // A new URL came in because of a browser action, discard the current UrlState
         // and use the new one, which was probably serialized from the URL, or stored

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -370,21 +370,6 @@ const profileName: Reducer<string> = (state = '', action) => {
 };
 
 /**
- * This reducer holds the state for whether or not a profile was newly uploaded
- * or not. This way we can show a friendly message to the user.
- */
-const isNewlyPublished: Reducer<boolean> = (state = false, action) => {
-  switch (action.type) {
-    case 'PROFILE_PUBLISHED':
-      return true;
-    case 'DISMISS_NEWLY_PUBLISHED':
-      return false;
-    default:
-      return state;
-  }
-};
-
-/**
  * These values are specific to an individual profile.
  */
 const profileSpecific = combineReducers({
@@ -449,7 +434,6 @@ const urlStateReducer: Reducer<UrlState> = wrapReducerInResetter(
     pathInZipFile,
     profileSpecific,
     profileName,
-    isNewlyPublished,
   })
 );
 

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -37,7 +37,7 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
     case 'WAITING_FOR_PROFILE_FROM_FILE':
       return 'from-file';
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return 'public';
     case 'TRIGGER_LOADING_FROM_URL':
       return 'from-url';
@@ -49,7 +49,7 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
 const hash: Reducer<string> = (state = '', action) => {
   switch (action.type) {
     case 'PROFILE_PUBLISHED':
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       return action.hash;
     default:
       return state;
@@ -92,7 +92,7 @@ const committedRanges: Reducer<StartEndRange[]> = (state = [], action) => {
     }
     case 'POP_COMMITTED_RANGES':
       return state.slice(0, action.firstPoppedFilterIndex);
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       // This value may be updated due to profile sanitization.
       return action.committedRanges ? action.committedRanges : state;
     default:
@@ -112,7 +112,7 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
     case 'ISOLATE_LOCAL_TRACK':
       // Only switch to non-null selected threads.
       return (action.selectedThreadIndex: ThreadIndex);
-    case 'SANITIZE_PROFILE_PUBLISHED': {
+    case 'SANITIZED_PROFILE_PUBLISHED': {
       const { oldThreadIndexToNew } = action;
       if (state === null || !oldThreadIndexToNew) {
         // Either there was no selected thread, or the thread indexes were not modified.
@@ -178,7 +178,7 @@ const transforms: Reducer<TransformStacksPerThread> = (state = {}, action) => {
         [threadIndex]: transforms.slice(0, firstPoppedFilterIndex),
       });
     }
-    case 'SANITIZE_PROFILE_PUBLISHED': {
+    case 'SANITIZED_PROFILE_PUBLISHED': {
       const { oldThreadIndexToNew } = action;
       if (!oldThreadIndexToNew) {
         // The thread indexes weren't modified, just return the old value here.
@@ -253,7 +253,7 @@ const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
     case 'VIEW_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
       return action.globalTrackOrder;
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       // If some threads were removed, do not even attempt to figure this out. It's
       // complicated, and not many people use this feature.
       return action.oldThreadIndexToNew ? [] : state;
@@ -282,7 +282,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
       hiddenGlobalTracks.delete(action.trackIndex);
       return hiddenGlobalTracks;
     }
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       // If any threads were removed, this was because they were hidden.
       // Reset this state.
       return action.oldThreadIndexToNew ? new Set() : state;
@@ -318,7 +318,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
       hiddenLocalTracksByPid.set(action.pid, action.hiddenLocalTracks);
       return hiddenLocalTracksByPid;
     }
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       // If any threads were removed then this information is no longer valid.
       return action.oldThreadIndexToNew ? new Map() : state;
     default:
@@ -338,7 +338,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
       localTrackOrderByPid.set(action.pid, action.localTrackOrder);
       return localTrackOrderByPid;
     }
-    case 'SANITIZE_PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
       // If any threads were removed then remove this information. It's complicated
       // to compute, and not many people use it.
       return action.oldThreadIndexToNew ? new Map() : state;

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -48,6 +48,8 @@ export const getLastVisibleThreadTabSlug: Selector<TabSlug> = state =>
 export const getTrackThreadHeights: Selector<
   Array<ThreadIndex | void>
 > = state => getApp(state).trackThreadHeights;
+export const getIsNewlyPublished: Selector<boolean> = state =>
+  getApp(state).isNewlyPublished;
 
 /**
  * Visible tabs are computed based on the current state of the profile. Some

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -23,9 +23,15 @@ import { getHiddenGlobalTracks, getHiddenLocalTracksByPid } from './url-state';
 import { ensureExists } from '../utils/flow';
 import { formatNumber } from '../utils/format-numbers';
 
-import type { PublishState, UploadState, UploadPhase } from '../types/state';
+import type {
+  PublishState,
+  UploadState,
+  UploadPhase,
+  UrlState,
+} from '../types/state';
 import type { Selector } from '../types/store';
 import type { CheckedSharingOptions } from '../types/actions';
+import type { Profile } from '../types/profile';
 import type { RemoveProfileInformation } from '../types/profile-derived';
 
 export const getPublishState: Selector<PublishState> = state => state.publish;
@@ -191,15 +197,20 @@ export const getUploadGeneration: Selector<number> = state =>
 export const getUploadProgress: Selector<number> = state =>
   getUploadState(state).uploadProgress;
 
-export const getUploadUrl: Selector<string> = state =>
-  getUploadState(state).url;
-
 export const getUploadError: Selector<Error | mixed> = state =>
   getUploadState(state).error;
 
 export const getUploadProgressString: Selector<string> = createSelector(
   getUploadProgress,
-  progress => formatNumber(progress, 0, 0, 'percent')
+  progress =>
+    formatNumber(
+      // Create a minimum value of 0.1 so that there is at least some user feedback
+      // that the upload started.
+      Math.max(progress, 0.1),
+      0,
+      0,
+      'percent'
+    )
 );
 
 export const getAbortFunction: Selector<() => void> = state =>
@@ -209,3 +220,15 @@ export const getShouldSanitizeByDefault: Selector<boolean> = createSelector(
   getProfile,
   getShouldSanitizeByDefaultImpl
 );
+
+export const getOriginalProfile: Selector<null | Profile> = state =>
+  getPublishState(state).originalProfile;
+
+export const getOriginalUrlState: Selector<null | UrlState> = state =>
+  getPublishState(state).originalUrlState;
+
+export const getIsHidingStaleProfile: Selector<boolean> = state =>
+  getPublishState(state).isHidingStaleProfile;
+
+export const getHasSanitizedProfile: Selector<boolean> = state =>
+  getPublishState(state).hasSanitizedProfile;

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -41,8 +41,6 @@ export const getProfilesToCompare: Selector<string[] | null> = state =>
   getUrlState(state).profilesToCompare;
 export const getProfileNameFromUrl: Selector<string> = state =>
   getUrlState(state).profileName;
-export const getIsNewlyPublished: Selector<boolean> = state =>
-  getUrlState(state).isNewlyPublished;
 export const getAllCommittedRanges: Selector<StartEndRange[]> = state =>
   getProfileSpecificState(state).committedRanges;
 export const getImplementationFilter: Selector<ImplementationFilter> = state =>

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -15,6 +15,7 @@ describe('shared/ButtonWithPanel', () => {
     return render(
       <ButtonWithPanel
         className="button"
+        buttonClassName="buttonButton"
         label="My Button"
         panel={
           <ArrowPanel className="panel">

--- a/src/test/components/MenuButtonsPermalinks.test.js
+++ b/src/test/components/MenuButtonsPermalinks.test.js
@@ -10,7 +10,6 @@ import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import { ensureExists } from '../../utils/flow';
-import { getIsNewlyPublished } from '../../selectors/url-state';
 
 describe('<Permalink>', function() {
   function setup(search = '', injectedUrlShortener) {
@@ -73,21 +72,5 @@ describe('<Permalink>', function() {
       'Unable to find the permalink input text field'
     );
     expect(input.getAttribute('value')).toBe(shortUrl);
-  });
-
-  it('shows the permalink when visiting a published profile', async function() {
-    const { queryInput, shortUrl, shortUrlPromise } = setup('?published');
-    await shortUrlPromise;
-    const input = ensureExists(
-      queryInput(),
-      'Unable to find the permalink input text field'
-    );
-    expect(input.getAttribute('value')).toBe(shortUrl);
-  });
-
-  it('resets the isNewlyPublishedState in the URL when mounted', async function() {
-    const { originalState, getState } = setup('?published');
-    expect(getIsNewlyPublished(originalState)).toBe(true);
-    expect(getIsNewlyPublished(getState())).toBe(false);
   });
 });

--- a/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
+++ b/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
@@ -144,7 +144,7 @@ exports[`shared/ButtonWithPanel renders a button with a panel 1`] = `
     class="buttonWithPanelButtonWrapper"
   >
     <input
-      class="buttonWithPanelButton buttonButton"
+      class="buttonWithPanelButton"
       type="button"
       value="My Button"
     />

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -6,42 +6,20 @@ exports[`app/MenuButtons <Publish> matches the snapshot for an error 1`] = `
   data-testid="MenuButtonsPublish-container"
 >
   <div
-    class="menuButtonsPublishUploadTop"
+    class="photon-message-bar photon-message-bar-error"
   >
-    <div
-      class="menuButtonsPublishUploadTitle"
+    Uh oh, something went wrong when publishing the profile.
+    <button
+      class="photon-button photon-button-micro"
+      type="button"
     >
-      Publishing profile…
-    </div>
-    <div
-      class="menuButtonsPublishUploadPercentage"
-    >
-      0%
-    </div>
-    <div
-      class="menuButtonsPublishUploadBar"
-    >
-      <div
-        class="menuButtonsPublishUploadBarInner"
-        style="width: 0%;"
-      />
-    </div>
+      Try again
+    </button>
   </div>
   <div
-    class="menuButtonsPublishButtons"
+    class="menuButtonsPublishError"
   >
-    <button
-      class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload menuButtonsPublishButtonDisabled"
-      type="button"
-    >
-      Compressing…
-    </button>
-    <button
-      class="photon-button photon-button-default menuButtonsPublishButton menuButtonsPublishButtonsCancelUpload"
-      type="button"
-    >
-      Cancel Upload
-    </button>
+    This is a mock error
   </div>
 </div>
 `;
@@ -76,13 +54,13 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the closed state 1`]
     class="menuButtons"
   >
     <div
-      class="buttonWithPanel menuButtonsShareButton"
+      class="buttonWithPanel menuButtonsShareButton menuButtonsShareButtonOriginal"
     >
       <div
         class="buttonWithPanelButtonWrapper"
       >
         <input
-          class="buttonWithPanelButton menuButtonsShareButtonButton"
+          class="buttonWithPanelButton"
           type="button"
           value="Publish…"
         />
@@ -110,52 +88,6 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the closed state 1`]
         class="open-in-new"
       />
     </a>
-  </div>
-</div>
-`;
-
-exports[`app/MenuButtons <Publish> matches the snapshot for the completed upload panel 1`] = `
-<div
-  class="menuButtonsPublishUpload"
-  data-testid="MenuButtonsPublish-container"
->
-  <div
-    class="menuButtonsPublishUploadTop"
-  >
-    <div
-      class="menuButtonsPublishUploadTitle"
-    >
-      Publishing profile…
-    </div>
-    <div
-      class="menuButtonsPublishUploadPercentage"
-    >
-      0%
-    </div>
-    <div
-      class="menuButtonsPublishUploadBar"
-    >
-      <div
-        class="menuButtonsPublishUploadBarInner"
-        style="width: 0%;"
-      />
-    </div>
-  </div>
-  <div
-    class="menuButtonsPublishButtons"
-  >
-    <button
-      class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload menuButtonsPublishButtonDisabled"
-      type="button"
-    >
-      Compressing…
-    </button>
-    <button
-      class="photon-button photon-button-default menuButtonsPublishButton menuButtonsPublishButtonsCancelUpload"
-      type="button"
-    >
-      Cancel Upload
-    </button>
   </div>
 </div>
 `;
@@ -364,51 +296,5 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       </button>
     </div>
   </form>
-</div>
-`;
-
-exports[`app/MenuButtons <Publish> matches the snapshot for the uploading panel 1`] = `
-<div
-  class="menuButtonsPublishUpload"
-  data-testid="MenuButtonsPublish-container"
->
-  <div
-    class="menuButtonsPublishUploadTop"
-  >
-    <div
-      class="menuButtonsPublishUploadTitle"
-    >
-      Publishing profile…
-    </div>
-    <div
-      class="menuButtonsPublishUploadPercentage"
-    >
-      0%
-    </div>
-    <div
-      class="menuButtonsPublishUploadBar"
-    >
-      <div
-        class="menuButtonsPublishUploadBarInner"
-        style="width: 0%;"
-      />
-    </div>
-  </div>
-  <div
-    class="menuButtonsPublishButtons"
-  >
-    <button
-      class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload menuButtonsPublishButtonDisabled"
-      type="button"
-    >
-      Compressing…
-    </button>
-    <button
-      class="photon-button photon-button-default menuButtonsPublishButton menuButtonsPublishButtonsCancelUpload"
-      type="button"
-    >
-      Cancel Upload
-    </button>
-  </div>
 </div>
 `;

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -179,19 +179,6 @@ describe('attemptToPublish', function() {
     expect(getUploadError(getState())).toBe(error);
   });
 
-  it('calls window.open after publishing a profile', async function() {
-    const { dispatch, resolveUpload } = setup();
-    const publishAttempt = dispatch(attemptToPublish());
-    resolveUpload('FAKEHASH');
-
-    expect(await publishAttempt).toEqual(true);
-
-    expect(window.open).toHaveBeenCalledWith(
-      'http://localhost/public/FAKEHASH/calltree/?globalTrackOrder=0&localTrackOrderByPid=0-0~&thread=0&v=3',
-      '_blank'
-    );
-  });
-
   it('updates with upload progress', async function() {
     const {
       waitUntilPhase,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -319,7 +319,7 @@ type UrlStateAction =
   | {| +type: 'CHANGE_PROFILES_TO_COMPARE', +profiles: string[] |}
   | {| +type: 'CHANGE_PROFILE_NAME', +profileName: string |}
   | {|
-      +type: 'SANITIZE_PROFILE_PUBLISHED',
+      +type: 'SANITIZED_PROFILE_PUBLISHED',
       +hash: string,
       +committedRanges: StartEndRange[] | null,
       +oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex> | null,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -319,10 +319,12 @@ type UrlStateAction =
   | {| +type: 'CHANGE_PROFILES_TO_COMPARE', +profiles: string[] |}
   | {| +type: 'CHANGE_PROFILE_NAME', +profileName: string |}
   | {|
-      +type: 'SANITIZE_PROFILE',
+      +type: 'SANITIZE_PROFILE_PUBLISHED',
       +hash: string,
       +committedRanges: StartEndRange[] | null,
       +oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex> | null,
+      +originalProfile: Profile,
+      +originalUrlState: UrlState,
     |};
 
 type IconsAction =
@@ -349,10 +351,6 @@ type PublishAction =
       +uploadProgress: number,
     |}
   | {|
-      +type: 'UPLOAD_FINISHED',
-      +url: string,
-    |}
-  | {|
       +type: 'UPLOAD_FAILED',
       +error: mixed,
     |}
@@ -368,7 +366,12 @@ type PublishAction =
   | {|
       +type: 'CHANGE_UPLOAD_STATE',
       +changes: $Shape<UploadState>,
-    |};
+    |}
+  | {|
+      +type: 'REVERT_TO_ORIGINAL_PROFILE',
+      +originalUrlState: UrlState,
+    |}
+  | {| +type: 'HIDE_STALE_PROFILE' |};
 
 export type Action =
   | ProfileAction

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -116,6 +116,7 @@ export type AppState = {|
   +panelLayoutGeneration: number,
   +lastVisibleThreadTabSlug: TabSlug,
   +trackThreadHeights: Array<ThreadIndex | void>,
+  +isNewlyPublished: boolean,
 |};
 
 export type UploadPhase =
@@ -159,7 +160,6 @@ export type UrlState = {|
   +selectedTab: TabSlug,
   +pathInZipFile: string | null,
   +profileName: string,
-  +isNewlyPublished: boolean,
   +profileSpecific: {|
     selectedThread: ThreadIndex | null,
     globalTrackOrder: TrackIndex[],

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -61,6 +61,7 @@ export type ProfileViewState = {|
 
 export type AppViewState =
   | {| +phase: 'ROUTE_NOT_FOUND' |}
+  | {| +phase: 'TRANSITIONING_FROM_STALE_PROFILE' |}
   | {| +phase: 'DATA_LOADED' |}
   | {| +phase: 'FATAL_ERROR', +error: Error |}
   | {|
@@ -130,7 +131,6 @@ export type UploadState = {|
   phase: UploadPhase,
   uploadProgress: number,
   error: Error | mixed,
-  url: string,
   abortFunction: () => void,
   generation: number,
 |};
@@ -138,6 +138,10 @@ export type UploadState = {|
 export type PublishState = {|
   +checkedSharingOptions: CheckedSharingOptions,
   +upload: UploadState,
+  +originalProfile: null | Profile,
+  +originalUrlState: null | UrlState,
+  +isHidingStaleProfile: boolean,
+  +hasSanitizedProfile: boolean,
 |};
 
 export type ZippedProfilesState = {


### PR DESCRIPTION
This is a new publish workflow that keeps the profile on the page, and allows you to revert it if it's been sanitized.

### Example sanitized workflow

* Capture profile
* Upload and sanitize
* The profile gets swapped out on the page
* Share link
* Revert to original profile
* Sanitize it again.
* Share link
* Re-publish the profile with different settings

### Example non-sanitize workflow
* Capture profile
* Upload full profile
* Share link
* Re-publish profile

Note that you can also cancel an upload, and an upload can fail. I've handled both of these cases as well.