### PR TITLE
Convert JS tracer into the profile format

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -39,3 +39,6 @@ export const TRACK_PROCESS_BLANK_HEIGHT = 30;
 
 // Height of timeline ruler.
 export const TIMELINE_RULER_HEIGHT = 20;
+
+// JS Tracer has very high fidelity information, and needs a more fine-grained zoom.
+export const JS_TRACER_MAXIMUM_CHART_ZOOM = 0.001;

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -280,16 +280,21 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
         categories={categories}
         durationText={`${(100 * duration).toFixed(2)}%`}
         callTree={callTree}
-        timings={this._getTimingsForCallNodeIndex(
-          callNodeIndex,
-          callNodeInfo,
-          interval,
-          isInverted,
-          thread,
-          unfilteredThread,
-          sampleIndexOffset,
-          categories
-        )}
+        timings={
+          thread.isJsTracer
+            ? // This is currently too slow for JS Tracer threads.
+              undefined
+            : this._getTimingsForCallNodeIndex(
+                callNodeIndex,
+                callNodeInfo,
+                interval,
+                isInverted,
+                thread,
+                unfilteredThread,
+                sampleIndexOffset,
+                categories
+              )
+        }
       />
     );
   };

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -7,6 +7,7 @@ import * as React from 'react';
 import {
   TIMELINE_MARGIN_LEFT,
   TIMELINE_MARGIN_RIGHT,
+  JS_TRACER_MAXIMUM_CHART_ZOOM,
 } from '../../app-logic/constants';
 import explicitConnect from '../../utils/connect';
 import JsTracerCanvas from './Canvas';
