### PR TITLE
add usertiming logic and selectors

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1065,6 +1065,10 @@ export function isNetworkMarker(marker: Marker): boolean {
   return !!(marker.data && marker.data.type === 'Network');
 }
 
+export function isUserTimingMarker(marker: Marker): boolean {
+  return !!(marker.data && marker.data.type === 'UserTiming');
+}
+
 export function isNavigationMarker({ name, data }: Marker) {
   if (name === 'TTI') {
     // TTI is only selectable by name, as it doesn't have a structured payload.

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -48,12 +48,14 @@ import type {
 export type StackTimingDepth = number;
 export type IndexIntoStackTiming = number;
 
-export type StackTimingByDepth = Array<{
+export type StackTiming = {|
   start: Milliseconds[],
   end: Milliseconds[],
   callNode: IndexIntoCallNodeTable[],
   length: number,
-}>;
+|};
+
+export type StackTimingByDepth = Array<StackTiming>;
 
 type LastSeen = {
   startTimeByDepth: number[],

--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -10,6 +10,15 @@ import { tabSlugs, type TabSlug } from '../../app-logic/tabs-handling';
 import type { Selector } from '../../types/store';
 import type { $ReturnType } from '../../types/utils';
 import type { Thread, JsTracerTable } from '../../types/profile';
+import type {
+  MarkerTimingRows,
+  CombinedTimingRows,
+  MarkerTiming,
+} from '../../types/profile-derived';
+import type {
+  StackTiming,
+  StackTimingByDepth,
+} from '../../profile-logic/stack-timing';
 
 /**
  * Infer the return type from the getStackAndSampleSelectorsPerThread function. This
@@ -29,6 +38,8 @@ type NeededThreadSelectors = {
   getThread: Selector<Thread>,
   getIsNetworkChartEmptyInFullRange: Selector<boolean>,
   getJsTracerTable: Selector<JsTracerTable | null>,
+  getUserTimingMarkerTiming: Selector<MarkerTimingRows>,
+  getStackTimingByDepth: Selector<StackTimingByDepth>,
 };
 
 /**
@@ -66,7 +77,24 @@ export function getComposedSelectorsPerThread(
     }
   );
 
+  /**
+   * This selector combines the marker timing and stack timing for the stack chart.
+   * This way it displays UserTiming along with the stack chart.
+   */
+  const getCombinedTimingRows: Selector<CombinedTimingRows> = createSelector(
+    threadSelectors.getUserTimingMarkerTiming,
+    threadSelectors.getStackTimingByDepth,
+    (
+      userTimingMarkerTiming,
+      stackTimingByDepth
+    ): Array<MarkerTiming | StackTiming> => [
+      ...userTimingMarkerTiming,
+      ...stackTimingByDepth,
+    ]
+  );
+
   return {
     getUsefulTabs,
+    getCombinedTimingRows,
   };
 }

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -282,6 +282,12 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     filterMarkerIndexesCreator(MarkerData.isNetworkMarker)
   );
 
+  const getUserTimingMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
+    getMarkerGetter,
+    getCommittedRangeFilteredMarkerIndexes,
+    filterMarkerIndexesCreator(MarkerData.isUserTimingMarker)
+  );
+
   /**
    * This filters network markers using a search string.
    */
@@ -373,6 +379,16 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   );
 
   /**
+   * Creates the layout for the UserTiming markers so they can be displayed
+   * with the stack chart.
+   */
+  const getUserTimingMarkerTiming: Selector<MarkerTiming[]> = createSelector(
+    getMarkerGetter,
+    getUserTimingMarkerIndexes,
+    MarkerTimingLogic.getMarkerTiming
+  );
+
+  /**
    * This groups screenshot markers by their window ID.
    */
   const getRangeFilteredScreenshotsById: Selector<
@@ -451,5 +467,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getRightClickedMarkerIndex,
     getRightClickedMarker,
     getIsNetworkChartEmptyInFullRange,
