### PR TITLE
Fix switching between threads with allocations, and no allocations

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -13,6 +13,7 @@ import {
   getLocalTrackFromReference,
   getGlobalTrackFromReference,
   getPreviewSelection,
+  getThreads,
 } from '../selectors/profile';
 import {
   getThreadSelectors,
@@ -26,6 +27,7 @@ import {
   getLocalTrackOrder,
   getHiddenLocalTracks,
   getSelectedTab,
+  getCallTreeSummaryStrategy,
 } from '../selectors/url-state';
 import {
   getCallNodePathFromIndex,
@@ -227,6 +229,7 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
     // These get assigned based on the track type.
     let selectedThreadIndex = null;
     let selectedTab = currentlySelectedTab;
+    let callTreeSummaryStrategy = getCallTreeSummaryStrategy(getState());
 
     if (trackReference.type === 'global') {
       // Handle the case of global tracks.
@@ -314,10 +317,42 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
       return;
     }
 
+    {
+      // Verify that the call tree summary strategy is still valid for the new tab.
+      // Otherwise, switch back to "timing", which is valid everywhere.
+      const strategy = callTreeSummaryStrategy;
+      const selectedThread = getThreads(getState())[selectedThreadIndex];
+      switch (strategy) {
+        case 'timing':
+          // Timing is valid everywhere.
+          break;
+        case 'js-allocations':
+          if (!selectedThread.jsAllocations) {
+            // Attempting to view a thread with no JS allocations, switch back to timing.
+            callTreeSummaryStrategy = 'timing';
+          }
+          break;
+        case 'native-allocations':
+        case 'native-deallocations':
+          if (!selectedThread.nativeAllocations) {
+            // Attempting to view a thread with no native allocations, switch back
+            // to timing.
+            callTreeSummaryStrategy = 'timing';
+          }
+          break;
+        default:
+          assertExhaustiveCheck(
+            strategy,
+            'Unhandled call tree sumary strategy.'
+          );
+      }
+    }
+
     dispatch({
       type: 'SELECT_TRACK',
       selectedThreadIndex,
       selectedTab,
+      callTreeSummaryStrategy,
     });
   };
 }
