### PR TITLE
Give synchronous IPC messages a different color/position on the IPC timeline track

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -620,7 +620,10 @@ export function deriveMarkersFromRawMarkerTable(
 
       case 'IPC': {
         const pairData = ipcCorrelations.get(threadId, i);
-        const name = data.direction === 'sending' ? 'IPCOut' : 'IPCIn';
+        let name = data.direction === 'sending' ? 'IPCOut' : 'IPCIn';
+        if (data.sync) {
+          name = 'Sync' + name;
+        }
         const dir = data.direction === 'sending' ? 'sent to' : 'received from';
         if (pairData) {
           matchedMarkers.push({

--- a/src/profile-logic/marker-styles.js
+++ b/src/profile-logic/marker-styles.js
@@ -155,13 +155,23 @@ export const markerStyles: MarkerStyles = {
 
   IPCOut: {
     ...defaultStyle,
-    background: colors.TEAL_50,
-    top: 5,
+    background: colors.BLUE_50,
+    top: 2,
+  },
+  SyncIPCOut: {
+    ...defaultStyle,
+    background: colors.BLUE_70,
+    top: 6,
   },
   IPCIn: {
     ...defaultStyle,
-    background: colors.PURPLE_50,
-    top: 10,
+    background: colors.PURPLE_40,
+    top: 13,
+  },
+  SyncIPCIn: {
+    ...defaultStyle,
+    background: colors.PURPLE_70,
+    top: 17,
   },
 };
 


### PR DESCRIPTION
This helps developers identify more easily when sync IPC is happening, which can be useful when trying to determine the cause of UI hiccups/janks.