### PR TITLE
Include all source error messages in the SymbolsNotFound error message.

### DIFF
--- a/src/profile-logic/errors.js
+++ b/src/profile-logic/errors.js
@@ -10,14 +10,16 @@ import type { RequestedLib } from '../types/actions';
 // symbols for a specific library
 export class SymbolsNotFoundError extends Error {
   library: RequestedLib;
-  error: ?Error;
+  errors: Error[];
 
-  constructor(message: string, library: RequestedLib, error?: Error) {
-    super(message);
+  constructor(message: string, library: RequestedLib, ...errors: Error[]) {
+    super(
+      [message, ...errors.map(e => ` - ${e.name}: ${e.message}`)].join('\n')
+    );
     // Workaround for a babel issue when extending Errors
     (this: any).__proto__ = SymbolsNotFoundError.prototype;
     this.name = 'SymbolsNotFoundError';
     this.library = library;
-    this.error = error;
+    this.errors = errors;
   }
 }

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -281,6 +281,7 @@ export async function symbolicateProfile(
         throw error;
       }
       // We could not find symbols for this library.
+      console.warn(error);
     }
   );
 }

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -4,6 +4,7 @@
 // @flow
 
 import { SymbolStore } from '../../profile-logic/symbol-store';
+import { SymbolsNotFoundError } from '../../profile-logic/errors';
 import { TextDecoder } from 'util';
 import exampleSymbolTable from '../fixtures/example-symbol-table';
 import fakeIndexedDB from 'fake-indexeddb';
