### PR TITLE
Use the documented API to access the public objects in Google Cloud S…

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -780,7 +780,13 @@ async function _extractJsonFromResponse(
 }
 
 function getProfileUrlForHash(hash: string): string {
-  return `https://profile-store.commondatastorage.googleapis.com/${hash}`;
+  // See https://cloud.google.com/storage/docs/access-public-data
+  // The URL is https://storage.googleapis.com/<BUCKET>/<FILEPATH>.
+  // https://<BUCKET>.storage.googleapis.com/<FILEPATH> seems to also work but
+  // is not documented nowadays.
+  // By convention, "profile-store" is the name of our bucket, and the file path
+  // is the hash we receive in the URL.
+  return `https://storage.googleapis.com/profile-store/${hash}`;
 }
 
 export function retrieveProfileFromStore(

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -507,7 +507,7 @@ describe('actions/receive-profile', function() {
 
     it('can retrieve a profile from the web and save it to state', async function() {
       const hash = 'c5e53f9ab6aecef926d4be68c84f2de550e2ac2f';
-      const expectedUrl = `https://profile-store.commondatastorage.googleapis.com/${hash}`;
+      const expectedUrl = `https://storage.googleapis.com/profile-store/${hash}`;
 
       window.fetch = jest.fn(url =>
         Promise.resolve(
@@ -561,7 +561,7 @@ describe('actions/receive-profile', function() {
 
     it('requests several times in case of 403', async function() {
       const hash = 'c5e53f9ab6aecef926d4be68c84f2de550e2ac2f';
-      const expectedUrl = `https://profile-store.commondatastorage.googleapis.com/${hash}`;
+      const expectedUrl = `https://storage.googleapis.com/profile-store/${hash}`;
       window.fetch
         .mockImplementationOnce(_ => Promise.resolve(fetch403Response))
         .mockImplementationOnce(url =>


### PR DESCRIPTION
…torage

When I looked for some documentation about our URL I couldn't find any reference to the one we were using. So I decided to update it to follow the latest documentation in case they decide to retire the old URL.

[Here is a deploy preview](https://deploy-preview-2237--perf-html.netlify.com/public/24a9fdbdab160a8b11390de381f1c8b334f50f24/calltree/?globalTrackOrder=5-0-2-3-4-1&hiddenGlobalTracks=2-3-4&implementation=js&localTrackOrderByPid=3823-0~&thread=2&v=4) to check that this still works.