+    getUserTimingMarkerIndexes,
+    getUserTimingMarkerTiming,
   };
 }

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -31,6 +31,7 @@ import type {
   NetworkPayload,
   NavigationMarkerPayload,
   IPCMarkerPayload,
+  UserTimingMarkerPayload,
 } from '../../../types/markers';
 import type { Milliseconds } from '../../../types/units';
 
@@ -98,6 +99,24 @@ export function getThreadWithMarkers(markers: TestDefinedMarkers) {
   const thread = getEmptyThread();
   addMarkersToThreadWithCorrespondingSamples(thread, markers);
   return thread;
+}
+
+export function getUserTiming(
+  name: string,
+  startTime: number,
+  duration: number
+) {
+  return [
+    'UserTiming',
+    startTime,
+    ({
+      type: 'UserTiming',
+      startTime,
+      endTime: startTime + duration,
+      name,
+      entryType: 'measure',
+    }: UserTimingMarkerPayload),
+  ];
 }
 
 export function getProfileWithMarkers(

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -5,6 +5,7 @@
 import { storeWithProfile } from '../fixtures/stores';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import {
+  getUserTiming,
   getProfileWithMarkers,
   getNetworkTrackProfile,
 } from '../fixtures/profiles/processed-profile';
@@ -321,5 +322,48 @@ describe('memory markers', function() {
     expect(
       markerIndexes.map(markerIndex => getMarker(markerIndex).name)
     ).toEqual(['A', 'B', 'C']);
+  });
+});
+
+describe('selectors/getUserTimingMarkerTiming', function() {
+  it('simple profile', function() {
+    const profile = getProfileWithMarkers([
+      getUserTiming('renderFunction', 0, 10),
+      getUserTiming('componentA', 1, 8),
+      getUserTiming('componentB', 2, 4),
+    ]);
+    const { getState } = storeWithProfile(profile);
+
+    expect(
+      selectedThreadSelectors.getUserTimingMarkerTiming(getState())
+    ).toEqual([
+      {
+        start: [0],
+        end: [10],
+        index: [0],
+        label: ['renderFunction'],
+        name: 'UserTiming',
+        bucket: 'None',
+        length: 1,
+      },
+      {
+        start: [1],
+        end: [9],
+        index: [1],
+        label: ['componentA'],
+        name: 'UserTiming',
+        bucket: 'None',
+        length: 1,
+      },
+      {
+        start: [2],
+        end: [6],
+        index: [2],
+        label: ['componentB'],
+        name: 'UserTiming',
+        bucket: 'None',
+        length: 1,
+      },
+    ]);
   });
 });

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -13,6 +13,7 @@ import type {
   IndexIntoCategoryList,
   CounterIndex,
 } from './profile';
+import type { StackTiming } from '../profile-logic/stack-timing';
 export type IndexIntoCallNodeTable = number;
 
 /**
@@ -124,7 +125,7 @@ export type CallNodeDisplayData = $Exact<
  * The marker timing contains the necessary information to draw markers very quickly
  * in the marker chart. It represents a single row of markers in the chart.
  */
-export type MarkerTiming = {
+export type MarkerTiming = {|
   // Start time in milliseconds.
   start: number[],
   // End time in milliseconds.
@@ -134,7 +135,18 @@ export type MarkerTiming = {
   name: string,
   bucket: string,
   length: number,
-};
+|};
+
+export type MarkerTimingRows = Array<MarkerTiming>;
+
+/**
+ * Combined timing can be used in the Stack Chart. When this happens, the chart will
+ * either take both marker timing and stack timing, or just the stack timing information.
+ * This way, UserTiming markers can be shown together with the stack information.
+ */
+export type CombinedTimingRows =
+  | Array<MarkerTiming | StackTiming>
+  | Array<StackTiming>;
 
 /**
  * This type contains the necessary information to fully draw the marker chart. Each


### PR DESCRIPTION
This is part 2 of the user-timings stack chart project. The goal is to add `getCombinedTimingRows` and necessary types.