### PR TITLE
Do not select the heaviest stack if it's in the Idle category

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -164,7 +164,15 @@ class CallTreeComponent extends PureComponent<Props> {
       newExpandedCallNodeIndexes.push(currentCallNodeIndex);
     }
     this._onExpandedCallNodesChange(newExpandedCallNodeIndexes);
-    this._onSelectedCallNodeChange(currentCallNodeIndex);
+
+    const category = tree.getDisplayData(currentCallNodeIndex).categoryName;
+    if (category !== 'Idle') {
+      // If we selected the call node with a "idle" category, we'd have a
+      // completely dimmed activity graph because idle stacks are not drawn in
+      // this graph. Because this isn't probably what the average user wants we
+      // do it only when the category is something different.
+      this._onSelectedCallNodeChange(currentCallNodeIndex);
+    }
   }
 
   render() {

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -270,6 +270,26 @@ describe('calltree/ProfileCallTreeView', function() {
     expect(getRowElement('A')).toHaveClass('isSelected');
     expect(getRowElement('A')).not.toHaveClass('isRightClicked');
   });
+
+  it('selects the heaviest stack if it is not idle', () => {
+    const { profile } = getProfileFromTextSamples(`
+      A  A  A  A  A
+      B  C  C  C  D
+      E           E
+    `);
+    const { getRowElement } = setup(profile);
+    expect(getRowElement('C')).toHaveClass('isSelected');
+  });
+
+  it('does not select the heaviest stack if it is idle', () => {
+    const { profile } = getProfileFromTextSamples(`
+      A  A            A            A            A
+      B  C[cat:Idle]  C[cat:Idle]  C[cat:Idle]  D
+      E                                         E
+    `);
+    const { container } = setup(profile);
+    expect(container.querySelector('.treeViewRow.isSelected')).toBeFalsy();
+  });
 });
 
 describe('calltree/ProfileCallTreeView EmptyReasons', function() {


### PR DESCRIPTION
Fixes #2105

[Example when not selecting an idle stack](https://deploy-preview-2107--perf-html.netlify.com/public/a2132f475f0dcbb12d94338ed1433c7681509a82/calltree/?globalTrackOrder=9-0-1-2-3-4-5-6-7-8&hiddenGlobalTracks=2-3-5-6-7&localTrackOrderByPid=3198-1-0~17138-0~10890-0~&thread=0&v=3)
[Example when selecting a not idle stack](https://deploy-preview-2107--perf-html.netlify.com/public/a2132f475f0dcbb12d94338ed1433c7681509a82/calltree/?globalTrackOrder=9-0-1-2-3-4-5-6-7-8&hiddenGlobalTracks=2-3-5-6-7&localTrackOrderByPid=3198-1-0~17138-0~10890-0~&range=3.1329_3.8066&thread=0&v=3)