### PR TITLE
Fix symbolication in local builds

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -57,6 +57,7 @@ import type {
   ThreadIndex,
   IndexIntoFuncTable,
 } from '../types/profile';
+import { assertExhaustiveCheck } from '../utils/flow';
 
 /**
  * This file collects all the actions that are used for receiving the profile in the
@@ -1035,7 +1036,10 @@ export function getProfilesFromRawUrl(
       case 'local':
         throw new Error(`There is no profile to download`);
       default:
-        throw new Error(`Unknown datasource ${dataSource}`);
+        throw assertExhaustiveCheck(
+          dataSource,
+          `Unknown dataSource ${dataSource}.`
+        );
     }
 
     return {

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -84,28 +84,27 @@ class UrlManager extends React.PureComponent<Props> {
       setupInitialUrlState,
       urlSetupDone,
     } = this.props;
-    let profile: Profile | null = null;
-    let error;
-
     startFetchingProfiles();
 
     try {
       // Process the raw url and fetch the profile.
       // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
-      profile = await getProfilesFromRawUrl(window.location);
-    } catch (err) {
-      error = err;
-    }
+      const results: {
+        profile: Profile,
+        shouldSetupInitialUrlState: boolean,
+      } = await getProfilesFromRawUrl(window.location);
 
-    if (profile) {
-      setupInitialUrlState(window.location, profile);
-    } else if (error) {
-      // Just silently finish the url setup.
+      // Manually coerce these into the proper type due to the FlowFixMe above.
+      const profile: Profile = results.profile;
+      const shouldSetupInitialUrlState: boolean = results.dataSource;
+      if (shouldSetupInitialUrlState) {
+        setupInitialUrlState(window.location, profile);
+      } else {
+        urlSetupDone();
+      }
+    } catch (error) {
+      // Silently complete the url setup.
       urlSetupDone();
-    } else {
-      throw new Error(
-        'An unhandled case was reached during the initial processing of URLs'
-      );
     }
   }
 

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -100,7 +100,7 @@ class UrlManager extends React.PureComponent<Props> {
     if (profile) {
       setupInitialUrlState(window.location, profile);
     } else if (error) {
-      // Just silently finish the url setup and return to home.
+      // Just silently finish the url setup.
       urlSetupDone();
     } else {
       throw new Error(
@@ -154,8 +154,7 @@ class UrlManager extends React.PureComponent<Props> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { urlSetupPhase } = this.props;
-    if (urlSetupPhase !== 'done') {
+    if (nextProps.urlSetupPhase !== 'done') {
       return;
     }
     const newUrl = urlFromState(nextProps.urlState);


### PR DESCRIPTION
Removing initialLoad argument from retrieveProfileFromAddon function
because we don't need to upgrade the urls during intial url processing
for the profiles from addon anyway. After removing this argument,
`finalizeProfileView` will be called immediately after `loadProfile`
and symbolication will happen at that time instead of waiting for url
processing.

Fixes #2110.