### PR TITLE
JS allocations

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -29,7 +29,7 @@ import {
 } from '../selectors/url-state';
 import {
   getCallNodePathFromIndex,
-  getSampleCallNodes,
+  getSampleIndexToCallNodeIndex,
   getSampleCategories,
   findBestAncestorCallNode,
 } from '../profile-logic/profile-data';
@@ -164,11 +164,11 @@ export function selectBestAncestorCallNodeAndExpandCallTree(
     }
 
     const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
-    const sampleCallNodes = getSampleCallNodes(
-      filteredThread.samples,
+    const sampleIndexToCallNodeIndex = getSampleIndexToCallNodeIndex(
+      filteredThread.samples.stack,
       stackIndexToCallNodeIndex
     );
-    const clickedCallNode = sampleCallNodes[sampleIndex];
+    const clickedCallNode = sampleIndexToCallNodeIndex[sampleIndex];
     const clickedCategory = fullThread.stackTable.category[unfilteredStack];
 
     if (clickedCallNode === null) {
@@ -181,7 +181,7 @@ export function selectBestAncestorCallNodeAndExpandCallTree(
     );
     const bestAncestorCallNode = findBestAncestorCallNode(
       callNodeInfo,
-      sampleCallNodes,
+      sampleIndexToCallNodeIndex,
       sampleCategories,
       clickedCallNode,
       clickedCategory

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { ensureExists } from '../../../utils/flow';
 import { timeCode } from '../../../utils/time-code';
 import {
-  getSampleCallNodes,
+  getSampleIndexToCallNodeIndex,
   getSamplesSelectedStates,
   getSampleIndexClosestToTime,
 } from '../../../profile-logic/profile-data';
@@ -87,8 +87,8 @@ class StackGraph extends PureComponent<Props> {
     const ctx = canvas.getContext('2d');
     let maxDepth = 0;
     const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
-    const sampleCallNodes = getSampleCallNodes(
-      thread.samples,
+    const sampleCallNodes = getSampleIndexToCallNodeIndex(
+      thread.samples.stack,
       stackIndexToCallNodeIndex
     );
     const samplesSelectedStates = getSamplesSelectedStates(

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -147,7 +147,7 @@ class StackChartGraph extends React.PureComponent<Props> {
         role="tabpanel"
         aria-labelledby="stack-chart-tab-button"
       >
-        <StackSettings />
+        <StackSettings disableCallTreeSummaryButtons={true} />
         <TransformNavigator />
         {maxStackDepth === 0 ? (
           <StackChartEmptyReasons />

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -11,7 +11,7 @@
 import { stripIndent } from 'common-tags';
 
 import {
-  adjustSampleTimestamps,
+  adjustTableTimestamps,
   adjustMarkerTimestamps,
 } from './process-profile';
 import {
@@ -152,10 +152,7 @@ export function mergeProfiles(
     // We adjust the various times so that the 2 profiles are aligned at the
     // start and the data is consistent.
     const startTimeAdjustment = -thread.samples.time[0];
-    thread.samples = adjustSampleTimestamps(
-      thread.samples,
-      startTimeAdjustment
-    );
+    thread.samples = adjustTableTimestamps(thread.samples, startTimeAdjustment);
     thread.markers = adjustMarkerTimestamps(
       thread.markers,
       startTimeAdjustment

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -16,6 +16,7 @@ import type {
   StackTable,
   FuncTable,
   RawMarkerTable,
+  JsAllocationsTable,
   ResourceTable,
   Profile,
   ExtensionTable,
@@ -149,6 +150,23 @@ export function getEmptyRawMarkerTable(): RawMarkerTable {
     data: [],
     name: [],
     time: [],
+    length: 0,
+  };
+}
+
+export function getEmptyJsAllocationsTable(): JsAllocationsTable {
+  // Important!
+  // If modifying this structure, please update all callers of this function to ensure
+  // that they are pushing on correctly to the data structure. These pushes may not
+  // be caught by the type system.
+  return {
+    time: [],
+    className: [],
+    typeName: [],
+    coarseType: [],
+    duration: [],
+    inNursery: [],
+    stack: [],
     length: 0,
   };
 }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -21,6 +21,7 @@ import type {
   Category,
   Counter,
   CounterSamplesTable,
+  JsAllocationsTable,
 } from '../types/profile';
 import type {
   CallNodeInfo,
@@ -146,13 +147,13 @@ export function getCallNodeInfo(
  * Take a samples table, and return an array that contain indexes that point to the
  * leaf most call node, or null.
  */
-export function getSampleCallNodes(
-  samples: SamplesTable,
+export function getSampleIndexToCallNodeIndex(
+  stacks: Array<IndexIntoStackTable | null>,
   stackIndexToCallNodeIndex: {
     [key: IndexIntoStackTable]: IndexIntoCallNodeTable,
   }
 ): Array<IndexIntoCallNodeTable | null> {
-  return samples.stack.map(stack => {
+  return stacks.map(stack => {
     return stack === null ? null : stackIndexToCallNodeIndex[stack];
   });
 }

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -143,13 +143,13 @@ export function getStackAndSampleSelectorsPerThread(
       { callNodeTable, stackIndexToCallNodeIndex },
       selectedCallNode
     ) => {
-      const sampleCallNodes = ProfileData.getSampleIndexToCallNodeIndex(
+      const sampleIndexToCallNodeIndex = ProfileData.getSampleIndexToCallNodeIndex(
         thread.samples.stack,
         stackIndexToCallNodeIndex
       );
       return ProfileData.getSamplesSelectedStates(
         callNodeTable,
-        sampleCallNodes,
+        sampleIndexToCallNodeIndex,
         selectedCallNode
       );
     }
@@ -161,11 +161,14 @@ export function getStackAndSampleSelectorsPerThread(
     threadSelectors.getFilteredThread,
     getCallNodeInfo,
     (thread, { callNodeTable, stackIndexToCallNodeIndex }) => {
-      const sampleCallNodes = ProfileData.getSampleIndexToCallNodeIndex(
+      const sampleIndexToCallNodeIndex = ProfileData.getSampleIndexToCallNodeIndex(
         thread.samples.stack,
         stackIndexToCallNodeIndex
       );
-      return ProfileData.getTreeOrderComparator(callNodeTable, sampleCallNodes);
+      return ProfileData.getTreeOrderComparator(
+        callNodeTable,
+        sampleIndexToCallNodeIndex
+      );
     }
   );
 

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -11,10 +11,13 @@ import * as FlameGraph from '../../profile-logic/flame-graph';
 import * as CallTree from '../../profile-logic/call-tree';
 import { PathSet } from '../../utils/path';
 import * as ProfileSelectors from '../profile';
+import { assertExhaustiveCheck, ensureExists } from '../../utils/flow';
 
 import type {
-  IndexIntoCategoryList,
   Thread,
+  SamplesTable,
+  JsAllocationsTable,
+  IndexIntoCategoryList,
   IndexIntoSamplesTable,
 } from '../../types/profile';
 import type {
@@ -140,8 +143,8 @@ export function getStackAndSampleSelectorsPerThread(
       { callNodeTable, stackIndexToCallNodeIndex },
       selectedCallNode
     ) => {
-      const sampleCallNodes = ProfileData.getSampleCallNodes(
-        thread.samples,
+      const sampleCallNodes = ProfileData.getSampleIndexToCallNodeIndex(
+        thread.samples.stack,
         stackIndexToCallNodeIndex
       );
       return ProfileData.getSamplesSelectedStates(
@@ -158,16 +161,40 @@ export function getStackAndSampleSelectorsPerThread(
     threadSelectors.getFilteredThread,
     getCallNodeInfo,
     (thread, { callNodeTable, stackIndexToCallNodeIndex }) => {
-      const sampleCallNodes = ProfileData.getSampleCallNodes(
-        thread.samples,
+      const sampleCallNodes = ProfileData.getSampleIndexToCallNodeIndex(
+        thread.samples.stack,
         stackIndexToCallNodeIndex
       );
       return ProfileData.getTreeOrderComparator(callNodeTable, sampleCallNodes);
     }
   );
 
-  const getCallTreeCountsAndTimings: Selector<CallTree.CallTreeCountsAndTimings> = createSelector(
+  const getSamplesForCallTree: Selector<
+    SamplesTable | JsAllocationsTable
+  > = createSelector(
     threadSelectors.getPreviewFilteredThread,
+    UrlState.getCallTreeSummaryStrategy,
+    (thread, strategy) => {
+      switch (strategy) {
+        case 'timing':
+          return thread.samples;
+        case 'js-allocations':
+          return ensureExists(
+            thread.jsAllocations,
+            'Expected the JsAllocationTable to exist when using a "js-allocation" strategy'
+          );
+        case 'native-allocations':
+          throw new Error(
+            'Native allocations have not been implemented for the call tree.'
+          );
+        default:
+          throw assertExhaustiveCheck(strategy);
+      }
+    }
+  );
+
+  const getCallTreeCountsAndTimings: Selector<CallTree.CallTreeCountsAndTimings> = createSelector(
+    getSamplesForCallTree,
     getCallNodeInfo,
     ProfileSelectors.getProfileInterval,
     UrlState.getInvertCallstack,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -154,6 +154,13 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     ProfileSelectors.getProfileViewOptions(state).perThread[threadIndex];
 
   /**
+   * Check to see if there are any JS allocations for this thread. This way we
+   * can display a custom thread.
+   */
+  const getHasJsAllocations: Selector<boolean> = state =>
+    Boolean(getThread(state).jsAllocations);
+
+  /**
    * The JS tracer selectors are placed in the thread selectors since there are
    * not many of them. If this section grows, then consider breaking them out
    * into their own file.
@@ -209,5 +216,6 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getJsTracerTable,
     getExpensiveJsTracerTiming,
     getExpensiveJsTracerLeafTiming,
+    getHasJsAllocations,
   };
 }

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -1,5 +1,648 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS allocations 1`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-strategy"
+            title="Change how the call tree numerically summarizes the thread"
+            type="radio"
+            value="timing"
+          />
+          Timing
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-strategy"
+            title="Change how the call tree numerically summarizes the thread"
+            type="radio"
+            value="js-allocations"
+          />
+          JavaScript Allocations
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Invert call stack
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      data-index="0"
+      title="Complete \\"Empty\\""
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete "Empty"
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalTimePercent"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalTime"
+      >
+        Total Size (bytes)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn selfTime"
+      >
+        Self (bytes)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-8"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 112px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="15"
+                >
+                  15
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="15"
+                >
+                  15
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="80%"
+                >
+                  80%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="12"
+                >
+                  12
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="80%"
+                >
+                  80%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="12"
+                >
+                  12
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="5"
+                >
+                  5
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="47%"
+                >
+                  47%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="7"
+                >
+                  7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="47%"
+                >
+                  47%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="7"
+                >
+                  7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="7"
+                >
+                  7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="20%"
+                >
+                  20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 112px; width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, running time is 15ms (100%), self time is 0ms"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, running time is 15ms (100%), self time is 0ms"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="F.js, running time is 12ms (80%), self time is 0ms"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  F.js
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="G.js, running time is 12ms (80%), self time is 5ms"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  G.js
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="H.js, running time is 7ms (47%), self time is 0ms"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-7"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  H.js
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="I, running time is 7ms (47%), self time is 7ms"
+                aria-level="6"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
+                id="treeViewRow-8"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 50px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  I
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="C, running time is 3ms (20%), self time is 0ms"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tree with no samples 1`] = `
 <div
   aria-labelledby="calltree-tab-button"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -487,7 +487,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
               </div>
               <div
                 aria-expanded="true"
-                aria-label="F.js, running time is 12ms (80%), self time is 0ms"
+                aria-label="Fjs, running time is 12ms (80%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns even"
@@ -509,7 +509,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                     class="colored-square category-color-grey"
                     title="Other"
                   />
-                  F.js
+                  Fjs
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -517,7 +517,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
               </div>
               <div
                 aria-expanded="true"
-                aria-label="G.js, running time is 12ms (80%), self time is 5ms"
+                aria-label="Gjs, running time is 12ms (80%), self time is 5ms"
                 aria-level="4"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns odd"
@@ -539,7 +539,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                     class="colored-square category-color-grey"
                     title="Other"
                   />
-                  G.js
+                  Gjs
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -547,7 +547,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
               </div>
               <div
                 aria-expanded="true"
-                aria-label="H.js, running time is 7ms (47%), self time is 0ms"
+                aria-label="Hjs, running time is 7ms (47%), self time is 0ms"
                 aria-level="5"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns even"
@@ -569,7 +569,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                     class="colored-square category-color-grey"
                     title="Other"
                   />
-                  H.js
+                  Hjs
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -43,7 +43,7 @@ export function createGeckoMarkerStack({
   };
 
   if (stackIndex !== null) {
-    // Only add a sample if the stack exists. There have been same cases observed
+    // Only add a sample if the stack exists. There have been some cases observed
     // on profiles where a sample wasn't collected here. This is probably an error
     // in the GeckoProfiler mechanism, but the front-end should be able to handle
     // it. See Bug 1566576.

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -17,6 +17,42 @@ import type {
 
 import { GECKO_PROFILE_VERSION } from '../../../app-logic/constants';
 
+export function createGeckoMarkerStack({
+  stackIndex,
+  time,
+}: {
+  stackIndex: number | null,
+  time: number,
+}): GeckoMarkerStack {
+  const markerStack = {
+    registerTime: null,
+    unregisterTime: null,
+    processType: 'default',
+    tid: 1111,
+    pid: 2222,
+    markers: { schema: { name: 0, time: 1, data: 2 }, data: [] },
+    name: 'SyncProfile',
+    samples: {
+      schema: {
+        stack: 0,
+        time: 1,
+        responsiveness: 2,
+      },
+      data: [],
+    },
+  };
+
+  if (stackIndex !== null) {
+    // Only add a sample if the stack exists. There have been same cases observed
+    // on profiles where a sample wasn't collected here. This is probably an error
+    // in the GeckoProfiler mechanism, but the front-end should be able to handle
+    // it. See Bug 1566576.
+    markerStack.samples.data.push([stackIndex, time, 0]);
+  }
+
+  return markerStack;
+}
+
 export function createGeckoSubprocessProfile(
   parentProfile: GeckoProfile
 ): GeckoSubprocessProfile {
@@ -271,23 +307,7 @@ function _createGeckoThread(): GeckoThread {
           {
             category: 'Paint',
             interval: 'start',
-            stack: ({
-              registerTime: null,
-              unregisterTime: null,
-              processType: 'default',
-              tid: 1111,
-              pid: 2222,
-              markers: { schema: { name: 0, time: 1, data: 2 }, data: [] },
-              name: 'SyncProfile',
-              samples: {
-                schema: {
-                  stack: 0,
-                  time: 1,
-                  responsiveness: 2,
-                },
-                data: [[2, 1, 0]], // (root), 0x100000f84, 0x100001a45
-              },
-            }: GeckoMarkerStack),
+            stack: createGeckoMarkerStack({ stackIndex: 2, time: 1 }), // (root), 0x100000f84, 0x100001a45
             type: 'tracing',
           },
         ],

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -821,9 +821,9 @@ export function getCounterForThread(
  *
  * - A (total: 15, self: —)
  *   - B (total: 15, self: —)
- *     - F.js (total: 12, self: —)
- *       - G.js (total: 12, self: 5)
- *         - H.js (total: 7, self: —)
+ *     - Fjs (total: 12, self: —)
+ *       - Gjs (total: 12, self: 5)
+ *         - Hjs (total: 7, self: —)
  *           - I (total: 7, self: 7)
  *     - C (total: 3, self: —)
  *       - D (total: 3, self: —)
@@ -838,9 +838,9 @@ export function getProfileWithJsAllocations(): * {
   } = getProfileFromTextSamples(`
     A  A     A
     B  B     B
-    C  F.js  F.js
-    D  G.js  G.js
-    E        H.js
+    C  Fjs   Fjs
+    D  Gjs   Gjs
+    E        Hjs
              I
   `);
 
@@ -850,13 +850,12 @@ export function getProfileWithJsAllocations(): * {
 
   // The stack table is built sequentially, so we can assume that the stack indexes
   // match the func indexes.
-  const { E, I } = funcNamesDict;
-  const G = funcNamesDict['G.js'];
+  const { E, I, Gjs } = funcNamesDict;
 
   // Create a list of allocations.
   const allocations = [
     { byteSize: 3, stack: E },
-    { byteSize: 5, stack: G },
+    { byteSize: 5, stack: Gjs },
     { byteSize: 7, stack: I },
   ];
 

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -8,6 +8,7 @@ import {
   getEmptyThread,
   getEmptyJsTracerTable,
   resourceTypes,
+  getEmptyJsAllocationsTable,
 } from '../../../profile-logic/data-structures';
 import { mergeProfiles } from '../../../profile-logic/comparison';
 import { stateFromLocation } from '../../../app-logic/url-handling';
@@ -813,4 +814,65 @@ export function getCounterForThread(
     },
   };
   return counter;
+}
+
+/**
+ * Get a profile with JS allocations. The allocations will form the following call tree.
+ *
+ * - A (total: 15, self: —)
+ *   - B (total: 15, self: —)
+ *     - F.js (total: 12, self: —)
+ *       - G.js (total: 12, self: 5)
+ *         - H.js (total: 7, self: —)
+ *           - I (total: 7, self: 7)
+ *     - C (total: 3, self: —)
+ *       - D (total: 3, self: —)
+ *         - E (total: 3, self: 3)
+ */
+
+export function getProfileWithJsAllocations(): * {
+  // First create a normal sample-based profile.
+  const {
+    profile,
+    funcNamesDictPerThread: [funcNamesDict],
+  } = getProfileFromTextSamples(`
+    A  A     A
+    B  B     B
+    C  F.js  F.js
+    D  G.js  G.js
+    E        H.js
+             I
+  `);
+
+  // Now add a JsAllocationsTable.
+  const jsAllocations = getEmptyJsAllocationsTable();
+  profile.threads[0].jsAllocations = jsAllocations;
+
+  // The stack table is built sequentially, so we can assume that the stack indexes
+  // match the func indexes.
+  const { E, I } = funcNamesDict;
+  const G = funcNamesDict['G.js'];
+
+  // Create a list of allocations.
+  const allocations = [
+    { byteSize: 3, stack: E },
+    { byteSize: 5, stack: G },
+    { byteSize: 7, stack: I },
+  ];
+
+  // Loop through and add them to the table.
+  let time = 0;
+  for (const { byteSize, stack } of allocations) {
+    const thisTime = time++;
+    jsAllocations.time.push(thisTime);
+    jsAllocations.className.push('Function');
+    jsAllocations.typeName.push('JSObject');
+    jsAllocations.coarseType.push('Object');
+    jsAllocations.duration.push(byteSize);
+    jsAllocations.inNursery.push(true);
+    jsAllocations.stack.push(stack);
+    jsAllocations.length++;
+  }
+
+  return { profile, funcNamesDict };
 }

--- a/src/test/unit/js-allocations.test.js
+++ b/src/test/unit/js-allocations.test.js
@@ -37,9 +37,9 @@ describe('JS allocation call trees', function() {
     expect(formatTree(callTree)).toEqual([
       '- A (total: 15, self: —)',
       '  - B (total: 15, self: —)',
-      '    - F.js (total: 12, self: —)',
-      '      - G.js (total: 12, self: 5)',
-      '        - H.js (total: 7, self: —)',
+      '    - Fjs (total: 12, self: —)',
+      '      - Gjs (total: 12, self: 5)',
+      '        - Hjs (total: 7, self: —)',
       '          - I (total: 7, self: 7)',
       '    - C (total: 3, self: —)',
       '      - D (total: 3, self: —)',
@@ -55,9 +55,9 @@ describe('JS allocation call trees', function() {
     expect(formatTree(callTree)).toEqual([
       '- A (total: 7, self: —)',
       '  - B (total: 7, self: —)',
-      '    - F.js (total: 7, self: —)',
-      '      - G.js (total: 7, self: —)',
-      '        - H.js (total: 7, self: —)',
+      '    - Fjs (total: 7, self: —)',
+      '      - Gjs (total: 7, self: —)',
+      '        - Hjs (total: 7, self: —)',
       '          - I (total: 7, self: 7)',
     ]);
   });
@@ -69,13 +69,13 @@ describe('JS allocation call trees', function() {
 
     expect(formatTree(callTree)).toEqual([
       '- I (total: 7, self: 7)',
-      '  - H.js (total: 7, self: —)',
-      '    - G.js (total: 7, self: —)',
-      '      - F.js (total: 7, self: —)',
+      '  - Hjs (total: 7, self: —)',
+      '    - Gjs (total: 7, self: —)',
+      '      - Fjs (total: 7, self: —)',
       '        - B (total: 7, self: —)',
       '          - A (total: 7, self: —)',
-      '- G.js (total: 5, self: 5)',
-      '  - F.js (total: 5, self: —)',
+      '- Gjs (total: 5, self: 5)',
+      '  - Fjs (total: 5, self: —)',
       '    - B (total: 5, self: —)',
       '      - A (total: 5, self: —)',
       '- E (total: 3, self: 3)',
@@ -92,9 +92,9 @@ describe('JS allocation call trees', function() {
     const callTree = selectedThreadSelectors.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
-      '- F.js (total: 12, self: —)',
-      '  - G.js (total: 12, self: 5)',
-      '    - H.js (total: 7, self: 7)',
+      '- Fjs (total: 12, self: —)',
+      '  - Gjs (total: 12, self: 5)',
+      '    - Hjs (total: 7, self: 7)',
     ]);
   });
 
@@ -122,9 +122,9 @@ describe('JS allocation call trees', function() {
     expect(formatTree(callTree)).toEqual([
       '- A (total: 15, self: —)',
       '  - B (total: 15, self: —)',
-      '    - F.js (total: 12, self: —)',
-      '      - G.js (total: 12, self: 5)',
-      '        - H.js (total: 7, self: —)',
+      '    - Fjs (total: 12, self: —)',
+      '      - Gjs (total: 12, self: 5)',
+      '        - Hjs (total: 7, self: —)',
       '          - I (total: 7, self: 7)',
       '    - D (total: 3, self: —)',
       '      - E (total: 3, self: 3)',
@@ -140,8 +140,8 @@ describe('JS allocation call trees', function() {
     expect(formatTree(callTree)).toEqual([
       '- A (total: 8, self: —)',
       '  - B (total: 8, self: —)',
-      '    - F.js (total: 5, self: —)',
-      '      - G.js (total: 5, self: 5)',
+      '    - Fjs (total: 5, self: —)',
+      '      - Gjs (total: 5, self: 5)',
       '    - C (total: 3, self: —)',
       '      - D (total: 3, self: —)',
       '        - E (total: 3, self: 3)',

--- a/src/test/unit/js-allocations.test.js
+++ b/src/test/unit/js-allocations.test.js
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import { getProfileWithJsAllocations } from '../fixtures/profiles/processed-profile';
+import { formatTree } from '../fixtures/utils';
+import { storeWithProfile } from '../fixtures/stores';
+import {
+  changeCallTreeSummaryStrategy,
+  changeCallTreeSearchString,
+  changeInvertCallstack,
+  changeImplementationFilter,
+  addTransformToStack,
+  commitRange,
+  updatePreviewSelection,
+} from '../../actions/profile-view';
+import { selectedThreadSelectors } from '../../selectors/per-thread';
+
+/**
+ * Test that the JsAllocationTable structure can by used with all of the call tree
+ * functionality, and that it obeys all of the transformation pipeline.
+ */
+describe('JS allocation call trees', function() {
+  function setup() {
+    const { profile, funcNamesDict } = getProfileWithJsAllocations();
+
+    // Create the store and switch to the JS allocations view.
+    const store = storeWithProfile(profile);
+    store.dispatch(changeCallTreeSummaryStrategy('js-allocations'));
+    return { ...store, funcNamesDict };
+  }
+
+  it('can create a call tree from JS allocations', function() {
+    const { getState } = setup();
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 15, self: —)',
+      '  - B (total: 15, self: —)',
+      '    - F.js (total: 12, self: —)',
+      '      - G.js (total: 12, self: 5)',
+      '        - H.js (total: 7, self: —)',
+      '          - I (total: 7, self: 7)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
+  });
+
+  it('can search the allocations', function() {
+    const { getState, dispatch } = setup();
+    dispatch(changeCallTreeSearchString('H'));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 7, self: —)',
+      '  - B (total: 7, self: —)',
+      '    - F.js (total: 7, self: —)',
+      '      - G.js (total: 7, self: —)',
+      '        - H.js (total: 7, self: —)',
+      '          - I (total: 7, self: 7)',
+    ]);
+  });
+
+  it('can invert the allocation tree', function() {
+    const { getState, dispatch } = setup();
+    dispatch(changeInvertCallstack(true));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- I (total: 7, self: 7)',
+      '  - H.js (total: 7, self: —)',
+      '    - G.js (total: 7, self: —)',
+      '      - F.js (total: 7, self: —)',
+      '        - B (total: 7, self: —)',
+      '          - A (total: 7, self: —)',
+      '- G.js (total: 5, self: 5)',
+      '  - F.js (total: 5, self: —)',
+      '    - B (total: 5, self: —)',
+      '      - A (total: 5, self: —)',
+      '- E (total: 3, self: 3)',
+      '  - D (total: 3, self: —)',
+      '    - C (total: 3, self: —)',
+      '      - B (total: 3, self: —)',
+      '        - A (total: 3, self: —)',
+    ]);
+  });
+
+  it('can use an implementation filter', function() {
+    const { getState, dispatch } = setup();
+    dispatch(changeImplementationFilter('js'));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- F.js (total: 12, self: —)',
+      '  - G.js (total: 12, self: 5)',
+      '    - H.js (total: 7, self: 7)',
+    ]);
+  });
+
+  /**
+   * This test doesn't go through every single call tree transform, but lightly
+   * checks out the merge function transform, since the transforms should all go
+   * through the same stack updating path. This test only checks that one is correctly
+   * wired up.
+   */
+  it('can apply a call tree transform', function() {
+    const {
+      getState,
+      dispatch,
+      funcNamesDict: { C },
+    } = setup();
+    dispatch(
+      addTransformToStack(0, {
+        type: 'merge-function',
+        funcIndex: C,
+      })
+    );
+
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 15, self: —)',
+      '  - B (total: 15, self: —)',
+      '    - F.js (total: 12, self: —)',
+      '      - G.js (total: 12, self: 5)',
+      '        - H.js (total: 7, self: —)',
+      '          - I (total: 7, self: 7)',
+      '    - D (total: 3, self: —)',
+      '      - E (total: 3, self: 3)',
+    ]);
+  });
+
+  it('will apply a committed range selection', function() {
+    const { getState, dispatch } = setup();
+
+    dispatch(commitRange(0, 1.5));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 8, self: —)',
+      '  - B (total: 8, self: —)',
+      '    - F.js (total: 5, self: —)',
+      '      - G.js (total: 5, self: 5)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
+  });
+
+  it('will apply a preview selection', function() {
+    const { getState, dispatch } = setup();
+
+    dispatch(commitRange(0, 1.5));
+    dispatch(
+      updatePreviewSelection({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 0,
+        selectionEnd: 1,
+      })
+    );
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 3, self: —)',
+      '  - B (total: 3, self: —)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
+  });
+});

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -18,7 +18,7 @@ import {
   convertStackToCallNodePath,
   invertCallstack,
   getTimingsForPath,
-  getSampleCallNodes,
+  getSampleIndexToCallNodeIndex,
   getCallNodeIndexFromPath,
   getTreeOrderComparator,
   getSamplesSelectedStates,
@@ -1257,8 +1257,8 @@ describe('getSamplesSelectedStates', function() {
     thread.funcTable,
     0
   );
-  const sampleCallNodes = getSampleCallNodes(
-    thread.samples,
+  const sampleCallNodes = getSampleIndexToCallNodeIndex(
+    thread.samples.stack,
     stackIndexToCallNodeIndex
   );
 

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -38,7 +38,7 @@ function callTreeFromProfile(
     defaultCategory
   );
   const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
-    thread,
+    thread.samples,
     callNodeInfo,
     interval,
     false
@@ -97,7 +97,7 @@ describe('unfiltered call tree', function() {
     it('yields expected results', function() {
       expect(
         computeCallTreeCountsAndTimings(
-          thread,
+          thread.samples,
           callNodeInfo,
           profile.meta.interval,
           false
@@ -428,7 +428,7 @@ describe('inverted call tree', function() {
       defaultCategory
     );
     const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
-      thread,
+      thread.samples,
       callNodeInfo,
       interval,
       true
@@ -467,7 +467,7 @@ describe('inverted call tree', function() {
       defaultCategory
     );
     const invertedCallTreeCountsAndTimings = computeCallTreeCountsAndTimings(
-      invertedThread,
+      invertedThread.samples,
       invertedCallNodeInfo,
       interval,
       true
@@ -600,7 +600,7 @@ describe('diffing trees', function() {
       defaultCategory
     );
     const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
-      thread,
+      thread.samples,
       callNodeInfo,
       interval,
       false

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { Milliseconds, Microseconds, Seconds } from './units';
+import type { Milliseconds, Microseconds, Seconds, Bytes } from './units';
 import type { GeckoMarkerStack } from './gecko-profile';
 import type { IndexIntoStackTable, IndexIntoStringTable } from './profile';
 
@@ -493,8 +493,8 @@ export type JsAllocationPayload_Gecko = {|
   className: string,
   typeName: string, // Currently only 'JSObject'
   coarseType: string, // Currently only 'Object',
-  size: number, // in bytes.
-  inNursery: true,
+  size: Bytes,
+  inNursery: boolean,
   stack: GeckoMarkerStack,
 |};
 

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -486,6 +486,20 @@ export type DummyForTestsMarkerPayload = {|
   endTime: Milliseconds,
 |};
 
+export type JsAllocationPayload = {|
+  type: 'JS allocation',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  className: 'Function',
+  typeName: string, // Currently only 'JSObject'
+  coarseType: string, // Currently only 'Object',
+  size: number, // in bytes.
+  inNursery: true,
+  // There is some failure case where stacks are not collected
+  // correctly. Make sure the cause is optional.
+  cause?: CauseBacktrace,
+|};
+
 /**
  * The union of all the different marker payloads that profiler.firefox.com knows about,
  * this is not guaranteed to be all the payloads that we actually get from the Gecko
@@ -514,6 +528,7 @@ export type MarkerPayload =
   | FrameConstructionMarkerPayload
   | DummyForTestsMarkerPayload
   | NavigationMarkerPayload
+  | JsAllocationPayload
   | null;
 
 export type MarkerPayload_Gecko =
@@ -533,6 +548,7 @@ export type MarkerPayload_Gecko =
   | CcMarkerTracing
   | ArbitraryEventTracing
   | NavigationMarkerPayload
+  | JsAllocationPayload
   // The following payloads come in with a stack property. During the profile processing
   // the "stack" property is are converted into a "cause". See the CauseBacktrace type
   // for more information.

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -486,18 +486,16 @@ export type DummyForTestsMarkerPayload = {|
   endTime: Milliseconds,
 |};
 
-export type JsAllocationPayload = {|
+export type JsAllocationPayload_Gecko = {|
   type: 'JS allocation',
   startTime: Milliseconds,
   endTime: Milliseconds,
-  className: 'Function',
+  className: string,
   typeName: string, // Currently only 'JSObject'
   coarseType: string, // Currently only 'Object',
   size: number, // in bytes.
   inNursery: true,
-  // There is some failure case where stacks are not collected
-  // correctly. Make sure the cause is optional.
-  cause?: CauseBacktrace,
+  stack: GeckoMarkerStack,
 |};
 
 /**
@@ -528,7 +526,6 @@ export type MarkerPayload =
   | FrameConstructionMarkerPayload
   | DummyForTestsMarkerPayload
   | NavigationMarkerPayload
-  | JsAllocationPayload
   | null;
 
 export type MarkerPayload_Gecko =
@@ -548,7 +545,7 @@ export type MarkerPayload_Gecko =
   | CcMarkerTracing
   | ArbitraryEventTracing
   | NavigationMarkerPayload
-  | JsAllocationPayload
+  | JsAllocationPayload_Gecko
   // The following payloads come in with a stack property. During the profile processing
   // the "stack" property is are converted into a "cause". See the CauseBacktrace type
   // for more information.

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Milliseconds, MemoryOffset, Microseconds } from './units';
+import type { Milliseconds, MemoryOffset, Microseconds, Bytes } from './units';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { MarkerPayload } from './markers';
 export type IndexIntoStackTable = number;
@@ -93,6 +93,24 @@ export type SamplesTable = {|
   stack: Array<IndexIntoStackTable | null>,
   time: Milliseconds[],
   duration?: Milliseconds[],
+  length: number,
+|};
+
+/**
+ * JS allocations are recorded as a marker payload, but in profile processing they
+ * are moved to the Thread. This allows them to be part of the stack processing pipeline.
+ */
+export type JsAllocationsTable = {|
+  time: Milliseconds[],
+  className: string[],
+  typeName: string[], // Currently only 'JSObject'
+  coarseType: string[], // Currently only 'Object',
+  // "duration" is a bit odd of a name for this field, but it's "duck typing" the byte
+  // size so that we can use a SamplesTable and JsAllocationsTable in the same call tree
+  // computation functions.
+  duration: Bytes[],
+  inNursery: boolean[],
+  stack: Array<IndexIntoStackTable | null>,
   length: number,
 |};
 
@@ -297,6 +315,7 @@ export type Thread = {|
   pid: Pid,
   tid: number | void,
   samples: SamplesTable,
+  jsAllocations?: JsAllocationsTable,
   markers: RawMarkerTable,
   stackTable: StackTable,
   frameTable: FrameTable,

--- a/src/types/units.js
+++ b/src/types/units.js
@@ -39,3 +39,5 @@ export type HorizontalViewport = {
 export type StartEndRange = { start: Milliseconds, end: Milliseconds };
 
 export type MemoryOffset = number;
+
+export type Bytes = number;


### PR DESCRIPTION
This is a prototype for using the new JS allocation information from [Bug 1545582](https://bugzilla.mozilla.org/show_bug.cgi?id=1545582)

------------

Edit: this is now ready for review, and is no longer a prototype!

[deploy preview](https://deploy-preview-2061--perf-html.netlify.com/public/481b6f49adefd3e4ad127149c198f251baa11f9c/calltree/?ctSummary=js-allocations&globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=21209-1-2-0~67704-0~21210-0~21233-0~21235-0~67532-0-1~&thread=0&v=4)

Also, this should work locally on Nightly if you enable the JS allocations feature:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/1588648/61564190-7c7efc00-aa3b-11e9-9307-84deff15fb04.png">
