### PR TITLE
[discussion] Selectors refactor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,12 @@
     // default in babel v6.
     ["@babel/plugin-proposal-class-properties", { loose: true }],
     ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
-    "syntax-dynamic-import"
+    "syntax-dynamic-import",
+    ["module-resolver", {
+      "alias": {
+        "firefox-profiler": "./src",
+      }
+    }]
   ],
   env: {
     test: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,7 +106,7 @@ module.exports = {
     'import/resolver': {
       alias: {
         map: [
-          ['firefox-profiler/selectors', './src/selectors'],
+          ['firefox-profiler', './src'],
         ],
         extensions: ['.js']
       }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,5 +103,13 @@ module.exports = {
       version: '15.0',
       flowVersion: '0.63.1',
     },
+    'import/resolver': {
+      alias: {
+        map: [
+          ['selectors', './src/selectors'],
+        ],
+        extensions: ['.js']
+      }
+    }
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,7 +106,7 @@ module.exports = {
     'import/resolver': {
       alias: {
         map: [
-          ['selectors', './src/selectors'],
+          ['firefox-profiler/selectors', './src/selectors'],
         ],
         extensions: ['.js']
       }

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,8 @@
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 include_warnings=true
+module.name_mapper='^selectors\/\(.*\)$' -> '<PROJECT_ROOT>/src/selectors/\1'
+module.name_mapper='^selectors$' -> '<PROJECT_ROOT>/src/selectors'
 
 [ignore]
 .*node_modules/.*

--- a/.flowconfig
+++ b/.flowconfig
@@ -2,8 +2,7 @@
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 include_warnings=true
-module.name_mapper='^selectors\/\(.*\)$' -> '<PROJECT_ROOT>/src/selectors/\1'
-module.name_mapper='^selectors$' -> '<PROJECT_ROOT>/src/selectors'
+module.name_mapper='^firefox-profiler\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 
 [ignore]
 .*node_modules/.*

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.3.1",
     "babel-loader": "^8.0.5",
+    "babel-plugin-module-resolver": "^4.0.0",
     "browserslist": "^4.6.6",
     "caniuse-lite": "^1.0.30000989",
     "circular-dependency-plugin": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "docsify-cli": "^4.3.0",
     "eslint": "^4.18.2",
     "eslint-config-prettier": "^2.4.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.8.0",

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -3,8 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getSelectedTab, getDataSource } from 'selectors/url-state';
-import { getTrackThreadHeights } from 'selectors/app';
+import {
+  getSelectedTab,
+  getDataSource,
+  getTrackThreadHeights,
+} from 'selectors';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -7,7 +7,7 @@ import {
   getSelectedTab,
   getDataSource,
   getTrackThreadHeights,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getSelectedTab, getDataSource } from '../selectors/url-state';
-import { getTrackThreadHeights } from '../selectors/app';
+import { getSelectedTab, getDataSource } from 'selectors/url-state';
+import { getTrackThreadHeights } from 'selectors/app';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -22,7 +22,7 @@ import {
   getHiddenLocalTracks,
   getSelectedTab,
   getLastVisibleThreadTabSlug,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   getCallNodePathFromIndex,
   getSampleIndexToCallNodeIndex,

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -4,7 +4,6 @@
 
 // @flow
 import { oneLine } from 'common-tags';
-import { getLastVisibleThreadTabSlug } from 'selectors/app';
 import {
   getCounterSelectors,
   getGlobalTracks,
@@ -13,12 +12,8 @@ import {
   getLocalTrackFromReference,
   getGlobalTrackFromReference,
   getPreviewSelection,
-} from 'selectors/profile';
-import {
   getThreadSelectors,
-  selectedThreadSelectors,
-} from 'selectors/per-thread';
-import {
+  selectedThread,
   getImplementationFilter,
   getSelectedThreadIndex,
   getHiddenGlobalTracks,
@@ -26,7 +21,8 @@ import {
   getLocalTrackOrder,
   getHiddenLocalTracks,
   getSelectedTab,
-} from 'selectors/url-state';
+  getLastVisibleThreadTabSlug,
+} from 'selectors';
 import {
   getCallNodePathFromIndex,
   getSampleIndexToCallNodeIndex,
@@ -882,10 +878,10 @@ export function expandAllCallNodeDescendants(
   callNodeInfo: CallNodeInfo
 ): ThunkAction<void> {
   return (dispatch, getState) => {
-    const expandedCallNodeIndexes = selectedThreadSelectors.getExpandedCallNodeIndexes(
+    const expandedCallNodeIndexes = selectedThread.getExpandedCallNodeIndexes(
       getState()
     );
-    const tree = selectedThreadSelectors.getCallTree(getState());
+    const tree = selectedThread.getCallTree(getState());
 
     // Create a set with the selected call node and its descendants
     const descendants = tree.getAllDescendants(callNodeIndex);
@@ -964,7 +960,7 @@ export function changeImplementationFilter(
       getSelectedThreadIndex(getState()),
       'Attempting to add an implementation filter when no thread is currently selected.'
     );
-    const transformedThread = selectedThreadSelectors.getRangeAndTransformFilteredThread(
+    const transformedThread = selectedThread.getRangeAndTransformFilteredThread(
       getState()
     );
 
@@ -1019,9 +1015,8 @@ export function changeInvertCallstack(
       type: 'CHANGE_INVERT_CALLSTACK',
       invertCallstack,
       selectedThreadIndex: getSelectedThreadIndex(getState()),
-      callTree: selectedThreadSelectors.getCallTree(getState()),
-      callNodeTable: selectedThreadSelectors.getCallNodeInfo(getState())
-        .callNodeTable,
+      callTree: selectedThread.getCallTree(getState()),
+      callNodeTable: selectedThread.getCallNodeInfo(getState()).callNodeTable,
     });
   };
 }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -4,7 +4,7 @@
 
 // @flow
 import { oneLine } from 'common-tags';
-import { getLastVisibleThreadTabSlug } from '../selectors/app';
+import { getLastVisibleThreadTabSlug } from 'selectors/app';
 import {
   getCounterSelectors,
   getGlobalTracks,
@@ -13,11 +13,11 @@ import {
   getLocalTrackFromReference,
   getGlobalTrackFromReference,
   getPreviewSelection,
-} from '../selectors/profile';
+} from 'selectors/profile';
 import {
   getThreadSelectors,
   selectedThreadSelectors,
-} from '../selectors/per-thread';
+} from 'selectors/per-thread';
 import {
   getImplementationFilter,
   getSelectedThreadIndex,
@@ -26,7 +26,7 @@ import {
   getLocalTrackOrder,
   getHiddenLocalTracks,
   getSelectedTab,
-} from '../selectors/url-state';
+} from 'selectors/url-state';
 import {
   getCallNodePathFromIndex,
   getSampleIndexToCallNodeIndex,

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -12,8 +12,8 @@ import {
   getSanitizedProfileData,
   getRemoveProfileInformation,
   getPrePublishedState,
-} from '../selectors/publish';
-import { getDataSource } from '../selectors/url-state';
+} from 'selectors/publish';
+import { getDataSource } from 'selectors/url-state';
 import { viewProfile } from './receive-profile';
 import { ensureExists } from '../utils/flow';
 import { setHistoryReplaceState } from '../app-logic/url-handling';

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -12,8 +12,8 @@ import {
   getSanitizedProfileData,
   getRemoveProfileInformation,
   getPrePublishedState,
-} from 'selectors/publish';
-import { getDataSource } from 'selectors/url-state';
+  getDataSource,
+} from 'selectors';
 import { viewProfile } from './receive-profile';
 import { ensureExists } from '../utils/flow';
 import { setHistoryReplaceState } from '../app-logic/url-handling';

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -13,7 +13,7 @@ import {
   getRemoveProfileInformation,
   getPrePublishedState,
   getDataSource,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { viewProfile } from './receive-profile';
 import { ensureExists } from '../utils/flow';
 import { setHistoryReplaceState } from '../app-logic/url-handling';

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -27,7 +27,7 @@ import {
   getLegacyHiddenThreads,
   getProfileOrNull,
   getView,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   stateFromLocation,
   getDataSourceFromPathParts,

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -25,7 +25,9 @@ import {
   getLocalTrackOrderByPid,
   getLegacyThreadOrder,
   getLegacyHiddenThreads,
-} from 'selectors/url-state';
+  getProfileOrNull,
+  getView,
+} from 'selectors';
 import {
   stateFromLocation,
   getDataSourceFromPathParts,
@@ -40,8 +42,6 @@ import {
   initializeHiddenGlobalTracks,
   getVisibleThreads,
 } from '../profile-logic/tracks';
-import { getProfileOrNull } from 'selectors/profile';
-import { getView } from 'selectors/app';
 import { setDataSource } from './profile-view';
 
 import type {

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -25,7 +25,7 @@ import {
   getLocalTrackOrderByPid,
   getLegacyThreadOrder,
   getLegacyHiddenThreads,
-} from '../selectors/url-state';
+} from 'selectors/url-state';
 import {
   stateFromLocation,
   getDataSourceFromPathParts,
@@ -40,8 +40,8 @@ import {
   initializeHiddenGlobalTracks,
   getVisibleThreads,
 } from '../profile-logic/tracks';
-import { getProfileOrNull } from '../selectors/profile';
-import { getView } from '../selectors/app';
+import { getProfileOrNull } from 'selectors/profile';
+import { getView } from 'selectors/app';
 import { setDataSource } from './profile-view';
 
 import type {

--- a/src/actions/zipped-profiles.js
+++ b/src/actions/zipped-profiles.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getZipFileTable, getZipFileState } from 'selectors/zipped-profiles';
+import { getZipFileTable, getZipFileState } from 'selectors';
 import { unserializeProfileOfArbitraryFormat } from '../profile-logic/process-profile';
 import { loadProfile } from './receive-profile';
 

--- a/src/actions/zipped-profiles.js
+++ b/src/actions/zipped-profiles.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getZipFileTable, getZipFileState } from 'selectors';
+import { getZipFileTable, getZipFileState } from 'firefox-profiler/selectors';
 import { unserializeProfileOfArbitraryFormat } from '../profile-logic/process-profile';
 import { loadProfile } from './receive-profile';
 

--- a/src/actions/zipped-profiles.js
+++ b/src/actions/zipped-profiles.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getZipFileTable, getZipFileState } from '../selectors/zipped-profiles';
+import { getZipFileTable, getZipFileState } from 'selectors/zipped-profiles';
 import { unserializeProfileOfArbitraryFormat } from '../profile-logic/process-profile';
 import { loadProfile } from './receive-profile';
 

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -17,7 +17,7 @@ import {
   getHasZipFile,
   getDataSource,
   getProfilesToCompare,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -12,9 +12,12 @@ import ZipFileViewer from './ZipFileViewer';
 import Home from './Home';
 import CompareHome from './CompareHome';
 import { ProfileRootMessage } from './ProfileRootMessage';
-import { getView } from 'selectors/app';
-import { getHasZipFile } from 'selectors/zipped-profiles';
-import { getDataSource, getProfilesToCompare } from 'selectors/url-state';
+import {
+  getView,
+  getHasZipFile,
+  getDataSource,
+  getProfilesToCompare,
+} from 'selectors';
 import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -12,9 +12,9 @@ import ZipFileViewer from './ZipFileViewer';
 import Home from './Home';
 import CompareHome from './CompareHome';
 import { ProfileRootMessage } from './ProfileRootMessage';
-import { getView } from '../../selectors/app';
-import { getHasZipFile } from '../../selectors/zipped-profiles';
-import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
+import { getView } from 'selectors/app';
+import { getHasZipFile } from 'selectors/zipped-profiles';
+import { getDataSource, getProfilesToCompare } from 'selectors/url-state';
 import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -20,9 +20,7 @@ import JsTracer from '../js-tracer/';
 import selectSidebar from '../sidebar';
 
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
-import { getSelectedTab } from 'selectors/url-state';
-import { getIsSidebarOpen } from 'selectors/app';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedTab, getIsSidebarOpen, selectedThread } from 'selectors';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerContextMenu from '../shared/MarkerContextMenu';
 import TimelineTrackContextMenu from '../timeline/TrackContextMenu';
@@ -115,7 +113,7 @@ class ProfileViewer extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
-    visibleTabs: selectedThreadSelectors.getUsefulTabs(state),
+    visibleTabs: selectedThread.getUsefulTabs(state),
     selectedTab: getSelectedTab(state),
     isSidebarOpen: getIsSidebarOpen(state),
   }),

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -20,7 +20,11 @@ import JsTracer from '../js-tracer/';
 import selectSidebar from '../sidebar';
 
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
-import { getSelectedTab, getIsSidebarOpen, selectedThread } from 'selectors';
+import {
+  getSelectedTab,
+  getIsSidebarOpen,
+  selectedThread,
+} from 'firefox-profiler/selectors';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerContextMenu from '../shared/MarkerContextMenu';
 import TimelineTrackContextMenu from '../timeline/TrackContextMenu';

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -20,9 +20,9 @@ import JsTracer from '../js-tracer/';
 import selectSidebar from '../sidebar';
 
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
-import { getSelectedTab } from '../../selectors/url-state';
-import { getIsSidebarOpen } from '../../selectors/app';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getSelectedTab } from 'selectors/url-state';
+import { getIsSidebarOpen } from 'selectors/app';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerContextMenu from '../shared/MarkerContextMenu';
 import TimelineTrackContextMenu from '../timeline/TrackContextMenu';

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -10,8 +10,8 @@ import Details from './Details';
 import selectSidebar from '../sidebar';
 
 import { invalidatePanelLayout } from '../../actions/app';
-import { getSelectedTab } from '../../selectors/url-state';
-import { getIsSidebarOpen } from '../../selectors/app';
+import { getSelectedTab } from 'selectors/url-state';
+import { getIsSidebarOpen } from 'selectors/app';
 import explicitConnect from '../../utils/connect';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -10,8 +10,7 @@ import Details from './Details';
 import selectSidebar from '../sidebar';
 
 import { invalidatePanelLayout } from '../../actions/app';
-import { getSelectedTab } from 'selectors/url-state';
-import { getIsSidebarOpen } from 'selectors/app';
+import { getSelectedTab, getIsSidebarOpen } from 'selectors';
 import explicitConnect from '../../utils/connect';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -10,7 +10,7 @@ import Details from './Details';
 import selectSidebar from '../sidebar';
 
 import { invalidatePanelLayout } from '../../actions/app';
-import { getSelectedTab, getIsSidebarOpen } from 'selectors';
+import { getSelectedTab, getIsSidebarOpen } from 'firefox-profiler/selectors';
 import explicitConnect from '../../utils/connect';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -16,7 +16,7 @@ import {
   getProfile,
   getProfileRootRange,
   getHasPreferenceMarkers,
-} from '../../../selectors/profile';
+} from 'selectors/profile';
 import {
   getCheckedSharingOptions,
   getFilenameString,
@@ -26,7 +26,7 @@ import {
   getUploadProgressString,
   getUploadError,
   getShouldSanitizeByDefault,
-} from '../../../selectors/publish';
+} from 'selectors/publish';
 import { BlobUrlLink } from '../../shared/BlobUrlLink';
 import { assertExhaustiveCheck } from '../../../utils/flow';
 

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -16,8 +16,6 @@ import {
   getProfile,
   getProfileRootRange,
   getHasPreferenceMarkers,
-} from 'selectors/profile';
-import {
   getCheckedSharingOptions,
   getFilenameString,
   getDownloadSize,
@@ -26,7 +24,7 @@ import {
   getUploadProgressString,
   getUploadError,
   getShouldSanitizeByDefault,
-} from 'selectors/publish';
+} from 'selectors';
 import { BlobUrlLink } from '../../shared/BlobUrlLink';
 import { assertExhaustiveCheck } from '../../../utils/flow';
 

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -24,7 +24,7 @@ import {
   getUploadProgressString,
   getUploadError,
   getShouldSanitizeByDefault,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { BlobUrlLink } from '../../shared/BlobUrlLink';
 import { assertExhaustiveCheck } from '../../../utils/flow';
 

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -7,9 +7,9 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
-import { getProfile, getProfileRootRange } from '../../../selectors/profile';
-import { getDataSource } from '../../../selectors/url-state';
-import { getIsNewlyPublished } from '../../../selectors/app';
+import { getProfile, getProfileRootRange } from 'selectors/profile';
+import { getDataSource } from 'selectors/url-state';
+import { getIsNewlyPublished } from 'selectors/app';
 import { MenuButtonsMetaInfo } from './MetaInfo';
 import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';
@@ -20,10 +20,7 @@ import {
   abortUpload,
 } from '../../../actions/publish';
 import { dismissNewlyPublished } from '../../../actions/app';
-import {
-  getUploadPhase,
-  getHasPrePublishedState,
-} from '../../../selectors/publish';
+import { getUploadPhase, getHasPrePublishedState } from 'selectors/publish';
 
 import type { StartEndRange } from '../../../types/units';
 import type { Profile } from '../../../types/profile';

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -7,9 +7,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
-import { getProfile, getProfileRootRange } from 'selectors/profile';
-import { getDataSource } from 'selectors/url-state';
-import { getIsNewlyPublished } from 'selectors/app';
+import {
+  getProfile,
+  getProfileRootRange,
+  getDataSource,
+  getIsNewlyPublished,
+  getUploadPhase,
+  getHasPrePublishedState,
+} from 'selectors';
 import { MenuButtonsMetaInfo } from './MetaInfo';
 import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';
@@ -20,7 +25,6 @@ import {
   abortUpload,
 } from '../../../actions/publish';
 import { dismissNewlyPublished } from '../../../actions/app';
-import { getUploadPhase, getHasPrePublishedState } from 'selectors/publish';
 
 import type { StartEndRange } from '../../../types/units';
 import type { Profile } from '../../../types/profile';

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -14,7 +14,7 @@ import {
   getIsNewlyPublished,
   getUploadPhase,
   getHasPrePublishedState,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { MenuButtonsMetaInfo } from './MetaInfo';
 import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -6,7 +6,10 @@
 
 import explicitConnect from '../../utils/connect';
 import { popCommittedRanges } from '../../actions/profile-view';
-import { getPreviewSelection, getCommittedRangeLabels } from 'selectors';
+import {
+  getPreviewSelection,
+  getCommittedRangeLabels,
+} from 'firefox-profiler/selectors';
 import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import FilterNavigatorBar from '../shared/FilterNavigatorBar';
 

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -6,8 +6,7 @@
 
 import explicitConnect from '../../utils/connect';
 import { popCommittedRanges } from '../../actions/profile-view';
-import { getPreviewSelection } from 'selectors/profile';
-import { getCommittedRangeLabels } from 'selectors/url-state';
+import { getPreviewSelection, getCommittedRangeLabels } from 'selectors';
 import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import FilterNavigatorBar from '../shared/FilterNavigatorBar';
 

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -6,8 +6,8 @@
 
 import explicitConnect from '../../utils/connect';
 import { popCommittedRanges } from '../../actions/profile-view';
-import { getPreviewSelection } from '../../selectors/profile';
-import { getCommittedRangeLabels } from '../../selectors/url-state';
+import { getPreviewSelection } from 'selectors/profile';
+import { getCommittedRangeLabels } from 'selectors/url-state';
 import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import FilterNavigatorBar from '../shared/FilterNavigatorBar';
 

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -18,7 +18,7 @@ import {
   getHash,
   getProfileUrl,
   getProfilesToCompare,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -18,7 +18,7 @@ import {
   getHash,
   getProfileUrl,
   getProfilesToCompare,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -18,7 +18,7 @@ import {
   getHash,
   getProfileUrl,
   getProfilesToCompare,
-} from 'selectors/url-state';
+} from 'selectors';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
 import { ProfileRootMessage } from './ProfileRootMessage';
-import { getView, getDataSource } from 'selectors';
+import { getView, getDataSource } from 'firefox-profiler/selectors';
 
 import type { AppViewState, State } from '../../types/state';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -8,8 +8,8 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
 import { ProfileRootMessage } from './ProfileRootMessage';
-import { getView } from '../../selectors/app';
-import { getDataSource } from '../../selectors/url-state';
+import { getView } from 'selectors/app';
+import { getDataSource } from 'selectors/url-state';
 
 import type { AppViewState, State } from '../../types/state';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -8,8 +8,7 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
 import { ProfileRootMessage } from './ProfileRootMessage';
-import { getView } from 'selectors/app';
-import { getDataSource } from 'selectors/url-state';
+import { getView, getDataSource } from 'selectors';
 
 import type { AppViewState, State } from '../../types/state';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -12,18 +12,18 @@ import MenuButtons from './MenuButtons';
 import WindowTitle from '../shared/WindowTitle';
 import SymbolicationStatusOverlay from './SymbolicationStatusOverlay';
 import { returnToZipFileList } from '../../actions/zipped-profiles';
-import { getProfileName } from 'selectors/url-state';
 import Timeline from '../timeline';
-import { getHasZipFile } from 'selectors/zipped-profiles';
 import SplitterLayout from 'react-splitter-layout';
 import { invalidatePanelLayout } from '../../actions/app';
-import { getTimelineHeight } from 'selectors/app';
 import {
+  getProfileName,
+  getHasZipFile,
   getUploadProgressString,
   getUploadPhase,
+  getTimelineHeight,
   getIsHidingStaleProfile,
   getHasSanitizedProfile,
-} from 'selectors/publish';
+} from 'selectors';
 import classNames from 'classnames';
 
 import type { CssPixels } from '../../types/units';

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -23,7 +23,7 @@ import {
   getTimelineHeight,
   getIsHidingStaleProfile,
   getHasSanitizedProfile,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import classNames from 'classnames';
 
 import type { CssPixels } from '../../types/units';

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -12,18 +12,18 @@ import MenuButtons from './MenuButtons';
 import WindowTitle from '../shared/WindowTitle';
 import SymbolicationStatusOverlay from './SymbolicationStatusOverlay';
 import { returnToZipFileList } from '../../actions/zipped-profiles';
-import { getProfileName } from '../../selectors/url-state';
+import { getProfileName } from 'selectors/url-state';
 import Timeline from '../timeline';
-import { getHasZipFile } from '../../selectors/zipped-profiles';
+import { getHasZipFile } from 'selectors/zipped-profiles';
 import SplitterLayout from 'react-splitter-layout';
 import { invalidatePanelLayout } from '../../actions/app';
-import { getTimelineHeight } from '../../selectors/app';
+import { getTimelineHeight } from 'selectors/app';
 import {
   getUploadProgressString,
   getUploadPhase,
   getIsHidingStaleProfile,
   getHasSanitizedProfile,
-} from '../../selectors/publish';
+} from 'selectors/publish';
 import classNames from 'classnames';
 
 import type { CssPixels } from '../../types/units';

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import { getDataSource, getView } from 'selectors';
+import { getDataSource, getView } from 'firefox-profiler/selectors';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -7,8 +7,8 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import { getDataSource } from '../../selectors/url-state';
-import { getView } from '../../selectors/app';
+import { getDataSource } from 'selectors/url-state';
+import { getView } from 'selectors/app';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -7,8 +7,7 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import { getDataSource } from 'selectors/url-state';
-import { getView } from 'selectors/app';
+import { getDataSource, getView } from 'selectors';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { DataSource } from '../../types/actions';

--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -5,7 +5,10 @@
 // @flow
 
 import React, { PureComponent } from 'react';
-import { getProfileViewOptions, getSymbolicationStatus } from 'selectors';
+import {
+  getProfileViewOptions,
+  getSymbolicationStatus,
+} from 'firefox-profiler/selectors';
 import explicitConnect from '../../utils/connect';
 
 import type { RequestedLib } from '../../types/actions';

--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -5,10 +5,7 @@
 // @flow
 
 import React, { PureComponent } from 'react';
-import {
-  getProfileViewOptions,
-  getSymbolicationStatus,
-} from 'selectors/profile';
+import { getProfileViewOptions, getSymbolicationStatus } from 'selectors';
 import explicitConnect from '../../utils/connect';
 
 import type { RequestedLib } from '../../types/actions';

--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import {
   getProfileViewOptions,
   getSymbolicationStatus,
-} from '../../selectors/profile';
+} from 'selectors/profile';
 import explicitConnect from '../../utils/connect';
 
 import type { RequestedLib } from '../../types/actions';

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getUrlSetupPhase } from '../../selectors/app';
+import { getUrlSetupPhase } from 'selectors/app';
 import {
   updateUrlState,
   startFetchingProfiles,

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getUrlSetupPhase } from 'selectors';
+import { getUrlSetupPhase } from 'firefox-profiler/selectors';
 import {
   updateUrlState,
   startFetchingProfiles,

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getUrlSetupPhase } from 'selectors/app';
+import { getUrlSetupPhase } from 'selectors';
 import {
   updateUrlState,
   startFetchingProfiles,

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -21,8 +21,8 @@ import {
   getSelectedZipFileIndex,
   getExpandedZipFileIndexes,
   getZipFileErrorMessage,
-} from '../../selectors/zipped-profiles';
-import { getPathInZipFileFromUrl } from '../../selectors/url-state';
+} from 'selectors/zipped-profiles';
+import { getPathInZipFileFromUrl } from 'selectors/url-state';
 import TreeView from '../shared/TreeView';
 import ProfileViewer from './ProfileViewer';
 

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -21,8 +21,8 @@ import {
   getSelectedZipFileIndex,
   getExpandedZipFileIndexes,
   getZipFileErrorMessage,
-} from 'selectors/zipped-profiles';
-import { getPathInZipFileFromUrl } from 'selectors/url-state';
+  getPathInZipFileFromUrl,
+} from 'selectors';
 import TreeView from '../shared/TreeView';
 import ProfileViewer from './ProfileViewer';
 

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -22,7 +22,7 @@ import {
   getExpandedZipFileIndexes,
   getZipFileErrorMessage,
   getPathInZipFileFromUrl,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import TreeView from '../shared/TreeView';
 import ProfileViewer from './ProfileViewer';
 

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -19,7 +19,7 @@ import {
   getPreviewSelection,
   selectedThread,
   getIconsWithClassNames,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -14,14 +14,12 @@ import {
   getImplementationFilter,
   getSearchStringsAsRegExp,
   getSelectedThreadIndex,
-} from 'selectors/url-state';
-import {
   getScrollToSelectionGeneration,
   getFocusCallTreeGeneration,
   getPreviewSelection,
-} from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getIconsWithClassNames } from 'selectors/icons';
+  selectedThread,
+  getIconsWithClassNames,
+} from 'selectors';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
@@ -244,26 +242,20 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     threadIndex: getSelectedThreadIndex(state),
     scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
     focusCallTreeGeneration: getFocusCallTreeGeneration(state),
-    tree: selectedThreadSelectors.getCallTree(state),
-    callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
-    selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
+    tree: selectedThread.getCallTree(state),
+    callNodeInfo: selectedThread.getCallNodeInfo(state),
+    selectedCallNodeIndex: selectedThread.getSelectedCallNodeIndex(state),
+    rightClickedCallNodeIndex: selectedThread.getRightClickedCallNodeIndex(
       state
     ),
-    rightClickedCallNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(
-      state
-    ),
-    expandedCallNodeIndexes: selectedThreadSelectors.getExpandedCallNodeIndexes(
-      state
-    ),
+    expandedCallNodeIndexes: selectedThread.getExpandedCallNodeIndexes(state),
     searchStringsRegExp: getSearchStringsAsRegExp(state),
     disableOverscan: getPreviewSelection(state).isModifying,
     invertCallstack: getInvertCallstack(state),
     implementationFilter: getImplementationFilter(state),
     icons: getIconsWithClassNames(state),
-    callNodeMaxDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
-    callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
-      state
-    ),
+    callNodeMaxDepth: selectedThread.getCallNodeMaxDepth(state),
+    callTreeSummaryStrategy: selectedThread.getCallTreeSummaryStrategy(state),
   }),
   mapDispatchToProps: {
     changeSelectedCallNode,

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -14,14 +14,14 @@ import {
   getImplementationFilter,
   getSearchStringsAsRegExp,
   getSelectedThreadIndex,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import {
   getScrollToSelectionGeneration,
   getFocusCallTreeGeneration,
   getPreviewSelection,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getIconsWithClassNames } from '../../selectors/icons';
+} from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getIconsWithClassNames } from 'selectors/icons';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,

--- a/src/components/calltree/CallTreeEmptyReasons.js
+++ b/src/components/calltree/CallTreeEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -53,9 +53,9 @@ class CallTreeEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-    thread: selectedThreadSelectors.getThread(state),
-    rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
+    threadName: selectedThread.getFriendlyThreadName(state),
+    thread: selectedThread.getThread(state),
+    rangeFilteredThread: selectedThread.getRangeFilteredThread(state),
   }),
   component: CallTreeEmptyReasons,
 });

--- a/src/components/calltree/CallTreeEmptyReasons.js
+++ b/src/components/calltree/CallTreeEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/calltree/CallTreeEmptyReasons.js
+++ b/src/components/calltree/CallTreeEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -13,19 +13,19 @@ import {
   getScrollToSelectionGeneration,
   getProfileInterval,
   getPageList,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+} from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import {
   getSelectedThreadIndex,
   getInvertCallstack,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
 } from '../../actions/profile-view';
-import { getIconsWithClassNames } from '../../selectors/icons';
+import { getIconsWithClassNames } from 'selectors/icons';
 import { BackgroundImageStyleDef } from '../shared/StyleDef';
 
 import type { Thread, CategoryList, PageList } from '../../types/profile';

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -13,19 +13,17 @@ import {
   getScrollToSelectionGeneration,
   getProfileInterval,
   getPageList,
-} from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import {
+  selectedThread,
   getSelectedThreadIndex,
   getInvertCallstack,
-} from 'selectors/url-state';
+  getIconsWithClassNames,
+} from 'selectors';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
 } from '../../actions/profile-view';
-import { getIconsWithClassNames } from 'selectors/icons';
 import { BackgroundImageStyleDef } from '../shared/StyleDef';
 
 import type { Thread, CategoryList, PageList } from '../../types/profile';
@@ -343,34 +341,28 @@ function viewportNeedsUpdate() {
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
-      thread: selectedThreadSelectors.getFilteredThread(state),
-      unfilteredThread: selectedThreadSelectors.getThread(state),
-      sampleIndexOffset: selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(
+      thread: selectedThread.getFilteredThread(state),
+      unfilteredThread: selectedThread.getThread(state),
+      sampleIndexOffset: selectedThread.getSampleIndexOffsetFromCommittedRange(
         state
       ),
-      maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
-        state
-      ),
-      flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
-      callTree: selectedThreadSelectors.getCallTree(state),
+      maxStackDepth: selectedThread.getCallNodeMaxDepthForFlameGraph(state),
+      flameGraphTiming: selectedThread.getFlameGraphTiming(state),
+      callTree: selectedThread.getCallTree(state),
       timeRange: getCommittedRange(state),
       previewSelection: getPreviewSelection(state),
-      callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+      callNodeInfo: selectedThread.getCallNodeInfo(state),
       categories: getCategories(state),
       threadIndex: getSelectedThreadIndex(state),
-      selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
-        state
-      ),
-      rightClickedCallNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(
+      selectedCallNodeIndex: selectedThread.getSelectedCallNodeIndex(state),
+      rightClickedCallNodeIndex: selectedThread.getRightClickedCallNodeIndex(
         state
       ),
       scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
       icons: getIconsWithClassNames(state),
       interval: getProfileInterval(state),
       isInverted: getInvertCallstack(state),
-      callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
-        state
-      ),
+      callTreeSummaryStrategy: selectedThread.getCallTreeSummaryStrategy(state),
       pages: getPageList(state),
     };
   },

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -17,7 +17,7 @@ import {
   getSelectedThreadIndex,
   getInvertCallstack,
   getIconsWithClassNames,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {

--- a/src/components/flame-graph/FlameGraphEmptyReasons.js
+++ b/src/components/flame-graph/FlameGraphEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -53,9 +53,9 @@ class FlameGraphEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-    thread: selectedThreadSelectors.getThread(state),
-    rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
+    threadName: selectedThread.getFriendlyThreadName(state),
+    thread: selectedThread.getThread(state),
+    rangeFilteredThread: selectedThread.getRangeFilteredThread(state),
   }),
   component: FlameGraphEmptyReasons,
 });

