### PR TITLE
Match up function names to the JS tracer information

### DIFF
--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -218,11 +218,11 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     JsTracerTiming[] | null
   > = createSelector(
     getJsTracerTable,
-    getStringTable,
-    (jsTracerTable, stringTable) =>
+    getThread,
+    (jsTracerTable, thread) =>
       jsTracerTable === null
         ? null
-        : JsTracer.getJsTracerTiming(jsTracerTable, stringTable)
+        : JsTracer.getJsTracerTiming(jsTracerTable, thread)
   );
 
   /**

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -138,6 +138,7 @@ export type JsTracerTiming = {
   index: IndexIntoJsTracerEvents[],
   label: string[],
   name: string,
+  func: Array<IndexIntoFuncTable | null>,
   length: number,
 };
 


### PR DESCRIPTION
The JS tracer information does not know about functions, it only knows about events. The events are only strings. This makes it hard to know what is going on in the data. This PR tries to match up script, line, and column information in the data to augment the data in JS tracer, with the data in the sample stacks.