### PR TITLE
Remove the library name from the func name in the test fixtures

### DIFF
--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -24,19 +24,17 @@ describe('calltree/CallNodeContextMenu', function() {
     // Create a profile that every transform can be applied to.
     const {
       profile,
-      funcNamesPerThread: [funcNames],
+      funcNamesDictPerThread: [{ A, B }],
     } = getProfileFromTextSamples(`
-      A          A          A
-      B:library  B:library  B:library
-      B:library  B:library  B:library
-      B:library  B:library  B:library
-      C          C          H
-      D          F          I
-      E          E
+      A               A               A
+      B[lib:library]  B[lib:library]  B[lib:library]
+      B[lib:library]  B[lib:library]  B[lib:library]
+      B[lib:library]  B[lib:library]  B[lib:library]
+      C               C               H
+      D               F               I
+      E               E
     `);
     const store = storeWithProfile(profile);
-    const A = funcNames.indexOf('A');
-    const B = funcNames.indexOf('B:library');
 
     store.dispatch(changeExpandedCallNodes(0, [[A]]));
     store.dispatch(changeRightClickedCallNode(0, [A, B]));
@@ -127,7 +125,7 @@ describe('calltree/CallNodeContextMenu', function() {
       jest.spyOn(window, 'open').mockImplementation(() => {});
       fireEvent.click(getByText(/Searchfox/));
       expect(window.open).toBeCalledWith(
-        'https://searchfox.org/mozilla-central/search?q=B%3Alibrary',
+        'https://searchfox.org/mozilla-central/search?q=B',
         '_blank'
       );
     });
@@ -136,7 +134,7 @@ describe('calltree/CallNodeContextMenu', function() {
       const { getByText } = setup();
       // Copy is a mocked module, clear it both before and after.
       fireEvent.click(getByText('Copy function name'));
-      expect(copy).toBeCalledWith('B:library');
+      expect(copy).toBeCalledWith('B');
     });
 
     it('can copy a script URL', function() {
@@ -166,7 +164,7 @@ describe('calltree/CallNodeContextMenu', function() {
       const { getByText } = setup();
       // Copy is a mocked module, clear it both before and after.
       fireEvent.click(getByText('Copy stack'));
-      expect(copy).toBeCalledWith(`B:library\nA\n`);
+      expect(copy).toBeCalledWith(`B\nA\n`);
     });
   });
 });

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -420,7 +420,7 @@ describe('actions/receive-profile', function() {
 
     it('symbolicates a profile if it is not symbolicated yet', async () => {
       const { profile: unsymbolicatedProfile } = getProfileFromTextSamples(
-        '0xA:libxul'
+        '0xA[lib:libxul]'
       );
       unsymbolicatedProfile.meta.symbolicated = false;
 

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -614,13 +614,14 @@ describe('"focus-function" transform', function() {
 describe('"collapse-resource" transform', function() {
   describe('combined implementation', function() {
     /**
-     *               A                                   A
-     *             /   \                                 |
-     *            v     v        Collapse firefox        v
-     *    B:firefox    E:firefox       ->             firefox
-     *        |            |                         /       \
-     *        v            v                        D        F
-     *    C:firefox        F
+     *                A
+     *          -----´ `-----                                  A
+     *         /             \                                 |
+     *        v               v        Collapse firefox        v
+     *  B[lib:firefox]  E[lib:firefox]       ->             firefox
+     *        |               |                            /       \
+     *        v               v                           D         F
+     *  C[lib:firefox]        F
      *        |
      *        v
      *        D
@@ -629,9 +630,9 @@ describe('"collapse-resource" transform', function() {
       profile,
       funcNamesPerThread: [funcNames],
     } = getProfileFromTextSamples(`
-      A          A
-      B:firefox  E:firefox
-      C:firefox  F
+      A               A
+      B[lib:firefox]  E[lib:firefox]
+      C[lib:firefox]  F
       D
     `);
     const collapsedFuncNames = [...funcNames, 'firefox'];
@@ -657,10 +658,10 @@ describe('"collapse-resource" transform', function() {
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
         '- A (total: 2, self: —)',
-        '  - B:firefox (total: 1, self: —)',
-        '    - C:firefox (total: 1, self: —)',
+        '  - B (total: 1, self: —)',
+        '    - C (total: 1, self: —)',
         '      - D (total: 1, self: 1)',
-        '  - E:firefox (total: 1, self: —)',
+        '  - E (total: 1, self: —)',
         '    - F (total: 1, self: 1)',
       ]);
     });
@@ -684,9 +685,7 @@ describe('"collapse-resource" transform', function() {
       dispatch(
         changeSelectedCallNode(
           threadIndex,
-          ['A', 'B:firefox', 'C:firefox', 'D'].map(name =>
-            collapsedFuncNames.indexOf(name)
-          )
+          ['A', 'B', 'C', 'D'].map(name => collapsedFuncNames.indexOf(name))
         )
       );
       dispatch(addTransformToStack(threadIndex, collapseTransform));
@@ -730,10 +729,10 @@ describe('"collapse-resource" transform', function() {
       profile,
       funcNamesPerThread: [funcNames],
     } = getProfileFromTextSamples(`
-      A.js           A.js
-      B.cpp:firefox  H.cpp:firefox
-      C.js           I.js
-      D.cpp:firefox
+      A.js                A.js
+      B.cpp[lib:firefox]  H.cpp[lib:firefox]
+      C.js                I.js
+      D.cpp[lib:firefox]
       E.js
       F.cpp
       G.js
@@ -761,13 +760,13 @@ describe('"collapse-resource" transform', function() {
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
         '- A.js (total: 2, self: —)',
-        '  - B.cpp:firefox (total: 1, self: —)',
+        '  - B.cpp (total: 1, self: —)',
         '    - C.js (total: 1, self: —)',
-        '      - D.cpp:firefox (total: 1, self: —)',
+        '      - D.cpp (total: 1, self: —)',
         '        - E.js (total: 1, self: —)',
         '          - F.cpp (total: 1, self: —)',
         '            - G.js (total: 1, self: 1)',
-        '  - H.cpp:firefox (total: 1, self: —)',
+        '  - H.cpp (total: 1, self: —)',
         '    - I.js (total: 1, self: 1)',
       ]);
     });
@@ -795,9 +794,7 @@ describe('"collapse-resource" transform', function() {
       dispatch(
         changeSelectedCallNode(
           threadIndex,
-          ['B.cpp:firefox', 'D.cpp:firefox'].map(name =>
-            collapsedFuncNames.indexOf(name)
-          )
+          ['B.cpp', 'D.cpp'].map(name => collapsedFuncNames.indexOf(name))
         )
       );
       dispatch(changeImplementationFilter('cpp'));

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -330,11 +330,13 @@ describe('unfiltered call tree', function() {
     describe('icons from the call tree', function() {
       it('upgrades http to https', function() {
         const { profile } = getProfileFromTextSamples(`
-          A:examplecom.js
+          A[lib:examplecom.js]
         `);
         const callTree = callTreeFromProfile(profile);
         const [thread] = profile.threads;
-        const hostStringIndex = thread.stringTable.indexForString('examplecom');
+        const hostStringIndex = thread.stringTable.indexForString(
+          'examplecom.js'
+        );
 
         thread.resourceTable.type[0] = resourceTypes.webhost;
         thread.resourceTable.host[0] = hostStringIndex;


### PR DESCRIPTION
The current way to specify the libraries comes from the first implementation. I rewrote this to use the "modifiers" mechanism I introduced some time ago. The goal is that the library name isn't part of the func name anymore.
I needed this to write good tests in #1883.