--- a/src/components/flame-graph/FlameGraphEmptyReasons.js
+++ b/src/components/flame-graph/FlameGraphEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/flame-graph/FlameGraphEmptyReasons.js
+++ b/src/components/flame-graph/FlameGraphEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -5,8 +5,8 @@
 // @flow
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getInvertCallstack } from '../../selectors/url-state';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getInvertCallstack } from 'selectors/url-state';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { changeInvertCallstack } from '../../actions/profile-view';
 import FlameGraphEmptyReasons from './FlameGraphEmptyReasons';
 import FlameGraph from './FlameGraph';

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -5,7 +5,7 @@
 // @flow
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getInvertCallstack, selectedThread } from 'selectors';
+import { getInvertCallstack, selectedThread } from 'firefox-profiler/selectors';
 import { changeInvertCallstack } from '../../actions/profile-view';
 import FlameGraphEmptyReasons from './FlameGraphEmptyReasons';
 import FlameGraph from './FlameGraph';

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -5,8 +5,7 @@
 // @flow
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getInvertCallstack } from 'selectors/url-state';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getInvertCallstack, selectedThread } from 'selectors';
 import { changeInvertCallstack } from '../../actions/profile-view';
 import FlameGraphEmptyReasons from './FlameGraphEmptyReasons';
 import FlameGraph from './FlameGraph';
@@ -60,9 +59,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
       invertCallstack: getInvertCallstack(state),
