### PR TITLE
Harmonize use of user-select in CSS

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -50,7 +50,6 @@ body,
   border-top: 1px solid var(--grey-30);
   cursor: default;
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 
@@ -342,7 +341,8 @@ body,
   text-overflow: ellipsis;
   transition: background-color 200ms, border-color 200ms;
   transition-timing-function: var(--animation-timing);
-  -moz-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
   white-space: nowrap;
 }
 .tabBarTab.selected {
@@ -486,7 +486,6 @@ body,
   font-size: 12px;
   text-align: left;
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 .react-contextmenu-separator {

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -23,7 +23,8 @@
   cursor: default;
   line-height: 24px;
   text-align: center;
-  -moz-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .menuButtonsShareButtonOriginal {

--- a/src/components/js-tracer/Settings.css
+++ b/src/components/js-tracer/Settings.css
@@ -32,7 +32,6 @@
   flex-flow: row nowrap;
   align-items: center;
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -8,7 +8,6 @@
   flex-flow: column nowrap;
   cursor: default;
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 

--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -8,7 +8,6 @@
   flex-flow: column nowrap;
   cursor: default;
   -webkit-user-select: none;
-  -moz-user-select: none;
   user-select: none;
 }
 

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -13,7 +13,8 @@
   padding: 0;
   margin: 0;
   cursor: default;
-  -moz-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .filterNavigatorBarItem {

--- a/src/components/timeline/Ruler.css
+++ b/src/components/timeline/Ruler.css
@@ -36,7 +36,7 @@
   font-size: 9px;
   line-height: 20px;
   list-style: none;
-  -moz-user-select: none;
+  -webkit-user-select: none;
   user-select: none;
 }
 


### PR DESCRIPTION
Fixes #2222

- Use the unprefixed `user-select`, supported in Chrome + Firefox 69,
  and `-webkit-user-select` for compatibility with Firefox ESR (68).
- Make sure we use the same prefixes everywhere.

