### PR TITLE
Hide an empty global process track that has all of its local tracks hidden

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -204,6 +204,28 @@ export function finalizeProfileView(
       profile
     );
 
+    // If all of the local tracks were hidden for a process, and the main thread was
+    // not recorded for that process, hide the (empty) process track as well.
+    for (const [pid, localTracks] of localTracksByPid) {
+      const hiddenLocalTracks = hiddenLocalTracksByPid.get(pid);
+      if (!hiddenLocalTracks) {
+        continue;
+      }
+      if (hiddenLocalTracks.size === localTracks.length) {
+        // All of the local tracks were hidden.
+        const globalTrackIndex = globalTracks.findIndex(
+          globalTrack =>
+            globalTrack.type === 'process' &&
+            globalTrack.pid === pid &&
+            globalTrack.mainThreadIndex === null
+        );
+        if (globalTrackIndex !== -1) {
+          // An empty global track was found, hide it.
+          hiddenGlobalTracks.add(globalTrackIndex);
+        }
+      }
+    }
+
     dispatch({
       type: 'VIEW_PROFILE',
       selectedThreadIndex,

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -290,6 +290,37 @@ describe('actions/receive-profile', function() {
         'show [thread GeckoMain tab]',
       ]);
     });
+
+    it('will hide an empty global track when all child tracks are hidden', function() {
+      const store = blankStore();
+      const { profile } = getProfileFromTextSamples(
+        `work work work work work`, // pid 1
+        `work work work work work`, // pid 1
+        `idle[cat:Idle] idle[cat:Idle] idle[cat:Idle] idle[cat:Idle] idle[cat:Idle]`, // pid 2
+        `work work work work work` // pid 3
+      );
+
+      profile.threads[0].name = 'Work A';
+      profile.threads[1].name = 'Work B';
+      profile.threads[2].name = 'Idle C';
+      profile.threads[3].name = 'Work E';
+
+      profile.threads[0].pid = 1;
+      profile.threads[1].pid = 1;
+      profile.threads[2].pid = 2;
+      profile.threads[3].pid = 3;
+
+      store.dispatch(viewProfile(profile));
+      expect(getHumanReadableTracks(store.getState())).toEqual([
+        'show [process]',
+        '  - show [thread Work A] SELECTED',
+        '  - show [thread Work B]',
+        'hide [process]', // <- Ensure this process is hidden.
+        '  - hide [thread Idle C]',
+        'show [process]',
+        '  - show [thread Work E]',
+      ]);
+    });
   });
 
   describe('retrieveProfileFromAddon', function() {


### PR DESCRIPTION
Resolves #2177 

[Before](https://profiler.firefox.com/public/caf82fedc3b5822ba09233abbf3980083505da85)
[After](https://deploy-preview-2181--perf-html.netlify.com/public/caf82fedc3b5822ba09233abbf3980083505da85)