### PR TITLE
[deploy-preview] Display overhead data in additional tracks

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -7,6 +7,7 @@ import { oneLine } from 'common-tags';
 import { getLastVisibleThreadTabSlug } from '../selectors/app';
 import {
   getCounterSelectors,
+  getOverheadSelectors,
   getGlobalTracks,
   getGlobalTrackAndIndexByPid,
   getLocalTracks,
@@ -283,6 +284,13 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
             getState()
           );
           selectedThreadIndex = counter.mainThreadIndex;
+          break;
+        }
+        case 'overhead': {
+          const { overheadIndex } = localTrack;
+          const overheadSelectors = getOverheadSelectors(overheadIndex);
+          const overhead = overheadSelectors.getOverhead(getState());
+          selectedThreadIndex = overhead.mainThreadIndex;
           break;
         }
         default:

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -26,6 +26,8 @@ import { getThreadSelectors } from '../../selectors/per-thread';
 import TrackThread from './TrackThread';
 import TrackNetwork from './TrackNetwork';
 import { TrackMemory } from './TrackMemory';
+import { TrackOverhead } from './TrackOverhead';
+import { getOverheadTypeStrings } from '../../profile-logic/tracks';
 import type { TrackReference } from '../../types/actions';
 import type { Pid } from '../../types/profile';
 import type { TrackIndex, LocalTrack } from '../../types/profile-derived';
@@ -83,8 +85,15 @@ class LocalTrackComponent extends PureComponent<Props> {
         return <TrackNetwork threadIndex={localTrack.threadIndex} />;
       case 'memory':
         return <TrackMemory counterIndex={localTrack.counterIndex} />;
+      case 'overhead':
+        return (
+          <TrackOverhead
+            overheadIndex={localTrack.overheadIndex}
+            overheadType={localTrack.overheadType}
+          />
+        );
       default:
-        console.error('Unhandled localTrack type', (localTrack: empty));
+        console.error('Unhandled localTrack type', (localTrack: empty)); // TODO: change to exhaustive check
         return null;
     }
   }
@@ -161,6 +170,11 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
         titleText = getCounterSelectors(localTrack.counterIndex).getDescription(
           state
         );
+        break;
+      }
+      case 'overhead': {
+        titleText =
+          getOverheadTypeStrings(localTrack.overheadType).name + ' Overhead';
         break;
       }
       default:

--- a/src/components/timeline/TrackOverhead.js
+++ b/src/components/timeline/TrackOverhead.js
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import explicitConnect from '../../utils/connect';
+import {
+  getCommittedRange,
+  getOverheadSelectors,
+} from '../../selectors/profile';
+import { updatePreviewSelection } from '../../actions/profile-view';
+import { TrackOverheadGraph } from './TrackOverheadGraph';
+import {
+  TRACK_MEMORY_GRAPH_HEIGHT,
+  TRACK_MEMORY_MARKERS_HEIGHT,
+  TRACK_MEMORY_LINE_WIDTH,
+} from '../../app-logic/constants';
+
+import type { ThreadIndex } from '../../types/profile';
+import type { Milliseconds } from '../../types/units';
+import type { ConnectedProps } from '../../utils/connect';
+
+import './TrackMemory.css';
+
+type OwnProps = {|
+  +overheadIndex: number,
+  +overheadType: string,
+|};
+
+type StateProps = {|
+  +threadIndex: ThreadIndex,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+|};
+
+type DispatchProps = {|
+  updatePreviewSelection: typeof updatePreviewSelection,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+type State = {||};
+
+export class TrackOverheadImpl extends React.PureComponent<Props, State> {
+  _onMarkerSelect = (
+    threadIndex: ThreadIndex,
+    start: Milliseconds,
+    end: Milliseconds
+  ) => {
+    const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
+    updatePreviewSelection({
+      hasSelection: true,
+      isModifying: false,
+      selectionStart: Math.max(rangeStart, start),
+      selectionEnd: Math.min(rangeEnd, end),
+    });
+  };
+
+  render() {
+    const { overheadIndex, overheadType } = this.props;
+    return (
+      <div
+        className="timelineTrackMemory"
+        style={{
+          height: TRACK_MEMORY_GRAPH_HEIGHT + TRACK_MEMORY_MARKERS_HEIGHT,
+          '--graph-height': `${TRACK_MEMORY_GRAPH_HEIGHT}px`,
+          '--markers-height': `${TRACK_MEMORY_MARKERS_HEIGHT}px`,
+        }}
+      >
+        {/*  This is a placeholder for the marker height of memory track */}
+        <div style={{ height: '15px' }} />
+        <TrackOverheadGraph
+          overheadIndex={overheadIndex}
+          overheadType={overheadType}
+          lineWidth={TRACK_MEMORY_LINE_WIDTH}
+          graphHeight={TRACK_MEMORY_GRAPH_HEIGHT}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackOverhead = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { overheadIndex } = ownProps;
+    const overheadSelectors = getOverheadSelectors(overheadIndex);
+    const overhead = overheadSelectors.getOverhead(state);
+    const { start, end } = getCommittedRange(state);
+    return {
+      threadIndex: overhead.mainThreadIndex,
+      rangeStart: start,
+      rangeEnd: end,
+    };
+  },
+  mapDispatchToProps: { updatePreviewSelection },
+  component: TrackOverheadImpl,
+});

--- a/src/components/timeline/TrackOverhead.js
+++ b/src/components/timeline/TrackOverhead.js
@@ -14,7 +14,6 @@ import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackOverheadGraph } from './TrackOverheadGraph';
 import {
   TRACK_MEMORY_GRAPH_HEIGHT,
-  TRACK_MEMORY_MARKERS_HEIGHT,
   TRACK_MEMORY_LINE_WIDTH,
 } from '../../app-logic/constants';
 