@@ -991,18 +1026,18 @@ export function changeImplementationFilter(
  * in markers.
  */
 export function changeCallTreeSummaryStrategy(
-  strategy: CallTreeSummaryStrategy
+  callTreeSummaryStrategy: CallTreeSummaryStrategy
 ): Action {
   sendAnalytics({
     hitType: 'event',
     eventCategory: 'profile',
     eventAction: 'change call tree summary strategy',
-    eventLabel: strategy,
+    eventLabel: callTreeSummaryStrategy,
   });
 
   return {
     type: 'CHANGE_CALL_TREE_SUMMARY_STRATEGY',
-    strategy,
+    callTreeSummaryStrategy,
   };
 }
 

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -241,7 +241,8 @@ const callTreeSummaryStrategy: Reducer<CallTreeSummaryStrategy> = (
 ) => {
   switch (action.type) {
     case 'CHANGE_CALL_TREE_SUMMARY_STRATEGY':
-      return action.strategy;
+    case 'SELECT_TRACK':
+      return action.callTreeSummaryStrategy;
     default:
       return state;
   }

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -960,7 +960,7 @@ export function getProfileWithNativeAllocations(): * {
              I
   `);
 
-  // Now add a JsAllocationsTable.
+  // Now add a NativeAllocationsTable.
   const nativeAllocations = getEmptyNativeAllocationsTable();
   profile.threads[0].nativeAllocations = nativeAllocations;
 

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -15,6 +15,8 @@ import {
   getNetworkMarkers,
   getCounterForThread,
   getVisualProgressTrackProfile,
+  getProfileWithNativeAllocations,
+  getProfileWithJsAllocations,
 } from '../fixtures/profiles/processed-profile';
 import {
   getEmptyThread,
@@ -472,6 +474,88 @@ describe('actions/ProfileView', function() {
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'calltree'
         );
+      });
+    });
+
+    describe('with allocation-based tracks', function() {
+      function setup() {
+        const { profile } = getProfileWithNativeAllocations();
+        profile.threads.push(
+          getProfileWithJsAllocations().profile.threads[0],
+          getEmptyThread()
+        );
+
+        for (const thread of profile.threads) {
+          thread.pid = 0;
+        }
+
+        // Create some references in the same order that the threads were created
+        // in the threads array.
+        const nativeAllocationsThread: TrackReference = {
+          type: 'local',
+          trackIndex: 0,
+          pid: 0,
+        };
+        const jsAllocationsThread: TrackReference = {
+          type: 'local',
+          trackIndex: 1,
+          pid: 0,
+        };
+        const timingOnlyThread: TrackReference = {
+          type: 'local',
+          trackIndex: 2,
+          pid: 0,
+        };
+
+        return {
+          profile,
+          nativeAllocationsThread,
+          timingOnlyThread,
+          jsAllocationsThread,
+          ...storeWithProfile(profile),
+        };
+      }
+
+      it('will switch to a "timing" summary strategy when clicking from a native allocation, to a timings-only thread', function() {
+        const { profile, nativeAllocationsThread, timingOnlyThread } = setup();
+        const { dispatch, getState } = storeWithProfile(profile);
+
+        // Setup the test to view native allocations.
+        dispatch(ProfileView.selectTrack(nativeAllocationsThread));
+        dispatch(
+          ProfileView.changeCallTreeSummaryStrategy('native-allocations')
+        );
+        expect(
+          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+        ).toEqual('native-allocations');
+
+        // Switch to a thread without native allocations.
+        dispatch(ProfileView.selectTrack(timingOnlyThread));
+
+        // Expect that it switches the summary strategy to one it supports.
+        expect(
+          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+        ).toEqual('timing');
+      });
+
+      it('will switch to a "timing" summary strategy when clicking from a js allocation, to a timings-only thread', function() {
+        const { profile, jsAllocationsThread, timingOnlyThread } = setup();
+        const { dispatch, getState } = storeWithProfile(profile);
+
+        // Setup the test to view js allocations.
+        dispatch(ProfileView.selectTrack(jsAllocationsThread));
+        dispatch(ProfileView.changeCallTreeSummaryStrategy('js-allocations'));
+        expect(
+          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+        ).toEqual('js-allocations');
+
+        // Switch to a thread without js allocations.
+        dispatch(ProfileView.selectTrack(timingOnlyThread));
+
+        // Expect that it switches the summary strategy to one it supports.
+        expect(
+          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+        ).toEqual('timing');
       });
     });
 

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -68,6 +68,7 @@ describe('getUsefulTabs', function() {
       type: 'SELECT_TRACK',
       selectedThreadIndex: 2,
       selectedTab: 'calltree',
+      callTreeSummaryStrategy: 'timing',
     });
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -293,6 +293,7 @@ type UrlStateAction =
       +type: 'SELECT_TRACK',
       +selectedThreadIndex: ThreadIndex,
       +selectedTab: TabSlug,
+      +callTreeSummaryStrategy: CallTreeSummaryStrategy,
     |}
   | {|
       +type: 'CHANGE_RIGHT_CLICKED_TRACK',
@@ -324,7 +325,7 @@ type UrlStateAction =
     |}
   | {|
       type: 'CHANGE_CALL_TREE_SUMMARY_STRATEGY',
-      strategy: CallTreeSummaryStrategy,
+      callTreeSummaryStrategy: CallTreeSummaryStrategy,
     |}
   | {|
       +type: 'CHANGE_INVERT_CALLSTACK',


### PR DESCRIPTION
This fixes an issue where you view a thread with allocations,
and switch to an allocations based summary strategy, then
switch back to a thread with no allocations. This will cause
a crash through ensureExists checks for the .nativeAllocations
or .jsAllocations property.

Before: [click on the "Compositor" thread](https://profiler.firefox.com/public/b4d715c2febdf29fb83beaaeb7f4107fe722a7d2/calltree/?ctSummary=native-allocations&globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&hiddenLocalTracksByPid=91168-1-2-3~91191-0&localTrackOrderByPid=91168-5-6-0-1-2-3-4~91190-0~91214-0~91191-1-0~91213-0-1~&thread=0&v=4), it crashes
After: [click click](https://deploy-preview-2304--perf-html.netlify.com/public/b4d715c2febdf29fb83beaaeb7f4107fe722a7d2/calltree/?ctSummary=native-allocations&globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&hiddenLocalTracksByPid=91168-1-2-3~91191-0&localTrackOrderByPid=91168-5-6-0-1-2-3-4~91190-0~91214-0~91191-1-0~91213-0-1~&thread=0&v=)