### PR TITLE
Fix typo on video intro page

### DIFF
--- a/docs-user/videos-intro.md
+++ b/docs-user/videos-intro.md
@@ -1,6 +1,6 @@
 # Firefox Profiler intro
 
-This intro video explains how to get set up and start profiling. It explains a little bit of how the architecture works to better understand the relationship of the various tools and data sources. Please note that the video still refers to the Firefox Profiler by its previous name, the Firefox Profiler.
+This intro video explains how to get set up and start profiling. It explains a little bit of how the architecture works to better understand the relationship of the various tools and data sources. Please note that the video still refers to the Firefox Profiler by its previous name, the Gecko Profiler.
 
 [Watch the full series on YouTube](https://www.youtube.com/watch?v=MxgWOTqxOTg&list=PLxaZqnd-OQM620EZ_6eT8qurOnZ4eu6dz&index=1)
 


### PR DESCRIPTION
Right that the [video intro page](https://profiler.firefox.com/docs/#/./videos-intro) says "Please note that the video still refers to the Firefox Profiler by its previous name, the Firefox Profiler."

This doesn't make sense ("refers to $Foo by its previous name, $Foo").

If I understand correctly, the "previous name" used in the video (e.g. 10 seconds in) is really  "**Gecko** Profiler", and the new/current name is "Firefox Profiler".