@@ -60,22 +59,21 @@ export class TrackOverheadImpl extends React.PureComponent<Props, State> {
 
   render() {
     const { overheadIndex, overheadType } = this.props;
+    const graphHeight = TRACK_MEMORY_GRAPH_HEIGHT + 15;
     return (
       <div
         className="timelineTrackMemory"
         style={{
-          height: TRACK_MEMORY_GRAPH_HEIGHT + TRACK_MEMORY_MARKERS_HEIGHT,
-          '--graph-height': `${TRACK_MEMORY_GRAPH_HEIGHT}px`,
-          '--markers-height': `${TRACK_MEMORY_MARKERS_HEIGHT}px`,
+          height: graphHeight,
+          '--graph-height': `${graphHeight}px`,
+          '--markers-height': `${0}px`,
         }}
       >
-        {/*  This is a placeholder for the marker height of memory track */}
-        <div style={{ height: '15px' }} />
         <TrackOverheadGraph
           overheadIndex={overheadIndex}
           overheadType={overheadType}
           lineWidth={TRACK_MEMORY_LINE_WIDTH}
-          graphHeight={TRACK_MEMORY_GRAPH_HEIGHT}
+          graphHeight={graphHeight}
         />
       </div>
     );

--- a/src/components/timeline/TrackOverheadGraph.js
+++ b/src/components/timeline/TrackOverheadGraph.js
@@ -14,7 +14,6 @@ import {
   getProfileInterval,
 } from '../../selectors/profile';
 import { getThreadSelectors } from '../../selectors/per-thread';
-import { ORANGE_50 } from 'photon-colors';
 import Tooltip from '../tooltip/Tooltip';
 import EmptyThreadIndicator from './EmptyThreadIndicator';
 import bisection from 'bisection';
@@ -94,8 +93,8 @@ class TrackOverheadCanvas extends React.PureComponent<CanvasProps> {
       // Draw the chart.
       const rangeLength = rangeEnd - rangeStart;
       ctx.lineWidth = deviceLineWidth;
-      ctx.strokeStyle = ORANGE_50;
-      ctx.fillStyle = '#ff940088'; // Orange 50 with transparency.
+      ctx.strokeStyle = '#ff0026';
+      ctx.fillStyle = '#fc536d'; // Orange 50 with transparency.
       ctx.beginPath();
 
       // The x and y are used after the loop.
@@ -312,7 +311,10 @@ class TrackOverheadGraphImpl extends React.PureComponent<Props, State> {
       innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;
 
     return (
-      <div style={{ left, top }} className="timelineTrackMemoryGraphDot" />
+      <div
+        style={{ left, top, 'background-color': '#ff0026' }}
+        className="timelineTrackMemoryGraphDot"
+      />
     );
   }
 

--- a/src/components/timeline/TrackOverheadGraph.js
+++ b/src/components/timeline/TrackOverheadGraph.js
@@ -107,7 +107,17 @@ class TrackOverheadCanvas extends React.PureComponent<CanvasProps> {
         x = (deviceWidth * (overhead.time[i] - rangeStart)) / rangeLength;
         // Add on half the stroke's line width so that it won't be cut off the edge
         // of the graph.
-        const unitGraphCount = overhead[overheadType][i] / maxOverhead;
+        let currentOverhead;
+        if (overheadType === 'sum') {
+          currentOverhead =
+            overhead.counters[i] +
+            overhead.expiredMarkerCleaning[i] +
+            overhead.locking[i] +
+            overhead.threads[i];
+        } else {
+          currentOverhead = overhead[overheadType][i];
+        }
+        const unitGraphCount = currentOverhead / maxOverhead;
         // console.log('canova height', { innerDeviceHeight, deviceLineHalfWidth });
         y =
           innerDeviceHeight -
@@ -242,13 +252,22 @@ class TrackOverheadGraphImpl extends React.PureComponent<Props, State> {
 
   _renderTooltip(overheadIndex: number): React.Node {
     const { overhead, overheadType } = this.props;
-    const overheadTime = overhead[overheadType][overheadIndex];
+    let currentOverhead;
+    if (overheadType === 'sum') {
+      currentOverhead =
+        overhead.counters[overheadIndex] +
+        overhead.expiredMarkerCleaning[overheadIndex] +
+        overhead.locking[overheadIndex] +
+        overhead.threads[overheadIndex];
+    } else {
+      currentOverhead = overhead[overheadType][overheadIndex];
+    }
 
     return (
       <div className="timelineTrackMemoryTooltip">
         <div className="timelineTrackMemoryTooltipLine">
           <span className="timelineTrackMemoryTooltipNumber">
-            {formatNanoseconds(overheadTime)}
+            {formatNanoseconds(currentOverhead)}
           </span>
           {' ' + getOverheadTypeStrings(overheadType).name}
         </div>
@@ -277,7 +296,17 @@ class TrackOverheadGraphImpl extends React.PureComponent<Props, State> {
     const { statistics } = overhead;
     const maxOverhead = statistics[getOverheadTypeStrings(overheadType).max];
 
-    const unitSampleCount = overhead[overheadType][overheadIndex] / maxOverhead;
+    let currentOverhead;
+    if (overheadType === 'sum') {
+      currentOverhead =
+        overhead.counters[overheadIndex] +
+        overhead.expiredMarkerCleaning[overheadIndex] +
+        overhead.locking[overheadIndex] +
+        overhead.threads[overheadIndex];
+    } else {
+      currentOverhead = overhead[overheadType][overheadIndex];
+    }
+    const unitSampleCount = currentOverhead / maxOverhead;
     const innerTrackHeight = graphHeight - lineWidth / 2;
     const top =
       innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;

--- a/src/components/timeline/TrackOverheadGraph.js
+++ b/src/components/timeline/TrackOverheadGraph.js
@@ -1,0 +1,363 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { withSize } from '../shared/WithSize';
+import explicitConnect from '../../utils/connect';
+import { formatNanoseconds } from '../../utils/format-numbers';
+import {
+  getCommittedRange,
+  getOverheadSelectors,
+  getProfileInterval,
+} from '../../selectors/profile';
+import { getThreadSelectors } from '../../selectors/per-thread';
+import { ORANGE_50 } from 'photon-colors';
+import Tooltip from '../tooltip/Tooltip';
+import EmptyThreadIndicator from './EmptyThreadIndicator';
+import bisection from 'bisection';
+import { getOverheadTypeStrings } from '../../profile-logic/tracks';
+
+import type { Thread, ThreadIndex } from '../../types/profile';
+import type { Milliseconds, CssPixels, StartEndRange } from '../../types/units';
+import type { SizeProps } from '../shared/WithSize';
+import type { ConnectedProps } from '../../utils/connect';
+
+import './TrackMemory.css';
+
+/**
+ * When adding properties to these props, please consider the comment above the component.
+ */
+type CanvasProps = {|
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +overhead: any,
+  +overheadType: string,
+  +interval: Milliseconds,
+  +width: CssPixels,
+  +height: CssPixels,
+  +lineWidth: CssPixels,
+|};
+
+/**
+ * This component controls the rendering of the canvas. Every render call through
+ * React triggers a new canvas render. Because of this, it's important to only pass
+ * in the props that are needed for the canvas draw call.
+ */
+class TrackOverheadCanvas extends React.PureComponent<CanvasProps> {
+  _canvas: null | HTMLCanvasElement = null;
+  _requestedAnimationFrame: boolean = false;
+
+  drawCanvas(canvas: HTMLCanvasElement): void {
+    const {
+      rangeStart,
+      rangeEnd,
+      overhead,
+      overheadType,
+      height,
+      width,
+      lineWidth,
+      interval,
+    } = this.props;
+    if (width === 0) {
+      // This is attempting to draw before the canvas was laid out.
+      return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    const devicePixelRatio = window.devicePixelRatio;
+    const deviceWidth = width * devicePixelRatio;
+    const deviceHeight = height * devicePixelRatio;
+    const deviceLineWidth = lineWidth * devicePixelRatio;
+    const deviceLineHalfWidth = deviceLineWidth * 0.5;
+    const innerDeviceHeight = deviceHeight - deviceLineWidth;
+
+    // Resize and clear the canvas.
+    canvas.width = Math.round(deviceWidth);
+    canvas.height = Math.round(deviceHeight);
+    ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+
+    if (overhead.length === 0) {
+      // There's no reason to draw the samples, there are none.
+      return;
+    }
+
+    // Take the sample information, and convert it into chart coordinates. Use a slightly
+    // smaller space than the deviceHeight, so that the stroke will be fully visible
+    // both at the top and bottom of the chart.
+    const { statistics } = overhead;
+    const maxOverhead = statistics[getOverheadTypeStrings(overheadType).max];
+
+    {
+      // Draw the chart.
+      const rangeLength = rangeEnd - rangeStart;
+      ctx.lineWidth = deviceLineWidth;
+      ctx.strokeStyle = ORANGE_50;
+      ctx.fillStyle = '#ff940088'; // Orange 50 with transparency.
+      ctx.beginPath();
+
+      // The x and y are used after the loop.
+      let x = 0;
+      let y = 0;
+      for (let i = 0; i < overhead.length; i++) {
+        // Create a path for the top of the chart. This is the line that will have
+        // a stroke applied to it.
+        x = (deviceWidth * (overhead.time[i] - rangeStart)) / rangeLength;
+        // Add on half the stroke's line width so that it won't be cut off the edge
+        // of the graph.
+        const unitGraphCount = overhead[overheadType][i] / maxOverhead;
+        // console.log('canova height', { innerDeviceHeight, deviceLineHalfWidth });
+        y =
+          innerDeviceHeight -
+          innerDeviceHeight * unitGraphCount +
+          deviceLineHalfWidth;
+        if (i === 0) {
+          // This is the first iteration, only move the line.
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+      // The samples range ends at the time of the last sample, plus the interval.
+      // Draw this last bit.
+      ctx.lineTo(x + interval, y);
+
+      // Don't do the fill yet, just stroke the top line.
+      ctx.stroke();
+
+      // After doing the stroke, continue the path to complete the fill to the bottom
+      // of the canvas.
+      ctx.lineTo(x + interval, deviceHeight);
+      ctx.lineTo(
+        (deviceWidth * (overhead.time[0] - rangeStart)) / rangeLength +
+          interval,
+        deviceHeight
+      );
+      ctx.fill();
+    }
+  }
+
+  _scheduleDraw() {
+    if (!this._requestedAnimationFrame) {
+      this._requestedAnimationFrame = true;
+      window.requestAnimationFrame(() => {
+        this._requestedAnimationFrame = false;
+        const canvas = this._canvas;
+        if (canvas) {
+          this.drawCanvas(canvas);
+        }
+      });
+    }
+  }
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  render() {
+    this._scheduleDraw();
+
+    return (
+      <canvas className="timelineTrackMemoryCanvas" ref={this._takeCanvasRef} />
+    );
+  }
+}
+
+type OwnProps = {|
+  +overheadIndex: number,
+  +overheadType: string,
+  +lineWidth: CssPixels,
+  +graphHeight: CssPixels,
+|};
+
+type StateProps = {|
+  +threadIndex: ThreadIndex,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +overhead: any,
+  +interval: Milliseconds,
+  +filteredThread: Thread,
+  +unfilteredSamplesRange: StartEndRange | null,
+|};
+
+type DispatchProps = {||};
+
+type Props = {|
+  ...SizeProps,
+  ...ConnectedProps<OwnProps, StateProps, DispatchProps>,
+|};
+
+type State = {|
+  hoveredCounter: null | number,
+  mouseX: CssPixels,
+  mouseY: CssPixels,
+|};
+
+/**
+ * The memory track graph takes memory information from counters, and renders it as a
+ * graph in the timeline.
+ */
+class TrackOverheadGraphImpl extends React.PureComponent<Props, State> {
+  state = {
+    hoveredCounter: null,
+    mouseX: 0,
+    mouseY: 0,
+  };
+
+  _onMouseLeave = () => {
+    this.setState({ hoveredCounter: null });
+  };
+
+  _onMouseMove = (event: SyntheticMouseEvent<HTMLDivElement>) => {
+    const { pageX: mouseX, pageY: mouseY } = event;
+    // Get the offset from here, and apply it to the time lookup.
+    const { left } = event.currentTarget.getBoundingClientRect();
+    const { width, rangeStart, rangeEnd, overhead, interval } = this.props;
+    const rangeLength = rangeEnd - rangeStart;
+    const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
+    if (
+      timeAtMouse < overhead.time[0] ||
+      timeAtMouse > overhead.time[overhead.length - 1] + interval
+    ) {
+      // We are outside the range of the samples, do not display hover information.
+      this.setState({ hoveredCounter: null });
+    } else {
+      let hoveredCounter = bisection.right(overhead.time, timeAtMouse);
+      if (hoveredCounter === overhead.length) {
+        // When hovering the last sample, it's possible the mouse is past the time.
+        // In this case, hover over the last sample. This happens because of the
+        // ` + interval` line in the `if` condition above.
+        hoveredCounter = overhead.time.length - 1;
+      }
+
+      this.setState({
+        mouseX,
+        mouseY,
+        hoveredCounter,
+      });
+    }
+  };
+
+  _renderTooltip(overheadIndex: number): React.Node {
+    const { overhead, overheadType } = this.props;
+    const overheadTime = overhead[overheadType][overheadIndex];
+
+    return (
+      <div className="timelineTrackMemoryTooltip">
+        <div className="timelineTrackMemoryTooltipLine">
+          <span className="timelineTrackMemoryTooltipNumber">
+            {formatNanoseconds(overheadTime)}
+          </span>
+          {' ' + getOverheadTypeStrings(overheadType).name}
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Create a div that is a dot on top of the graph representing the current
+   * height of the graph.
+   */
+  _renderMemoryDot(overheadIndex: number): React.Node {
+    const {
+      overhead,
+      overheadType,
+      rangeStart,
+      rangeEnd,
+      graphHeight,
+      width,
+      lineWidth,
+    } = this.props;
+    const rangeLength = rangeEnd - rangeStart;
+    const left =
+      (width * (overhead.time[overheadIndex] - rangeStart)) / rangeLength;
+
+    const { statistics } = overhead;
+    const maxOverhead = statistics[getOverheadTypeStrings(overheadType).max];
+
+    const unitSampleCount = overhead[overheadType][overheadIndex] / maxOverhead;
+    const innerTrackHeight = graphHeight - lineWidth / 2;
+    const top =
+      innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;
+
+    return (
+      <div style={{ left, top }} className="timelineTrackMemoryGraphDot" />
+    );
+  }
+
+  render() {
+    const { hoveredCounter, mouseX, mouseY } = this.state;
+    const {
+      filteredThread,
+      interval,
+      rangeStart,
+      rangeEnd,
+      unfilteredSamplesRange,
+      overhead,
+      overheadType,
+      graphHeight,
+      width,
+      lineWidth,
+    } = this.props;
+
+    return (
+      <div
+        className="timelineTrackMemoryGraph"
+        onMouseMove={this._onMouseMove}
+        onMouseLeave={this._onMouseLeave}
+      >
+        <TrackOverheadCanvas
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          overhead={overhead}
+          overheadType={overheadType}
+          height={graphHeight}
+          width={width}
+          lineWidth={lineWidth}
+          interval={interval}
+        />
+        {hoveredCounter === null ? null : (
+          <>
+            {this._renderMemoryDot(hoveredCounter)}
+            <Tooltip mouseX={mouseX} mouseY={mouseY}>
+              {this._renderTooltip(hoveredCounter)}
+            </Tooltip>
+          </>
+        )}
+        <EmptyThreadIndicator
+          thread={filteredThread}
+          interval={interval}
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          unfilteredSamplesRange={unfilteredSamplesRange}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackOverheadGraph = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { overheadIndex } = ownProps;
+    const overheadSelectors = getOverheadSelectors(overheadIndex);
+    const overhead = overheadSelectors.getOverhead(state);
+    const { start, end } = getCommittedRange(state);
+    const selectors = getThreadSelectors(overhead.mainThreadIndex);
+    return {
+      overhead,
+      threadIndex: overhead.mainThreadIndex,
+      rangeStart: start,
+      rangeEnd: end,
+      interval: getProfileInterval(state),
+      filteredThread: selectors.getFilteredThread(state),
+      unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),
+    };
+  },
+  component: withSize<Props>(TrackOverheadGraphImpl),
+});

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -259,6 +259,11 @@ export function computeLocalTracksByPid(
       tracks.push({
         type: 'overhead',
         overheadIndex,
+        overheadType: 'sum',
+      });
+      tracks.push({
+        type: 'overhead',
+        overheadIndex,
         overheadType: 'counters',
       });
       tracks.push({
@@ -596,7 +601,9 @@ export function getLocalTrackName(
   }
 }
 
-export function getOverheadTypeStrings(overheadType: any): {
+export function getOverheadTypeStrings(
+  overheadType: any
+): {
   name: string,
   min: string,
   max: string,
@@ -620,6 +627,10 @@ export function getOverheadTypeStrings(overheadType: any): {
     case 'threads':
       name = 'Threads';
       string = 'Thread';
+      break;
+    case 'sum':
+      name = 'Overall';
+      string = 'Overhead';
       break;
     default:
       throw assertExhaustiveCheck(overheadType, `Unhandled overheadType type.`);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -143,6 +143,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
               height += TRACK_NETWORK_HEIGHT + border;
               break;
             case 'memory':
+            case 'overhead':
               height += TRACK_MEMORY_HEIGHT + border;
               break;
             default:

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -176,6 +176,48 @@ function _createCounterSelectors(counterIndex: CounterIndex): * {
   };
 }
 
+type OverheadSelectors = $ReturnType<typeof _createOverheadSelectors>;
+
+const _OverheadSelectors = {};
+export const getOverheadSelectors = (
+  index: CounterIndex
+): OverheadSelectors => {
+  let selectors = _OverheadSelectors[index];
+  if (!selectors) {
+    selectors = _createOverheadSelectors(index);
+    _OverheadSelectors[index] = selectors;
+  }
+  return selectors;
+};
+
+/**
+ * This function creates selectors for each of the Counters in the profile. The type
+ * signature of each selector is defined in the function body, and inferred in the return
+ * type of the function.
+ */
+function _createOverheadSelectors(overheadIndex: CounterIndex): * {
+  const getOverhead: Selector<any> = state =>
+    ensureExists(
+      getProfile(state).profilerOverhead,
+      'Attempting to get an overhead by index, but no overheads exist.'
+    )[overheadIndex];
+
+  const getPid: Selector<Pid> = state => getOverhead(state).pid;
+
+  // FIXME:
+  // const getCommittedRangeFilteredOverhead: Selector<Counter> = createSelector(
+  //   getOverhead,
+  //   getCommittedRange,
+  //   (counters, range) => filterCounterToRange(counters, range.start, range.end)
+  // );
+
+  return {
+    getOverhead,
+    getPid,
+    // getCommittedRangeFilteredCounter,
+  };
+}
+
 /**
  * Tracks
  *

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -86,6 +86,10 @@ export function getHumanReadableTracks(state: State): string[] {
           trackName = profileViewSelectors
             .getCounterSelectors(track.counterIndex)
             .getPid(state);
+        } else if (track.type === 'overhead') {
+          trackName = profileViewSelectors
+            .getOverheadSelectors(track.overheadIndex)
+            .getPid(state);
         } else {
           trackName = threads[track.threadIndex].name;
         }

--- a/src/test/unit/__snapshots__/profile-conversion.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.js.snap
@@ -3949,6 +3949,9 @@ Object {
     "version": 16,
   },
   "pages": Array [],
+  "profilerOverhead": Array [
+    Array [],
+  ],
   "threads": Array [
     Object {
       "frameTable": Object {
@@ -10216,6 +10219,9 @@ Object {
     "version": 16,
   },
   "pages": Array [],
+  "profilerOverhead": Array [
+    Array [],
+  ],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -89,6 +89,9 @@ Object {
     "version": 16,
   },
   "pages": Array [],
+  "profilerOverhead": Array [
+    Array [],
+  ],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -242,6 +242,7 @@ export type GeckoProfileFullMeta = {|
 
 export type GeckoProfileWithMeta<Meta> = {|
   counters?: GeckoCounter[],
+  profilerOverhead_UNSTABLE?: any,
   meta: Meta,
   libs: Lib[],
   pages?: PageList,

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -162,7 +162,12 @@ export type GlobalTrack =
 export type LocalTrack =
   | {| +type: 'thread', +threadIndex: ThreadIndex |}
   | {| +type: 'network', +threadIndex: ThreadIndex |}
-  | {| +type: 'memory', +counterIndex: CounterIndex |};
+  | {| +type: 'memory', +counterIndex: CounterIndex |}
+  | {|
+      +type: 'overhead',
+      +overheadIndex: CounterIndex,
+      +overheadType: string,
+    |};
 
 export type Track = GlobalTrack | LocalTrack;
 export type TrackIndex = number;

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -417,5 +417,6 @@ export type Profile = {|
   // The counters list is optional only because old profilers may not have them.
   // An upgrader could be written to make this non-optional.
   counters?: Counter[],
+  profilerOverhead?: any[],
   threads: Thread[],
 |};

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -127,6 +127,14 @@ export function formatSI(num: number): string {
   return formatNumber(num / (1000 * 1000 * 1000), 3, 2) + 'G';
 }
 
+export function formatNanoseconds(
+  time: Milliseconds,
+  significantDigits: number = 3,
+  maxFractionalDigits: number = 5
+) {
+  return formatNumber(time, significantDigits, maxFractionalDigits) + 'ns';
+}
+
 export function formatMicroseconds(
   time: Microseconds,
   significantDigits: number = 2,


### PR DESCRIPTION
I hope this will be useful for @squelart's work.

Deploy preview url: https://deploy-preview-2196--perf-html.netlify.com/

Also here's an [example profile](https://deploy-preview-2196--perf-html.netlify.com/public/6d63963e6fc61b6bfdacab11bd69cea58c07d6cd/network-chart/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10-11&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10&localTrackOrderByPid=95151-3-4-5-6-1-2-0~95176-0-1-2-3-4-5~95175-1-2-3-4-0~95180-1-2-3-4-0~95152-1-2-3-4-0~95174-1-2-3-4-0~95179-1-2-3-4-0~95177-0-1-2-3-4-5~95178-1-2-3-4-0~95181-1-2-3-4-0~95182-1-2-3-4-0~95173-2-3-4-5-0-1~&thread=12&v=4)