@@ -68,7 +69,7 @@ class JsTracerExpensiveChartImpl extends React.PureComponent<Props> {
     const {
       timeRange: { start, end },
     } = this.props;
-    return 0.001 / (end - start);
+    return JS_TRACER_MAXIMUM_CHART_ZOOM / (end - start);
   }
 
   render() {

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -13,7 +13,6 @@ import JsTracerCanvas from './Canvas';
 
 import {
   getCommittedRange,
-  getProfileInterval,
   getPreviewSelection,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
@@ -50,7 +49,6 @@ type StateProps = {|
   +jsTracerTimingRows: JsTracerTiming[],
   +stringTable: UniqueStringArray,
   +timeRange: { start: Milliseconds, end: Milliseconds },
-  +interval: Milliseconds,
   +threadIndex: number,
   +previewSelection: PreviewSelection,
 |};
@@ -69,9 +67,8 @@ class JsTracerExpensiveChartImpl extends React.PureComponent<Props> {
   getMaximumZoom(): UnitIntervalOfProfileRange {
     const {
       timeRange: { start, end },
-      interval,
     } = this.props;
-    return interval / (end - start);
+    return 0.001 / (end - start);
   }
 
   render() {
@@ -136,7 +133,6 @@ const JsTracerExpensiveChart = explicitConnect<
   mapStateToProps: (state, ownProps) => ({
     timeRange: getCommittedRange(state),
     stringTable: selectedThreadSelectors.getStringTable(state),
-    interval: getProfileInterval(state),
     threadIndex: getSelectedThreadIndex(state),
     previewSelection: getPreviewSelection(state),
     jsTracerTimingRows: ensureExists(

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -33,7 +33,7 @@ export type Props = {|
   +rangeEnd: Milliseconds,
   +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
   +categories: CategoryList,
-  +samplesSelectedStates: SelectedState[],
+  +samplesSelectedStates: null | SelectedState[],
   +treeOrderSampleComparator?: (
     IndexIntoSamplesTable,
     IndexIntoSamplesTable

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -43,7 +43,7 @@ type RenderedComponentSettings = {|
     IndexIntoSamplesTable
   ) => number,
   +greyCategoryIndex: IndexIntoCategoryList,
-  +samplesSelectedStates: Array<SelectedState>,
+  +samplesSelectedStates: null | Array<SelectedState>,
   +categoryDrawStyles: CategoryDrawStyles,
 |};
 

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -53,7 +53,7 @@ type CanvasProps = {|
   +callNodeInfo: CallNodeInfo,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +categories: CategoryList,
-  +samplesSelectedStates: SelectedState[],
+  +samplesSelectedStates: null | SelectedState[],
   +treeOrderSampleComparator: (
     IndexIntoSamplesTable,
     IndexIntoSamplesTable
@@ -160,7 +160,7 @@ type StateProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +categories: CategoryList,
   +previewSelection: PreviewSelection,
-  +samplesSelectedStates: SelectedState[],
+  +samplesSelectedStates: null | SelectedState[],
   +treeOrderSampleComparator: (
     IndexIntoSamplesTable,
     IndexIntoSamplesTable

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -91,11 +91,14 @@ class StackGraph extends PureComponent<Props> {
       thread.samples.stack,
       stackIndexToCallNodeIndex
     );
-    const samplesSelectedStates = getSamplesSelectedStates(
-      callNodeTable,
-      sampleCallNodes,
-      selectedCallNodeIndex
-    );
+    // This is currently too slow to compute for the JS Tracer threads.
+    const samplesSelectedStates = thread.isJsTracer
+      ? null
+      : getSamplesSelectedStates(
+          callNodeTable,
+          sampleCallNodes,
+          selectedCallNodeIndex
+        );
     for (let i = 0; i < callNodeTable.depth.length; i++) {
       if (callNodeTable.depth[i] > maxDepth) {
         maxDepth = callNodeTable.depth[i];
@@ -154,7 +157,10 @@ class StackGraph extends PureComponent<Props> {
       const height = callNodeTable.depth[callNodeIndex] * yPixelsPerDepth;
       const xPos = (sampleTime - range[0]) * xPixelsPerMs;
       let samplesBucket;
-      if (samplesSelectedStates[i] === 'SELECTED') {
+      if (
+        samplesSelectedStates !== null &&
+        samplesSelectedStates[i] === 'SELECTED'
+      ) {
         samplesBucket = highlightedSamples;
       } else {
         const stackIndex = ensureExists(

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -79,8 +79,11 @@ class StackChartGraph extends React.PureComponent<Props> {
     const {
       timeRange: { start, end },
       interval,
+      thread,
     } = this.props;
-    return interval / (end - start);
+    // JS Tracer does not care about the interval.
+    const modifier = thread.jsTracer ? 0.01 : interval;
+    return modifier / (end - start);
   }
 
   _onSelectedCallNodeChange = (

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -7,6 +7,7 @@ import * as React from 'react';
 import {
   TIMELINE_MARGIN_LEFT,
   TIMELINE_MARGIN_RIGHT,
+  JS_TRACER_MAXIMUM_CHART_ZOOM,
 } from '../../app-logic/constants';
 import explicitConnect from '../../utils/connect';
 import StackChartCanvas from './Canvas';
@@ -82,7 +83,7 @@ class StackChartGraph extends React.PureComponent<Props> {
       thread,
     } = this.props;
     // JS Tracer does not care about the interval.
-    const modifier = thread.jsTracer ? 0.01 : interval;
+    const modifier = thread.jsTracer ? JS_TRACER_MAXIMUM_CHART_ZOOM : interval;
     return modifier / (end - start);
   }
 

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -70,7 +70,7 @@ type StateProps = {|
   +categories: CategoryList,
   +timelineType: TimelineType,
   +hasFileIoMarkers: boolean,
-  +samplesSelectedStates: SelectedState[],
+  +samplesSelectedStates: null | SelectedState[],
 |};
 
 type DispatchProps = {|
@@ -179,7 +179,7 @@ class TimelineTrackThread extends PureComponent<Props> {
             onSelect={this._onMarkerSelect}
           />
         ) : null}
-        {timelineType === 'category' ? (
+        {timelineType === 'category' && !filteredThread.isJsTracer ? (
           <ThreadActivityGraph
             className="threadActivityGraph"
             interval={interval}

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { getStackType } from '../../profile-logic/transforms';
 import { objectEntries } from '../../utils/flow';
-import { formatNumberDependingOnInterval } from '../../utils/format-numbers';
+import { formatCallNodeNumber } from '../../utils/format-numbers';
 import NodeIcon from '../shared/NodeIcon';
 import {
   getFriendlyStackTypeName,
@@ -62,8 +62,10 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     const sortedTotalBreakdownByImplementation = objectEntries(
       totalTime.breakdownByImplementation
     ).sort((a, b) => b[1] - a[1]);
-    const { interval } = this.props;
-    const isIntegerInterval = Number.isInteger(interval);
+    const { interval, thread } = this.props;
+
+    // JS Tracer threads have data relevant to the microsecond level.
+    const isHighPrecision = Boolean(thread.isJsTracer);
 
     return (
       <div className="tooltipCallNodeImplementation">
@@ -125,13 +127,14 @@ export class TooltipCallNode extends React.PureComponent<Props> {
                   />
                 </div>
                 <div className="tooltipCallNodeImplementationTiming">
-                  {formatNumberDependingOnInterval(isIntegerInterval, time)}ms
+                  {formatCallNodeNumber(interval, isHighPrecision, time)}ms
                 </div>
                 <div className="tooltipCallNodeImplementationTiming">
                   {selfTimeValue === 0
                     ? '—'
-                    : `${formatNumberDependingOnInterval(
-                        isIntegerInterval,
+                    : `${formatCallNodeNumber(
+                        interval,
+                        isHighPrecision,
                         selfTimeValue
                       )}ms`}
                 </div>

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -241,8 +241,8 @@ export function getEmptyJsTracerTable(): JsTracerTable {
     events: [],
     timestamps: [],
     durations: [],
-    lines: [],
-    columns: [],
+    line: [],
+    column: [],
     length: 0,
   };
 }

--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -3,12 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+import {
+  getEmptyFrameTable,
+  getEmptyStackTable,
+  getEmptySamplesTable,
+  getEmptyRawMarkerTable,
+} from './data-structures';
+import { ensureExists } from '../utils/flow';
 import type {
   JsTracerTable,
   IndexIntoStringTable,
   IndexIntoJsTracerEvents,
   IndexIntoFuncTable,
   Thread,
+  IndexIntoStackTable,
+  SamplesTable,
+  CategoryList,
 } from '../types/profile';
 import type { JsTracerTiming } from '../types/profile-derived';
 import type { Microseconds } from '../types/units';
@@ -440,4 +450,590 @@ export function getJsTracerLeafTiming(
 
     return 0;
   });
+}
+
+/**
+ * This function builds a Thread structure without any samples. It derives the functions
+ * and stacks from the JS Tracer data.
+
+ * Given JS tracer data:
+ *
+ *   [A------------------------------]
+ *      [B-------][D--------------]
+ *         [C--]      [E-------]
+ *
+ * Build this StackTable:
+ *
+ *   A -> B -> C
+ *     \
+ *        D -> E
+ *
+ * This function is also in charge of matching up JS tracer events that have script
+ * locations to functions that we sampled in the Gecko Profiler sampling mechanism.
+ * If an event shares the same script location, row, and column numbers as a JS
+ * function, then the function information is used.
+ */
+export function convertJsTracerToThreadWithoutSamples(
+  fromThread: Thread,
+  jsTracer: JsTracerFixed,
+  categories: CategoryList
+): {
+  thread: Thread,
+  stackMap: Map<IndexIntoJsTracerEvents, IndexIntoStackTable>,
+} {
+  // Create a new thread, with empty information, but preserve some of the existing
+  // thread information.
+  const frameTable = getEmptyFrameTable();
+  const stackTable = getEmptyStackTable();
+  const samples: SamplesTable = {
+    ...getEmptySamplesTable(),
+    duration: [],
+  };
+  const markers = getEmptyRawMarkerTable();
+  const funcTable = { ...fromThread.funcTable };
+  const { stringTable } = fromThread;
+
+  const thread: Thread = {
+    ...fromThread,
+    markers,
+    funcTable,
+    stackTable,
+    frameTable,
+    samples,
+  };
+
+  // Create a map that keys off of the string `${fileName}:${line}:${column}`. This maps
+  // the JS tracer script locations to functions in the profiling data structure.
+  // This operation can fail, as there is no guarantee that every location in the JS
+  // tracer information was sampled.
+  const keyToFuncIndex: Map<string, IndexIntoFuncTable | null> = new Map();
+  for (let funcIndex = 0; funcIndex < funcTable.length; funcIndex++) {
+    if (!funcTable.isJS[funcIndex]) {
+      continue;
+    }
+    const line = funcTable.lineNumber[funcIndex];
+    const column = funcTable.columnNumber[funcIndex];
+    const fileNameIndex = funcTable.fileName[funcIndex];
+    if (line !== null && column !== null && fileNameIndex !== null) {
+      const fileName = stringTable.getString(fileNameIndex);
+      const key = `${fileName}:${line}:${column}`;
+      if (keyToFuncIndex.has(key)) {
+        // Multiple functions map to this script location.
+        keyToFuncIndex.set(key, null);
+      } else {
+        keyToFuncIndex.set(key, funcIndex);
+      }
+    }
+  }
+
+  // Keep a stack of js tracer events, and end timings, that will be used to find
+  // the stack prefixes. Once a JS tracer event starts past another event end, the
+  // stack will be "popped" by decrementing the unmatchedIndex.
+  let unmatchedIndex = 0;
+  const unmatchedEventIndexes = [null];
+  const unmatchedEventEnds = [0];
+
+  // Build up maps between index values.
+  const funcMap: Map<IndexIntoStringTable, IndexIntoFuncTable> = new Map();
+  const stackMap: Map<IndexIntoJsTracerEvents, IndexIntoStackTable> = new Map();
+
+  // Get some computed values before entering the loop.
+  const blankStringIndex = stringTable.indexForString('');
+  const otherCategory = categories.findIndex(c => c.name === 'Other');
+  if (otherCategory === -1) {
+    throw new Error("Expected to find an 'Other' category.");
+  }
+  const scriptLocationToFuncIndex = getScriptLocationToFuncIndex(thread);
+
+  // Go through all of the JS tracer events, and build up the func, stack, and
+  // frame tables.
+  for (
+    let tracerEventIndex = 0;
+    tracerEventIndex < jsTracer.length;
+    tracerEventIndex++
+  ) {
+    // Look up various values for this event.
+    const eventStringIndex = jsTracer.events[tracerEventIndex];
+    const eventName = stringTable.getString(eventStringIndex);
+    const end = jsTracer.end[tracerEventIndex];
+    const column = jsTracer.column[tracerEventIndex];
+    const line = jsTracer.line[tracerEventIndex];
+    let funcIndex: null | IndexIntoFuncTable = null;
+
+    // First try to look up the func index by script location.
+    if (column !== null && line !== null) {
+      // Look up to see if this script location has a function in the sampled data.
+      const key = `${eventName}:${line}:${column}`;
+      const maybeFuncIndex = scriptLocationToFuncIndex.get(key);
+      if (maybeFuncIndex !== undefined && maybeFuncIndex !== null) {
+        funcIndex = maybeFuncIndex;
+        funcMap.set(eventStringIndex, funcIndex);
+      }
+    }
+
+    if (funcIndex === null) {
+      const generatedFuncIndex = funcMap.get(eventStringIndex);
+      if (generatedFuncIndex === undefined) {
+        // Create a new function only if the event string is different.
+        funcIndex = funcTable.length++;
+        funcTable.address.push(0);
+        funcTable.name.push(eventStringIndex);
+        funcTable.isJS.push(false);
+        funcTable.resource.push(-1);
+        funcTable.relevantForJS.push(true);
+        funcTable.fileName.push(null);
+        funcTable.lineNumber.push(null);
+        funcTable.columnNumber.push(null);
+
+        funcMap.set(eventStringIndex, funcIndex);
+      } else {
+        funcIndex = generatedFuncIndex;
+      }
+    }
+
+    // Try to find the prefix stack for this event.
+    let prefixIndex = unmatchedEventIndexes[unmatchedIndex];
+    while (prefixIndex !== null) {
+      const prefixEnd = unmatchedEventEnds[unmatchedIndex];
+      if (end <= prefixEnd) {
+        // This prefix is the correct one.
+        break;
+      }
+      // Keep on searching for the next prefix.
+      prefixIndex = unmatchedEventIndexes[unmatchedIndex];
+      unmatchedIndex--;
+    }
+
+    // Every event gets a unique frame entry.
+    const frameIndex = frameTable.length++;
+    frameTable.address.push(blankStringIndex);
+    frameTable.category.push(otherCategory);
+    frameTable.func.push(funcIndex);
+    // TODO - We could figure out the implementation, by tracking what the callee was.
+    frameTable.implementation.push(null);
+    frameTable.line.push(line);
+    frameTable.column.push(column);
+    frameTable.column.push(null);
+    frameTable.optimizations.push(null);
+
+    // Each event gets a stack table entry.
+    const stackIndex = stackTable.length++;
+    stackTable.frame.push(frameIndex);
+    stackTable.category.push(otherCategory);
+    stackTable.prefix.push(prefixIndex);
+    stackMap.set(tracerEventIndex, stackIndex);
+
+    // Add this stack to the unmatched stacks of events.
+    unmatchedIndex++;
+    if (unmatchedIndex === 0) {
+      // Reached a new root, reset the index to 1.
+      unmatchedIndex = 1;
+    }
+    unmatchedEventIndexes[unmatchedIndex] = tracerEventIndex;
+    unmatchedEventEnds[unmatchedIndex] = end;
+  }
+
+  return { thread, stackMap };
+}
+
+type JsTracerFixed = {|
+  events: Array<IndexIntoStringTable>,
+  start: Array<Microseconds>,
+  end: Array<Microseconds>,
+  line: Array<number | null>, // Line number.
+  column: Array<number | null>, // Column number.
+  length: number,
+|};
+
+/**
+ * JS Tracer information has a start and duration, but due to precision issues, this
+ * can lead to errors with computing parent/child relationships. This function converts
+ * it into a start and end time, and corrects issues where the events incorrectly
+ * overlap.
+ */
+export function getJsTracerFixed(jsTracer: JsTracerTable): JsTracerFixed {
+  if (jsTracer.length === 0) {
+    return {
+      events: [],
+      start: [],
+      end: [],
+      line: [],
+      column: [],
+      length: 0,
+    };
+  }
+  let prevStart = jsTracer.timestamps[0];
+  let prevEnd = prevStart + jsTracer.durations[0];
+  const start = [prevStart];
+  const end = [prevEnd];
+  const jsTracerFixed = {
+    events: jsTracer.events,
+    start,
+    end,
+    line: jsTracer.line,
+    column: jsTracer.column,
+    length: jsTracer.length,
+  };
+  for (let eventIndex = 1; eventIndex < jsTracer.length; eventIndex++) {
+    const duration = jsTracer.durations[eventIndex];
+    let currStart = jsTracer.timestamps[eventIndex];
+    let currEnd = currStart + (duration === null ? 0 : duration);
+
+    // The following if branches were produced to enumerate through all possible
+    // overlapping cases.
+    if (currStart < prevStart) {
+      if (prevStart < currEnd) {
+        //                       | Adjust to this:
+        // prev:        [-----]  |    [----]
+        // curr:  [---------]    |    [---]
+        currStart = prevStart;
+      } else {
+        //                       | Adjust to this:
+        // prev:        [-----]  |    [----]
+        // curr: [---]           |    [---]
+        const duration = currEnd - currStart;
+        currStart = prevStart;
+        currEnd = Math.min(prevEnd, currStart + duration);
+      }
+    } else {
+      if (currEnd < prevEnd) {
+        // No adjustment needed
+        // prev: [-----]
+        // curr:  [--]
+      } else {
+        if (prevEnd <= currStart) {
+          // There is no need to adjust the timing.
+          // prev: [----]
+          // curr:         [----]
+        } else {
+          if (prevEnd - currStart < currEnd - prevEnd) {
+            // Fix the timing       | Adjust to this:
+            // prev: [---]          | [---][----]
+            // curr:    [-----]     |
+            currStart = prevEnd;
+          } else {
+            // Fix the timing       | Adjust to this:
+            // prev: [----]         | [----]
+            // curr:   [---]        |   [--]
+            currEnd = prevEnd;
+          }
+        }
+      }
+    }
+
+    start.push(currStart);
+    end.push(currEnd);
+
+    prevStart = currStart;
+    prevEnd = currEnd;
+  }
+  return jsTracerFixed;
+}
+
+/**
+ * This function controls all of the finer-grained steps to convert JS Tracer information
+ * into Thread data structure. See each of those functions for more documentation on
+ * what is going on.
+ */
+export function convertJsTracerToThread(
+  fromThread: Thread,
+  jsTracer: JsTracerTable,
+  categories: CategoryList
+): Thread {
+  const jsTracerFixed = getJsTracerFixed(jsTracer);
+  const { thread, stackMap } = convertJsTracerToThreadWithoutSamples(
+    fromThread,
+    jsTracerFixed,
+    categories
+  );
+  thread.samples = getSelfTimeSamplesFromJsTracer(
+    thread,
+    jsTracerFixed,
+    stackMap
+  );
+  return thread;
+}
+
+/**
+ * This function walks along the end of the JS tracer events, pushing and popping events
+ * on to a stack. It then determines the self time for the events, and translates the
+ * self time into individual weighted samples in the SamplesTable.
+ *
+ * Given JS tracer data:
+ *
+ *   [A------------------------------]
+ *      [B-------][D--------------]
+ *         [C--]      [E-------]
+ *
+ * This StackTable is generated in convertJsTracerToThreadWithoutSamples:
+ *
+ *   A -> B -> C
+ *     \
+ *        D -> E
+ *
+ * This data would then have the following self time:
+ *
+ *            0         10        20        30
+ *   Time:    |123456789|123456789|123456789|12
+ *   Node:    AAABBBCCCCBBBDDDDEEEEEEEEEEDDDAAA
+ *   Sample:  ⎣A⎦⎣B⎦⎣C-⎦⎣B⎦⎣D-⎦⎣E-------⎦⎣D⎦⎣A⎦
+ *
+ * Insert a sample for each discrete bit of self time.
+ *
+ *   SampleTable = {
+ *     stack:  [A,  B,  C,  B,  D,  E,  D,  A ],
+ *     time:   [0,  3,  6,  10, 14, 17, 27, 30],
+ *     weight: [3,  3,  4,  3,  4,  10, 3,  3 ]
+ *   }
+
+ */
+export function getSelfTimeSamplesFromJsTracer(
+  thread: Thread,
+  jsTracer: JsTracerFixed,
+  stackMap: Map<IndexIntoJsTracerEvents, IndexIntoStackTable>
+): SamplesTable {
+  // Give more leeway for floating number precision issues.
+  const epsilon = 1e-5;
+  const isNearlyEqual = (a, b) => Math.abs(a - b) < epsilon;
+  // Each event type will have it's own timing information, later collapse these into
+  // a single array.
+  const { stringTable } = thread;
+  const samples = getEmptySamplesTable();
+  const sampleWeights = [];
+  samples.duration = sampleWeights;
+
+  function addSelfTimeAsASample(
+    eventIndex: IndexIntoJsTracerEvents,
+    start: Microseconds,
+    end: Microseconds
+  ): void {
+    // Use a check against the epsilon, for float precision issues.
+    if (isNearlyEqual(start, end)) {
+      // If this self time is 0, do not report it.
+      return;
+    }
+    const stackIndex = ensureExists(
+      stackMap.get(eventIndex),
+      'The JS tracer event did not exist in the stack map.'
+    );
+    samples.stack.push(stackIndex);
+    samples.time.push(
+      // Convert from microseconds.
+      start / 1000
+    );
+    sampleWeights.push(
+      // The weight of the sample is in microseconds.
+      (end - start) / 1000
+    );
+    samples.length++;
+  }
+  // Determine the self time of the various events.
+
+  // These arrays implement the stack of "prefix" events. This is implemented as 3
+  // arrays instead of an array of objects to reduce the GC pressure in this tight
+  // loop, but conceptually this is just one stack, not 3 stacks. At any given time,
+  // the stack represents the prefixes, aka the parents, of the current event.
+  const prefixesStarts: Microseconds[] = [];
+  const prefixesEnds: Microseconds[] = [];
+  const prefixesEventIndexes: IndexIntoJsTracerEvents[] = [];
+
+  // If there is no prefix, set it to -1. This simplifies some of the real-time
+  // type checks that would be required by Flow for this mutable variable.
+  let prefixesTip = -1;
+
+  // Go through all of the events. Each `if` branch is documented with a small diagram
+  // that includes a little bit of ascii art to help explain the step.
+  //
+  // Legend:
+  // xxxxxxxx - Already reported information, not part of the prefix stack.
+  // [======] - Some event on the stack that has not been reported.
+  // [prefix] - The prefix event to consider, the top of the prefix stack. This
+  //            could also be only part of an event, that has been split into multiple
+  //            pieces.
+  // [current] - The current event to add.
+
+  for (
+    let currentEventIndex = 0;
+    currentEventIndex < jsTracer.length;
+    currentEventIndex++
+  ) {
+    const currentStart = jsTracer.start[currentEventIndex];
+    const currentEnd = jsTracer.end[currentEventIndex];
+
+    if (prefixesTip === -1) {
+      // Nothing has been added yet, add this "current" event to the stack of prefixes.
+      prefixesTip = 0;
+      prefixesStarts[prefixesTip] = currentStart;
+      prefixesEnds[prefixesTip] = currentEnd;
+      prefixesEventIndexes[prefixesTip] = currentEventIndex;
+      continue;
+    }
+
+    while (true) {
+      const prefixStart = prefixesStarts[prefixesTip];
+      const prefixEnd = prefixesEnds[prefixesTip];
+      const prefixEventIndex = prefixesEventIndexes[prefixesTip];
+
+      // The following if/else blocks go through every potential case of timing for the
+      // the data, and finally throw if those cases weren't handled. Each block should
+      // have a diagram explaining the various states the timing can be in. Inside the
+      // if checks, the loop is either continued or broken.
+
+      if (prefixEnd <= currentStart + epsilon) {
+        // In this case, the "current" event has passed the other "prefix" event.
+        //
+        //    xxxxxxxxxxxxxxxx[================]
+        //    xxxxxxxx[======]     [current]
+        //    [prefix]
+        //
+        // This next step would match too:
+        //
+        //    xxxxxxxxxxxxxxxx[================]
+        //    xxxxxxxx[prefix]     [current]
+        //    xxxxxxxx
+
+        // Commit the previous "prefix" event, then continue on with this loop.
+        addSelfTimeAsASample(prefixEventIndex, prefixStart, prefixEnd);
+
+        // Move the tip towards the prefix.
+        prefixesTip--;
+
+        if (prefixesTip === -1) {
+          // This next step would match too:
+          //
+          //   [prefix]     [current]
+
+          // There are no more "prefix" events to commit. Add the "current" event on, and
+          // break out of this loop.
+          prefixesTip = 0;
+          prefixesEventIndexes[prefixesTip] = currentEventIndex;
+          prefixesStarts[prefixesTip] = currentStart;
+          prefixesEnds[prefixesTip] = currentEnd;
+          break;
+        }
+
+        // Move up the prefix stack to report more self times. This is the only branch
+        // that has a `continue`, and not a `break`.
+        continue;
+      } else if (currentEnd < prefixEnd + epsilon) {
+        // The current event occludes the prefix event.
+        //
+        //   [prefix=================]
+        //           [current]
+        //
+        // Split the reported self time of the prefix.
+        //
+        //   [prefix]xxxxxxxxx[prefix]
+        //           [current]
+        //
+        //                    ^leave the second prefix piece on the "prefixes" stack
+        //   ^report the first prefix piece
+        //
+        //   After reporting we are left with:
+        //
+        //   xxxxxxxxxxxxxxxxx[======]
+        //           [current]
+
+        // Report the first part of the prefix's self time.
+        addSelfTimeAsASample(prefixEventIndex, prefixStart, currentStart);
+
+        // Shorten the prefix's start time.
+        prefixesStarts[prefixesTip] = currentEnd;
+
+        // Now add on the "current" event to the stack of prefixes.
+        prefixesTip++;
+        prefixesStarts[prefixesTip] = currentStart;
+        prefixesEnds[prefixesTip] = currentEnd;
+        prefixesEventIndexes[prefixesTip] = currentEventIndex;
+        break;
+      } else if (isNearlyEqual(prefixEnd, currentEnd)) {
+        if (!isNearlyEqual(prefixStart, currentStart)) {
+          // The current event splits the event above it, so split the reported self
+          // time of the prefix.
+          //
+          //   [prefix]xxxxxxxxx
+          //           [current]
+
+          // Report the prefix's self time.
+          addSelfTimeAsASample(prefixEventIndex, prefixStart, currentStart);
+
+          // Update both the index and the start time.
+          prefixesStarts[prefixesTip] = currentStart;
+          prefixesEventIndexes[prefixesTip] = currentEventIndex;
+        } else {
+          // The prefix and current events completely match, so don't report any
+          // self time from the prefix. Replace the prefix's index.
+          prefixesEventIndexes[prefixesTip] = currentEventIndex;
+        }
+        break;
+      } else {
+        // There is some error in the data structure or this functions logic. Throw
+        // an error, and report some nice information to the console.
+        const prefixName = stringTable.getString(
+          jsTracer.events[prefixEventIndex]
+        );
+        const currentName = stringTable.getString(
+          jsTracer.events[currentEventIndex]
+        );
+        console.error('Current JS Tracer information:', {
+          jsTracer,
+          stringTable,
+          prefixEventIndex,
+          currentEventIndex,
+        });
+        console.error(
+          `Prefix (parent) times for "${prefixName}": ${prefixStart}ms to ${prefixEnd}ms`
+        );
+        console.error(
+          `Current (child) times for "${currentName}": ${currentStart}ms to ${currentEnd}ms`
+        );
+        throw new Error(
+          'The JS Tracer information was malformed. Some event lasted longer than its parent event.'
+        );
+      }
+    }
+  }
+
+  // Drain off the remaining "prefixes" from the stack, and report the self time.
+  for (; prefixesTip >= 0; prefixesTip--) {
+    addSelfTimeAsASample(
+      prefixesEventIndexes[prefixesTip],
+      prefixesStarts[prefixesTip],
+      prefixesEnds[prefixesTip]
+    );
+  }
+
+  return samples;
+}
+
+/**
+ * Create a map that keys off of the string `${fileName}:${line}:${column}`. This maps
+ * the JS tracer script locations to functions in the profiling data structure.
+ * This operation can fail, as there is no guarantee that every location in the JS
+ * tracer information was sampled.
+ */
+function getScriptLocationToFuncIndex(
+  thread: Thread
+): Map<string, IndexIntoFuncTable | null> {
+  const { funcTable, stringTable } = thread;
+  const scriptLocationToFuncIndex = new Map();
+  for (let funcIndex = 0; funcIndex < funcTable.length; funcIndex++) {
+    if (!funcTable.isJS[funcIndex]) {
+      continue;
+    }
+    const line = funcTable.lineNumber[funcIndex];
+    const column = funcTable.columnNumber[funcIndex];
+    const fileNameIndex = funcTable.fileName[funcIndex];
+    if (column !== null && line !== null && fileNameIndex !== null) {
+      const fileName = stringTable.getString(fileNameIndex);
+      const key = `${fileName}:${line}:${column}`;
+      if (scriptLocationToFuncIndex.has(key)) {
+        // Multiple functions map to this script location.
+        scriptLocationToFuncIndex.set(key, null);
+      } else {
+        scriptLocationToFuncIndex.set(key, funcIndex);
+      }
+    }
+  }
+  return scriptLocationToFuncIndex;
 }

--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -67,8 +67,8 @@ export function getJsTracerTiming(
     tracerEventIndex++
   ) {
     const stringIndex = jsTracer.events[tracerEventIndex];
-    const column = jsTracer.columns[tracerEventIndex];
-    const line = jsTracer.lines[tracerEventIndex];
+    const column = jsTracer.column[tracerEventIndex];
+    const line = jsTracer.line[tracerEventIndex];
 
     // By default we use the display name from JS tracer, but we may update it if
     // we can figure out more information about it.

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -133,7 +133,7 @@ export function getStackAndSampleSelectorsPerThread(
   );
 
   const getSamplesSelectedStatesInFilteredThread: Selector<
-    SelectedState[]
+    null | SelectedState[]
   > = createSelector(
     threadSelectors.getFilteredThread,
     getCallNodeInfo,
@@ -143,6 +143,10 @@ export function getStackAndSampleSelectorsPerThread(
       { callNodeTable, stackIndexToCallNodeIndex },
       selectedCallNode
     ) => {
+      if (thread.isJsTracer) {
+        // This is currently to slow to compute in JS Tracer threads.
+        return null;
+      }
       const sampleIndexToCallNodeIndex = ProfileData.getSampleIndexToCallNodeIndex(
         thread.samples.stack,
         stackIndexToCallNodeIndex

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -690,8 +690,8 @@ export function getJsTracerTable(
     jsTracer.events.push(stringIndex);
     jsTracer.timestamps.push(start * 1000);
     jsTracer.durations.push((end - start) * 1000);
-    jsTracer.lines.push(null);
-    jsTracer.columns.push(null);
+    jsTracer.line.push(null);
+    jsTracer.column.push(null);
     jsTracer.length++;
   }
 

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1837,7 +1837,8 @@ CallTree {
       -1,
     ],
   },
-  "_isIntegerInterval": true,
+  "_interval": 1,
+  "_isHighPrecision": false,
   "_jsOnly": false,
   "_resourceTable": Object {
     "host": Array [],

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -7,12 +7,138 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
 import {
+  convertJsTracerToThread,
+  getJsTracerFixed,
+} from '../../profile-logic/js-tracer';
+import { getEmptyProfile } from '../../profile-logic/data-structures';
+import { formatTree } from '../fixtures/utils';
+import {
   getProfileFromTextSamples,
   getProfileWithJsTracerEvents,
   type TestDefinedJsTracerEvent,
 } from '../fixtures/profiles/processed-profile';
 
 import type { Profile } from '../../types/profile';
+
+describe('jsTracerFixed', function() {
+  function fixTiming(events: *) {
+    const profile = getProfileWithJsTracerEvents(events);
+    const jsTracer = ensureExists(profile.threads[0].jsTracer);
+    const jsTracerFixed = getJsTracerFixed(jsTracer);
+    return {
+      start: jsTracerFixed.start,
+      end: jsTracerFixed.end,
+    };
+  }
+  it('does not modify a valid structure', function() {
+    const timing = fixTiming([
+      // [mozilla                  ]
+      //  [int   ][ion          ]
+      //   [int]    [ion      ]
+      ['https://mozilla.org', 0, 20],
+      ['Interpreter', 1, 5],
+      ['Interpreter', 2, 4],
+      ['IonMonkey', 5, 19],
+      ['IonMonkey', 6, 18],
+    ]);
+    expect(timing).toEqual({
+      start: [0, 1000, 2000, 5000, 6000],
+      end: [20000, 5000, 4000, 19000, 18000],
+    });
+  });
+
+  it('fixes overlapping structures, cutting off the beginning', function() {
+    const timing = fixTiming([
+      // [aaaaaa]
+      //      [bbbbbbbbb]
+      ['a', 0, 5],
+      ['b', 4, 9],
+    ]);
+    expect(timing).toEqual({
+      // [aaaaaa][bbbbbb]
+      start: [0, 5000],
+      end: [5000, 9000],
+    });
+  });
+
+  it('fixes overlapping structures, cutting off the end', function() {
+    const timing = fixTiming([
+      // [aaaaaa]
+      //   [bbbbbb]
+      ['a', 0, 5],
+      ['b', 1, 6],
+    ]);
+    expect(timing).toEqual({
+      // [aaaaaa][bbbbbb]
+      start: [0, 1000],
+      end: [5000, 5000],
+    });
+  });
+
+  it('fixes events which are too early', function() {
+    const timing = fixTiming([
+      //    [aaaaaa]
+      // [bbbbbb]
+      ['a', 3, 8],
+      ['b', 1, 6],
+    ]);
+    expect(timing).toEqual({
+      //    [aaaaaa]
+      //    [bbb]
+      start: [3000, 3000],
+      end: [8000, 6000],
+    });
+  });
+
+  it('fixes events which are way too early', function() {
+    const timing = fixTiming([
+      //         [aaaa]
+      // [bbb]
+      ['a', 5, 9],
+      ['b', 0, 2],
+    ]);
+    expect(timing).toEqual({
+      //    [aaaaaa]
+      //    [bbb]
+      start: [5000, 5000],
+      end: [9000, 7000],
+    });
+  });
+});
+
+describe('convertJsTracerToThread', function() {
+  it('can generate stacks correctly', function() {
+    const existingProfile = getProfileWithJsTracerEvents([
+      // [mozilla                  ]
+      //  [int   ][ion          ]
+      //   [int]    [ion      ]
+      ['https://mozilla.org', 0, 20],
+      ['Interpreter', 1, 5],
+      ['Interpreter', 2, 4],
+      ['IonMonkey', 5, 19],
+      ['IonMonkey', 6, 18],
+    ]);
+    const existingThread = existingProfile.threads[0];
+    const categories = existingProfile.meta.categories;
+
+    const profile = getEmptyProfile();
+    const jsTracer = ensureExists(existingThread.jsTracer);
+    profile.threads = [
+      convertJsTracerToThread(existingThread, jsTracer, categories),
+    ];
+    const { getState } = storeWithProfile(profile);
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      // This is the real timing:
+      '- https://mozilla.org (total: 20, self: 2)',
+      '  - Interpreter (total: 18, self: 2)',
+      '    - IonMonkey (total: 14, self: 2)',
+      '      - IonMonkey (total: 12, self: 12)',
+      '    - Interpreter (total: 2, self: 2)',
+    ]);
+  });
+});
 
 describe('selectors/getJsTracerTiming', function() {
   describe('full stack-based view', function() {

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -236,10 +236,10 @@ describe('selectors/getJsTracerTiming', function() {
         );
 
         // Manually update the JS tracer events to point to the right column numbers.
-        jsTracer.lines[2] = fooLine;
-        jsTracer.columns[2] = fooColumn;
-        jsTracer.lines[3] = barLine;
-        jsTracer.columns[3] = barColumn;
+        jsTracer.line[2] = fooLine;
+        jsTracer.column[2] = fooColumn;
+        jsTracer.line[3] = barLine;
+        jsTracer.column[3] = barColumn;
       }
 
       expect(

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -266,8 +266,8 @@ export type JsTracerTable = {|
   events: Array<IndexIntoStringTable>,
   timestamps: Array<Microseconds>,
   durations: Array<Microseconds | null>,
-  lines: Array<number | null>, // Line number.
-  columns: Array<number | null>, // Column number.
+  line: Array<number | null>, // Line number.
+  column: Array<number | null>, // Column number.
   length: number,
 |};
 

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -376,6 +376,7 @@ export type Thread = {|
   pausedRanges: PausedRange[],
   name: string,
   processName?: string,
+  isJsTracer?: boolean,
   pid: Pid,
   tid: number | void,
   samples: SamplesTable,

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -76,22 +76,22 @@ export function formatNumber(
 }
 
 /**
- * When the interval is an integer, then there will never be fractions for timing
- * information in the call tree. In this case it's nice to display integers. If the
- * interval is fractional, then timing information could be nicer with more precise
- * numbers. This function handles this formatting method.
- *
- * e.g. (true, 6.0) => "6"
- * e.g. (false, 6.0) => "6.0"
- * e.g. (true, 6.555) => "6"
- * e.g. (false, 6.555) => "6.6"
+ * Format call node numbers consistently.
  */
-export function formatNumberDependingOnInterval(
-  isIntegerInterval: boolean,
+export function formatCallNodeNumber(
+  interval: number,
+  isHighPrecision: boolean,
   number: number
 ): string {
-  const maxFractionalDigits = isIntegerInterval ? 0 : 1;
-  return formatNumber(number, 3, maxFractionalDigits);
+  // If the interval is an integer, display the number as an integer.
+  let precision = Number.isInteger(interval) ? 0 : 1;
+
+  if (isHighPrecision) {
+    // Sometimes the number should be high precision, such as on a JS tracer thread
+    // which has timing to the microsecond.
+    precision = 3;
+  }
+  return formatNumber(number, 3, precision);
 }
 
 export function formatPercent(value: number): string {


### PR DESCRIPTION
This PR takes the JS Tracer data format, and converts it into a process profile `Thread`. It also tweaks the UI so that it doesn't (mostly) catastrophically fail and hang on bad performance issues.

I had to go back in time a bit and build an older Firefox to capture the JS tracer information. It's currently disabled and column information is wrong.

[Deploy preview](https://deploy-preview-2104--perf-html.netlify.com/public/51f0d427c46cddee939eee0b4567e9711c373d58)

