### PR TITLE
Bug dot marker overdraw

### DIFF
--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -163,21 +163,23 @@ describe('MarkerChart', function() {
 
   it('does not render several dot markers on the same pixel', () => {
     window.devicePixelRatio = 1;
+    const rowName = 'TestMarker';
+
     const markers = [
-      // 'Marker first' and 'Marker last' define our range.
-      ['Marker first', 0, null],
-      // Then 2 very close dot markers with the same name. They shouldn't be
-      // drawn both together.
-      ['Marker A', 5000, null],
-      ['Marker A', 5001, null],
-      // This is a longer marker, it should always be drawn even if it starts at
-      // the same location as a dot marker
-      ['Marker A', 5001, { startTime: 5001, endTime: 7000 }],
-      [
-        'Marker last',
-        15000,
-        null,
-      ] /* add a marker that's quite far away to have a big range */,
+      // RENDERED: This marker defines the start of our range.
+      [rowName, 0, null],
+      // RENDERED: Now create three "dot" markers that should only be rendered once.
+      [rowName, 5000, null],
+      // NOT-RENDERED: This marker has a duration, but it's very small, and would get
+      // rendered as a dot.
+      [rowName, 5001, { startTime: 5001, endTime: 5001.1 }],
+      // NOT-RENDERED: The final dot marker
+      [rowName, 5002, null],
+      // RENDERED: This is a longer marker, it should always be drawn even if it starts
+      // at the same location as a dot marker
+      [rowName, 5002, { startTime: 5002, endTime: 7000 }],
+      // RENDERED: Add a final marker that's quite far away to have a big time range.
+      [rowName, 15000, null],
     ];
 
     const profile = getProfileWithMarkers(markers);


### PR DESCRIPTION
Please only consider the last commit. This fixes a small bug with overdrawing dot markers in the marker chart. I also clarified some variable names and comments that were confusing me when I was working on it.

Here is a test profile from Florian where it was slow, and is now much faster. I'm cheating because this PR combines several different commits though.

https://deploy-preview-2293--perf-html.netlify.com/public/07e7072fcd4b9441a5be97104ee4b00396757cdb/marker-chart/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25-26&hiddenGlobalTracks=14-17-18-19-21-24-25-26&localTrackOrderByPid=10946-1-2-0~14449-0-1~14494-0-1~14537-0-1~14579-0-1~14623-0-1~14663-0-1~14706-0-1~15038-0-1~15365-0-1~15692-0-1~16019-0-1~16349-0-1~16391-0-1~16434-0-1~16592-0~16626-0-1~16673-0-1~16705-0-1~16747-0~16787-0-1~16836-0-1~16869-0-1~16910-0-1~17552-0~11001-0~11057-0~&thread=0&v=4