### PR TITLE
Change the call tree summary to use a selector

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -13,7 +13,6 @@ import {
   getLocalTrackFromReference,
   getGlobalTrackFromReference,
   getPreviewSelection,
-  getThreads,
 } from '../selectors/profile';
 import {
   getThreadSelectors,
@@ -27,7 +26,6 @@ import {
   getLocalTrackOrder,
   getHiddenLocalTracks,
   getSelectedTab,
-  getCallTreeSummaryStrategy,
 } from '../selectors/url-state';
 import {
   getCallNodePathFromIndex,
@@ -229,7 +227,6 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
     // These get assigned based on the track type.
     let selectedThreadIndex = null;
     let selectedTab = currentlySelectedTab;
-    let callTreeSummaryStrategy = getCallTreeSummaryStrategy(getState());
 
     if (trackReference.type === 'global') {
       // Handle the case of global tracks.
@@ -317,43 +314,10 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
       return;
     }
 
-    {
-      // Verify that the call tree summary strategy is still valid for the new tab.
-      // Otherwise, switch back to "timing", which is valid everywhere.
-      const strategy = callTreeSummaryStrategy;
-      const selectedThread = getThreads(getState())[selectedThreadIndex];
-      switch (strategy) {
-        case 'timing':
-          // Timing is valid everywhere.
-          break;
-        case 'js-allocations':
-          if (!selectedThread.jsAllocations) {
-            // Attempting to view a thread with no JS allocations, switch back to timing.
-            callTreeSummaryStrategy = 'timing';
-          }
-          break;
-        case 'native-allocations':
-        case 'native-retained-allocations':
-        case 'native-deallocations':
-          if (!selectedThread.nativeAllocations) {
-            // Attempting to view a thread with no native allocations, switch back
-            // to timing.
-            callTreeSummaryStrategy = 'timing';
-          }
-          break;
-        default:
-          assertExhaustiveCheck(
-            strategy,
-            'Unhandled call tree sumary strategy.'
-          );
-      }
-    }
-
     dispatch({
       type: 'SELECT_TRACK',
       selectedThreadIndex,
       selectedTab,
-      callTreeSummaryStrategy,
     });
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -246,9 +246,10 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
           ) || undefined;
       }
       query.ctSummary =
-        urlState.profileSpecific.callTreeSummaryStrategy === 'timing'
+        urlState.profileSpecific.lastSelectedCallTreeSummaryStrategy ===
+        'timing'
           ? undefined
-          : urlState.profileSpecific.callTreeSummaryStrategy;
+          : urlState.profileSpecific.lastSelectedCallTreeSummaryStrategy;
       break;
     }
     case 'marker-table':
