### PR TITLE
Update the error message when there's an unknown color

### DIFF
--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -158,7 +158,7 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
       };
     default:
       console.error(
-        'Unknown color name encountered. Consider updating this code to handle it.'
+        `Unknown color name '${colorName}' encountered. Consider updating this code to handle it.`
       );
       return {
         selectedFillStyle: GREY_30,


### PR DESCRIPTION
I've seen this error in the console when looking at [this profile](https://profiler.firefox.com/public/1a537103378c03445b43b9ea789c1f12eafac8e9/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-5&hiddenLocalTracksByPid=3616-1&localTrackOrderByPid=7052-2-3-0-1~5252-0~4312-0~3616-2-0-1~2460-0-1~1940-0~&thread=0&v=4). It wasn't super helpful:
```
Unknown color name encountered. Consider updating this code to handle it.
```

Now [look how the error message is much better](https://deploy-preview-2298--perf-html.netlify.com/public/1a537103378c03445b43b9ea789c1f12eafac8e9/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-5&hiddenLocalTracksByPid=3616-1&localTrackOrderByPid=7052-2-3-0-1~5252-0~4312-0~3616-2-0-1~2460-0-1~1940-0~&thread=0&v=4):
```
Unknown color name 'lightgreen' encountered. Consider updating this code to handle it.
```

Much better!