-      maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
-        state
-      ),
+      maxStackDepth: selectedThread.getCallNodeMaxDepthForFlameGraph(state),
     };
   },
   mapDispatchToProps: {

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -17,7 +17,7 @@ import {
   getPreviewSelection,
   selectedThread,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { ensureExists } from '../../utils/flow';
 

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -12,9 +12,12 @@ import {
 import explicitConnect from '../../utils/connect';
 import JsTracerCanvas from './Canvas';
 
-import { getCommittedRange, getPreviewSelection } from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+import {
+  getCommittedRange,
+  getPreviewSelection,
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'selectors';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { ensureExists } from '../../utils/flow';
 
@@ -130,13 +133,13 @@ const JsTracerExpensiveChart = explicitConnect<
 >({
   mapStateToProps: (state, ownProps) => ({
     timeRange: getCommittedRange(state),
-    stringTable: selectedThreadSelectors.getStringTable(state),
+    stringTable: selectedThread.getStringTable(state),
     threadIndex: getSelectedThreadIndex(state),
     previewSelection: getPreviewSelection(state),
     jsTracerTimingRows: ensureExists(
       ownProps.showJsTracerSummary
-        ? selectedThreadSelectors.getExpensiveJsTracerLeafTiming(state)
-        : selectedThreadSelectors.getExpensiveJsTracerTiming(state),
+        ? selectedThread.getExpensiveJsTracerLeafTiming(state)
+        : selectedThread.getExpensiveJsTracerTiming(state),
       'The JS tracer information must exist when mounting this component'
     ),
   }),

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -12,12 +12,9 @@ import {
 import explicitConnect from '../../utils/connect';
 import JsTracerCanvas from './Canvas';
 
-import {
-  getCommittedRange,
-  getPreviewSelection,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { getCommittedRange, getPreviewSelection } from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { ensureExists } from '../../utils/flow';
 

--- a/src/components/js-tracer/EmptyReasons.js
+++ b/src/components/js-tracer/EmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/js-tracer/EmptyReasons.js
+++ b/src/components/js-tracer/EmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -33,7 +33,7 @@ class MarkerChartEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
+    threadName: selectedThread.getFriendlyThreadName(state),
   }),
   component: MarkerChartEmptyReasons,
 });

--- a/src/components/js-tracer/EmptyReasons.js
+++ b/src/components/js-tracer/EmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/js-tracer/Settings.js
+++ b/src/components/js-tracer/Settings.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
-import { getShowJsTracerSummary } from 'selectors';
+import { getShowJsTracerSummary } from 'firefox-profiler/selectors';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
 import './Settings.css';

--- a/src/components/js-tracer/Settings.js
+++ b/src/components/js-tracer/Settings.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
-import { getShowJsTracerSummary } from 'selectors/url-state';
+import { getShowJsTracerSummary } from 'selectors';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
 import './Settings.css';

--- a/src/components/js-tracer/Settings.js
+++ b/src/components/js-tracer/Settings.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
-import { getShowJsTracerSummary } from '../../selectors/url-state';
+import { getShowJsTracerSummary } from 'selectors/url-state';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
 import './Settings.css';

--- a/src/components/js-tracer/index.js
+++ b/src/components/js-tracer/index.js
@@ -9,12 +9,12 @@ import JsTracerChart from './Chart';
 import JsTracerSettings from './Settings';
 import EmptyReasons from './EmptyReasons';
 
-import { getProfile } from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getProfile } from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import {
   getShowJsTracerSummary,
   getSelectedThreadIndex,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type { Profile, JsTracerTable, ThreadIndex } from '../../types/profile';

--- a/src/components/js-tracer/index.js
+++ b/src/components/js-tracer/index.js
@@ -14,7 +14,7 @@ import {
   selectedThread,
   getShowJsTracerSummary,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type { Profile, JsTracerTable, ThreadIndex } from '../../types/profile';

--- a/src/components/js-tracer/index.js
+++ b/src/components/js-tracer/index.js
@@ -9,12 +9,12 @@ import JsTracerChart from './Chart';
 import JsTracerSettings from './Settings';
 import EmptyReasons from './EmptyReasons';
 
-import { getProfile } from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
 import {
+  getProfile,
+  selectedThread,
   getShowJsTracerSummary,
   getSelectedThreadIndex,
-} from 'selectors/url-state';
+} from 'selectors';
 import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type { Profile, JsTracerTable, ThreadIndex } from '../../types/profile';
@@ -70,7 +70,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     return {
       profile: getProfile(state),
       threadIndex: getSelectedThreadIndex(state),
-      jsTracerTable: selectedThreadSelectors.getJsTracerTable(state),
+      jsTracerTable: selectedThread.getJsTracerTable(state),
       showJsTracerSummary: getShowJsTracerSummary(state),
     };
   },

--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -38,8 +38,8 @@ class MarkerChartEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-    isMarkerChartEmptyInFullRange: selectedThreadSelectors.getAreMarkerPanelsEmptyInFullRange(
+    threadName: selectedThread.getFriendlyThreadName(state),
+    isMarkerChartEmptyInFullRange: selectedThread.getAreMarkerPanelsEmptyInFullRange(
       state
     ),
   }),

--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -19,7 +19,7 @@ import {
   getPreviewSelection,
   selectedThread,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   updatePreviewSelection,
   changeRightClickedMarker,

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -17,9 +17,9 @@ import {
   getCommittedRange,
   getProfileInterval,
   getPreviewSelection,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+} from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import {
   updatePreviewSelection,
   changeRightClickedMarker,

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -17,9 +17,9 @@ import {
   getCommittedRange,
   getProfileInterval,
   getPreviewSelection,
-} from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'selectors';
 import {
   updatePreviewSelection,
   changeRightClickedMarker,
@@ -168,20 +168,18 @@ function viewportNeedsUpdate(
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
-    const markerTimingAndBuckets = selectedThreadSelectors.getMarkerChartTimingAndBuckets(
+    const markerTimingAndBuckets = selectedThread.getMarkerChartTimingAndBuckets(
       state
     );
     return {
-      getMarker: selectedThreadSelectors.getMarkerGetter(state),
+      getMarker: selectedThread.getMarkerGetter(state),
       markerTimingAndBuckets,
       maxMarkerRows: markerTimingAndBuckets.length,
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       threadIndex: getSelectedThreadIndex(state),
       previewSelection: getPreviewSelection(state),
-      rightClickedMarker: selectedThreadSelectors.getRightClickedMarkerIndex(
-        state
-      ),
+      rightClickedMarker: selectedThread.getRightClickedMarkerIndex(state),
     };
   },
   mapDispatchToProps: { updatePreviewSelection, changeRightClickedMarker },

--- a/src/components/marker-table/MarkerTableEmptyReasons.js
+++ b/src/components/marker-table/MarkerTableEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/marker-table/MarkerTableEmptyReasons.js
+++ b/src/components/marker-table/MarkerTableEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -38,8 +38,8 @@ class MarkerTableEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-    isMarkerTableEmptyInFullRange: selectedThreadSelectors.getAreMarkerPanelsEmptyInFullRange(
+    threadName: selectedThread.getFriendlyThreadName(state),
+    isMarkerTableEmptyInFullRange: selectedThread.getAreMarkerPanelsEmptyInFullRange(
       state
     ),
   }),

--- a/src/components/marker-table/MarkerTableEmptyReasons.js
+++ b/src/components/marker-table/MarkerTableEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -15,7 +15,7 @@ import {
   getScrollToSelectionGeneration,
   selectedThread,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   changeSelectedMarker,
   changeRightClickedMarker,

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -10,9 +10,12 @@ import memoize from 'memoize-immutable';
 import explicitConnect from '../../utils/connect';
 import TreeView from '../shared/TreeView';
 import MarkerTableEmptyReasons from './MarkerTableEmptyReasons';
-import { getZeroAt, getScrollToSelectionGeneration } from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+import {
+  getZeroAt,
+  getScrollToSelectionGeneration,
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'selectors';
 import {
   changeSelectedMarker,
   changeRightClickedMarker,
@@ -234,14 +237,10 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     threadIndex: getSelectedThreadIndex(state),
     scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
-    getMarker: selectedThreadSelectors.getMarkerGetter(state),
-    markerIndexes: selectedThreadSelectors.getPreviewFilteredMarkerIndexes(
-      state
-    ),
-    selectedMarker: selectedThreadSelectors.getSelectedMarkerIndex(state),
-    rightClickedMarker: selectedThreadSelectors.getRightClickedMarkerIndex(
-      state
-    ),
+    getMarker: selectedThread.getMarkerGetter(state),
+    markerIndexes: selectedThread.getPreviewFilteredMarkerIndexes(state),
+    selectedMarker: selectedThread.getSelectedMarkerIndex(state),
+    rightClickedMarker: selectedThread.getRightClickedMarkerIndex(state),
     zeroAt: getZeroAt(state),
   }),
   mapDispatchToProps: { changeSelectedMarker, changeRightClickedMarker },

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -10,12 +10,9 @@ import memoize from 'memoize-immutable';
 import explicitConnect from '../../utils/connect';
 import TreeView from '../shared/TreeView';
 import MarkerTableEmptyReasons from './MarkerTableEmptyReasons';
-import {
-  getZeroAt,
-  getScrollToSelectionGeneration,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { getZeroAt, getScrollToSelectionGeneration } from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import {
   changeSelectedMarker,
   changeRightClickedMarker,

--- a/src/components/network-chart/NetworkChartEmptyReasons.js
+++ b/src/components/network-chart/NetworkChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { oneLine } from 'common-tags';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';

--- a/src/components/network-chart/NetworkChartEmptyReasons.js
+++ b/src/components/network-chart/NetworkChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { oneLine } from 'common-tags';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';

--- a/src/components/network-chart/NetworkChartEmptyReasons.js
+++ b/src/components/network-chart/NetworkChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { oneLine } from 'common-tags';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
@@ -42,7 +42,7 @@ class MarkerChartEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
+    threadName: selectedThread.getFriendlyThreadName(state),
   }),
   component: MarkerChartEmptyReasons,
 });

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -18,9 +18,9 @@ import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import {
   getPreviewSelection,
   getPreviewSelectionRange,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+} from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import { changeRightClickedMarker } from '../../actions/profile-view';
 
 import type { SizeProps } from '../shared/WithSize';

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -18,9 +18,9 @@ import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import {
   getPreviewSelection,
   getPreviewSelectionRange,
-} from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'selectors';
 import { changeRightClickedMarker } from '../../actions/profile-view';
 
 import type { SizeProps } from '../shared/WithSize';
@@ -174,11 +174,11 @@ const ConnectedComponent = explicitConnect<OwnProps, StateProps, DispatchProps>(
   {
     mapStateToProps: state => {
       return {
-        markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+        markerIndexes: selectedThread.getSearchFilteredNetworkMarkerIndexes(
           state
         ),
-        getMarker: selectedThreadSelectors.getMarkerGetter(state),
-        rightClickedMarkerIndex: selectedThreadSelectors.getRightClickedMarkerIndex(
+        getMarker: selectedThread.getMarkerGetter(state),
+        rightClickedMarkerIndex: selectedThread.getRightClickedMarkerIndex(
           state
         ),
         timeRange: getPreviewSelectionRange(state),

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -20,7 +20,7 @@ import {
   getPreviewSelectionRange,
   selectedThread,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { changeRightClickedMarker } from '../../actions/profile-view';
 
 import type { SizeProps } from '../shared/WithSize';

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -21,7 +21,7 @@ import {
   getImplementationFilter,
   getInvertCallstack,
   selectedThread,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 
 import {
   convertToTransformType,

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -7,7 +7,6 @@ import React, { PureComponent, Fragment } from 'react';
 import { MenuItem } from 'react-contextmenu';
 import ContextMenu from '../shared/ContextMenu';
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from 'selectors/per-thread';
 import { funcHasRecursiveCall } from '../../profile-logic/transforms';
 import { getFunctionName } from '../../profile-logic/function-info';
 import copy from 'copy-to-clipboard';
@@ -21,7 +20,8 @@ import {
   getSelectedThreadIndex,
   getImplementationFilter,
   getInvertCallstack,
-} from 'selectors/url-state';
+  selectedThread,
+} from 'selectors';
 
 import {
   convertToTransformType,
@@ -503,13 +503,13 @@ class CallNodeContextMenu extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
-    thread: selectedThreadSelectors.getFilteredThread(state),
+    thread: selectedThread.getFilteredThread(state),
     threadIndex: getSelectedThreadIndex(state),
-    callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+    callNodeInfo: selectedThread.getCallNodeInfo(state),
     implementation: getImplementationFilter(state),
     inverted: getInvertCallstack(state),
-    callNodePath: selectedThreadSelectors.getRightClickedCallNodePath(state),
-    callNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(state),
+    callNodePath: selectedThread.getRightClickedCallNodePath(state),
+    callNodeIndex: selectedThread.getRightClickedCallNodeIndex(state),
     selectedTab: getSelectedTab(state),
   }),
   mapDispatchToProps: {

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -7,7 +7,7 @@ import React, { PureComponent, Fragment } from 'react';
 import { MenuItem } from 'react-contextmenu';
 import ContextMenu from '../shared/ContextMenu';
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { funcHasRecursiveCall } from '../../profile-logic/transforms';
 import { getFunctionName } from '../../profile-logic/function-info';
 import copy from 'copy-to-clipboard';
@@ -21,7 +21,7 @@ import {
   getSelectedThreadIndex,
   getImplementationFilter,
   getInvertCallstack,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 
 import {
   convertToTransformType,

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -11,8 +11,12 @@ import {
   setContextMenuVisibility,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { getPreviewSelection, getCommittedRange } from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import {
+  getPreviewSelection,
+  getCommittedRange,
+  selectedThread,
+  getImplementationFilter,
+} from 'selectors';
 import copy from 'copy-to-clipboard';
 
 import type { Marker } from '../../types/profile-derived';
@@ -22,7 +26,6 @@ import type {
   ImplementationFilter,
 } from '../../types/actions';
 import type { ConnectedProps } from '../../utils/connect';
-import { getImplementationFilter } from 'selectors/url-state';
 import type { Thread, IndexIntoStackTable } from '../../types/profile';
 import { filterCallNodePathByImplementation } from '../../profile-logic/transforms';
 import {
@@ -264,9 +267,9 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     previewSelection: getPreviewSelection(state),
     committedRange: getCommittedRange(state),
-    thread: selectedThreadSelectors.getThread(state),
+    thread: selectedThread.getThread(state),
     implementationFilter: getImplementationFilter(state),
-    selectedMarker: selectedThreadSelectors.getRightClickedMarker(state),
+    selectedMarker: selectedThread.getRightClickedMarker(state),
   }),
   mapDispatchToProps: { updatePreviewSelection, setContextMenuVisibility },
   component: MarkerContextMenu,

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -11,11 +11,8 @@ import {
   setContextMenuVisibility,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import {
-  getPreviewSelection,
-  getCommittedRange,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getPreviewSelection, getCommittedRange } from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import copy from 'copy-to-clipboard';
 
 import type { Marker } from '../../types/profile-derived';
@@ -25,7 +22,7 @@ import type {
   ImplementationFilter,
 } from '../../types/actions';
 import type { ConnectedProps } from '../../utils/connect';
-import { getImplementationFilter } from '../../selectors/url-state';
+import { getImplementationFilter } from 'selectors/url-state';
 import type { Thread, IndexIntoStackTable } from '../../types/profile';
 import { filterCallNodePathByImplementation } from '../../profile-logic/transforms';
 import {

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -16,7 +16,7 @@ import {
   getCommittedRange,
   selectedThread,
   getImplementationFilter,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import copy from 'copy-to-clipboard';
 
 import type { Marker } from '../../types/profile-derived';

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { changeMarkersSearchString } from '../../actions/profile-view';
-import { getMarkersSearchString } from 'selectors';
+import { getMarkersSearchString } from 'firefox-profiler/selectors';
 import PanelSearch from '../shared/PanelSearch';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { changeMarkersSearchString } from '../../actions/profile-view';
-import { getMarkersSearchString } from '../../selectors/url-state';
+import { getMarkersSearchString } from 'selectors/url-state';
 import PanelSearch from '../shared/PanelSearch';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { changeMarkersSearchString } from '../../actions/profile-view';
-import { getMarkersSearchString } from 'selectors/url-state';
+import { getMarkersSearchString } from 'selectors';
 import PanelSearch from '../shared/PanelSearch';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/NetworkSettings.js
+++ b/src/components/shared/NetworkSettings.js
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { changeNetworkSearchString } from '../../actions/profile-view';
-import { getNetworkSearchString } from 'selectors/url-state';
+import { getNetworkSearchString } from 'selectors';
 import PanelSearch from '../shared/PanelSearch';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/NetworkSettings.js
+++ b/src/components/shared/NetworkSettings.js
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { changeNetworkSearchString } from '../../actions/profile-view';
-import { getNetworkSearchString } from 'selectors';
+import { getNetworkSearchString } from 'firefox-profiler/selectors';
 import PanelSearch from '../shared/PanelSearch';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/NetworkSettings.js
+++ b/src/components/shared/NetworkSettings.js
@@ -7,7 +7,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import { changeNetworkSearchString } from '../../actions/profile-view';
-import { getNetworkSearchString } from '../../selectors/url-state';
+import { getNetworkSearchString } from 'selectors/url-state';
 import PanelSearch from '../shared/PanelSearch';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/NodeIcon.js
+++ b/src/components/shared/NodeIcon.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-import { getIconClassNameForCallNode } from '../../selectors/icons';
+import { getIconClassNameForCallNode } from 'selectors/icons';
 import { iconStartLoading } from '../../actions/icons';
 
 import type { CallNodeDisplayData } from '../../types/profile-derived';

--- a/src/components/shared/NodeIcon.js
+++ b/src/components/shared/NodeIcon.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-import { getIconClassNameForCallNode } from 'selectors/icons';
+import { getIconClassNameForCallNode } from 'selectors';
 import { iconStartLoading } from '../../actions/icons';
 
 import type { CallNodeDisplayData } from '../../types/profile-derived';

--- a/src/components/shared/NodeIcon.js
+++ b/src/components/shared/NodeIcon.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-import { getIconClassNameForCallNode } from 'selectors';
+import { getIconClassNameForCallNode } from 'firefox-profiler/selectors';
 import { iconStartLoading } from '../../actions/icons';
 
 import type { CallNodeDisplayData } from '../../types/profile-derived';

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -15,14 +15,14 @@ import {
   getImplementationFilter,
   getInvertCallstack,
   getCurrentSearchString,
-} from 'selectors/url-state';
+  selectedThread,
+} from 'selectors';
 import PanelSearch from '../shared/PanelSearch';
 import {
   toValidImplementationFilter,
   toValidCallTreeSummaryStrategy,
 } from '../../profile-logic/profile-data';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
-import { selectedThreadSelectors } from 'selectors/per-thread';
 
 import './StackSettings.css';
 
@@ -211,16 +211,10 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     invertCallstack: getInvertCallstack(state),
     implementationFilter: getImplementationFilter(state),
     currentSearchString: getCurrentSearchString(state),
-    hasJsAllocations: selectedThreadSelectors.getHasJsAllocations(state),
-    hasNativeAllocations: selectedThreadSelectors.getHasNativeAllocations(
-      state
-    ),
-    canShowRetainedMemory: selectedThreadSelectors.getCanShowRetainedMemory(
-      state
-    ),
-    callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
-      state
-    ),
+    hasJsAllocations: selectedThread.getHasJsAllocations(state),
+    hasNativeAllocations: selectedThread.getHasNativeAllocations(state),
+    canShowRetainedMemory: selectedThread.getCanShowRetainedMemory(state),
+    callTreeSummaryStrategy: selectedThread.getCallTreeSummaryStrategy(state),
   }),
   mapDispatchToProps: {
     changeImplementationFilter,

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -16,7 +16,7 @@ import {
   getInvertCallstack,
   getCurrentSearchString,
   selectedThread,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import PanelSearch from '../shared/PanelSearch';
 import {
   toValidImplementationFilter,

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -15,14 +15,14 @@ import {
   getImplementationFilter,
   getInvertCallstack,
   getCurrentSearchString,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import PanelSearch from '../shared/PanelSearch';
 import {
   toValidImplementationFilter,
   toValidCallTreeSummaryStrategy,
 } from '../../profile-logic/profile-data';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 import './StackSettings.css';
 

--- a/src/components/shared/TransformNavigator.js
+++ b/src/components/shared/TransformNavigator.js
@@ -5,7 +5,7 @@
 // @flow
 
 import explicitConnect from '../../utils/connect';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import FilterNavigatorBar from './FilterNavigatorBar';
 import { popTransformsFromStack } from '../../actions/profile-view';
 

--- a/src/components/shared/TransformNavigator.js
+++ b/src/components/shared/TransformNavigator.js
@@ -5,7 +5,7 @@
 // @flow
 
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import FilterNavigatorBar from './FilterNavigatorBar';
 import { popTransformsFromStack } from '../../actions/profile-view';
 

--- a/src/components/shared/TransformNavigator.js
+++ b/src/components/shared/TransformNavigator.js
@@ -5,7 +5,7 @@
 // @flow
 
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import FilterNavigatorBar from './FilterNavigatorBar';
 import { popTransformsFromStack } from '../../actions/profile-view';
 
@@ -22,7 +22,7 @@ type StateProps = $Diff<Props, DispatchProps>;
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: (state: State) => {
-    const items = selectedThreadSelectors.getTransformLabels(state);
+    const items = selectedThread.getTransformLabels(state);
     return {
       className: 'calltreeTransformNavigator',
       items,

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -7,8 +7,8 @@
 import { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
-import { getProfileName, getDataSource } from '../../selectors/url-state';
-import { getProfile } from '../../selectors/profile';
+import { getProfileName, getDataSource } from 'selectors/url-state';
+import { getProfile } from 'selectors/profile';
 
 import type { Profile, ProfileMeta } from '../../types/profile';
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -7,7 +7,11 @@
 import { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
-import { getProfileName, getDataSource, getProfile } from 'selectors';
+import {
+  getProfileName,
+  getDataSource,
+  getProfile,
+} from 'firefox-profiler/selectors';
 
 import type { Profile, ProfileMeta } from '../../types/profile';
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -7,8 +7,7 @@
 import { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
-import { getProfileName, getDataSource } from 'selectors/url-state';
-import { getProfile } from 'selectors/profile';
+import { getProfileName, getDataSource, getProfile } from 'selectors';
 
 import type { Profile, ProfileMeta } from '../../types/profile';
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -6,10 +6,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
-import {
-  getHasZoomedViaMousewheel,
-  getPanelLayoutGeneration,
-} from 'selectors/app';
+import { getHasZoomedViaMousewheel, getPanelLayoutGeneration } from 'selectors';
 import { setHasZoomedViaMousewheel } from '../../../actions/app';
 import { updatePreviewSelection } from '../../../actions/profile-view';
 

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -6,7 +6,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
-import { getHasZoomedViaMousewheel, getPanelLayoutGeneration } from 'selectors';
+import {
+  getHasZoomedViaMousewheel,
+  getPanelLayoutGeneration,
+} from 'firefox-profiler/selectors';
 import { setHasZoomedViaMousewheel } from '../../../actions/app';
 import { updatePreviewSelection } from '../../../actions/profile-view';
 

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -9,7 +9,7 @@ import explicitConnect from '../../../utils/connect';
 import {
   getHasZoomedViaMousewheel,
   getPanelLayoutGeneration,
-} from '../../../selectors/app';
+} from 'selectors/app';
 import { setHasZoomedViaMousewheel } from '../../../actions/app';
 import { updatePreviewSelection } from '../../../actions/profile-view';
 

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -13,9 +13,9 @@ import {
   getPreviewSelection,
   getProfile,
   getCommittedRange,
-} from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'selectors';
 import {
   selectBestAncestorCallNodeAndExpandCallTree,
   focusCallTree,
@@ -243,19 +243,17 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     return {
       interval: getProfile(state).meta.interval,
       selectedThreadIndex: getSelectedThreadIndex(state),
-      fullThread: selectedThreadSelectors.getRangeFilteredThread(state),
-      filteredThread: selectedThreadSelectors.getFilteredThread(state),
+      fullThread: selectedThread.getRangeFilteredThread(state),
+      filteredThread: selectedThread.getFilteredThread(state),
       rangeStart,
       rangeEnd,
-      callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
-      selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
-        state
-      ),
+      callNodeInfo: selectedThread.getCallNodeInfo(state),
+      selectedCallNodeIndex: selectedThread.getSelectedCallNodeIndex(state),
       categories: getProfile(state).meta.categories,
-      samplesSelectedStates: selectedThreadSelectors.getSamplesSelectedStatesInFilteredThread(
+      samplesSelectedStates: selectedThread.getSamplesSelectedStatesInFilteredThread(
         state
       ),
-      treeOrderSampleComparator: selectedThreadSelectors.getTreeOrderComparatorInFilteredThread(
+      treeOrderSampleComparator: selectedThread.getTreeOrderComparatorInFilteredThread(
         state
       ),
       timeRange: getCommittedRange(state),

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -15,7 +15,7 @@ import {
   getCommittedRange,
   selectedThread,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   selectBestAncestorCallNodeAndExpandCallTree,
   focusCallTree,

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -13,9 +13,9 @@ import {
   getPreviewSelection,
   getProfile,
   getCommittedRange,
-} from '../../../selectors/profile';
-import { selectedThreadSelectors } from '../../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../../selectors/url-state';
+} from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import {
   selectBestAncestorCallNodeAndExpandCallTree,
   focusCallTree,

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -8,11 +8,12 @@ import * as React from 'react';
 
 import explicitConnect from '../../utils/connect';
 import {
-  selectedThreadSelectors,
-  selectedNodeSelectors,
-} from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
-import { getCategories, getProfileInterval } from 'selectors/profile';
+  selectedThread,
+  selectedNode,
+  getSelectedThreadIndex,
+  getCategories,
+  getProfileInterval,
+} from 'selectors';
 import { getFunctionName } from '../../profile-logic/function-info';
 import {
   getFriendlyStackTypeName,
@@ -351,12 +352,12 @@ class CallTreeSidebar extends React.PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: state => ({
-    selectedNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(state),
-    callNodeTable: selectedThreadSelectors.getCallNodeInfo(state).callNodeTable,
+    selectedNodeIndex: selectedThread.getSelectedCallNodeIndex(state),
+    callNodeTable: selectedThread.getCallNodeInfo(state).callNodeTable,
     selectedThreadIndex: getSelectedThreadIndex(state),
-    name: getFunctionName(selectedNodeSelectors.getName(state)),
-    lib: selectedNodeSelectors.getLib(state),
-    timings: selectedNodeSelectors.getTimingsForSidebar(state),
+    name: getFunctionName(selectedNode.getName(state)),
+    lib: selectedNode.getLib(state),
+    timings: selectedNode.getTimingsForSidebar(state),
     categoryList: getCategories(state),
     isIntervalInteger: Number.isInteger(getProfileInterval(state)),
   }),

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -13,7 +13,7 @@ import {
   getSelectedThreadIndex,
   getCategories,
   getProfileInterval,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { getFunctionName } from '../../profile-logic/function-info';
 import {
   getFriendlyStackTypeName,

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -10,9 +10,9 @@ import explicitConnect from '../../utils/connect';
 import {
   selectedThreadSelectors,
   selectedNodeSelectors,
-} from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
-import { getCategories, getProfileInterval } from '../../selectors/profile';
+} from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
+import { getCategories, getProfileInterval } from 'selectors/profile';
 import { getFunctionName } from '../../profile-logic/function-info';
 import {
   getFriendlyStackTypeName,

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -7,8 +7,8 @@
 import * as React from 'react';
 
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import { TooltipMarker } from '../tooltip/Marker';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -7,7 +7,10 @@
 import * as React from 'react';
 
 import explicitConnect from '../../utils/connect';
-import { selectedThread, getSelectedThreadIndex } from 'selectors';
+import {
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'firefox-profiler/selectors';
 import { TooltipMarker } from '../tooltip/Marker';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -7,8 +7,7 @@
 import * as React from 'react';
 
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+import { selectedThread, getSelectedThreadIndex } from 'selectors';
 import { TooltipMarker } from '../tooltip/Marker';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -46,7 +45,7 @@ class MarkerSidebar extends React.PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: state => ({
-    marker: selectedThreadSelectors.getSelectedMarker(state),
+    marker: selectedThread.getSelectedMarker(state),
     selectedThreadIndex: getSelectedThreadIndex(state),
   }),
   component: MarkerSidebar,

--- a/src/components/stack-chart/StackChartEmptyReasons.js
+++ b/src/components/stack-chart/StackChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -53,9 +53,9 @@ class StackChartEmptyReasons extends PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
-    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-    thread: selectedThreadSelectors.getThread(state),
-    rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
+    threadName: selectedThread.getFriendlyThreadName(state),
+    thread: selectedThread.getThread(state),
+    rangeFilteredThread: selectedThread.getRangeFilteredThread(state),
   }),
   component: StackChartEmptyReasons,
 });

--- a/src/components/stack-chart/StackChartEmptyReasons.js
+++ b/src/components/stack-chart/StackChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/stack-chart/StackChartEmptyReasons.js
+++ b/src/components/stack-chart/StackChartEmptyReasons.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -20,7 +20,7 @@ import {
   getPageList,
   selectedThread,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import StackChartEmptyReasons from './StackChartEmptyReasons';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import StackSettings from '../shared/StackSettings';

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -18,9 +18,9 @@ import {
   getScrollToSelectionGeneration,
   getCategories,
   getPageList,
-} from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+} from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import StackChartEmptyReasons from './StackChartEmptyReasons';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import StackSettings from '../shared/StackSettings';

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -18,9 +18,9 @@ import {
   getScrollToSelectionGeneration,
   getCategories,
   getPageList,
-} from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'selectors';
 import StackChartEmptyReasons from './StackChartEmptyReasons';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import StackSettings from '../shared/StackSettings';
@@ -206,24 +206,20 @@ class StackChartGraph extends React.PureComponent<Props> {
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(
-      state
-    );
+    const stackTimingByDepth = selectedThread.getStackTimingByDepth(state);
 
     return {
-      thread: selectedThreadSelectors.getFilteredThread(state),
-      maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
+      thread: selectedThread.getFilteredThread(state),
+      maxStackDepth: selectedThread.getCallNodeMaxDepth(state),
       stackTimingByDepth,
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       previewSelection: getPreviewSelection(state),
       threadIndex: getSelectedThreadIndex(state),
-      callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+      callNodeInfo: selectedThread.getCallNodeInfo(state),
       categories: getCategories(state),
-      selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
-        state
-      ),
-      rightClickedCallNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(
+      selectedCallNodeIndex: selectedThread.getSelectedCallNodeIndex(state),
+      rightClickedCallNodeIndex: selectedThread.getRightClickedCallNodeIndex(
         state
       ),
       scrollToSelectionGeneration: getScrollToSelectionGeneration(state),

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -26,7 +26,7 @@ import {
   getPerceptualSpeedIndexProgress,
   getContentfulSpeedIndexProgress,
   getThreadSelectors,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import './Track.css';
 import TimelineTrackThread from './TrackThread';
 import TimelineTrackScreenshots from './TrackScreenshots';

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -12,14 +12,12 @@ import {
   selectTrack,
 } from '../../actions/profile-view';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
+import explicitConnect from '../../utils/connect';
 import {
   getSelectedThreadIndex,
   getHiddenGlobalTracks,
   getLocalTrackOrder,
   getSelectedTab,
-} from 'selectors/url-state';
-import explicitConnect from '../../utils/connect';
-import {
   getGlobalTracks,
   getLocalTracks,
   getGlobalTrackName,
@@ -27,8 +25,8 @@ import {
   getVisualProgress,
   getPerceptualSpeedIndexProgress,
   getContentfulSpeedIndexProgress,
-} from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
+  getThreadSelectors,
+} from 'selectors';
 import './Track.css';
 import TimelineTrackThread from './TrackThread';
 import TimelineTrackScreenshots from './TrackScreenshots';

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -17,7 +17,7 @@ import {
   getHiddenGlobalTracks,
   getLocalTrackOrder,
   getSelectedTab,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import explicitConnect from '../../utils/connect';
 import {
   getGlobalTracks,
@@ -27,8 +27,8 @@ import {
   getVisualProgress,
   getPerceptualSpeedIndexProgress,
   getContentfulSpeedIndexProgress,
-} from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
+} from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
 import './Track.css';
 import TimelineTrackThread from './TrackThread';
 import TimelineTrackScreenshots from './TrackScreenshots';

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -16,13 +16,10 @@ import {
   getSelectedThreadIndex,
   getHiddenLocalTracks,
   getSelectedTab,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import explicitConnect from '../../utils/connect';
-import {
-  getLocalTrackName,
-  getCounterSelectors,
-} from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
+import { getLocalTrackName, getCounterSelectors } from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
 import TrackThread from './TrackThread';
 import TrackNetwork from './TrackNetwork';
 import { TrackMemory } from './TrackMemory';

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -16,10 +16,11 @@ import {
   getSelectedThreadIndex,
   getHiddenLocalTracks,
   getSelectedTab,
-} from 'selectors/url-state';
+  getLocalTrackName,
+  getCounterSelectors,
+  getThreadSelectors,
+} from 'selectors';
 import explicitConnect from '../../utils/connect';
-import { getLocalTrackName, getCounterSelectors } from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
 import TrackThread from './TrackThread';
 import TrackNetwork from './TrackNetwork';
 import { TrackMemory } from './TrackMemory';

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -19,7 +19,7 @@ import {
   getLocalTrackName,
   getCounterSelectors,
   getThreadSelectors,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import explicitConnect from '../../utils/connect';
 import TrackThread from './TrackThread';
 import TrackNetwork from './TrackNetwork';

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -15,7 +15,7 @@ import {
   getPreviewSelection,
   getThreadSelectors,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import './Markers.css';
 
 import type { Milliseconds, CssPixels } from '../../types/units';

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -11,9 +11,9 @@ import Tooltip from '../tooltip/Tooltip';
 import { TooltipMarker } from '../tooltip/Marker';
 import { markerStyles, overlayFills } from '../../profile-logic/marker-styles';
 import explicitConnect from '../../utils/connect';
-import { getPreviewSelection } from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { getPreviewSelection } from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import './Markers.css';
 
 import type { Milliseconds, CssPixels } from '../../types/units';

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -11,9 +11,11 @@ import Tooltip from '../tooltip/Tooltip';
 import { TooltipMarker } from '../tooltip/Marker';
 import { markerStyles, overlayFills } from '../../profile-logic/marker-styles';
 import explicitConnect from '../../utils/connect';
-import { getPreviewSelection } from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+import {
+  getPreviewSelection,
+  getThreadSelectors,
+  getSelectedThreadIndex,
+} from 'selectors';
 import './Markers.css';
 
 import type { Milliseconds, CssPixels } from '../../types/units';

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -12,7 +12,7 @@ import {
   getPreviewSelection,
   getCommittedRange,
   getZeroAt,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   updatePreviewSelection,
   commitRange,

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -12,7 +12,7 @@ import {
   getPreviewSelection,
   getCommittedRange,
   getZeroAt,
-} from 'selectors/profile';
+} from 'selectors';
 import {
   updatePreviewSelection,
   commitRange,

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -12,7 +12,7 @@ import {
   getPreviewSelection,
   getCommittedRange,
   getZeroAt,
-} from '../../selectors/profile';
+} from 'selectors/profile';
 import {
   updatePreviewSelection,
   commitRange,

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -26,13 +26,13 @@ import {
   getLocalTrackNamesByPid,
   getGlobalTrackNames,
   getLocalTracksByPid,
-} from '../../selectors/profile';
+} from 'selectors/profile';
 import {
   getGlobalTrackOrder,
   getHiddenGlobalTracks,
   getHiddenLocalTracksByPid,
   getLocalTrackOrderByPid,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import classNames from 'classnames';
 
 import type { Thread, ThreadIndex, Pid } from '../../types/profile';

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -26,13 +26,11 @@ import {
   getLocalTrackNamesByPid,
   getGlobalTrackNames,
   getLocalTracksByPid,
-} from 'selectors/profile';
-import {
   getGlobalTrackOrder,
   getHiddenGlobalTracks,
   getHiddenLocalTracksByPid,
   getLocalTrackOrderByPid,
-} from 'selectors/url-state';
+} from 'selectors';
 import classNames from 'classnames';
 
 import type { Thread, ThreadIndex, Pid } from '../../types/profile';

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -30,7 +30,7 @@ import {
   getHiddenGlobalTracks,
   getHiddenLocalTracksByPid,
   getLocalTrackOrderByPid,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import classNames from 'classnames';
 
 import type { Thread, ThreadIndex, Pid } from '../../types/profile';

--- a/src/components/timeline/TrackIPC.js
+++ b/src/components/timeline/TrackIPC.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange } from '../../selectors/profile';
+import { getCommittedRange } from 'selectors/profile';
 import { TimelineMarkersIPC } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TRACK_IPC_MARKERS_HEIGHT } from '../../app-logic/constants';

--- a/src/components/timeline/TrackIPC.js
+++ b/src/components/timeline/TrackIPC.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange } from 'selectors';
+import { getCommittedRange } from 'firefox-profiler/selectors';
 import { TimelineMarkersIPC } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TRACK_IPC_MARKERS_HEIGHT } from '../../app-logic/constants';

--- a/src/components/timeline/TrackIPC.js
+++ b/src/components/timeline/TrackIPC.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange } from 'selectors/profile';
+import { getCommittedRange } from 'selectors';
 import { TimelineMarkersIPC } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TRACK_IPC_MARKERS_HEIGHT } from '../../app-logic/constants';

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange, getCounterSelectors } from 'selectors/profile';
+import { getCommittedRange, getCounterSelectors } from 'selectors';
 import { TimelineMarkersMemory } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackMemoryGraph } from './TrackMemoryGraph';

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -6,7 +6,10 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange, getCounterSelectors } from 'selectors';
+import {
+  getCommittedRange,
+  getCounterSelectors,
+} from 'firefox-profiler/selectors';
 import { TimelineMarkersMemory } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackMemoryGraph } from './TrackMemoryGraph';

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -6,10 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import {
-  getCommittedRange,
-  getCounterSelectors,
-} from '../../selectors/profile';
+import { getCommittedRange, getCounterSelectors } from 'selectors/profile';
 import { TimelineMarkersMemory } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackMemoryGraph } from './TrackMemoryGraph';

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -12,8 +12,8 @@ import {
   getCommittedRange,
   getCounterSelectors,
   getProfileInterval,
-} from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
+} from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
 import { ORANGE_50 } from 'photon-colors';
 import Tooltip from '../tooltip/Tooltip';
 import EmptyThreadIndicator from './EmptyThreadIndicator';

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -13,7 +13,7 @@ import {
   getCounterSelectors,
   getProfileInterval,
   getThreadSelectors,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { ORANGE_50 } from 'photon-colors';
 import Tooltip from '../tooltip/Tooltip';
 import EmptyThreadIndicator from './EmptyThreadIndicator';

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -12,8 +12,8 @@ import {
   getCommittedRange,
   getCounterSelectors,
   getProfileInterval,
-} from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
+  getThreadSelectors,
+} from 'selectors';
 import { ORANGE_50 } from 'photon-colors';
 import Tooltip from '../tooltip/Tooltip';
 import EmptyThreadIndicator from './EmptyThreadIndicator';

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -7,12 +7,8 @@
 import React, { PureComponent } from 'react';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
-import {
-  getCommittedRange,
-  getZeroAt,
-  getPageList,
-} from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
+import { getCommittedRange, getZeroAt, getPageList } from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
 import { VerticalIndicators } from './VerticalIndicators';
 import {
   TRACK_NETWORK_ROW_HEIGHT,

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -12,7 +12,7 @@ import {
   getZeroAt,
   getPageList,
   getThreadSelectors,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { VerticalIndicators } from './VerticalIndicators';
 import {
   TRACK_NETWORK_ROW_HEIGHT,

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -7,8 +7,12 @@
 import React, { PureComponent } from 'react';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange, getZeroAt, getPageList } from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
+import {
+  getCommittedRange,
+  getZeroAt,
+  getPageList,
+  getThreadSelectors,
+} from 'selectors';
 import { VerticalIndicators } from './VerticalIndicators';
 import {
   TRACK_NETWORK_ROW_HEIGHT,

--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -10,7 +10,7 @@ import {
   getCommittedRange,
   getPreviewSelection,
   getThreadSelectors,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { withSize, type SizeProps } from '../shared/WithSize';
 import { createPortal } from 'react-dom';
 import { TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';

--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -6,8 +6,11 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange, getPreviewSelection } from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
+import {
+  getCommittedRange,
+  getPreviewSelection,
+  getThreadSelectors,
+} from 'selectors';
 import { withSize, type SizeProps } from '../shared/WithSize';
 import { createPortal } from 'react-dom';
 import { TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';

--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -6,11 +6,8 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-import {
-  getCommittedRange,
-  getPreviewSelection,
-} from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
+import { getCommittedRange, getPreviewSelection } from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
 import { withSize, type SizeProps } from '../shared/WithSize';
 import { createPortal } from 'react-dom';
 import { TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -16,7 +16,7 @@ import {
   getThreadSelectors,
   getSelectedThreadIndex,
   getTimelineType,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 
 import {
   TimelineMarkersJank,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -13,13 +13,10 @@ import {
   getProfileInterval,
   getCommittedRange,
   getCategories,
-} from '../../selectors/profile';
-import { getThreadSelectors } from '../../selectors/per-thread';
+} from 'selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
 
-import {
-  getSelectedThreadIndex,
-  getTimelineType,
-} from '../../selectors/url-state';
+import { getSelectedThreadIndex, getTimelineType } from 'selectors/url-state';
 import {
   TimelineMarkersJank,
   TimelineMarkersFileIo,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -13,10 +13,11 @@ import {
   getProfileInterval,
   getCommittedRange,
   getCategories,
-} from 'selectors/profile';
-import { getThreadSelectors } from 'selectors/per-thread';
+  getThreadSelectors,
+  getSelectedThreadIndex,
+  getTimelineType,
+} from 'selectors';
 
-import { getSelectedThreadIndex, getTimelineType } from 'selectors/url-state';
 import {
   TimelineMarkersJank,
   TimelineMarkersFileIo,

--- a/src/components/timeline/TrackVisualProgress.js
+++ b/src/components/timeline/TrackVisualProgress.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange } from 'selectors';
+import { getCommittedRange } from 'firefox-profiler/selectors';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackVisualProgressGraph } from './TrackVisualProgressGraph';
 import {

--- a/src/components/timeline/TrackVisualProgress.js
+++ b/src/components/timeline/TrackVisualProgress.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange } from 'selectors/profile';
+import { getCommittedRange } from 'selectors';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackVisualProgressGraph } from './TrackVisualProgressGraph';
 import {

--- a/src/components/timeline/TrackVisualProgress.js
+++ b/src/components/timeline/TrackVisualProgress.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
-import { getCommittedRange } from '../../selectors/profile';
+import { getCommittedRange } from 'selectors/profile';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TrackVisualProgressGraph } from './TrackVisualProgressGraph';
 import {

--- a/src/components/timeline/TrackVisualProgressGraph.js
+++ b/src/components/timeline/TrackVisualProgressGraph.js
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
 import { formatPercent } from '../../utils/format-numbers';
-import { getCommittedRange, getProfileInterval } from 'selectors/profile';
+import { getCommittedRange, getProfileInterval } from 'selectors';
 import Tooltip from '../tooltip/Tooltip';
 import bisection from 'bisection';
 import { BLUE_50, BLUE_60 } from 'photon-colors';

--- a/src/components/timeline/TrackVisualProgressGraph.js
+++ b/src/components/timeline/TrackVisualProgressGraph.js
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
 import { formatPercent } from '../../utils/format-numbers';
-import { getCommittedRange, getProfileInterval } from '../../selectors/profile';
+import { getCommittedRange, getProfileInterval } from 'selectors/profile';
 import Tooltip from '../tooltip/Tooltip';
 import bisection from 'bisection';
 import { BLUE_50, BLUE_60 } from 'photon-colors';

--- a/src/components/timeline/TrackVisualProgressGraph.js
+++ b/src/components/timeline/TrackVisualProgressGraph.js
@@ -8,7 +8,10 @@ import * as React from 'react';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
 import { formatPercent } from '../../utils/format-numbers';
-import { getCommittedRange, getProfileInterval } from 'selectors';
+import {
+  getCommittedRange,
+  getProfileInterval,
+} from 'firefox-profiler/selectors';
 import Tooltip from '../tooltip/Tooltip';
 import bisection from 'bisection';
 import { BLUE_50, BLUE_60 } from 'photon-colors';

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -22,7 +22,7 @@ import {
   getPanelLayoutGeneration,
   getGlobalTrackOrder,
   getTimelineType,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   TIMELINE_MARGIN_LEFT,
   TIMELINE_MARGIN_RIGHT,

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -13,15 +13,16 @@ import OverflowEdgeIndicator from './OverflowEdgeIndicator';
 import Reorderable from '../shared/Reorderable';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
-import { getPanelLayoutGeneration } from 'selectors/app';
 import {
   getCommittedRange,
   getZeroAt,
   getGlobalTracks,
   getGlobalTrackReferences,
   getHiddenTrackCount,
-} from 'selectors/profile';
-import { getGlobalTrackOrder, getTimelineType } from 'selectors/url-state';
+  getPanelLayoutGeneration,
+  getGlobalTrackOrder,
+  getTimelineType,
+} from 'selectors';
 import {
   TIMELINE_MARGIN_LEFT,
   TIMELINE_MARGIN_RIGHT,

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -13,18 +13,15 @@ import OverflowEdgeIndicator from './OverflowEdgeIndicator';
 import Reorderable from '../shared/Reorderable';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
-import { getPanelLayoutGeneration } from '../../selectors/app';
+import { getPanelLayoutGeneration } from 'selectors/app';
 import {
   getCommittedRange,
   getZeroAt,
   getGlobalTracks,
   getGlobalTrackReferences,
   getHiddenTrackCount,
-} from '../../selectors/profile';
-import {
-  getGlobalTrackOrder,
-  getTimelineType,
-} from '../../selectors/url-state';
+} from 'selectors/profile';
+import { getGlobalTrackOrder, getTimelineType } from 'selectors/url-state';
 import {
   TIMELINE_MARGIN_LEFT,
   TIMELINE_MARGIN_RIGHT,

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -16,9 +16,9 @@ import {
   formatValueTotal,
 } from '../../utils/format-numbers';
 import explicitConnect from '../../utils/connect';
-import { getThreadSelectors } from '../../selectors/per-thread';
-import { getImplementationFilter } from '../../selectors/url-state';
-import { getPageList, getZeroAt } from '../../selectors/profile';
+import { getThreadSelectors } from 'selectors/per-thread';
+import { getImplementationFilter } from 'selectors/url-state';
+import { getPageList, getZeroAt } from 'selectors/profile';
 
 import { TooltipNetworkMarker } from './NetworkMarker';
 import { TooltipDetails, TooltipDetail } from './TooltipDetails';

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -16,9 +16,12 @@ import {
   formatValueTotal,
 } from '../../utils/format-numbers';
 import explicitConnect from '../../utils/connect';
-import { getThreadSelectors } from 'selectors/per-thread';
-import { getImplementationFilter } from 'selectors/url-state';
-import { getPageList, getZeroAt } from 'selectors/profile';
+import {
+  getThreadSelectors,
+  getImplementationFilter,
+  getPageList,
+  getZeroAt,
+} from 'selectors';
 
 import { TooltipNetworkMarker } from './NetworkMarker';
 import { TooltipDetails, TooltipDetail } from './TooltipDetails';

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -21,7 +21,7 @@ import {
   getImplementationFilter,
   getPageList,
   getZeroAt,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 
 import { TooltipNetworkMarker } from './NetworkMarker';
 import { TooltipDetails, TooltipDetail } from './TooltipDetails';

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -3,15 +3,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
+export * from './app';
+export * from './per-thread';
+export * from './profile';
+export * from './url-state';
+export * from './icons';
+export * from './publish';
+export * from './zipped-profiles';
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
 import * as app from './app';
-import { selectedThreadSelectors as selectedThread } from './per-thread';
+import { selectedThread } from './per-thread';
 import * as profile from './profile';
 import * as urlState from './url-state';
 import * as icons from './icons';
 import * as publish from './publish';
 import * as zippedProfiles from './zipped-profiles';
 
-const allSelectors = {
+const _selectorsForConsole = {
   app,
   profile,
   urlState,
@@ -21,5 +34,5 @@ const allSelectors = {
   selectedThread,
 };
 
-// Flow requires that all exported object is explicitely typed.
-export default (allSelectors: typeof allSelectors);
+// Exports require explicit typing. Deduce the type with typeof.
+export const selectorsForConsole: typeof _selectorsForConsole = _selectorsForConsole;

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -79,7 +79,7 @@ export const getThreadSelectors = (
  * Most of the time, we only want to work with the selected thread. This object
  * collects the selectors for the currently selected thread.
  */
-export const selectedThreadSelectors: ThreadSelectors = (() => {
+export const selectedThread: ThreadSelectors = (() => {
   const anyThreadSelectors: ThreadSelectors = getThreadSelectors(0);
   const result: $Shape<ThreadSelectors> = {};
   for (const key in anyThreadSelectors) {
@@ -97,10 +97,10 @@ export type NodeSelectors = {|
   +getTimingsForSidebar: Selector<TimingsForPath>,
 |};
 
-export const selectedNodeSelectors: NodeSelectors = (() => {
+export const selectedNode: NodeSelectors = (() => {
   const getName: Selector<string> = createSelector(
-    selectedThreadSelectors.getSelectedCallNodePath,
-    selectedThreadSelectors.getFilteredThread,
+    selectedThread.getSelectedCallNodePath,
+    selectedThread.getFilteredThread,
     (selectedPath, { stringTable, funcTable }) => {
       if (!selectedPath.length) {
         return '';
@@ -112,8 +112,8 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
   );
 
   const getIsJS: Selector<boolean> = createSelector(
-    selectedThreadSelectors.getSelectedCallNodePath,
-    selectedThreadSelectors.getFilteredThread,
+    selectedThread.getSelectedCallNodePath,
+    selectedThread.getFilteredThread,
     (selectedPath, { funcTable }) => {
       if (!selectedPath.length) {
         return false;
@@ -125,8 +125,8 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
   );
 
   const getLib: Selector<string> = createSelector(
-    selectedThreadSelectors.getSelectedCallNodePath,
-    selectedThreadSelectors.getFilteredThread,
+    selectedThread.getSelectedCallNodePath,
+    selectedThread.getFilteredThread,
     (selectedPath, { stringTable, funcTable, resourceTable }) => {
       if (!selectedPath.length) {
         return '';
@@ -142,13 +142,13 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
   );
 
   const getTimingsForSidebar: Selector<TimingsForPath> = createSelector(
-    selectedThreadSelectors.getSelectedCallNodePath,
-    selectedThreadSelectors.getCallNodeInfo,
+    selectedThread.getSelectedCallNodePath,
+    selectedThread.getCallNodeInfo,
     ProfileSelectors.getProfileInterval,
     UrlState.getInvertCallstack,
-    selectedThreadSelectors.getPreviewFilteredThread,
-    selectedThreadSelectors.getThread,
-    selectedThreadSelectors.getSampleIndexOffsetFromPreviewRange,
+    selectedThread.getPreviewFilteredThread,
+    selectedThread.getThread,
+    selectedThread.getSampleIndexOffsetFromPreviewRange,
     ProfileSelectors.getCategories,
     ProfileData.getTimingsForPath
   );

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -113,7 +113,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
    * This selector returns a function that's used to retrieve a marker object
    * from its MarkerIndex:
    *
-   *   const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+   *   const getMarker = selectedThread.getMarkerGetter(state);
    *   const marker = getMarker(markerIndex);
    *
    * This is essentially the same as using the full marker list, but it's more

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -14,7 +14,7 @@ import {
   setContextMenuVisibility,
 } from '../../actions/profile-view';
 import { Provider } from 'react-redux';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 import copy from 'copy-to-clipboard';
 

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -14,7 +14,7 @@ import {
   setContextMenuVisibility,
 } from '../../actions/profile-view';
 import { Provider } from 'react-redux';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { ensureExists } from '../../utils/flow';
 import copy from 'copy-to-clipboard';
 
@@ -90,9 +90,7 @@ describe('calltree/CallNodeContextMenu', function() {
       it(`adds a transform for "${type}"`, function() {
         const { getState, getByText } = setup();
         fireEvent.click(getByText(matcher));
-        expect(
-          selectedThreadSelectors.getTransformStack(getState())[0].type
-        ).toBe(type);
+        expect(selectedThread.getTransformStack(getState())[0].type).toBe(type);
       });
     });
   });
@@ -101,14 +99,14 @@ describe('calltree/CallNodeContextMenu', function() {
     it('can expand all call nodes in the call tree', function() {
       const { getState, getByText } = setup();
       expect(
-        selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
+        selectedThread.getExpandedCallNodeIndexes(getState())
       ).toHaveLength(1);
 
       fireEvent.click(getByText('Expand all'));
 
       // This test only asserts that a bunch of call nodes were actually expanded.
       expect(
-        selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
+        selectedThread.getExpandedCallNodeIndexes(getState())
       ).toHaveLength(11);
     });
 

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -14,7 +14,7 @@ import {
   setContextMenuVisibility,
 } from '../../actions/profile-view';
 import { Provider } from 'react-redux';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 import copy from 'copy-to-clipboard';
 

--- a/src/test/components/CompareHome.test.js
+++ b/src/test/components/CompareHome.test.js
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent, cleanup } from 'react-testing-library';
 
 import CompareHome from '../../components/app/CompareHome';
-import { getProfilesToCompare } from 'selectors/url-state';
+import { getProfilesToCompare } from 'selectors';
 
 import { blankStore } from '../fixtures/stores';
 

--- a/src/test/components/CompareHome.test.js
+++ b/src/test/components/CompareHome.test.js
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent, cleanup } from 'react-testing-library';
 
 import CompareHome from '../../components/app/CompareHome';
-import { getProfilesToCompare } from '../../selectors/url-state';
+import { getProfilesToCompare } from 'selectors/url-state';
 
 import { blankStore } from '../fixtures/stores';
 

--- a/src/test/components/CompareHome.test.js
+++ b/src/test/components/CompareHome.test.js
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent, cleanup } from 'react-testing-library';
 
 import CompareHome from '../../components/app/CompareHome';
-import { getProfilesToCompare } from 'selectors';
+import { getProfilesToCompare } from 'firefox-profiler/selectors';
 
 import { blankStore } from '../fixtures/stores';
 

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -32,9 +32,8 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread, getInvertCallstack } from 'selectors';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
-import { getInvertCallstack } from 'selectors/url-state';
 import { ensureExists } from '../../utils/flow';
 
 import type { CssPixels } from '../../types/units';
@@ -86,9 +85,7 @@ describe('FlameGraph', function() {
     const div = getContentDiv();
 
     function selectedNode() {
-      const callNodeIndex = selectedThreadSelectors.getSelectedCallNodeIndex(
-        getState()
-      );
+      const callNodeIndex = selectedThread.getSelectedCallNodeIndex(getState());
       return callNodeIndex && funcNames[callNodeIndex];
     }
 

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -32,9 +32,9 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
-import { getInvertCallstack } from '../../selectors/url-state';
+import { getInvertCallstack } from 'selectors/url-state';
 import { ensureExists } from '../../utils/flow';
 
 import type { CssPixels } from '../../types/units';

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -32,7 +32,7 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
-import { selectedThread, getInvertCallstack } from 'selectors';
+import { selectedThread, getInvertCallstack } from 'firefox-profiler/selectors';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { ensureExists } from '../../utils/flow';
 

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -17,7 +17,7 @@ import {
   getGlobalTracks,
   getRightClickedTrack,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -13,8 +13,11 @@ import {
   hideGlobalTrack,
 } from '../../actions/profile-view';
 import GlobalTrack from '../../components/timeline/GlobalTrack';
-import { getGlobalTracks, getRightClickedTrack } from 'selectors/profile';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+import {
+  getGlobalTracks,
+  getRightClickedTrack,
+  getSelectedThreadIndex,
+} from 'selectors';
 import { ensureExists } from '../../utils/flow';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -13,8 +13,8 @@ import {
   hideGlobalTrack,
 } from '../../actions/profile-view';
 import GlobalTrack from '../../components/timeline/GlobalTrack';
-import { getGlobalTracks, getRightClickedTrack } from '../../selectors/profile';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { getGlobalTracks, getRightClickedTrack } from 'selectors/profile';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import { ensureExists } from '../../utils/flow';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -20,7 +20,7 @@ import {
   removeRootOverlayElement,
 } from '../fixtures/utils';
 import { getProfileWithJsTracerEvents } from '../fixtures/profiles/processed-profile';
-import { getShowJsTracerSummary } from 'selectors/url-state';
+import { getShowJsTracerSummary } from 'selectors';
 jest.useFakeTimers();
 
 const GRAPH_BASE_WIDTH = 200;

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -20,7 +20,7 @@ import {
   removeRootOverlayElement,
 } from '../fixtures/utils';
 import { getProfileWithJsTracerEvents } from '../fixtures/profiles/processed-profile';
-import { getShowJsTracerSummary } from 'selectors';
+import { getShowJsTracerSummary } from 'firefox-profiler/selectors';
 jest.useFakeTimers();
 
 const GRAPH_BASE_WIDTH = 200;

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -20,7 +20,7 @@ import {
   removeRootOverlayElement,
 } from '../fixtures/utils';
 import { getProfileWithJsTracerEvents } from '../fixtures/profiles/processed-profile';
-import { getShowJsTracerSummary } from '../../selectors/url-state';
+import { getShowJsTracerSummary } from 'selectors/url-state';
 jest.useFakeTimers();
 
 const GRAPH_BASE_WIDTH = 200;

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -22,9 +22,9 @@ import {
   getRightClickedTrack,
   getLocalTrackFromReference,
   getProfile,
-} from 'selectors/profile';
+  getSelectedThreadIndex,
+} from 'selectors';
 import { ensureExists } from '../../utils/flow';
-import { getSelectedThreadIndex } from 'selectors/url-state';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import {
   getNetworkTrackProfile,

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -23,7 +23,7 @@ import {
   getLocalTrackFromReference,
   getProfile,
   getSelectedThreadIndex,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import {

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -22,9 +22,9 @@ import {
   getRightClickedTrack,
   getLocalTrackFromReference,
   getProfile,
-} from '../../selectors/profile';
+} from 'selectors/profile';
 import { ensureExists } from '../../utils/flow';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import {
   getNetworkTrackProfile,

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -10,7 +10,7 @@ import { render, fireEvent } from 'react-testing-library';
 import copy from 'copy-to-clipboard';
 import fakeIndexedDB from 'fake-indexeddb';
 
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
 import CallNodeContextMenu from '../../components/shared/CallNodeContextMenu';
 import { processProfile } from '../../profile-logic/process-profile';

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -10,7 +10,7 @@ import { render, fireEvent } from 'react-testing-library';
 import copy from 'copy-to-clipboard';
 import fakeIndexedDB from 'fake-indexeddb';
 
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
 import CallNodeContextMenu from '../../components/shared/CallNodeContextMenu';
 import { processProfile } from '../../profile-logic/process-profile';

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -10,7 +10,7 @@ import { render, fireEvent } from 'react-testing-library';
 import copy from 'copy-to-clipboard';
 import fakeIndexedDB from 'fake-indexeddb';
 
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
 import CallNodeContextMenu from '../../components/shared/CallNodeContextMenu';
 import { processProfile } from '../../profile-logic/process-profile';
@@ -513,21 +513,21 @@ describe('ProfileCallTreeView with JS Allocations', function() {
     const { changeSelect, getState } = setup();
 
     // It starts out with timing.
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('timing');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
 
     // It switches to JS allocations.
     changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('js-allocations');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'js-allocations'
+    );
 
     // And finally it can be switched back.
     changeSelect({ from: 'JavaScript Allocations', to: 'Timing Data' });
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('timing');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
   });
 
   it('shows byte related labels for JS allocations', function() {
@@ -569,22 +569,22 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
     const { getState, changeSelect } = setup();
 
     // It starts out with timing.
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('timing');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
 
     // Switch to native allocations.
     changeSelect({ from: 'Timing Data', to: 'Allocations' });
 
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('native-allocations');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'native-allocations'
+    );
 
     // And finally it can be switched back.
     changeSelect({ from: 'Allocations', to: 'Timing Data' });
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('timing');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
   });
 
   it('shows byte related labels for native allocations', function() {
@@ -637,22 +637,22 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     const { getState, changeSelect } = setup();
 
     // It starts out with timing.
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('timing');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
 
     // Switch to retained memory native allocations.
     changeSelect({ from: 'Timing Data', to: 'Retained Allocations' });
 
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('native-retained-allocations');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'native-retained-allocations'
+    );
 
     // And finally it can be switched back.
     changeSelect({ from: 'Retained Allocations', to: 'Timing Data' });
-    expect(
-      selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
-    ).toEqual('timing');
+    expect(selectedThread.getCallTreeSummaryStrategy(getState())).toEqual(
+      'timing'
+    );
   });
 
   it('shows byte related labels for retained allocations', function() {

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -25,7 +25,7 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -25,7 +25,7 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -199,9 +199,7 @@ describe('StackChart', function() {
 
     // Start out deselected
     dispatch(changeSelectedCallNode(0, []));
-    expect(selectedThreadSelectors.getSelectedCallNodeIndex(getState())).toBe(
-      null
-    );
+    expect(selectedThread.getSelectedCallNodeIndex(getState())).toBe(null);
 
     // Click the first frame
     leftClick({
@@ -209,9 +207,7 @@ describe('StackChart', function() {
       y: 10,
     });
 
-    expect(selectedThreadSelectors.getSelectedCallNodeIndex(getState())).toBe(
-      0
-    );
+    expect(selectedThread.getSelectedCallNodeIndex(getState())).toBe(0);
 
     // Click on a region without any drawn box to deselect
     leftClick({
@@ -219,9 +215,7 @@ describe('StackChart', function() {
       y: 100,
     });
 
-    expect(selectedThreadSelectors.getSelectedCallNodeIndex(getState())).toBe(
-      null
-    );
+    expect(selectedThread.getSelectedCallNodeIndex(getState())).toBe(null);
   });
 
   it('can display a context menu when right clicking the chart', function() {

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -25,7 +25,7 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/StackSettings.test.js
+++ b/src/test/components/StackSettings.test.js
@@ -7,7 +7,10 @@ import { render, fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import StackSettings from '../../components/shared/StackSettings';
 import { storeWithProfile } from '../fixtures/stores';
-import { getImplementationFilter, getCurrentSearchString } from 'selectors';
+import {
+  getImplementationFilter,
+  getCurrentSearchString,
+} from 'firefox-profiler/selectors';
 
 describe('StackSettings', function() {
   function setup() {

--- a/src/test/components/StackSettings.test.js
+++ b/src/test/components/StackSettings.test.js
@@ -7,10 +7,7 @@ import { render, fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import StackSettings from '../../components/shared/StackSettings';
 import { storeWithProfile } from '../fixtures/stores';
-import {
-  getImplementationFilter,
-  getCurrentSearchString,
-} from 'selectors/url-state';
+import { getImplementationFilter, getCurrentSearchString } from 'selectors';
 
 describe('StackSettings', function() {
   function setup() {

--- a/src/test/components/StackSettings.test.js
+++ b/src/test/components/StackSettings.test.js
@@ -10,7 +10,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import {
   getImplementationFilter,
   getCurrentSearchString,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 
 describe('StackSettings', function() {
   function setup() {

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -12,7 +12,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
 import SelectedThreadActivityGraph from '../../components/shared/thread/SelectedActivityGraph';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -12,7 +12,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
 import SelectedThreadActivityGraph from '../../components/shared/thread/SelectedActivityGraph';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -103,7 +103,7 @@ describe('SelectedThreadActivityGraph', function() {
 
     // This function gets the selected call node path as a list of function names.
     function getCallNodePath() {
-      return selectedThreadSelectors
+      return selectedThread
         .getSelectedCallNodePath(getState())
         .map(funcIndex =>
           thread.stringTable.getString(thread.funcTable.name[funcIndex])

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -12,7 +12,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
 import SelectedThreadActivityGraph from '../../components/shared/thread/SelectedActivityGraph';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -12,8 +12,8 @@ import {
   getProfileWithUnbalancedNativeAllocations,
   getProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import * as ProfileSelectors from '../../selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import * as ProfileSelectors from 'selectors/profile';
 import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -12,8 +12,7 @@ import {
   getProfileWithUnbalancedNativeAllocations,
   getProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import * as ProfileSelectors from 'selectors/profile';
+import * as selectors from 'selectors';
 import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,
@@ -30,18 +29,18 @@ describe('TooltipCallNode', function() {
       return render(
         <Provider store={store}>
           <TooltipCallNode
-            thread={selectedThreadSelectors.getThread(getState())}
-            pages={ProfileSelectors.getPageList(getState())}
+            thread={selectors.selectedThread.getThread(getState())}
+            pages={selectors.getPageList(getState())}
             callNodeIndex={ensureExists(
-              selectedThreadSelectors.getSelectedCallNodeIndex(getState()),
+              selectors.selectedThread.getSelectedCallNodeIndex(getState()),
               'Unable to find a selected call node index.'
             )}
-            callNodeInfo={selectedThreadSelectors.getCallNodeInfo(getState())}
-            categories={ProfileSelectors.getCategories(getState())}
-            interval={ProfileSelectors.getProfileInterval(getState())}
+            callNodeInfo={selectors.selectedThread.getCallNodeInfo(getState())}
+            categories={selectors.getCategories(getState())}
+            interval={selectors.getProfileInterval(getState())}
             durationText="Fake Duration Text"
-            callTree={selectedThreadSelectors.getCallTree(getState())}
-            callTreeSummaryStrategy={selectedThreadSelectors.getCallTreeSummaryStrategy(
+            callTree={selectors.selectedThread.getCallTree(getState())}
+            callTreeSummaryStrategy={selectors.selectedThread.getCallTreeSummaryStrategy(
               getState()
             )}
           />

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -12,7 +12,7 @@ import {
   getProfileWithUnbalancedNativeAllocations,
   getProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -14,8 +14,7 @@ import {
   getNetworkMarkers,
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
-import { getSelectedThreadIndex } from 'selectors/url-state';
+import { selectedThread, getSelectedThreadIndex } from 'selectors';
 
 describe('TooltipMarker', function() {
   it('renders tooltips for various markers', () => {
@@ -391,10 +390,8 @@ describe('TooltipMarker', function() {
     const store = storeWithProfile(profile);
     const state = store.getState();
     const threadIndex = getSelectedThreadIndex(state);
-    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
-    const markerIndexes = selectedThreadSelectors.getFullMarkerListIndexes(
-      state
-    );
+    const getMarker = selectedThread.getMarkerGetter(state);
+    const markerIndexes = selectedThread.getFullMarkerListIndexes(state);
 
     markerIndexes.forEach(markerIndex => {
       const marker = getMarker(markerIndex);
@@ -427,10 +424,8 @@ describe('TooltipMarker', function() {
     const store = storeWithProfile(profile);
     const state = store.getState();
 
-    const getMarker = selectedThreadSelectors.getMarkerGetter(state);
-    const markerIndexes = selectedThreadSelectors.getFullMarkerListIndexes(
-      state
-    );
+    const getMarker = selectedThread.getMarkerGetter(state);
+    const markerIndexes = selectedThread.getFullMarkerListIndexes(state);
 
     // We render the first marker.
     const marker = getMarker(markerIndexes[0]);

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -14,8 +14,8 @@ import {
   getNetworkMarkers,
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadIndex } from '../../selectors/url-state';
+import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getSelectedThreadIndex } from 'selectors/url-state';
 
 describe('TooltipMarker', function() {
   it('renders tooltips for various markers', () => {

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -14,7 +14,10 @@ import {
   getNetworkMarkers,
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
-import { selectedThread, getSelectedThreadIndex } from 'selectors';
+import {
+  selectedThread,
+  getSelectedThreadIndex,
+} from 'firefox-profiler/selectors';
 
 describe('TooltipMarker', function() {
   it('renders tooltips for various markers', () => {

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -19,7 +19,7 @@ import {
   getLocalTracks,
   getHiddenGlobalTracks,
   getHiddenLocalTracks,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import {
   getProfileWithNiceTracks,
   getHumanReadableTracks,

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -14,11 +14,12 @@ import {
   changeRightClickedTrack,
 } from '../../actions/profile-view';
 import TrackContextMenu from '../../components/timeline/TrackContextMenu';
-import { getGlobalTracks, getLocalTracks } from 'selectors/profile';
 import {
+  getGlobalTracks,
+  getLocalTracks,
   getHiddenGlobalTracks,
   getHiddenLocalTracks,
-} from 'selectors/url-state';
+} from 'selectors';
 import {
   getProfileWithNiceTracks,
   getHumanReadableTracks,

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -14,11 +14,11 @@ import {
   changeRightClickedTrack,
 } from '../../actions/profile-view';
 import TrackContextMenu from '../../components/timeline/TrackContextMenu';
-import { getGlobalTracks, getLocalTracks } from '../../selectors/profile';
+import { getGlobalTracks, getLocalTracks } from 'selectors/profile';
 import {
   getHiddenGlobalTracks,
   getHiddenLocalTracks,
-} from '../../selectors/url-state';
+} from 'selectors/url-state';
 import {
   getProfileWithNiceTracks,
   getHumanReadableTracks,

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -21,7 +21,7 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
 } from '../fixtures/utils';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { getNetworkTrackProfile } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -21,7 +21,7 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
 } from '../fixtures/utils';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { getNetworkTrackProfile } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 
@@ -63,7 +63,7 @@ describe('VerticalIndicators', function() {
 
   it('creates the vertical indicators', function() {
     const { getIndicatorLines, getState } = setup();
-    const markerIndexes = selectedThreadSelectors.getTimelineVerticalMarkerIndexes(
+    const markerIndexes = selectedThread.getTimelineVerticalMarkerIndexes(
       getState()
     );
     const markerCount = 5;

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -21,7 +21,7 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
 } from '../fixtures/utils';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { getNetworkTrackProfile } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -13,7 +13,10 @@ import { oneLine } from 'common-tags';
 
 import { changeTimelineType } from '../../actions/profile-view';
 import TrackThread from '../../components/timeline/TrackThread';
-import { getPreviewSelection, selectedThread } from 'selectors';
+import {
+  getPreviewSelection,
+  selectedThread,
+} from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -13,8 +13,8 @@ import { oneLine } from 'common-tags';
 
 import { changeTimelineType } from '../../actions/profile-view';
 import TrackThread from '../../components/timeline/TrackThread';
-import { getPreviewSelection } from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getPreviewSelection } from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -13,8 +13,7 @@ import { oneLine } from 'common-tags';
 
 import { changeTimelineType } from '../../actions/profile-view';
 import TrackThread from '../../components/timeline/TrackThread';
-import { getPreviewSelection } from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { getPreviewSelection, selectedThread } from 'selectors';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -142,7 +141,7 @@ describe('timeline/TrackThread', function() {
 
     // Provide a quick helper for nicely asserting the call node path.
     const getCallNodePath = () =>
-      selectedThreadSelectors
+      selectedThread
         .getSelectedCallNodePath(getState())
         .map(funcIndex =>
           thread.stringTable.getString(thread.funcTable.name[funcIndex])

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -7,10 +7,9 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
 
-import { getUrlSetupPhase } from 'selectors/app';
+import { getUrlSetupPhase, getDataSource } from 'selectors';
 import UrlManager from '../../components/app/UrlManager';
 import { blankStore } from '../fixtures/stores';
-import { getDataSource } from 'selectors/url-state';
 import { waitUntilState } from '../fixtures/utils';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import * as receiveProfile from '../../actions/receive-profile';

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
 
-import { getUrlSetupPhase, getDataSource } from 'selectors';
+import { getUrlSetupPhase, getDataSource } from 'firefox-profiler/selectors';
 import UrlManager from '../../components/app/UrlManager';
 import { blankStore } from '../fixtures/stores';
 import { waitUntilState } from '../fixtures/utils';

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -7,10 +7,10 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from 'react-testing-library';
 
-import { getUrlSetupPhase } from '../../selectors/app';
+import { getUrlSetupPhase } from 'selectors/app';
 import UrlManager from '../../components/app/UrlManager';
 import { blankStore } from '../fixtures/stores';
-import { getDataSource } from '../../selectors/url-state';
+import { getDataSource } from 'selectors/url-state';
 import { waitUntilState } from '../fixtures/utils';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import * as receiveProfile from '../../actions/receive-profile';

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -8,7 +8,10 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
 import { withChartViewport } from '../../components/shared/chart/Viewport';
-import { getCommittedRange, getPreviewSelection } from 'selectors';
+import {
+  getCommittedRange,
+  getPreviewSelection,
+} from 'firefox-profiler/selectors';
 
 import { changeSidebarOpenState } from '../../actions/app';
 

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
 import { withChartViewport } from '../../components/shared/chart/Viewport';
-import { getCommittedRange, getPreviewSelection } from 'selectors/profile';
+import { getCommittedRange, getPreviewSelection } from 'selectors';
 
 import { changeSidebarOpenState } from '../../actions/app';
 

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -8,10 +8,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
 import { withChartViewport } from '../../components/shared/chart/Viewport';
-import {
-  getCommittedRange,
-  getPreviewSelection,
-} from '../../selectors/profile';
+import { getCommittedRange, getPreviewSelection } from 'selectors/profile';
 
 import { changeSidebarOpenState } from '../../actions/app';
 

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -8,7 +8,7 @@ import ZipFileViewer from '../../components/app/ZipFileViewer';
 import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -8,8 +8,8 @@ import ZipFileViewer from '../../components/app/ZipFileViewer';
 import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
-import * as UrlStateSelectors from '../../selectors/url-state';
-import * as ZippedProfileSelectors from '../../selectors/zipped-profiles';
+import * as UrlStateSelectors from 'selectors/url-state';
+import * as ZippedProfileSelectors from 'selectors/zipped-profiles';
 
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -8,8 +8,7 @@ import ZipFileViewer from '../../components/app/ZipFileViewer';
 import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 
-import * as UrlStateSelectors from 'selectors/url-state';
-import * as ZippedProfileSelectors from 'selectors/zipped-profiles';
+import * as selectors from 'selectors';
 
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -74,7 +73,7 @@ describe('calltree/ZipFileTree', function() {
         waitUntilState(
           store,
           state =>
-            ZippedProfileSelectors.getZipFileState(state).phase ===
+            selectors.getZipFileState(state).phase ===
             'VIEW_PROFILE_IN_ZIP_FILE'
         );
 
@@ -92,7 +91,7 @@ describe('calltree/ZipFileTree', function() {
 
     it('starts out without any path in the zip file', async () => {
       const { getState, profileViewer } = await setupClickingTest();
-      expect(UrlStateSelectors.getPathInZipFileFromUrl(getState())).toBe(null);
+      expect(selectors.getPathInZipFileFromUrl(getState())).toBe(null);
       expect(profileViewer()).toBeFalsy();
     });
 
@@ -105,7 +104,7 @@ describe('calltree/ZipFileTree', function() {
         profileViewer,
       } = await setupClickingTest();
       fireEvent.click(profile1OpenLink);
-      expect(UrlStateSelectors.getPathInZipFileFromUrl(getState())).toBe(
+      expect(selectors.getPathInZipFileFromUrl(getState())).toBe(
         'foo/bar/profile1.json'
       );
 

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import * as profileViewSelectors from '../../../selectors/profile';
-import * as urlStateReducers from '../../../selectors/url-state';
+import * as profileViewSelectors from 'selectors/profile';
+import * as urlStateReducers from 'selectors/url-state';
 import {
   getProfileFromTextSamples,
   getCounterForThread,

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import * as profileViewSelectors from 'selectors/profile';
-import * as urlStateReducers from 'selectors/url-state';
+import * as selectors from 'selectors';
 import {
   getProfileFromTextSamples,
   getCounterForThread,
@@ -39,12 +38,12 @@ import type { State } from '../../../types/state';
  * Local Track naming - `[thread ThreadName]` | `[TrackType]`
  */
 export function getHumanReadableTracks(state: State): string[] {
-  const threads = profileViewSelectors.getThreads(state);
-  const globalTracks = profileViewSelectors.getGlobalTracks(state);
-  const hiddenGlobalTracks = urlStateReducers.getHiddenGlobalTracks(state);
-  const selectedThreadIndex = urlStateReducers.getSelectedThreadIndex(state);
+  const threads = selectors.getThreads(state);
+  const globalTracks = selectors.getGlobalTracks(state);
+  const hiddenGlobalTracks = selectors.getHiddenGlobalTracks(state);
+  const selectedThreadIndex = selectors.getSelectedThreadIndex(state);
   const text: string[] = [];
-  for (const globalTrackIndex of urlStateReducers.getGlobalTrackOrder(state)) {
+  for (const globalTrackIndex of selectors.getGlobalTrackOrder(state)) {
     const globalTrack = globalTracks[globalTrackIndex];
     const globalHiddenText = hiddenGlobalTracks.has(globalTrackIndex)
       ? 'hide'
@@ -70,26 +69,20 @@ export function getHumanReadableTracks(state: State): string[] {
     }
 
     if (globalTrack.type === 'process') {
-      const trackOrder = urlStateReducers.getLocalTrackOrder(
-        state,
-        globalTrack.pid
-      );
-      const tracks = profileViewSelectors.getLocalTracks(
-        state,
-        globalTrack.pid
-      );
+      const trackOrder = selectors.getLocalTrackOrder(state, globalTrack.pid);
+      const tracks = selectors.getLocalTracks(state, globalTrack.pid);
 
       for (const trackIndex of trackOrder) {
         const track = tracks[trackIndex];
         let trackName;
         if (track.type === 'memory') {
-          trackName = profileViewSelectors
+          trackName = selectors
             .getCounterSelectors(track.counterIndex)
             .getPid(state);
         } else {
           trackName = threads[track.threadIndex].name;
         }
-        const hiddenTracks = urlStateReducers.getHiddenLocalTracks(
+        const hiddenTracks = selectors.getHiddenLocalTracks(
           state,
           globalTrack.pid
         );
@@ -170,7 +163,7 @@ export function getStoreWithMemoryTrack(pid: number = 222): * {
   }
 
   const store = storeWithProfile(profile);
-  const localTrack = profileViewSelectors.getLocalTrackFromReference(
+  const localTrack = selectors.getLocalTrackFromReference(
     store.getState(),
     trackReference
   );

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import {
   getProfileFromTextSamples,
   getCounterForThread,

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1427,7 +1427,7 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile matches the last stored run of selectedNodeSelectors.getTimingsForSidebar 1`] = `
+exports[`snapshots of selectors/profile matches the last stored run of selectedNode.getTimingsForSidebar 1`] = `
 Object {
   "forFunc": Object {
     "selfTime": Object {

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1427,138 +1427,6 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile matches the last stored run of selectedNode.getTimingsForSidebar 1`] = `
-Object {
-  "forFunc": Object {
-    "selfTime": Object {
-      "breakdownByCategory": null,
-      "breakdownByImplementation": null,
-      "value": 0,
-    },
-    "totalTime": Object {
-      "breakdownByCategory": Array [
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 2,
-          "subcategoryBreakdown": Array [
-            2,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-      ],
-      "breakdownByImplementation": Object {
-        "native": 2,
-      },
-      "value": 2,
-    },
-  },
-  "forPath": Object {
-    "selfTime": Object {
-      "breakdownByCategory": null,
-      "breakdownByImplementation": null,
-      "value": 0,
-    },
-    "totalTime": Object {
-      "breakdownByCategory": Array [
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 2,
-          "subcategoryBreakdown": Array [
-            2,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-      ],
-      "breakdownByImplementation": Object {
-        "native": 2,
-      },
-      "value": 2,
-    },
-  },
-  "rootTime": 2,
-}
-`;
-
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getCallNodeInfo 1`] = `
 Object {
   "callNodeTable": Object {
@@ -3270,5 +3138,137 @@ Object {
     1,
   ],
   "selectedMarker": 1,
+}
+`;
+
+exports[`snapshots of selectors/profile matches the last stored run of selectors.selectedNode.getTimingsForSidebar 1`] = `
+Object {
+  "forFunc": Object {
+    "selfTime": Object {
+      "breakdownByCategory": null,
+      "breakdownByImplementation": null,
+      "value": 0,
+    },
+    "totalTime": Object {
+      "breakdownByCategory": Array [
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 2,
+          "subcategoryBreakdown": Array [
+            2,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+      ],
+      "breakdownByImplementation": Object {
+        "native": 2,
+      },
+      "value": 2,
+    },
+  },
+  "forPath": Object {
+    "selfTime": Object {
+      "breakdownByCategory": null,
+      "breakdownByImplementation": null,
+      "value": 0,
+    },
+    "totalTime": Object {
+      "breakdownByCategory": Array [
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 2,
+          "subcategoryBreakdown": Array [
+            2,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
+          ],
+        },
+      ],
+      "breakdownByImplementation": Object {
+        "native": 2,
+      },
+      "value": 2,
+    },
+  },
+  "rootTime": 2,
 }
 `;

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -4,8 +4,8 @@
 // @flow
 
 import { storeWithProfile } from '../fixtures/stores';
-import * as ProfileViewSelectors from '../../selectors/profile';
-import * as UrlStateSelectors from '../../selectors/url-state';
+import * as ProfileViewSelectors from 'selectors/profile';
+import * as UrlStateSelectors from 'selectors/url-state';
 
 import {
   changeCallTreeSearchString,
@@ -17,7 +17,7 @@ import {
   changeShowUserTimings,
 } from '../../actions/profile-view';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 describe('selectors/getStackTimingByDepth', function() {
   /**

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -4,8 +4,7 @@
 // @flow
 
 import { storeWithProfile } from '../fixtures/stores';
-import * as ProfileViewSelectors from 'selectors/profile';
-import * as UrlStateSelectors from 'selectors/url-state';
+import * as selectors from 'selectors';
 
 import {
   changeCallTreeSearchString,
@@ -17,7 +16,6 @@ import {
   changeShowUserTimings,
 } from '../../actions/profile-view';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
 
 describe('selectors/getStackTimingByDepth', function() {
   /**
@@ -38,7 +36,7 @@ describe('selectors/getStackTimingByDepth', function() {
 
   it('computes unfiltered stack timing by depth', function() {
     const store = storeWithProfile();
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(
+    const stackTimingByDepth = selectors.selectedThread.getStackTimingByDepth(
       store.getState()
     );
     expect(stackTimingByDepth).toEqual([
@@ -60,7 +58,7 @@ describe('selectors/getStackTimingByDepth', function() {
   it('uses search strings', function() {
     const store = storeWithProfile();
     store.dispatch(changeCallTreeSearchString('javascript'));
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(
+    const stackTimingByDepth = selectors.selectedThread.getStackTimingByDepth(
       store.getState()
     );
     expect(stackTimingByDepth).toEqual([
@@ -93,7 +91,7 @@ describe('selectors/getStackTimingByDepth', function() {
   it('can handle inverted stacks', function() {
     const store = storeWithProfile();
     store.dispatch(changeInvertCallstack(true));
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(
+    const stackTimingByDepth = selectors.selectedThread.getStackTimingByDepth(
       store.getState()
     );
     expect(stackTimingByDepth).toEqual([
@@ -136,10 +134,10 @@ describe('selectors/getFlameGraphTiming', function() {
    * "FunctionName1 (StartTime:EndTime) | FunctionName2 (StartTime:EndTime)"
    */
   function getHumanReadableFlameGraphRanges(store, funcNames) {
-    const { callNodeTable } = selectedThreadSelectors.getCallNodeInfo(
+    const { callNodeTable } = selectors.selectedThread.getCallNodeInfo(
       store.getState()
     );
-    const flameGraphTiming = selectedThreadSelectors.getFlameGraphTiming(
+    const flameGraphTiming = selectors.selectedThread.getFlameGraphTiming(
       store.getState()
     );
 
@@ -166,10 +164,10 @@ describe('selectors/getFlameGraphTiming', function() {
    * "FunctionName1 (SelfTimeRelative) | ..."
    */
   function getHumanReadableFlameGraphTimings(store, funcNames) {
-    const { callNodeTable } = selectedThreadSelectors.getCallNodeInfo(
+    const { callNodeTable } = selectors.selectedThread.getCallNodeInfo(
       store.getState()
     );
-    const flameGraphTiming = selectedThreadSelectors.getFlameGraphTiming(
+    const flameGraphTiming = selectors.selectedThread.getFlameGraphTiming(
       store.getState()
     );
 
@@ -279,7 +277,7 @@ describe('selectors/getCallNodeMaxDepthForFlameGraph', function() {
     `);
 
     const store = storeWithProfile(profile);
-    const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+    const allSamplesMaxDepth = selectors.selectedThread.getCallNodeMaxDepthForFlameGraph(
       store.getState()
     );
     expect(allSamplesMaxDepth).toEqual(4);
@@ -288,7 +286,7 @@ describe('selectors/getCallNodeMaxDepthForFlameGraph', function() {
   it('returns zero if there are no samples', function() {
     const { profile } = getProfileFromTextSamples(` `);
     const store = storeWithProfile(profile);
-    const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+    const allSamplesMaxDepth = selectors.selectedThread.getCallNodeMaxDepthForFlameGraph(
       store.getState()
     );
     expect(allSamplesMaxDepth).toEqual(0);
@@ -299,13 +297,13 @@ describe('actions/changeImplementationFilter', function() {
   const store = storeWithProfile();
 
   it('is initially set to filter to all', function() {
-    const filter = UrlStateSelectors.getImplementationFilter(store.getState());
+    const filter = selectors.getImplementationFilter(store.getState());
     expect(filter).toEqual('combined');
   });
 
   it('can be changed to cpp', function() {
     store.dispatch(changeImplementationFilter('cpp'));
-    const filter = UrlStateSelectors.getImplementationFilter(store.getState());
+    const filter = selectors.getImplementationFilter(store.getState());
     expect(filter).toEqual('cpp');
   });
 });
@@ -314,9 +312,7 @@ describe('actions/updatePreviewSelection', function() {
   it('can update the selection with new values', function() {
     const store = storeWithProfile();
 
-    const initialSelection = ProfileViewSelectors.getPreviewSelection(
-      store.getState()
-    );
+    const initialSelection = selectors.getPreviewSelection(store.getState());
     expect(initialSelection).toEqual({
       hasSelection: false,
       isModifying: false,
@@ -331,9 +327,7 @@ describe('actions/updatePreviewSelection', function() {
       })
     );
 
-    const secondSelection = ProfileViewSelectors.getPreviewSelection(
-      store.getState()
-    );
+    const secondSelection = selectors.getPreviewSelection(store.getState());
     expect(secondSelection).toEqual({
       hasSelection: true,
       isModifying: false,
@@ -366,11 +360,11 @@ describe('actions/changeInvertCallstack', function() {
   // Make tests more readable by grabbing the relevant paths, and transforming
   // them to their function names, rather than indexes.
   const getPaths = state => ({
-    selectedCallNodePath: selectedThreadSelectors
+    selectedCallNodePath: selectors.selectedThread
       .getSelectedCallNodePath(state)
       .map(index => funcNames[index]),
     expandedCallNodePaths: Array.from(
-      selectedThreadSelectors.getExpandedCallNodePaths(state)
+      selectors.selectedThread.getExpandedCallNodePaths(state)
     ).map(path => path.map(index => funcNames[index])),
   });
 
@@ -443,9 +437,9 @@ describe('actions/changeShowJsTracerSummary', function() {
   it('can change the view to show a summary', function() {
     const { profile } = getProfileFromTextSamples(`A`);
     const { dispatch, getState } = storeWithProfile(profile);
-    expect(UrlStateSelectors.getShowJsTracerSummary(getState())).toBe(false);
+    expect(selectors.getShowJsTracerSummary(getState())).toBe(false);
     dispatch(changeShowJsTracerSummary(true));
-    expect(UrlStateSelectors.getShowJsTracerSummary(getState())).toBe(true);
+    expect(selectors.getShowJsTracerSummary(getState())).toBe(true);
   });
 });
 
@@ -453,8 +447,8 @@ describe('actions/changeShowUserTimings', function() {
   it('can change the view to show a summary', function() {
     const { profile } = getProfileFromTextSamples(`A`);
     const { dispatch, getState } = storeWithProfile(profile);
-    expect(UrlStateSelectors.getShowUserTimings(getState())).toBe(false);
+    expect(selectors.getShowUserTimings(getState())).toBe(false);
     dispatch(changeShowUserTimings(true));
-    expect(UrlStateSelectors.getShowUserTimings(getState())).toBe(true);
+    expect(selectors.getShowUserTimings(getState())).toBe(true);
   });
 });

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -4,7 +4,7 @@
 // @flow
 
 import { storeWithProfile } from '../fixtures/stores';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 
 import {
   changeCallTreeSearchString,

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -4,8 +4,7 @@
 // @flow
 
 import { storeWithSimpleProfile, storeWithProfile } from '../fixtures/stores';
-import * as UrlStateSelectors from 'selectors/url-state';
-import * as AppSelectors from 'selectors/app';
+import * as selectors from 'selectors';
 import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { isolateProcess } from '../../actions/profile-view';
@@ -17,11 +16,9 @@ describe('app actions', function() {
   describe('changeSelectedTab', function() {
     it('can change tabs', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
-      expect(UrlStateSelectors.getSelectedTab(getState())).toEqual('calltree');
+      expect(selectors.getSelectedTab(getState())).toEqual('calltree');
       dispatch(AppActions.changeSelectedTab('stack-chart'));
-      expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-        'stack-chart'
-      );
+      expect(selectors.getSelectedTab(getState())).toEqual('stack-chart');
     });
 
     it('records an analytics event when changing tabs', function() {
@@ -44,9 +41,9 @@ describe('app actions', function() {
   describe('urlSetupDone', function() {
     it('will remember when url setup is done', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
-      expect(AppSelectors.getUrlSetupPhase(getState())).toEqual('initial-load');
+      expect(selectors.getUrlSetupPhase(getState())).toEqual('initial-load');
       dispatch(AppActions.urlSetupDone());
-      expect(AppSelectors.getUrlSetupPhase(getState())).toEqual('done');
+      expect(selectors.getUrlSetupPhase(getState())).toEqual('done');
     });
 
     it('records analytics events for pageview and datasource', function() {
@@ -77,11 +74,11 @@ describe('app actions', function() {
   describe('show404', function() {
     it('tracks when the route is not found', function() {
       const { dispatch, getState } = createStore();
-      expect(AppSelectors.getView(getState())).toEqual({
+      expect(selectors.getView(getState())).toEqual({
         phase: 'INITIALIZING',
       });
       dispatch(AppActions.show404('http://foobar.com'));
-      expect(AppSelectors.getView(getState())).toEqual({
+      expect(selectors.getView(getState())).toEqual({
         phase: 'ROUTE_NOT_FOUND',
       });
     });
@@ -90,15 +87,15 @@ describe('app actions', function() {
   describe('isSidebarOpen', function() {
     it('can change the state of the sidebar', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
-      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+      expect(selectors.getIsSidebarOpen(getState())).toEqual(false);
       dispatch(AppActions.changeSidebarOpenState('calltree', true));
-      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+      expect(selectors.getIsSidebarOpen(getState())).toEqual(true);
       dispatch(AppActions.changeSelectedTab('flame-graph'));
-      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+      expect(selectors.getIsSidebarOpen(getState())).toEqual(false);
       dispatch(AppActions.changeSidebarOpenState('flame-graph', true));
-      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+      expect(selectors.getIsSidebarOpen(getState())).toEqual(true);
       dispatch(AppActions.changeSidebarOpenState('calltree', false));
-      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+      expect(selectors.getIsSidebarOpen(getState())).toEqual(true);
     });
   });
 
@@ -107,49 +104,45 @@ describe('app actions', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
 
       // The URL state starts out on the calltree tab.
-      const originalUrlState = UrlStateSelectors.getUrlState(getState());
-      expect(UrlStateSelectors.getSelectedTab(getState())).toEqual('calltree');
+      const originalUrlState = selectors.getUrlState(getState());
+      expect(selectors.getSelectedTab(getState())).toEqual('calltree');
 
       // Change it, and make sure the URL state updates.
       dispatch(AppActions.changeSelectedTab('stack-chart'));
-      expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-        'stack-chart'
-      );
-      expect(UrlStateSelectors.getUrlState(getState())).not.toBe(
-        originalUrlState
-      );
+      expect(selectors.getSelectedTab(getState())).toEqual('stack-chart');
+      expect(selectors.getUrlState(getState())).not.toBe(originalUrlState);
 
       // Now revert it to the original, and make sure everything resets.
       dispatch(AppActions.updateUrlState(originalUrlState));
-      expect(UrlStateSelectors.getUrlState(getState())).toBe(originalUrlState);
-      expect(UrlStateSelectors.getSelectedTab(getState())).toEqual('calltree');
+      expect(selectors.getUrlState(getState())).toBe(originalUrlState);
+      expect(selectors.getSelectedTab(getState())).toEqual('calltree');
     });
   });
 
   describe('panelLayoutGeneration', function() {
     it('can be manually updated using an action', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(0);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(0);
       dispatch(AppActions.invalidatePanelLayout());
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(1);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(1);
       dispatch(AppActions.invalidatePanelLayout());
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(2);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(2);
     });
 
     it('will be updated when working with the sidebar', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(0);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(0);
       dispatch(AppActions.changeSidebarOpenState('flame-graph', false));
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(1);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(1);
     });
 
     it('will be updated when working with the timeline', function() {
       const { dispatch, getState } = storeWithProfile(
         getProfileWithNiceTracks()
       );
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(0);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(0);
       dispatch(isolateProcess(0));
-      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(1);
+      expect(selectors.getPanelLayoutGeneration(getState())).toBe(1);
     });
   });
 });

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -4,7 +4,7 @@
 // @flow
 
 import { storeWithSimpleProfile, storeWithProfile } from '../fixtures/stores';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { isolateProcess } from '../../actions/profile-view';

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -4,8 +4,8 @@
 // @flow
 
 import { storeWithSimpleProfile, storeWithProfile } from '../fixtures/stores';
-import * as UrlStateSelectors from '../../selectors/url-state';
-import * as AppSelectors from '../../selectors/app';
+import * as UrlStateSelectors from 'selectors/url-state';
+import * as AppSelectors from 'selectors/app';
 import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { isolateProcess } from '../../actions/profile-view';

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -5,7 +5,7 @@
 
 import { createImageMock } from '../fixtures/mocks/image';
 import { blankStore } from '../fixtures/stores';
-import * as iconsAccessors from 'selectors';
+import * as iconsAccessors from 'firefox-profiler/selectors';
 import * as iconsActions from '../../actions/icons';
 import type { CallNodeDisplayData } from '../../types/profile-derived';
 

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -5,7 +5,7 @@
 
 import { createImageMock } from '../fixtures/mocks/image';
 import { blankStore } from '../fixtures/stores';
-import * as iconsAccessors from 'selectors/icons';
+import * as iconsAccessors from 'selectors';
 import * as iconsActions from '../../actions/icons';
 import type { CallNodeDisplayData } from '../../types/profile-derived';
 

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -5,7 +5,7 @@
 
 import { createImageMock } from '../fixtures/mocks/image';
 import { blankStore } from '../fixtures/stores';
-import * as iconsAccessors from '../../selectors/icons';
+import * as iconsAccessors from 'selectors/icons';
 import * as iconsActions from '../../actions/icons';
 import type { CallNodeDisplayData } from '../../types/profile-derived';
 

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { storeWithProfile } from '../fixtures/stores';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
 import {

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { storeWithProfile } from '../fixtures/stores';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
 import {

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { storeWithProfile } from '../fixtures/stores';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import { ensureExists } from '../../utils/flow';
 import { changeShowJsTracerSummary } from '../../actions/profile-view';
 import {
@@ -127,7 +127,7 @@ describe('convertJsTracerToThread', function() {
       convertJsTracerToThread(existingThread, jsTracer, categories),
     ];
     const { getState } = storeWithProfile(profile);
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       // This is the real timing:
@@ -180,9 +180,9 @@ describe('selectors/getJsTracerTiming', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { getState } = storeWithProfile(profile);
       expect(profile.threads[0].jsTracer).toBe(undefined);
-      expect(
-        selectedThreadSelectors.getExpensiveJsTracerTiming(getState())
-      ).toEqual(null);
+      expect(selectedThread.getExpensiveJsTracerTiming(getState())).toEqual(
+        null
+      );
     });
 
     it('has empty JS tracer timing if no events are in the js tracer table', function() {
@@ -442,8 +442,8 @@ function getHumanReadableJsTracerTiming({
   }
   const { dispatch, getState } = storeWithProfile(profile);
   const computeTiming = useSelfTime
-    ? selectedThreadSelectors.getExpensiveJsTracerLeafTiming
-    : selectedThreadSelectors.getExpensiveJsTracerTiming;
+    ? selectedThread.getExpensiveJsTracerLeafTiming
+    : selectedThread.getExpensiveJsTracerTiming;
   dispatch(changeShowJsTracerSummary(useSelfTime));
 
   return ensureExists(computeTiming(getState())).map(

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { storeWithProfile } from '../fixtures/stores';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import {
   getProfileWithMarkers,
   getNetworkTrackProfile,

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { storeWithProfile } from '../fixtures/stores';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import {
   getProfileWithMarkers,
   getNetworkTrackProfile,
@@ -13,7 +13,7 @@ describe('selectors/getMarkerChartTimingAndBuckets', function() {
   function getMarkerChartTimingAndBuckets(testMarkers) {
     const profile = getProfileWithMarkers(testMarkers);
     const { getState } = storeWithProfile(profile);
-    return selectedThreadSelectors.getMarkerChartTimingAndBuckets(getState());
+    return selectedThread.getMarkerChartTimingAndBuckets(getState());
   }
 
   it('has no marker timing if no markers are present', function() {
@@ -146,7 +146,7 @@ describe('getProcessedRawMarkerTable', function() {
   function setup(testMarkers) {
     const profile = getProfileWithMarkers(testMarkers);
     const { getState } = storeWithProfile(profile);
-    return selectedThreadSelectors.getProcessedRawMarkerTable(getState());
+    return selectedThread.getProcessedRawMarkerTable(getState());
   }
 
   it('can process Invalidation markers', function() {
@@ -247,13 +247,11 @@ describe('getProcessedRawMarkerTable', function() {
 describe('getTimelineVerticalMarkers', function() {
   it('gets the appropriate markers', function() {
     const { getState } = storeWithProfile(getNetworkTrackProfile());
-    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-    const markerIndexes = selectedThreadSelectors.getTimelineVerticalMarkerIndexes(
+    const getMarker = selectedThread.getMarkerGetter(getState());
+    const markerIndexes = selectedThread.getTimelineVerticalMarkerIndexes(
       getState()
     );
-    const allMarkers = selectedThreadSelectors.getFullMarkerListIndexes(
-      getState()
-    );
+    const allMarkers = selectedThread.getFullMarkerListIndexes(getState());
 
     expect(allMarkers.length).toBeGreaterThan(markerIndexes.length);
     expect(markerIndexes).toHaveLength(5);
@@ -303,10 +301,8 @@ describe('memory markers', function() {
 
   it('can get memory markers using getMemoryMarkers', function() {
     const { getState } = setup();
-    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-    const markerIndexes = selectedThreadSelectors.getMemoryMarkerIndexes(
-      getState()
-    );
+    const getMarker = selectedThread.getMarkerGetter(getState());
+    const markerIndexes = selectedThread.getMemoryMarkerIndexes(getState());
     expect(
       markerIndexes.map(markerIndex => getMarker(markerIndex).name)
     ).toEqual(['IdleForgetSkippable', 'GCMinor', 'GCMajor', 'GCSlice']);
@@ -314,8 +310,8 @@ describe('memory markers', function() {
 
   it('ignores memory markers in getCommittedRangeFilteredMarkersForHeader', function() {
     const { getState } = setup();
-    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-    const markerIndexes = selectedThreadSelectors.getCommittedRangeFilteredMarkerIndexesForHeader(
+    const getMarker = selectedThread.getMarkerGetter(getState());
+    const markerIndexes = selectedThread.getCommittedRangeFilteredMarkerIndexesForHeader(
       getState()
     );
     expect(

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { storeWithProfile } from '../fixtures/stores';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import {
   getProfileWithMarkers,
   getNetworkTrackProfile,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -30,7 +30,7 @@ import { assertSetContainsOnly } from '../fixtures/custom-assertions';
 import * as App from '../../actions/app';
 import * as ProfileView from '../../actions/profile-view';
 import { viewProfile } from '../../actions/receive-profile';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import { ensureExists } from '../../utils/flow';
 

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -30,14 +30,8 @@ import { assertSetContainsOnly } from '../fixtures/custom-assertions';
 import * as App from '../../actions/app';
 import * as ProfileView from '../../actions/profile-view';
 import { viewProfile } from '../../actions/receive-profile';
-import * as ProfileViewSelectors from 'selectors/profile';
-import * as UrlStateSelectors from 'selectors/url-state';
+import * as selectors from 'selectors';
 import { stateFromLocation } from '../../app-logic/url-handling';
-import {
-  selectedThreadSelectors,
-  selectedNodeSelectors,
-  getThreadSelectors,
-} from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
 import type { Milliseconds } from '../../types/units';
@@ -65,12 +59,12 @@ describe('call node paths on implementation filter change', function() {
   it('starts with combined CallNodePaths', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(ProfileView.changeSelectedCallNode(threadIndex, [A, B, C, D, E]));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, B, C, D, E]
-    );
+    expect(
+      selectors.selectedThread.getSelectedCallNodePath(getState())
+    ).toEqual([A, B, C, D, E]);
 
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectors.selectedThread.getExpandedCallNodePaths(getState()),
       [
         // Paths
         [A],
@@ -85,12 +79,12 @@ describe('call node paths on implementation filter change', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(ProfileView.changeImplementationFilter('js'));
     dispatch(ProfileView.changeSelectedCallNode(threadIndex, [B, D, E]));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [B, D, E]
-    );
+    expect(
+      selectors.selectedThread.getSelectedCallNodePath(getState())
+    ).toEqual([B, D, E]);
 
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectors.selectedThread.getExpandedCallNodePaths(getState()),
       [
         // Paths
         [B],
@@ -103,12 +97,12 @@ describe('call node paths on implementation filter change', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(ProfileView.changeSelectedCallNode(threadIndex, [A, B, C, D, E]));
     dispatch(ProfileView.changeImplementationFilter('js'));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [B, D, E]
-    );
+    expect(
+      selectors.selectedThread.getSelectedCallNodePath(getState())
+    ).toEqual([B, D, E]);
 
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectors.selectedThread.getExpandedCallNodePaths(getState()),
       [
         // Paths
         [B],
@@ -122,12 +116,12 @@ describe('call node paths on implementation filter change', function() {
     dispatch(ProfileView.changeImplementationFilter('js'));
     dispatch(ProfileView.changeSelectedCallNode(threadIndex, [B, D, E]));
     dispatch(ProfileView.changeImplementationFilter('combined'));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, B, C, D, E]
-    );
+    expect(
+      selectors.selectedThread.getSelectedCallNodePath(getState())
+    ).toEqual([A, B, C, D, E]);
 
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectors.selectedThread.getExpandedCallNodePaths(getState()),
       [
         // Paths
         [A],
@@ -143,11 +137,11 @@ describe('call node paths on implementation filter change', function() {
     dispatch(ProfileView.changeImplementationFilter('js'));
     dispatch(ProfileView.changeSelectedCallNode(threadIndex, [B, D, E]));
     dispatch(ProfileView.changeImplementationFilter('cpp'));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, C]
-    );
+    expect(
+      selectors.selectedThread.getSelectedCallNodePath(getState())
+    ).toEqual([A, C]);
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectors.selectedThread.getExpandedCallNodePaths(getState()),
       [
         // Paths
         [A],
@@ -166,8 +160,8 @@ describe('getJankMarkersForHeader', function() {
     delete profile.threads[0].samples.eventDelay;
     profile.threads[0].samples.responsiveness = responsiveness;
     const { getState } = storeWithProfile(profile);
-    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-    return selectedThreadSelectors
+    const getMarker = selectors.selectedThread.getMarkerGetter(getState());
+    return selectors.selectedThread
       .getJankMarkerIndexesForHeader(getState())
       .map(getMarker);
   }
@@ -181,8 +175,8 @@ describe('getJankMarkersForHeader', function() {
     delete profile.threads[0].samples.eventDelay;
     profile.threads[0].samples.eventDelay = eventDelay;
     const { getState } = storeWithProfile(profile);
-    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-    return selectedThreadSelectors
+    const getMarker = selectors.selectedThread.getMarkerGetter(getState());
+    return selectors.selectedThread
       .getJankMarkerIndexesForHeader(getState())
       .map(getMarker);
   }
@@ -266,11 +260,11 @@ describe('actions/ProfileView', function() {
       const { dispatch, getState } = storeWithProfile(profile);
 
       expect(
-        selectedThreadSelectors.getSelectedCallNodePath(getState())
+        selectors.selectedThread.getSelectedCallNodePath(getState())
       ).toEqual([]);
       dispatch(ProfileView.changeSelectedCallNode(0, [0, 1]));
       expect(
-        selectedThreadSelectors.getSelectedCallNodePath(getState())
+        selectors.selectedThread.getSelectedCallNodePath(getState())
       ).toEqual([0, 1]);
     });
   });
@@ -280,9 +274,9 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A', 'B');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
+      expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
       dispatch(ProfileView.changeSelectedThread(1));
-      expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(1);
+      expect(selectors.getSelectedThreadIndex(getState())).toEqual(1);
     });
   });
 
@@ -319,15 +313,15 @@ describe('actions/ProfileView', function() {
 
     function setup(tabSlug: TabSlug = 'calltree') {
       const { profile, dispatch, getState } = storeWithTab(tabSlug);
-      const parentTrack = ProfileViewSelectors.getGlobalTrackFromReference(
+      const parentTrack = selectors.getGlobalTrackFromReference(
         getState(),
         parentTrackReference
       );
-      const tabTrack = ProfileViewSelectors.getGlobalTrackFromReference(
+      const tabTrack = selectors.getGlobalTrackFromReference(
         getState(),
         tabTrackReference
       );
-      const workerTrack = ProfileViewSelectors.getLocalTrackFromReference(
+      const workerTrack = selectors.getLocalTrackFromReference(
         getState(),
         workerTrackReference
       );
@@ -350,7 +344,7 @@ describe('actions/ProfileView', function() {
     describe('with a thread tracks', function() {
       it('starts out with the tab thread selected', function() {
         const { getState, tabTrack } = setup();
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(
           tabTrack.mainThreadIndex
         );
       });
@@ -358,7 +352,7 @@ describe('actions/ProfileView', function() {
       it('can switch to another global track', function() {
         const { getState, dispatch, parentTrack } = setup();
         dispatch(ProfileView.selectTrack(parentTrackReference));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(
           parentTrack.mainThreadIndex
         );
       });
@@ -366,7 +360,7 @@ describe('actions/ProfileView', function() {
       it('can switch to a local track', function() {
         const { getState, dispatch, workerTrack } = setup();
         dispatch(ProfileView.selectTrack(workerTrackReference));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(
           workerTrack.threadIndex
         );
       });
@@ -386,38 +380,28 @@ describe('actions/ProfileView', function() {
       it('it starts out with the thread track and call tree selected', function() {
         const profile = getNetworkTrackProfile();
         const { getState } = storeWithProfile(profile);
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedTab(getState())).toEqual('calltree');
       });
       it('it can switch to the network track, which selects the network chart tab', function() {
         const profile = getNetworkTrackProfile();
         const { dispatch, getState } = storeWithProfile(profile);
         dispatch(ProfileView.selectTrack(networkTrack));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'network-chart'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedTab(getState())).toEqual('network-chart');
       });
       it('it can switch back to the thread, which remembers the last viewed panel', function() {
         const profile = getNetworkTrackProfile();
         const { dispatch, getState } = storeWithProfile(profile);
         dispatch(App.changeSelectedTab('flame-graph'));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'flame-graph'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedTab(getState())).toEqual('flame-graph');
         dispatch(ProfileView.selectTrack(networkTrack));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'network-chart'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedTab(getState())).toEqual('network-chart');
         dispatch(ProfileView.selectTrack(threadTrack));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'flame-graph'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedTab(getState())).toEqual('flame-graph');
       });
     });
 
@@ -447,7 +431,7 @@ describe('actions/ProfileView', function() {
 
         {
           // Verify the memory track reference is correct.
-          const memoryTrack = ProfileViewSelectors.getLocalTrackFromReference(
+          const memoryTrack = selectors.getLocalTrackFromReference(
             store.getState(),
             memoryTrackReference
           );
@@ -461,20 +445,16 @@ describe('actions/ProfileView', function() {
 
       it('changes the thread index when selected', function() {
         const { getState, dispatch } = setup();
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(1);
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(1);
         dispatch(ProfileView.selectTrack(memoryTrackReference));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
       });
 
       it('does not change the tab when selected', function() {
         const { getState, dispatch } = setup();
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
-        );
+        expect(selectors.getSelectedTab(getState())).toEqual('calltree');
         dispatch(ProfileView.selectTrack(memoryTrackReference));
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
-        );
+        expect(selectors.getSelectedTab(getState())).toEqual('calltree');
       });
     });
 
@@ -492,16 +472,12 @@ describe('actions/ProfileView', function() {
         const { getState, dispatch } = storeWithProfile(profile);
 
         dispatch(App.changeSelectedTab('flame-graph'));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(0);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'flame-graph'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(0);
+        expect(selectors.getSelectedTab(getState())).toEqual('flame-graph');
 
         dispatch(ProfileView.selectTrack(diffingTrackReference));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(2);
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
-        );
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(2);
+        expect(selectors.getSelectedTab(getState())).toEqual('calltree');
       });
     });
 
@@ -554,7 +530,7 @@ describe('actions/ProfileView', function() {
           ProfileView.changeCallTreeSummaryStrategy('native-allocations')
         );
         expect(
-          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+          selectors.selectedThread.getCallTreeSummaryStrategy(getState())
         ).toEqual('native-allocations');
 
         // Switch to a thread without native allocations.
@@ -562,7 +538,7 @@ describe('actions/ProfileView', function() {
 
         // Expect that it switches the summary strategy to one it supports.
         expect(
-          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+          selectors.selectedThread.getCallTreeSummaryStrategy(getState())
         ).toEqual('timing');
       });
 
@@ -574,7 +550,7 @@ describe('actions/ProfileView', function() {
         dispatch(ProfileView.selectTrack(jsAllocationsThread));
         dispatch(ProfileView.changeCallTreeSummaryStrategy('js-allocations'));
         expect(
-          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+          selectors.selectedThread.getCallTreeSummaryStrategy(getState())
         ).toEqual('js-allocations');
 
         // Switch to a thread without js allocations.
@@ -582,7 +558,7 @@ describe('actions/ProfileView', function() {
 
         // Expect that it switches the summary strategy to one it supports.
         expect(
-          selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
+          selectors.selectedThread.getCallTreeSummaryStrategy(getState())
         ).toEqual('timing');
       });
     });
@@ -590,30 +566,22 @@ describe('actions/ProfileView', function() {
     describe('when the loaded panel is not the call tree', function() {
       it('stays in the same panel when selecting another track', function() {
         const { getState, dispatch, parentTrack } = setup('marker-chart');
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'marker-chart'
-        );
+        expect(selectors.getSelectedTab(getState())).toEqual('marker-chart');
         dispatch(ProfileView.selectTrack(parentTrackReference));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(
           parentTrack.mainThreadIndex
         );
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'marker-chart'
-        );
+        expect(selectors.getSelectedTab(getState())).toEqual('marker-chart');
       });
 
       it('moves to the call tree when then initial tab is the network chart', function() {
         const { getState, dispatch, parentTrack } = setup('network-chart');
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'network-chart'
-        );
+        expect(selectors.getSelectedTab(getState())).toEqual('network-chart');
         dispatch(ProfileView.selectTrack(parentTrackReference));
-        expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+        expect(selectors.getSelectedThreadIndex(getState())).toEqual(
           parentTrack.mainThreadIndex
         );
-        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
-        );
+        expect(selectors.getSelectedTab(getState())).toEqual('calltree');
       });
     });
   });
@@ -623,13 +591,9 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(
-        ProfileViewSelectors.getFocusCallTreeGeneration(getState())
-      ).toEqual(0);
+      expect(selectors.getFocusCallTreeGeneration(getState())).toEqual(0);
       dispatch(ProfileView.focusCallTree());
-      expect(
-        ProfileViewSelectors.getFocusCallTreeGeneration(getState())
-      ).toEqual(1);
+      expect(selectors.getFocusCallTreeGeneration(getState())).toEqual(1);
     });
   });
 
@@ -638,13 +602,11 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A', 'B');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(ProfileViewSelectors.getRightClickedTrack(getState())).toEqual(
-        null
-      );
+      expect(selectors.getRightClickedTrack(getState())).toEqual(null);
       dispatch(
         ProfileView.changeRightClickedTrack({ trackIndex: 1, type: 'global' })
       );
-      expect(ProfileViewSelectors.getRightClickedTrack(getState())).toEqual({
+      expect(selectors.getRightClickedTrack(getState())).toEqual({
         trackIndex: 1,
         type: 'global',
       });
@@ -657,13 +619,9 @@ describe('actions/ProfileView', function() {
       const { dispatch, getState } = storeWithProfile(profile);
 
       withAnalyticsMock(() => {
-        expect(UrlStateSelectors.getCurrentSearchString(getState())).toEqual(
-          ''
-        );
+        expect(selectors.getCurrentSearchString(getState())).toEqual('');
         dispatch(ProfileView.changeCallTreeSearchString('foobar'));
-        expect(UrlStateSelectors.getCurrentSearchString(getState())).toEqual(
-          'foobar'
-        );
+        expect(selectors.getCurrentSearchString(getState())).toEqual('foobar');
 
         expect(self.ga).toBeCalledWith('send', {
           eventAction: 'call tree search string',
@@ -700,11 +658,13 @@ describe('actions/ProfileView', function() {
 
     it('expands whole tree from root', function() {
       const { getState, dispatch, threadIndex, A, B, C, D, E } = setupStore();
-      const callNodeInfo = selectedThreadSelectors.getCallNodeInfo(getState());
+      const callNodeInfo = selectors.selectedThread.getCallNodeInfo(getState());
 
       // Before expand all action is dispatched, nothing is expanded
       expect(
-        Array.from(selectedThreadSelectors.getExpandedCallNodePaths(getState()))
+        Array.from(
+          selectors.selectedThread.getExpandedCallNodePaths(getState())
+        )
       ).toEqual([]);
 
       dispatch(
@@ -716,7 +676,7 @@ describe('actions/ProfileView', function() {
       );
 
       assertSetContainsOnly(
-        selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+        selectors.selectedThread.getExpandedCallNodePaths(getState()),
         [
           // Paths
           [A],
@@ -734,11 +694,11 @@ describe('actions/ProfileView', function() {
       // First expand A by selecting B
       dispatch(ProfileView.changeSelectedCallNode(threadIndex, [A, B]));
 
-      const callNodeInfo = selectedThreadSelectors.getCallNodeInfo(getState());
+      const callNodeInfo = selectors.selectedThread.getCallNodeInfo(getState());
 
       // Before expand all action is dispatched, only A is expanded
       assertSetContainsOnly(
-        selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+        selectors.selectedThread.getExpandedCallNodePaths(getState()),
         [
           // Paths
           [A],
@@ -754,7 +714,7 @@ describe('actions/ProfileView', function() {
       );
 
       assertSetContainsOnly(
-        selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+        selectors.selectedThread.getExpandedCallNodePaths(getState()),
         [
           // Paths
           [A],
@@ -777,11 +737,13 @@ describe('actions/ProfileView', function() {
       const { dispatch, getState } = storeWithProfile(profile);
 
       expect(
-        Array.from(selectedThreadSelectors.getExpandedCallNodePaths(getState()))
+        Array.from(
+          selectors.selectedThread.getExpandedCallNodePaths(getState())
+        )
       ).toEqual([]);
       dispatch(ProfileView.changeExpandedCallNodes(0, [[0], [0, 1]]));
       assertSetContainsOnly(
-        selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+        selectors.selectedThread.getExpandedCallNodePaths(getState()),
         [[0], [0, 1]]
       );
     });
@@ -793,11 +755,11 @@ describe('actions/ProfileView', function() {
       const { dispatch, getState } = storeWithProfile(profile);
 
       expect(
-        selectedThreadSelectors.getViewOptions(getState()).selectedMarker
+        selectors.selectedThread.getViewOptions(getState()).selectedMarker
       ).toEqual(null);
       dispatch(ProfileView.changeSelectedMarker(0, 0));
       expect(
-        selectedThreadSelectors.getViewOptions(getState()).selectedMarker
+        selectors.selectedThread.getViewOptions(getState()).selectedMarker
       ).toEqual(0);
     });
   });
@@ -807,9 +769,9 @@ describe('actions/ProfileView', function() {
       const profile = getProfileWithMarkers([['a', 0, null], ['b', 1, null]]);
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getMarkersSearchString(getState())).toEqual('');
+      expect(selectors.getMarkersSearchString(getState())).toEqual('');
       dispatch(ProfileView.changeMarkersSearchString('a'));
-      expect(UrlStateSelectors.getMarkersSearchString(getState())).toEqual('a');
+      expect(selectors.getMarkersSearchString(getState())).toEqual('a');
     });
 
     it('filters the markers', function() {
@@ -821,12 +783,12 @@ describe('actions/ProfileView', function() {
       const { dispatch, getState } = storeWithProfile(profile);
 
       expect(
-        selectedThreadSelectors.getSearchFilteredMarkerIndexes(getState())
+        selectors.selectedThread.getSearchFilteredMarkerIndexes(getState())
       ).toHaveLength(3);
       dispatch(ProfileView.changeMarkersSearchString('A, b'));
 
-      const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-      const markerIndexes = selectedThreadSelectors.getSearchFilteredMarkerIndexes(
+      const getMarker = selectors.selectedThread.getMarkerGetter(getState());
+      const markerIndexes = selectors.selectedThread.getSearchFilteredMarkerIndexes(
         getState()
       );
       expect(markerIndexes).toHaveLength(2);
@@ -840,9 +802,9 @@ describe('actions/ProfileView', function() {
       const profile = getNetworkTrackProfile();
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getNetworkSearchString(getState())).toEqual('');
+      expect(selectors.getNetworkSearchString(getState())).toEqual('');
       dispatch(ProfileView.changeNetworkSearchString('a'));
-      expect(UrlStateSelectors.getNetworkSearchString(getState())).toEqual('a');
+      expect(selectors.getNetworkSearchString(getState())).toEqual('a');
     });
 
     it('filters the network markers', function() {
@@ -851,14 +813,14 @@ describe('actions/ProfileView', function() {
       const networkSearchString = '3';
 
       expect(
-        selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+        selectors.selectedThread.getSearchFilteredNetworkMarkerIndexes(
           getState()
         )
       ).toHaveLength(10);
       dispatch(ProfileView.changeNetworkSearchString(networkSearchString));
 
-      const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-      const markerIndexes = selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+      const getMarker = selectors.selectedThread.getMarkerGetter(getState());
+      const markerIndexes = selectors.selectedThread.getSearchFilteredNetworkMarkerIndexes(
         getState()
       );
       expect(markerIndexes).toHaveLength(1);
@@ -873,14 +835,14 @@ describe('actions/ProfileView', function() {
       const networkSearchString = '3, 4';
 
       expect(
-        selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+        selectors.selectedThread.getSearchFilteredNetworkMarkerIndexes(
           getState()
         )
       ).toHaveLength(10);
       dispatch(ProfileView.changeNetworkSearchString(networkSearchString));
 
-      const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
-      const markerIndexes = selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+      const getMarker = selectors.selectedThread.getMarkerGetter(getState());
+      const markerIndexes = selectors.selectedThread.getSearchFilteredNetworkMarkerIndexes(
         getState()
       );
       expect(markerIndexes).toHaveLength(2);
@@ -894,9 +856,7 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getImplementationFilter(getState())).toEqual(
-        'combined'
-      );
+      expect(selectors.getImplementationFilter(getState())).toEqual('combined');
       withAnalyticsMock(() => {
         dispatch(ProfileView.changeImplementationFilter('js'));
         expect(self.ga).toBeCalledWith('send', {
@@ -906,9 +866,7 @@ describe('actions/ProfileView', function() {
           hitType: 'event',
         });
       });
-      expect(UrlStateSelectors.getImplementationFilter(getState())).toEqual(
-        'js'
-      );
+      expect(selectors.getImplementationFilter(getState())).toEqual('js');
     });
   });
 
@@ -917,7 +875,7 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(false);
+      expect(selectors.getInvertCallstack(getState())).toEqual(false);
       withAnalyticsMock(() => {
         dispatch(ProfileView.changeInvertCallstack(true));
         expect(self.ga).toBeCalledWith('send', {
@@ -926,7 +884,7 @@ describe('actions/ProfileView', function() {
           hitType: 'event',
         });
       });
-      expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
+      expect(selectors.getInvertCallstack(getState())).toEqual(true);
     });
   });
 
@@ -935,7 +893,7 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+      expect(selectors.getPreviewSelection(getState())).toEqual({
         hasSelection: false,
         isModifying: false,
       });
@@ -947,7 +905,7 @@ describe('actions/ProfileView', function() {
           selectionEnd: 1,
         })
       );
-      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+      expect(selectors.getPreviewSelection(getState())).toEqual({
         hasSelection: true,
         isModifying: false,
         selectionStart: 0,
@@ -961,31 +919,27 @@ describe('actions/ProfileView', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([]);
       dispatch(ProfileView.commitRange(0, 10));
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
       ]);
 
-      expect(ProfileViewSelectors.getPreviewSelectionRange(getState())).toEqual(
-        {
-          start: 0,
-          end: 10,
-        }
-      );
+      expect(selectors.getPreviewSelectionRange(getState())).toEqual({
+        start: 0,
+        end: 10,
+      });
 
       dispatch(ProfileView.commitRange(1, 9));
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
 
-      expect(ProfileViewSelectors.getPreviewSelectionRange(getState())).toEqual(
-        {
-          start: 1,
-          end: 9,
-        }
-      );
+      expect(selectors.getPreviewSelectionRange(getState())).toEqual({
+        start: 1,
+        end: 9,
+      });
     });
   });
 
@@ -1003,37 +957,33 @@ describe('actions/ProfileView', function() {
           selectionEnd: 9,
         })
       );
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
       ]);
-      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+      expect(selectors.getPreviewSelection(getState())).toEqual({
         hasSelection: true,
         isModifying: false,
         selectionStart: 1,
         selectionEnd: 9,
       });
-      expect(ProfileViewSelectors.getPreviewSelectionRange(getState())).toEqual(
-        {
-          start: 1,
-          end: 9,
-        }
-      );
+      expect(selectors.getPreviewSelectionRange(getState())).toEqual({
+        start: 1,
+        end: 9,
+      });
 
       dispatch(ProfileView.commitRange(2, 8));
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 2, end: 8 },
       ]);
-      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+      expect(selectors.getPreviewSelection(getState())).toEqual({
         hasSelection: false,
         isModifying: false,
       });
-      expect(ProfileViewSelectors.getPreviewSelectionRange(getState())).toEqual(
-        {
-          start: 2,
-          end: 8,
-        }
-      );
+      expect(selectors.getPreviewSelectionRange(getState())).toEqual({
+        start: 2,
+        end: 8,
+      });
     });
   });
 
@@ -1050,14 +1000,14 @@ describe('actions/ProfileView', function() {
 
     it('pops a committed range', function() {
       const { getState, dispatch } = setupStore();
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
         { start: 2, end: 8 },
         { start: 3, end: 7 },
       ]);
       dispatch(ProfileView.popCommittedRanges(2));
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
@@ -1073,13 +1023,13 @@ describe('actions/ProfileView', function() {
           selectionEnd: 9,
         })
       );
-      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+      expect(selectors.getPreviewSelection(getState())).toEqual({
         hasSelection: true,
         isModifying: false,
         selectionEnd: 9,
         selectionStart: 1,
       });
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
         { start: 2, end: 8 },
@@ -1087,11 +1037,11 @@ describe('actions/ProfileView', function() {
       ]);
 
       dispatch(ProfileView.popCommittedRanges(2));
-      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+      expect(selectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
-      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+      expect(selectors.getPreviewSelection(getState())).toEqual({
         hasSelection: false,
         isModifying: false,
       });
@@ -1107,7 +1057,7 @@ describe('actions/ProfileView', function() {
         `);
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getTransformStack(getState(), 0)).toEqual([]);
+      expect(selectors.getTransformStack(getState(), 0)).toEqual([]);
       withAnalyticsMock(() => {
         dispatch(
           ProfileView.addTransformToStack(0, {
@@ -1122,7 +1072,7 @@ describe('actions/ProfileView', function() {
           hitType: 'event',
         });
       });
-      expect(UrlStateSelectors.getTransformStack(getState(), 0)).toEqual([
+      expect(selectors.getTransformStack(getState(), 0)).toEqual([
         {
           type: 'merge-function',
           funcIndex: 1,
@@ -1152,7 +1102,7 @@ describe('actions/ProfileView', function() {
           funcIndex: 2,
         })
       );
-      expect(UrlStateSelectors.getTransformStack(getState(), 0)).toEqual([
+      expect(selectors.getTransformStack(getState(), 0)).toEqual([
         {
           type: 'merge-function',
           funcIndex: 1,
@@ -1163,7 +1113,7 @@ describe('actions/ProfileView', function() {
         },
       ]);
       dispatch(ProfileView.popTransformsFromStack(1));
-      expect(UrlStateSelectors.getTransformStack(getState(), 0)).toEqual([
+      expect(selectors.getTransformStack(getState(), 0)).toEqual([
         {
           type: 'merge-function',
           funcIndex: 1,
@@ -1176,7 +1126,7 @@ describe('actions/ProfileView', function() {
     it('can extract some network markers and match the snapshot', function() {
       const profile = getScreenshotTrackProfile();
       const { getState } = storeWithProfile(profile);
-      const screenshotMarkersById = selectedThreadSelectors.getRangeFilteredScreenshotsById(
+      const screenshotMarkersById = selectors.selectedThread.getRangeFilteredScreenshotsById(
         getState()
       );
       const keys = [...screenshotMarkersById.keys()];
@@ -1210,7 +1160,7 @@ describe('actions/ProfileView', function() {
       dispatch(ProfileView.commitRange(startTime, endTime));
 
       // Get out the markers.
-      const screenshotMarkersById = selectedThreadSelectors.getRangeFilteredScreenshotsById(
+      const screenshotMarkersById = selectors.selectedThread.getRangeFilteredScreenshotsById(
         getState()
       );
       const [key] = [...screenshotMarkersById.keys()];
@@ -1287,8 +1237,8 @@ describe('snapshots of selectors/profile', function() {
       dispatch,
       samplesThread,
       mergeFunction,
-      markerThreadSelectors: getThreadSelectors(1),
-      getMarker: getThreadSelectors(1).getMarkerGetter(getState()),
+      markerThreadSelectors: selectors.getThreadSelectors(1),
+      getMarker: selectors.getThreadSelectors(1).getMarkerGetter(getState()),
       A,
       B,
       C,
@@ -1296,48 +1246,48 @@ describe('snapshots of selectors/profile', function() {
   }
   it('matches the last stored run of getProfile', function() {
     const { getState } = setupStore();
-    expect(ProfileViewSelectors.getProfile(getState())).toMatchSnapshot();
+    expect(selectors.getProfile(getState())).toMatchSnapshot();
   });
   it('matches the last stored run of getProfileInterval', function() {
     const { getState } = setupStore();
-    expect(ProfileViewSelectors.getProfileInterval(getState())).toEqual(1);
+    expect(selectors.getProfileInterval(getState())).toEqual(1);
   });
   it('matches the last stored run of getThreads', function() {
     const { getState } = setupStore();
-    expect(ProfileViewSelectors.getThreads(getState())).toMatchSnapshot();
+    expect(selectors.getThreads(getState())).toMatchSnapshot();
   });
   it('matches the last stored run of getThreadNames', function() {
     const { getState } = setupStore();
-    expect(ProfileViewSelectors.getThreadNames(getState())).toEqual([
+    expect(selectors.getThreadNames(getState())).toEqual([
       'Thread with samples',
       'Thread with markers',
     ]);
   });
   it('matches the last stored run of getRightClickedTrack', function() {
     const { getState } = setupStore();
-    expect(ProfileViewSelectors.getRightClickedTrack(getState())).toEqual(null);
+    expect(selectors.getRightClickedTrack(getState())).toEqual(null);
   });
   it('matches the last stored run of selectedThreadSelector.getThread', function() {
     const { getState, samplesThread } = setupStore();
-    expect(selectedThreadSelectors.getThread(getState())).toEqual(
+    expect(selectors.selectedThread.getThread(getState())).toEqual(
       samplesThread
     );
   });
   it('matches the last stored run of selectedThreadSelector.getViewOptions', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getViewOptions(getState())
+      selectors.selectedThread.getViewOptions(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getTransformStack', function() {
     const { getState, mergeFunction } = setupStore();
-    expect(selectedThreadSelectors.getTransformStack(getState())).toEqual([
+    expect(selectors.selectedThread.getTransformStack(getState())).toEqual([
       mergeFunction,
     ]);
   });
   it('matches the last stored run of selectedThreadSelector.getTransformLabels', function() {
     const { getState } = setupStore();
-    expect(selectedThreadSelectors.getTransformLabels(getState())).toEqual([
+    expect(selectors.selectedThread.getTransformLabels(getState())).toEqual([
       'Complete "Thread with samples"',
       'Merge: C',
     ]);
@@ -1345,20 +1295,20 @@ describe('snapshots of selectors/profile', function() {
   it('matches the last stored run of selectedThreadSelector.getRangeFilteredThread', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getRangeFilteredThread(getState())
+      selectors.selectedThread.getRangeFilteredThread(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getRangeAndTransformFilteredThread', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getRangeAndTransformFilteredThread(getState())
+      selectors.selectedThread.getRangeAndTransformFilteredThread(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getJankMarkersForHeader', function() {
     const { getState } = setupStore();
-    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+    const getMarker = selectors.selectedThread.getMarkerGetter(getState());
     expect(
-      selectedThreadSelectors
+      selectors.selectedThread
         .getJankMarkerIndexesForHeader(getState())
         .map(getMarker)
     ).toMatchSnapshot();
@@ -1400,70 +1350,70 @@ describe('snapshots of selectors/profile', function() {
   it('matches the last stored run of selectedThreadSelector.getFilteredThread', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getFilteredThread(getState())
+      selectors.selectedThread.getFilteredThread(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getPreviewFilteredThread', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getPreviewFilteredThread(getState())
+      selectors.selectedThread.getPreviewFilteredThread(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getCallNodeInfo', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getCallNodeInfo(getState())
+      selectors.selectedThread.getCallNodeInfo(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getCallNodeMaxDepth', function() {
     const { getState } = setupStore();
-    expect(selectedThreadSelectors.getCallNodeMaxDepth(getState())).toEqual(4);
+    expect(selectors.selectedThread.getCallNodeMaxDepth(getState())).toEqual(4);
   });
   it('matches the last stored run of selectedThreadSelector.getSelectedCallNodePath', function() {
     const { getState, A, B } = setupStore();
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, B]
-    );
+    expect(
+      selectors.selectedThread.getSelectedCallNodePath(getState())
+    ).toEqual([A, B]);
   });
   it('matches the last stored run of selectedThreadSelector.getSelectedCallNodeIndex', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getSelectedCallNodeIndex(getState())
+      selectors.selectedThread.getSelectedCallNodeIndex(getState())
     ).toEqual(1);
   });
   it('matches the last stored run of selectedThreadSelector.getExpandedCallNodePaths', function() {
     const { getState, A, B } = setupStore();
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectors.selectedThread.getExpandedCallNodePaths(getState()),
       [[A], [A, B]]
     );
   });
   it('matches the last stored run of selectedThreadSelector.getExpandedCallNodeIndexes', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
+      selectors.selectedThread.getExpandedCallNodeIndexes(getState())
     ).toEqual([0, 1]);
   });
   it('matches the last stored run of selectedThreadSelector.getCallTree', function() {
     const { getState } = setupStore();
-    expect(selectedThreadSelectors.getCallTree(getState())).toMatchSnapshot();
+    expect(selectors.selectedThread.getCallTree(getState())).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getFlameGraphTiming', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getFlameGraphTiming(getState())
+      selectors.selectedThread.getFlameGraphTiming(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getFriendlyThreadName', function() {
     const { getState } = setupStore();
-    expect(selectedThreadSelectors.getFriendlyThreadName(getState())).toEqual(
+    expect(selectors.selectedThread.getFriendlyThreadName(getState())).toEqual(
       'Thread with samples'
     );
   });
   it('matches the last stored run of selectedThreadSelector.getThreadProcessDetails', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getThreadProcessDetails(getState())
+      selectors.selectedThread.getThreadProcessDetails(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of markerThreadSelectors.getSearchFilteredMarkerIndexes', function() {
@@ -1476,31 +1426,33 @@ describe('snapshots of selectors/profile', function() {
   });
   it('matches the last stored run of selectedThreadSelector.unfilteredSamplesRange', function() {
     const { getState } = setupStore();
-    expect(selectedThreadSelectors.unfilteredSamplesRange(getState())).toEqual({
-      end: 9,
-      start: 0,
-    });
+    expect(selectors.selectedThread.unfilteredSamplesRange(getState())).toEqual(
+      {
+        end: 9,
+        start: 0,
+      }
+    );
   });
 
-  it('matches the last stored run of selectedNodeSelectors.getName', () => {
+  it('matches the last stored run of selectors.selectedNode.getName', () => {
     const { getState } = setupStore();
-    expect(selectedNodeSelectors.getName(getState())).toEqual('B');
+    expect(selectors.selectedNode.getName(getState())).toEqual('B');
   });
 
-  it('matches the last stored run of selectedNodeSelectors.getIsJS', () => {
+  it('matches the last stored run of selectors.selectedNode.getIsJS', () => {
     const { getState } = setupStore();
-    expect(selectedNodeSelectors.getIsJS(getState())).toEqual(false);
+    expect(selectors.selectedNode.getIsJS(getState())).toEqual(false);
   });
 
-  it('matches the last stored run of selectedNodeSelectors.getLib', () => {
+  it('matches the last stored run of selectors.selectedNode.getLib', () => {
     const { getState } = setupStore();
-    expect(selectedNodeSelectors.getLib(getState())).toEqual('');
+    expect(selectors.selectedNode.getLib(getState())).toEqual('');
   });
 
-  it('matches the last stored run of selectedNodeSelectors.getTimingsForSidebar', () => {
+  it('matches the last stored run of selectors.selectedNode.getTimingsForSidebar', () => {
     const { getState } = setupStore();
     expect(
-      selectedNodeSelectors.getTimingsForSidebar(getState())
+      selectors.selectedNode.getTimingsForSidebar(getState())
     ).toMatchSnapshot();
   });
 });
@@ -1524,7 +1476,7 @@ describe('getTimingsForSidebar', () => {
 
     const getTimingsForPath = path => {
       store.dispatch(ProfileView.changeSelectedCallNode(0, path));
-      return selectedNodeSelectors.getTimingsForSidebar(store.getState());
+      return selectors.selectedNode.getTimingsForSidebar(store.getState());
     };
 
     return {
@@ -2166,7 +2118,7 @@ describe('getTimingsForSidebar', () => {
 
       const getTimingsForPath = path => {
         store.dispatch(ProfileView.changeSelectedCallNode(2, path));
-        return selectedNodeSelectors.getTimingsForSidebar(store.getState());
+        return selectors.selectedNode.getTimingsForSidebar(store.getState());
       };
 
       return {
@@ -2212,7 +2164,9 @@ describe('getFriendlyThreadName', function() {
 
     const getFriendlyThreadNames = () =>
       profile.threads.map((_, threadIndex) =>
-        getThreadSelectors(threadIndex).getFriendlyThreadName(getState())
+        selectors
+          .getThreadSelectors(threadIndex)
+          .getFriendlyThreadName(getState())
       );
 
     return { profile, dispatch, getState, getFriendlyThreadNames };
@@ -2275,7 +2229,7 @@ describe('getFriendlyThreadName', function() {
 });
 
 describe('counter selectors', function() {
-  const { getCounterSelectors } = ProfileViewSelectors;
+  const { getCounterSelectors } = selectors;
   function setup() {
     const { profile } = getProfileFromTextSamples(
       Array(10)
@@ -2363,7 +2317,7 @@ describe('counter selectors', function() {
 });
 
 describe('meta selector', function() {
-  const { getMeta } = ProfileViewSelectors;
+  const { getMeta } = selectors;
   function setup() {
     const { profile } = getProfileFromTextSamples(
       Array(10)
@@ -2387,7 +2341,7 @@ describe('visual metrics selectors', function() {
     getVisualProgress,
     getPerceptualSpeedIndexProgress,
     getContentfulSpeedIndexProgress,
-  } = ProfileViewSelectors;
+  } = selectors;
   function setup() {
     const profile = getVisualProgressTrackProfile(
       Array(10)

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -30,14 +30,14 @@ import { assertSetContainsOnly } from '../fixtures/custom-assertions';
 import * as App from '../../actions/app';
 import * as ProfileView from '../../actions/profile-view';
 import { viewProfile } from '../../actions/receive-profile';
-import * as ProfileViewSelectors from '../../selectors/profile';
-import * as UrlStateSelectors from '../../selectors/url-state';
+import * as ProfileViewSelectors from 'selectors/profile';
+import * as UrlStateSelectors from 'selectors/url-state';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import {
   selectedThreadSelectors,
   selectedNodeSelectors,
   getThreadSelectors,
-} from '../../selectors/per-thread';
+} from 'selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
 import type { Milliseconds } from '../../types/units';

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -26,7 +26,7 @@ import {
   getDataSource,
   getProfileName,
   getHasZipFile,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
 import { TextEncoder } from 'util';

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -22,13 +22,13 @@ import {
   getUploadError,
   getUploadProgress,
   getUploadGeneration,
-} from '../../selectors/publish';
+} from 'selectors/publish';
 import {
   getSelectedTab,
   getDataSource,
   getProfileName,
-} from '../../selectors/url-state';
-import { getHasZipFile } from '../../selectors/zipped-profiles';
+} from 'selectors/url-state';
+import { getHasZipFile } from 'selectors/zipped-profiles';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
 import { TextEncoder } from 'util';

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -22,13 +22,11 @@ import {
   getUploadError,
   getUploadProgress,
   getUploadGeneration,
-} from 'selectors/publish';
-import {
   getSelectedTab,
   getDataSource,
   getProfileName,
-} from 'selectors/url-state';
-import { getHasZipFile } from 'selectors/zipped-profiles';
+  getHasZipFile,
+} from 'selectors';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
 import { TextEncoder } from 'util';

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -12,11 +12,7 @@ import { getEmptyProfile } from '../../profile-logic/data-structures';
 import { getTimeRangeForThread } from '../../profile-logic/profile-data';
 import { viewProfileFromPathInZipFile } from '../../actions/zipped-profiles';
 import { blankStore } from '../fixtures/stores';
-import * as ProfileViewSelectors from 'selectors/profile';
-import * as ZippedProfilesSelectors from 'selectors/zipped-profiles';
-import * as UrlStateSelectors from 'selectors/url-state';
-import { getThreadSelectors } from 'selectors/per-thread';
-import { getView } from 'selectors/app';
+import * as selectors from 'selectors';
 import { urlFromState } from '../../app-logic/url-handling';
 import {
   viewProfile,
@@ -106,28 +102,26 @@ describe('actions/receive-profile', function() {
       const store = blankStore();
 
       expect(() => {
-        ProfileViewSelectors.getProfile(store.getState());
+        selectors.getProfile(store.getState());
       }).toThrow();
 
-      const initialProfile = ProfileViewSelectors.getProfileOrNull(
-        store.getState()
-      );
+      const initialProfile = selectors.getProfileOrNull(store.getState());
       expect(initialProfile).toBeNull();
       const profile = _getSimpleProfile();
       store.dispatch(viewProfile(profile));
-      expect(ProfileViewSelectors.getProfile(store.getState())).toBe(profile);
+      expect(selectors.getProfile(store.getState())).toBe(profile);
     });
 
     it('will be a fatal error if a profile has no threads', function() {
       const store = blankStore();
-      expect(getView(store.getState()).phase).toBe('INITIALIZING');
+      expect(selectors.getView(store.getState()).phase).toBe('INITIALIZING');
       const emptyProfile = getEmptyProfile();
 
       // Stop console.error from spitting out an error message:
       const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
       store.dispatch(viewProfile(emptyProfile));
-      expect(getView(store.getState()).phase).toBe('FATAL_ERROR');
+      expect(selectors.getView(store.getState()).phase).toBe('FATAL_ERROR');
       expect(spy).toHaveBeenCalled();
     });
 
@@ -408,8 +402,8 @@ describe('actions/receive-profile', function() {
         await dispatch(retrieveProfileFromAddon());
 
         const state = getState();
-        expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-        expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
+        expect(selectors.getView(state)).toEqual({ phase: 'DATA_LOADED' });
+        expect(selectors.getCommittedRange(state)).toEqual({
           start: 0,
           // The end can be computed as the sum of:
           // - difference of the starts of the subprocess and the main process (1000)
@@ -418,7 +412,7 @@ describe('actions/receive-profile', function() {
           end: 1007,
         });
         // not empty
-        expect(ProfileViewSelectors.getProfile(state).threads).toHaveLength(3);
+        expect(selectors.getProfile(state).threads).toHaveLength(3);
       });
     }
 
@@ -451,7 +445,7 @@ describe('actions/receive-profile', function() {
         jest.advanceTimersByTime(30000);
         return dispatchResultPromise;
       });
-      const views = states.map(state => getView(state));
+      const views = states.map(state => selectors.getView(state));
 
       const errorMessage =
         'We were unable to connect to the Gecko profiler add-on within thirty seconds. This might be because the profile is big or your machine is slower than usual. Still waiting...';
@@ -466,12 +460,12 @@ describe('actions/receive-profile', function() {
       ]);
 
       const state = store.getState();
-      expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
+      expect(selectors.getView(state)).toEqual({ phase: 'DATA_LOADED' });
+      expect(selectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007, // see the above test for more explanation on this value
       });
-      expect(ProfileViewSelectors.getProfile(state).threads).toHaveLength(3); // not empty
+      expect(selectors.getProfile(state).threads).toHaveLength(3); // not empty
     });
   });
 
@@ -517,12 +511,12 @@ describe('actions/receive-profile', function() {
       await store.dispatch(retrieveProfileFromStore(hash));
 
       const state = store.getState();
-      expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
+      expect(selectors.getView(state)).toEqual({ phase: 'DATA_LOADED' });
+      expect(selectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1,
       });
-      expect(ProfileViewSelectors.getProfile(state).threads.length).toBe(1); // not empty
+      expect(selectors.getProfile(state).threads.length).toBe(1); // not empty
     });
 
     it('symbolicates a profile if it is not symbolicated yet', async () => {
@@ -571,7 +565,7 @@ describe('actions/receive-profile', function() {
       const store = blankStore();
       const views = (await observeStoreStateChanges(store, () =>
         store.dispatch(retrieveProfileFromStore(hash))
-      )).map(state => getView(state));
+      )).map(state => selectors.getView(state));
 
       const errorMessage = 'Profile not found on remote server.';
       expect(views).toEqual([
@@ -588,11 +582,11 @@ describe('actions/receive-profile', function() {
       ]);
 
       const state = store.getState();
-      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
+      expect(selectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1,
       });
-      expect(ProfileViewSelectors.getProfile(state).threads.length).toBe(1); // not empty
+      expect(selectors.getProfile(state).threads.length).toBe(1); // not empty
     });
 
     it('fails in case the profile cannot be found after several tries', async function() {
@@ -600,7 +594,7 @@ describe('actions/receive-profile', function() {
       const store = blankStore();
       const views = (await observeStoreStateChanges(store, () =>
         store.dispatch(retrieveProfileFromStore(hash))
-      )).map(state => getView(state));
+      )).map(state => selectors.getView(state));
 
       const steps = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
@@ -624,7 +618,7 @@ describe('actions/receive-profile', function() {
 
       const store = blankStore();
       await store.dispatch(retrieveProfileFromStore(hash));
-      expect(getView(store.getState())).toEqual({
+      expect(selectors.getView(store.getState())).toEqual({
         phase: 'FATAL_ERROR',
         error: expect.any(Error),
       });
@@ -671,12 +665,12 @@ describe('actions/receive-profile', function() {
       await store.dispatch(retrieveProfileOrZipFromUrl(expectedUrl));
 
       const state = store.getState();
-      expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
+      expect(selectors.getView(state)).toEqual({ phase: 'DATA_LOADED' });
+      expect(selectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1,
       });
-      expect(ProfileViewSelectors.getProfile(state).threads.length).toBe(1); // not empty
+      expect(selectors.getProfile(state).threads.length).toBe(1); // not empty
     });
 
     it('requests several times in case of 403', async function() {
@@ -693,7 +687,7 @@ describe('actions/receive-profile', function() {
       const store = blankStore();
       const views = (await observeStoreStateChanges(store, () =>
         store.dispatch(retrieveProfileOrZipFromUrl(expectedUrl))
-      )).map(state => getView(state));
+      )).map(state => selectors.getView(state));
 
       const errorMessage = 'Profile not found on remote server.';
       expect(views).toEqual([
@@ -710,11 +704,11 @@ describe('actions/receive-profile', function() {
       ]);
 
       const state = store.getState();
-      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
+      expect(selectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1,
       });
-      expect(ProfileViewSelectors.getProfile(state).threads.length).toBe(1); // not empty
+      expect(selectors.getProfile(state).threads.length).toBe(1); // not empty
     });
 
     it('fails in case the profile cannot be found after several tries', async function() {
@@ -722,7 +716,7 @@ describe('actions/receive-profile', function() {
       const store = blankStore();
       const views = (await observeStoreStateChanges(store, () =>
         store.dispatch(retrieveProfileOrZipFromUrl(expectedUrl))
-      )).map(state => getView(state));
+      )).map(state => selectors.getView(state));
 
       const steps = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
@@ -746,7 +740,7 @@ describe('actions/receive-profile', function() {
 
       const store = blankStore();
       await store.dispatch(retrieveProfileOrZipFromUrl(expectedUrl));
-      expect(getView(store.getState())).toEqual({
+      expect(selectors.getView(store.getState())).toEqual({
         phase: 'FATAL_ERROR',
         error: expect.any(Error),
       });
@@ -985,7 +979,7 @@ describe('actions/receive-profile', function() {
       const file = mockFile(mockFileOptions);
       const { dispatch, getState } = blankStore();
       await dispatch(retrieveProfileFromFile(file, mockFileReader));
-      const view = getView(getState());
+      const view = selectors.getView(getState());
       return { getState, dispatch, view };
     }
 
@@ -998,7 +992,7 @@ describe('actions/receive-profile', function() {
         payload: serializeProfile(profile),
       });
       expect(view.phase).toBe('DATA_LOADED');
-      expect(ProfileViewSelectors.getProfile(getState()).meta.product).toEqual(
+      expect(selectors.getProfile(getState()).meta.product).toEqual(
         'JSON Test'
       );
     });
@@ -1039,7 +1033,7 @@ describe('actions/receive-profile', function() {
         payload: serializeProfile(profile),
       });
       expect(view.phase).toBe('DATA_LOADED');
-      expect(ProfileViewSelectors.getProfile(getState()).meta.product).toEqual(
+      expect(selectors.getProfile(getState()).meta.product).toEqual(
         'JSON Test'
       );
     });
@@ -1092,7 +1086,7 @@ describe('actions/receive-profile', function() {
         serializeProfile(_getSimpleProfile())
       );
       expect(view.phase).toBe('DATA_LOADED');
-      const zipInStore = ZippedProfilesSelectors.getZipFile(getState());
+      const zipInStore = selectors.getZipFile(getState());
       if (zipInStore === null) {
         throw new Error('Expected zipInStore to exist.');
       }
@@ -1105,16 +1099,14 @@ describe('actions/receive-profile', function() {
         serializeProfile(_getSimpleProfile())
       );
 
-      expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+      expect(selectors.getZipFileState(getState()).phase).toEqual(
         'LIST_FILES_IN_ZIP_FILE'
       );
       await dispatch(viewProfileFromPathInZipFile('profile.json'));
-      expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+      expect(selectors.getZipFileState(getState()).phase).toEqual(
         'VIEW_PROFILE_IN_ZIP_FILE'
       );
-      const errorMessage = ZippedProfilesSelectors.getZipFileErrorMessage(
-        getState()
-      );
+      const errorMessage = selectors.getZipFileErrorMessage(getState());
       expect(errorMessage).toEqual(null);
     });
 
@@ -1124,27 +1116,23 @@ describe('actions/receive-profile', function() {
         serializeProfile(getEmptyProfile())
       );
 
-      expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+      expect(selectors.getZipFileState(getState()).phase).toEqual(
         'LIST_FILES_IN_ZIP_FILE'
       );
-      expect(
-        ZippedProfilesSelectors.getZipFileErrorMessage(getState())
-      ).toEqual(null);
+      expect(selectors.getZipFileErrorMessage(getState())).toEqual(null);
 
       // Stop console.error from spitting out an error message:
       jest.spyOn(console, 'error').mockImplementation(() => {});
 
       await dispatch(viewProfileFromPathInZipFile('profile.json'));
 
-      expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+      expect(selectors.getZipFileState(getState()).phase).toEqual(
         'FAILED_TO_PROCESS_PROFILE_FROM_ZIP_FILE'
       );
-      expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+      expect(selectors.getZipFileState(getState()).phase).toEqual(
         'FAILED_TO_PROCESS_PROFILE_FROM_ZIP_FILE'
       );
-      const errorMessage = ZippedProfilesSelectors.getZipFileErrorMessage(
-        getState()
-      );
+      const errorMessage = selectors.getZipFileErrorMessage(getState());
       expect(typeof errorMessage).toEqual('string');
       expect(errorMessage).toMatchSnapshot();
     });
@@ -1280,14 +1268,14 @@ describe('actions/receive-profile', function() {
 
       // To find stupid mistakes more easily, check that we didn't get a fatal
       // error here. If we got one, let's rethrow the error.
-      const view = getView(getState());
+      const view = selectors.getView(getState());
       if (view.phase === 'FATAL_ERROR') {
         throw view.error;
       }
 
-      const resultProfile = ProfileViewSelectors.getProfile(getState());
-      const globalTracks = ProfileViewSelectors.getGlobalTracks(getState());
-      const rootRange = ProfileViewSelectors.getProfileRootRange(getState());
+      const resultProfile = selectors.getProfile(getState());
+      const globalTracks = selectors.getGlobalTracks(getState());
+      const rootRange = selectors.getProfileRootRange(getState());
       return {
         profile1,
         profile2,
@@ -1382,7 +1370,7 @@ describe('actions/receive-profile', function() {
         urlSearch2: 'thread=1&implementation=js',
       });
 
-      expect(UrlStateSelectors.getImplementationFilter(getState())).toBe('js');
+      expect(selectors.getImplementationFilter(getState())).toBe('js');
     });
 
     it('does not reuse the implementation information if one profile used it', async function() {
@@ -1391,9 +1379,7 @@ describe('actions/receive-profile', function() {
         urlSearch2: 'thread=1',
       });
 
-      expect(UrlStateSelectors.getImplementationFilter(getState())).not.toBe(
-        'js'
-      );
+      expect(selectors.getImplementationFilter(getState())).not.toBe('js');
     });
 
     it('reuses transforms', async function() {
@@ -1402,7 +1388,7 @@ describe('actions/receive-profile', function() {
         urlSearch2: 'thread=1',
       });
 
-      expect(UrlStateSelectors.getTransformStack(getState(), 0)).toEqual([
+      expect(selectors.getTransformStack(getState(), 0)).toEqual([
         {
           type: 'focus-function',
           funcIndex: 42,
@@ -1421,7 +1407,7 @@ describe('actions/receive-profile', function() {
       });
 
       expect(resultProfile.threads).toHaveLength(3);
-      const selectors = getThreadSelectors(2);
+      const selectors = selectors.getThreadSelectors(2);
       const callTree = selectors.getCallTree(getState());
       const [firstChild] = callTree.getRoots();
       const nodeData = callTree.getNodeData(firstChild);
@@ -1471,18 +1457,21 @@ describe('actions/receive-profile', function() {
 
       // To find stupid mistakes more easily, check that we didn't get a fatal
       // error here. If we got one, let's rethrow the error.
-      const view = getView(store.getState());
+      const view = selectors.getView(store.getState());
       if (view.phase === 'FATAL_ERROR') {
         throw view.error;
       }
 
       const waitUntilPhase = phase =>
-        waitUntilState(store, state => getView(state).phase === phase);
+        waitUntilState(
+          store,
+          state => selectors.getView(state).phase === phase
+        );
 
       const waitUntilSymbolication = () =>
         waitUntilState(
           store,
-          state => ProfileViewSelectors.getSymbolicationStatus(state) === 'DONE'
+          state => selectors.getSymbolicationStatus(state) === 'DONE'
         );
 
       return {
@@ -1517,12 +1506,12 @@ describe('actions/receive-profile', function() {
       });
 
       // Check if we loaded the profile data successfully.
-      expect(ProfileViewSelectors.getProfile(getState())).toEqual(profile);
-      expect(getView(getState()).phase).toBe('PROFILE_LOADED');
+      expect(selectors.getProfile(getState())).toEqual(profile);
+      expect(selectors.getView(getState()).phase).toBe('PROFILE_LOADED');
 
       // Check if we can successfully finalize the profile view.
       await dispatch(finalizeProfileView());
-      expect(getView(getState()).phase).toBe('DATA_LOADED');
+      expect(selectors.getView(getState()).phase).toBe('DATA_LOADED');
     });
 
     it('retrieves profile from a `from-url` data source and loads it', async function() {
@@ -1534,12 +1523,12 @@ describe('actions/receive-profile', function() {
       });
 
       // Check if we loaded the profile data successfully.
-      expect(ProfileViewSelectors.getProfile(getState())).toEqual(profile);
-      expect(getView(getState()).phase).toBe('PROFILE_LOADED');
+      expect(selectors.getProfile(getState())).toEqual(profile);
+      expect(selectors.getView(getState()).phase).toBe('PROFILE_LOADED');
 
       // Check if we can successfully finalize the profile view.
       await dispatch(finalizeProfileView());
-      expect(getView(getState()).phase).toBe('DATA_LOADED');
+      expect(selectors.getView(getState()).phase).toBe('DATA_LOADED');
     });
 
     it('keeps the `from-url` value in the URL', async function() {
@@ -1551,7 +1540,7 @@ describe('actions/receive-profile', function() {
       });
       await dispatch(finalizeProfileView());
       const [, fromAddon, urlString] = urlFromState(
-        UrlStateSelectors.getUrlState(getState())
+        selectors.getUrlState(getState())
       ).split('/');
       expect(fromAddon).toEqual('from-url');
       expect(urlString).toEqual('https%3A%2F%2Ffakeurl.com%2Ffakeprofile.json');
@@ -1573,11 +1562,11 @@ describe('actions/receive-profile', function() {
       );
 
       // Check if we loaded the profile data successfully.
-      expect(getView(getState()).phase).toBe('PROFILE_LOADED');
+      expect(selectors.getView(getState()).phase).toBe('PROFILE_LOADED');
 
       // Check if we can successfully finalize the profile view.
       await dispatch(finalizeProfileView());
-      expect(getView(getState()).phase).toBe('DATA_LOADED');
+      expect(selectors.getView(getState()).phase).toBe('DATA_LOADED');
     });
 
     it('retrieves profile from a `from-addon` data source and loads it', async function() {
@@ -1594,9 +1583,7 @@ describe('actions/receive-profile', function() {
       // we don't need to call it again.
       await waitUntilPhase('DATA_LOADED');
       const processedProfile = processProfile(geckoProfile);
-      expect(ProfileViewSelectors.getProfile(getState())).toEqual(
-        processedProfile
-      );
+      expect(selectors.getProfile(getState())).toEqual(processedProfile);
     });
 
     it('finishes symbolication for `from-addon` data source', async function() {

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -12,7 +12,7 @@ import { getEmptyProfile } from '../../profile-logic/data-structures';
 import { getTimeRangeForThread } from '../../profile-logic/profile-data';
 import { viewProfileFromPathInZipFile } from '../../actions/zipped-profiles';
 import { blankStore } from '../fixtures/stores';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import { urlFromState } from '../../app-logic/url-handling';
 import {
   viewProfile,
@@ -1407,8 +1407,8 @@ describe('actions/receive-profile', function() {
       });
 
       expect(resultProfile.threads).toHaveLength(3);
-      const selectors = selectors.getThreadSelectors(2);
-      const callTree = selectors.getCallTree(getState());
+      const { getCallTree } = selectors.getThreadSelectors(2);
+      const callTree = getCallTree(getState());
       const [firstChild] = callTree.getRoots();
       const nodeData = callTree.getNodeData(firstChild);
       expect(nodeData.selfTime).toBe(4);

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -12,11 +12,11 @@ import { getEmptyProfile } from '../../profile-logic/data-structures';
 import { getTimeRangeForThread } from '../../profile-logic/profile-data';
 import { viewProfileFromPathInZipFile } from '../../actions/zipped-profiles';
 import { blankStore } from '../fixtures/stores';
-import * as ProfileViewSelectors from '../../selectors/profile';
-import * as ZippedProfilesSelectors from '../../selectors/zipped-profiles';
-import * as UrlStateSelectors from '../../selectors/url-state';
-import { getThreadSelectors } from '../../selectors/per-thread';
-import { getView } from '../../selectors/app';
+import * as ProfileViewSelectors from 'selectors/profile';
+import * as ZippedProfilesSelectors from 'selectors/zipped-profiles';
+import * as UrlStateSelectors from 'selectors/url-state';
+import { getThreadSelectors } from 'selectors/per-thread';
+import { getView } from 'selectors/app';
 import { urlFromState } from '../../app-logic/url-handling';
 import {
   viewProfile,

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -6,8 +6,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import exampleSymbolTable from '../fixtures/example-symbol-table';
 import { SymbolStore } from '../../profile-logic/symbol-store.js';
-import * as ProfileViewSelectors from 'selectors/profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import * as selectors from 'selectors';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { doSymbolicateProfile } from '../../actions/receive-profile';
 import {
@@ -85,7 +84,7 @@ describe('doSymbolicateProfile', function() {
     getExpandedCallNodePaths,
     getThread,
     getCallTree,
-  } = selectedThreadSelectors;
+  } = selectors.selectedThread;
 
   describe('doSymbolicateProfile', function() {
     it('can symbolicate a profile', async () => {
@@ -120,21 +119,17 @@ describe('doSymbolicateProfile', function() {
         symbolStore,
       } = init();
       // Starts out as DONE.
-      expect(ProfileViewSelectors.getSymbolicationStatus(getState())).toEqual(
-        'DONE'
-      );
+      expect(selectors.getSymbolicationStatus(getState())).toEqual('DONE');
       const symbolication = doSymbolicateProfile(
         dispatch,
         profile,
         symbolStore
       );
-      expect(ProfileViewSelectors.getSymbolicationStatus(getState())).toEqual(
+      expect(selectors.getSymbolicationStatus(getState())).toEqual(
         'SYMBOLICATING'
       );
       await symbolication;
-      expect(ProfileViewSelectors.getSymbolicationStatus(getState())).toEqual(
-        'DONE'
-      );
+      expect(selectors.getSymbolicationStatus(getState())).toEqual('DONE');
     });
   });
 

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -6,8 +6,8 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import exampleSymbolTable from '../fixtures/example-symbol-table';
 import { SymbolStore } from '../../profile-logic/symbol-store.js';
-import * as ProfileViewSelectors from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import * as ProfileViewSelectors from 'selectors/profile';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { doSymbolicateProfile } from '../../actions/receive-profile';
 import {

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -6,7 +6,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import exampleSymbolTable from '../fixtures/example-symbol-table';
 import { SymbolStore } from '../../profile-logic/symbol-store.js';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { doSymbolicateProfile } from '../../actions/receive-profile';
 import {

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -8,8 +8,8 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { getEmptyThread } from '../../profile-logic/data-structures';
 import { storeWithProfile } from '../fixtures/stores';
-import * as ProfileViewSelectors from '../../selectors/profile';
-import * as UrlStateSelectors from '../../selectors/url-state';
+import * as ProfileViewSelectors from 'selectors/profile';
+import * as UrlStateSelectors from 'selectors/url-state';
 import {
   getHumanReadableTracks,
   getProfileWithNiceTracks,

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -8,7 +8,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { getEmptyThread } from '../../profile-logic/data-structures';
 import { storeWithProfile } from '../fixtures/stores';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import {
   getHumanReadableTracks,
   getProfileWithNiceTracks,

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -8,8 +8,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { getEmptyThread } from '../../profile-logic/data-structures';
 import { storeWithProfile } from '../fixtures/stores';
-import * as ProfileViewSelectors from 'selectors/profile';
-import * as UrlStateSelectors from 'selectors/url-state';
+import * as selectors from 'selectors';
 import {
   getHumanReadableTracks,
   getProfileWithNiceTracks,
@@ -48,7 +47,7 @@ describe('ordering and hiding', function() {
     );
     const parentPid = profile.threads[parentThreadIndex].pid;
     const tabPid = profile.threads[workerThreadIndex].pid;
-    const globalTracks = ProfileViewSelectors.getGlobalTracks(getState());
+    const globalTracks = selectors.getGlobalTracks(getState());
     const parentTrackIndex = globalTracks.findIndex(
       track =>
         track.type === 'process' && track.mainThreadIndex === parentThreadIndex
@@ -61,9 +60,7 @@ describe('ordering and hiding', function() {
       thread => thread.name === 'GeckoMain' && thread.processType === 'tab'
     );
     let styleTrackIndex, workerTrackIndex;
-    for (const [, tracks] of ProfileViewSelectors.getLocalTracksByPid(
-      getState()
-    )) {
+    for (const [, tracks] of selectors.getLocalTracksByPid(getState())) {
       for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
         const track = tracks[trackIndex];
         if (track.type === 'thread') {
@@ -260,11 +257,11 @@ describe('ordering and hiding', function() {
         tabThreadIndex,
         parentThreadIndex,
       } = init();
-      expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+      expect(selectors.getSelectedThreadIndex(getState())).toEqual(
         tabThreadIndex
       );
       dispatch(hideGlobalTrack(tabTrackIndex));
-      expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+      expect(selectors.getSelectedThreadIndex(getState())).toEqual(
         parentThreadIndex
       );
     });
@@ -277,11 +274,11 @@ describe('ordering and hiding', function() {
         parentThreadIndex,
         parentTrackIndex,
       } = init();
-      expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+      expect(selectors.getSelectedThreadIndex(getState())).toEqual(
         tabThreadIndex
       );
       dispatch(isolateProcess(parentTrackIndex));
-      expect(UrlStateSelectors.getSelectedThreadIndex(getState())).toEqual(
+      expect(selectors.getSelectedThreadIndex(getState())).toEqual(
         parentThreadIndex
       );
     });
@@ -339,8 +336,8 @@ describe('ordering and hiding', function() {
         threadA.pid = 2;
         const { getState } = storeWithProfile(profile);
         return {
-          globalTracks: ProfileViewSelectors.getGlobalTracks(getState()),
-          globalTrackOrder: UrlStateSelectors.getGlobalTrackOrder(getState()),
+          globalTracks: selectors.getGlobalTracks(getState()),
+          globalTrackOrder: selectors.getGlobalTrackOrder(getState()),
         };
       }
 
@@ -380,7 +377,7 @@ describe('ordering and hiding', function() {
     it('can count hidden local tracks', function() {
       const { getState, dispatch, workerTrackIndex, tabPid } = init();
       dispatch(hideLocalTrack(tabPid, workerTrackIndex));
-      expect(ProfileViewSelectors.getHiddenTrackCount(getState())).toEqual({
+      expect(selectors.getHiddenTrackCount(getState())).toEqual({
         hidden: 1,
         total: 4,
       });
@@ -389,7 +386,7 @@ describe('ordering and hiding', function() {
     it('can count hidden global tracks and their hidden local tracks', function() {
       const { getState, dispatch, tabTrackIndex } = init();
       dispatch(hideGlobalTrack(tabTrackIndex));
-      expect(ProfileViewSelectors.getHiddenTrackCount(getState())).toEqual({
+      expect(selectors.getHiddenTrackCount(getState())).toEqual({
         hidden: 3,
         total: 4,
       });
@@ -621,11 +618,8 @@ describe('ordering and hiding', function() {
         profile.threads[0].pid = pid;
         const { getState } = storeWithProfile(profile);
         return {
-          localTracks: ProfileViewSelectors.getLocalTracks(getState(), pid),
-          localTrackOrder: UrlStateSelectors.getLocalTrackOrder(
-            getState(),
-            pid
-          ),
+          localTracks: selectors.getLocalTracks(getState(), pid),
+          localTrackOrder: selectors.getLocalTrackOrder(getState(), pid),
         };
       }
 
@@ -644,12 +638,12 @@ describe('ordering and hiding', function() {
   });
 });
 
-describe('ProfileViewSelectors.getProcessesWithMemoryTrack', function() {
+describe('selectors.getProcessesWithMemoryTrack', function() {
   it('knows when a profile does not have a memory track', function() {
     const profile = getProfileWithNiceTracks();
     const [thread] = profile.threads;
     const { getState } = storeWithProfile(profile);
-    const processesWithMemoryTrack = ProfileViewSelectors.getProcessesWithMemoryTrack(
+    const processesWithMemoryTrack = selectors.getProcessesWithMemoryTrack(
       getState()
     );
     expect(processesWithMemoryTrack.has(thread.pid)).toEqual(false);
@@ -658,7 +652,7 @@ describe('ProfileViewSelectors.getProcessesWithMemoryTrack', function() {
   it('knows when a profile has a memory track', function() {
     const { getState, profile } = getStoreWithMemoryTrack();
     const [thread] = profile.threads;
-    const processesWithMemoryTrack = ProfileViewSelectors.getProcessesWithMemoryTrack(
+    const processesWithMemoryTrack = selectors.getProcessesWithMemoryTrack(
       getState()
     );
     expect(processesWithMemoryTrack.has(thread.pid)).toEqual(true);

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -21,7 +21,7 @@ import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 describe('"focus-subtree" transform', function() {
   describe('on a call tree', function() {

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -21,7 +21,7 @@ import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,
 } from '../../actions/profile-view';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 
 describe('"focus-subtree" transform', function() {
   describe('on a call tree', function() {

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -21,7 +21,7 @@ import {
   changeSelectedCallNode,
   changeCallTreeSummaryStrategy,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 
 describe('"focus-subtree" transform', function() {
   describe('on a call tree', function() {
@@ -53,7 +53,7 @@ describe('"focus-subtree" transform', function() {
       E  G
     `);
     const { dispatch, getState } = storeWithProfile(profile);
-    const originalCallTree = selectedThreadSelectors.getCallTree(getState());
+    const originalCallTree = selectedThread.getCallTree(getState());
     const threadIndex = 0;
     const A = funcNames.indexOf('A');
     const B = funcNames.indexOf('B');
@@ -82,7 +82,7 @@ describe('"focus-subtree" transform', function() {
           inverted: false,
         })
       );
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- C (total: 2, self: —)',
         '  - D (total: 1, self: —)',
@@ -94,7 +94,7 @@ describe('"focus-subtree" transform', function() {
 
     it('can remove the transform', function() {
       dispatch(popTransformsFromStack(0));
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       const formattedTree = formatTree(callTree);
       expect(formattedTree).toEqual([
         '- A (total: 3, self: —)',
@@ -154,7 +154,7 @@ describe('"focus-subtree" transform', function() {
     dispatch(changeInvertCallstack(true));
 
     it('starts as an inverted call tree', function() {
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- Z (total: 2, self: 2)',
         '  - Y (total: 2, self: —)',
@@ -186,7 +186,7 @@ describe('"focus-subtree" transform', function() {
           inverted: true,
         })
       );
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- X (total: 2, self: 2)',
         '  - B (total: 1, self: —)',
@@ -199,7 +199,7 @@ describe('"focus-subtree" transform', function() {
 
     it('can be un-inverted and keep the transform', function() {
       dispatch(changeInvertCallstack(false));
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- A (total: 2, self: —)',
         '  - B (total: 2, self: —)',
@@ -241,7 +241,7 @@ describe('"merge-call-node" transform', function() {
       E  G
     `);
     const { dispatch, getState } = storeWithProfile(profile);
-    const originalCallTree = selectedThreadSelectors.getCallTree(getState());
+    const originalCallTree = selectedThread.getCallTree(getState());
     const threadIndex = 0;
     const A = funcNames.indexOf('A');
     const B = funcNames.indexOf('B');
@@ -269,7 +269,7 @@ describe('"merge-call-node" transform', function() {
           implementation: 'combined',
         })
       );
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- A (total: 3, self: —)',
         '  - B (total: 3, self: —)',
@@ -326,9 +326,7 @@ describe('"merge-call-node" transform', function() {
        *                   b
        */
       const { getState } = storeWithProfile(profile);
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- JS::RunScript.cpp (total: 3, self: —)',
         '  - onLoad.js (total: 3, self: —)',
         '    - js::jit::IonCannon.cpp (total: 2, self: —)',
@@ -349,9 +347,7 @@ describe('"merge-call-node" transform', function() {
        */
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(changeImplementationFilter('js'));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- onLoad.js (total: 3, self: —)',
         '  - a.js (total: 3, self: —)',
         '    - b.js (total: 3, self: 3)',
@@ -367,9 +363,7 @@ describe('"merge-call-node" transform', function() {
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(changeImplementationFilter('js'));
       dispatch(addTransformToStack(threadIndex, mergeJSPathAB));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- onLoad.js (total: 3, self: —)',
         '  - b.js (total: 3, self: 3)',
       ]);
@@ -387,9 +381,7 @@ describe('"merge-call-node" transform', function() {
        */
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(addTransformToStack(threadIndex, mergeJSPathAB));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- JS::RunScript.cpp (total: 3, self: —)',
         '  - onLoad.js (total: 3, self: —)',
         '    - js::jit::IonCannon.cpp (total: 2, self: —)',
@@ -409,9 +401,7 @@ describe('"merge-call-node" transform', function() {
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(changeImplementationFilter('js'));
       dispatch(addTransformToStack(threadIndex, mergeCombinedPathToA));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- onLoad.js (total: 3, self: —)',
         '  - a.js (total: 2, self: —)',
         '    - b.js (total: 2, self: 2)',
@@ -454,7 +444,7 @@ describe('"merge-function" transform', function() {
     const C = funcNames.indexOf('C');
 
     const { dispatch, getState } = storeWithProfile(profile);
-    const originalCallTree = selectedThreadSelectors.getCallTree(getState());
+    const originalCallTree = selectedThread.getCallTree(getState());
 
     it('starts as an unfiltered call tree', function() {
       expect(formatTree(originalCallTree)).toEqual([
@@ -477,7 +467,7 @@ describe('"merge-function" transform', function() {
           funcIndex: C,
         })
       );
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- A (total: 3, self: —)',
         '  - B (total: 3, self: —)',
@@ -506,7 +496,7 @@ describe('"drop-function" transform', function() {
     const C = funcNames.indexOf('C');
 
     const { dispatch, getState } = storeWithProfile(profile);
-    const originalCallTree = selectedThreadSelectors.getCallTree(getState());
+    const originalCallTree = selectedThread.getCallTree(getState());
 
     it('starts as an unfiltered call tree', function() {
       expect(formatTree(originalCallTree)).toEqual([
@@ -526,7 +516,7 @@ describe('"drop-function" transform', function() {
           funcIndex: C,
         })
       );
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
       expect(formatTree(callTree)).toEqual([
         '- A (total: 1, self: —)',
         '  - B (total: 1, self: —)',
@@ -579,9 +569,7 @@ describe('"focus-function" transform', function() {
 
     it('starts as an unfiltered call tree', function() {
       const { getState } = storeWithProfile(profile);
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A (total: 3, self: —)',
         '  - B (total: 2, self: —)',
         '    - X (total: 2, self: —)',
@@ -603,9 +591,7 @@ describe('"focus-function" transform', function() {
           funcIndex: X,
         })
       );
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- X (total: 3, self: —)',
         '  - Y (total: 3, self: —)',
         '    - X (total: 2, self: —)',
@@ -660,9 +646,7 @@ describe('"collapse-resource" transform', function() {
 
     it('starts as an unfiltered call tree', function() {
       const { getState } = storeWithProfile(profile);
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A (total: 2, self: —)',
         '  - B (total: 1, self: —)',
         '    - C (total: 1, self: —)',
@@ -675,9 +659,7 @@ describe('"collapse-resource" transform', function() {
     it('can collapse the "firefox" library', function() {
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(addTransformToStack(threadIndex, collapseTransform));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A (total: 2, self: —)',
         '  - firefox (total: 2, self: —)',
         '    - D (total: 1, self: 1)',
@@ -695,9 +677,7 @@ describe('"collapse-resource" transform', function() {
         )
       );
       dispatch(addTransformToStack(threadIndex, collapseTransform));
-      expect(
-        selectedThreadSelectors.getSelectedCallNodePath(getState())
-      ).toEqual(
+      expect(selectedThread.getSelectedCallNodePath(getState())).toEqual(
         ['A', 'firefox', 'D'].map(name => collapsedFuncNames.indexOf(name))
       );
     });
@@ -762,9 +742,7 @@ describe('"collapse-resource" transform', function() {
 
     it('starts as an unfiltered call tree', function() {
       const { getState } = storeWithProfile(profile);
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A.js (total: 2, self: —)',
         '  - B.cpp (total: 1, self: —)',
         '    - C.js (total: 1, self: —)',
@@ -783,9 +761,7 @@ describe('"collapse-resource" transform', function() {
         // Note the 'cpp' implementation filter.
         addTransformToStack(threadIndex, collapseTransform)
       );
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A.js (total: 2, self: —)',
         '  - firefox (total: 2, self: 1)',
         '    - F.cpp (total: 1, self: —)',
@@ -805,9 +781,9 @@ describe('"collapse-resource" transform', function() {
       );
       dispatch(changeImplementationFilter('cpp'));
       dispatch(addTransformToStack(threadIndex, collapseTransform));
-      expect(
-        selectedThreadSelectors.getSelectedCallNodePath(getState())
-      ).toEqual(['firefox'].map(name => collapsedFuncNames.indexOf(name)));
+      expect(selectedThread.getSelectedCallNodePath(getState())).toEqual(
+        ['firefox'].map(name => collapsedFuncNames.indexOf(name))
+      );
     });
   });
 });
@@ -846,35 +822,31 @@ describe('"collapse-function-subtree" transform', function() {
 
   it('starts as an unfiltered call tree', function() {
     const { getState } = storeWithProfile(profile);
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- A (total: 4, self: —)',
-        '  - B (total: 4, self: —)',
-        '    - C (total: 2, self: —)', // <- C is here!
-        '      - D (total: 1, self: —)',
-        '        - E (total: 1, self: 1)',
-        '      - F (total: 1, self: —)',
-        '        - G (total: 1, self: 1)',
-        '    - H (total: 2, self: —)',
-        '      - C (total: 2, self: —)', // <- C is here!
-        '        - I (total: 1, self: 1)',
-        '        - J (total: 1, self: 1)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- A (total: 4, self: —)',
+      '  - B (total: 4, self: —)',
+      '    - C (total: 2, self: —)', // <- C is here!
+      '      - D (total: 1, self: —)',
+      '        - E (total: 1, self: 1)',
+      '      - F (total: 1, self: —)',
+      '        - G (total: 1, self: 1)',
+      '    - H (total: 2, self: —)',
+      '      - C (total: 2, self: —)', // <- C is here!
+      '        - I (total: 1, self: 1)',
+      '        - J (total: 1, self: 1)',
+    ]);
   });
 
   it('can collapse the C function', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(addTransformToStack(threadIndex, collapseTransform));
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- A (total: 4, self: —)',
-        '  - B (total: 4, self: —)',
-        '    - C (total: 2, self: 2)', // All children are gone, and the self time was applied.
-        '    - H (total: 2, self: —)',
-        '      - C (total: 2, self: 2)', // All children are gone, and the self time was applied.
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- A (total: 4, self: —)',
+      '  - B (total: 4, self: —)',
+      '    - C (total: 2, self: 2)', // All children are gone, and the self time was applied.
+      '    - H (total: 2, self: —)',
+      '      - C (total: 2, self: 2)', // All children are gone, and the self time was applied.
+    ]);
   });
 
   it('can update apply the transform to the selected CallNodePaths', function() {
@@ -886,16 +858,14 @@ describe('"collapse-function-subtree" transform', function() {
       )
     );
     dispatch(addTransformToStack(threadIndex, collapseTransform));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual(
       ['A', 'B', 'C'].map(name => funcNames.indexOf(name))
     );
 
     // Popping transforms resets the selected path
     // see https://github.com/firefox-devtools/profiler/issues/882
     dispatch(popTransformsFromStack(0));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      []
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([]);
   });
 
   it('can update apply the transform to the expanded CallNodePaths', function() {
@@ -909,7 +879,7 @@ describe('"collapse-function-subtree" transform', function() {
       )
     );
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectedThread.getExpandedCallNodePaths(getState()),
       toIds([
         // Force Prettier to make this readable:
         ['A'],
@@ -920,7 +890,7 @@ describe('"collapse-function-subtree" transform', function() {
     );
     dispatch(addTransformToStack(threadIndex, collapseTransform));
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectedThread.getExpandedCallNodePaths(getState()),
       toIds([
         // Force Prettier to make this readable:
         ['A'],
@@ -933,7 +903,7 @@ describe('"collapse-function-subtree" transform', function() {
     // see https://github.com/firefox-devtools/profiler/issues/882
     dispatch(popTransformsFromStack(0));
     assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
+      selectedThread.getExpandedCallNodePaths(getState()),
       []
     );
   });
@@ -972,9 +942,7 @@ describe('"collapse-direct-recursion" transform', function() {
 
     it('starts as an unfiltered call tree', function() {
       const { getState } = storeWithProfile(profile);
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A (total: 4, self: —)',
         '  - B (total: 3, self: —)',
         '    - B (total: 2, self: —)',
@@ -989,9 +957,7 @@ describe('"collapse-direct-recursion" transform', function() {
     it('can collapse the B function', function() {
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(addTransformToStack(threadIndex, collapseDirectRecursion));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A (total: 4, self: —)',
         '  - B (total: 3, self: —)',
         '    - C (total: 1, self: 1)',
@@ -1011,9 +977,9 @@ describe('"collapse-direct-recursion" transform', function() {
         )
       );
       dispatch(addTransformToStack(threadIndex, collapseDirectRecursion));
-      expect(
-        selectedThreadSelectors.getSelectedCallNodePath(getState())
-      ).toEqual(['A', 'B', 'C'].map(name => funcNames.indexOf(name)));
+      expect(selectedThread.getSelectedCallNodePath(getState())).toEqual(
+        ['A', 'B', 'C'].map(name => funcNames.indexOf(name))
+      );
     });
   });
 
@@ -1055,9 +1021,7 @@ describe('"collapse-direct-recursion" transform', function() {
 
     it('starts as an unfiltered call tree', function() {
       const { getState } = storeWithProfile(profile);
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A.js (total: 5, self: —)',
         '  - B.js (total: 4, self: —)',
         '    - B.js (total: 3, self: —)',
@@ -1073,9 +1037,7 @@ describe('"collapse-direct-recursion" transform', function() {
     it('can collapse the B function', function() {
       const { dispatch, getState } = storeWithProfile(profile);
       dispatch(addTransformToStack(threadIndex, collapseDirectRecursion));
-      expect(
-        formatTree(selectedThreadSelectors.getCallTree(getState()))
-      ).toEqual([
+      expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
         '- A.js (total: 5, self: —)',
         '  - B.js (total: 4, self: 1)',
         '    - D.js (total: 1, self: 1)',
@@ -1110,19 +1072,19 @@ describe('expanded and selected CallNodePaths', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     // This opens expands the call nodes up to this point.
     dispatch(changeSelectedCallNode(threadIndex, selectedCallNodePath));
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, B, C, D]
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([
+      A,
+      B,
+      C,
+      D,
+    ]);
 
-    assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
-      [
-        // Expanded nodes:
-        [A],
-        [A, B],
-        [A, B, C],
-      ]
-    );
+    assertSetContainsOnly(selectedThread.getExpandedCallNodePaths(getState()), [
+      // Expanded nodes:
+      [A],
+      [A, B],
+      [A, B, C],
+    ]);
   });
 
   it('can update call node references for focusing a subtree', function() {
@@ -1138,17 +1100,16 @@ describe('expanded and selected CallNodePaths', function() {
       })
     );
 
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [B, C, D]
-    );
-    assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
-      [
-        // Expanded nodes:
-        [B],
-        [B, C],
-      ]
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([
+      B,
+      C,
+      D,
+    ]);
+    assertSetContainsOnly(selectedThread.getExpandedCallNodePaths(getState()), [
+      // Expanded nodes:
+      [B],
+      [B, C],
+    ]);
   });
 
   it('can update call node references for merging a node', function() {
@@ -1163,17 +1124,16 @@ describe('expanded and selected CallNodePaths', function() {
       })
     );
 
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, C, D]
-    );
-    assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
-      [
-        // Expanded nodes:
-        [A],
-        [A, C],
-      ]
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([
+      A,
+      C,
+      D,
+    ]);
+    assertSetContainsOnly(selectedThread.getExpandedCallNodePaths(getState()), [
+      // Expanded nodes:
+      [A],
+      [A, C],
+    ]);
   });
 });
 
@@ -1203,18 +1163,18 @@ describe('expanded and selected CallNodePaths on inverted trees', function() {
     dispatch(changeInvertCallstack(true));
     dispatch(changeSelectedCallNode(threadIndex, selectedCallNodePath));
 
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [Z, Y, X, B]
-    );
-    assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
-      [
-        // Expanded nodes:
-        [Z],
-        [Z, Y],
-        [Z, Y, X],
-      ]
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([
+      Z,
+      Y,
+      X,
+      B,
+    ]);
+    assertSetContainsOnly(selectedThread.getExpandedCallNodePaths(getState()), [
+      // Expanded nodes:
+      [Z],
+      [Z, Y],
+      [Z, Y, X],
+    ]);
   });
 
   it('can update call node references for focusing a subtree', function() {
@@ -1231,17 +1191,16 @@ describe('expanded and selected CallNodePaths on inverted trees', function() {
       })
     );
 
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [Y, X, B]
-    );
-    assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
-      [
-        // Expanded nodes:
-        [Y],
-        [Y, X],
-      ]
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([
+      Y,
+      X,
+      B,
+    ]);
+    assertSetContainsOnly(selectedThread.getExpandedCallNodePaths(getState()), [
+      // Expanded nodes:
+      [Y],
+      [Y, X],
+    ]);
   });
 
   it('can update call node references for merging a call node', function() {
@@ -1257,17 +1216,16 @@ describe('expanded and selected CallNodePaths on inverted trees', function() {
       })
     );
 
-    expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [Z, X, B]
-    );
-    assertSetContainsOnly(
-      selectedThreadSelectors.getExpandedCallNodePaths(getState()),
-      [
-        // Expanded nodes:
-        [Z],
-        [Z, X],
-      ]
-    );
+    expect(selectedThread.getSelectedCallNodePath(getState())).toEqual([
+      Z,
+      X,
+      B,
+    ]);
+    assertSetContainsOnly(selectedThread.getExpandedCallNodePaths(getState()), [
+      // Expanded nodes:
+      [Z],
+      [Z, X],
+    ]);
   });
 });
 
@@ -1279,19 +1237,17 @@ describe('transform js allocations', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('js-allocations'));
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- A (total: 15, self: —)',
-        '  - B (total: 15, self: —)',
-        '    - Fjs (total: 12, self: —)',
-        '      - Gjs (total: 12, self: 5)',
-        '        - Hjs (total: 7, self: —)',
-        '          - I (total: 7, self: 7)',
-        '    - C (total: 3, self: —)',
-        '      - D (total: 3, self: —)',
-        '        - E (total: 3, self: 3)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- A (total: 15, self: —)',
+      '  - B (total: 15, self: —)',
+      '    - Fjs (total: 12, self: —)',
+      '      - Gjs (total: 12, self: 5)',
+      '        - Hjs (total: 7, self: —)',
+      '          - I (total: 7, self: 7)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
   });
 
   it('is modified when performing a transform to the stacks', function() {
@@ -1308,14 +1264,12 @@ describe('transform js allocations', function() {
       })
     );
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- Fjs (total: 12, self: —)',
-        '  - Gjs (total: 12, self: 5)',
-        '    - Hjs (total: 7, self: —)',
-        '      - I (total: 7, self: 7)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- Fjs (total: 12, self: —)',
+      '  - Gjs (total: 12, self: 5)',
+      '    - Hjs (total: 7, self: —)',
+      '      - I (total: 7, self: 7)',
+    ]);
   });
 });
 
@@ -1327,19 +1281,17 @@ describe('transform native allocations', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-allocations'));
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- A (total: 15, self: —)',
-        '  - B (total: 15, self: —)',
-        '    - Fjs (total: 12, self: —)',
-        '      - Gjs (total: 12, self: 5)',
-        '        - Hjs (total: 7, self: —)',
-        '          - I (total: 7, self: 7)',
-        '    - C (total: 3, self: —)',
-        '      - D (total: 3, self: —)',
-        '        - E (total: 3, self: 3)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- A (total: 15, self: —)',
+      '  - B (total: 15, self: —)',
+      '    - Fjs (total: 12, self: —)',
+      '      - Gjs (total: 12, self: 5)',
+      '        - Hjs (total: 7, self: —)',
+      '          - I (total: 7, self: 7)',
+      '    - C (total: 3, self: —)',
+      '      - D (total: 3, self: —)',
+      '        - E (total: 3, self: 3)',
+    ]);
   });
 
   it('is modified when performing a transform to the stacks', function() {
@@ -1356,14 +1308,12 @@ describe('transform native allocations', function() {
       })
     );
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- Fjs (total: 12, self: —)',
-        '  - Gjs (total: 12, self: 5)',
-        '    - Hjs (total: 7, self: —)',
-        '      - I (total: 7, self: 7)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- Fjs (total: 12, self: —)',
+      '  - Gjs (total: 12, self: 5)',
+      '    - Hjs (total: 7, self: —)',
+      '      - I (total: 7, self: 7)',
+    ]);
   });
 });
 
@@ -1375,19 +1325,17 @@ describe('transform native deallocations', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-deallocations'));
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- A (total: -41, self: —)',
-        '  - B (total: -41, self: —)',
-        '    - Fjs (total: -30, self: —)',
-        '      - Gjs (total: -30, self: -13)',
-        '        - Hjs (total: -17, self: —)',
-        '          - I (total: -17, self: -17)',
-        '    - C (total: -11, self: —)',
-        '      - D (total: -11, self: —)',
-        '        - E (total: -11, self: -11)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- A (total: -41, self: —)',
+      '  - B (total: -41, self: —)',
+      '    - Fjs (total: -30, self: —)',
+      '      - Gjs (total: -30, self: -13)',
+      '        - Hjs (total: -17, self: —)',
+      '          - I (total: -17, self: -17)',
+      '    - C (total: -11, self: —)',
+      '      - D (total: -11, self: —)',
+      '        - E (total: -11, self: -11)',
+    ]);
   });
 
   it('is modified when performing a transform to the stacks', function() {
@@ -1404,14 +1352,12 @@ describe('transform native deallocations', function() {
       })
     );
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- Fjs (total: -30, self: —)',
-        '  - Gjs (total: -30, self: -13)',
-        '    - Hjs (total: -17, self: —)',
-        '      - I (total: -17, self: -17)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- Fjs (total: -30, self: —)',
+      '  - Gjs (total: -30, self: -13)',
+      '    - Hjs (total: -17, self: —)',
+      '      - I (total: -17, self: -17)',
+    ]);
   });
 });
 
@@ -1423,19 +1369,17 @@ describe('transform retained native allocations', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-retained-allocations'));
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- A (total: 41, self: —)',
-        '  - B (total: 41, self: —)',
-        '    - Fjs (total: 30, self: —)',
-        '      - Gjs (total: 30, self: 13)',
-        '        - Hjs (total: 17, self: —)',
-        '          - I (total: 17, self: 17)',
-        '    - C (total: 11, self: —)',
-        '      - D (total: 11, self: —)',
-        '        - E (total: 11, self: 11)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- A (total: 41, self: —)',
+      '  - B (total: 41, self: —)',
+      '    - Fjs (total: 30, self: —)',
+      '      - Gjs (total: 30, self: 13)',
+      '        - Hjs (total: 17, self: —)',
+      '          - I (total: 17, self: 17)',
+      '    - C (total: 11, self: —)',
+      '      - D (total: 11, self: —)',
+      '        - E (total: 11, self: 11)',
+    ]);
   });
 
   it('is modified when performing a transform to the stacks', function() {
@@ -1452,13 +1396,11 @@ describe('transform retained native allocations', function() {
       })
     );
 
-    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
-      [
-        '- Fjs (total: 42, self: —)',
-        '  - Gjs (total: 42, self: 18)',
-        '    - Hjs (total: 24, self: —)',
-        '      - I (total: 24, self: 24)',
-      ]
-    );
+    expect(formatTree(selectedThread.getCallTree(getState()))).toEqual([
+      '- Fjs (total: 42, self: —)',
+      '  - Gjs (total: 42, self: 18)',
+      '    - Hjs (total: 24, self: —)',
+      '      - I (total: 24, self: 24)',
+    ]);
   });
 });

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 
 import { storeWithProfile } from '../fixtures/stores';
 import {

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 import { storeWithProfile } from '../fixtures/stores';
 import {

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -18,7 +18,7 @@ describe('getUsefulTabs', function() {
   it('hides the network chart and JS tracer when no data is in the thread', function() {
     const { profile } = getProfileFromTextSamples('A');
     const { getState } = storeWithProfile(profile);
-    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+    expect(selectedThread.getUsefulTabs(getState())).toEqual([
       'calltree',
       'flame-graph',
       'stack-chart',
@@ -30,7 +30,7 @@ describe('getUsefulTabs', function() {
   it('shows the network chart when network markers are present in the thread', function() {
     const profile = getProfileWithMarkers(getNetworkMarkers());
     const { getState } = storeWithProfile(profile);
-    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+    expect(selectedThread.getUsefulTabs(getState())).toEqual([
       'calltree',
       'flame-graph',
       'stack-chart',
@@ -43,7 +43,7 @@ describe('getUsefulTabs', function() {
   it('shows the js tracer when it is available in a thread', function() {
     const profile = getProfileWithJsTracerEvents([['A', 0, 10]]);
     const { getState } = storeWithProfile(profile);
-    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+    expect(selectedThread.getUsefulTabs(getState())).toEqual([
       'calltree',
       'flame-graph',
       'stack-chart',
@@ -56,7 +56,7 @@ describe('getUsefulTabs', function() {
   it('shows only the call tree when a diffing track is selected', function() {
     const { profile } = getMergedProfileFromTextSamples('A  B  C', 'A  B  B');
     const { getState, dispatch } = storeWithProfile(profile);
-    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+    expect(selectedThread.getUsefulTabs(getState())).toEqual([
       'calltree',
       'flame-graph',
       'stack-chart',
@@ -69,8 +69,6 @@ describe('getUsefulTabs', function() {
       selectedThreadIndex: 2,
       selectedTab: 'calltree',
     });
-    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
-      'calltree',
-    ]);
+    expect(selectedThread.getUsefulTabs(getState())).toEqual(['calltree']);
   });
 });

--- a/src/test/store/zipped-profiles.test.js
+++ b/src/test/store/zipped-profiles.test.js
@@ -8,9 +8,9 @@ import {
   storeWithZipFile,
 } from '../fixtures/profiles/zip-file';
 import { procureInitialInterestingExpandedNodes } from '../../profile-logic/zip-files';
-import * as ProfileViewSelectors from '../../selectors/profile';
-import * as ZippedProfilesSelectors from '../../selectors/zipped-profiles';
-import * as UrlStateSelectors from '../../selectors/url-state';
+import * as ProfileViewSelectors from 'selectors/profile';
+import * as ZippedProfilesSelectors from 'selectors/zipped-profiles';
+import * as UrlStateSelectors from 'selectors/url-state';
 import createStore from '../../app-logic/create-store';
 import { ensureExists } from '../../utils/flow';
 import JSZip from 'jszip';

--- a/src/test/store/zipped-profiles.test.js
+++ b/src/test/store/zipped-profiles.test.js
@@ -8,9 +8,7 @@ import {
   storeWithZipFile,
 } from '../fixtures/profiles/zip-file';
 import { procureInitialInterestingExpandedNodes } from '../../profile-logic/zip-files';
-import * as ProfileViewSelectors from 'selectors/profile';
-import * as ZippedProfilesSelectors from 'selectors/zipped-profiles';
-import * as UrlStateSelectors from 'selectors/url-state';
+import * as selectors from 'selectors';
 import createStore from '../../app-logic/create-store';
 import { ensureExists } from '../../utils/flow';
 import JSZip from 'jszip';
@@ -31,7 +29,7 @@ describe('reducer zipFileState', function() {
       'foo/profile2.json',
       'baz/profile3.json',
     ]);
-    expect(ProfileViewSelectors.getProfileOrNull(getState())).toEqual(null);
+    expect(selectors.getProfileOrNull(getState())).toEqual(null);
 
     await dispatch(
       ZippedProfilesActions.viewProfileFromPathInZipFile(
@@ -39,10 +37,10 @@ describe('reducer zipFileState', function() {
       )
     );
 
-    expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toBe(
+    expect(selectors.getZipFileState(getState()).phase).toBe(
       'VIEW_PROFILE_IN_ZIP_FILE'
     );
-    const profile1 = ProfileViewSelectors.getProfile(getState());
+    const profile1 = selectors.getProfile(getState());
 
     expect(profile1).toBeTruthy();
   });
@@ -69,7 +67,7 @@ describe('reducer zipFileState', function() {
       const { getState } = await setup();
 
       const expectedName = 'bar/profile1.json';
-      expect(UrlStateSelectors.getProfileName(getState())).toBe(expectedName);
+      expect(selectors.getProfileName(getState())).toBe(expectedName);
     });
 
     it('computes a profile when no folder present', async function() {
@@ -85,7 +83,7 @@ describe('reducer zipFileState', function() {
       );
 
       const expectedName = 'profile4.json';
-      expect(UrlStateSelectors.getProfileName(getState())).toBe(expectedName);
+      expect(selectors.getProfileName(getState())).toBe(expectedName);
     });
 
     it('prefers ProfileName if it is given in the URL', async function() {
@@ -93,9 +91,7 @@ describe('reducer zipFileState', function() {
       const profileNameFromURL = 'good profile';
 
       dispatch(ProfileViewActions.changeProfileName(profileNameFromURL));
-      expect(UrlStateSelectors.getProfileName(getState())).toBe(
-        profileNameFromURL
-      );
+      expect(selectors.getProfileName(getState())).toBe(profileNameFromURL);
     });
   });
 
@@ -112,7 +108,7 @@ describe('reducer zipFileState', function() {
       ZippedProfilesActions.viewProfileFromPathInZipFile('not-a-profile.json')
     );
 
-    expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+    expect(selectors.getZipFileState(getState()).phase).toEqual(
       'FAILED_TO_PROCESS_PROFILE_FROM_ZIP_FILE'
     );
     // console error was called.
@@ -128,7 +124,7 @@ describe('reducer zipFileState', function() {
       ZippedProfilesActions.viewProfileFromPathInZipFile('nothing-here.json')
     );
 
-    expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toEqual(
+    expect(selectors.getZipFileState(getState()).phase).toEqual(
       'FILE_NOT_FOUND_IN_ZIP_FILE'
     );
   });
@@ -142,7 +138,7 @@ describe('reducer zipFileState', function() {
       'baz/profile5.json',
     ]);
 
-    const zipFileTable = ZippedProfilesSelectors.getZipFileTable(getState());
+    const zipFileTable = selectors.getZipFileTable(getState());
     expect(formatZipFileTable(zipFileTable)).toEqual([
       'foo (dir)',
       '  bar (dir)',
@@ -163,7 +159,7 @@ describe('reducer zipFileState', function() {
       'foo/profile4.json',
       'baz/profile5.json',
     ]);
-    expect(ZippedProfilesSelectors.getZipFileMaxDepth(getState())).toEqual(2);
+    expect(selectors.getZipFileMaxDepth(getState())).toEqual(2);
   });
 });
 
@@ -171,15 +167,15 @@ describe('selected and expanded zip files', function() {
   it('can expand selections in the zip file', function() {
     const { dispatch, getState } = createStore();
 
-    expect(
-      ZippedProfilesSelectors.getExpandedZipFileIndexes(getState())
-    ).toEqual([]);
+    expect(selectors.getExpandedZipFileIndexes(getState())).toEqual([]);
 
     // The indexes don't check that they are valid when you add them.
     dispatch(ZippedProfilesActions.changeExpandedZipFile([123, 456, 789]));
-    expect(
-      ZippedProfilesSelectors.getExpandedZipFileIndexes(getState())
-    ).toEqual([123, 456, 789]);
+    expect(selectors.getExpandedZipFileIndexes(getState())).toEqual([
+      123,
+      456,
+      789,
+    ]);
   });
 
   it('can procure an interesting selection', async function() {
@@ -194,8 +190,8 @@ describe('selected and expanded zip files', function() {
       'd/profile8.json',
     ]);
 
-    const zipFileTree = ZippedProfilesSelectors.getZipFileTree(getState());
-    const zipFileTable = ZippedProfilesSelectors.getZipFileTable(getState());
+    const zipFileTree = selectors.getZipFileTree(getState());
+    const zipFileTable = selectors.getZipFileTable(getState());
 
     dispatch(
       ZippedProfilesActions.changeExpandedZipFile(
@@ -203,9 +199,7 @@ describe('selected and expanded zip files', function() {
       )
     );
 
-    const expanded = ZippedProfilesSelectors.getExpandedZipFileIndexes(
-      getState()
-    );
+    const expanded = selectors.getExpandedZipFileIndexes(getState());
     const expandedNames = expanded.map(
       index => zipFileTable.path[ensureExists(index)]
     );
@@ -215,16 +209,12 @@ describe('selected and expanded zip files', function() {
   it('can select a zip file', function() {
     const { dispatch, getState } = createStore();
 
-    expect(ZippedProfilesSelectors.getSelectedZipFileIndex(getState())).toEqual(
-      null
-    );
+    expect(selectors.getSelectedZipFileIndex(getState())).toEqual(null);
 
     // The indexes don't check that they are valid when you add them.
     dispatch(ZippedProfilesActions.changeSelectedZipFile(123));
 
-    expect(ZippedProfilesSelectors.getSelectedZipFileIndex(getState())).toEqual(
-      123
-    );
+    expect(selectors.getSelectedZipFileIndex(getState())).toEqual(123);
   });
 });
 
@@ -246,18 +236,18 @@ describe('profile state invalidation when switching between profiles', function(
     viewProfile('profile1.json');
 
     // It starts out empty.
-    expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
+    expect(selectors.getAllCommittedRanges(getState())).toEqual([]);
 
     // Add a url-encoded bit of state.
     dispatch(ProfileViewActions.commitRange(0, 10));
-    expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+    expect(selectors.getAllCommittedRanges(getState())).toEqual([
       { start: 0, end: 10 },
     ]);
 
     // It switches to another profile and invalidates.
     dispatch(ZippedProfilesActions.returnToZipFileList());
     viewProfile('profile2.json');
-    expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
+    expect(selectors.getAllCommittedRanges(getState())).toEqual([]);
   });
 
   it('invalidates profile view state', async function() {
@@ -275,21 +265,17 @@ describe('profile state invalidation when switching between profiles', function(
     });
 
     // It starts with no selection.
-    expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual(
-      getNoSelection()
-    );
+    expect(selectors.getPreviewSelection(getState())).toEqual(getNoSelection());
 
     // Add a selection.
     dispatch(ProfileViewActions.updatePreviewSelection(getSomeSelection()));
-    expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual(
+    expect(selectors.getPreviewSelection(getState())).toEqual(
       getSomeSelection()
     );
     dispatch(ZippedProfilesActions.returnToZipFileList());
     viewProfile('profile2.json');
 
     // It no longer has a selection when viewing another profile.
-    expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual(
-      getNoSelection()
-    );
+    expect(selectors.getPreviewSelection(getState())).toEqual(getNoSelection());
   });
 });

--- a/src/test/store/zipped-profiles.test.js
+++ b/src/test/store/zipped-profiles.test.js
@@ -8,7 +8,7 @@ import {
   storeWithZipFile,
 } from '../fixtures/profiles/zip-file';
 import { procureInitialInterestingExpandedNodes } from '../../profile-logic/zip-files';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import createStore from '../../app-logic/create-store';
 import { ensureExists } from '../../utils/flow';
 import JSZip from 'jszip';

--- a/src/test/unit/js-allocations.test.js
+++ b/src/test/unit/js-allocations.test.js
@@ -14,7 +14,7 @@ import {
   commitRange,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 
 /**
  * Test that the JsAllocationTable structure can by used with all of the call tree

--- a/src/test/unit/js-allocations.test.js
+++ b/src/test/unit/js-allocations.test.js
@@ -14,7 +14,7 @@ import {
   commitRange,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 
 /**
  * Test that the JsAllocationTable structure can by used with all of the call tree

--- a/src/test/unit/js-allocations.test.js
+++ b/src/test/unit/js-allocations.test.js
@@ -14,7 +14,7 @@ import {
   commitRange,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 
 /**
  * Test that the JsAllocationTable structure can by used with all of the call tree
@@ -32,7 +32,7 @@ describe('JS allocation call trees', function() {
 
   it('can create a call tree from JS allocations', function() {
     const { getState } = setup();
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 15, self: —)',
@@ -50,7 +50,7 @@ describe('JS allocation call trees', function() {
   it('can search the allocations', function() {
     const { getState, dispatch } = setup();
     dispatch(changeCallTreeSearchString('H'));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 7, self: —)',
@@ -65,7 +65,7 @@ describe('JS allocation call trees', function() {
   it('can invert the allocation tree', function() {
     const { getState, dispatch } = setup();
     dispatch(changeInvertCallstack(true));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- I (total: 7, self: 7)',
@@ -89,7 +89,7 @@ describe('JS allocation call trees', function() {
   it('can use an implementation filter', function() {
     const { getState, dispatch } = setup();
     dispatch(changeImplementationFilter('js'));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- Fjs (total: 12, self: —)',
@@ -117,7 +117,7 @@ describe('JS allocation call trees', function() {
       })
     );
 
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 15, self: —)',
@@ -135,7 +135,7 @@ describe('JS allocation call trees', function() {
     const { getState, dispatch } = setup();
 
     dispatch(commitRange(0, 1.5));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 8, self: —)',
@@ -160,7 +160,7 @@ describe('JS allocation call trees', function() {
         selectionEnd: 1,
       })
     );
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 3, self: —)',

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { getThreadSelectors } from 'selectors/per-thread';
+import { getThreadSelectors } from 'selectors';
 import { processProfile } from '../../profile-logic/process-profile';
 import {
   IPCMarkerCorrelations,

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { getThreadSelectors } from 'selectors';
+import { getThreadSelectors } from 'firefox-profiler/selectors';
 import { processProfile } from '../../profile-logic/process-profile';
 import {
   IPCMarkerCorrelations,

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { getThreadSelectors } from '../../selectors/per-thread';
+import { getThreadSelectors } from 'selectors/per-thread';
 import { processProfile } from '../../profile-logic/process-profile';
 import {
   IPCMarkerCorrelations,

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -16,7 +16,7 @@ import {
   commitRange,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import type { CallTreeSummaryStrategy } from '../../types/actions';
 
 /**

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -16,7 +16,7 @@ import {
   commitRange,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { selectedThreadSelectors } from 'selectors/per-thread';
+import { selectedThread } from 'selectors';
 import type { CallTreeSummaryStrategy } from '../../types/actions';
 
 /**
@@ -42,7 +42,7 @@ describe('Native allocation call trees', function() {
   describe('with balanced allocations', function() {
     it('can create a call tree from allocations only', function() {
       const { getState } = setup('balanced', 'native-allocations');
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
         '- A (total: 56, self: —)',
@@ -59,7 +59,7 @@ describe('Native allocation call trees', function() {
 
     it('can create a call tree from deallocations only', function() {
       const { getState } = setup('balanced', 'native-deallocations');
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
         '- A (total: -86, self: —)',
@@ -76,7 +76,7 @@ describe('Native allocation call trees', function() {
 
     it('can create a call tree from retained allocations', function() {
       const { getState } = setup('balanced', 'native-retained-allocations');
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
         '- A (total: 41, self: —)',
@@ -95,7 +95,7 @@ describe('Native allocation call trees', function() {
   describe('with unbalanced allocations', function() {
     it('can create a call tree from allocations only', function() {
       const { getState } = setup('unbalanced', 'native-allocations');
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
         '- A (total: 15, self: —)',
@@ -112,7 +112,7 @@ describe('Native allocation call trees', function() {
 
     it('can create a call tree from deallocations only', function() {
       const { getState } = setup('unbalanced', 'native-deallocations');
-      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callTree = selectedThread.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
         '- A (total: -41, self: —)',
@@ -130,7 +130,7 @@ describe('Native allocation call trees', function() {
     it('cannot create a call tree from retained allocations', function() {
       const { getState } = setup('unbalanced', 'native-retained-allocations');
       expect(() => {
-        selectedThreadSelectors.getCallTree(getState());
+        selectedThread.getCallTree(getState());
       }).toThrow();
     });
   });
@@ -138,7 +138,7 @@ describe('Native allocation call trees', function() {
   it('can search the allocations', function() {
     const { getState, dispatch } = setup('balanced', 'native-allocations');
     dispatch(changeCallTreeSearchString('Hjs'));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 24, self: —)',
@@ -153,7 +153,7 @@ describe('Native allocation call trees', function() {
   it('can invert the allocation tree', function() {
     const { getState, dispatch } = setup('balanced', 'native-allocations');
     dispatch(changeInvertCallstack(true));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- I (total: 24, self: 24)',
@@ -177,7 +177,7 @@ describe('Native allocation call trees', function() {
   it('can use an implementation filter', function() {
     const { getState, dispatch } = setup('balanced', 'native-allocations');
     dispatch(changeImplementationFilter('js'));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- Fjs (total: 42, self: —)',
@@ -190,7 +190,7 @@ describe('Native allocation call trees', function() {
     const { getState, dispatch } = setup('balanced', 'native-allocations');
 
     dispatch(commitRange(0, 1.5));
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 8, self: —)',
@@ -215,7 +215,7 @@ describe('Native allocation call trees', function() {
         selectionEnd: 1,
       })
     );
-    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const callTree = selectedThread.getCallTree(getState());
 
     expect(formatTree(callTree)).toEqual([
       '- A (total: 3, self: —)',

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -16,7 +16,7 @@ import {
   commitRange,
   updatePreviewSelection,
 } from '../../actions/profile-view';
-import { selectedThread } from 'selectors';
+import { selectedThread } from 'firefox-profiler/selectors';
 import type { CallTreeSummaryStrategy } from '../../types/actions';
 
 /**

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -10,11 +10,11 @@ import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 import type { RemoveProfileInformation } from '../../types/profile-derived';
 import { storeWithProfile } from '../fixtures/stores';
-import { getHasPreferenceMarkers } from '../../selectors/profile';
+import { getHasPreferenceMarkers } from 'selectors/profile';
 import {
   getCheckedSharingOptions,
   getRemoveProfileInformation,
-} from '../../selectors/publish';
+} from 'selectors/publish';
 import { toggleCheckedSharingOptions } from '../../actions/publish';
 
 describe('sanitizePII', function() {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -14,7 +14,7 @@ import {
   getHasPreferenceMarkers,
   getCheckedSharingOptions,
   getRemoveProfileInformation,
-} from 'selectors';
+} from 'firefox-profiler/selectors';
 import { toggleCheckedSharingOptions } from '../../actions/publish';
 
 describe('sanitizePII', function() {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -10,11 +10,11 @@ import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 import type { RemoveProfileInformation } from '../../types/profile-derived';
 import { storeWithProfile } from '../fixtures/stores';
-import { getHasPreferenceMarkers } from 'selectors/profile';
 import {
+  getHasPreferenceMarkers,
   getCheckedSharingOptions,
   getRemoveProfileInformation,
-} from 'selectors/publish';
+} from 'selectors';
 import { toggleCheckedSharingOptions } from '../../actions/publish';
 
 describe('sanitizePII', function() {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { oneLineTrim } from 'common-tags';
-import * as urlStateReducers from '../selectors/url-state';
+import * as urlStateReducers from 'selectors/url-state';
 import {
   changeCallTreeSearchString,
   changeMarkersSearchString,
@@ -30,7 +30,7 @@ import {
   getProfileWithNiceTracks,
 } from './fixtures/profiles/tracks';
 import { getProfileFromTextSamples } from './fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from '../selectors/per-thread';
+import { selectedThreadSelectors } from 'selectors/per-thread';
 import { uintArrayToString } from '../utils/uintarray-encoding';
 
 function _getStoreWithURL(

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { oneLineTrim } from 'common-tags';
-import * as selectors from 'selectors';
+import * as selectors from 'firefox-profiler/selectors';
 import {
   changeCallTreeSearchString,
   changeMarkersSearchString,

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { oneLineTrim } from 'common-tags';
-import * as urlStateReducers from 'selectors/url-state';
+import * as selectors from 'selectors';
 import {
   changeCallTreeSearchString,
   changeMarkersSearchString,
@@ -30,7 +30,6 @@ import {
   getProfileWithNiceTracks,
 } from './fixtures/profiles/tracks';
 import { getProfileFromTextSamples } from './fixtures/profiles/processed-profile';
-import { selectedThreadSelectors } from 'selectors/per-thread';
 import { uintArrayToString } from '../utils/uintarray-encoding';
 
 function _getStoreWithURL(
@@ -119,14 +118,14 @@ describe('selectedThread', function() {
 
   it('selects the right thread when receiving a profile from web', function() {
     const { getState } = setup(1);
-    expect(urlStateReducers.getSelectedThreadIndex(getState())).toBe(1);
+    expect(selectors.getSelectedThreadIndex(getState())).toBe(1);
   });
 
   it('selects a default thread when a wrong thread has been requested', function() {
     const { getState } = setup(100);
 
     // "2" is the content process' main tab
-    expect(urlStateReducers.getSelectedThreadIndex(getState())).toBe(2);
+    expect(selectors.getSelectedThreadIndex(getState())).toBe(2);
   });
 });
 
@@ -168,16 +167,14 @@ describe('url handling tracks', function() {
 
     it('will not accept invalid tracks in the thread order', function() {
       const { getState } = initWithSearchParams('?globalTrackOrder=1-0');
-      expect(urlStateReducers.getGlobalTrackOrder(getState())).toEqual([1, 0]);
+      expect(selectors.getGlobalTrackOrder(getState())).toEqual([1, 0]);
     });
 
     it('will not accept invalid hidden threads', function() {
       const { getState } = initWithSearchParams(
         '?hiddenGlobalTracks=0-8-2-a&thread=1'
       );
-      expect(urlStateReducers.getHiddenGlobalTracks(getState())).toEqual(
-        new Set([0])
-      );
+      expect(selectors.getHiddenGlobalTracks(getState())).toEqual(new Set([0]));
     });
   });
 
@@ -273,18 +270,18 @@ describe('url handling tracks', function() {
 describe('search strings', function() {
   it('properly handles the call tree search string stacks with 1 item', function() {
     const { getState } = _getStoreWithURL({ search: '?search=string' });
-    expect(urlStateReducers.getCurrentSearchString(getState())).toBe('string');
-    expect(urlStateReducers.getSearchStrings(getState())).toEqual(['string']);
+    expect(selectors.getCurrentSearchString(getState())).toBe('string');
+    expect(selectors.getSearchStrings(getState())).toEqual(['string']);
   });
 
   it('properly handles the call tree search string stacks with several items', function() {
     const { getState } = _getStoreWithURL({
       search: '?search=string,foo,%20bar',
     });
-    expect(urlStateReducers.getCurrentSearchString(getState())).toBe(
+    expect(selectors.getCurrentSearchString(getState())).toBe(
       'string,foo, bar'
     );
-    expect(urlStateReducers.getSearchStrings(getState())).toEqual([
+    expect(selectors.getSearchStrings(getState())).toEqual([
       'string',
       'foo',
       'bar',
@@ -295,19 +292,17 @@ describe('search strings', function() {
     const { getState } = _getStoreWithURL({
       search: '?markerSearch=otherString',
     });
-    expect(urlStateReducers.getMarkersSearchString(getState())).toBe(
-      'otherString'
-    );
+    expect(selectors.getMarkersSearchString(getState())).toBe('otherString');
   });
 
   it('properly handles showUserTimings strings', function() {
     const { getState } = _getStoreWithURL({ search: '' });
-    expect(urlStateReducers.getShowUserTimings(getState())).toBe(false);
+    expect(selectors.getShowUserTimings(getState())).toBe(false);
   });
 
   it('defaults to not showing user timings', function() {
     const { getState } = _getStoreWithURL();
-    expect(urlStateReducers.getShowUserTimings(getState())).toBe(false);
+    expect(selectors.getShowUserTimings(getState())).toBe(false);
   });
 
   it('serializes the call tree search strings in the URL', function() {
@@ -319,7 +314,7 @@ describe('search strings', function() {
 
     ['calltree', 'stack-chart', 'flame-graph'].forEach(tabSlug => {
       dispatch(changeSelectedTab(tabSlug));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = selectors.getUrlState(getState());
       const { query } = urlStateToUrlObject(urlState);
       expect(query.search).toBe(callTreeSearchString);
     });
@@ -334,7 +329,7 @@ describe('search strings', function() {
 
     ['marker-chart', 'marker-table'].forEach(tabSlug => {
       dispatch(changeSelectedTab(tabSlug));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = selectors.getUrlState(getState());
       const { query } = urlStateToUrlObject(urlState);
       expect(query.markerSearch).toBe(markerSearchString);
     });
@@ -347,7 +342,7 @@ describe('search strings', function() {
 
     dispatch(changeNetworkSearchString(networkSearchString));
     dispatch(changeSelectedTab('network-chart'));
-    const urlState = urlStateReducers.getUrlState(getState());
+    const urlState = selectors.getUrlState(getState());
     const { query } = urlStateToUrlObject(urlState);
     expect(query.networkSearch).toBe(networkSearchString);
   });
@@ -359,7 +354,7 @@ describe('profileName', function() {
     const profileName = 'Good Profile';
 
     dispatch(changeProfileName(profileName));
-    const urlState = urlStateReducers.getUrlState(getState());
+    const urlState = selectors.getUrlState(getState());
     const { query } = urlStateToUrlObject(urlState);
     expect(query.profileName).toBe(profileName);
   });
@@ -368,14 +363,14 @@ describe('profileName', function() {
     const { getState } = _getStoreWithURL({
       search: '?profileName=XXX',
     });
-    expect(urlStateReducers.getProfileNameFromUrl(getState())).toBe('XXX');
-    expect(urlStateReducers.getProfileName(getState())).toBe('XXX');
+    expect(selectors.getProfileNameFromUrl(getState())).toBe('XXX');
+    expect(selectors.getProfileName(getState())).toBe('XXX');
   });
 
   it('returns empty string when profileName is not specified', function() {
     const { getState } = _getStoreWithURL();
-    expect(urlStateReducers.getProfileNameFromUrl(getState())).toBe('');
-    expect(urlStateReducers.getProfileName(getState())).toBe('');
+    expect(selectors.getProfileNameFromUrl(getState())).toBe('');
+    expect(selectors.getProfileName(getState())).toBe('');
   });
 });
 
@@ -391,7 +386,7 @@ describe('url upgrading', function() {
           '?callTreeFilters=prefix-012~prefixjs-123~postfix-234~postfixjs-345',
         v: false,
       });
-      const transforms = selectedThreadSelectors.getTransformStack(getState());
+      const transforms = selectors.selectedThread.getTransformStack(getState());
       expect(transforms).toEqual([
         {
           type: 'focus-subtree',
@@ -427,7 +422,7 @@ describe('url upgrading', function() {
         pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/timeline/',
         v: 1,
       });
-      expect(urlStateReducers.getSelectedTab(getState())).toBe('stack-chart');
+      expect(selectors.getSelectedTab(getState())).toBe('stack-chart');
     });
 
     it('switches to the marker-table when given a markers tab', function() {
@@ -435,7 +430,7 @@ describe('url upgrading', function() {
         pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/markers/',
         v: false,
       });
-      expect(urlStateReducers.getSelectedTab(getState())).toBe('marker-table');
+      expect(selectors.getSelectedTab(getState())).toBe('marker-table');
     });
   });
 
@@ -446,7 +441,7 @@ describe('url upgrading', function() {
         search: '?hidePlatformDetails',
         v: 2,
       });
-      expect(urlStateReducers.getImplementationFilter(getState())).toBe('js');
+      expect(selectors.getImplementationFilter(getState())).toBe('js');
     });
   });
 
@@ -721,9 +716,7 @@ describe('url upgrading', function() {
     // state of the application, so we won't have 'markers' as result.
     // We should change this to something more meaningful when we have eg
     // converters that reuse query names.
-    expect(urlStateReducers.getSelectedTab(getState())).not.toBe(
-      'marker-table'
-    );
+    expect(selectors.getSelectedTab(getState())).not.toBe('marker-table');
   });
 });
 
@@ -736,7 +729,7 @@ describe('URL serialization of the transform stack', function() {
   });
 
   it('deserializes focus subtree transforms', function() {
-    const transformStack = selectedThreadSelectors.getTransformStack(
+    const transformStack = selectors.selectedThread.getTransformStack(
       getState()
     );
 
@@ -790,9 +783,7 @@ describe('URL serialization of the transform stack', function() {
   });
 
   it('re-serializes the focus subtree transforms', function() {
-    const { query } = urlStateToUrlObject(
-      urlStateReducers.getUrlState(getState())
-    );
+    const { query } = urlStateToUrlObject(selectors.getUrlState(getState()));
     expect(query.transforms).toBe(transformString);
   });
 });
@@ -828,7 +819,7 @@ describe('compare', function() {
       /* no profile */ null
     );
 
-    expect(urlStateReducers.getProfilesToCompare(store.getState())).toEqual([
+    expect(selectors.getProfilesToCompare(store.getState())).toEqual([
       url1,
       url2,
     ]);
@@ -840,22 +831,18 @@ describe('compare', function() {
       /* no profile */ null
     );
 
-    const initialUrl = urlFromState(
-      urlStateReducers.getUrlState(store.getState())
-    );
+    const initialUrl = urlFromState(selectors.getUrlState(store.getState()));
     expect(initialUrl).toEqual('/compare/');
 
     store.dispatch(changeProfilesToCompare([url1, url2]));
-    const resultingUrl = urlFromState(
-      urlStateReducers.getUrlState(store.getState())
-    );
+    const resultingUrl = urlFromState(selectors.getUrlState(store.getState()));
     expect(resultingUrl).toMatch(`profiles[]=${encodeURIComponent(url1)}`);
     expect(resultingUrl).toMatch(`profiles[]=${encodeURIComponent(url2)}`);
   });
 });
 
 describe('last requested call tree summary strategy', function() {
-  const { getLastSelectedCallTreeSummaryStrategy } = urlStateReducers;
+  const { getLastSelectedCallTreeSummaryStrategy } = selectors;
   it('defaults to timing', function() {
     const { getState } = _getStoreWithURL();
     expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -90,7 +90,7 @@ export type Marker = {|
  * and the marker object is returned using the function `getMarker` as returned
  * by the selector `getMarkerGetter`:
  *
- *   const getMarker = selectedThreadSelectors.getMarkerGetter(state);
+ *   const getMarker = selectedThread.getMarkerGetter(state);
  *   const marker = getMarker(markerIndex);
  */
 export type MarkerIndex = number;

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -4,7 +4,7 @@
 // @flow
 import { stripIndent } from 'common-tags';
 import type { GetState, Dispatch } from '../types/store';
-import selectors from '../selectors';
+import selectors from 'selectors';
 import actions from '../actions';
 
 // Despite providing a good libdef for Object.defineProperty, Flow still

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -4,7 +4,7 @@
 // @flow
 import { stripIndent } from 'common-tags';
 import type { GetState, Dispatch } from '../types/store';
-import { selectorsForConsole } from 'selectors';
+import { selectorsForConsole } from 'firefox-profiler/selectors';
 import actions from '../actions';
 
 // Despite providing a good libdef for Object.defineProperty, Flow still

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -4,7 +4,7 @@
 // @flow
 import { stripIndent } from 'common-tags';
 import type { GetState, Dispatch } from '../types/store';
-import selectors from 'selectors';
+import { selectorsForConsole } from 'selectors';
 import actions from '../actions';
 
 // Despite providing a good libdef for Object.defineProperty, Flow still
@@ -25,21 +25,23 @@ export function addDataToWindowObject(
   defineProperty(target, 'profile', {
     enumerable: true,
     get() {
-      return selectors.profile.getProfile(getState());
+      return selectorsForConsole.profile.getProfile(getState());
     },
   });
 
   defineProperty(target, 'filteredThread', {
     enumerable: true,
     get() {
-      return selectors.selectedThread.getPreviewFilteredThread(getState());
+      return selectorsForConsole.selectedThread.getPreviewFilteredThread(
+        getState()
+      );
     },
   });
 
   defineProperty(target, 'callTree', {
     enumerable: true,
     get() {
-      return selectors.selectedThread.getCallTree(getState());
+      return selectorsForConsole.selectedThread.getCallTree(getState());
     },
   });
 
@@ -47,8 +49,10 @@ export function addDataToWindowObject(
     enumerable: true,
     get() {
       const state = getState();
-      const getMarker = selectors.selectedThread.getMarkerGetter(state);
-      const markerIndexes = selectors.selectedThread.getPreviewFilteredMarkerIndexes(
+      const getMarker = selectorsForConsole.selectedThread.getMarkerGetter(
+        state
+      );
+      const markerIndexes = selectorsForConsole.selectedThread.getPreviewFilteredMarkerIndexes(
         state
       );
       return markerIndexes.map(getMarker);
@@ -56,7 +60,7 @@ export function addDataToWindowObject(
   });
 
   target.getState = getState;
-  target.selectors = selectors;
+  target.selectors = selectorsForConsole;
   target.dispatch = dispatch;
   target.actions = actions;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,6 @@ const config = {
       'redux-devtools/lib': path.join(__dirname, '..', '..', 'src'),
       'redux-devtools': path.join(__dirname, '..', '..', 'src'),
       react: path.join(__dirname, 'node_modules', 'react'),
-      selectors: path.join(__dirname, 'src', 'selectors'),
     },
     extensions: ['.js', '.wasm'],
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const config = {
       'redux-devtools/lib': path.join(__dirname, '..', '..', 'src'),
       'redux-devtools': path.join(__dirname, '..', '..', 'src'),
       react: path.join(__dirname, 'node_modules', 'react'),
+      selectors: path.join(__dirname, 'src', 'selectors'),
     },
     extensions: ['.js', '.wasm'],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,6 +2064,17 @@ babel-plugin-jest-hoist@^24.3.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-module-resolver@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.0.0.tgz#8f3a3d9d48287dc1d3b0d5595113adabd36a847f"
+  integrity sha512-3pdEq3PXALilSJ6dnC4wMWr0AZixHRM4utpdpBR9g5QG7B7JwWyukQv7a9hVxkbGFl+nQbrHDqqQOIBtTXTP/Q==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
@@ -4983,6 +4994,14 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
@@ -5435,6 +5454,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -7434,7 +7465,7 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -9831,6 +9862,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -11417,6 +11455,13 @@ resolve@^1.10.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.13.1:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.0.tgz#6d14c6f9db9f8002071332b600039abf82053f64"
+  integrity sha512-uviWSi5N67j3t3UKFxej1loCH0VZn5XuqdNxoLShPcYPw6cUZn74K1VRj+9myynRX03bxIBEkwlkob/ujLsJVw==
   dependencies:
     path-parse "^1.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4351,6 +4351,11 @@ eslint-config-prettier@^2.4.0:
   dependencies:
     get-stdin "^5.0.1"
 
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"


### PR DESCRIPTION
I was feeling frustrated around the complexity of importing selectors and other things in our codebase. In DevTools we have consensus that absolute paths are a good thing. I was thinking it would be nice to experiment with selectors this way, since they are complicated to import, and it really doesn't matter what file they are in.

I flagged @julienw and @canova for review just to get feedback and discussion on this.