### PR TITLE
feat: Include more path information for zipped profile

### DIFF
--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -195,8 +195,10 @@ export const getProfileName: Selector<null | string> = createSelector(
       return profileName;
     }
     if (pathInZipFile) {
-      const pathParts = pathInZipFile.split('/');
-      return pathParts[pathParts.length - 1];
+      const matchResult = pathInZipFile.match(/(?:[^/]+\/)?[^/]+$/);
+      if (matchResult !== null) {
+        return matchResult[0];
+      }
     }
     return '';
   }

--- a/src/test/store/zipped-profiles.test.js
+++ b/src/test/store/zipped-profiles.test.js
@@ -53,6 +53,7 @@ describe('reducer zipFileState', function() {
         'foo/bar/profile1.json',
         'foo/profile2.json',
         'baz/profile3.json',
+        'profile4.json',
       ]);
 
       await dispatch(
@@ -67,7 +68,23 @@ describe('reducer zipFileState', function() {
     it('computes a profile name from the loaded file', async function() {
       const { getState } = await setup();
 
-      const expectedName = 'profile1.json';
+      const expectedName = 'bar/profile1.json';
+      expect(UrlStateSelectors.getProfileName(getState())).toBe(expectedName);
+    });
+
+    it('computes a profile when no folder present', async function() {
+      const { dispatch, getState } = await storeWithZipFile([
+        'foo/bar/profile1.json',
+        'foo/profile2.json',
+        'baz/profile3.json',
+        'profile4.json',
+      ]);
+
+      await dispatch(
+        ZippedProfilesActions.viewProfileFromPathInZipFile('profile4.json')
+      );
+
+      const expectedName = 'profile4.json';
       expect(UrlStateSelectors.getProfileName(getState())).toBe(expectedName);
     });
 


### PR DESCRIPTION
Show the last two members of the complete file path
when looking at the individual tests of a zip profile
in the treeherder.

fixes: #1448