### PR TITLE
Display profiler overhead statistics information in the metadata panel

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -6,16 +6,9 @@
 import * as React from 'react';
 import ButtonWithPanel from '../../shared/ButtonWithPanel';
 import ArrowPanel from '../../shared/ArrowPanel';
-import {
-  formatNanoseconds,
-  formatPercent,
-} from '../../../utils/format-numbers';
+import { MetaOverheadStatistics } from './MetaOverheadStatistics';
 
-import type {
-  Profile,
-  ProfileMeta,
-  ProfilerOverhead,
-} from '../../../types/profile';
+import type { Profile, ProfileMeta } from '../../../types/profile';
 
 import './MetaInfo.css';
 
@@ -28,55 +21,7 @@ type Props = {
  */
 export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
   render() {
-    const meta = this.props.profile.meta;
-    const overheads: ?(ProfilerOverhead[]) = this.props.profile
-      .profilerOverhead;
-    const calculatedStats: Map<string, ProfilerStats> = new Map();
-    // These 3 values only have single values, so we are not using ProfilerStats class for them.
-    let overheadDurations = 0;
-    let overheadPercentage = 0;
-    let profiledDuration = 0;
-    let totalSamplingCount = 0;
-
-    // Older profiles(Before FF 70) don't have any overhead info. Don't show anything if
-    // that's the case.
-    if (overheads) {
-      // Overhead keys that have min/max/mean values to loop.
-      const statKeys = [
-        'Overhead',
-        'Cleaning',
-        'Counter',
-        'Interval',
-        'Lockings',
-      ];
-
-      for (const overhead of overheads) {
-        const { statistics } = overhead;
-        const { samplingCount } = statistics;
-
-        // Calculation the single values without any loop, it's not worth it.
-        overheadDurations += statistics.overheadDurations * samplingCount;
-        overheadPercentage += statistics.overheadPercentage * samplingCount;
-        profiledDuration += statistics.profiledDuration * samplingCount;
-        totalSamplingCount += samplingCount;
-
-        // Looping through the overhead values that have min/max/mean values
-        // and calculating them.
-        for (const stat of statKeys) {
-          const max = statistics['max' + stat];
-          const mean = statistics['mean' + stat];
-          const min = statistics['min' + stat];
-
-          let currentStat = calculatedStats.get(stat);
-          if (currentStat === undefined) {
-            currentStat = new ProfilerStats();
-            calculatedStats.set(stat, currentStat);
-          }
-
-          currentStat.count(min, max, mean, samplingCount);
-        }
-      }
-    }
+    const { meta, profilerOverhead } = this.props.profile;
 
     return (
       <ButtonWithPanel
@@ -179,64 +124,7 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                 </div>
               ) : null}
             </div>
-            {calculatedStats.size > 0 ? (
-              <details>
-                <summary className="arrowPanelSubTitle">
-                  Profiler Overhead
-                </summary>
-                <div className="arrowPanelSection">
-                  <div className="metaInfoGrid">
-                    <div />
-                    <div>Mean</div>
-                    <div>Max</div>
-                    <div>Min</div>
-                    {Array.from(calculatedStats).map(([key, val]) => [
-                      <div key={key}>{key}</div>,
-                      <div key={key + 'mean'}>
-                        {formatNanoseconds(val.mean)}
-                      </div>,
-                      <div key={key + 'max'}>{formatNanoseconds(val.max)}</div>,
-                      <div key={key + 'min'}>{formatNanoseconds(val.min)}</div>,
-                    ])}
-                  </div>
-
-                  {overheadDurations !== 0 ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoWideLabel">
-                        Overhead Durations:
-                      </span>
-                      <span className="metaInfoValueRight">
-                        {formatNanoseconds(
-                          overheadDurations / totalSamplingCount
-                        )}
-                      </span>
-                    </div>
-                  ) : null}
-                  {overheadPercentage !== 0 ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoWideLabel">
-                        Overhead Percentage:
-                      </span>
-                      <span className="metaInfoValueRight">
-                        {formatPercent(overheadPercentage / totalSamplingCount)}
-                      </span>
-                    </div>
-                  ) : null}
-                  {profiledDuration !== 0 ? (
-                    <div className="metaInfoRow">
-                      <span className="metaInfoWideLabel">
-                        Profiled Duration:
-                      </span>
-                      <span className="metaInfoValueRight">
-                        {formatNanoseconds(
-                          profiledDuration / totalSamplingCount
-                        )}
-                      </span>
-                    </div>
-                  ) : null}
-                </div>
-              </details>
-            ) : null}
+            <MetaOverheadStatistics profilerOverhead={profilerOverhead} />
           </ArrowPanel>
         }
       />
