### PR TITLE
Extract the time-based range -> sampleIndex-based range computation into a selector

### DIFF
--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -24,6 +24,7 @@ import {
   getEmptyRawMarkerTable,
 } from './data-structures';
 import {
+  getSampleIndexRangeForSelection,
   filterThreadSamplesToRange,
   getTimeRangeForThread,
   getTimeRangeIncludingAllThreads,
@@ -214,7 +215,12 @@ function filterThreadToRange(
   rangeStart: number,
   rangeEnd: number
 ): Thread {
-  thread = filterThreadSamplesToRange(thread, rangeStart, rangeEnd);
+  const { sampleStart, sampleEnd } = getSampleIndexRangeForSelection(
+    thread.samples,
+    rangeStart,
+    rangeEnd
+  );
+  thread = filterThreadSamplesToRange(thread, sampleStart, sampleEnd);
   thread.markers = filterRawMarkerTableToRange(
     thread.markers,
     rangeStart,

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -14,7 +14,10 @@ import {
   removeNetworkMarkerURLs,
   filterRawMarkerTableToRangeWithMarkersToDelete,
 } from './marker-data';
-import { filterThreadSamplesToRange } from './profile-data';
+import {
+  getSampleIndexRangeForSelection,
+  filterThreadSamplesToRange,
+} from './profile-data';
 import type { Profile, Thread, ThreadIndex } from '../types/profile';
 import type { RemoveProfileInformation } from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
@@ -227,7 +230,12 @@ function sanitizeThreadPII(
     // to range.
     if (PIIToBeRemoved.shouldFilterToCommittedRange !== null) {
       const { start, end } = PIIToBeRemoved.shouldFilterToCommittedRange;
-      newThread = filterThreadSamplesToRange(thread, start, end);
+      const { sampleStart, sampleEnd } = getSampleIndexRangeForSelection(
+        thread.samples,
+        start,
+        end
+      );
+      newThread = filterThreadSamplesToRange(thread, sampleStart, sampleEnd);
     } else {
       // Copying the thread even if we don't filter samples because we are gonna
       // change some fields later.

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -17,6 +17,7 @@ import {
   invertCallstack,
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
+  getSampleIndexRangeForSelection,
   filterThreadSamplesToRange,
 } from '../../profile-logic/profile-data';
 import { resourceTypes } from '../../profile-logic/data-structures';
@@ -572,9 +573,14 @@ describe('diffing trees', function() {
     const profile = getProfile();
     const rangeStart = 1;
     const rangeEnd = 3;
-    profile.threads = profile.threads.map(thread =>
-      filterThreadSamplesToRange(thread, rangeStart, rangeEnd)
-    );
+    profile.threads = profile.threads.map(thread => {
+      const { sampleStart, sampleEnd } = getSampleIndexRangeForSelection(
+        thread.samples,
+        rangeStart,
+        rangeEnd
+      );
+      return filterThreadSamplesToRange(thread, sampleStart, sampleEnd);
+    });
     const callTree = callTreeFromProfile(profile, /* threadIndex */ 2);
     const formattedTree = formatTree(callTree);
     expect(formattedTree).toEqual([

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -21,6 +21,10 @@ export type resourceTypeEnum = number;
 export type ThreadIndex = number;
 export type IndexIntoJsTracerEvents = number;
 export type CounterIndex = number;
+export type StartEndSampleRange = {|
+  +sampleStart: IndexIntoSamplesTable,
+  +sampleEnd: IndexIntoSamplesTable,
+|};
 
 /**
  * If a pid is a number, then it is the int value that came from the profiler.


### PR DESCRIPTION
Because we slice our samples table, I need the start index so that I can use it as an offset when retrieving a sample's duration in #2129. That's why I extracted this computation in a selectors.

I didn't add any new test because I thought the existing test would cover this new code as well. Tell me if you think otherwise and I can look at adding some!

There should be no behavior difference with this PR.

[production](https://profiler.firefox.com/public/280e10708c0660695ef5af145c53179d29d9796c/calltree/?globalTrackOrder=0-1-2-3-4&localTrackOrderByPid=31626-0~&range=5.7476_18.7125~8.7912_14.6125&thread=4&v=4)
[deploy preview](https://deploy-preview-2135--perf-html.netlify.com/public/280e10708c0660695ef5af145c53179d29d9796c/calltree/?globalTrackOrder=0-1-2-3-4&localTrackOrderByPid=31626-0~&range=5.7476_18.7125~8.7912_14.6125&thread=4&v=4)