### PR TITLE
(WIP) View the user timings in the stack chart

### DIFF
--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -60,6 +60,7 @@ type StateProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +scrollToSelectionGeneration: number,
+  getMarker: Function
 |};
 
 type DispatchProps = {|
@@ -136,6 +137,7 @@ class StackChartGraph extends React.PureComponent<Props> {
       categories,
       selectedCallNodeIndex,
       scrollToSelectionGeneration,
+      getMarker,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -159,6 +161,7 @@ class StackChartGraph extends React.PureComponent<Props> {
             }}
           >
             <div className="stackChartContent">
+            {/* yooooooo */}
               <StackChartCanvas
                 viewportProps={{
                   previewSelection,
@@ -174,6 +177,7 @@ class StackChartGraph extends React.PureComponent<Props> {
                   interval,
                   thread,
                   stackTimingByDepth,
+                  getMarker,
                   // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
                   updatePreviewSelection,
                   rangeStart: timeRange.start,
@@ -219,6 +223,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
         state
       ),
       scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
+      getMarker: selectedThreadSelectors.getMarkerGetter(state)
     };
   },
   mapDispatchToProps: {

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -891,6 +891,10 @@ export function isNetworkMarker(marker: Marker): boolean {
   return !!(marker.data && marker.data.type === 'Network');
 }
 
+export function isUserTimingMarker(marker: Marker): boolean {
+  return !!(marker.data && marker.data.type === 'UserTiming');
+}
+
 export function isNavigationMarker({ name, data }: Marker) {
   if (name === 'TTI') {
     // TTI is only selectable by name, as it doesn't have a structured payload.

--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -10,6 +10,8 @@ import { tabSlugs, type TabSlug } from '../../app-logic/tabs-handling';
 import type { Selector } from '../../types/store';
 import type { $ReturnType } from '../../types/utils';
 import type { Thread, JsTracerTable } from '../../types/profile';
+import * as ProfileSelectors from "../profile";
+import * as StackTiming from '../../profile-logic/stack-timing';
 
 /**
  * Infer the return type from the getStackAndSampleSelectorsPerThread function. This
@@ -29,13 +31,19 @@ type NeededThreadSelectors = {
   getThread: Selector<Thread>,
   getIsNetworkChartEmptyInFullRange: Selector<boolean>,
   getJsTracerTable: Selector<JsTracerTable | null>,
+   getCallNodeInfo: *,
+  getUserTimingMarkers: *,
+  getCallNodeMaxDepth: *,
+  getMarkerGetter: *,
 };
+
+
 
 /**
  * Create the selectors for a thread that have to do with either stacks or samples.
  */
 export function getComposedSelectorsPerThread(
-  threadSelectors: NeededThreadSelectors
+  threadSelectors: NeededThreadSelectors,
 ): * {
   /**
    * Visible tabs are computed based on the current state of the profile. Some
@@ -66,7 +74,19 @@ export function getComposedSelectorsPerThread(
     }
   );
 
+
+  const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> = createSelector(
+    threadSelectors.getFilteredThread,
+    threadSelectors.getCallNodeInfo,
+    threadSelectors.getCallNodeMaxDepth,
+    threadSelectors.getUserTimingMarkersIndexes,
+    threadSelectors.getMarkerGetter,
+    ProfileSelectors.getProfileInterval,
+    StackTiming.getStackTimingByDepth
+  );
+
   return {
     getUsefulTabs,
+    getStackTimingByDepth,
   };
 }

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -103,6 +103,8 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
       )
   );
 
+
+
   /**
    * This selector returns a function that's used to retrieve a marker object
    * from its MarkerIndex:
@@ -275,6 +277,13 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     filterMarkerIndexesCreator(MarkerData.isNetworkMarker)
   );
 
+  const getUserTimingMarkersIndexes: Selector<MarkerIndex[]> = createSelector(
+    getMarkerGetter,
+    getCommittedRangeFilteredMarkerIndexes,
+    filterMarkerIndexesCreator(MarkerData.isUserTimingMarker)
+  );
+
+
   /**
    * This filters network markers using a search string.
    */
@@ -433,5 +442,6 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getRightClickedMarkerIndex,
     getRightClickedMarker,
     getIsNetworkChartEmptyInFullRange,
+    getUserTimingMarkersIndexes
   };
 }

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -214,14 +214,6 @@ export function getStackAndSampleSelectorsPerThread(
     CallTree.getCallTree
   );
 
-  const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> = createSelector(
-    threadSelectors.getFilteredThread,
-    getCallNodeInfo,
-    getCallNodeMaxDepth,
-    ProfileSelectors.getProfileInterval,
-    StackTiming.getStackTimingByDepth
-  );
-
   const getCallNodeMaxDepthForFlameGraph: Selector<number> = createSelector(
     threadSelectors.getPreviewFilteredThread,
     getCallNodeInfo,
@@ -248,7 +240,6 @@ export function getStackAndSampleSelectorsPerThread(
     getSamplesSelectedStatesInFilteredThread,
     getTreeOrderComparatorInFilteredThread,
     getCallTree,
-    getStackTimingByDepth,
     getCallNodeMaxDepthForFlameGraph,
     getFlameGraphTiming,
   };


### PR DESCRIPTION
This is a work in progress patch for viewing the user timings in context of the stack chart

http://localhost:4242/public/8ea9ecb28444ce61127fc369bb3d977c3a534d89/stack-chart/?globalTrackOrder=0&hiddenLocalTracksByPid=81724-0-1&implementation=js&localTrackOrderByPid=81724-0-1~&range=6.3805_9.2548&thread=0&v=4

<img width="2368" alt="Screen Shot 2019-09-20 at 2 03 47 PM" src="https://user-images.githubusercontent.com/254562/65359155-8a263e80-dbb0-11e9-853c-05d7c57b3d1e.png">
