### PR TITLE
Handle esm with webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   presets: [
-    "@babel/preset-env",
+    ["@babel/preset-env", { "modules": false }],
     "@babel/preset-react",
     // The "all" property is needed for Flow to properly parse the syntax. It has
     // trouble understanding when the flow comment is the second comment.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,10 +95,6 @@ const config = {
     chunkFilename: '[id].[hash].bundle.js',
     publicPath: '/',
   },
-  optimization: {
-    // Workaround for https://github.com/webpack/webpack/issues/7760
-    usedExports: false,
-  },
 };
 
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
This is supposed to make webpack tree-shake our code, but from what I see there's no improvement in our prod size. This could still be good to configure because maybe this would yield improvements in the future (when we update some dependencies), or allow us to use more tools to analyze our bundle size.