### PR TITLE
Add copy marker name 

### DIFF
--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -187,6 +187,13 @@ class MarkerContextMenu extends PureComponent<Props> {
     }
   };
 
+  copyMarkerName = () => {
+    const { selectedMarker } = this.props;
+    if (selectedMarker && selectedMarker.data && selectedMarker.data.name) {
+      copy(selectedMarker.data.name);
+    }
+  };
+
   // Using setTimeout here is a bit complex, but is necessary to make the menu
   // work fine when we want to display it somewhere when it's already open
   // somewhere else.
@@ -258,6 +265,9 @@ class MarkerContextMenu extends PureComponent<Props> {
           <MenuItem onClick={this.copyUrl}>Copy URL</MenuItem>
         ) : null}
         <MenuItem onClick={this.copyMarkerJSON}>Copy marker JSON</MenuItem>
+        {selectedMarker.data && typeof selectedMarker.data.name === 'string' ? (
+          <MenuItem onClick={this.copyMarkerName}>Copy Marker Name</MenuItem>
+        ) : null}
       </ContextMenu>
     );
   }


### PR DESCRIPTION
Fixes #1251 
I added the Copy Marker Name option for markers that have the ```name``` property. 

![Screenshot_20191009_211918](https://user-images.githubusercontent.com/32024054/66566120-27cab900-eb32-11e9-89e3-fa6bd83995b1.png)
