### PR TITLE
Retained allocations view

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -333,6 +333,7 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
           }
           break;
         case 'native-allocations':
+        case 'native-retained-allocations':
         case 'native-deallocations':
           if (!selectedThread.nativeAllocations) {
             // Attempting to view a thread with no native allocations, switch back

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -206,6 +206,7 @@ class CallTreeComponent extends PureComponent<Props> {
       case 'timing':
         fixedColumns = this._fixedColumnsTiming;
         break;
+      case 'native-retained-allocations':
       case 'native-allocations':
       case 'native-deallocations':
       case 'js-allocations':

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -41,3 +41,8 @@
   align-items: center;
   padding: 0 5px 0 0;
 }
+
+.stackSettingsSelect {
+  height: 24px;
+  font-size: inherit;
+}

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -43,6 +43,9 @@
 }
 
 .stackSettingsSelect {
+  /* Create a new stacking context for the select using a position:relative. This way
+   * the focus ring around the select breaks out of its surrounding container. */
+  position: relative;
   height: 24px;
   font-size: inherit;
 }

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -145,6 +145,7 @@ class StackSettings extends PureComponent<Props> {
               <label>
                 Summarize:{' '}
                 <select
+                  className="stackSettingsSelect"
                   onChange={this._onCallTreeSummaryStrategyChange}
                   defaultValue={callTreeSummaryStrategy}
                 >

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -107,12 +107,7 @@ class StackSettings extends PureComponent<Props> {
     tooltip: string
   ) {
     return (
-      <option
-        title={tooltip}
-        key={strategy}
-        value={strategy}
-        checked={this.props.callTreeSummaryStrategy === strategy}
-      >
+      <option title={tooltip} key={strategy} value={strategy}>
         {label}
       </option>
     );
@@ -147,7 +142,7 @@ class StackSettings extends PureComponent<Props> {
                 <select
                   className="stackSettingsSelect"
                   onChange={this._onCallTreeSummaryStrategyChange}
-                  defaultValue={callTreeSummaryStrategy}
+                  value={callTreeSummaryStrategy}
                 >
                   {this._renderCallTreeStrategyOption(
                     'Timing Data',

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -127,6 +127,7 @@ class StackSettings extends PureComponent<Props> {
       hasNativeAllocations,
       canShowRetainedMemory,
       disableCallTreeSummaryButtons,
+      callTreeSummaryStrategy,
     } = this.props;
 
     const hasAllocations = hasJsAllocations || hasNativeAllocations;
@@ -143,7 +144,10 @@ class StackSettings extends PureComponent<Props> {
             <li className="stackSettingsListItem stackSettingsFilter">
               <label>
                 Summarize:{' '}
-                <select onChange={this._onCallTreeSummaryStrategyChange}>
+                <select
+                  onChange={this._onCallTreeSummaryStrategyChange}
+                  defaultValue={callTreeSummaryStrategy}
+                >
                   {this._renderCallTreeStrategyOption(
                     'Timing Data',
                     'timing',

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -100,27 +100,20 @@ class StackSettings extends PureComponent<Props> {
     );
   }
 
-  _renderCallTreeStrategyRadioButton(
+  _renderCallTreeStrategyOption(
     label: string,
     strategy: CallTreeSummaryStrategy,
     tooltip: string
   ) {
     return (
-      <label
-        className="photon-label photon-label-micro stackSettingsFilterLabel"
+      <option
         title={tooltip}
         key={strategy}
+        value={strategy}
+        checked={this.props.callTreeSummaryStrategy === strategy}
       >
-        <input
-          type="radio"
-          className="photon-radio photon-radio-micro stackSettingsFilterInput"
-          value={strategy}
-          name="stack-settings-strategy"
-          onChange={this._onCallTreeSummaryStrategyChange}
-          checked={this.props.callTreeSummaryStrategy === strategy}
-        />
         {label}
-      </label>
+      </option>
     );
   }
 
@@ -146,32 +139,37 @@ class StackSettings extends PureComponent<Props> {
           </li>
           {hasAllocations && !disableCallTreeSummaryButtons ? (
             <li className="stackSettingsListItem stackSettingsFilter">
-              {this._renderCallTreeStrategyRadioButton(
-                'Timing',
-                'timing',
-                'Summarize using sampled stacks of executed code over time'
-              )}
-              {hasJsAllocations
-                ? this._renderCallTreeStrategyRadioButton(
-                    'JavaScript Allocations',
-                    'js-allocations',
-                    'Summarize using bytes of JavaScript allocated (no de-allocations)'
-                  )
-                : null}
-              {hasNativeAllocations
-                ? [
-                    this._renderCallTreeStrategyRadioButton(
-                      'Allocations',
-                      'native-allocations',
-                      'Summarize using bytes of memory allocated'
-                    ),
-                    this._renderCallTreeStrategyRadioButton(
-                      'Deallocations',
-                      'native-deallocations',
-                      'Summarize using bytes of memory deallocated'
-                    ),
-                  ]
-                : null}
+              <label>
+                Summarize:{' '}
+                <select onChange={this._onCallTreeSummaryStrategyChange}>
+                  {this._renderCallTreeStrategyOption(
+                    'Timing Data',
+                    'timing',
+                    'Summarize using sampled stacks of executed code over time'
+                  )}
+                  {hasJsAllocations
+                    ? this._renderCallTreeStrategyOption(
+                        'JavaScript Allocations',
+                        'js-allocations',
+                        'Summarize using bytes of JavaScript allocated (no de-allocations)'
+                      )
+                    : null}
+                  {hasNativeAllocations
+                    ? this._renderCallTreeStrategyOption(
+                        'Allocations',
+                        'native-allocations',
+                        'Summarize using bytes of memory allocated'
+                      )
+                    : null}
+                  {hasNativeAllocations
+                    ? this._renderCallTreeStrategyOption(
+                        'Deallocations',
+                        'native-deallocations',
+                        'Summarize using bytes of memory deallocated'
+                      )
+                    : null}
+                </select>
+              </label>
             </li>
           ) : null}
           {hideInvertCallstack ? null : (

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -44,6 +44,7 @@ type StateProps = {|
   +currentSearchString: string,
   +hasJsAllocations: boolean,
   +hasNativeAllocations: boolean,
+  +canShowRetainedMemory: boolean,
 |};
 
 type DispatchProps = {|
@@ -124,6 +125,7 @@ class StackSettings extends PureComponent<Props> {
       currentSearchString,
       hasJsAllocations,
       hasNativeAllocations,
+      canShowRetainedMemory,
       disableCallTreeSummaryButtons,
     } = this.props;
 
@@ -152,6 +154,13 @@ class StackSettings extends PureComponent<Props> {
                         'JavaScript Allocations',
                         'js-allocations',
                         'Summarize using bytes of JavaScript allocated (no de-allocations)'
+                      )
+                    : null}
+                  {canShowRetainedMemory
+                    ? this._renderCallTreeStrategyOption(
+                        'Retained Allocations',
+                        'native-retained-allocations',
+                        'Summarize using bytes of memory that were allocated, and never freed while profiling'
                       )
                     : null}
                   {hasNativeAllocations
@@ -205,6 +214,9 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     currentSearchString: getCurrentSearchString(state),
     hasJsAllocations: selectedThreadSelectors.getHasJsAllocations(state),
     hasNativeAllocations: selectedThreadSelectors.getHasNativeAllocations(
+      state
+    ),
+    canShowRetainedMemory: selectedThreadSelectors.getCanShowRetainedMemory(
       state
     ),
     callTreeSummaryStrategy: getCallTreeSummaryStrategy(state),

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -257,6 +257,7 @@ export class CallTree {
         }
         case 'js-allocations':
         case 'native-allocations':
+        case 'native-retained-allocations':
         case 'native-deallocations': {
           totalTimeWithUnit = `${formattedTotalTime} bytes`;
           selfTimeWithUnit = `${formattedSelfTime} bytes`;

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -17,7 +17,8 @@ import type {
   FuncTable,
   RawMarkerTable,
   JsAllocationsTable,
-  NativeAllocationsTable,
+  UnbalancedNativeAllocationsTable,
+  BalancedNativeAllocationsTable,
   ResourceTable,
   Profile,
   ExtensionTable,
@@ -198,7 +199,11 @@ export function getEmptyJsAllocationsTable(): JsAllocationsTable {
   };
 }
 
-export function getEmptyNativeAllocationsTable(): NativeAllocationsTable {
+/**
+ * The native allocation tables come in two varieties. Get one of the members of the
+ * union.
+ */
+export function getEmptyUnbalancedNativeAllocationsTable(): UnbalancedNativeAllocationsTable {
   // Important!
   // If modifying this structure, please update all callers of this function to ensure
   // that they are pushing on correctly to the data structure. These pushes may not
@@ -207,6 +212,25 @@ export function getEmptyNativeAllocationsTable(): NativeAllocationsTable {
     time: [],
     duration: [],
     stack: [],
+    length: 0,
+  };
+}
+
+/**
+ * The native allocation tables come in two varieties. Get one of the members of the
+ * union.
+ */
+export function getEmptyBalancedNativeAllocationsTable(): BalancedNativeAllocationsTable {
+  // Important!
+  // If modifying this structure, please update all callers of this function to ensure
+  // that they are pushing on correctly to the data structure. These pushes may not
+  // be caught by the type system.
+  return {
+    time: [],
+    duration: [],
+    stack: [],
+    memoryAddress: [],
+    threadId: [],
     length: 0,
   };
 }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -13,7 +13,7 @@ import {
   getEmptyResourceTable,
   getEmptyRawMarkerTable,
   getEmptyJsAllocationsTable,
-  getEmptyNativeAllocationsTable,
+  getEmptyUnbalancedNativeAllocationsTable,
 } from './data-structures';
 import { immutableUpdate } from '../utils/flow';
 import {
@@ -630,7 +630,7 @@ function _processMarkers(
 |} {
   const markers = getEmptyRawMarkerTable();
   const jsAllocations = getEmptyJsAllocationsTable();
-  const nativeAllocations = getEmptyNativeAllocationsTable();
+  const nativeAllocations = getEmptyUnbalancedNativeAllocationsTable();
 
   for (let markerIndex = 0; markerIndex < geckoMarkers.length; markerIndex++) {
     const geckoPayload: MarkerPayload_Gecko = geckoMarkers.data[markerIndex];

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -6,7 +6,7 @@
 
 import memoize from 'memoize-immutable';
 import MixedTupleMap from 'mixedtuplemap';
-import { getEmptyNativeAllocationsTable } from './data-structures';
+import { getEmptyUnbalancedNativeAllocationsTable } from './data-structures';
 
 import type {
   Profile,
@@ -2000,7 +2000,7 @@ export function getCategoryPairLabel(
 export function filterToAllocations(
   nativeAllocations: NativeAllocationsTable
 ): NativeAllocationsTable {
-  const newNativeAllocations = getEmptyNativeAllocationsTable();
+  const newNativeAllocations = getEmptyUnbalancedNativeAllocationsTable();
   for (let i = 0; i < nativeAllocations.length; i++) {
     const duration = nativeAllocations.duration[i];
     if (duration > 0) {
@@ -2020,7 +2020,7 @@ export function filterToAllocations(
 export function filterToDeallocations(
   nativeAllocations: NativeAllocationsTable
 ): NativeAllocationsTable {
-  const newNativeAllocations = getEmptyNativeAllocationsTable();
+  const newNativeAllocations = getEmptyUnbalancedNativeAllocationsTable();
   for (let i = 0; i < nativeAllocations.length; i++) {
     const duration = nativeAllocations.duration[i];
     if (duration < 0) {

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2115,9 +2115,9 @@ export function filterToRetainedAllocations(
     allocationIndex < nativeAllocations.length;
     allocationIndex++
   ) {
-    const duration = nativeAllocations.duration[allocationIndex];
+    const bytes = nativeAllocations.duration[allocationIndex];
     const memoryAddress = nativeAllocations.memoryAddress[allocationIndex];
-    if (duration >= 0) {
+    if (bytes >= 0) {
       // Handle the allocation.
 
       // Provide a map back to this index.

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -189,20 +189,33 @@ export function getStackAndSampleSelectorsPerThread(
         case 'js-allocations':
           return ensureExists(
             thread.jsAllocations,
-            'Expected the JsAllocationTable to exist when using a "js-allocation" strategy'
+            'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
           );
+        case 'native-retained-allocations': {
+          const nativeAllocations = ensureExists(
+            thread.nativeAllocations,
+            'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
+          );
+
+          if (!nativeAllocations.memoryAddress) {
+            throw new Error(
+              'Attempting to filter by retained allocations data that is missing the memory addresses.'
+            );
+          }
+          return ProfileData.filterToRetainedAllocations(nativeAllocations);
+        }
         case 'native-allocations':
           return ProfileData.filterToAllocations(
             ensureExists(
               thread.nativeAllocations,
-              'Expected the JsAllocationTable to exist when using a "js-allocation" strategy'
+              'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
             )
           );
         case 'native-deallocations':
           return ProfileData.filterToDeallocations(
             ensureExists(
               thread.nativeAllocations,
-              'Expected the JsAllocationTable to exist when using a "js-allocation" strategy'
+              'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
             )
           );
         default:

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -17,6 +17,7 @@ import type {
   ThreadIndex,
   JsTracerTable,
   SamplesTable,
+  NativeAllocationsTable,
 } from '../../types/profile';
 import type { Selector } from '../../types/store';
 import type { ThreadViewOptions } from '../../types/state';
@@ -46,6 +47,8 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getThread(state).stringTable;
   const getSamplesTable: Selector<SamplesTable> = state =>
     getThread(state).samples;
+  const getNativeAllocations: Selector<NativeAllocationsTable | void> = state =>
+    getThread(state).nativeAllocations;
   const getThreadRange: Selector<StartEndRange> = state =>
     // This function is already memoized in profile-data.js, so we don't need to
     // memoize it here with `createSelector`.
@@ -222,7 +225,7 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
    * balanced allocations and deallocations.
    */
   const getCanShowRetainedMemory: Selector<boolean> = state => {
-    const { nativeAllocations } = getThread(state);
+    const nativeAllocations = getNativeAllocations(state);
     if (!nativeAllocations) {
       return false;
     }
@@ -273,6 +276,7 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getThread,
     getStringTable,
     getSamplesTable,
+    getNativeAllocations,
     getThreadRange,
     getFilteredThread,
     getRangeFilteredThread,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -217,6 +217,19 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     Boolean(getThread(state).nativeAllocations);
 
   /**
+   * We can only compute the retained memory in the versions of the native allocations
+   * format that provide the memory address. The earlier versions did not have
+   * balanced allocations and deallocations.
+   */
+  const getCanShowRetainedMemory: Selector<boolean> = state => {
+    const { nativeAllocations } = getThread(state);
+    if (!nativeAllocations) {
+      return false;
+    }
+    return 'memoryAddress' in nativeAllocations;
+  };
+
+  /**
    * The JS tracer selectors are placed in the thread selectors since there are
    * not many of them. If this section grows, then consider breaking them out
    * into their own file.
@@ -277,5 +290,6 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getExpensiveJsTracerLeafTiming,
     getHasJsAllocations,
     getHasNativeAllocations,
+    getCanShowRetainedMemory,
   };
 }

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -17,7 +17,7 @@ import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
-import { getBoundingBox } from '../fixtures/utils';
+import { getBoundingBox, createSelectChanger } from '../fixtures/utils';
 import {
   getProfileFromTextSamples,
   getProfileWithJsAllocations,
@@ -503,33 +503,34 @@ describe('ProfileCallTreeView with JS Allocations', function() {
         <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
+    const changeSelect = createSelectChanger(renderResult);
 
-    return { profile, ...renderResult, ...store };
+    return { profile, changeSelect, ...renderResult, ...store };
   }
 
   it('can switch to JS allocations and back to timing', function() {
-    const { getByText, getState } = setup();
+    const { changeSelect, getState } = setup();
 
     // It starts out with timing.
     expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
 
     // It switches to JS allocations.
-    getByText('JavaScript Allocations').click();
+    changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
     expect(getCallTreeSummaryStrategy(getState())).toEqual('js-allocations');
 
     // And finally it can be switched back.
-    getByText('Timing').click();
+    changeSelect({ from: 'JavaScript Allocations', to: 'Timing Data' });
     expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
   });
 
   it('shows byte related labels for JS allocations', function() {
-    const { getByText, queryByText } = setup();
+    const { getByText, queryByText, changeSelect } = setup();
 
     // These labels do not exist.
     expect(queryByText('Total Size (bytes)')).toBe(null);
     expect(queryByText('Self (bytes)')).toBe(null);
 
-    getByText('JavaScript Allocations').click();
+    changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
 
     // After clicking, they do.
     getByText('Total Size (bytes)');
@@ -537,8 +538,8 @@ describe('ProfileCallTreeView with JS Allocations', function() {
   });
 
   it('matches the snapshot for JS allocations', function() {
-    const { getByText, container } = setup();
-    getByText('JavaScript Allocations').click();
+    const { changeSelect, container } = setup();
+    changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });
@@ -552,50 +553,52 @@ describe('ProfileCallTreeView with Native Allocations', function() {
         <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
+    const changeSelect = createSelectChanger(renderResult);
 
-    return { profile, ...renderResult, ...store };
+    return { profile, ...renderResult, changeSelect, ...store };
   }
 
   it('can switch to native allocations and back to timing', function() {
-    const { getByText, getState } = setup();
+    const { getState, changeSelect } = setup();
 
     // It starts out with timing.
     expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
 
-    // It switches to native allocations.
-    getByText('Allocations').click();
+    // Switch to native allocations.
+    changeSelect({ from: 'Timing Data', to: 'Allocations' });
+
     expect(getCallTreeSummaryStrategy(getState())).toEqual(
       'native-allocations'
     );
 
     // And finally it can be switched back.
-    getByText('Timing').click();
+    changeSelect({ from: 'Allocations', to: 'Timing Data' });
     expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
   });
 
   it('shows byte related labels for native allocations', function() {
-    const { getByText, queryByText } = setup();
+    const { getByText, queryByText, changeSelect } = setup();
 
     // These labels do not exist.
     expect(queryByText('Total Size (bytes)')).toBe(null);
     expect(queryByText('Self (bytes)')).toBe(null);
 
-    getByText('Allocations').click();
+    changeSelect({ from: 'Timing Data', to: 'Allocations' });
 
-    // After clicking, they do.
+    // After changing to native allocations, they do.
     getByText('Total Size (bytes)');
     getByText('Self (bytes)');
   });
 
   it('matches the snapshot for native allocations', function() {
-    const { getByText, container } = setup();
-    getByText('Allocations').click();
+    const { container, changeSelect } = setup();
+    changeSelect({ from: 'Timing Data', to: 'Allocations' });
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('matches the snapshot for native deallocations', function() {
-    const { getByText, container } = setup();
-    getByText('Deallocations').click();
+    const { container, changeSelect } = setup();
+    changeSelect({ from: 'Timing Data', to: 'Deallocations' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -21,7 +21,7 @@ import { getBoundingBox, createSelectChanger } from '../fixtures/utils';
 import {
   getProfileFromTextSamples,
   getProfileWithJsAllocations,
-  getProfileWithNativeAllocations,
+  getProfileWithUnbalancedNativeAllocations,
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getCallTreeSummaryStrategy } from '../../selectors/url-state';
@@ -544,9 +544,9 @@ describe('ProfileCallTreeView with JS Allocations', function() {
   });
 });
 
-describe('ProfileCallTreeView with Native Allocations', function() {
+describe('ProfileCallTreeView with unbalanced native allocations', function() {
   function setup() {
-    const { profile } = getProfileWithNativeAllocations();
+    const { profile } = getProfileWithUnbalancedNativeAllocations();
     const store = storeWithProfile(profile);
     const renderResult = render(
       <Provider store={store}>

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import { TooltipCallNode } from '../../components/tooltip/CallNode';
 import { render } from 'react-testing-library';
 import { storeWithProfile } from '../fixtures/stores';
-import { getProfileWithNativeAllocations } from '../fixtures/profiles/processed-profile';
+import { getProfileWithUnbalancedNativeAllocations } from '../fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import * as ProfileSelectors from '../../selectors/profile';
 import * as UrlState from '../../selectors/url-state';
@@ -50,7 +50,10 @@ describe('TooltipCallNode', function() {
   }
 
   it('handles native allocations', () => {
-    const { profile, funcNamesDict } = getProfileWithNativeAllocations();
+    const {
+      profile,
+      funcNamesDict,
+    } = getProfileWithUnbalancedNativeAllocations();
     const threadIndex = 0;
     const callNodePath = ['A', 'B', 'Fjs', 'Gjs'].map(
       name => funcNamesDict[name]

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -57,30 +57,23 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
       <li
         class="stackSettingsListItem stackSettingsFilter"
       >
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using sampled stacks of executed code over time"
-        >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="timing"
-          />
-          Timing
-        </label>
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using bytes of JavaScript allocated (no de-allocations)"
-        >
-          <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="js-allocations"
-          />
-          JavaScript Allocations
+        <label>
+          Summarize:
+           
+          <select>
+            <option
+              title="Summarize using sampled stacks of executed code over time"
+              value="timing"
+            >
+              Timing Data
+            </option>
+            <option
+              title="Summarize using bytes of JavaScript allocated (no de-allocations)"
+              value="js-allocations"
+            >
+              JavaScript Allocations
+            </option>
+          </select>
         </label>
       </li>
       <li
@@ -700,42 +693,29 @@ exports[`ProfileCallTreeView with Native Allocations matches the snapshot for na
       <li
         class="stackSettingsListItem stackSettingsFilter"
       >
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using sampled stacks of executed code over time"
-        >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="timing"
-          />
-          Timing
-        </label>
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using bytes of memory allocated"
-        >
-          <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="native-allocations"
-          />
-          Allocations
-        </label>
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using bytes of memory deallocated"
-        >
-          <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="native-deallocations"
-          />
-          Deallocations
+        <label>
+          Summarize:
+           
+          <select>
+            <option
+              title="Summarize using sampled stacks of executed code over time"
+              value="timing"
+            >
+              Timing Data
+            </option>
+            <option
+              title="Summarize using bytes of memory allocated"
+              value="native-allocations"
+            >
+              Allocations
+            </option>
+            <option
+              title="Summarize using bytes of memory deallocated"
+              value="native-deallocations"
+            >
+              Deallocations
+            </option>
+          </select>
         </label>
       </li>
       <li
@@ -1355,42 +1335,29 @@ exports[`ProfileCallTreeView with Native Allocations matches the snapshot for na
       <li
         class="stackSettingsListItem stackSettingsFilter"
       >
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using sampled stacks of executed code over time"
-        >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="timing"
-          />
-          Timing
-        </label>
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using bytes of memory allocated"
-        >
-          <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="native-allocations"
-          />
-          Allocations
-        </label>
-        <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
-          title="Summarize using bytes of memory deallocated"
-        >
-          <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
-            name="stack-settings-strategy"
-            type="radio"
-            value="native-deallocations"
-          />
-          Deallocations
+        <label>
+          Summarize:
+           
+          <select>
+            <option
+              title="Summarize using sampled stacks of executed code over time"
+              value="timing"
+            >
+              Timing Data
+            </option>
+            <option
+              title="Summarize using bytes of memory allocated"
+              value="native-allocations"
+            >
+              Allocations
+            </option>
+            <option
+              title="Summarize using bytes of memory deallocated"
+              value="native-deallocations"
+            >
+              Deallocations
+            </option>
+          </select>
         </label>
       </li>
       <li

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -60,7 +60,9 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
         <label>
           Summarize:
            
-          <select>
+          <select
+            class="stackSettingsSelect"
+          >
             <option
               selected=""
               title="Summarize using sampled stacks of executed code over time"
@@ -697,7 +699,9 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         <label>
           Summarize:
            
-          <select>
+          <select
+            class="stackSettingsSelect"
+          >
             <option
               selected=""
               title="Summarize using sampled stacks of executed code over time"
@@ -1346,7 +1350,9 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         <label>
           Summarize:
            
-          <select>
+          <select
+            class="stackSettingsSelect"
+          >
             <option
               selected=""
               title="Summarize using sampled stacks of executed code over time"
@@ -1989,7 +1995,9 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         <label>
           Summarize:
            
-          <select>
+          <select
+            class="stackSettingsSelect"
+          >
             <option
               selected=""
               title="Summarize using sampled stacks of executed code over time"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -636,7 +636,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
 </div>
 `;
 
-exports[`ProfileCallTreeView with Native Allocations matches the snapshot for native allocations 1`] = `
+exports[`ProfileCallTreeView with unbalanced native allocations matches the snapshot for native allocations 1`] = `
 <div
   aria-labelledby="calltree-tab-button"
   class="treeAndSidebarWrapper"
@@ -1278,7 +1278,7 @@ exports[`ProfileCallTreeView with Native Allocations matches the snapshot for na
 </div>
 `;
 
-exports[`ProfileCallTreeView with Native Allocations matches the snapshot for native deallocations 1`] = `
+exports[`ProfileCallTreeView with unbalanced native allocations matches the snapshot for native deallocations 1`] = `
 <div
   aria-labelledby="calltree-tab-button"
   class="treeAndSidebarWrapper"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -636,6 +636,654 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
 </div>
 `;
 
+exports[`ProfileCallTreeView with balanced native allocations matches the snapshot for retained allocations 1`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label>
+          Summarize:
+           
+          <select>
+            <option
+              title="Summarize using sampled stacks of executed code over time"
+              value="timing"
+            >
+              Timing Data
+            </option>
+            <option
+              title="Summarize using bytes of memory that were allocated, and never freed while profiling"
+              value="native-retained-allocations"
+            >
+              Retained Allocations
+            </option>
+            <option
+              title="Summarize using bytes of memory allocated"
+              value="native-allocations"
+            >
+              Allocations
+            </option>
+            <option
+              title="Summarize using bytes of memory deallocated"
+              value="native-deallocations"
+            >
+              Deallocations
+            </option>
+          </select>
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Invert call stack
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      data-index="0"
+      title="Complete \\"Empty\\""
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete "Empty"
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalTimePercent"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalTime"
+      >
+        Total Size (bytes)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn selfTime"
+      >
+        Self (bytes)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-8"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 112px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="41"
+                >
+                  41
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="41"
+                >
+                  41
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="73%"
+                >
+                  73%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="30"
+                >
+                  30
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="73%"
+                >
+                  73%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="30"
+                >
+                  30
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="13"
+                >
+                  13
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="41%"
+                >
+                  41%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="17"
+                >
+                  17
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="41%"
+                >
+                  41%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="17"
+                >
+                  17
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="17"
+                >
+                  17
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="27%"
+                >
+                  27%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="11"
+                >
+                  11
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 112px; width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, total size is 41 bytes (100%), self size is 0 bytes"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, total size is 41 bytes (100%), self size is 0 bytes"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="Fjs, total size is 30 bytes (73%), self size is 0 bytes"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-yellow"
+                    title="JavaScript"
+                  />
+                  Fjs
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="Gjs, total size is 30 bytes (73%), self size is 13 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-yellow"
+                    title="JavaScript"
+                  />
+                  Gjs
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="Hjs, total size is 17 bytes (41%), self size is 0 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-7"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-yellow"
+                    title="JavaScript"
+                  />
+                  Hjs
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="I, total size is 17 bytes (41%), self size is 17 bytes"
+                aria-level="6"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
+                id="treeViewRow-8"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 50px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-yellow"
+                    title="JavaScript"
+                  />
+                  I
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="C, total size is 11 bytes (27%), self size is 0 bytes"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProfileCallTreeView with unbalanced native allocations matches the snapshot for native allocations 1`] = `
 <div
   aria-labelledby="calltree-tab-button"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -62,6 +62,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
            
           <select>
             <option
+              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
@@ -698,6 +699,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
            
           <select>
             <option
+              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
@@ -1346,6 +1348,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
            
           <select>
             <option
+              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
@@ -1988,6 +1991,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
            
           <select>
             <option
+              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -64,7 +64,6 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
             class="stackSettingsSelect"
           >
             <option
-              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
@@ -703,7 +702,6 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             class="stackSettingsSelect"
           >
             <option
-              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
@@ -1354,7 +1352,6 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             class="stackSettingsSelect"
           >
             <option
-              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
@@ -1999,7 +1996,6 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             class="stackSettingsSelect"
           >
             <option
-              selected=""
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -9,7 +9,7 @@ import {
   getEmptyJsTracerTable,
   resourceTypes,
   getEmptyJsAllocationsTable,
-  getEmptyNativeAllocationsTable,
+  getEmptyUnbalancedNativeAllocationsTable,
 } from '../../../profile-logic/data-structures';
 import { mergeProfiles } from '../../../profile-logic/comparison';
 import { stateFromLocation } from '../../../app-logic/url-handling';
@@ -921,9 +921,12 @@ export function getProfileWithJsAllocations(): * {
 }
 
 /**
- * Get a profile with Native allocations. The allocations will form the following trees.
+ * Get a profile with unbalanced native allocations. The allocations will form the
+ * following trees. The profile is unbalanced because the allocations do not have
+ * the memory addresses where they were allocated/deallocated from, and so
+ * cannot be matched up to form a balanced view.
  *
- * Allocations:
+ * Retained Allocations:
  *
  * - A (total: 15, self: —)
  *   - B (total: 15, self: —)
@@ -947,8 +950,7 @@ export function getProfileWithJsAllocations(): * {
  *       - D (total: -11, self: —)
  *         - E (total: -11, self: -11)
  */
-
-export function getProfileWithNativeAllocations(): * {
+export function getProfileWithUnbalancedNativeAllocations(): * {
   // First create a normal sample-based profile.
   const {
     profile,
@@ -963,7 +965,7 @@ export function getProfileWithNativeAllocations(): * {
   `);
 
   // Now add a NativeAllocationsTable.
-  const nativeAllocations = getEmptyNativeAllocationsTable();
+  const nativeAllocations = getEmptyUnbalancedNativeAllocationsTable();
   profile.threads[0].nativeAllocations = nativeAllocations;
 
   // The stack table is built sequentially, so we can assume that the stack indexes

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -10,6 +10,7 @@ import {
   resourceTypes,
   getEmptyJsAllocationsTable,
   getEmptyUnbalancedNativeAllocationsTable,
+  getEmptyBalancedNativeAllocationsTable,
 } from '../../../profile-logic/data-structures';
 import { mergeProfiles } from '../../../profile-logic/comparison';
 import { stateFromLocation } from '../../../app-logic/url-handling';
@@ -991,6 +992,85 @@ export function getProfileWithUnbalancedNativeAllocations(): * {
     nativeAllocations.time.push(thisTime);
     nativeAllocations.duration.push(byteSize);
     nativeAllocations.stack.push(stack);
+    nativeAllocations.length++;
+  }
+
+  return { profile, funcNamesDict };
+}
+
+/**
+ * Get a profile with balanced native allocations. The allocations will form the
+ * following trees. The profile is balanced because the allocations have memory
+ * addresses, so the allocations and deallocations can be balanced based on the
+ * allocation site.
+ *
+ * Retained Allocations:
+ *
+ * - A (total: 30, self: —)
+ *   - B (total: 30, self: —)
+ *     - C (total: 17, self: —)
+ *       - D (total: 17, self: —)
+ *         - E (total: 17, self: 17)
+ *     - Fjs (total: 13, self: —)
+ *       - Gjs (total: 13, self: 13)
+ */
+
+export function getProfileWithBalancedNativeAllocations(): * {
+  // First create a normal sample-based profile.
+  const {
+    profile,
+    funcNamesDictPerThread: [funcNamesDict],
+  } = getProfileFromTextSamples(`
+    A  A     A
+    B  B     B
+    C  Fjs   Fjs
+    D  Gjs   Gjs
+    E        Hjs
+             I
+  `);
+
+  // Now add a NativeAllocationsTable.
+  const nativeAllocations = getEmptyBalancedNativeAllocationsTable();
+  const [thread] = profile.threads;
+  thread.nativeAllocations = nativeAllocations;
+  const threadId = ensureExists(
+    thread.tid,
+    'Expected there to be a tid on the thread'
+  );
+
+  // The stack table is built sequentially, so we can assume that the stack indexes
+  // match the func indexes.
+  const { E, I, Gjs } = funcNamesDict;
+
+  // Create a list of allocations.
+  const allocations = [
+    // Matched allocations:
+    { byteSize: 3, stack: E, memoryAddress: 0x10 },
+    { byteSize: 5, stack: Gjs, memoryAddress: 0x11 },
+    { byteSize: 7, stack: I, memoryAddress: 0x12 },
+    // Unmatched allocations:
+    { byteSize: 11, stack: E, memoryAddress: 0x20 },
+    { byteSize: 13, stack: Gjs, memoryAddress: 0x21 },
+    { byteSize: 17, stack: I, memoryAddress: 0x22 },
+    // Deallocations that match the first group.
+    { byteSize: -3, stack: E, memoryAddress: 0x10 },
+    { byteSize: -5, stack: Gjs, memoryAddress: 0x11 },
+    { byteSize: -7, stack: I, memoryAddress: 0x12 },
+    // Unmatched deallocations:
+    { byteSize: -19, stack: E, memoryAddress: 0x30 },
+    { byteSize: -23, stack: Gjs, memoryAddress: 0x31 },
+    { byteSize: -29, stack: I, memoryAddress: 0x32 },
+  ];
+
+  // Loop through and add them to the table.
+  let time = 0;
+  for (const { byteSize, stack, memoryAddress } of allocations) {
+    const thisTime = time++;
+    nativeAllocations.time.push(thisTime);
+    nativeAllocations.duration.push(byteSize);
+    nativeAllocations.stack.push(stack);
+    nativeAllocations.memoryAddress.push(memoryAddress);
+    nativeAllocations.threadId.push(threadId);
     nativeAllocations.length++;
   }
 

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -6,6 +6,7 @@ import { CallTree } from '../../profile-logic/call-tree';
 import type { IndexIntoCallNodeTable } from '../../types/profile-derived';
 import type { Store, State } from '../../types/store';
 import { ensureExists } from '../../utils/flow';
+import { fireEvent, type RenderResult } from 'react-testing-library';
 
 export function getBoundingBox(width: number, height: number) {
   return {
@@ -209,4 +210,22 @@ export function removeRootOverlayElement() {
       'Expected to find a root overlay element to clean up.'
     )
   );
+}
+
+/**
+ * You can't change <select>s by just clicking them using react-testing-library. This
+ * utility makes it so that selects can be changed by the text that is in them.
+ *
+ * Usage:
+ * changeSelect({ from: 'Timing Data', to: 'Deallocations' });
+ */
+export function createSelectChanger(renderResult: RenderResult) {
+  return function changeSelect({ from, to }: {| from: string, to: string |}) {
+    // Look up the <option> with the text label.
+    const option = renderResult.getByText(to);
+    // Fire a change event to the select.
+    fireEvent.change(renderResult.getByDisplayValue(from), {
+      target: { value: option.getAttribute('value') },
+    });
+  };
 }

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -15,7 +15,7 @@ import {
   getNetworkMarkers,
   getCounterForThread,
   getVisualProgressTrackProfile,
-  getProfileWithNativeAllocations,
+  getProfileWithUnbalancedNativeAllocations,
   getProfileWithJsAllocations,
 } from '../fixtures/profiles/processed-profile';
 import {
@@ -507,7 +507,7 @@ describe('actions/ProfileView', function() {
 
     describe('with allocation-based tracks', function() {
       function setup() {
-        const { profile } = getProfileWithNativeAllocations();
+        const { profile } = getProfileWithUnbalancedNativeAllocations();
         profile.threads.push(
           getProfileWithJsAllocations().profile.threads[0],
           getEmptyThread()

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -5,7 +5,7 @@
 // @flow
 import {
   getProfileFromTextSamples,
-  getProfileWithNativeAllocations,
+  getProfileWithUnbalancedNativeAllocations,
   getProfileWithJsAllocations,
 } from '../fixtures/profiles/processed-profile';
 import { formatTree } from '../fixtures/utils';
@@ -1322,7 +1322,7 @@ describe('transform native allocations', function() {
   const threadIndex = 0;
 
   it('can render a normal call tree', function() {
-    const { profile } = getProfileWithNativeAllocations();
+    const { profile } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-allocations'));
 
@@ -1345,7 +1345,7 @@ describe('transform native allocations', function() {
     const {
       profile,
       funcNamesDict: { Fjs },
-    } = getProfileWithNativeAllocations();
+    } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-allocations'));
     dispatch(
@@ -1370,7 +1370,7 @@ describe('transform native deallocations', function() {
   const threadIndex = 0;
 
   it('can render a normal call tree', function() {
-    const { profile } = getProfileWithNativeAllocations();
+    const { profile } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-deallocations'));
 
@@ -1393,7 +1393,7 @@ describe('transform native deallocations', function() {
     const {
       profile,
       funcNamesDict: { Fjs },
-    } = getProfileWithNativeAllocations();
+    } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-deallocations'));
     dispatch(

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import {
+  getProfileWithBalancedNativeAllocations,
+  getProfileWithUnbalancedNativeAllocations,
+} from '../fixtures/profiles/processed-profile';
+import { formatTree } from '../fixtures/utils';
+import { storeWithProfile } from '../fixtures/stores';
+import {
+  changeCallTreeSummaryStrategy,
+  changeCallTreeSearchString,
+  changeInvertCallstack,
+  changeImplementationFilter,
+  commitRange,
+  updatePreviewSelection,
+} from '../../actions/profile-view';
+import { selectedThreadSelectors } from '../../selectors/per-thread';
+import type { CallTreeSummaryStrategy } from '../../types/actions';
+
+/**
+ * Test that the NativeAllocationTable structure can by used with all of the call tree
+ * functionality, and that it obeys all of the transformation pipeline.
+ */
+describe('Native allocation call trees', function() {
+  function setup(
+    type: 'balanced' | 'unbalanced',
+    summaryStrategy: CallTreeSummaryStrategy
+  ) {
+    const { profile, funcNamesDict } =
+      type === 'balanced'
+        ? getProfileWithBalancedNativeAllocations()
+        : getProfileWithUnbalancedNativeAllocations();
+
+    // Create the store and switch to the summary view.
+    const store = storeWithProfile(profile);
+    store.dispatch(changeCallTreeSummaryStrategy(summaryStrategy));
+    return { ...store, funcNamesDict };
+  }
+
+  describe('with balanced allocations', function() {
+    it('can create a call tree from allocations only', function() {
+      const { getState } = setup('balanced', 'native-allocations');
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+
+      expect(formatTree(callTree)).toEqual([
+        '- A (total: 56, self: —)',
+        '  - B (total: 56, self: —)',
+        '    - Fjs (total: 42, self: —)',
+        '      - Gjs (total: 42, self: 18)',
+        '        - Hjs (total: 24, self: —)',
+        '          - I (total: 24, self: 24)',
+        '    - C (total: 14, self: —)',
+        '      - D (total: 14, self: —)',
+        '        - E (total: 14, self: 14)',
+      ]);
+    });
+
+    it('can create a call tree from deallocations only', function() {
+      const { getState } = setup('balanced', 'native-deallocations');
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+
+      expect(formatTree(callTree)).toEqual([
+        '- A (total: -86, self: —)',
+        '  - B (total: -86, self: —)',
+        '    - Fjs (total: -64, self: —)',
+        '      - Gjs (total: -64, self: -28)',
+        '        - Hjs (total: -36, self: —)',
+        '          - I (total: -36, self: -36)',
+        '    - C (total: -22, self: —)',
+        '      - D (total: -22, self: —)',
+        '        - E (total: -22, self: -22)',
+      ]);
+    });
+
+    it('can create a call tree from retained allocations', function() {
+      const { getState } = setup('balanced', 'native-retained-allocations');
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+
+      expect(formatTree(callTree)).toEqual([
+        '- A (total: 41, self: —)',
+        '  - B (total: 41, self: —)',
+        '    - Fjs (total: 30, self: —)',
+        '      - Gjs (total: 30, self: 13)',
+        '        - Hjs (total: 17, self: —)',
+        '          - I (total: 17, self: 17)',
+        '    - C (total: 11, self: —)',
+        '      - D (total: 11, self: —)',
+        '        - E (total: 11, self: 11)',
+      ]);
+    });
+  });
+
+  describe('with balanced allocations', function() {
+    it('can create a call tree from allocations only', function() {
+      const { getState } = setup('unbalanced', 'native-allocations');
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+
+      expect(formatTree(callTree)).toEqual([
+        '- A (total: 15, self: —)',
+        '  - B (total: 15, self: —)',
+        '    - Fjs (total: 12, self: —)',
+        '      - Gjs (total: 12, self: 5)',
+        '        - Hjs (total: 7, self: —)',
+        '          - I (total: 7, self: 7)',
+        '    - C (total: 3, self: —)',
+        '      - D (total: 3, self: —)',
+        '        - E (total: 3, self: 3)',
+      ]);
+    });
+
+    it('can create a call tree from deallocations only', function() {
+      const { getState } = setup('unbalanced', 'native-deallocations');
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+
+      expect(formatTree(callTree)).toEqual([
+        '- A (total: -41, self: —)',
+        '  - B (total: -41, self: —)',
+        '    - Fjs (total: -30, self: —)',
+        '      - Gjs (total: -30, self: -13)',
+        '        - Hjs (total: -17, self: —)',
+        '          - I (total: -17, self: -17)',
+        '    - C (total: -11, self: —)',
+        '      - D (total: -11, self: —)',
+        '        - E (total: -11, self: -11)',
+      ]);
+    });
+
+    it('cannot create a call tree from retained allocations', function() {
+      const { getState } = setup('unbalanced', 'native-retained-allocations');
+      expect(() => {
+        selectedThreadSelectors.getCallTree(getState());
+      }).toThrow();
+    });
+  });
+
+  it('can search the allocations', function() {
+    const { getState, dispatch } = setup('balanced', 'native-allocations');
+    dispatch(changeCallTreeSearchString('Hjs'));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 24, self: —)',
+      '  - B (total: 24, self: —)',
+      '    - Fjs (total: 24, self: —)',
+      '      - Gjs (total: 24, self: —)',
+      '        - Hjs (total: 24, self: —)',
+      '          - I (total: 24, self: 24)',
+    ]);
+  });
+
+  it('can invert the allocation tree', function() {
+    const { getState, dispatch } = setup('balanced', 'native-allocations');
+    dispatch(changeInvertCallstack(true));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- I (total: 24, self: 24)',
+      '  - Hjs (total: 24, self: —)',
+      '    - Gjs (total: 24, self: —)',
+      '      - Fjs (total: 24, self: —)',
+      '        - B (total: 24, self: —)',
+      '          - A (total: 24, self: —)',
+      '- Gjs (total: 18, self: 18)',
+      '  - Fjs (total: 18, self: —)',
+      '    - B (total: 18, self: —)',
+      '      - A (total: 18, self: —)',
+      '- E (total: 14, self: 14)',
+      '  - D (total: 14, self: —)',
+      '    - C (total: 14, self: —)',
+      '      - B (total: 14, self: —)',
+      '        - A (total: 14, self: —)',
+    ]);
+  });
+
+  it('can use an implementation filter', function() {
+    const { getState, dispatch } = setup('balanced', 'native-allocations');
+    dispatch(changeImplementationFilter('js'));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- Fjs (total: 42, self: —)',
+      '  - Gjs (total: 42, self: 18)',
+      '    - Hjs (total: 24, self: 24)',
+    ]);
+  });
+
+  it('will apply a committed range selection', function() {
+    const { getState, dispatch } = setup('balanced', 'native-allocations');
+
+    dispatch(commitRange(0, 1.5));
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 8, self: —)',
+      '  - B (total: 8, self: —)',
+      '    - Fjs (total: 5, self: —)',
+      '      - Gjs (total: 5, self: 5)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
+  });
+
+  it('will apply a preview selection', function() {
+    const { getState, dispatch } = setup('balanced', 'native-allocations');
+
+    dispatch(commitRange(0, 1.5));
+    dispatch(
+      updatePreviewSelection({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 0,
+        selectionEnd: 1,
+      })
+    );
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+
+    expect(formatTree(callTree)).toEqual([
+      '- A (total: 3, self: —)',
+      '  - B (total: 3, self: —)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
+  });
+});

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -92,7 +92,7 @@ describe('Native allocation call trees', function() {
     });
   });
 
-  describe('with balanced allocations', function() {
+  describe('with unbalanced allocations', function() {
     it('can create a call tree from allocations only', function() {
       const { getState } = setup('unbalanced', 'native-allocations');
       const callTree = selectedThreadSelectors.getCallTree(getState());

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -86,6 +86,7 @@ export type ImplementationFilter = 'combined' | 'js' | 'cpp';
 export type CallTreeSummaryStrategy =
   | 'timing'
   | 'js-allocations'
+  | 'native-retained-allocations'
   | 'native-allocations'
   | 'native-deallocations';
 

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -524,6 +524,9 @@ export type NativeAllocationPayload_Gecko = {|
   endTime: Milliseconds,
   size: Bytes,
   stack: GeckoMarkerStack,
+  // Older versions of the Gecko format did not have these values.
+  memoryAddress?: number,
+  threadId?: number,
 |};
 
 export type IPCMarkerPayload = {|

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -129,12 +129,10 @@ export type JsAllocationsTable = {|
 |};
 
 /**
- * Native allocations are recorded as a marker payload, but in profile processing they
- * are moved to the Thread. This allows them to be part of the stack processing pipeline.
- * Currently they include native allocations and deallocations. However, both
- * of them are sampled independently, so they will be unbalanced if summed togther.
+ * This variant is the original version of the table, before the memory address
+ * and threadId were added.
  */
-export type NativeAllocationsTable = {|
+export type UnbalancedNativeAllocationsTable = {|
   time: Milliseconds[],
   // "duration" is a bit odd of a name for this field, but it's "duck typing" the byte
   // size so that we can use a SamplesTable and NativeAllocationsTable in the same call
@@ -143,6 +141,25 @@ export type NativeAllocationsTable = {|
   stack: Array<IndexIntoStackTable | null>,
   length: number,
 |};
+
+/**
+ * The memory address and thread ID were added later.
+ */
+export type BalancedNativeAllocationsTable = {|
+  ...UnbalancedNativeAllocationsTable,
+  memoryAddress: number[],
+  threadId: number[],
+|};
+
+/**
+ * Native allocations are recorded as a marker payload, but in profile processing they
+ * are moved to the Thread. This allows them to be part of the stack processing pipeline.
+ * Currently they include native allocations and deallocations. However, both
+ * of them are sampled independently, so they will be unbalanced if summed togther.
+ */
+export type NativeAllocationsTable =
+  | UnbalancedNativeAllocationsTable
+  | BalancedNativeAllocationsTable;
 
 /**
  * This is the base abstract class that marker payloads inherit from. This probably isn't


### PR DESCRIPTION
This is the front-end for the work in [Bug 1582741](https://bugzilla.mozilla.org/show_bug.cgi?id=1582741) to be able to show retained memory. The changes are broken up commit-by-commit, and will be easier to read that way.

[Deploy preview](https://deploy-preview-2306--perf-html.netlify.com/public/7be90f46338b895a5b2e8f869aabcd9ece222f8f/calltree/?ctSummary=native-retained-allocations&globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&hiddenLocalTracksByPid=22117-1-2-3&localTrackOrderByPid=22117-5-0-1-2-3-4~22135-0~22330-0~22159-0~22136-0~&range=1.6014_7.9738&thread=0&v=4)