### PR TITLE
Separated the drag and drop functionality and added it to the profiler main view

### DIFF
--- a/src/components/app/DragAndDrop.js
+++ b/src/components/app/DragAndDrop.js
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import classNames from 'classnames';
+import { retrieveProfileFromFile } from '../../actions/receive-profile';
+import type { ConnectedProps } from '../../utils/connect';
+
+function _dragPreventDefault(event: DragEvent) {
+  event.preventDefault();
+}
+
+type OwnDragAndDropProps = {|
+  +className: string,
+  +children?: React.Node,
+|};
+
+type DispatchDragAndDropProps = {|
+  +retrieveProfileFromFile: typeof retrieveProfileFromFile,
+|};
+
+type DragAndDropState = {
+  isDragging: boolean,
+};
+
+type DragAndDropProps = ConnectedProps<
+  OwnDragAndDropProps,
+  {||},
+  DispatchDragAndDropProps
+>;
+
+class DragAndDrop extends React.PureComponent<
+  DragAndDropProps,
+  DragAndDropState
+> {
+  state = {
+    isDragging: false,
+  };
+
+  componentDidMount() {
+    // Prevent dropping files on the document.
+    document.addEventListener('drag', _dragPreventDefault, false);
+    document.addEventListener('dragover', _dragPreventDefault, false);
+    document.addEventListener('drop', _dragPreventDefault, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('drag', _dragPreventDefault, false);
+    document.removeEventListener('dragover', _dragPreventDefault, false);
+    document.removeEventListener('drop', _dragPreventDefault, false);
+  }
+
+  _startDragging = (event: Event) => {
+    event.preventDefault();
+    this.setState({ isDragging: true });
+  };
+
+  _stopDragging = (event: Event) => {
+    event.preventDefault();
+    this.setState({ isDragging: false });
+  };
+
+  _handleProfileDrop = (event: DragEvent) => {
+    event.preventDefault();
+    this.setState({ isDragging: false });
+
+    if (!event.dataTransfer) {
+      return;
+    }
+
+    const { files } = event.dataTransfer;
+    if (files.length > 0) {
+      this.props.retrieveProfileFromFile(files[0]);
+    }
+  };
+
+  render() {
+    const { className, children } = this.props;
+
+    return (
+      <div
+        className={className}
+        onDragEnter={this._startDragging}
+        onDragExit={this._stopDragging}
+        onDrop={this._handleProfileDrop}
+      >
+        {children}
+        <div
+          className={classNames(
+            'homeDrop',
+            this.state.isDragging ? 'dragging' : false
+          )}
+        >
+          <div className="homeDropMessage">Drop a saved profile here</div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DragAndDrop;

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -27,6 +27,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 200ms;
+  z-index: 10;
 }
 
 .homeDropMessage {

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -14,6 +14,7 @@
 
 .homeDrop {
   position: absolute;
+  z-index: 10;
   top: 0;
   left: 0;
   display: flex;
@@ -27,7 +28,6 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 200ms;
-  z-index: 10;
 }
 
 .homeDropMessage {

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -164,6 +164,7 @@ class LoadFromUrl extends React.PureComponent<
           placeholder="https://"
           value={this.state.value}
           onChange={this.handleChange}
+          autoFocus
         />
         <input
           type="submit"

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -12,6 +12,7 @@ import MenuButtons from './MenuButtons';
 import WindowTitle from '../shared/WindowTitle';
 import SymbolicationStatusOverlay from './SymbolicationStatusOverlay';
 import { returnToZipFileList } from '../../actions/zipped-profiles';
+import { retrieveProfileFromFile } from '../../actions/receive-profile';
 import { getProfileName } from '../../selectors/url-state';
 import Timeline from '../timeline';
 import { getHasZipFile } from '../../selectors/zipped-profiles';
@@ -25,6 +26,7 @@ import {
   getHasSanitizedProfile,
 } from '../../selectors/publish';
 import classNames from 'classnames';
+import DragAndDrop from './DragAndDrop';
 
 import type { CssPixels } from '../../types/units';
 import type { ConnectedProps } from '../../utils/connect';
@@ -44,6 +46,7 @@ type StateProps = {|
 type DispatchProps = {|
   +returnToZipFileList: typeof returnToZipFileList,
   +invalidatePanelLayout: typeof invalidatePanelLayout,
+  +retrieveProfileFromFile: typeof retrieveProfileFromFile,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -60,14 +63,16 @@ class ProfileViewer extends PureComponent<Props> {
       uploadProgress,
       isHidingStaleProfile,
       hasSanitizedProfile,
+      retrieveProfileFromFile,
     } = this.props;
 
     return (
-      <div
+      <DragAndDrop
         className={classNames({
           profileViewerWrapper: true,
           profileViewerWrapperBackground: hasSanitizedProfile,
         })}
+        retrieveProfileFromFile={retrieveProfileFromFile}
       >
         <div
           className={classNames({
@@ -127,7 +132,7 @@ class ProfileViewer extends PureComponent<Props> {
           <WindowTitle />
           <SymbolicationStatusOverlay />
         </div>
-      </div>
+      </DragAndDrop>
     );
   }
 }
@@ -145,6 +150,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapDispatchToProps: {
     returnToZipFileList,
     invalidatePanelLayout,
+    retrieveProfileFromFile,
   },
   component: ProfileViewer,
 });

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -131,16 +131,16 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="homeDrop"
-    >
-      <div
-        class="homeDropMessage"
-      >
-        Drop a saved profile here
-      </div>
-    </div>
   </section>
+  <div
+    class="homeDrop"
+  >
+    <div
+      class="homeDropMessage"
+    >
+      Drop a saved profile here
+    </div>
+  </div>
 </div>
 `;
 
@@ -276,16 +276,16 @@ exports[`app/Home renders the install screen for the extension 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="homeDrop"
-    >
-      <div
-        class="homeDropMessage"
-      >
-        Drop a saved profile here
-      </div>
-    </div>
   </section>
+  <div
+    class="homeDrop"
+  >
+    <div
+      class="homeDropMessage"
+    >
+      Drop a saved profile here
+    </div>
+  </div>
 </div>
 `;
 
@@ -451,16 +451,16 @@ exports[`app/Home renders the install screen for the legacy add-on 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="homeDrop"
-    >
-      <div
-        class="homeDropMessage"
-      >
-        Drop a saved profile here
-      </div>
-    </div>
   </section>
+  <div
+    class="homeDrop"
+  >
+    <div
+      class="homeDropMessage"
+    >
+      Drop a saved profile here
+    </div>
+  </div>
 </div>
 `;
 
@@ -617,15 +617,15 @@ exports[`app/Home renders the usage instructions for pages with the extension in
         </div>
       </div>
     </div>
-    <div
-      class="homeDrop"
-    >
-      <div
-        class="homeDropMessage"
-      >
-        Drop a saved profile here
-      </div>
-    </div>
   </section>
+  <div
+    class="homeDrop"
+  >
+    <div
+      class="homeDropMessage"
+    >
+      Drop a saved profile here
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
So I am pushing this as a draft PR because I am not quite sure if this is what was originally expected in #2001. First of all, I've removed the D&D part from Home component and created a separate one (it should probably have tests even though I am not quite sure how to test it yet. Suggestions?). Secondly, it works as a container, so it basically accepts any component as a child. This is a bit tricky regarding previous code as the D&D overlay previously adapts to the area (picture below).
![first](https://user-images.githubusercontent.com/16244425/59466852-f584a580-8e36-11e9-8ea9-cfdc88cef1a2.png)

Now because of the separation it looks a bit different.
![second](https://user-images.githubusercontent.com/16244425/59466914-13520a80-8e37-11e9-8bea-58a002a268ac.png)

And finally, the profiles can be added from main view.
![third](https://user-images.githubusercontent.com/16244425/59466957-32e93300-8e37-11e9-82cf-aca9ac2b94a4.png)

Because the overlay looks different, the snapshots were updated. Seeking for suggestions and insights.

