### PR TITLE
Fix the wrong marker category filtering during sanitization

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1004,7 +1004,7 @@ export function filterRawMarkerTableToRangeWithMarkersToDelete(
     newMarkerTable.name.push(oldMarkers.name[index]);
     newMarkerTable.time.push(oldMarkers.time[index]);
     newMarkerTable.data.push(oldMarkers.data[index]);
-    newMarkerTable.category.push(newMarkerTable.category[index]);
+    newMarkerTable.category.push(oldMarkers.category[index]);
     newMarkerTable.length++;
   };
 

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -339,6 +339,26 @@ describe('sanitizePII', function() {
         marker.prefValue === ''
     ).toBeTruthy();
   });
+
+  it('should not push any null values to marker values by mistake while filtering', function() {
+    const profile = processProfile(createGeckoProfile());
+    const PIIToRemove = getRemoveProfileInformation({
+      shouldRemoveThreadsWithScreenshots: new Set([0, 1, 2]),
+    });
+
+    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
+    for (const thread of sanitizedProfile.threads) {
+      const markersTable = thread.markers;
+      for (let i = 0; i < markersTable.length; i++) {
+        // `toBeTruthy` doesn't work here because there are marker categories with `0` value.
+        // expect.anything() means anything other than null or undefined.
+        expect(markersTable.name[i]).toEqual(expect.anything());
+        expect(markersTable.time[i]).toEqual(expect.anything());
+        expect(markersTable.data[i]).toEqual(expect.anything());
+        expect(markersTable.category[i]).toEqual(expect.anything());
+      }
+    }
+  });
 });
 
 describe('getRemoveProfileInformation', function() {


### PR DESCRIPTION
It looks like we made a typo while adding `category` field to markers.