### PR TITLE
Dim frame labels in the call tree for all 'implementation' configurations

### DIFF
--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -256,7 +256,7 @@ class TreeViewRowScrolledColumns<
           odd: index % 2 !== 0,
           isSelected,
           isRightClicked,
-          dim: displayData.dim,
+          dim: displayData.isFrameLabel,
         })}
         style={rowHeightStyle}
         onMouseDown={this._onMouseDown}

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -280,7 +280,7 @@ export class CallTree {
         name: funcName,
         lib: libName.slice(0, 1000),
         // Dim platform pseudo-stacks.
-        dim: isFrameLabel,
+        isFrameLabel,
         categoryName: getCategoryPairLabel(
           this._categories,
           categoryIndex,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -222,7 +222,7 @@ export class CallTree {
       const subcategoryIndex = this._callNodeTable.subcategory[callNodeIndex];
       const resourceIndex = this._funcTable.resource[funcIndex];
       const resourceType = this._resourceTable.type[resourceIndex];
-      const isJS = this._funcTable.isJS[funcIndex];
+      const isFrameLabel = resourceIndex === -1;
       const libName = this._getOriginAnnotation(funcIndex);
 
       let icon = null;
@@ -280,7 +280,7 @@ export class CallTree {
         name: funcName,
         lib: libName.slice(0, 1000),
         // Dim platform pseudo-stacks.
-        dim: !isJS && this._jsOnly,
+        dim: isFrameLabel,
         categoryName: getCategoryPairLabel(
           this._categories,
           categoryIndex,

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -65,7 +65,7 @@ describe('calltree/ProfileCallTreeView', function() {
       profile = getProfileFromTextSamples(`
         A  A  A
         B  B  B
-        C  C  H
+        C  C  H[lib:libH.so]
         D  F  I
         E  E
       `).profile;
@@ -124,12 +124,12 @@ describe('calltree/ProfileCallTreeView', function() {
 
   it('renders an inverted call tree', () => {
     const profileForInvertedTree = getProfileFromTextSamples(`
-      A  A  A
-      B  B  B
-      C  X  C
-      D  Y  X
-      E  Z  Y
-            Z
+      A  A               A
+      B  B               B
+      C  X[lib:libX.so]  C
+      D  Y               X[lib:libX.so]
+      E  Z               Y
+                         Z
     `).profile;
 
     // Note: we're not using the setup function because we want to change the

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -425,7 +425,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                 aria-label="A, total size is 15 bytes (100%), self size is 0 bytes"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -455,7 +455,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                 aria-label="B, total size is 15 bytes (100%), self size is 0 bytes"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -485,7 +485,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                 aria-label="Fjs, total size is 12 bytes (80%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -515,7 +515,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                 aria-label="Gjs, total size is 12 bytes (80%), self size is 5 bytes"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-6"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -568,7 +568,9 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  jQuery.js
+                </span>
               </div>
               <div
                 aria-label="I, total size is 7 bytes (47%), self size is 7 bytes"
@@ -597,14 +599,16 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libI.so
+                </span>
               </div>
               <div
                 aria-expanded="false"
                 aria-label="C, total size is 3 bytes (20%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1075,7 +1079,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 aria-label="A, total size is 41 bytes (100%), self size is 0 bytes"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1105,7 +1109,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 aria-label="B, total size is 41 bytes (100%), self size is 0 bytes"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1135,7 +1139,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 aria-label="Fjs, total size is 30 bytes (73%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1165,7 +1169,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 aria-label="Gjs, total size is 30 bytes (73%), self size is 13 bytes"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-6"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1218,7 +1222,9 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  jQuery.js
+                </span>
               </div>
               <div
                 aria-label="I, total size is 17 bytes (41%), self size is 17 bytes"
@@ -1247,14 +1253,16 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libI.so
+                </span>
               </div>
               <div
                 aria-expanded="false"
                 aria-label="C, total size is 11 bytes (27%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1719,7 +1727,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="A, total size is 15 bytes (100%), self size is 0 bytes"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1749,7 +1757,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="B, total size is 15 bytes (100%), self size is 0 bytes"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1779,7 +1787,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="Fjs, total size is 12 bytes (80%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1809,7 +1817,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="Gjs, total size is 12 bytes (80%), self size is 5 bytes"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-6"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -1862,7 +1870,9 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  jQuery.js
+                </span>
               </div>
               <div
                 aria-label="I, total size is 7 bytes (47%), self size is 7 bytes"
@@ -1891,14 +1901,16 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libI.so
+                </span>
               </div>
               <div
                 aria-expanded="false"
                 aria-label="C, total size is 3 bytes (20%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -2363,7 +2375,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="A, total size is -41 bytes (-100%), self size is 0 bytes"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -2393,7 +2405,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="B, total size is -41 bytes (-100%), self size is 0 bytes"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -2423,7 +2435,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="Fjs, total size is -30 bytes (-73%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -2453,7 +2465,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 aria-label="Gjs, total size is -30 bytes (-73%), self size is -13 bytes"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-6"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -2506,7 +2518,9 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  jQuery.js
+                </span>
               </div>
               <div
                 aria-label="I, total size is -17 bytes (-41%), self size is -17 bytes"
@@ -2535,14 +2549,16 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libI.so
+                </span>
               </div>
               <div
                 aria-expanded="false"
                 aria-label="C, total size is -11 bytes (-27%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3431,7 +3447,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 aria-label="Z, running time is 2ms (67%), self time is 2ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3461,7 +3477,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 aria-label="Y, running time is 2ms (67%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-6"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3514,14 +3530,16 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libX.so
+                </span>
               </div>
               <div
                 aria-expanded="true"
                 aria-label="B, running time is 1ms (33%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-8"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3550,7 +3568,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 aria-label="A, running time is 1ms (33%), self time is 0ms"
                 aria-level="5"
                 aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected dim"
                 id="treeViewRow-9"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3580,7 +3598,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 aria-label="C, running time is 1ms (33%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-10"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3610,7 +3628,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
                 aria-label="E, running time is 1ms (33%), self time is 1ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4045,7 +4063,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 aria-label="A, running time is 3ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4075,7 +4093,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 aria-label="B, running time is 3ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4105,7 +4123,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 aria-label="C, running time is 2ms (67%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4135,7 +4153,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 aria-label="D, running time is 1ms (33%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-3"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4164,7 +4182,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 aria-label="E, running time is 1ms (33%), self time is 1ms"
                 aria-level="5"
                 aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected dim"
                 id="treeViewRow-4"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4194,7 +4212,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 aria-label="F, running time is 1ms (33%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4247,7 +4265,9 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libH.so
+                </span>
               </div>
             </div>
           </div>
@@ -4659,7 +4679,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="A, running time is 3ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4689,7 +4709,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="B, running time is 3ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4719,7 +4739,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="C, running time is 2ms (67%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4749,7 +4769,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="D, running time is 1ms (33%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-3"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4778,7 +4798,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="E, running time is 1ms (33%), self time is 1ms"
                 aria-level="5"
                 aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected dim"
                 id="treeViewRow-4"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4808,7 +4828,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="F, running time is 1ms (33%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4861,7 +4881,9 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
+                >
+                  libH.so
+                </span>
               </div>
             </div>
           </div>
@@ -5242,7 +5264,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="A, running time is 2ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5274,7 +5296,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="B, running time is 2ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5306,7 +5328,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="C, running time is 2ms (100%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5344,7 +5366,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="D, running time is 1ms (50%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-3"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5375,7 +5397,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="E, running time is 1ms (50%), self time is 1ms"
                 aria-level="5"
                 aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected dim"
                 id="treeViewRow-4"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5407,7 +5429,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="F, running time is 1ms (50%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5813,7 +5835,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="A, running time is 2ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5845,7 +5867,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="B, running time is 2ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5877,7 +5899,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="C, running time is 2ms (100%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5915,7 +5937,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="D, running time is 1ms (50%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-3"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5946,7 +5968,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="E, running time is 1ms (50%), self time is 1ms"
                 aria-level="5"
                 aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected dim"
                 id="treeViewRow-4"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5978,7 +6000,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="F, running time is 1ms (50%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6322,7 +6344,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="A, running time is 1ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6354,7 +6376,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="B, running time is 1ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6386,7 +6408,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="C, running time is 1ms (100%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6424,7 +6446,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="F, running time is 1ms (100%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6774,7 +6796,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="A, running time is 1ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6806,7 +6828,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="B, running time is 1ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6838,7 +6860,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="C, running time is 1ms (100%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -6876,7 +6898,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="F, running time is 1ms (100%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -7288,7 +7310,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="A, running time is 2ms (100%), self time is 0ms"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -7320,7 +7342,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="B, running time is 2ms (100%), self time is 0ms"
                 aria-level="2"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-1"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -7352,7 +7374,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="C, running time is 2ms (100%), self time is 0ms"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
                 id="treeViewRow-2"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -7390,7 +7412,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="D, running time is 1ms (50%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-3"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -7421,7 +7443,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="E, running time is 1ms (50%), self time is 1ms"
                 aria-level="5"
                 aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected dim"
                 id="treeViewRow-4"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -7459,7 +7481,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
                 aria-label="F, running time is 1ms (50%), self time is 0ms"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -885,8 +885,8 @@ export function getProfileWithJsAllocations(): * {
     B  B     B
     C  Fjs   Fjs
     D  Gjs   Gjs
-    E        Hjs
-             I
+    E        Hjs[lib:jQuery.js]
+             I[lib:libI.so]
   `);
 
   // Now add a JsAllocationsTable.
@@ -961,8 +961,8 @@ export function getProfileWithUnbalancedNativeAllocations(): * {
     B  B     B
     C  Fjs   Fjs
     D  Gjs   Gjs
-    E        Hjs
-             I
+    E        Hjs[lib:jQuery.js]
+             I[lib:libI.so]
   `);
 
   // Now add a NativeAllocationsTable.
@@ -1025,8 +1025,8 @@ export function getProfileWithBalancedNativeAllocations(): * {
     B  B     B
     C  Fjs   Fjs
     D  Gjs   Gjs
-    E        Hjs
-             I
+    E        Hjs[lib:jQuery.js]
+             I[lib:libI.so]
   `);
 
   // Now add a NativeAllocationsTable.

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -42,7 +42,7 @@ describe('actions/icons', function() {
       selfTimeWithUnit: '0 ms',
       name: 'icon',
       lib: 'icon',
-      dim: false,
+      isFrameLabel: false,
       categoryName: 'Other',
       categoryColor: 'grey',
       icon,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -321,7 +321,7 @@ describe('unfiltered call tree', function() {
       it('gets a node for a given callNodeIndex', function() {
         expect(callTree.getDisplayData(A)).toEqual({
           ariaLabel: 'A, running time is 3ms (100%), self time is 0ms',
-          dim: true,
+          isFrameLabel: true,
           icon: null,
           lib: '',
           name: 'A',
@@ -335,7 +335,7 @@ describe('unfiltered call tree', function() {
         });
         expect(callTree.getDisplayData(I)).toEqual({
           ariaLabel: 'I, running time is 1ms (33%), self time is 1ms',
-          dim: false,
+          isFrameLabel: false,
           icon: null,
           lib: 'libI.so',
           name: 'I',

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -247,7 +247,7 @@ describe('unfiltered call tree', function() {
       A  A  A
       B  B  B
       C  C  H
-      D  F  I
+      D  F  I[lib:libI.so]
       E  G
     `);
     const callTree = callTreeFromProfile(profile);
@@ -321,7 +321,7 @@ describe('unfiltered call tree', function() {
       it('gets a node for a given callNodeIndex', function() {
         expect(callTree.getDisplayData(A)).toEqual({
           ariaLabel: 'A, running time is 3ms (100%), self time is 0ms',
-          dim: false,
+          dim: true,
           icon: null,
           lib: '',
           name: 'A',
@@ -330,6 +330,20 @@ describe('unfiltered call tree', function() {
           totalTime: '3',
           totalTimeWithUnit: '3ms',
           totalTimePercent: '100%',
+          categoryColor: 'grey',
+          categoryName: 'Other',
+        });
+        expect(callTree.getDisplayData(I)).toEqual({
+          ariaLabel: 'I, running time is 1ms (33%), self time is 1ms',
+          dim: false,
+          icon: null,
+          lib: 'libI.so',
+          name: 'I',
+          selfTime: '1',
+          selfTimeWithUnit: '1ms',
+          totalTime: '1',
+          totalTimeWithUnit: '1ms',
+          totalTimePercent: '33%',
           categoryColor: 'grey',
           categoryName: 'Other',
         });

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -112,7 +112,7 @@ export type CallNodeDisplayData = $Exact<
     selfTimeWithUnit: string,
     name: string,
     lib: string,
-    dim: boolean,
+    isFrameLabel: boolean,
     categoryName: string,
     categoryColor: string,
     icon: string | null,


### PR DESCRIPTION
Fixes #100

[Before](https://profiler.firefox.com/public/242e4dba140f19fb8acd7408e39ea97c5fb2f620/calltree/?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=4649-2-0-1~4823-0~4918-0~4728-0~4776-0-1~&range=3.9982_6.4171&thread=6&v=4)
[After](https://deploy-preview-2329--perf-html.netlify.com/public/242e4dba140f19fb8acd7408e39ea97c5fb2f620/calltree/?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=4649-2-0-1~4823-0~4918-0~4728-0~4776-0-1~&range=3.9982_6.4171&thread=6&v=4)

![Capture](https://user-images.githubusercontent.com/454175/70156908-ed564600-16b4-11ea-96ef-e33e98aabf16.png)
