### PR TITLE
Look at the markers while calculating time range only if there are no samples

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -678,12 +678,10 @@ function _getTimeRangeForThread(
     const lastSampleIndex = samples.length - 1;
     result.start = samples.time[0];
     result.end = samples.time[lastSampleIndex] + interval;
-  }
-
-  if (markers.length) {
+  } else if (markers.length) {
+    // Looking at the markers only if there are no samples in the profile.
+    // We need to look at those because it can be a marker only profile(no-sampling mode).
     // Finding start and end times sadly requires looping through all markers :(
-    let startTime = +Infinity;
-    let endTime = -Infinity;
     for (let i = 0; i < markers.length; i++) {
       const thisStartTime =
         markers.data[i] && typeof markers.data[i].startTime === 'number'
@@ -699,12 +697,9 @@ function _getTimeRangeForThread(
           ? markers.data[i].endTime + interval
           : markers.time[i] + interval;
 
-      startTime = Math.min(startTime, thisStartTime);
-      endTime = Math.max(endTime, thisEndTime);
+      result.start = Math.min(result.start, thisStartTime);
+      result.end = Math.max(result.end, thisEndTime);
     }
-
-    result.start = Math.min(result.start, startTime);
-    result.end = Math.max(result.end, endTime);
   }
 
   if (jsAllocations) {

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -413,9 +413,9 @@ describe('actions/receive-profile', function() {
           start: 0,
           // The end can be computed as the sum of:
           // - difference of the starts of the subprocess and the main process (1000)
-          // - the max of the last marker or sample. (in this case, last marker's time is 100)
+          // - the max of the last sample. (in this case, last sample's time is 6.
           // - the interval (1)
-          end: 1101,
+          end: 1007,
         });
         // not empty
         expect(ProfileViewSelectors.getProfile(state).threads).toHaveLength(3);
@@ -469,7 +469,7 @@ describe('actions/receive-profile', function() {
       expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
       expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
-        end: 1101, // see the above test for more explanation on this value
+        end: 1007, // see the above test for more explanation on this value
       });
       expect(ProfileViewSelectors.getProfile(state).threads).toHaveLength(3); // not empty
     });

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -142,11 +142,7 @@ describe('deriveMarkersFromRawMarkerTable', function() {
     const { markers } = setup();
     expect(markers[16]).toMatchObject({
       start: 100,
-      // This is the last marker; as a result, the time range is computed by
-      // adding the interval to its time. Because it's incomplete, it lasts
-      // until the end of the range, and as a result its duration is the same as
-      // the interval, which is 1.
-      dur: 1,
+      dur: 0,
       name: 'Rasterize',
       title: null,
       incomplete: true,
@@ -334,10 +330,7 @@ describe('deriveMarkersFromRawMarkerTable', function() {
       },
       name: 'CompositorScreenshot',
       start: 25,
-      // Because the last compositor screenshot lasts until the end of the
-      // range, and the range ends at 101 (because of the last marker's time is
-      // at 100), the duration is 76 accordingly.
-      dur: 76,
+      dur: 0,
       title: null,
     });
   });


### PR DESCRIPTION
Markers are pretty unreliable for determining the range. We still need to look at those in case there are no samples. Otherwise we can ignore them. 