### PR TITLE
Render implementation breakdown only if self/total time is not zero

### DIFF
--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -284,7 +284,7 @@ class CallTreeSidebar extends React.PureComponent<Props> {
               />
             </>
           ) : null}
-          {totalTime.breakdownByImplementation ? (
+          {totalTime.breakdownByImplementation && totalTime.value ? (
             <React.Fragment>
               <h4 className="sidebar-title3">Implementation – running time</h4>
               <ImplementationBreakdown
@@ -293,7 +293,7 @@ class CallTreeSidebar extends React.PureComponent<Props> {
               />
             </React.Fragment>
           ) : null}
-          {selfTime.breakdownByImplementation ? (
+          {selfTime.breakdownByImplementation && selfTime.value ? (
             <React.Fragment>
               <h4 className="sidebar-title3">Implementation – self time</h4>
               <ImplementationBreakdown
@@ -323,7 +323,8 @@ class CallTreeSidebar extends React.PureComponent<Props> {
                 )} (${selfTimeForFuncPercent}%)`
               : '—'}
           </SidebarDetail>
-          {totalTimeForFunc.breakdownByImplementation ? (
+          {totalTimeForFunc.breakdownByImplementation &&
+          totalTimeForFunc.value ? (
             <React.Fragment>
               <h4 className="sidebar-title3">Implementation – running time</h4>
               <ImplementationBreakdown
@@ -332,7 +333,8 @@ class CallTreeSidebar extends React.PureComponent<Props> {
               />
             </React.Fragment>
           ) : null}
-          {selfTimeForFunc.breakdownByImplementation ? (
+          {selfTimeForFunc.breakdownByImplementation &&
+          selfTimeForFunc.value ? (
             <React.Fragment>
               <h4 className="sidebar-title3">Implementation – self time</h4>
               <ImplementationBreakdown


### PR DESCRIPTION
This PR adds the check for `value` before rendering the `ImplementationBreakdown` component. I tried to add a test but struggled to make a mock data with helper methods, so I would appreciate some guidance on what would be the best approach there 😅

|Before|After|
|---|---|
|<img width="304" alt="image" src="https://user-images.githubusercontent.com/5036933/62106083-8d820580-b2a4-11e9-988b-532f7e1cb47f.png">|<img width="304" alt="image" src="https://user-images.githubusercontent.com/5036933/62106006-5b70a380-b2a4-11e9-8a24-e77475740710.png">|

Closes #2150 