### PR TITLE
Disable overscroll behavior, which is obvious on Chrome

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -10,6 +10,10 @@ body {
   font: message-box;
   font-size: 11px;
 
+  /* Disable the "rubberband" overscrolling effect in Chrome. This happens when
+   * using the charts and the scroll wheel. */
+  overscroll-behavior: none;
+
   /* background-color is defined in the HTML file to prevent flashing a white screen. */
 }
 


### PR DESCRIPTION
I noticed this when seeing Brian's prototype tweets on twitter:

https://twitter.com/brian_d_vaughn/status/1201322254430298113