### PR TITLE
Remove the excess frameTable.column push in js tracer logic

### DIFF
--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -636,7 +636,6 @@ export function convertJsTracerToThreadWithoutSamples(
     frameTable.implementation.push(implementation);
     frameTable.line.push(line);
     frameTable.column.push(column);
-    frameTable.column.push(null);
     frameTable.optimizations.push(null);
 
     // Each event gets a stack table entry.


### PR DESCRIPTION
Just saw that we are pushing to `frameTable.column` twice per frame while I was touching the frameTable fields.