@@ -47,10 +48,6 @@ describe('SymbolStore', function() {
   });
 
   it('should only request symbols from the symbol provider once per library', async function() {
-    // Because of the promise rejection below, our code outputs logs for easier
-    // debugging. This mock silences these logs, but we'll check some
-    // expectations about these logs at the end.
-    jest.spyOn(console, 'log').mockImplementation(() => {});
     symbolProvider = {
       requestSymbolsFromServer: jest.fn(requests =>
         requests.map(request => {
@@ -70,15 +67,17 @@ describe('SymbolStore', function() {
 
     const lib1 = { debugName: 'firefox', breakpadId: 'dont-care' };
     let secondAndThirdSymbol = new Map();
+    const errorCallback = jest.fn((_request, _error) => {});
     await symbolStore.getSymbols(
       [{ lib: lib1, addresses: new Set([0xf01, 0x1a50]) }],
       (request, results) => {
         secondAndThirdSymbol = results;
       },
-      (_request, _error) => {}
+      errorCallback
     );
     expect(symbolProvider.requestSymbolsFromServer).toHaveBeenCalledTimes(1);
     expect(symbolProvider.requestSymbolTableFromAddon).toHaveBeenCalledTimes(1);
+    expect(errorCallback).not.toHaveBeenCalled();
     expect(secondAndThirdSymbol.get(0xf01)).toEqual({
       name: 'second symbol',
       functionOffset: 1,
@@ -95,10 +94,11 @@ describe('SymbolStore', function() {
       (request, results) => {
         firstAndLastSymbol = results;
       },
-      (_request, _error) => {}
+      errorCallback
     );
     expect(symbolProvider.requestSymbolsFromServer).toHaveBeenCalledTimes(2);
     expect(symbolProvider.requestSymbolTableFromAddon).toHaveBeenCalledTimes(2);
+    expect(errorCallback).not.toHaveBeenCalled();
     expect(firstAndLastSymbol.get(0x33)).toEqual({
       name: 'first symbol',
       functionOffset: 0x33,
@@ -115,15 +115,23 @@ describe('SymbolStore', function() {
     await symbolStore.getSymbols(
       [{ lib: libWithEmptyBreakpadId, addresses: new Set([0x33, 0x2000]) }],
       (_request, _results) => {},
-      (_request, _error) => {}
+      errorCallback
     );
     expect(symbolProvider.requestSymbolsFromServer).toHaveBeenCalledTimes(2);
     expect(symbolProvider.requestSymbolTableFromAddon).toHaveBeenCalledTimes(2);
-    expect(console.log).toHaveBeenCalledTimes(2); // Once for each uncached call
+
+    // Empty breakpadIds should result in an error.
+    expect(errorCallback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lib: { breakpadId: '', debugName: 'dalvik-jit-code-cache' },
+      }),
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid debugName or breakpadId'),
+      })
+    );
   });
 
   it('should persist in DB', async function() {
-    jest.spyOn(console, 'log').mockImplementation(() => {});
     symbolProvider = {
       requestSymbolsFromServer: jest.fn(requests =>
         requests.map(() =>
@@ -137,11 +145,13 @@ describe('SymbolStore', function() {
     symbolStore = new SymbolStore('profiler-async-storage', symbolProvider);
 
     const lib = { debugName: 'firefox', breakpadId: 'dont-care' };
+    const errorCallback = jest.fn((_request, _error) => {});
     await symbolStore.getSymbols(
       [{ lib: lib, addresses: new Set([0]) }],
       (_request, _results) => {},
-      (_request, _error) => {}
+      errorCallback
     );
+    expect(errorCallback).not.toHaveBeenCalled();
 
     // Using another symbol store simulates a page reload
     // Due to https://github.com/dumbmatter/fakeIndexedDB/issues/22 we need to
@@ -152,23 +162,20 @@ describe('SymbolStore', function() {
     await symbolStore.getSymbols(
       [{ lib: lib, addresses: new Set([0x1]) }],
       (_request, _results) => {},
-      (_request, _error) => {}
+      errorCallback
     );
 
     expect(symbolProvider.requestSymbolTableFromAddon).toHaveBeenCalledTimes(1);
-    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(errorCallback).not.toHaveBeenCalled();
   });
 
   it('should call requestSymbolsFromServer first', async function() {
-    // This test has some console output because of unrecognized mock data. This is
-    // fine, but hide it from the test runner.
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-
-    const symbolTable = new Map();
-    symbolTable.set(0, 'first symbol');
-    symbolTable.set(0xf00, 'second symbol');
-    symbolTable.set(0x1a00, 'third symbol');
-    symbolTable.set(0x2000, 'last symbol');
+    const symbolTable = new Map([
+      [0, 'first symbol'],
+      [0xf00, 'second symbol'],
+      [0x1a00, 'third symbol'],
+      [0x2000, 'last symbol'],
+    ]);
     const fakeSymbolStore = new FakeSymbolStore(
       new Map([['available-for-addresses', symbolTable]])
     );
@@ -205,6 +212,7 @@ describe('SymbolStore', function() {
     };
 
     const symbolsPerLibrary = new Map();
+    const errorCallback = jest.fn((_request, _error) => {});
     await symbolStore.getSymbols(
       [
         { lib: lib1, addresses: new Set([0xf01, 0x1a50]) },
@@ -213,13 +221,14 @@ describe('SymbolStore', function() {
       (request, results) => {
         symbolsPerLibrary.set(request.lib, results);
       },
-      (_request, _error) => {}
+      errorCallback
     );
 
     // Both requests should have been coalesced into one call to
     // requestSymbolsFromServer.
     expect(symbolProvider.requestSymbolsFromServer).toHaveBeenCalledTimes(1);
     expect(symbolsForAddressesRequestCount).toEqual(2);
+    expect(errorCallback).not.toHaveBeenCalled();
 
     // requestSymbolsFromServer should have failed for lib2, so
     // requestSymbolTableFromAddon should have been called for it, once.
@@ -258,16 +267,140 @@ describe('SymbolStore', function() {
         { lib: lib2, addresses: new Set([0x33, 0x2000]) },
       ],
       (_request, _results) => {},
-      (_request, _error) => {}
+      errorCallback
     );
 
     // The symbolStore should already have a cached symbol table for lib2 now,
     // so requestSymbolsFromServer should only have been called for one request.
     expect(symbolProvider.requestSymbolsFromServer).toHaveBeenCalledTimes(2);
     expect(symbolsForAddressesRequestCount).toEqual(3);
+    expect(errorCallback).not.toHaveBeenCalled();
 
     // requestSymbolsFromServer should have succeeded for that one request,
     // so requestSymbolTableFromAddon should not have been called again.
     expect(symbolProvider.requestSymbolTableFromAddon).toHaveBeenCalledTimes(1);
+  });
+
+  it('should should report the right errors', async function() {
+    const libs = [
+      {
+        debugName: 'available-from-both-server-and-addon',
+        breakpadId: 'dont-care',
+      },
+      {
+        debugName: 'available-from-server',
+        breakpadId: 'dont-care',
+      },
+      {
+        debugName: 'available-from-addon',
+        breakpadId: 'dont-care',
+      },
+      {
+        debugName: 'available-from-neither',
+        breakpadId: 'dont-care',
+      },
+      {
+        debugName: 'empty-breakpadid',
+        breakpadId: '',
+      },
+      {
+        debugName: '',
+        breakpadId: 'empty-debugname',
+      },
+    ];
+
+    const symbolTable = new Map([
+      [0, 'first symbol'],
+      [0xf00, 'second symbol'],
+      [0x1a00, 'third symbol'],
+      [0x2000, 'last symbol'],
+    ]);
+    const fakeSymbolStore = new FakeSymbolStore(
+      new Map([
+        ['available-from-both-server-and-addon', symbolTable],
+        ['available-from-server', symbolTable],
+      ])
+    );
+    symbolProvider = {
+      requestSymbolsFromServer: requests => {
+        return requests.map(request => {
+          const { debugName, breakpadId } = request.lib;
+          expect(debugName).not.toEqual('');
+          expect(breakpadId).not.toEqual('');
+          return new Promise((resolve, reject) => {
+            fakeSymbolStore.getSymbols(
+              [request],
+              (_request, results) => resolve(results),
+              (_request, error) => reject(error)
+            );
+          });
+        });
+      },
+      requestSymbolTableFromAddon: async ({ debugName, breakpadId }) => {
+        expect(debugName).not.toEqual('');
+        expect(breakpadId).not.toEqual('');
+        if (
+          debugName === 'available-from-addon' ||
+          debugName === 'available-from-both-server-and-addon'
+        ) {
+          return exampleSymbolTable;
+        }
+        throw new Error('The add-on does not have symbols for this library.');
+      },
+    };
+    symbolStore = new SymbolStore('profiler-async-storage', symbolProvider);
+
+    const addresses = new Set([0xf01, 0x1a50]);
+    const succeededLibs = new Set();
+    const failedLibs = new Map();
+    await symbolStore.getSymbols(
+      libs.map(lib => ({ lib, addresses })),
+      (request, _results) => {
+        succeededLibs.add(request.lib);
+      },
+      (request, error) => {
+        failedLibs.set(request.lib.debugName, error);
+      }
+    );
+
+    // If symbols are available from at least one source, symbolication for that
+    // library should be successful and no error should be returned.
+    expect(succeededLibs).toEqual(
+      new Set([
+        expect.objectContaining({ debugName: 'available-from-addon' }),
+        expect.objectContaining({ debugName: 'available-from-server' }),
+        expect.objectContaining({
+          debugName: 'available-from-both-server-and-addon',
+        }),
+      ])
+    );
+
+    // Empty debugNames or breakpadIds should cause errors. And if symbols are
+    // not available from any source, all errors along the way should be included
+    // in the reported error.
+    expect(failedLibs.size).toBe(3);
+    expect(failedLibs.get('empty-breakpadid')).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid debugName or breakpadId'),
+      })
+    );
+    expect(failedLibs.get('')).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('Invalid debugName or breakpadId'),
+      })
+    );
+
+    // For error objects, Jest's deep equality checks only check the message.
+    expect(failedLibs.get('available-from-neither')).toEqual(
+      new SymbolsNotFoundError(
+        'Could not obtain symbols for available-from-neither/dont-care.\n' +
+          ' - Error: symbol table not found\n' +
+          ' - Error: The add-on does not have symbols for this library.',
+        {
+          debugName: 'available-from-neither',
+          breakpadId: 'dont-care',
+        }
+      )
+    );
   });
 });


### PR DESCRIPTION
At the moment, we only print an error to the console if the symbol server doesn't have symbols. Then we ask the browser for symbols, and if that fails, we just swallow that error silently.

This change makes us log the error in both cases. It also changes the `error` field of the `SymbolsNotFound` class into an `errors` array so that multiple source errors can be tracked.
In addition, it changes the `message` of the error to include all messages of the source errors. This is necessary because otherwise the source error messages are not accessible on the logged errors (see [bug 1595152](https://bugzilla.mozilla.org/show_bug.cgi?id=1595152)).

I have some screenshots.

Before:
![Screen Shot 2019-11-08 at 11 33 12 AM](https://user-images.githubusercontent.com/961291/68499855-4f439d00-0228-11ea-9010-23ac10a27c98.png)

After:
![Screen Shot 2019-11-08 at 10 21 02 AM](https://user-images.githubusercontent.com/961291/68499881-5cf92280-0228-11ea-8775-949b5a23c9fa.png)
![Screen Shot 2019-11-08 at 10 37 07 AM](https://user-images.githubusercontent.com/961291/68499900-6da99880-0228-11ea-8fc7-31f7169499fa.png)
