### PR TITLE
Move the getVisibleTabs selector to the threadSelectors so that we ca…

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -289,13 +289,13 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
       }
     }
 
-    if (
-      selectedTab === 'js-tracer' &&
-      getThreadSelectors(selectedThreadIndex).getJsTracerTable(getState()) ===
-        null
-    ) {
-      // If the user switches to another thread that doesn't have JS Tracer information,
-      // then switch to the calltree.
+    const doesNextTrackHaveSelectedTab = getThreadSelectors(selectedThreadIndex)
+      .getUsefulTabs(getState())
+      .includes(selectedTab);
+
+    if (!doesNextTrackHaveSelectedTab) {
+      // If the user switches to another track that doesn't have the current
+      // selectedTab then switch to the calltree.
       selectedTab = 'calltree';
     }
 

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -21,7 +21,8 @@ import selectSidebar from '../sidebar';
 
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
 import { getSelectedTab } from '../../selectors/url-state';
-import { getIsSidebarOpen, getVisibleTabs } from '../../selectors/app';
+import { getIsSidebarOpen } from '../../selectors/app';
+import { selectedThreadSelectors } from '../../selectors/per-thread';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerContextMenu from '../shared/MarkerContextMenu';
 import TimelineTrackContextMenu from '../timeline/TrackContextMenu';
@@ -114,7 +115,7 @@ class ProfileViewer extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
-    visibleTabs: getVisibleTabs(state),
+    visibleTabs: selectedThreadSelectors.getUsefulTabs(state),
     selectedTab: getSelectedTab(state),
     isSidebarOpen: getIsSidebarOpen(state),
   }),

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -10,8 +10,6 @@ import {
   getHiddenGlobalTracks,
   getHiddenLocalTracksByPid,
 } from './url-state';