@@ -293,31 +181,4 @@ function _formatLabel(meta: ProfileMeta): string {
     return '';
   }
   return labelTitle;
-}
-
-// A helper class to calculate the weighted arithmetic mean statistic values.
-class ProfilerStats {
-  _max = 0;
-  _min = 0;
-  _mean = 0;
-  _weight = 0;
-
-  count(min: number, max: number, mean: number, weight: number) {
-    this._weight += weight;
-    this._min = min * weight;
-    this._max = max * weight;
-    this._mean = mean * weight;
-  }
-
-  get min(): number {
-    return this._min / this._weight;
-  }
-
-  get max(): number {
-    return this._max / this._weight;
-  }
-
-  get mean(): number {
-    return this._mean / this._weight;
-  }
 }

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -124,7 +124,13 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                 </div>
               ) : null}
             </div>
-            <MetaOverheadStatistics profilerOverhead={profilerOverhead} />
+            {/*
+              Older profiles(before FF 70) don't have any overhead info.
+              Don't show anything if that's the case.
+            */}
+            {profilerOverhead ? (
+              <MetaOverheadStatistics profilerOverhead={profilerOverhead} />
+            ) : null}
           </ArrowPanel>
         }
       />

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -205,9 +205,11 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                       <span className="metaInfoWideLabel">
                         Overhead Durations:
                       </span>
-                      {formatNanoseconds(
-                        overheadDurations / totalSamplingCount
-                      )}
+                      <span className="metaInfoValueRight">
+                        {formatNanoseconds(
+                          overheadDurations / totalSamplingCount
+                        )}
+                      </span>
                     </div>
                   ) : null}
                   {overheadPercentage !== 0 ? (
@@ -215,7 +217,9 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                       <span className="metaInfoWideLabel">
                         Overhead Percentage:
                       </span>
-                      {formatPercent(overheadPercentage / totalSamplingCount)}
+                      <span className="metaInfoValueRight">
+                        {formatPercent(overheadPercentage / totalSamplingCount)}
+                      </span>
                     </div>
                   ) : null}
                   {profiledDuration !== 0 ? (
@@ -223,7 +227,11 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                       <span className="metaInfoWideLabel">
                         Profiled Duration:
                       </span>
-                      {formatNanoseconds(profiledDuration / totalSamplingCount)}
+                      <span className="metaInfoValueRight">
+                        {formatNanoseconds(
+                          profiledDuration / totalSamplingCount
+                        )}
+                      </span>
                     </div>
                   ) : null}
                 </div>

