### PR TITLE
Add markers context menu to the timeline

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -338,15 +338,13 @@ export function changeRightClickedTrack(
 }
 
 export function setContextMenuVisibility(
-  isVisible: boolean
-): ThunkAction<void> {
-  return (dispatch, getState) => {
-    const selectedThreadIndex = getSelectedThreadIndex(getState());
-    dispatch({
-      type: 'SET_CONTEXT_MENU_VISIBILITY',
-      threadIndex: selectedThreadIndex,
-      isVisible,
-    });
+  isVisible: boolean,
+  threadIndex: ThreadIndex
+): Action {
+  return {
+    type: 'SET_CONTEXT_MENU_VISIBILITY',
+    threadIndex,
+    isVisible,
   };
 }
 

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -68,7 +68,7 @@ class CallNodeContextMenu extends PureComponent<Props> {
   // somewhere else.
   // This is the order of events in such a situation:
   // 0. The menu is open somewhere, it means the user right clicked somewhere
-  //     previously, and as a result some node has the "right clicked" status.
+  //    previously, and as a result some node has the "right clicked" status.
   // 1. The user right clicks on another node. This is actually happening in
   //    several events, the first event is "mousedown": this is where our own
   //    components react for right click (both our TreeView and our charts)
@@ -89,13 +89,13 @@ class CallNodeContextMenu extends PureComponent<Props> {
   //    just a bit, just in case we get a `_onShow` call right after that.
   _onShow = () => {
     clearTimeout(this._hidingTimeout);
-    this.props.setContextMenuVisibility(true);
+    this.props.setContextMenuVisibility(true, this.props.threadIndex);
   };
 
   _onHide = () => {
     this._hidingTimeout = setTimeout(() => {
       this._hidingTimeout = null;
-      this.props.setContextMenuVisibility(false);
+      this.props.setContextMenuVisibility(false, this.props.threadIndex);
     });
   };
 

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -22,6 +22,10 @@ import {
   getImplementationFilter,
   getInvertCallstack,
 } from '../../selectors/url-state';
+import {
+  getRightClickedCallNodePath,
+  getRightClickedCallNodeIndex,
+} from '../../selectors/right-clicked-call-node-path';
 
 import {
   convertToTransformType,
@@ -508,8 +512,8 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
     implementation: getImplementationFilter(state),
     inverted: getInvertCallstack(state),
-    callNodePath: selectedThreadSelectors.getRightClickedCallNodePath(state),
-    callNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(state),
+    callNodePath: getRightClickedCallNodePath(state),
+    callNodeIndex: getRightClickedCallNodeIndex(state),
     selectedTab: getSelectedTab(state),
   }),
   mapDispatchToProps: {

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -35,6 +35,17 @@ export type ThreadSelectorsPerThread = $ReturnType<
   typeof getThreadSelectorsPerThread
 >;
 
+export const getThreadIndexWithSelectedMarker: Selector<ThreadIndex | null> = createSelector(
+  ProfileSelectors.getProfileViewOptions,
+  viewOptions => {
+    const threadIndex = viewOptions.perThread.findIndex(
+      thread => thread.rightClickedMarker !== null
+    );
+
+    return threadIndex === -1 ? null : threadIndex;
+  }
+);
+
 /**
  * Create the selectors for a thread that have to do with an entire thread. This includes
  * the general filtering pipeline for threads.

--- a/src/selectors/right-clicked-call-node-path.js
+++ b/src/selectors/right-clicked-call-node-path.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { createSelector } from 'reselect';
+import { getCallNodeIndexFromPath } from '../profile-logic/profile-data';
+import { getThreadSelectors } from './per-thread';
+import { getProfileViewOptions } from './profile';
+
+import type {
+  CallNodePath,
+  IndexIntoCallNodeTable,
+} from '../types/profile-derived';
+import type { Selector } from '../types/store';
+
+export const getRightClickedCallNodePath: Selector<CallNodePath | null> = createSelector(
+  getProfileViewOptions,
+  viewOptions => {
+    return viewOptions.rightClickedCallNodePath
+      ? viewOptions.rightClickedCallNodePath.callNodePath
+      : null;
+  }
+);
+
+export const getRightClickedCallNodeIndex: Selector<IndexIntoCallNodeTable | null> = state => {
+  const viewOptions = getProfileViewOptions(state);
+
+  if (viewOptions.rightClickedCallNodePath === null) {
+    return null;
+  }
+
+  const { threadIndex, callNodePath } = viewOptions.rightClickedCallNodePath;
+  const { getCallNodeInfo } = getThreadSelectors(threadIndex);
+  const { callNodeTable } = getCallNodeInfo(state);
+
+  return getCallNodeIndexFromPath(callNodePath, callNodeTable);
+};

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -42,7 +42,7 @@ describe('calltree/CallNodeContextMenu', function() {
   }
 
   function setup(store = createStore(), openMenuState = true) {
-    store.dispatch(setContextMenuVisibility(openMenuState));
+    store.dispatch(setContextMenuVisibility(openMenuState, 0));
 
     const renderResult = render(
       <Provider store={store}>

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -35,25 +35,37 @@ process: \\"tab\\" (222)"
           class="timelineMarkers timelineMarkersMemory"
           data-testid="TimelineMarkersMemory"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="timelineMarkers"
           data-testid="TimelineMarkersJank"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="timelineMarkers timelineMarkersGeckoMain"
           data-testid="TimelineMarkersOverview"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="threadActivityGraph"
@@ -101,9 +113,13 @@ process: \\"tab\\" (222)"
               class="timelineMarkers selected"
               data-testid="TimelineMarkersJank"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-              />
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <canvas
+                  class="timelineMarkersCanvas"
+                />
+              </div>
             </div>
             <div
               class="threadActivityGraph"
@@ -149,9 +165,13 @@ process: \\"tab\\" (222)"
               class="timelineMarkers"
               data-testid="TimelineMarkersJank"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-              />
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <canvas
+                  class="timelineMarkersCanvas"
+                />
+              </div>
             </div>
             <div
               class="threadActivityGraph"
@@ -229,9 +249,13 @@ process: \\"default\\" (5555)"
               class="timelineMarkers"
               data-testid="TimelineMarkersJank"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-              />
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <canvas
+                  class="timelineMarkersCanvas"
+                />
+              </div>
             </div>
             <div
               class="threadActivityGraph"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -29,9 +29,13 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
           class="timelineMarkers timelineMarkersMemory"
           data-testid="TimelineMarkersMemory"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="timelineTrackMemoryGraph"
@@ -141,9 +145,13 @@ process: \\"tab\\" (222)"
           class="timelineMarkers"
           data-testid="TimelineMarkersJank"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="threadActivityGraph"

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -5,11 +5,15 @@ exports[`TimelineMarkers renders correctly 1`] = `
   class="timelineMarkers selected"
   data-testid="TimelineMarkersOverview"
 >
-  <canvas
-    class="timelineMarkersCanvas"
-    height="300"
-    width="200"
-  />
+  <div
+    class="react-contextmenu-wrapper"
+  >
+    <canvas
+      class="timelineMarkersCanvas"
+      height="300"
+      width="200"
+    />
+  </div>
 </div>
 `;
 

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -148,9 +148,13 @@ exports[`TrackMemory matches the component snapshot 1`] = `
     class="timelineMarkers timelineMarkersMemory selected"
     data-testid="TimelineMarkersMemory"
   >
-    <canvas
-      class="timelineMarkersCanvas"
-    />
+    <div
+      class="react-contextmenu-wrapper"
+    >
+      <canvas
+        class="timelineMarkersCanvas"
+      />
+    </div>
   </div>
   <div
     class="timelineTrackMemoryGraph"

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -8,9 +8,13 @@ exports[`timeline/TrackThread matches the snapshot 1`] = `
     class="timelineMarkers selected"
     data-testid="TimelineMarkersJank"
   >
-    <canvas
-      class="timelineMarkersCanvas"
-    />
+    <div
+      class="react-contextmenu-wrapper"
+    >
+      <canvas
+        class="timelineMarkersCanvas"
+      />
+    </div>
   </div>
   <div
     class="threadStackGraph"

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -43,6 +43,11 @@ export type ThreadViewOptions = {|
   +rightClickedMarker: MarkerIndex | null,
 |};
 
+export type RightClickedCallNodePath = {|
+  +threadIndex: ThreadIndex,
+  +callNodePath: CallNodePath,
+|};
+
 export type ProfileViewState = {|
   +viewOptions: {|
     perThread: ThreadViewOptions[],
@@ -53,6 +58,7 @@ export type ProfileViewState = {|
     focusCallTreeGeneration: number,
     rootRange: StartEndRange,
     rightClickedTrack: TrackReference | null,
+    rightClickedCallNodePath: RightClickedCallNodePath | null,
   |},
   +globalTracks: GlobalTrack[],
   +localTracksByPid: Map<Pid, LocalTrack[]>,


### PR DESCRIPTION
This PR adds marker context menu to markers in the timeline. I haven't added any new tests just yet as I was hoping to get some feedback on the approach first. I'm happy to add some if needed if you feel like the taken approach is okay.

The gist of the implementation is as follows:

- Trigger `changeRightClickedMarker` action when markers in the timeline are right clicked
- Wrap timeline canvases in marker context trigger
- Look for any selected marker in MarkerContextMenu instead of only looking for one in selected thread. This is needed as the user can right click a marker that is not in selected thread
- Pass `threadIndex` when changing context visibility as it's not happening only for selected thread now (same reason as above)

Closes #2189

EDIT: whoops, accidentally metioned the wrong issue in the PR description, now it's the correct one
