### PR TITLE
Use the unfiltered thread when computing categories 

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -33,6 +33,8 @@ import type { Viewport } from '../shared/chart/Viewport';
 
 export type OwnProps = {|
   +thread: Thread,
+  +unfilteredThread: Thread,
+  +sampleIndexOffset: number,
   +maxStackDepth: number,
   +flameGraphTiming: FlameGraphTiming,
   +callNodeInfo: CallNodeInfo,
@@ -246,6 +248,8 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
   }: HoveredStackTiming): React.Node => {
     const {
       thread,
+      unfilteredThread,
+      sampleIndexOffset,
       flameGraphTiming,
       callTree,
       callNodeInfo,
@@ -282,6 +286,8 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
           interval,
           isInverted,
           thread,
+          unfilteredThread,
+          sampleIndexOffset,
           categories
         )}
       />

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -53,6 +53,8 @@ const SELECTABLE_THRESHOLD = 0.001;
 
 type StateProps = {|
   +thread: Thread,
+  +unfilteredThread: Thread,
+  +sampleIndexOffset: number,
   +maxStackDepth: number,
   +timeRange: { start: Milliseconds, end: Milliseconds },
   +previewSelection: PreviewSelection,
@@ -245,6 +247,8 @@ class FlameGraph extends React.PureComponent<Props> {
   render() {
     const {
       thread,
+      unfilteredThread,
+      sampleIndexOffset,
       threadIndex,
       maxStackDepth,
       flameGraphTiming,
@@ -295,6 +299,8 @@ class FlameGraph extends React.PureComponent<Props> {
             // FlameGraphCanvas props
             chartProps={{
               thread,
+              unfilteredThread,
+              sampleIndexOffset,
               maxStackDepth,
               flameGraphTiming,
               callTree,
@@ -328,6 +334,10 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
       thread: selectedThreadSelectors.getFilteredThread(state),
+      unfilteredThread: selectedThreadSelectors.getThread(state),
+      sampleIndexOffset: selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(
+        state
+      ),
       maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
         state
       ),

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -913,7 +913,7 @@ export function filterThreadToSearchString(
 /**
  * This function takes both a SamplesTable and can be used on CounterSamplesTable.
  */
-function _getSampleIndexRangeForSelection(
+export function getSampleIndexRangeForSelection(
   samples: SamplesTable | CounterSamplesTable | JsAllocationsTable,
   rangeStart: number,
   rangeEnd: number
@@ -938,7 +938,7 @@ export function filterThreadSamplesToRange(
   rangeEnd: number
 ): Thread {
   const { samples, jsAllocations } = thread;
-  const [beginSampleIndex, endSampleIndex] = _getSampleIndexRangeForSelection(
+  const [beginSampleIndex, endSampleIndex] = getSampleIndexRangeForSelection(
     samples,
     rangeStart,
     rangeEnd
@@ -962,7 +962,7 @@ export function filterThreadSamplesToRange(
   };
 
   if (jsAllocations) {
-    const [startAllocIndex, endAllocIndex] = _getSampleIndexRangeForSelection(
+    const [startAllocIndex, endAllocIndex] = getSampleIndexRangeForSelection(
       jsAllocations,
       rangeStart,
       rangeEnd
@@ -991,7 +991,7 @@ export function filterCounterToRange(
   rangeEnd: number
 ): Counter {
   const samples = counter.sampleGroups.samples;
-  let [sBegin, sEnd] = _getSampleIndexRangeForSelection(
+  let [sBegin, sEnd] = getSampleIndexRangeForSelection(
     samples,
     rangeStart,
     rangeEnd

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -147,6 +147,8 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
     ProfileSelectors.getProfileInterval,
     UrlState.getInvertCallstack,
     selectedThreadSelectors.getPreviewFilteredThread,
+    selectedThreadSelectors.getThread,
+    selectedThreadSelectors.getSampleIndexOffsetFromPreviewRange,
     ProfileSelectors.getCategories,
     ProfileData.getTimingsForPath
   );

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -132,6 +132,47 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     }
   );
 
+  /**
+   * This selector returns the offset to add to a sampleIndex when accessing the
+   * base thread, if your thread is a range filtered thread (all but the base
+   * `getThread` or the last `getPreviewFilteredThread`).
+   */
+  const getSampleIndexOffsetFromCommittedRange: Selector<number> = createSelector(
+    getThread,
+    ProfileSelectors.getCommittedRange,
+    ({ samples }, { start, end }) => {
+      const [beginSampleIndex] = ProfileData.getSampleIndexRangeForSelection(
+        samples,
+        start,
+        end
+      );
+      return beginSampleIndex;
+    }
+  );
+
+  /**
+   * This selector returns the offset to add to a sampleIndex when accessing the
+   * base thread, if your thread is the preview filtered thread.
+   */
+  const getSampleIndexOffsetFromPreviewRange: Selector<number> = createSelector(
+    getFilteredThread,
+    ProfileSelectors.getPreviewSelection,
+    getSampleIndexOffsetFromCommittedRange,
+    ({ samples }, previewSelection, sampleIndexFromCommittedRange) => {
+      if (!previewSelection.hasSelection) {
+        return sampleIndexFromCommittedRange;
+      }
+
+      const [beginSampleIndex] = ProfileData.getSampleIndexRangeForSelection(
+        samples,
+        previewSelection.selectionStart,
+        previewSelection.selectionEnd
+      );
+
+      return sampleIndexFromCommittedRange + beginSampleIndex;
+    }
+  );
+
   const getFriendlyThreadName: Selector<string> = createSelector(
     ProfileSelectors.getThreads,
     getThread,
@@ -208,6 +249,8 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getRangeFilteredThread,
     getRangeAndTransformFilteredThread,
     getPreviewFilteredThread,
+    getSampleIndexOffsetFromCommittedRange,
+    getSampleIndexOffsetFromPreviewRange,
     getFriendlyThreadName,
     getThreadProcessDetails,
     getTransformLabels,


### PR DESCRIPTION
Fixes #1732

Here is an example where you see a difference:
[master](https://profiler.firefox.com/public/4199815215349c715dfa9a397d0bc2ebfb64e4bc/calltree/?globalTrackOrder=6-7-0-1-2-3-4-5&hiddenGlobalTracks=1-2-3&implementation=js&localTrackOrderByPid=25709-1-2-0~26020-0~25830-0~25783-0~25932-0~25917-0-1~&thread=0&transforms=ff-1166&v=4)
[deploy preview](https://deploy-preview-2154--perf-html.netlify.com/public/4199815215349c715dfa9a397d0bc2ebfb64e4bc/calltree/?globalTrackOrder=6-7-0-1-2-3-4-5&hiddenGlobalTracks=1-2-3&implementation=js&localTrackOrderByPid=25709-1-2-0~26020-0~25830-0~25783-0~25932-0~25917-0-1~&thread=0&transforms=ff-1166&v=4)

Focus the root node (it's a focused function) and look at the sidebar information. Then switch between the JS view and the combined view. With the deploy preview, the categories should stay the same.


The general idea is that we use the original thread to find the category information. The main issue with that is that the current thread can be sliced from the original thread, and therefore there's an offset that we need to take into account.
Just passing the "range filtered thread" could work for committed range (I think this is how it's done for the activity graph) but not for preview selections that we support in the sidebar, that's why we need this more complex solution.
I left some more details as comments in the PR.