--- a/src/components/app/MenuButtons/MetaOverheadStatistics.css
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.css
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.metaInfoGrid {
+  display: grid;
+  margin-bottom: 20px;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.metaInfoGrid > div {
+  margin: 2px 0;
+}
+
+.metaInfoGrid > div:nth-child(-n + 4) {
+  display: block;
+  font-weight: 500;
+}
+
+.metaInfoGrid > div:nth-child(4n + 1) {
+  color: var(--grey-50);
+  font-weight: 500;
+}
+
+.metaInfoGrid > div:not(:nth-child(4n + 1)) {
+  text-align: right;
+}
+
+.metaInfoValueRight {
+  display: inline-block;
+  width: calc(100% - 140px);
+  text-align: right;
+}

--- a/src/components/app/MenuButtons/MetaOverheadStatistics.js
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.js
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import {
+  formatNanoseconds,
+  formatPercent,
+} from '../../../utils/format-numbers';
+
+import type { ProfilerOverhead } from '../../../types/profile';
+
+import './MetaOverheadStatistics.css';
+
+type Props = {
+  profilerOverhead?: ProfilerOverhead[],
+};
+
+/**
+ * This component formats the profile's meta information into a dropdown panel.
+ */
+export class MetaOverheadStatistics extends React.PureComponent<Props> {
+  render() {
+    const { profilerOverhead } = this.props;
+
+    const calculatedStats: Map<string, ProfilerStats> = new Map();
+    // These 3 values only have single values, so we are not using ProfilerStats class for them.
+    let overheadDurations = 0;
+    let overheadPercentage = 0;
+    let profiledDuration = 0;
+    let totalSamplingCount = 0;
+
+    // Older profiles(Before FF 70) don't have any overhead info. Don't show anything if
+    // that's the case.
+    if (profilerOverhead) {
+      // Overhead keys that have min/max/mean values to loop.
+      const statKeys = [
+        'Overhead',
+        'Cleaning',
+        'Counter',
+        'Interval',
+        'Lockings',
+      ];
+
+      for (const overhead of profilerOverhead) {
+        const { statistics } = overhead;
+        const { samplingCount } = statistics;
+
+        // Calculation the single values without any loop, it's not worth it.
+        overheadDurations += statistics.overheadDurations * samplingCount;
+        overheadPercentage += statistics.overheadPercentage * samplingCount;
+        profiledDuration += statistics.profiledDuration * samplingCount;
+        totalSamplingCount += samplingCount;
+
+        // Looping through the overhead values that have min/max/mean values
+        // and calculating them.
+        for (const stat of statKeys) {
+          const max = statistics['max' + stat];
+          const mean = statistics['mean' + stat];
+          const min = statistics['min' + stat];
+
+          let currentStat = calculatedStats.get(stat);
+          if (currentStat === undefined) {
+            currentStat = new ProfilerStats();
+            calculatedStats.set(stat, currentStat);
+          }
+
+          currentStat.count(min, max, mean, samplingCount);
+        }
+      }
+    }
+
+    return calculatedStats.size > 0 ? (
+      <details>
+        <summary className="arrowPanelSubTitle">Profiler Overhead</summary>
+        <div className="arrowPanelSection">
+          <div className="metaInfoGrid">
+            <div />
+            <div>Mean</div>
+            <div>Max</div>
+            <div>Min</div>
+            {Array.from(calculatedStats).map(([key, val]) => [
+              <div key={key}>{key}</div>,
+              <div key={key + 'mean'}>{formatNanoseconds(val.mean)}</div>,
+              <div key={key + 'max'}>{formatNanoseconds(val.max)}</div>,
+              <div key={key + 'min'}>{formatNanoseconds(val.min)}</div>,
+            ])}
+          </div>
+
+          {overheadDurations !== 0 ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoWideLabel">Overhead Durations:</span>
+              <span className="metaInfoValueRight">
+                {formatNanoseconds(overheadDurations / totalSamplingCount)}
+              </span>
+            </div>
+          ) : null}
+          {overheadPercentage !== 0 ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoWideLabel">Overhead Percentage:</span>
+              <span className="metaInfoValueRight">
+                {formatPercent(overheadPercentage / totalSamplingCount)}
+              </span>
+            </div>
+          ) : null}
+          {profiledDuration !== 0 ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoWideLabel">Profiled Duration:</span>
+              <span className="metaInfoValueRight">
+                {formatNanoseconds(profiledDuration / totalSamplingCount)}
+              </span>
+            </div>
+          ) : null}
+        </div>
+      </details>
+    ) : null;
+  }
+}
+
+// A helper class to calculate the weighted arithmetic mean statistic values.
+class ProfilerStats {
+  _max = 0;
+  _min = 0;
+  _mean = 0;
+  _weight = 0;
+
+  count(min: number, max: number, mean: number, weight: number) {
+    this._weight += weight;
+    this._min = min * weight;
+    this._max = max * weight;
+    this._mean = mean * weight;
+  }
+
+  get min(): number {
+    return this._min / this._weight;
+  }
+
+  get max(): number {
+    return this._max / this._weight;
+  }
+
+  get mean(): number {
+    return this._mean / this._weight;
+  }
+}

