### PR TITLE
Process profilerOverhead data and serialize it

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -818,13 +818,13 @@ function _processProfilerOverhead(
   delta: Milliseconds
 ): ProfilerOverhead | null {
   const geckoProfilerOverhead: ?GeckoProfilerOverhead =
-    geckoProfile.profilerOverhead_UNSTABLE;
+    geckoProfile.profilerOverhead;
   const mainThread = geckoProfile.threads.find(
     thread => thread.name === 'GeckoMain'
   );
 
   if (!mainThread || !geckoProfilerOverhead) {
-    // Profiler overhad or a main thread weren't found, bail out, and return an empty array.
+    // Profiler overhead or a main thread weren't found, bail out, and return an empty array.
     return null;
   }
 
@@ -841,15 +841,14 @@ function _processProfilerOverhead(
     );
   }
 
-  const statistics = geckoProfilerOverhead.statistics;
   return {
-    ...adjustProfilerOverheadTimestamps(
-      _toStructOfArrays(geckoProfilerOverhead),
+    samples: adjustProfilerOverheadTimestamps(
+      _toStructOfArrays(geckoProfilerOverhead.samples),
       delta
     ),
     pid: mainThread.pid,
     mainThreadIndex,
-    statistics,
+    statistics: geckoProfilerOverhead.statistics,
   };
 }
 
@@ -1012,7 +1011,7 @@ export function adjustProfilerOverheadTimestamps<
 >(table: Table, delta: Milliseconds): Table {
   return {
     ...table,
-    // Converting microseconds to millicesonds here since we use millicesonds
+    // Converting microseconds to milliseconds here since we use milliseconds
     // inside the tracks.
     time: table.time.map(time => time / 1000 + delta),
   };

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -110,6 +110,25 @@ export function sanitizePII(
           return acc;
         }, [])
       : undefined,
