### PR TITLE
Feature - added option for "hide other screenshots"

### DIFF
--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -459,7 +459,7 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
       return null;
     }
 
-    const isDisabled = this.getVisibleScreenshotTracks().length === 1;
+    const isDisabled = this.getVisibleScreenshotTracks().length <= 1;
     return (
       <MenuItem onClick={this._isolateScreenshot} disabled={isDisabled}>
         Hide other screenshot tracks

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -154,7 +154,7 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
         'Attempted to isolate the screenshot with no right clicked track.'
       );
     }
-    if (rightClickedTrack.type === 'screenshots') {
+    if (rightClickedTrack.type !== 'global') {
       throw new Error(
         'Attempting to isolate a screenshot track with a local track is selected.'
       );
@@ -436,6 +436,20 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
     );
   }
 
+  findTotalVisibleScreenshots(globalTracks, hiddenGlobalTracks) {
+    let hiddenScreenshotTypeTracks = 0;
+    let screenshotTypeTracks = 0;
+    for (const globalTrack of globalTracks) {
+      if (globalTrack.type === 'screenshots') {
+        screenshotTypeTracks++;
+        if (hiddenGlobalTracks.has(globalTrack.threadIndex)) {
+          hiddenScreenshotTypeTracks++;
+        }
+      }
+    }
+    return screenshotTypeTracks - hiddenScreenshotTypeTracks === 1;
+  }
+
   renderIsolateScreenshot() {
     const { rightClickedTrack, globalTracks, hiddenGlobalTracks } = this.props;
 
@@ -445,14 +459,14 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
 
     const track = globalTracks[rightClickedTrack.trackIndex];
     if (track.type !== 'screenshots') {
-      // Only process tracks with a main thread can be isolated.
+      // Only process screenshot tracks
       return null;
     }
 
-    const isDisabled =
-      // Is there only one global track and one screenshot visible?
-      globalTracks.length - hiddenGlobalTracks.size === 2;
-
+    const isDisabled = this.findTotalVisibleScreenshots(
+      globalTracks,
+      hiddenGlobalTracks
+    );
     return (
       <MenuItem onClick={this._isolateScreenshot} disabled={isDisabled}>
         Hide other screenshot tracks

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -436,22 +436,18 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
     );
   }
 
