### PR TITLE
Successfully bail out early during sanitization when there is no preference marker

### DIFF
--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -10,6 +10,7 @@ import {
   getCommittedRange,
   getGlobalTracks,
   getLocalTracksByPid,
+  getHasPreferenceMarkers,
 } from './profile';
 import { compress } from '../utils/gz';
 import { serializeProfile } from '../profile-logic/process-profile';
@@ -69,6 +70,7 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
   getHiddenLocalTracksByPid,
   getGlobalTracks,
   getLocalTracksByPid,
+  getHasPreferenceMarkers,
   (
     checkedSharingOptions,
     profile,
@@ -76,11 +78,19 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
     hiddenGlobalTracks,
     hiddenLocalTracksByPid,
     globalTracks,
-    localTracksByPid
+    localTracksByPid,
+    hasPreferenceMarkers
   ) => {
     let isIncludingEverything = true;
-    for (const value of Object.values(checkedSharingOptions)) {
-      isIncludingEverything = isIncludingEverything && value;
+    for (const prop in checkedSharingOptions) {
+      // Do not include preference values checkbox if it's hidden.
+      // Even though `includePreferenceValues` is not taken into account, it's
+      // is false, if the profile updateChannel is not nightly or custom build.
+      if (prop === 'includePreferenceValues' && !hasPreferenceMarkers) {
+        continue;
+      }
+      isIncludingEverything =
+        isIncludingEverything && checkedSharingOptions[prop];
     }
     if (isIncludingEverything) {
       // No sanitization is happening, bail out early.

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -9,6 +9,13 @@ import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 import type { RemoveProfileInformation } from '../../types/profile-derived';
+import { storeWithProfile } from '../fixtures/stores';
+import { getHasPreferenceMarkers } from '../../selectors/profile';
+import {
+  getCheckedSharingOptions,
+  getRemoveProfileInformation,
+} from '../../selectors/publish';
+import { toggleCheckedSharingOptions } from '../../actions/publish';
 
 describe('sanitizePII', function() {
   function getRemoveProfileInformation(
@@ -331,5 +338,23 @@ describe('sanitizePII', function() {
         marker.type === 'PreferenceRead' &&
         marker.prefValue === ''
     ).toBeTruthy();
+  });
+});
+
+describe('getRemoveProfileInformation', function() {
+  it('should bail out early when there is no preference marker in the profile', function() {
+    const { getState, dispatch } = storeWithProfile();
+    // Checking to see that we don't have Preference markers.
+    expect(getHasPreferenceMarkers(getState())).toEqual(false);
+
+    // Setting includePreferenceValues option to false
+    dispatch(toggleCheckedSharingOptions('includePreferenceValues'));
+    expect(
+      getCheckedSharingOptions(getState()).includePreferenceValues
+    ).toEqual(false);
+
+    const removeProfileInformation = getRemoveProfileInformation(getState());
+    // It should return early with null value.
+    expect(removeProfileInformation).toEqual(null);
   });
 });


### PR DESCRIPTION
Previously sanitizer was always running because `includePreferenceValues` field was always unchecked when there is no preference marker in the profile.
Fixes #2247.

[deploy preview](https://deploy-preview-2271--perf-html.netlify.com/public/1b4526251deae1831cbcde94f556e76400c5199e/calltree/?globalTrackOrder=0&localTrackOrderByPid=68731-2-3-0-1~&thread=0&v=4).
You need to put a breakpoint to that place to see the return value though, because it's not a visible behaviour change.
STR:
1. Put a breakpoint to selectors/publish.js:95(the if branch that has `// No sanitization is happening, bail out early.` comment in it.)
2. Open the profile publish panel.
3. See if that code goes inside of that branch when all of the check boxes are checked. It should go inside of it.
