### PR TITLE
Add some tests for JS frame page fields in tooltips

### DIFF
--- a/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
@@ -1,6 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TooltipCallNode displays Page URL for iframe pages 1`] = `
+exports[`TooltipCallNode handles native allocations 1`] = `
+<div
+  class="tooltipCallNode"
+>
+  <div
+    class="tooltipOneLine tooltipHeader"
+  >
+    <div
+      class="tooltipTiming"
+    >
+      Fake Duration Text
+    </div>
+    <div
+      class="tooltipTitle"
+    >
+      Gjs
+    </div>
+    <div
+      class="tooltipIcon"
+    />
+  </div>
+  <div
+    class="tooltipCallNodeDetails"
+  >
+    <div
+      class="tooltipDetails tooltipCallNodeDetailsLeft"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Total Bytes:
+      </div>
+      <div>
+        12 bytes
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Self Bytes:
+      </div>
+      <div>
+        5 bytes
+      </div>
+    </div>
+    <div
+      class="tooltipDetails tooltipCallNodeDetailsLeft"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Stack Type:
+      </div>
+      <div>
+        JavaScript
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Category:
+      </div>
+      <div>
+        <span
+          class="colored-square category-color-yellow"
+        />
+        JavaScript
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipCallNode with page information displays Page URL for iframe pages 1`] = `
 <div
   class="tooltipCallNode"
 >
@@ -67,7 +138,7 @@ exports[`TooltipCallNode displays Page URL for iframe pages 1`] = `
 </div>
 `;
 
-exports[`TooltipCallNode displays Page URL for non-iframe pages 1`] = `
+exports[`TooltipCallNode with page information displays Page URL for non-iframe pages 1`] = `
 <div
   class="tooltipCallNode"
 >
@@ -120,77 +191,6 @@ exports[`TooltipCallNode displays Page URL for non-iframe pages 1`] = `
       </div>
       <div>
         https://developer.mozilla.org/en-US/
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`TooltipCallNode handles native allocations 1`] = `
-<div
-  class="tooltipCallNode"
->
-  <div
-    class="tooltipOneLine tooltipHeader"
-  >
-    <div
-      class="tooltipTiming"
-    >
-      Fake Duration Text
-    </div>
-    <div
-      class="tooltipTitle"
-    >
-      Gjs
-    </div>
-    <div
-      class="tooltipIcon"
-    />
-  </div>
-  <div
-    class="tooltipCallNodeDetails"
-  >
-    <div
-      class="tooltipDetails tooltipCallNodeDetailsLeft"
-    >
-      <div
-        class="tooltipLabel"
-      >
-        Total Bytes:
-      </div>
-      <div>
-        12 bytes
-      </div>
-      <div
-        class="tooltipLabel"
-      >
-        Self Bytes:
-      </div>
-      <div>
-        5 bytes
-      </div>
-    </div>
-    <div
-      class="tooltipDetails tooltipCallNodeDetailsLeft"
-    >
-      <div
-        class="tooltipLabel"
-      >
-        Stack Type:
-      </div>
-      <div>
-        JavaScript
-      </div>
-      <div
-        class="tooltipLabel"
-      >
-        Category:
-      </div>
-      <div>
-        <span
-          class="colored-square category-color-yellow"
-        />
-        JavaScript
       </div>
     </div>
   </div>

--- a/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
@@ -1,5 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipCallNode displays Page URL for iframe pages 1`] = `
+<div
+  class="tooltipCallNode"
+>
+  <div
+    class="tooltipOneLine tooltipHeader"
+  >
+    <div
+      class="tooltipTiming"
+    >
+      Fake Duration Text
+    </div>
+    <div
+      class="tooltipTitle"
+    >
+      Cjs
+    </div>
+    <div
+      class="tooltipIcon"
+    />
+  </div>
+  <div
+    class="tooltipCallNodeDetails"
+  >
+    <div
+      class="tooltipDetails tooltipCallNodeDetailsLeft"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Stack Type:
+      </div>
+      <div>
+        JavaScript
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Category:
+      </div>
+      <div>
+        <span
+          class="colored-square category-color-yellow"
+        />
+        JavaScript
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        iframe URL:
+      </div>
+      <div>
+        https://iframe.example.com/
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Page URL:
+      </div>
+      <div>
+        https://developer.mozilla.org/en-US/
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TooltipCallNode displays Page URL for non-iframe pages 1`] = `
+<div
+  class="tooltipCallNode"
+>
+  <div
+    class="tooltipOneLine tooltipHeader"
+  >
+    <div
+      class="tooltipTiming"
+    >
+      Fake Duration Text
+    </div>
+    <div
+      class="tooltipTitle"
+    >
+      Cjs
+    </div>
+    <div
+      class="tooltipIcon"
+    />
+  </div>
+  <div
+    class="tooltipCallNodeDetails"
+  >
+    <div
+      class="tooltipDetails tooltipCallNodeDetailsLeft"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Stack Type:
+      </div>
+      <div>
+        JavaScript
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Category:
+      </div>
+      <div>
+        <span
+          class="colored-square category-color-yellow"
+        />
+        JavaScript
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Page URL:
+      </div>
+      <div>
+        https://developer.mozilla.org/en-US/
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TooltipCallNode handles native allocations 1`] = `
 <div
   class="tooltipCallNode"


### PR DESCRIPTION
Follow-up of #2300. Added some tests for the JS frame tooltips to make sure that we have Page URL and iframe URL fields in place with the correct data.