-  findTotalVisibleScreenshots(globalTracks, hiddenGlobalTracks) {
-    let hiddenScreenshotTypeTracks = 0;
-    let screenshotTypeTracks = 0;
-    for (const globalTrack of globalTracks) {
-      if (globalTrack.type === 'screenshots') {
-        screenshotTypeTracks++;
-        if (hiddenGlobalTracks.has(globalTrack.threadIndex)) {
-          hiddenScreenshotTypeTracks++;
-        }
-      }
-    }
-    return screenshotTypeTracks - hiddenScreenshotTypeTracks === 1;
+  getVisibleScreenshotTracks(): TrackIndex[] {
+    const { globalTracks, hiddenGlobalTracks } = this.props;
+    const visibleScreenshotTracks = globalTracks.filter(
+      (globalTrack, trackIndex) =>
+        globalTrack.type === 'screenshots' &&
+        !hiddenGlobalTracks.has(trackIndex)
+    );
+    return visibleScreenshotTracks.length === 1;
   }
 
   renderIsolateScreenshot() {
-    const { rightClickedTrack, globalTracks, hiddenGlobalTracks } = this.props;
+    const { rightClickedTrack, globalTracks } = this.props;
 
     if (rightClickedTrack === null) {
       return null;
@@ -463,10 +459,7 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
       return null;
     }
 
-    const isDisabled = this.findTotalVisibleScreenshots(
-      globalTracks,
-      hiddenGlobalTracks
-    );
+    const isDisabled = this.getVisibleScreenshotTracks();
     return (
       <MenuItem onClick={this._isolateScreenshot} disabled={isDisabled}>
         Hide other screenshot tracks

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -436,14 +436,14 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
     );
   }
 
-  getVisibleScreenshotTracks(): TrackIndex[] {
+  getVisibleScreenshotTracks(): GlobalTrack[] {
     const { globalTracks, hiddenGlobalTracks } = this.props;
     const visibleScreenshotTracks = globalTracks.filter(
       (globalTrack, trackIndex) =>
         globalTrack.type === 'screenshots' &&
         !hiddenGlobalTracks.has(trackIndex)
     );
-    return visibleScreenshotTracks.length === 1;
+    return visibleScreenshotTracks;
   }
 
   renderIsolateScreenshot() {
@@ -459,7 +459,7 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
       return null;
     }
 
-    const isDisabled = this.getVisibleScreenshotTracks();
+    const isDisabled = this.getVisibleScreenshotTracks().length === 1;
     return (
       <MenuItem onClick={this._isolateScreenshot} disabled={isDisabled}>
         Hide other screenshot tracks

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -290,6 +290,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
     case 'ISOLATE_LOCAL_TRACK':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
+    case 'ISOLATE_SCREENSHOT_TRACK':
       return action.hiddenGlobalTracks;
     case 'HIDE_GLOBAL_TRACK': {
       const hiddenGlobalTracks = new Set(state);

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -79,6 +79,8 @@ describe('timeline/TrackContextMenu', function() {
       const isolateProcessMainThreadItem = () =>
         getByText(/Only show "Content Process"/);
       const trackItem = () => getByText('Content Process');
+      const isolateScreenshotTrack = () =>
+        getByText(/Hide other screenshot tracks/);
 
       return {
         ...results,
@@ -87,6 +89,7 @@ describe('timeline/TrackContextMenu', function() {
         threadIndex,
         isolateProcessItem,
         isolateProcessMainThreadItem,
+        isolateScreenshotTrack,
         trackItem,
       };
     }
@@ -157,6 +160,19 @@ describe('timeline/TrackContextMenu', function() {
         'show [process]',
         '  - show [thread DOM Worker] SELECTED',
         '  - show [thread Style]',
+      ]);
+    });
+
+    it('isolates a screenshot track', () => {
+      const { isolateScreenshotTrack, getState } = setupGlobalTrack(
+        getScreenshotTrackProfile()
+      );
+      fireEvent.click(isolateScreenshotTrack());
+      expect(getHumanReadableTracks(getState())).toEqual([
+        'show [screenshots]',
+        'hide [screenshots]',
+        'show [process]',
+        '  - show [thread Empty] SELECTED',
       ]);
     });
 

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -7,6 +7,33 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
   style="position: fixed; opacity: 0; pointer-events: none;"
   tabindex="-1"
 >
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Hide other screenshot tracks
+  </div>
+  <div
+    class="react-contextmenu-separator"
+  />
+  <div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
+      role="menuitem"
+      tabindex="-1"
+      title="Screenshots"
+    >
+      <span>
+        Screenshots
+      </span>
+      <span
+        class="timelineTrackContextMenuSpacer"
+      />
+    </div>
+  </div>
   <div>
     <div
       aria-disabled="false"

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -718,7 +718,7 @@ export function getNetworkTrackProfile() {
 }
 
 export function getScreenshotTrackProfile() {
-  return getProfileWithMarkers(
+  const screenshotMarkersForWindowId = windowID =>
     Array(10)
       .fill()
       .map((_, i) => [
@@ -727,12 +727,15 @@ export function getScreenshotTrackProfile() {
         {
           type: 'CompositorScreenshot',
           url: 0, // Some arbitrary string.
-          windowID: '0',
+          windowID,
           windowWidth: 300,
           windowHeight: 150,
         },
-      ])
-  );
+      ]);
+  return getProfileWithMarkers([
+    ...screenshotMarkersForWindowId('0'),
+    ...screenshotMarkersForWindowId('1'),
+  ]);
 }
 
 export function getJsTracerTable(

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1067,13 +1067,13 @@ describe('actions/ProfileView', function() {
         getState()
       );
       const keys = [...screenshotMarkersById.keys()];
-      expect(keys.length).toEqual(1);
+      expect(keys.length).toEqual(2);
 
       const [screenshots] = [...screenshotMarkersById.values()];
       if (!screenshots) {
         throw new Error('No screenshots found.');
       }
-      expect(screenshots.length).toEqual(profile.threads[0].markers.length);
+      expect(screenshots.length).toEqual(profile.threads[0].markers.length / 2);
       for (const screenshot of screenshots) {
         expect(screenshot.name).toEqual('CompositorScreenshot');
       }
@@ -1086,7 +1086,7 @@ describe('actions/ProfileView', function() {
 
       // Double check that there are 10 markers in the test data, and commit a
       // subsection of that range.
-      expect(markers.length).toBe(10);
+      expect(markers.length).toBe(20);
       const startIndex = 3;
       const endIndex = 8;
       const startTime = markers.time[startIndex];

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1073,6 +1073,9 @@ describe('actions/ProfileView', function() {
       if (!screenshots) {
         throw new Error('No screenshots found.');
       }
+      // The profile contains the same markers twice, but with different window ids.
+      // `screenshots` contains the screenshots for only one window id.
+      // That's why we need to halve the markers length when comparing the 2 lengths.
       expect(screenshots.length).toEqual(profile.threads[0].markers.length / 2);
       for (const screenshot of screenshots) {
         expect(screenshot.name).toEqual('CompositorScreenshot');

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -305,6 +305,7 @@ describe('ordering and hiding', function() {
       const { getState } = storeWithProfile(getScreenshotTrackProfile());
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [screenshots]',
+        'show [screenshots]',
         'show [process]',
         '  - show [thread Empty] SELECTED',
       ]);
@@ -316,9 +317,11 @@ describe('ordering and hiding', function() {
         'process',
         // Screenshots are last.
         'screenshots',
+        'screenshots',
       ];
       const userFacingSortOrder = [
         // Screenshots are first.
+        'screenshots',
         'screenshots',
         'process',
         'process',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -186,7 +186,7 @@ type ProfileAction =
       selectedThreadIndex: ThreadIndex,
       hiddenLocalTracks: Set<TrackIndex>,
     |}
-    | {|
+  | {|
       // Isolate only the screenshot track
       +type: 'ISOLATE_SCREENSHOT_TRACK',
       +hiddenGlobalTracks: Set<TrackIndex>,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -186,6 +186,11 @@ type ProfileAction =
       selectedThreadIndex: ThreadIndex,
       hiddenLocalTracks: Set<TrackIndex>,
     |}
+    | {|
+      // Isolate only the screenshot track
+      +type: 'ISOLATE_SCREENSHOT_TRACK',
+      +hiddenGlobalTracks: Set<TrackIndex>,
+    |}
   | {|
       +type: 'CHANGE_LOCAL_TRACK_ORDER',
       +localTrackOrder: TrackIndex[],


### PR DESCRIPTION
Fixes #1428 

Hey @julienw and @gregtatum !

I think I was able to do most of what was required in accordance with [this comment](https://github.com/firefox-devtools/profiler/issues/1428#issuecomment-435509977).

However, while testing the changes I made, I get this error after clicking ```Hide all other screenshots```:

```
flow.js:147 Uncaught Error: Unable to get the track order from the given pid
    at ensureExists (flow.js:147)
    at getLocalTrackOrder (url-state.js:118)
    at profile-view.js:550
    at index.js:11
    at bindActionCreators.js:3
    at TimelineTrackContextMenu._isolateScreenshot (TrackContextMenu.js:162)
    at callIfExists (helpers.js:6)
    at MenuItem._this.handleClick (MenuItem.js:40)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
```

I scratched my head a bit around this, but I cannot figure out what I'm missing!

I would appreciate some help here! 

Thanks! :)