@@ -366,7 +367,9 @@ export function stateFromLocation(
     profileName: query.profileName,
     profileSpecific: {
       implementation,
-      callTreeSummaryStrategy: toValidCallTreeSummaryStrategy(query.ctSummary),
+      lastSelectedCallTreeSummaryStrategy: toValidCallTreeSummaryStrategy(
+        query.ctSummary
+      ),
       invertCallstack: query.invertCallstack !== undefined,
       showJsTracerSummary: query.summary !== undefined,
       committedRanges: query.range ? parseCommittedRanges(query.range) : [],

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -12,7 +12,6 @@ import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   getInvertCallstack,
   getImplementationFilter,
-  getCallTreeSummaryStrategy,
   getSearchStringsAsRegExp,
   getSelectedThreadIndex,
 } from '../../selectors/url-state';
@@ -262,7 +261,9 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     implementationFilter: getImplementationFilter(state),
     icons: getIconsWithClassNames(state),
     callNodeMaxDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
-    callTreeSummaryStrategy: getCallTreeSummaryStrategy(state),
+    callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
+      state
+    ),
   }),
   mapDispatchToProps: {
     changeSelectedCallNode,

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -18,7 +18,6 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import {
   getSelectedThreadIndex,
   getInvertCallstack,
-  getCallTreeSummaryStrategy,
 } from '../../selectors/url-state';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
@@ -369,7 +368,9 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
       icons: getIconsWithClassNames(state),
       interval: getProfileInterval(state),
       isInverted: getInvertCallstack(state),
-      callTreeSummaryStrategy: getCallTreeSummaryStrategy(state),
+      callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
+        state
+      ),
       pages: getPageList(state),
     };
   },

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -15,7 +15,6 @@ import {
   getImplementationFilter,
   getInvertCallstack,
   getCurrentSearchString,
-  getCallTreeSummaryStrategy,
 } from '../../selectors/url-state';
 import PanelSearch from '../shared/PanelSearch';
 import {
@@ -219,7 +218,9 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     canShowRetainedMemory: selectedThreadSelectors.getCanShowRetainedMemory(
       state
     ),
-    callTreeSummaryStrategy: getCallTreeSummaryStrategy(state),
+    callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
+      state
+    ),
   }),
   mapDispatchToProps: {
     changeImplementationFilter,

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -232,16 +232,16 @@ const implementation: Reducer<ImplementationFilter> = (
 };
 
 /**
- * Represents the current strategy used to summarize numeric information in the call
- * call tree.
+ * Represents the last selected call tree summary strategy, which will be used to
+ * summarize the the call tree. A strategy can be selected that is not supported
+ * by the current thread, in this case it will default back to timing.
  */
-const callTreeSummaryStrategy: Reducer<CallTreeSummaryStrategy> = (
+const lastSelectedCallTreeSummaryStrategy: Reducer<CallTreeSummaryStrategy> = (
   state = 'timing',
   action
 ) => {
   switch (action.type) {
     case 'CHANGE_CALL_TREE_SUMMARY_STRATEGY':
-    case 'SELECT_TRACK':
       return action.callTreeSummaryStrategy;
     default:
       return state;
@@ -402,7 +402,7 @@ const profileSpecific = combineReducers({
   hiddenLocalTracksByPid,
   localTrackOrderByPid,
   implementation,
-  callTreeSummaryStrategy,
+  lastSelectedCallTreeSummaryStrategy,
   invertCallstack,
   showJsTracerSummary,
   committedRanges,

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -30,6 +30,7 @@ import type {
 import type { StartEndRange } from '../../types/units';
 import type { Selector } from '../../types/store';
 import type { $ReturnType } from '../../types/utils';
+import type { CallTreeSummaryStrategy } from '../../types/actions';
 import type { ThreadSelectorsPerThread } from './thread';
 
 /**
@@ -177,11 +178,50 @@ export function getStackAndSampleSelectorsPerThread(
     }
   );
 
+  /**
+   * The CallTreeSummaryStrategy determines how the call tree summarizes the
+   * the current thread. By default, this is done by timing, but other
+   * methods are also available. This selectors also ensures that the current
+   * thread supports the last selected call tree summary strategy.
+   */
+  const getCallTreeSummaryStrategy: Selector<CallTreeSummaryStrategy> = createSelector(
+    threadSelectors.getThread,
+    UrlState.getLastSelectedCallTreeSummaryStrategy,
+    (thread, lastSelectedCallTreeSummaryStrategy) => {
+      switch (lastSelectedCallTreeSummaryStrategy) {
+        case 'timing':
+          // Timing is valid everywhere.
+          break;
+        case 'js-allocations':
+          if (!thread.jsAllocations) {
+            // Attempting to view a thread with no JS allocations, switch back to timing.
+            return 'timing';
+          }
+          break;
+        case 'native-allocations':
+        case 'native-retained-allocations':
+        case 'native-deallocations':
+          if (!thread.nativeAllocations) {
+            // Attempting to view a thread with no native allocations, switch back
+            // to timing.
+            return 'timing';
+          }
+          break;
+        default:
+          assertExhaustiveCheck(
+            lastSelectedCallTreeSummaryStrategy,
+            'Unhandled call tree sumary strategy.'
+          );
+      }
+      return lastSelectedCallTreeSummaryStrategy;
+    }
+  );
+
   const getSamplesForCallTree: Selector<
     SamplesTable | JsAllocationsTable | NativeAllocationsTable
   > = createSelector(
     threadSelectors.getPreviewFilteredThread,
-    UrlState.getCallTreeSummaryStrategy,
+    getCallTreeSummaryStrategy,
     (thread, strategy) => {
       switch (strategy) {
         case 'timing':
@@ -239,7 +279,7 @@ export function getStackAndSampleSelectorsPerThread(
     ProfileSelectors.getCategories,
     UrlState.getImplementationFilter,
     getCallTreeCountsAndTimings,
-    UrlState.getCallTreeSummaryStrategy,
+    getCallTreeSummaryStrategy,
     CallTree.getCallTree
   );
 
@@ -276,6 +316,7 @@ export function getStackAndSampleSelectorsPerThread(
     getExpandedCallNodeIndexes,
     getSamplesSelectedStatesInFilteredThread,
     getTreeOrderComparatorInFilteredThread,
+    getCallTreeSummaryStrategy,
     getCallTree,
     getStackTimingByDepth,
     getCallNodeMaxDepthForFlameGraph,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -46,8 +46,8 @@ export const getAllCommittedRanges: Selector<StartEndRange[]> = state =>
   getProfileSpecificState(state).committedRanges;
 export const getImplementationFilter: Selector<ImplementationFilter> = state =>
   getProfileSpecificState(state).implementation;
-export const getCallTreeSummaryStrategy: Selector<CallTreeSummaryStrategy> = state =>
-  getProfileSpecificState(state).callTreeSummaryStrategy;
+export const getLastSelectedCallTreeSummaryStrategy: Selector<CallTreeSummaryStrategy> = state =>
+  getProfileSpecificState(state).lastSelectedCallTreeSummaryStrategy;
 export const getInvertCallstack: Selector<boolean> = state =>
   getProfileSpecificState(state).invertCallstack;
 export const getShowJsTracerSummary: Selector<boolean> = state =>

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -10,6 +10,7 @@ import { render, fireEvent } from 'react-testing-library';
 import copy from 'copy-to-clipboard';
 import fakeIndexedDB from 'fake-indexeddb';
 
+import { selectedThreadSelectors } from '../../selectors/per-thread';
 import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
 import CallNodeContextMenu from '../../components/shared/CallNodeContextMenu';
 import { processProfile } from '../../profile-logic/process-profile';
@@ -25,7 +26,6 @@ import {
   getProfileWithBalancedNativeAllocations,
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
-import { getCallTreeSummaryStrategy } from '../../selectors/url-state';
 
 import {
   getEmptyThread,
@@ -513,15 +513,21 @@ describe('ProfileCallTreeView with JS Allocations', function() {
     const { changeSelect, getState } = setup();
 
     // It starts out with timing.
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('timing');
 
     // It switches to JS allocations.
     changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('js-allocations');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('js-allocations');
 
     // And finally it can be switched back.
     changeSelect({ from: 'JavaScript Allocations', to: 'Timing Data' });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('timing');
   });
 
   it('shows byte related labels for JS allocations', function() {
@@ -563,18 +569,22 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
     const { getState, changeSelect } = setup();
 
     // It starts out with timing.
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('timing');
 
     // Switch to native allocations.
     changeSelect({ from: 'Timing Data', to: 'Allocations' });
 
-    expect(getCallTreeSummaryStrategy(getState())).toEqual(
-      'native-allocations'
-    );
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('native-allocations');
 
     // And finally it can be switched back.
     changeSelect({ from: 'Allocations', to: 'Timing Data' });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('timing');
   });
 
   it('shows byte related labels for native allocations', function() {
@@ -627,18 +637,22 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     const { getState, changeSelect } = setup();
 
     // It starts out with timing.
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('timing');
 
     // Switch to retained memory native allocations.
     changeSelect({ from: 'Timing Data', to: 'Retained Allocations' });
 
-    expect(getCallTreeSummaryStrategy(getState())).toEqual(
-      'native-retained-allocations'
-    );
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('native-retained-allocations');
 
     // And finally it can be switched back.
     changeSelect({ from: 'Retained Allocations', to: 'Timing Data' });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(
+      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+    ).toEqual('timing');
   });
 
   it('shows byte related labels for retained allocations', function() {

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -11,7 +11,6 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithUnbalancedNativeAllocations } from '../fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import * as ProfileSelectors from '../../selectors/profile';
-import * as UrlState from '../../selectors/url-state';
 import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,
@@ -39,7 +38,7 @@ describe('TooltipCallNode', function() {
             interval={ProfileSelectors.getProfileInterval(getState())}
             durationText="Fake Duration Text"
             callTree={selectedThreadSelectors.getCallTree(getState())}
-            callTreeSummaryStrategy={UrlState.getCallTreeSummaryStrategy(
+            callTreeSummaryStrategy={selectedThreadSelectors.getCallTreeSummaryStrategy(
               getState()
             )}
           />

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -554,7 +554,7 @@ describe('actions/ProfileView', function() {
           ProfileView.changeCallTreeSummaryStrategy('native-allocations')
         );
         expect(
-          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
         ).toEqual('native-allocations');
 
         // Switch to a thread without native allocations.
@@ -562,7 +562,7 @@ describe('actions/ProfileView', function() {
 
         // Expect that it switches the summary strategy to one it supports.
         expect(
-          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
         ).toEqual('timing');
       });
 
@@ -574,7 +574,7 @@ describe('actions/ProfileView', function() {
         dispatch(ProfileView.selectTrack(jsAllocationsThread));
         dispatch(ProfileView.changeCallTreeSummaryStrategy('js-allocations'));
         expect(
-          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
         ).toEqual('js-allocations');
 
         // Switch to a thread without js allocations.
@@ -582,7 +582,7 @@ describe('actions/ProfileView', function() {
 
         // Expect that it switches the summary strategy to one it supports.
         expect(
-          UrlStateSelectors.getCallTreeSummaryStrategy(getState())
+          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
         ).toEqual('timing');
       });
     });
@@ -2359,19 +2359,6 @@ describe('counter selectors', function() {
       maxCount: 30,
       minCount: -12,
     });
-  });
-});
-
-describe('call tree summary strategy', function() {
-  it('can change the call tree strategy', function() {
-    const { dispatch, getState } = storeWithProfile();
-    expect(UrlStateSelectors.getCallTreeSummaryStrategy(getState())).toEqual(
-      'timing'
-    );
-    dispatch(ProfileView.changeCallTreeSummaryStrategy('js-allocations'));
-    expect(UrlStateSelectors.getCallTreeSummaryStrategy(getState())).toEqual(
-      'js-allocations'
-    );
   });
 });
 

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -68,7 +68,6 @@ describe('getUsefulTabs', function() {
       type: 'SELECT_TRACK',
       selectedThreadIndex: 2,
       selectedTab: 'calltree',
-      callTreeSummaryStrategy: 'timing',
     });
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -844,26 +844,29 @@ describe('compare', function() {
   });
 });
 
-describe('call tree summary strategy', function() {
-  const { getCallTreeSummaryStrategy } = urlStateReducers;
-
+describe('last requested call tree summary strategy', function() {
+  const { getLastSelectedCallTreeSummaryStrategy } = urlStateReducers;
   it('defaults to timing', function() {
     const { getState } = _getStoreWithURL();
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
   });
 
   it('can be js allocations', function() {
     const { getState } = _getStoreWithURL({
       search: '?ctSummary=js-allocations',
     });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('js-allocations');
+    expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(
+      'js-allocations'
+    );
   });
 
   it('can be native allocations', function() {
     const { getState } = _getStoreWithURL({
       search: '?ctSummary=native-allocations',
     });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual(
+    expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(
       'native-allocations'
     );
   });
@@ -872,6 +875,8 @@ describe('call tree summary strategy', function() {
     const { getState } = _getStoreWithURL({
       search: '?ctSummary=unknown-value',
     });
-    expect(getCallTreeSummaryStrategy(getState())).toEqual('timing');
+    expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
   });
 });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -294,7 +294,6 @@ type UrlStateAction =
       +type: 'SELECT_TRACK',
       +selectedThreadIndex: ThreadIndex,
       +selectedTab: TabSlug,
-      +callTreeSummaryStrategy: CallTreeSummaryStrategy,
     |}
   | {|
       +type: 'CHANGE_RIGHT_CLICKED_TRACK',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -182,7 +182,7 @@ export type UrlState = {|
     hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
     localTrackOrderByPid: Map<Pid, TrackIndex[]>,
     implementation: ImplementationFilter,
-    callTreeSummaryStrategy: CallTreeSummaryStrategy,
+    lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy,
     invertCallstack: boolean,
     showJsTracerSummary: boolean,
     committedRanges: StartEndRange[],


### PR DESCRIPTION
Please only consider the last commit here, as it's built off of the native allocations work. This is a follow-up per @julienw 's suggestions in #2304 to move the logic to a selector.

[deploy preview](https://deploy-preview-2314--perf-html.netlify.com/public/b4d715c2febdf29fb83beaaeb7f4107fe722a7d2/calltree/?ctSummary=native-allocations&globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&hiddenLocalTracksByPid=91168-1-2-3~91191-0&localTrackOrderByPid=91168-5-6-0-1-2-3-4~91190-0~91214-0~91191-1-0~91213-0-1~&thread=0&v=4)