### PR TITLE
Add support for visualizing Preference markers

### DIFF
--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -12,7 +12,11 @@ import {
   abortUpload,
   resetUploadState,
 } from '../../../actions/publish';
-import { getProfile, getProfileRootRange } from '../../../selectors/profile';
+import {
+  getProfile,
+  getProfileRootRange,
+  getHasPreferenceMarkers,
+} from '../../../selectors/profile';
 import {
   getCheckedSharingOptions,
   getFilenameString,
@@ -42,6 +46,7 @@ type OwnProps = {|
 type StateProps = {|
   +profile: Profile,
   +rootRange: StartEndRange,
+  +shouldShowPreferenceOption: boolean,
   +checkedSharingOptions: CheckedSharingOptions,
   +downloadSizePromise: Promise<string>,
   +compressedProfileBlobPromise: Promise<Blob>,
@@ -72,6 +77,8 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
     includeUrls: () => this.props.toggleCheckedSharingOptions('includeUrls'),
     includeExtension: () =>
       this.props.toggleCheckedSharingOptions('includeExtension'),
+    includePreferenceValues: () =>
+      this.props.toggleCheckedSharingOptions('includePreferenceValues'),
   };
 
   _renderCheckbox(slug: $Keys<CheckedSharingOptions>, label: string) {
@@ -93,6 +100,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
 
   _renderPublishPanel() {
     const {
+      shouldShowPreferenceOption,
       downloadSizePromise,
       attemptToPublish,
       downloadFileName,
@@ -132,6 +140,12 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
               'includeExtension',
               'Include extension information'
             )}
+            {shouldShowPreferenceOption
+              ? this._renderCheckbox(
+                  'includePreferenceValues',
+                  'Include preference values'
+                )
+              : null}
           </div>
           <div className="menuButtonsPublishButtons">
             <DownloadButton
@@ -274,6 +288,7 @@ export const MenuButtonsPublish = explicitConnect<
   mapStateToProps: state => ({
     profile: getProfile(state),
     rootRange: getProfileRootRange(state),
+    shouldShowPreferenceOption: getHasPreferenceMarkers(state),
     checkedSharingOptions: getCheckedSharingOptions(state),
     downloadSizePromise: getDownloadSize(state),
     downloadFileName: getFilenameString(state),

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -545,6 +545,17 @@ function getMarkerDetails(
         );
         break;
       }
+      case 'PreferenceRead': {
+        tooltipDetails = (
+          <TooltipDetails>
+            <TooltipDetail label="Name">{data.prefName}</TooltipDetail>
+            <TooltipDetail label="Kind">{data.prefKind}</TooltipDetail>
+            <TooltipDetail label="Type">{data.prefType}</TooltipDetail>
+            <TooltipDetail label="Value">{data.prefValue}</TooltipDetail>
+          </TooltipDetails>
+        );
+        break;
+      }
       case 'Invalidation': {
         tooltipDetails = (
           <TooltipDetails>

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -12,7 +12,11 @@ import type {
   IndexIntoRawMarkerTable,
 } from '../types/profile';
 import type { Marker, MarkerIndex } from '../types/profile-derived';
-import type { BailoutPayload, NetworkPayload } from '../types/markers';
+import type {
+  BailoutPayload,
+  NetworkPayload,
+  PrefMarkerPayload,
+} from '../types/markers';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { StartEndRange } from '../types/units';
 
@@ -1019,6 +1023,12 @@ export function removeNetworkMarkerURLs(
   payload: NetworkPayload
 ): NetworkPayload {
   return { ...payload, URI: '', RedirectURI: '' };
+}
+
+export function removePrefMarkerPreferenceValues(
+  payload: PrefMarkerPayload
+): PrefMarkerPayload {
+  return { ...payload, prefValue: '' };
 }
 
 export function getMarkerFullDescription(marker: Marker) {

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -12,6 +12,7 @@ import {
 import { removeURLs } from '../utils/string';
 import {
   removeNetworkMarkerURLs,
+  removePrefMarkerPreferenceValues,
   filterRawMarkerTableToRangeWithMarkersToDelete,
 } from './marker-data';
 import { filterThreadSamplesToRange } from './profile-data';
@@ -169,10 +170,22 @@ function sanitizeThreadPII(
   const markersToDelete = new Set();
   if (
     PIIToBeRemoved.shouldRemoveUrls ||
+    PIIToBeRemoved.shouldRemovePreferenceValues ||
     PIIToBeRemoved.shouldRemoveThreadsWithScreenshots.size > 0
   ) {
     for (let i = 0; i < markerTable.length; i++) {
       const currentMarker = markerTable.data[i];
+
+      // Remove the all the preference values, if the user wants that.
+      if (
+        PIIToBeRemoved.shouldRemovePreferenceValues &&
+        currentMarker &&
+        currentMarker.type &&
+        currentMarker.type === 'PreferenceRead'
+      ) {
+        // Remove the preference value field from the marker payload.
+        markerTable.data[i] = removePrefMarkerPreferenceValues(currentMarker);
+      }
 
       // Remove the all network URLs if user wants to remove them.
       if (

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -23,6 +23,7 @@ function _getDefaultSharingOptions(): CheckedSharingOptions {
     includeScreenshots: false,
     includeUrls: false,
     includeExtension: false,
+    includePreferenceValues: false,
   };
 }
 

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -199,6 +199,21 @@ export const getGlobalTrackReferences: Selector<
     }))
 );
 
+export const getHasPreferenceMarkers: Selector<boolean> = createSelector(
+  getThreads,
+  threads => {
+    return threads.some(({ stringTable, markers }) => {
+      /*
+       * Does this particular thread have a Preference in it?
+       */
+      const indexForPreferenceString = stringTable.indexForString(
+        'PreferenceRead'
+      );
+      return markers.name.some(name => name === indexForPreferenceString);
+    });
+  }
+);
+
 /**
  * This finds a GlobalTrack from its TrackReference. No memoization is needed
  * as this is a simple value look-up.

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -140,6 +140,7 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
       ),
       shouldRemoveThreads,
       shouldRemoveExtensions: !checkedSharingOptions.includeExtension,
+      shouldRemovePreferenceValues: !checkedSharingOptions.includePreferenceValues,
     };
   }
 );

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -367,6 +367,20 @@ describe('TooltipMarker', function() {
             },
           },
         ],
+        [
+          'PreferenceRead',
+          114.9,
+          {
+            type: 'PreferenceRead',
+            startTime: 114.9,
+            endTime: 114.9,
+            prefAccessTime: 114.9,
+            prefName: 'layout.css.dpi',
+            prefKind: 'User',
+            prefType: 'Int',
+            prefValue: '-1',
+          },
+        ],
       ],
       profile.meta.interval
     );

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1782,6 +1782,74 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
 </div>
 `;
 
+exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.9 1`] = `
+<div
+  class="tooltipMarker propClass"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        —
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        PreferenceRead
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Main Thread
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Name
+      :
+    </div>
+    layout.css.dpi
+    <div
+      class="tooltipLabel"
+    >
+      Kind
+      :
+    </div>
+    User
+    <div
+      class="tooltipLabel"
+    >
+      Type
+      :
+    </div>
+    Int
+    <div
+      class="tooltipLabel"
+    >
+      Value
+      :
+    </div>
+    -1
+  </div>
+</div>
+`;
+
 exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
 <div
   class="tooltipMarker propClass"

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -542,6 +542,21 @@ function _createGeckoThread(): GeckoThread {
           },
         ],
 
+        [
+          17, // PreferenceRead
+          114.9,
+          {
+            type: 'PreferenceRead',
+            startTime: 114.9,
+            endTime: 114.9,
+            prefAccessTime: 114.9,
+            prefName: 'layout.css.dpi',
+            prefKind: 'User',
+            prefType: 'Int',
+            prefValue: '-1',
+          },
+        ],
+
         // INSERT NEW MARKERS HERE
 
         // Start a tracing marker but never finish it.
@@ -577,6 +592,7 @@ function _createGeckoThread(): GeckoThread {
       'FileIO', // 14
       'CompositorScreenshot', // 15
       'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAUD', // 16
+      'PreferenceRead', // 17
     ],
   };
 }

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -35,6 +35,7 @@ describe('getCheckedSharingOptions', function() {
       includeHiddenThreads: false,
       includeScreenshots: false,
       includeUrls: false,
+      includePreferenceValues: false,
     };
     const isNotFiltering = {
       includeExtension: true,
@@ -42,6 +43,7 @@ describe('getCheckedSharingOptions', function() {
       includeHiddenThreads: true,
       includeScreenshots: true,
       includeUrls: true,
+      includePreferenceValues: true,
     };
     function getDefaultsWith(updateChannel: string) {
       const { profile } = getProfileFromTextSamples('A');

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -59,9 +59,9 @@ describe('deriveMarkersFromRawMarkerTable', function() {
     expect(contentThread.processType).toBe('tab');
   });
 
-  it('creates 14 markers given the test data', function() {
+  it('creates 15 markers given the test data', function() {
     const { markers } = setup();
-    expect(markers.length).toEqual(14);
+    expect(markers.length).toEqual(15);
   });
   it('creates a marker even if there is no start or end time', function() {
     const { markers } = setup();
@@ -83,7 +83,7 @@ describe('deriveMarkersFromRawMarkerTable', function() {
   });
   it('should fold the two reflow markers into one marker', function() {
     const { markers } = setup();
-    expect(markers.length).toEqual(14);
+    expect(markers.length).toEqual(15);
     expect(markers[2]).toMatchObject({
       start: 3,
       dur: 5,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -98,6 +98,7 @@ export type CheckedSharingOptions = {|
   includeScreenshots: boolean,
   includeUrls: boolean,
   includeExtension: boolean,
+  includePreferenceValues: boolean,
 |};
 
 type ProfileAction =

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -417,6 +417,17 @@ export type DOMEventMarkerPayload = {|
   docshellHistoryId?: number,
 |};
 
+export type PrefMarkerPayload = {|
+  type: 'PreferenceRead',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  prefAccessTime: Milliseconds,
+  prefName: string,
+  prefKind: string,
+  prefType: string,
+  prefValue: string,
+|};
+
 export type NavigationMarkerPayload = {|
   type: 'tracing',
   category: 'Navigation',
@@ -526,6 +537,7 @@ export type MarkerPayload =
   | FrameConstructionMarkerPayload
   | DummyForTestsMarkerPayload
   | NavigationMarkerPayload
+  | PrefMarkerPayload
   | null;
 
 export type MarkerPayload_Gecko =
@@ -546,6 +558,7 @@ export type MarkerPayload_Gecko =
   | ArbitraryEventTracing
   | NavigationMarkerPayload
   | JsAllocationPayload_Gecko
+  | PrefMarkerPayload
   // The following payloads come in with a stack property. During the profile processing
   // the "stack" property is are converted into a "cause". See the CauseBacktrace type
   // for more information.

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -182,6 +182,8 @@ export type RemoveProfileInformation = {
   shouldRemoveUrls: boolean,
   // Remove the extension list if it's true.
   shouldRemoveExtensions: boolean,
+  // Remove the preference values if it's true.
+  shouldRemovePreferenceValues: boolean,
 };
 
 /**


### PR DESCRIPTION
There is a new type of marker landing in Gecko called Preference.
This marker marks each time a preference is accessed, its name, kind,
type and value. This PR adds support for showing this marker's data
in a tooltip.

Bugzilla side: https://bugzilla.mozilla.org/show_bug.cgi?id=1551313