-import { tabSlugs } from '../app-logic/tabs-handling';
-import { selectedThreadSelectors } from './per-thread';
 import { getGlobalTracks, getLocalTracksByPid } from './profile';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import {
@@ -50,25 +48,6 @@ export const getTrackThreadHeights: Selector<
 > = state => getApp(state).trackThreadHeights;
 export const getIsNewlyPublished: Selector<boolean> = state =>
   getApp(state).isNewlyPublished;
-
-/**
- * Visible tabs are computed based on the current state of the profile. Some
- * effort is made to not show a tab when there is no data available for it.
- */
-export const getVisibleTabs: Selector<$ReadOnlyArray<TabSlug>> = createSelector(
-  selectedThreadSelectors.getIsNetworkChartEmptyInFullRange,
-  selectedThreadSelectors.getJsTracerTable,
-  (isNetworkChartEmpty, jsTracerTable) => {
-    let visibleTabs = tabSlugs;
-    if (isNetworkChartEmpty) {
-      visibleTabs = visibleTabs.filter(tabSlug => tabSlug !== 'network-chart');
-    }
-    if (!jsTracerTable) {
-      visibleTabs = visibleTabs.filter(tabSlug => tabSlug !== 'js-tracer');
-    }
-    return visibleTabs;
-  }
-);
 
 /**
  * This selector takes all of the tracks, and deduces the height in CssPixels

--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { createSelector } from 'reselect';
+
+import { tabSlugs, type TabSlug } from '../../app-logic/tabs-handling';
+
+import type { Selector } from '../../types/store';
+import type { $ReturnType } from '../../types/utils';
+import type { Thread, JsTracerTable } from '../../types/profile';
+
+/**
+ * Infer the return type from the getStackAndSampleSelectorsPerThread function. This
+ * is done that so that the local type definition with `Selector<T>` is the canonical
+ * definition for the type of the selector.
+ */
+export type ComposedSelectorsPerThread = $ReturnType<
+  typeof getComposedSelectorsPerThread
+>;
+
+/**
+ * This type contains the selectors needed for the extra selectors defined in
+ * this file. It's non-exact because the passed object _will_ contain more
+ * elements that we don't use here, and that's OK.
+ */
+type NeededThreadSelectors = {
+  getThread: Selector<Thread>,
+  getIsNetworkChartEmptyInFullRange: Selector<boolean>,
+  getJsTracerTable: Selector<JsTracerTable | null>,
+};
+
+/**
+ * Create the selectors for a thread that have to do with either stacks or samples.
+ */
+export function getComposedSelectorsPerThread(
+  threadSelectors: NeededThreadSelectors
+): * {
+  /**
+   * Visible tabs are computed based on the current state of the profile. Some
+   * effort is made to not show a tab when there is no data available for it or
+   * when it's absurd.
+   */
+  const getUsefulTabs: Selector<$ReadOnlyArray<TabSlug>> = createSelector(
+    threadSelectors.getIsNetworkChartEmptyInFullRange,
+    threadSelectors.getJsTracerTable,
+    (isNetworkChartEmpty, jsTracerTable) => {
+      let visibleTabs = tabSlugs;
+      if (isNetworkChartEmpty) {
+        visibleTabs = visibleTabs.filter(
+          tabSlug => tabSlug !== 'network-chart'
+        );
+      }
+      if (!jsTracerTable) {
+        visibleTabs = visibleTabs.filter(tabSlug => tabSlug !== 'js-tracer');
+      }
+      return visibleTabs;
+    }
+  );
+
+  return {
+    getUsefulTabs,
+  };
+}

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -17,6 +17,10 @@ import {
   getStackAndSampleSelectorsPerThread,
   type StackAndSampleSelectorsPerThread,
 } from './stack-sample';
+import {
+  getComposedSelectorsPerThread,
+  type ComposedSelectorsPerThread,
+} from './composed';
 import * as ProfileSelectors from '../profile';
 
 import type { ThreadIndex } from '../../types/profile';
@@ -34,6 +38,7 @@ export type ThreadSelectors = {|
   ...ThreadSelectorsPerThread,
   ...MarkerSelectorsPerThread,
   ...StackAndSampleSelectorsPerThread,
+  ...ComposedSelectorsPerThread,
 |};
 
 /**
@@ -50,11 +55,21 @@ export const getThreadSelectors = (
   threadIndex: ThreadIndex
 ): ThreadSelectors => {
   if (!(threadIndex in _threadSelectorsCache)) {
-    const threadSelectors = getThreadSelectorsPerThread(threadIndex);
+    // We define the thread selectors in 3 steps to ensure clarity in the
+    // separate files.
+    // 1. The basic selectors.
+    let selectors = getThreadSelectorsPerThread(threadIndex);
+    // 2. Stack, sample and marker selectors that need the previous basic
+    // selectors for their own definition.
+    selectors = {
+      ...selectors,
+      ...getStackAndSampleSelectorsPerThread(selectors),
+      ...getMarkerSelectorsPerThread(selectors),
+    };
+    // 3. Other selectors that need selectors from different files to be defined.
     _threadSelectorsCache[threadIndex] = {
-      ...threadSelectors,
-      ...getStackAndSampleSelectorsPerThread(threadSelectors),
-      ...getMarkerSelectorsPerThread(threadSelectors),
+      ...selectors,
+      ...getComposedSelectorsPerThread(selectors),
     };
   }
   return _threadSelectorsCache[threadIndex];

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -10,12 +10,6 @@ import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { isolateProcess } from '../../actions/profile-view';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
-import {
-  getProfileFromTextSamples,
-  getProfileWithMarkers,
-  getNetworkMarkers,
-  getProfileWithJsTracerEvents,
-} from '../fixtures/profiles/processed-profile';
 
 import * as AppActions from '../../actions/app';
 
@@ -44,46 +38,6 @@ describe('app actions', function() {
           ],
         ]);
       });
-    });
-  });
-
-  describe('visibleTabs', function() {
-    it('hides the network chart and JS tracer when no data is in the thread', function() {
-      const { profile } = getProfileFromTextSamples('A');
-      const { getState } = storeWithProfile(profile);
-      expect(AppSelectors.getVisibleTabs(getState())).toEqual([
-        'calltree',
-        'flame-graph',
-        'stack-chart',
-        'marker-chart',
-        'marker-table',
-      ]);
-    });
-
-    it('shows the network chart when network markers are present in the thread', function() {
-      const profile = getProfileWithMarkers(getNetworkMarkers());
-      const { getState } = storeWithProfile(profile);
-      expect(AppSelectors.getVisibleTabs(getState())).toEqual([
-        'calltree',
-        'flame-graph',
-        'stack-chart',
-        'marker-chart',
-        'marker-table',
-        'network-chart',
-      ]);
-    });
-
-    it('shows the js tracer when it is available in a thread', function() {
-      const profile = getProfileWithJsTracerEvents([['A', 0, 10]]);
-      const { getState } = storeWithProfile(profile);
-      expect(AppSelectors.getVisibleTabs(getState())).toEqual([
-        'calltree',
-        'flame-graph',
-        'stack-chart',
-        'marker-chart',
-        'marker-table',
-        'js-tracer',
-      ]);
     });
   });
 

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import { selectedThreadSelectors } from '../../selectors/per-thread';
+
+import { storeWithProfile } from '../fixtures/stores';
+import {
+  getProfileFromTextSamples,
+  getProfileWithMarkers,
+  getNetworkMarkers,
+  getProfileWithJsTracerEvents,
+} from '../fixtures/profiles/processed-profile';
+
+describe('getUsefulTabs', function() {
+  it('hides the network chart and JS tracer when no data is in the thread', function() {
+    const { profile } = getProfileFromTextSamples('A');
+    const { getState } = storeWithProfile(profile);
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'calltree',
+      'flame-graph',
+      'stack-chart',
+      'marker-chart',
+      'marker-table',
+    ]);
+  });
+
+  it('shows the network chart when network markers are present in the thread', function() {
+    const profile = getProfileWithMarkers(getNetworkMarkers());
+    const { getState } = storeWithProfile(profile);
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'calltree',
+      'flame-graph',
+      'stack-chart',
+      'marker-chart',
+      'marker-table',
+      'network-chart',
+    ]);
+  });
+
+  it('shows the js tracer when it is available in a thread', function() {
+    const profile = getProfileWithJsTracerEvents([['A', 0, 10]]);
+    const { getState } = storeWithProfile(profile);
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'calltree',
+      'flame-graph',
+      'stack-chart',
+      'marker-chart',
+      'marker-table',
+      'js-tracer',
+    ]);
+  });
+});


### PR DESCRIPTION
…n compute it for any thread

I needed this in the other PR for the diffing track: when selecting a track, I need to know the visible tabs for that track so that I can force a switch to the call tree in case the current tab isn't available. This is already done for the js tracer tab in a hardcoded way, but I need a more generic way for that patch, so here it is.

[deploy preview](https://deploy-preview-2111--perf-html.netlify.com/public/8fed9b4ab59d627c3d21cb512252aefbe9861d5a/calltree/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2&localTrackOrderByPid=4844-1-0~5002-0~4897-0~&thread=1&v=4): the Compositor track doesn't have a js tracer object, so we can test selecting it while the jstracer tab is displayed.