### PR TITLE
Include cause field on network markers.

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -622,6 +622,7 @@ export function deriveMarkersFromRawMarkerTable(
                 ...endData,
                 startTime: startData.startTime,
                 fetchStart: endData.startTime,
+                cause: startData.cause || endData.cause,
               },
             });
           } else {
@@ -638,6 +639,7 @@ export function deriveMarkersFromRawMarkerTable(
                 ...endData,
                 startTime: start,
                 fetchStart: endData.startTime,
+                cause: endData.cause,
               },
               incomplete: true,
             });

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1148,6 +1148,7 @@ Array [
     "category": 0,
     "data": Object {
       "URI": "https://mozilla.org",
+      "cause": undefined,
       "endTime": 7,
       "fetchStart": 6.5,
       "id": 6,
@@ -1218,6 +1219,7 @@ Array [
     "category": 0,
     "data": Object {
       "URI": "https://mozilla.org",
+      "cause": undefined,
       "endTime": 7,
       "fetchStart": 6.5,
       "id": 6,
@@ -1235,6 +1237,7 @@ Array [
     "category": 0,
     "data": Object {
       "URI": "https://mozilla.org",
+      "cause": undefined,
       "endTime": 8,
       "fetchStart": 7.5,
       "id": 7,
@@ -1424,6 +1427,7 @@ Array [
     "category": 0,
     "data": Object {
       "URI": "https://mozilla.org",
+      "cause": undefined,
       "endTime": 7,
       "fetchStart": 6.5,
       "id": 6,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -337,6 +337,7 @@ export type NetworkPayload = {|
   count?: number, // Total size of transfer, if any
   status: string,
   cache?: string,
+  cause?: CauseBacktrace,
 
   // NOTE: the following comments are valid for the merged markers. For the raw
   // markers, startTime and endTime have different meanings. Please look


### PR DESCRIPTION
For [bug 1548373](https://bugzilla.mozilla.org/show_bug.cgi?id=1548373)

[Deploy preview](https://deploy-preview-2220--perf-html.netlify.com/public/17cff0a904500d417fcf0de6ac83c2dafbb128f5/network-chart/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-3-4-5-2&hiddenLocalTracksByPid=17040-0-1-2-3-4-5-6-7-10-8~13268-1~21852-0-1-2-3-4-5-6-7-8~19984-0-1-2-3-4-5-6-7-8~21700-0-1-2-3-4-5-6-7-8~2560-0-1-2-3-4-5-6-7-8-10&localTrackOrderByPid=17040-9-10-0-1-2-3-4-5-6-7-8~21316-0~13268-2-0-1~21852-9-0-1-2-3-4-5-6-7-8~19984-9-0-1-2-3-4-5-6-7-8~21700-9-0-1-2-3-4-5-6-7-8~2560-9-10-0-1-2-3-4-5-6-7-8~&thread=44&v=4)
(look at the `https://edition.cnn.com/data/ocs/sectio.../zone-manager.izl` loads)

Bas has a patch in [bug 1548373](https://bugzilla.mozilla.org/show_bug.cgi?id=1548373) that adds cause information to network markers.