### PR TITLE
Handle the case where the counter sample data is incorrectly an empty…

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -816,21 +816,36 @@ function _processCounters(
     );
   }
 
-  return geckoCounters.map(
-    ({ name, category, description, sample_groups }) => ({
-      name,
-      category,
-      description,
-      pid: mainThread.pid,
-      mainThreadIndex,
-      sampleGroups: {
-        id: sample_groups.id,
-        samples: adjustTableTimestamps(
-          _toStructOfArrays(sample_groups.samples),
-          delta
-        ),
-      },
-    })
+  return geckoCounters.reduce(
+    (result, { name, category, description, sample_groups }) => {
+      if (
+        sample_groups.id === undefined ||
+        sample_groups.samples === undefined
+      ) {
+        // Due to a bug in Gecko, it's possible that we have a counter that has no
+        // sample data. This is likely a Gecko problem that we'll need to fix.
+        // See https://github.com/firefox-devtools/profiler/issues/2248 and
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1584190
+        return result;
+      }
+
+      result.push({
+        name,
+        category,
+        description,
+        pid: mainThread.pid,
+        mainThreadIndex,
+        sampleGroups: {
+          id: sample_groups.id,
+          samples: adjustTableTimestamps(
+            _toStructOfArrays(sample_groups.samples),
+            delta
+          ),
+        },
+      });
+      return result;
+    },
+    []
   );
 }
 

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -737,7 +737,7 @@ function _createGeckoThreadWithJsTimings(name: string): GeckoThread {
 }
 
 export function createGeckoCounter(thread: GeckoThread): GeckoCounter {
-  const geckoCounter: GeckoCounter = {
+  const geckoCounter = {
     name: 'My Counter',
     category: 'My Category',
     description: 'My Description',

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -168,17 +168,23 @@ export type GeckoCounter = {|
   name: string,
   category: string,
   description: string,
-  sample_groups: {|
-    id: number,
-    samples: {|
-      schema: {|
-        time: 0,
-        number: 1,
-        count: 2,
-      |},
-      data: Array<[number, number, number]>,
-    |},
-  |},
+  sample_groups:
+    | {|
+        id: number,
+        samples: {|
+          schema: {|
+            time: 0,
+            number: 1,
+            count: 2,
+          |},
+          data: Array<[number, number, number]>,
+        |},
+      |}
+    // Due to a bug in Gecko, it's possible that we have a counter that has no
+    // sample data. This is likely a Gecko problem that we'll need to fix.
+    // See https://github.com/firefox-devtools/profiler/issues/2248 and
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1584190
+    | {||},
 |};
 
 export type GeckoProfilerOverhead = {|


### PR DESCRIPTION
… object.

Fixes #2248

I didn't try to reproduce the issue myself, my guess is that we'd have to disable the counters or something. But this makes sense when looking at the C++ code.