### PR TITLE
Added check for local type in renderIsolateScreenshot() function

### DIFF
--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -453,6 +453,11 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
       return null;
     }
 
+    if (rightClickedTrack.type !== 'global') {
+      // This is not a valid candidate for isolating.
+      return null;
+    }
+
     const track = globalTracks[rightClickedTrack.trackIndex];
     if (track.type !== 'screenshots') {
       // Only process screenshot tracks


### PR DESCRIPTION
Fixes #2267 - added check for local type in renderIsolateScreenshot() function in /src/components/timeline/TrackContextMenu.js
@canova @julienw 