--- a/src/components/app/MenuButtons/MetaOverheadStatistics.js
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.js
@@ -16,9 +16,9 @@ import './MetaOverheadStatistics.css';
 // Profiler overhead statistics keys that have max/min/mean values.
 type StatKeys = 'Overhead' | 'Cleaning' | 'Counter' | 'Interval' | 'Lockings';
 
-type Props = {
-  profilerOverhead?: ProfilerOverhead[],
-};
+type Props = {|
+  +profilerOverhead: ProfilerOverhead[],
+|};
 
 /**
  * This component formats the profile's meta information into a dropdown panel.
@@ -39,43 +39,39 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
     // statistics values above.
     let totalSamplingCount = 0;
 
-    // Older profiles(before FF 70) don't have any overhead info. Don't show anything if
-    // that's the case.
-    if (profilerOverhead) {
-      // Overhead keys that have min/max/mean values to loop.
-      const statKeys = [
-        'Overhead',
-        'Cleaning',
-        'Counter',
-        'Interval',
-        'Lockings',
-      ];
+    // Overhead keys that have min/max/mean values to loop.
+    const statKeys = [
+      'Overhead',
+      'Cleaning',
+      'Counter',
+      'Interval',
+      'Lockings',
+    ];
 
-      for (const overhead of profilerOverhead) {
-        const { statistics } = overhead;
-        const { samplingCount } = statistics;
+    for (const overhead of profilerOverhead) {
+      const { statistics } = overhead;
+      const { samplingCount } = statistics;
 
-        // Calculation the single values without any loop, it's not worth it.
-        overheadDurations += statistics.overheadDurations * samplingCount;
-        overheadPercentage += statistics.overheadPercentage * samplingCount;
-        profiledDuration += statistics.profiledDuration * samplingCount;
-        totalSamplingCount += samplingCount;
+      // Calculation the single values without any loop, it's not worth it.
+      overheadDurations += statistics.overheadDurations * samplingCount;
+      overheadPercentage += statistics.overheadPercentage * samplingCount;
+      profiledDuration += statistics.profiledDuration * samplingCount;
+      totalSamplingCount += samplingCount;
 
-        // Looping through the overhead values that have min/max/mean values
-        // and calculating them.
-        for (const stat of statKeys) {
-          const max = statistics['max' + stat];
-          const mean = statistics['mean' + stat];
-          const min = statistics['min' + stat];
+      // Looping through the overhead values that have min/max/mean values
+      // and calculating them.
+      for (const stat of statKeys) {
+        const max = statistics['max' + stat];
+        const mean = statistics['mean' + stat];
+        const min = statistics['min' + stat];
 
-          let currentStat = calculatedStats.get(stat);
-          if (currentStat === undefined) {
-            currentStat = new ProfilerStats();
-            calculatedStats.set(stat, currentStat);
-          }
-
-          currentStat.count(min, max, mean, samplingCount);
+        let currentStat = calculatedStats.get(stat);
+        if (currentStat === undefined) {
+          currentStat = new ProfilerStats();
+          calculatedStats.set(stat, currentStat);
         }
+
+        currentStat.accumulate(min, max, mean, samplingCount);
       }
     }
 
@@ -140,7 +136,7 @@ class ProfilerStats {
   _accumulatedMean = 0;
   _accumulatedWeight = 0;
 
-  count(min: number, max: number, mean: number, weight: number) {
+  accumulate(min: number, max: number, mean: number, weight: number) {
     this._accumulatedWeight += weight;
     this._accumulatedMin += min * weight;
     this._accumulatedMax += max * weight;

--- a/src/components/app/MenuButtons/MetaOverheadStatistics.js
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.js
@@ -132,7 +132,8 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
 // For example let's say that we have 2 processes with these profile stats.
 // Process 1: samplingCount: 90, maxCounter: 10
 // Process 2: samplingCount: 10, maxCounter: 100
-// Since the process 2 has less samples, the weighted average maxCounter going to be 19.
+// Since the process 2 has less samples, the weighted average maxCounter going to be
+// (90 * 10 + 10 * 100) / (10 + 90) = 19
 class ProfilerStats {
   _accumulatedMax = 0;
   _accumulatedMin = 0;

--- a/src/components/shared/ArrowPanel.css
+++ b/src/components/shared/ArrowPanel.css
@@ -103,6 +103,7 @@
 .arrowPanelSubTitle {
   padding: 5px 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  font-weight: 700;
 }
 
 .arrowPanelContent {
@@ -185,10 +186,15 @@
   margin-bottom: 12px;
 }
 
-.metaInfoLabel {
+.metaInfoLabel,
+.metaInfoWideLabel {
   display: inline-block;
   width: 120px;
   color: var(--grey-50);
+}
+
+.metaInfoWideLabel {
+  width: 140px;
 }
 
 .metaInfoList {
@@ -198,4 +204,30 @@
 .metaInfoList .metaInfoListItem {
   margin-left: 110px;
   list-style: circle;
+}
+
+.metaInfoGrid {
+  display: grid;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  margin-bottom: 20px;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.metaInfoGrid > div {
+  margin: 2px 0;
+}
+
+.metaInfoGrid > div:nth-child(-n + 4) {
+  display: block;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  font-weight: 500;
+}
+
+.metaInfoGrid > div:nth-child(4n + 1) {
+  color: var(--grey-50);
+  font-weight: 500;
+}
+
+.metaInfoGrid > div:not(:nth-child(4n + 1)) {
+  text-align: right;
 }

--- a/src/components/shared/ArrowPanel.css
+++ b/src/components/shared/ArrowPanel.css
@@ -205,33 +205,3 @@
   margin-left: 110px;
   list-style: circle;
 }
-
-.metaInfoGrid {
-  display: grid;
-  margin-bottom: 20px;
-  grid-template-columns: repeat(4, 1fr);
-}
-
-.metaInfoGrid > div {
-  margin: 2px 0;
-}
-
-.metaInfoGrid > div:nth-child(-n + 4) {
-  display: block;
-  font-weight: 500;
-}
-
-.metaInfoGrid > div:nth-child(4n + 1) {
-  color: var(--grey-50);
-  font-weight: 500;
-}
-
-.metaInfoGrid > div:not(:nth-child(4n + 1)) {
-  text-align: right;
-}
-
-.metaInfoValueRight {
-  display: inline-block;
-  width: calc(100% - 140px);
-  text-align: right;
-}

--- a/src/components/shared/ArrowPanel.css
+++ b/src/components/shared/ArrowPanel.css
@@ -208,7 +208,6 @@
 
 .metaInfoGrid {
   display: grid;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   margin-bottom: 20px;
   grid-template-columns: repeat(4, 1fr);
 }
@@ -219,7 +218,6 @@
 
 .metaInfoGrid > div:nth-child(-n + 4) {
   display: block;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   font-weight: 500;
 }
 
@@ -229,5 +227,11 @@
 }
 
 .metaInfoGrid > div:not(:nth-child(4n + 1)) {
+  text-align: right;
+}
+
+.metaInfoValueRight {
+  display: inline-block;
+  width: calc(100% - 140px);
   text-align: right;
 }

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -262,7 +262,10 @@ describe('app/MenuButtons', function() {
       jest.useFakeTimers();
       jest
         .spyOn(Date.prototype, 'toLocaleString')
-        .mockImplementation(Date.prototype.toUTCString);
+        .mockImplementation(function() {
+          // eslint-disable-next-line babel/no-invalid-this
+          return 'toLocaleString ' + this.toUTCString();
+        });
       // Using gecko profile because it has metadata and profilerOverhead data in it.
       const profile = processProfile(createGeckoProfile());
       const store = storeWithProfile(profile);

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -5,6 +5,7 @@
 // @flow
 import * as React from 'react';
 import MenuButtons from '../../components/app/MenuButtons';
+import { MenuButtonsMetaInfo } from '../../components/app/MenuButtons/MetaInfo';
 import { render, fireEvent, wait } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
@@ -15,6 +16,8 @@ import {
   getProfileFromTextSamples,
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
+import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
+import { processProfile } from '../../profile-logic/process-profile';
 
 // Mocking SymbolStoreDB
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';
@@ -251,6 +254,30 @@ describe('app/MenuButtons', function() {
       // Now click the error button, and get a snapshot of the panel.
       clickAndRunTimers(getErrorButton());
       expect(getPanel()).toMatchSnapshot();
+    });
+  });
+
+  describe('<MenuButtonsMetaInfo>', function() {
+    it('matches the snapshot', async () => {
+      jest.useFakeTimers();
+      jest
+        .spyOn(Date.prototype, 'toLocaleString')
+        .mockImplementation(Date.prototype.toUTCString);
+      // Using gecko profile because it has metadata and profilerOverhead data in it.
+      const profile = processProfile(createGeckoProfile());
+      const store = storeWithProfile(profile);
+
+      const { container, getByValue } = render(
+        <Provider store={store}>
+          <MenuButtonsMetaInfo profile={profile} />
+        </Provider>
+      );
+
+      const metaInfoButton = getByValue('Firefox (48.0) Intel Mac OS X 10.11');
+      fireEvent.click(metaInfoButton);
+      jest.runAllTimers();
+
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,5 +1,317 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
+<div
+  class="buttonWithPanel menuButtonsMetaInfoButton open"
+>
+  <div
+    class="buttonWithPanelButtonWrapper"
+  >
+    <input
+      class="buttonWithPanelButton menuButtonsMetaInfoButtonButton"
+      type="button"
+      value="Firefox (48.0) Intel Mac OS X 10.11"
+    />
+  </div>
+  <div
+    class="arrowPanelAnchor"
+  >
+    <div
+      class="arrowPanel open arrowPanelOpenMetaInfo"
+    >
+      <div
+        class="arrowPanelArrow"
+      />
+      <div
+        class="arrowPanelContent"
+      >
+        <h2
+          class="arrowPanelSubTitle"
+        >
+          Timing
+        </h2>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Recording started:
+            </span>
+            Sat, 09 Apr 2016 17:02:32 GMT
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Interval:
+            </span>
+            1
+            ms
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Profile Version:
+            </span>
+            24
+          </div>
+        </div>
+        <h2
+          class="arrowPanelSubTitle"
+        >
+          Application
+        </h2>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Name:
+            </span>
+            Firefox
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Version:
+            </span>
+            48.0
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Update Channel:
+            </span>
+            nightly
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Build ID:
+            </span>
+            20181126165837
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Build Type:
+            </span>
+            Debug
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Extensions:
+            </span>
+            <ul
+              class="metaInfoList"
+            >
+              <li
+                class="metaInfoListItem"
+              >
+                Form Autofill
+              </li>
+              <li
+                class="metaInfoListItem"
+              >
+                Firefox Screenshots
+              </li>
+              <li
+                class="metaInfoListItem"
+              >
+                Gecko Profiler
+              </li>
+            </ul>
+          </div>
+        </div>
+        <h2
+          class="arrowPanelSubTitle"
+        >
+          Platform
+        </h2>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Platform:
+            </span>
+            Macintosh
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              OS:
+            </span>
+            Intel Mac OS X 10.11
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              ABI:
+            </span>
+            x86_64-gcc3
+          </div>
+        </div>
+        <details>
+          <summary
+            class="arrowPanelSubTitle"
+          >
+            Profiler Overhead
+          </summary>
+          <div
+            class="arrowPanelSection"
+          >
+            <div
+              class="metaInfoGrid"
+            >
+              <div />
+              <div>
+                Mean
+              </div>
+              <div>
+                Max
+              </div>
+              <div>
+                Min
+              </div>
+              <div>
+                Overhead
+              </div>
+              <div>
+                227ns
+              </div>
+              <div>
+                410ns
+              </div>
+              <div>
+                38.0ns
+              </div>
+              <div>
+                Cleaning
+              </div>
+              <div>
+                54.1ns
+              </div>
+              <div>
+                100ns
+              </div>
+              <div>
+                7.00ns
+              </div>
+              <div>
+                Counter
+              </div>
+              <div>
+                59.1ns
+              </div>
+              <div>
+                105ns
+              </div>
+              <div>
+                12.0ns
+              </div>
+              <div>
+                Interval
+              </div>
+              <div>
+                857ns
+              </div>
+              <div>
+                1,000ns
+              </div>
+              <div>
+                0.0000ns
+              </div>
+              <div>
+                Lockings
+              </div>
+              <div>
+                49.1ns
+              </div>
+              <div>
+                95.0ns
+              </div>
+              <div>
+                2.00ns
+              </div>
+            </div>
+            <div
+              class="metaInfoRow"
+            >
+              <span
+                class="metaInfoWideLabel"
+              >
+                Overhead Durations:
+              </span>
+              1,586ns
+            </div>
+            <div
+              class="metaInfoRow"
+            >
+              <span
+                class="metaInfoWideLabel"
+              >
+                Overhead Percentage:
+              </span>
+              26,433%
+            </div>
+            <div
+              class="metaInfoRow"
+            >
+              <span
+                class="metaInfoWideLabel"
+              >
+                Profiled Duration:
+              </span>
+              6.00ns
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`app/MenuButtons <Publish> matches the snapshot for an error 1`] = `
 <div
   class="menuButtonsPublishUpload"

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -282,7 +282,11 @@ exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
               >
                 Overhead Durations:
               </span>
-              1,586ns
+              <span
+                class="metaInfoValueRight"
+              >
+                1,586ns
+              </span>
             </div>
             <div
               class="metaInfoRow"
@@ -292,7 +296,11 @@ exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
               >
                 Overhead Percentage:
               </span>
-              26,433%
+              <span
+                class="metaInfoValueRight"
+              >
+                26,433%
+              </span>
             </div>
             <div
               class="metaInfoRow"
@@ -302,7 +310,11 @@ exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
               >
                 Profiled Duration:
               </span>
-              6.00ns
+              <span
+                class="metaInfoValueRight"
+              >
+                6.00ns
+              </span>
             </div>
           </div>
         </details>

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -41,7 +41,7 @@ exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
             >
               Recording started:
             </span>
-            Sat, 09 Apr 2016 17:02:32 GMT
+            toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
           </div>
           <div
             class="metaInfoRow"

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -518,6 +518,9 @@ export type Profile = {|
   // The counters list is optional only because old profilers may not have them.
   // An upgrader could be written to make this non-optional.
   counters?: Counter[],
+  // The profilerOverhead list is optional only because old profilers may not
+  // have them. An upgrader could be written to make this non-optional.
+  // This is list because there is a profiler overhead per process.
   profilerOverhead?: ProfilerOverhead[],
   threads: Thread[],
 |};

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -127,6 +127,14 @@ export function formatSI(num: number): string {
   return formatNumber(num / (1000 * 1000 * 1000), 3, 2) + 'G';
 }
 
+export function formatNanoseconds(
+  time: Milliseconds,
+  significantDigits: number = 3,
+  maxFractionalDigits: number = 4
+) {
+  return formatNumber(time, significantDigits, maxFractionalDigits) + 'ns';
+}
+
 export function formatMicroseconds(
   time: Microseconds,
   significantDigits: number = 2,

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -7,7 +7,7 @@
 import memoize from 'memoize-immutable';
 import NamedTupleMap from 'namedtuplemap';
 
-import type { Microseconds, Milliseconds } from '../types/units';
+import type { Microseconds, Milliseconds, Nanoseconds } from '../types/units';
 
 // Calling `toLocalestring` repeatedly in a tight loop can be a performance
 // problem. It's much better to reuse an instance of `Intl.NumberFormat`.
@@ -128,7 +128,7 @@ export function formatSI(num: number): string {
 }
 
 export function formatNanoseconds(
-  time: Milliseconds,
+  time: Nanoseconds,
   significantDigits: number = 3,
   maxFractionalDigits: number = 4
 ) {


### PR DESCRIPTION
The PR adds the profiler overhead information to the metadata panel. It adds a table for min/max/mean values and a small 3 item list for individual statistics fields.
Resolves #2185.

[deploy preview](https://deploy-preview-2233--perf-html.netlify.com/public/5805158eaa5555c7d3d6c993381a73dd36ddf2c7/calltree/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=8429-1-2-0~7451-0~7603-0~7545-0~7500-0-1~&thread=5&v=4)