### PR TITLE
Add User Timing UI

### DIFF
--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -10,10 +10,12 @@ import {
   changeInvertCallstack,
   changeCallTreeSearchString,
   changeCallTreeSummaryStrategy,
+  changeShowUserTimings,
 } from '../../actions/profile-view';
 import {
   getImplementationFilter,
   getInvertCallstack,
+  getShowUserTimings,
   getCurrentSearchString,
 } from '../../selectors/url-state';
 import PanelSearch from '../shared/PanelSearch';
@@ -40,6 +42,7 @@ type StateProps = {|
   +implementationFilter: ImplementationFilter,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
   +invertCallstack: boolean,
+  +showUserTimings: boolean,
   +currentSearchString: string,
   +hasJsAllocations: boolean,
   +hasNativeAllocations: boolean,
@@ -49,6 +52,7 @@ type StateProps = {|
 type DispatchProps = {|
   +changeImplementationFilter: typeof changeImplementationFilter,
   +changeInvertCallstack: typeof changeInvertCallstack,
+  +changeShowUserTimings: typeof changeShowUserTimings,
   +changeCallTreeSearchString: typeof changeCallTreeSearchString,
   +changeCallTreeSummaryStrategy: typeof changeCallTreeSummaryStrategy,
 |};
@@ -74,6 +78,10 @@ class StackSettings extends PureComponent<Props> {
 
   _onInvertCallstackClick = (e: SyntheticEvent<HTMLInputElement>) => {
     this.props.changeInvertCallstack(e.currentTarget.checked);
+  };
+
+  _onShowUserTimingsClick = (e: SyntheticEvent<HTMLInputElement>) => {
+    this.props.changeShowUserTimings(e.currentTarget.checked);
   };
 
   _onSearch = (value: string) => {
@@ -115,6 +123,7 @@ class StackSettings extends PureComponent<Props> {
   render() {
     const {
       invertCallstack,
+      showUserTimings,
       hideInvertCallstack,
       currentSearchString,
       hasJsAllocations,
@@ -193,6 +202,19 @@ class StackSettings extends PureComponent<Props> {
               </label>
             </li>
           )}
+          {
+            <li className="stackSettingsListItem">
+              <label className="photon-label photon-label-micro stackSettingsLabel">
+                <input
+                  type="checkbox"
+                  className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                  onChange={this._onShowUserTimingsClick}
+                  checked={showUserTimings}
+                />
+                {' Show user timing'}
+              </label>
+            </li>
+          }
         </ul>
         <PanelSearch
           className="stackSettingsSearchField"
@@ -209,6 +231,7 @@ class StackSettings extends PureComponent<Props> {
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     invertCallstack: getInvertCallstack(state),
+    showUserTimings: getShowUserTimings(state),
     implementationFilter: getImplementationFilter(state),
     currentSearchString: getCurrentSearchString(state),
     hasJsAllocations: selectedThreadSelectors.getHasJsAllocations(state),
@@ -227,6 +250,7 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     changeInvertCallstack,
     changeCallTreeSearchString,
     changeCallTreeSummaryStrategy,
+    changeShowUserTimings,
   },
   component: StackSettings,
 });

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -20,7 +20,10 @@ import {
   getPageList,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import {
+  getShowUserTimings,
+  getSelectedThreadIndex,
+} from '../../selectors/url-state';
 import StackChartEmptyReasons from './StackChartEmptyReasons';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import StackSettings from '../shared/StackSettings';
@@ -36,12 +39,14 @@ import type { Thread, CategoryList, PageList } from '../../types/profile';
 import type {
   CallNodeInfo,
   IndexIntoCallNodeTable,
+  CombinedTimingRows,
+  MarkerIndex,
+  Marker,
 } from '../../types/profile-derived';
 import type {
   Milliseconds,
   UnitIntervalOfProfileRange,
 } from '../../types/units';
-import type { StackTimingByDepth } from '../../profile-logic/stack-timing';
 import type { PreviewSelection } from '../../types/actions';
 import type { ConnectedProps } from '../../utils/connect';
 
@@ -53,7 +58,7 @@ type StateProps = {|
   +thread: Thread,
   +pages: PageList | null,
   +maxStackDepth: number,
-  +stackTimingByDepth: StackTimingByDepth,
+  +combinedTimingRows: CombinedTimingRows,
   +timeRange: { start: Milliseconds, end: Milliseconds },
   +interval: Milliseconds,
   +previewSelection: PreviewSelection,
@@ -63,6 +68,8 @@ type StateProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +scrollToSelectionGeneration: number,
+  +getMarker: MarkerIndex => Marker,
+  +userTimings: MarkerIndex[],
 |};
 
 type DispatchProps = {|
@@ -99,14 +106,13 @@ class StackChartGraph extends React.PureComponent<Props> {
     );
   };
 
-  _onRightClickedCallNodeChange = (
-    callNodeIndex: IndexIntoCallNodeTable | null
-  ) => {
+  _onRightClickedCallNodeChange = (callNodeIndex: number | null) => {
     const {
       callNodeInfo,
       threadIndex,
       changeRightClickedCallNode,
     } = this.props;
+
     changeRightClickedCallNode(
       threadIndex,
       getCallNodePathFromIndex(callNodeIndex, callNodeInfo.callNodeTable)
@@ -132,8 +138,9 @@ class StackChartGraph extends React.PureComponent<Props> {
   render() {
     const {
       thread,
+      threadIndex,
       maxStackDepth,
-      stackTimingByDepth,
+      combinedTimingRows,
       timeRange,
       interval,
       previewSelection,
@@ -143,6 +150,8 @@ class StackChartGraph extends React.PureComponent<Props> {
       selectedCallNodeIndex,
       scrollToSelectionGeneration,
       pages,
+      getMarker,
+      userTimings,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -156,7 +165,7 @@ class StackChartGraph extends React.PureComponent<Props> {
       >
         <StackSettings disableCallTreeSummaryButtons={true} />
         <TransformNavigator />
-        {maxStackDepth === 0 ? (
+        {maxStackDepth === 0 && userTimings.length === 0 ? (
           <StackChartEmptyReasons />
         ) : (
           <ContextMenuTrigger
@@ -181,7 +190,9 @@ class StackChartGraph extends React.PureComponent<Props> {
                   interval,
                   thread,
                   pages,
-                  stackTimingByDepth,
+                  threadIndex,
+                  combinedTimingRows,
+                  getMarker,
                   // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
                   updatePreviewSelection,
                   rangeStart: timeRange.start,
@@ -191,6 +202,7 @@ class StackChartGraph extends React.PureComponent<Props> {
                   categories,
                   selectedCallNodeIndex,
                   onSelectionChange: this._onSelectedCallNodeChange,
+                  // TODO: support right clicking user timing markers #2354.
                   onRightClick: this._onRightClickedCallNodeChange,
                   shouldDisplayTooltips: this._shouldDisplayTooltips,
                   scrollToSelectionGeneration,
@@ -206,14 +218,15 @@ class StackChartGraph extends React.PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(
-      state
-    );
+    const showUserTimings = getShowUserTimings(state);
+    const combinedTimingRows = showUserTimings
+      ? selectedThreadSelectors.getCombinedTimingRows(state)
+      : selectedThreadSelectors.getStackTimingByDepth(state);
 
     return {
       thread: selectedThreadSelectors.getFilteredThread(state),
       maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
-      stackTimingByDepth,
+      combinedTimingRows,
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       previewSelection: getPreviewSelection(state),
@@ -228,6 +241,8 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
       ),
       scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
       pages: getPageList(state),
+      getMarker: selectedThreadSelectors.getMarkerGetter(state),
+      userTimings: selectedThreadSelectors.getUserTimingMarkerIndexes(state),
     };
   },
   mapDispatchToProps: {
@@ -240,8 +255,8 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
 
 // This function is given the StackChartCanvas's chartProps.
 function viewportNeedsUpdate(
-  prevProps: { +stackTimingByDepth: StackTimingByDepth },
-  newProps: { +stackTimingByDepth: StackTimingByDepth }
+  prevProps: { +combinedTimingRows: CombinedTimingRows },
+  newProps: { +combinedTimingRows: CombinedTimingRows }
 ) {
-  return prevProps.stackTimingByDepth !== newProps.stackTimingByDepth;
+  return prevProps.combinedTimingRows !== newProps.combinedTimingRows;
 }

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -243,6 +243,19 @@ exports[`FlameGraph matches the snapshot 1`] = `
           Native
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -91,6 +91,19 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -745,6 +758,19 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -1391,6 +1417,19 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>
@@ -2041,6 +2080,19 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -2659,6 +2711,19 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -2792,6 +2857,19 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -2923,6 +3001,19 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>
@@ -3111,6 +3202,19 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>
@@ -3729,6 +3833,19 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -4343,6 +4460,19 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>
@@ -4961,6 +5091,19 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -5530,6 +5673,19 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>
@@ -6103,6 +6259,19 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -6555,6 +6724,19 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -7005,6 +7187,19 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -1,5 +1,913 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CombinedChart renders combined stack chart 1`] = `
+<div
+  aria-labelledby="stack-chart-tab-button"
+  class="stackChart"
+  id="stack-chart-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      data-index="0"
+      title="Complete \\"Empty\\""
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete "Empty"
+      </span>
+    </li>
+  </ol>
+  <div
+    class="react-contextmenu-wrapper treeViewContextMenu"
+  >
+    <div
+      class="stackChartContent"
+    >
+      <div
+        class="chartViewport"
+        tabindex="0"
+      >
+        <div>
+          <canvas
+            class="chartCanvas stackChartCanvas"
+            height="300"
+            style="width: 365px; height: 300px;"
+            width="365"
+          />
+        </div>
+        <div
+          class="chartViewportScroll hidden"
+        >
+          Zoom Chart:
+          <kbd
+            class="chartViewportScrollKbd"
+          >
+            Ctrl + Scroll
+          </kbd>
+          or
+          <kbd
+            class="chartViewportScrollKbd"
+          >
+            Shift + Scroll
+          </kbd>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CombinedChart renders combined stack chart 2`] = `
+Array [
+  Array [
+    "set font",
+    "10px sans-serif",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    0,
+    666.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "renderFunction",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "renderFunction",
+    153,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    216,
+    16,
+    533.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentA",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "componentA",
+    219.66666666666666,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    283,
+    32,
+    266.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentB",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "componentB",
+    286.3333333333333,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "fillRect",
+    150,
+    48,
+    199.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "A",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "A",
+    153,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "fillRect",
+    150,
+    64,
+    199.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "B",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "B",
+    153,
+    75,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    80,
+    133.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "C",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "C",
+    153,
+    91,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "fillRect",
+    284,
+    80,
+    65.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "H",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "H",
+    286.3333333333333,
+    91,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    96,
+    66.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "D",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "D",
+    153,
+    107,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    217,
+    96,
+    66.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "F",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "F",
+    219.66666666666666,
+    107,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "fillRect",
+    284,
+    96,
+    65.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "I",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "I",
+    286.3333333333333,
+    107,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    112,
+    66.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "E",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "E",
+    153,
+    123,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    217,
+    112,
+    66.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "G",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "G",
+    219.66666666666666,
+    123,
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "fillRect",
+    150,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    350,
+    0,
+    1,
+    300,
+  ],
+]
+`;
+
+exports[`MarkerChart matches the snapshots for the component and draw log 1`] = `
+<div
+  aria-labelledby="stack-chart-tab-button"
+  class="stackChart"
+  id="stack-chart-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      data-index="0"
+      title="Complete \\"Empty\\""
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete "Empty"
+      </span>
+    </li>
+  </ol>
+  <div
+    class="react-contextmenu-wrapper treeViewContextMenu"
+  >
+    <div
+      class="stackChartContent"
+    >
+      <div
+        class="chartViewport"
+        tabindex="0"
+      >
+        <div>
+          <canvas
+            class="chartCanvas stackChartCanvas"
+            height="300"
+            style="width: 365px; height: 300px;"
+            width="365"
+          />
+        </div>
+        <div
+          class="chartViewportScroll hidden"
+        >
+          Zoom Chart:
+          <kbd
+            class="chartViewportScrollKbd"
+          >
+            Ctrl + Scroll
+          </kbd>
+          or
+          <kbd
+            class="chartViewportScrollKbd"
+          >
+            Shift + Scroll
+          </kbd>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerChart matches the snapshots for the component and draw log 2`] = `
+Array [
+  Array [
+    "set font",
+    "10px sans-serif",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    0,
+    181.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "renderFunction",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "renderFunction",
+    153,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    168,
+    16,
+    145.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentA",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "componentA",
+    171.1818181818182,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    186,
+    32,
+    72.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentB",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "componentB",
+    189.36363636363637,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    277,
+    32,
+    18.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentD",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "c…",
+    280.27272727272725,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf060",
+  ],
+  Array [
+    "fillRect",
+    204,
+    48,
+    18.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentC",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "c…",
+    207.54545454545453,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "fillRect",
+    150,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    350,
+    0,
+    1,
+    300,
+  ],
+]
+`;
+
+exports[`MarkerChart shows a tooltip when hovering 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 200.36363636363637px; top: 54px;"
+>
+  <div
+    class="tooltipMarker"
+  >
+    <div
+      class="tooltipHeader"
+    >
+      <div
+        class="tooltipOneLine"
+      >
+        <div
+          class="tooltipTiming"
+        >
+          4.0ms
+        </div>
+        <div
+          class="tooltipTitle"
+        >
+          UserTiming
+        </div>
+      </div>
+      <div
+        class="tooltipDetails"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Thread
+          :
+        </div>
+        Empty
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Name
+        :
+      </div>
+      componentB
+    </div>
+  </div>
+</div>
+`;
+
 exports[`StackChart EmptyReasons shows reasons when a profile has no samples 1`] = `
 <div
   class="EmptyReasons"
@@ -116,6 +1024,19 @@ exports[`StackChart matches the snapshot 1`] = `
             type="checkbox"
           />
            Invert call stack
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -62,6 +62,19 @@ exports[`StackSettings matches the snapshot 1`] = `
            Invert call stack
         </label>
       </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Show user timing
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"


### PR DESCRIPTION
This 3rd and final patch adds the user timing UI to the stack chart component. It is blocked on #2344 and it is just uploaded to show the API boundaries between 2 & 3.