### PR TITLE
Make the statistics object optional since gecko may not add that field

### DIFF
--- a/src/components/app/MenuButtons/MetaOverheadStatistics.js
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.js
@@ -50,6 +50,13 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
 
     for (const overhead of profilerOverhead) {
       const { statistics } = overhead;
+
+      // Statistics can be undefined in case there is no sample in the
+      // profilerOverhead object. Ignore it and continue if that's the case.
+      if (statistics === undefined) {
+        continue;
+      }
+
       const { samplingCount } = statistics;
 
       // Calculation the single values without any loop, it's not worth it.

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -324,6 +324,203 @@ exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
 </div>
 `;
 
+exports[`app/MenuButtons <MenuButtonsMetaInfo> with no statistics object should not make the app crash 1`] = `
+<div
+  class="buttonWithPanel menuButtonsMetaInfoButton open"
+>
+  <div
+    class="buttonWithPanelButtonWrapper"
+  >
+    <input
+      class="buttonWithPanelButton menuButtonsMetaInfoButtonButton"
+      type="button"
+      value="Firefox (48.0) Intel Mac OS X 10.11"
+    />
+  </div>
+  <div
+    class="arrowPanelAnchor"
+  >
+    <div
+      class="arrowPanel open arrowPanelOpenMetaInfo"
+    >
+      <div
+        class="arrowPanelArrow"
+      />
+      <div
+        class="arrowPanelContent"
+      >
+        <h2
+          class="arrowPanelSubTitle"
+        >
+          Timing
+        </h2>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Recording started:
+            </span>
+            toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Interval:
+            </span>
+            1
+            ms
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Profile Version:
+            </span>
+            24
+          </div>
+        </div>
+        <h2
+          class="arrowPanelSubTitle"
+        >
+          Application
+        </h2>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Name:
+            </span>
+            Firefox
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Version:
+            </span>
+            48.0
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Update Channel:
+            </span>
+            nightly
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Build ID:
+            </span>
+            20181126165837
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Build Type:
+            </span>
+            Debug
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Extensions:
+            </span>
+            <ul
+              class="metaInfoList"
+            >
+              <li
+                class="metaInfoListItem"
+              >
+                Form Autofill
+              </li>
+              <li
+                class="metaInfoListItem"
+              >
+                Firefox Screenshots
+              </li>
+              <li
+                class="metaInfoListItem"
+              >
+                Gecko Profiler
+              </li>
+            </ul>
+          </div>
+        </div>
+        <h2
+          class="arrowPanelSubTitle"
+        >
+          Platform
+        </h2>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Platform:
+            </span>
+            Macintosh
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              OS:
+            </span>
+            Intel Mac OS X 10.11
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              ABI:
+            </span>
+            x86_64-gcc3
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`app/MenuButtons <Publish> matches the snapshot for an error 1`] = `
 <div
   class="menuButtonsPublishUpload"

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -201,7 +201,8 @@ export type GeckoProfilerOverhead = {|
       [Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds, Nanoseconds]
     >,
   |},
-  statistics: ProfilerOverheadStats,
+  // There is no statistics object if there is no sample.
+  statistics?: ProfilerOverheadStats,
 |};
 
 /* This meta object is used in subprocesses profiles.

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -360,7 +360,8 @@ export type ProfilerOverheadSamplesTable = {|
  */
 export type ProfilerOverhead = {|
   samples: ProfilerOverheadSamplesTable,
-  statistics: ProfilerOverheadStats,
+  // There is no statistics object if there is no sample.
+  statistics?: ProfilerOverheadStats,
   pid: Pid,
   mainThreadIndex: ThreadIndex,
 |};


### PR DESCRIPTION
We saw that problem in a profile with no samples. It's crashing the app, it shouldn't.

[production](https://profiler.firefox.com/public/96afc887493fb2a2454e256325944be8945ff4e5/calltree/?globalTrackOrder=0&localTrackOrderByPid=14704-0~&thread=0&v=4)
[deploy preview](https://deploy-preview-2262--perf-html.netlify.com/public/96afc887493fb2a2454e256325944be8945ff4e5/calltree/?globalTrackOrder=0&localTrackOrderByPid=14704-0~&thread=0&v=4)

STR is: open the profile info panel.