### PR TITLE
[deploy-preview] Source code viewer

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -991,6 +991,28 @@ export function changeNetworkSearchString(searchString: string): Action {
   };
 }
 
+export function changeSelectedCodeLine(
+  threadIndex: ThreadIndex,
+  selectedCodeLine: number
+): Action {
+  return {
+    type: 'CHANGE_SELECTED_CODE_LINE',
+    threadIndex,
+    selectedCodeLine,
+  };
+}
+
+export function changeExpandedCodeLines(
+  threadIndex: ThreadIndex,
+  expandedCodeLines: Array<number | null>
+): Action {
+  return {
+    type: 'CHANGE_EXPANDED_CODE_LINES',
+    expandedCodeLines,
+    threadIndex,
+  };
+}
+
 export function changeImplementationFilter(
   implementation: ImplementationFilter
 ): ThunkAction<void> {

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -17,6 +17,7 @@ export const tabsWithTitle = {
   'marker-table': 'Marker Table',
   'network-chart': 'Network',
   'js-tracer': 'JS Tracer',
+  'code-view': 'Code View',
 };
 
 export type TabSlug = $Keys<typeof tabsWithTitle>;

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -230,6 +230,7 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
   switch (selectedTab) {
     case 'stack-chart':
     case 'flame-graph':
+    case 'code-view':
     case 'calltree': {
       query.search = urlState.profileSpecific.callTreeSearchString || undefined;
       query.invertCallstack = urlState.profileSpecific.invertCallstack

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -17,6 +17,7 @@ import MarkerChart from '../marker-chart/';
 import NetworkChart from '../network-chart/';
 import FlameGraph from '../flame-graph/';
 import JsTracer from '../js-tracer/';
+import CodeView from '../code-view';
 import selectSidebar from '../sidebar';
 
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
@@ -102,6 +103,7 @@ class ProfileViewer extends PureComponent<Props> {
               'marker-table': <MarkerTable />,
               'network-chart': <NetworkChart />,
               'js-tracer': <JsTracer />,
+              'code-view': <CodeView />,
             }[selectedTab]
           }
         </ErrorBoundary>

--- a/src/components/code-view/index.css
+++ b/src/components/code-view/index.css
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.codeView {
+  display: flex;
+  flex: 1;
+  flex-flow: column nowrap;
+}
+
+.codeViewTable {
+  display: flex;
+  flex: 1;
+  flex-flow: column nowrap;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.treeViewFixedColumn.codeSelfTime {
+  left: 0;
+  width: 80px;
+  padding-right: 5px;
+  text-align: right;
+}
+
+.treeViewFixedColumn.codeRunningTime {
+  left: 80px;
+  width: 80px;
+  padding-right: 5px;
+  text-align: right;
+}
+
+.treeViewMainColumn.codeText {
+  left: 175px;
+}

--- a/src/components/code-view/index.js
+++ b/src/components/code-view/index.js
@@ -1,0 +1,359 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import explicitConnect from '../../utils/connect';
+import TreeView from '../shared/TreeView';
+import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getScrollToSelectionGeneration } from '../../selectors/profile';
+import { getSelectedThreadIndex } from '../../selectors/url-state';
+import {
+  changeExpandedCodeLines,
+  changeSelectedCodeLine,
+} from '../../actions/profile-view';
+import memoize from 'memoize-immutable';
+
+import type { Thread, ThreadIndex } from '../../types/profile';
+import type { IndexIntoCallNodeTable } from '../../types/profile-derived';
+import type { ConnectedProps } from '../../utils/connect';
+import type { CallTree } from '../../profile-logic/call-tree';
+
+require('./index.css');
+
+const FIXED_SCRIPT_LOCATION =
+  'http://localhost:4242/92196893a1cdcf9d6cfb.bundle.js';
+
+type CodeLine = number;
+
+export class CodeViewTree {
+  _code: string[];
+  _thread: Thread;
+  _callTree: CallTree;
+  // The index of the line of code.
+  _codeLinesIndexes: CodeLine[];
+  // These are arrays that are like: {[CodeLine]: Timing}
+  _selfTimes: number[];
+  _runningTimes: number[];
+
+  constructor(
+    resourceName: string,
+    code: string,
+    thread: Thread,
+    callTree: CallTree
+  ) {
+    this._code = code.split('\n');
+    this._thread = thread;
+    this._callTree = callTree;
+    this._selfTimes = Array(this._code.length).fill(0);
+    this._runningTimes = Array(this._code.length).fill(0);
+
+    // Compute the self and running times per line in the script.
+    this._computeTimingRecursive(callTree.getRoots());
+
+    // Build up an array of indexes, as needed by the TreeView interface.
+    // this._codeLinesIndexes = [];
+    // for (let i = 0; i < code.length; i++) {
+    //   this._codeLinesIndexes[i] = i;
+    // }
+
+    // Only build up an array of indexes that have timing.
+    this._codeLinesIndexes = [];
+    for (let i = 0; i < code.length; i++) {
+      if (this._runningTimes[i] > 0) {
+        this._codeLinesIndexes.push(i);
+      }
+    }
+  }
+
+  _computeTimingRecursive(callNodes: IndexIntoCallNodeTable[]): void {
+    const { funcTable, stringTable } = this._thread;
+    for (const callNodeIndex of callNodes) {
+      const { selfTime, totalTime, funcIndex } = this._callTree.getNodeData(
+        callNodeIndex
+      );
+      const fileNameIndex = funcTable.fileName[funcIndex];
+      const lineNumber = funcTable.lineNumber[funcIndex];
+      if (
+        fileNameIndex !== null &&
+        lineNumber !== null &&
+        stringTable.getString(fileNameIndex) === FIXED_SCRIPT_LOCATION
+      ) {
+        // Line number is 1 based, while arrays are 0 based.
+        this._selfTimes[lineNumber - 1] += selfTime;
+        this._runningTimes[lineNumber - 1] += totalTime;
+      }
+
+      this._computeTimingRecursive(this._callTree.getChildren(callNodeIndex));
+    }
+  }
+
+  getRoots(): CodeLine[] {
+    return this._codeLinesIndexes;
+  }
+
+  getChildren(codeLine: CodeLine): CodeLine[] {
+    if (codeLine === -1) {
+      return this.getRoots();
+    }
+    const children = [];
+    for (let i = codeLine + 1; i < this._code.length; i++) {
+      if (this._runningTimes[i] > 0) {
+        break;
+      }
+      children.push(i);
+    }
+    return children;
+  }
+
+  hasChildren(codeLine: CodeLine): boolean {
+    return (
+      // This running time is not zero.
+      this._runningTimes[codeLine] !== 0 &&
+      // And the next running time is zero, the line is collapsed into this one.
+      this._runningTimes[codeLine + 1] === 0
+    );
+  }
+
+  getAllDescendants(codeLine: CodeLine): Set<CodeLine> {
+    return new Set(this.getChildren(codeLine));
+  }
+
+  getParent(codeLine: CodeLine): CodeLine {
+    for (let i = codeLine - 1; i >= 0; i--) {
+      if (this._runningTimes[i] > 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  getDepth(codeLine: CodeLine) {
+    // TODO
+    return this._runningTimes[codeLine] === 0 ? 1 : 0;
+  }
+
+  hasSameNodeIds(tree: CodeViewTree) {
+    return this._codeLinesIndexes === tree._codeLinesIndexes;
+  }
+
+  getDisplayData(codeLine: CodeLine): * {
+    const selfTime = this._selfTimes[codeLine];
+    const runningTime = this._runningTimes[codeLine];
+    return {
+      codeText: <pre>{this._code[codeLine]}</pre>,
+      codeSelfTime: selfTime === 0 ? '–' : selfTime,
+      codeRunningTime: runningTime === 0 ? '–' : runningTime,
+    };
+  }
+}
+
+class CodeViewTable extends React.PureComponent<{|
+  code: string,
+  thread: Thread,
+  threadIndex: ThreadIndex,
+  scrollToSelectionGeneration: number,
+  callTree: CallTree,
+  changeExpandedCodeLines: typeof changeExpandedCodeLines,
+  changeSelectedCodeLine: typeof changeSelectedCodeLine,
+  selectedCodeLine: null | CodeLine,
+  expandedCodeLines: Array<null | CodeLine>,
+|}> {
+  _fixedColumns = [
+    { propName: 'codeSelfTime', title: 'Self Time' },
+    { propName: 'codeRunningTime', title: 'Running Time' },
+  ];
+  _mainColumn = { propName: 'codeText', title: 'Code' };
+  _expandedNodeIds: Array<CodeLine | null> = [];
+  _treeView: ?TreeView<*>;
+  _takeTreeViewRef = treeView => (this._treeView = treeView);
+
+  getCodeViewTree = memoize((...args) => new CodeViewTree(...args), {
+    limit: 1,
+  });
+
+  componentDidMount() {
+    this.focus();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.scrollToSelectionGeneration >
+      prevProps.scrollToSelectionGeneration
+    ) {
+      if (this._treeView) {
+        this._treeView.scrollSelectionIntoView();
+      }
+    }
+  }
+
+  focus() {
+    const treeView = this._treeView;
+    if (treeView) {
+      treeView.focus();
+    }
+  }
+
+  _onSelectionChange = (selectedCodeLine: CodeLine) => {
+    const { threadIndex, changeSelectedCodeLine } = this.props;
+    changeSelectedCodeLine(threadIndex, selectedCodeLine);
+  };
+
+  _onExpandedNodesChange = (selectedCodeLines: Array<null | CodeLine>) => {
+    const { threadIndex, changeExpandedCodeLines } = this.props;
+    changeExpandedCodeLines(threadIndex, selectedCodeLines);
+  };
+
+  _onRightClickSelection = (_selectedCodeLine: CodeLine) => {
+    // const { threadIndex, changeRightClickedCodeLine } = this.props;
+    // changeRightClickedCodeLine(threadIndex, selectedCodeLine);
+  };
+
+  render() {
+    const {
+      code,
+      thread,
+      callTree,
+      selectedCodeLine,
+      expandedCodeLines,
+    } = this.props;
+    const tree = this.getCodeViewTree(
+      FIXED_SCRIPT_LOCATION,
+      code,
+      thread,
+      callTree
+    );
+    return (
+      <div
+        className="codeViewTable"
+        id="code-view-tab"
+        role="tabpanel"
+        aria-labelledby="code-view-tab-button"
+      >
+        {/* <CodeViewSettings /> */}
+        {code.length === 0 ? (
+          'The code text is empty.'
+        ) : (
+          <TreeView
+            maxNodeDepth={0}
+            tree={tree}
+            fixedColumns={this._fixedColumns}
+            mainColumn={this._mainColumn}
+            onSelectionChange={this._onSelectionChange}
+            onRightClickSelection={this._onRightClickSelection}
+            onExpandedNodesChange={this._onExpandedNodesChange}
+            selectedNodeId={selectedCodeLine}
+            expandedNodeIds={expandedCodeLines}
+            rightClickedNodeId={null}
+            ref={this._takeTreeViewRef}
+            contextMenuId="MarkerContextMenu"
+            rowHeight={16}
+            indentWidth={10}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+type State = {|
+  code: string | null,
+  error: string | null,
+|};
+
+type DispatchProps = {|
+  changeExpandedCodeLines: typeof changeExpandedCodeLines,
+  changeSelectedCodeLine: typeof changeSelectedCodeLine,
+|};
+
+type StateProps = {|
+  thread: Thread,
+  threadIndex: ThreadIndex,
+  callTree: CallTree,
+  scrollToSelectionGeneration: number,
+  expandedCodeLines: Array<null | CodeLine>,
+  selectedCodeLine: CodeLine | null,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+class CodeView extends React.PureComponent<Props, State> {
+  _rafGeneration: number = 0;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      code: null,
+      error: null,
+    };
+    this.getCode();
+  }
+
+  async getCode() {
+    try {
+      const response = await fetch('/92196893a1cdcf9d6cfb.bundle.js.txt');
+      this.setState({
+        code: await response.text(),
+      });
+    } catch (error) {
+      this.setState({
+        error: `Unable to load the code: ${error.toString()}`,
+      });
+    }
+  }
+
+  render() {
+    const { code, error } = this.state;
+    if (error) {
+      return <div className="jsTracer">Code View</div>;
+    }
+
+    if (!code) {
+      return <div className="jsTracer">Loading the code</div>;
+    }
+
+    const {
+      thread,
+      threadIndex,
+      scrollToSelectionGeneration,
+      callTree,
+      changeExpandedCodeLines,
+      changeSelectedCodeLine,
+      expandedCodeLines,
+      selectedCodeLine,
+    } = this.props;
+
+    return (
+      <CodeViewTable
+        code={code}
+        thread={thread}
+        threadIndex={threadIndex}
+        callTree={callTree}
+        scrollToSelectionGeneration={scrollToSelectionGeneration}
+        changeExpandedCodeLines={changeExpandedCodeLines}
+        changeSelectedCodeLine={changeSelectedCodeLine}
+        expandedCodeLines={expandedCodeLines}
+        selectedCodeLine={selectedCodeLine}
+      />
+    );
+  }
+}
+
+export default explicitConnect<{||}, StateProps, DispatchProps>({
+  mapStateToProps: state => {
+    return {
+      thread: selectedThreadSelectors.getFilteredThread(state),
+      threadIndex: getSelectedThreadIndex(state),
+      callTree: selectedThreadSelectors.getCallTree(state),
+      scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
+      expandedCodeLines: selectedThreadSelectors.getExpandedCodeLines(state),
+      selectedCodeLine: selectedThreadSelectors.getSelectedCodeLine(state),
+    };
+  },
+  mapDispatchToProps: {
+    changeExpandedCodeLines,
+    changeSelectedCodeLine,
+  },
+  component: CodeView,
+});

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -23,5 +23,6 @@ export default function selectSidebar(
     'marker-table': MarkerSidebar, // MarkerSidebar
     'network-chart': null,
     'js-tracer': null,
+    'code-view': null,
   }[selectedTab];
 }

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -200,6 +200,7 @@ export class CallTree {
     const selfTimeRelative = selfTime / this._rootTotalTime;
 
     return {
+      funcIndex,
       funcName,
       totalTime,
       totalTimeRelative,

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -134,6 +134,8 @@ const viewOptionsPerThread: Reducer<ThreadViewOptions[]> = (
         expandedCallNodePaths: new PathSet(),
         selectedMarker: null,
         rightClickedMarker: null,
+        selectedCodeLine: null,
+        expandedCodeLines: [],
       }));
     case 'COALESCED_FUNCTIONS_UPDATE': {
       const { functionsUpdatePerThread } = action;
@@ -288,6 +290,23 @@ const viewOptionsPerThread: Reducer<ThreadViewOptions[]> = (
         ...state.slice(threadIndex + 1),
       ];
     }
+    case 'CHANGE_EXPANDED_CODE_LINES': {
+      const { threadIndex, expandedCodeLines } = action;
+      return [
+        ...state.slice(0, threadIndex),
+        { ...state[threadIndex], expandedCodeLines },
+        ...state.slice(threadIndex + 1),
+      ];
+    }
+    case 'CHANGE_SELECTED_CODE_LINE': {
+      const { threadIndex, selectedCodeLine } = action;
+      return [
+        ...state.slice(0, threadIndex),
+        { ...state[threadIndex], selectedCodeLine },
+        ...state.slice(threadIndex + 1),
+      ];
+    }
+
     case 'SET_CONTEXT_MENU_VISIBILITY': {
       // We want to change the state only when the menu is hidden.
       if (action.isVisible) {

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -205,6 +205,12 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
   const getViewOptions: Selector<ThreadViewOptions> = state =>
     ProfileSelectors.getProfileViewOptions(state).perThread[threadIndex];
 
+  const getSelectedCodeLine: Selector<number | null> = state =>
+    getViewOptions(state).selectedCodeLine;
+
+  const getExpandedCodeLines: Selector<Array<number | null>> = state =>
+    getViewOptions(state).expandedCodeLines;
+
   /**
    * Check to see if there are any JS allocations for this thread. This way we
    * can display a custom thread.
@@ -289,6 +295,8 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getTransformLabels,
     getTransformStack,
     getViewOptions,
+    getSelectedCodeLine,
+    getExpandedCodeLines,
     getJsTracerTable,
     getExpensiveJsTracerTiming,
     getExpensiveJsTracerLeafTiming,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -148,6 +148,16 @@ type ProfileAction =
       +markerIndex: MarkerIndex | null,
     |}
   | {|
+      +type: 'CHANGE_EXPANDED_CODE_LINES',
+      +threadIndex: ThreadIndex,
+      +expandedCodeLines: Array<number | null>,
+    |}
+  | {|
+      +type: 'CHANGE_SELECTED_CODE_LINE',
+      +threadIndex: ThreadIndex,
+      +selectedCodeLine: number,
+    |}
+  | {|
       +type: 'UPDATE_PREVIEW_SELECTION',
       +previewSelection: PreviewSelection,
     |}

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -96,6 +96,7 @@ export type Marker = {|
 export type MarkerIndex = number;
 
 export type CallNodeData = {
+  funcIndex: number,
   funcName: string,
   totalTime: number,
   totalTimeRelative: number,

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -41,6 +41,8 @@ export type ThreadViewOptions = {|
   +expandedCallNodePaths: PathSet,
   +selectedMarker: MarkerIndex | null,
   +rightClickedMarker: MarkerIndex | null,
+  +selectedCodeLine: number | null,
+  +expandedCodeLines: Array<number | null>,
 |};
 
 export type ProfileViewState = {|

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -49,6 +49,7 @@ export function toValidTabSlug(tabSlug: any): TabSlug | null {
     case 'marker-table':
     case 'flame-graph':
     case 'js-tracer':
+    case 'code-view':
       return coercedTabSlug;
     default: {
       // The coerced type SHOULD be empty here. If in reality we get

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,7 @@ const config = {
       { from: 'res/_redirects' },
       { from: 'docs-user', to: 'docs' },
       { from: 'res/zee-worker.js' },
+      { from: 'res/92196893a1cdcf9d6cfb.bundle.js.txt' },
       { from: 'res/before-load.js' },
       { from: 'res/contribute.json' },
     ]),


### PR DESCRIPTION
I spent some time thinking through what a source code viewer to start to look like, and I built a small prototype of one.

https://deploy-preview-2321--perf-html.netlify.com//public/4f84a91ad7051b9305f6c1fd3e72c6d65c720b75/code-view/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4-5&localTrackOrderByPid=68091-1-2-0~68114-0~42761-0~68092-0~68138-0~68115-0~38819-0-1~&thread=7&v=4

I don't think I'd recommend this specific UI approach for the profiler, but it's interesting to see how the timing works with the rest of the application.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-219)
