### PR TITLE
[deploy-preview] Include frame labels in JS implementation filtered threads

### DIFF
--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -40,10 +40,12 @@ import type {
 } from '../../profile-logic/stack-timing';
 import type { Viewport } from '../shared/chart/Viewport';
 import type { WrapFunctionInDispatch } from '../../utils/connect';
+import type { ImplementationFilter } from '../../types/actions';
 
 type OwnProps = {|
   +thread: Thread,
   +interval: Milliseconds,
+  +implementationFilter: ImplementationFilter,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +stackTimingByDepth: StackTimingByDepth,
@@ -146,6 +148,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
       stackFrameHeight,
       selectedCallNodeIndex,
       categories,
+      implementationFilter,
       callNodeInfo: { callNodeTable },
       viewport: {
         containerWidth,
@@ -297,10 +300,16 @@ class StackChartCanvas extends React.PureComponent<Props> {
           // Look up information about this stack frame.
           const callNodeIndex = stackTiming.callNode[i];
           const funcIndex = callNodeTable.func[callNodeIndex];
-          const funcNameIndex = thread.funcTable.name[funcIndex];
-          const text = thread.stringTable.getString(funcNameIndex);
           const categoryIndex = callNodeTable.category[callNodeIndex];
+          const isJS = thread.funcTable.isJS[funcIndex];
+          const relevantForJS = thread.funcTable.relevantForJS[funcIndex];
+          const funcNameIndex = thread.funcTable.name[funcIndex];
           const category = categories[categoryIndex];
+
+          const text =
+            implementationFilter === 'js' && !relevantForJS && !isJS
+              ? category.name
+              : thread.stringTable.getString(funcNameIndex);
 
           const isHovered =
             hoveredItem &&

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -301,15 +301,23 @@ class StackChartCanvas extends React.PureComponent<Props> {
           const callNodeIndex = stackTiming.callNode[i];
           const funcIndex = callNodeTable.func[callNodeIndex];
           const categoryIndex = callNodeTable.category[callNodeIndex];
+          const subCategoryIndex = callNodeTable.subcategory[callNodeIndex];
           const isJS = thread.funcTable.isJS[funcIndex];
           const relevantForJS = thread.funcTable.relevantForJS[funcIndex];
           const funcNameIndex = thread.funcTable.name[funcIndex];
           const category = categories[categoryIndex];
+          const subcategory = category.subcategories[subCategoryIndex];
 
-          const text =
-            implementationFilter === 'js' && !relevantForJS && !isJS
-              ? category.name
-              : thread.stringTable.getString(funcNameIndex);
+          let text;
+          if (implementationFilter === 'js' && !relevantForJS && !isJS) {
+            if (subcategory === 'Other') {
+              text = category.name;
+            } else {
+              text = subcategory;
+            }
+          } else {
+            text = thread.stringTable.getString(funcNameIndex);
+          }
 
           const isHovered =
             hoveredItem &&

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -18,7 +18,10 @@ import {
   getCategories,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import {
+  getSelectedThreadIndex,
+  getImplementationFilter,
+} from '../../selectors/url-state';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import StackSettings from '../shared/StackSettings';
 import TransformNavigator from '../shared/TransformNavigator';
@@ -39,7 +42,10 @@ import type {
   UnitIntervalOfProfileRange,
 } from '../../types/units';
 import type { StackTimingByDepth } from '../../profile-logic/stack-timing';
-import type { PreviewSelection } from '../../types/actions';
+import type {
+  PreviewSelection,
+  ImplementationFilter,
+} from '../../types/actions';
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');
@@ -48,6 +54,7 @@ const STACK_FRAME_HEIGHT = 16;
 
 type StateProps = {|
   +thread: Thread,
+  +implementationFilter: ImplementationFilter,
   +maxStackDepth: number,
   +stackTimingByDepth: StackTimingByDepth,
   +timeRange: { start: Milliseconds, end: Milliseconds },
@@ -135,6 +142,7 @@ class StackChartGraph extends React.PureComponent<Props> {
       categories,
       selectedCallNodeIndex,
       scrollToSelectionGeneration,
+      implementationFilter,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -169,6 +177,7 @@ class StackChartGraph extends React.PureComponent<Props> {
               chartProps={{
                 interval,
                 thread,
+                implementationFilter,
                 stackTimingByDepth,
                 // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
                 updatePreviewSelection,
@@ -207,6 +216,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
       threadIndex: getSelectedThreadIndex(state),
       callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
       categories: getCategories(state),
+      implementationFilter: getImplementationFilter(state),
       selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
         state
       ),

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -5,7 +5,7 @@
 import * as React from 'react';
 
 import { getStackType } from '../../profile-logic/transforms';
-import { objectEntries } from '../../utils/flow';
+import { objectEntries, assertExhaustiveCheck } from '../../utils/flow';
 import { formatNumberDependingOnInterval } from '../../utils/format-numbers';
 import NodeIcon from '../shared/NodeIcon';
 import {
@@ -210,8 +210,11 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           ? 'Unsymbolicated native'
           : 'Unsymbolicated or generated JIT instructions';
         break;
+      case 'label':
+        stackTypeLabel = 'Label';
+        break;
       default:
-        throw new Error(`Unknown stack type case "${stackType}".`);
+        throw assertExhaustiveCheck(stackType, 'Unhandled StackType.');
     }
 
     return (

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -1374,7 +1374,7 @@ export function getStackType(
   funcIndex: IndexIntoFuncTable
 ): StackType {
   if (FUNC_MATCHES.cpp(thread, funcIndex)) {
-    return 'native';
+    return thread.funcTable.address[funcIndex] === -1 ? 'label' : 'native';
   } else if (FUNC_MATCHES.js(thread, funcIndex)) {
     return 'js';
   }

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -153,7 +153,7 @@ export type AccumulatedCounterSamples = {|
   +accumulatedCounts: number[],
 |};
 
-export type StackType = 'js' | 'native' | 'unsymbolicated';
+export type StackType = 'js' | 'native' | 'unsymbolicated' | 'label';
 
 export type GlobalTrack =
   | {| +type: 'process', +pid: Pid, +mainThreadIndex: ThreadIndex | null |}


### PR DESCRIPTION
This is a hack to test out if it's useful to see label frame's categories in the JS-only implementation view.

[Deploy preview featuring subcategories](https://deploy-preview-2117--perf-html.netlify.com/public/01a5a01e1deffacdcb785c5930e34ef881ab8a90/stack-chart/?globalTrackOrder=7-0-1-5-2-3-4-6&hiddenGlobalTracks=2-3-4&implementation=js&localTrackOrderByPid=57585-1-0~57586-0~57589-0~&range=1.8988_2.8220&thread=6&v=4)

![image](https://user-images.githubusercontent.com/1588648/60532325-ae196880-9cc2-11e9-9dfc-908b27403128.png)
