### PR TITLE
Jest linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     'prettier',
     'prettier/flowtype',
     'prettier/react',
+    'plugin:jest/recommended'
   ],
   parserOptions: {
     ecmaVersion: '2017',

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jest": "^23.1.1",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.12.4",
     "fake-indexeddb": "^2.0.5",

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -483,6 +483,9 @@ describe('calltree/ProfileCallTreeView TransformNavigator', () => {
 });
 
 describe('ProfileCallTreeView/end-to-end', () => {
+  // This next test explicitly does not have an assertion, disable the eslint rule
+  // requiring one.
+  // eslint-disable-next-line jest/expect-expect
   it('can display a gecko profile without crashing', () => {
     const geckoProfile = createGeckoProfile();
     const processedProfile = processProfile(geckoProfile);

--- a/src/test/components/StackSettings.test.js
+++ b/src/test/components/StackSettings.test.js
@@ -34,14 +34,21 @@ describe('StackSettings', function() {
     expect(container).toMatchSnapshot();
   });
 
-  it('can change the implementation filter to JavaScript', function() {
+  /**
+   * Get around the type constraints of refining an HTMLElement into a radio input.
+   */
+  function getCheckedState(element: HTMLElement): mixed {
+    return (element: any).checked;
+  }
+
+  it('can change the implementation filter to JavaScript', async function() {
     const { getByLabelText, getState } = setup();
     expect(getImplementationFilter(getState())).toEqual('combined');
     const radioButton = getByLabelText(/JavaScript/);
 
     radioButton.click();
 
-    expect(radioButton.hasAttribute('checked'));
+    expect(getCheckedState(radioButton)).toBe(true);
     expect(getImplementationFilter(getState())).toEqual('js');
   });
 
@@ -52,7 +59,7 @@ describe('StackSettings', function() {
 
     radioButton.click();
 
-    expect(radioButton.hasAttribute('checked'));
+    expect(getCheckedState(radioButton)).toBe(true);
     expect(getImplementationFilter(getState())).toEqual('cpp');
   });
 
@@ -64,7 +71,7 @@ describe('StackSettings', function() {
 
     radioButton.click();
 
-    expect(radioButton.hasAttribute('checked'));
+    expect(getCheckedState(radioButton)).toBe(true);
     expect(getImplementationFilter(getState())).toEqual('combined');
   });
 

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -185,7 +185,8 @@ describe('timeline/TrackContextMenu', function() {
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(false);
     });
 
-    xit('can present a disabled isolate item on non-process tracks', function() {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('can present a disabled isolate item on non-process tracks', function() {
       // TODO - We should wait until we have some real tracks without a thread index.
     });
   });
@@ -265,7 +266,8 @@ describe('timeline/TrackContextMenu', function() {
       expect(getHiddenLocalTracks(getState(), pid).has(trackIndex)).toBe(false);
     });
 
-    xit('can isolate a non-thread track, as long as there process has a thread index', function() {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('can isolate a non-thread track, as long as there process has a thread index', function() {
       // TODO - We should wait until we have some real non-thread tracks
     });
   });

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -110,10 +110,14 @@ describe('Viewport', function() {
       expect(isTimerVisible()).toBe(false);
     });
 
+    // testScrollingHint has assertions.
+    // eslint-disable-next-line jest/expect-expect
     it('will not show a ctrl scrolling hint after zooming once', function() {
       testScrollingHint({ ctrlKey: true });
     });
 
+    // testScrollingHint has assertions.
+    // eslint-disable-next-line jest/expect-expect
     it('will not show a shift scrolling hint after zooming once', function() {
       testScrollingHint({ shiftKey: true });
     });

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -47,6 +47,8 @@ describe('calltree/ZipFileTree', function() {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  // getByText is an assertion, but eslint doesn't know that.
+  // eslint-disable-next-line jest/expect-expect
   it('contains a list of all the files', async () => {
     const { getByText } = await setup();
 

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -728,6 +728,8 @@ describe('actions/ProfileView', function() {
       );
     });
 
+    // assertSetContainsOnly is an assertion.
+    // eslint-disable-next-line jest/expect-expect
     it('expands subtrees', function() {
       const { getState, dispatch, threadIndex, A, B, C, D } = setupStore();
 
@@ -1195,7 +1197,7 @@ describe('actions/ProfileView', function() {
       }
     });
 
-    it('can extract some network markers and match the snapshot', function() {
+    it('only deliveres screenshots within a range selection', function() {
       const profile = getScreenshotTrackProfile();
       const [{ markers }] = profile.threads;
       const { dispatch, getState } = storeWithProfile(profile);
@@ -1431,6 +1433,8 @@ describe('snapshots of selectors/profile', function() {
       selectedThreadSelectors.getSelectedCallNodeIndex(getState())
     ).toEqual(1);
   });
+  // assertSetContainsOnly is an assertion
+  // eslint-disable-next-line jest/expect-expect
   it('matches the last stored run of selectedThreadSelector.getExpandedCallNodePaths', function() {
     const { getState, A, B } = setupStore();
     assertSetContainsOnly(

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1057,12 +1057,14 @@ describe('actions/receive-profile', function() {
       ).toMatchSnapshot();
     });
 
-    xit('can load gzipped json', async function() {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('can load gzipped json', async function() {
       // TODO - See issue #1023. The zee-worker is failing to compress/decompress
       // the profile.
     });
 
-    xit('will give an error when unable to parse gzipped profiles', async function() {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('will give an error when unable to parse gzipped profiles', async function() {
       // TODO - See issue #1023. The zee-worker is failing to compress/decompress
       // the profile.
     });
@@ -1610,7 +1612,7 @@ describe('actions/receive-profile', function() {
       );
 
       // It should successfully symbolicate the profiles that are loaded from addon.
-      await waitUntilSymbolication();
+      return expect(waitUntilSymbolication()).resolves.toBe(undefined);
     });
 
     it('does not retrieve profile from other data sources', async function() {

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -898,6 +898,8 @@ describe('"collapse-function-subtree" transform', function() {
     );
   });
 
+  // assertSetContainsOnly is an assertion.
+  // eslint-disable-next-line jest/expect-expect
   it('can update apply the transform to the expanded CallNodePaths', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     const toIds = (paths: Array<string[]>) =>

--- a/src/test/unit/profile-upgrading.test.js
+++ b/src/test/unit/profile-upgrading.test.js
@@ -17,6 +17,10 @@ import {
   PROCESSED_PROFILE_VERSION,
 } from '../../app-logic/constants';
 
+/* eslint-disable jest/expect-expect */
+// testProfileUpgrading and testCleopatraProfile are assertions, although eslint
+// doesn't realize it. Disable the rule.
+
 describe('upgrading old cleopatra profiles', function() {
   const oldCleopatraProfile = require('../fixtures/upgrades/old-cleopatra-profile.sps.json');
   const ancientCleopatraProfile = require('../fixtures/upgrades/ancient-cleopatra-profile.sps.json');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,6 +1227,11 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
 
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1278,6 +1283,28 @@
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.9.tgz#693e76a52f61a2f1e7fb48c0eef167b95ea4ffd0"
   integrity sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==
+
+"@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz#e0a76ffb6293e058748408a191921e453c31d40d"
+  integrity sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.12.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/typescript-estree@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz#bd9e547ccffd17dfab0c3ab0947c80c8e2eb914c"
+  integrity sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -4397,6 +4424,13 @@ eslint-plugin-import@^2.8.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-jest@^23.1.1:
+  version "23.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.1.1.tgz#1220ab53d5a4bf5c3c4cd07c0dabc6199d4064dd"
+  integrity sha512-2oPxHKNh4j1zmJ6GaCBuGcb8FVZU7YjFUOJzGOPnl9ic7VA/MGAskArLJiRIlnFUmi1EUxY+UiATAy8dv8s5JA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
+
 eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
@@ -4439,10 +4473,23 @@ eslint-scope@^4.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@^4.18.2:
   version "4.18.2"
@@ -6569,6 +6616,13 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-hexadecimal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
@@ -8007,6 +8061,11 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -11656,6 +11715,11 @@ semver-diff@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
 send@0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.16.1.tgz#a70e1ca21d1382c11d0d9f6231deb281080d7ab3"
@@ -13044,10 +13108,22 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
 
+tslib@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
In some of the PRs around UserTimings in the stack charts, there were some tests that were mistakenly skipped. This created some confusion around the CI passing, when in fact it shouldn't. In this PR, I add the recommended set of eslint rules for jest, and made our codebase pass them. I think this will help us have better control over what we're checking in. I tested locally and the warnings weren't too annoying when purposely skipping tests. It made it obvious without getting in the way, as only the `only` in `it.only` was underlined.