+    // Remove profilerOverhead which belong to the removed threads.
+    // Also adjust other overheads to point to the right thread.
+    profilerOverhead: profile.profilerOverhead
+      ? profile.profilerOverhead.reduce((acc, overhead) => {
+          const newThreadIndex = oldThreadIndexToNew.get(
+            overhead.mainThreadIndex
+          );
+
+          // Filtering out the overhead if it's undefined.
+          if (newThreadIndex !== undefined) {
+            acc.push({
+              ...overhead,
+              mainThreadIndex: newThreadIndex,
+            });
+          }
+
+          return acc;
+        }, [])
+      : undefined,
   };
 
   return {

--- a/src/test/unit/__snapshots__/profile-conversion.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.js.snap
@@ -3949,6 +3949,7 @@ Object {
     "version": 16,
   },
   "pages": Array [],
+  "profilerOverhead": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {
@@ -10216,6 +10217,7 @@ Object {
     "version": 16,
   },
   "pages": Array [],
+  "profilerOverhead": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -89,6 +89,7 @@ Object {
     "version": 16,
   },
   "pages": Array [],
+  "profilerOverhead": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -63,7 +63,7 @@ describe('sanitizePII', function() {
     }
   });
 
-  it('should not sanitize counters if its thread is deleted', function() {
+  it('should not sanitize counters if its thread is not deleted', function() {
     const profile = processProfile(createGeckoProfile());
     const { counters } = profile;
     expect(counters).not.toEqual(undefined);
@@ -86,6 +86,58 @@ describe('sanitizePII', function() {
     expect(sanitizedCounters).not.toEqual(undefined);
     if (sanitizedCounters !== undefined) {
       expect(sanitizedCounters.length).toEqual(1);
+    }
+  });
+
+  it('should sanitize profiler overhead if its thread is deleted', function() {
+    const profile = processProfile(createGeckoProfile());
+    const { profilerOverhead } = profile;
+    expect(profilerOverhead).not.toEqual(undefined);
+    if (profilerOverhead === undefined) {
+      return;
+    }
+    expect(profilerOverhead.length).toEqual(1);
+    // Assuming that the mainThreadIndex of the profiler overhead is 0.
+    // If that assertion fails, put back the profiler overhead where you moved from.
+    expect(profilerOverhead[0].mainThreadIndex).toEqual(0);
+
+    const PIIToRemove = getRemoveProfileInformation({
+      shouldRemoveThreads: new Set([0]),
+    });
+    const { profilerOverhead: sanitizedProfilerOverhead } = sanitizePII(
+      profile,
+      PIIToRemove
+    ).profile;
+    // The counter was for the first thread, it should be deleted now.
+    expect(sanitizedProfilerOverhead).not.toEqual(undefined);
+    if (sanitizedProfilerOverhead !== undefined) {
+      expect(sanitizedProfilerOverhead.length).toEqual(0);
+    }
+  });
+
+  it('should not sanitize profiler overhead if its thread is not deleted', function() {
+    const profile = processProfile(createGeckoProfile());
+    const { profilerOverhead } = profile;
+    expect(profilerOverhead).not.toEqual(undefined);
+    if (profilerOverhead === undefined) {
+      return;
+    }
+    expect(profilerOverhead.length).toEqual(1);
+    // Assuming that the mainThreadIndex of the counter is 0.
+    // If that assertion fails, put back the counter where you moved from.
+    expect(profilerOverhead[0].mainThreadIndex).toEqual(0);
+
+    const PIIToRemove = getRemoveProfileInformation({
+      shouldRemoveThreads: new Set([1, 2]),
+    });
+    const { profilerOverhead: sanitizedProfilerOverhead } = sanitizePII(
+      profile,
+      PIIToRemove
+    ).profile;
+    // The counter was for the first thread, it should not be deleted now.
+    expect(sanitizedProfilerOverhead).not.toEqual(undefined);
+    if (sanitizedProfilerOverhead !== undefined) {
+      expect(sanitizedProfilerOverhead.length).toEqual(1);
     }
   });
 

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -10,9 +10,10 @@ import type {
   CategoryList,
   PageList,
   JsTracerTable,
+  ProfilerOverheadStats,
 } from './profile';
 import type { MarkerPayload_Gecko } from './markers';
-import type { Milliseconds } from './units';
+import type { Milliseconds, Nanoseconds } from './units';
 
 export type IndexIntoGeckoFrameTable = number;
 export type IndexIntoGeckoStackTable = number;
@@ -171,6 +172,20 @@ export type GeckoCounter = {|
   |},
 |};
 
+export type GeckoProfilerOverhead = {|
+  schema: {|
+    time: 0,
+    locking: 1,
+    expiredMarkerCleaning: 2,
+    counters: 3,
+    threads: 4,
+  |},
+  data: Array<
+    [Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds]
+  >,
+  statistics: ProfilerOverheadStats,
+|};
+
 /* This meta object is used in subprocesses profiles.
  * Using https://searchfox.org/mozilla-central/rev/7556a400affa9eb99e522d2d17c40689fa23a729/tools/profiler/core/platform.cpp#1829
  * as source of truth. (Please update the link whenever there's a new property).
@@ -242,6 +257,7 @@ export type GeckoProfileFullMeta = {|
 
 export type GeckoProfileWithMeta<Meta> = {|
   counters?: GeckoCounter[],
+  profilerOverhead_UNSTABLE?: GeckoProfilerOverhead,
   meta: Meta,
   libs: Lib[],
   pages?: PageList,

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -173,16 +173,18 @@ export type GeckoCounter = {|
 |};
 
 export type GeckoProfilerOverhead = {|
-  schema: {|
-    time: 0,
-    locking: 1,
-    expiredMarkerCleaning: 2,
-    counters: 3,
-    threads: 4,
+  samples: {|
+    schema: {|
+      time: 0,
+      locking: 1,
+      expiredMarkerCleaning: 2,
+      counters: 3,
+      threads: 4,
+    |},
+    data: Array<
+      [Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds]
+    >,
   |},
-  data: Array<
-    [Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds]
-  >,
   statistics: ProfilerOverheadStats,
 |};
 
@@ -257,7 +259,9 @@ export type GeckoProfileFullMeta = {|
 
 export type GeckoProfileWithMeta<Meta> = {|
   counters?: GeckoCounter[],
-  profilerOverhead_UNSTABLE?: GeckoProfilerOverhead,
+  // Optional because older Firefox versions may not have that data and
+  // no upgrader was necessary.
+  profilerOverhead?: GeckoProfilerOverhead,
   meta: Meta,
   libs: Lib[],
   pages?: PageList,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -291,6 +291,10 @@ export type Counter = {|
   |},
 |};
 
+/**
+ * The statistics about profiler overhead. It includes max/min/mean values of
+ * individual and overall overhead timings.
+ */
 export type ProfilerOverheadStats = {|
   maxCleaning: Nanoseconds,
   maxCounter: Nanoseconds,
@@ -316,13 +320,29 @@ export type ProfilerOverheadStats = {|
   samplingCount: Nanoseconds,
 |};
 
-export type ProfilerOverhead = {|
+/**
+ * Gecko Profiler records profiler overhead samples of specific tasks that take time.
+ * counters: Time spent during collecting counter samples.
+ * expiredMarkerCleaning: Time spent during expired marker cleanup
+ * lockings: Time spent during acquiring locks.
+ * threads: Time spent during threads sampling and marker collection.
+ */
+export type ProfilerOverheadSamplesTable = {|
   counters: Array<Nanoseconds>,
   expiredMarkerCleaning: Array<Nanoseconds>,
   locking: Array<Nanoseconds>,
   threads: Array<Nanoseconds>,
   time: Array<Milliseconds>,
   length: number,
+|};
+
+/**
+ * Information about profiler overhead. It includes overhead timings for
+ * counters, expired marker cleanings, mutex locking and threads. Also it
+ * includes statistics about those individual and overall overhead.
+ */
+export type ProfilerOverhead = {|
+  samples: ProfilerOverheadSamplesTable,
   statistics: ProfilerOverheadStats,
   pid: Pid,
   mainThreadIndex: ThreadIndex,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -4,7 +4,13 @@
 
 // @flow
 
-import type { Milliseconds, MemoryOffset, Microseconds, Bytes } from './units';
+import type {
+  Milliseconds,
+  MemoryOffset,
+  Microseconds,
+  Bytes,
+  Nanoseconds,
+} from './units';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { MarkerPayload } from './markers';
 export type IndexIntoStackTable = number;
@@ -285,6 +291,43 @@ export type Counter = {|
   |},
 |};
 
+export type ProfilerOverheadStats = {|
+  maxCleaning: Nanoseconds,
+  maxCounter: Nanoseconds,
+  maxInterval: Nanoseconds,
+  maxLockings: Nanoseconds,
+  maxOverhead: Nanoseconds,
+  maxThread: Nanoseconds,
+  meanCleaning: Nanoseconds,
+  meanCounter: Nanoseconds,
+  meanInterval: Nanoseconds,
+  meanLockings: Nanoseconds,
+  meanOverhead: Nanoseconds,
+  meanThread: Nanoseconds,
+  minCleaning: Nanoseconds,
+  minCounter: Nanoseconds,
+  minInterval: Nanoseconds,
+  minLockings: Nanoseconds,
+  minOverhead: Nanoseconds,
+  minThread: Nanoseconds,
+  overheadDurations: Nanoseconds,
+  overheadPercentage: Nanoseconds,
+  profiledDuration: Nanoseconds,
+  samplingCount: Nanoseconds,
+|};
+
+export type ProfilerOverhead = {|
+  counters: Array<Nanoseconds>,
+  expiredMarkerCleaning: Array<Nanoseconds>,
+  locking: Array<Nanoseconds>,
+  threads: Array<Nanoseconds>,
+  time: Array<Milliseconds>,
+  length: number,
+  statistics: ProfilerOverheadStats,
+  pid: Pid,
+  mainThreadIndex: ThreadIndex,
+|};
+
 /**
  * Gecko has one or more processes. There can be multiple threads per processes. Each
  * thread has a unique set of tables for its data.
@@ -436,5 +479,6 @@ export type Profile = {|
   // The counters list is optional only because old profilers may not have them.
   // An upgrader could be written to make this non-optional.
   counters?: Counter[],
+  profilerOverhead?: ProfilerOverhead[],
   threads: Thread[],
 |};

--- a/src/types/units.js
+++ b/src/types/units.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+export type Nanoseconds = number;
 export type Microseconds = number;
 export type Milliseconds = number;
 export type Seconds = number;


### PR DESCRIPTION
Currently we just strip out that information from the profile. We have a deploy preview to visualize that data but since captured profiles don't include that data, it's only possible to see that data if we capture the profile with that deploy preview. After this PR, it's gonna be easier to use the deploy preview.