### PR TITLE
Deallocated memory

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -207,7 +207,8 @@ class CallTreeComponent extends PureComponent<Props> {
         break;
       case 'native-retained-allocations':
       case 'native-allocations':
-      case 'native-deallocations':
+      case 'native-deallocations-memory':
+      case 'native-deallocations-sites':
       case 'js-allocations':
         fixedColumns = this._fixedColumnsAllocations;
         break;

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -169,23 +169,23 @@ class StackSettings extends PureComponent<Props> {
                     : null}
                   {canShowRetainedMemory
                     ? this._renderCallTreeStrategyOption(
-                        'Retained Allocations',
+                        'Retained Memory',
                         'native-retained-allocations',
-                        'Summarize using bytes of memory that were allocated, and never freed while profiling'
+                        'Summarize using bytes of memory that were allocated, and never freed in the current preview selection'
                       )
                     : null}
                   {hasNativeAllocations
                     ? this._renderCallTreeStrategyOption(
-                        'Allocations',
+                        'Allocated Memory',
                         'native-allocations',
                         'Summarize using bytes of memory allocated'
                       )
                     : null}
                   {hasNativeAllocations
                     ? this._renderCallTreeStrategyOption(
-                        'Deallocations',
-                        'native-deallocations',
-                        'Summarize using bytes of memory deallocated'
+                        'Deallocation Sites',
+                        'native-deallocations-sites',
+                        'Summarize using bytes of memory deallocated, by the site where the memory was deallocated'
                       )
                     : null}
                 </select>

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -181,6 +181,13 @@ class StackSettings extends PureComponent<Props> {
                         'Summarize using bytes of memory allocated'
                       )
                     : null}
+                  {canShowRetainedMemory
+                    ? this._renderCallTreeStrategyOption(
+                        'Deallocated Memory',
+                        'native-deallocations-memory',
+                        'Summarize using bytes of memory deallocated, by the site where the memory was allocated'
+                      )
+                    : null}
                   {hasNativeAllocations
                     ? this._renderCallTreeStrategyOption(
                         'Deallocation Sites',

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -258,7 +258,8 @@ export class CallTree {
         case 'js-allocations':
         case 'native-allocations':
         case 'native-retained-allocations':
-        case 'native-deallocations': {
+        case 'native-deallocations-sites':
+        case 'native-deallocations-memory': {
           totalTimeWithUnit = `${formattedTotalTime} bytes`;
           selfTimeWithUnit = `${formattedSelfTime} bytes`;
           ariaLabel = `${funcName}, total size is ${totalTimeWithUnit} (${totalTimePercent}), self size is ${selfTimeWithUnit}`;

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -200,7 +200,8 @@ export function getStackAndSampleSelectorsPerThread(
           break;
         case 'native-allocations':
         case 'native-retained-allocations':
-        case 'native-deallocations':
+        case 'native-deallocations-sites':
+        case 'native-deallocations-memory':
           if (!thread.nativeAllocations) {
             // Attempting to view a thread with no native allocations, switch back
             // to timing.
@@ -234,7 +235,7 @@ export function getStackAndSampleSelectorsPerThread(
         case 'native-retained-allocations': {
           const nativeAllocations = ensureExists(
             thread.nativeAllocations,
-            'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
+            'Expected the NativeAllocationTable to exist when using a "native-allocation" strategy'
           );
 
           if (!nativeAllocations.memoryAddress) {
@@ -248,16 +249,35 @@ export function getStackAndSampleSelectorsPerThread(
           return ProfileData.filterToAllocations(
             ensureExists(
               thread.nativeAllocations,
-              'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
+              'Expected the NativeAllocationTable to exist when using a "native-allocations" strategy'
             )
           );
-        case 'native-deallocations':
-          return ProfileData.filterToDeallocations(
+        case 'native-deallocations-sites':
+          return ProfileData.filterToDeallocationsSites(
             ensureExists(
               thread.nativeAllocations,
+              'Expected the NativeAllocationTable to exist when using a "native-deallocations-sites" strategy'
+            )
+          );
+        case 'native-deallocations-memory': {
+          const nativeAllocations = ensureExists(
+            thread.nativeAllocations,
+            'Expected the NativeAllocationTable to exist when using a "native-deallocations-memory" strategy'
+          );
+
+          if (!nativeAllocations.memoryAddress) {
+            throw new Error(
+              'Attempting to filter by retained allocations data that is missing the memory addresses.'
+            );
+          }
+
+          return ProfileData.filterToDeallocationsMemory(
+            ensureExists(
+              nativeAllocations,
               'Expected the NativeAllocationTable to exist when using a "js-allocation" strategy'
             )
           );
+        }
         default:
           throw assertExhaustiveCheck(strategy);
       }

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -677,4 +677,10 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('matches the snapshot for deallocated memory', function() {
+    const { container, changeSelect } = setup();
+    changeSelect({ from: 'Timing Data', to: 'Deallocated Memory' });
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -577,14 +577,14 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
     ).toEqual('timing');
 
     // Switch to native allocations.
-    changeSelect({ from: 'Timing Data', to: 'Allocations' });
+    changeSelect({ from: 'Timing Data', to: 'Allocated Memory' });
 
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('native-allocations');
 
     // And finally it can be switched back.
-    changeSelect({ from: 'Allocations', to: 'Timing Data' });
+    changeSelect({ from: 'Allocated Memory', to: 'Timing Data' });
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('timing');
@@ -597,7 +597,7 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
     expect(queryByText('Total Size (bytes)')).toBe(null);
     expect(queryByText('Self (bytes)')).toBe(null);
 
-    changeSelect({ from: 'Timing Data', to: 'Allocations' });
+    changeSelect({ from: 'Timing Data', to: 'Allocated Memory' });
 
     // After changing to native allocations, they do.
     getByText('Total Size (bytes)');
@@ -606,18 +606,18 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
 
   it('does not have the retained memory option', function() {
     const { queryByText } = setup();
-    expect(queryByText('Retained Allocations')).toBeFalsy();
+    expect(queryByText('Retained Memory')).toBeFalsy();
   });
 
   it('matches the snapshot for native allocations', function() {
     const { container, changeSelect } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Allocations' });
+    changeSelect({ from: 'Timing Data', to: 'Allocated Memory' });
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('matches the snapshot for native deallocations', function() {
     const { container, changeSelect } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Deallocations' });
+    changeSelect({ from: 'Timing Data', to: 'Deallocation Sites' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });
@@ -636,7 +636,7 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     return { profile, ...renderResult, changeSelect, ...store };
   }
 
-  it('can switch to retained allocations and back to timing', function() {
+  it('can switch to retained memory and back to timing', function() {
     const { getState, changeSelect } = setup();
 
     // It starts out with timing.
@@ -645,14 +645,14 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     ).toEqual('timing');
 
     // Switch to retained memory native allocations.
-    changeSelect({ from: 'Timing Data', to: 'Retained Allocations' });
+    changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
 
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('native-retained-allocations');
 
     // And finally it can be switched back.
-    changeSelect({ from: 'Retained Allocations', to: 'Timing Data' });
+    changeSelect({ from: 'Retained Memory', to: 'Timing Data' });
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('timing');
@@ -665,7 +665,7 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     expect(queryByText('Total Size (bytes)')).toBe(null);
     expect(queryByText('Self (bytes)')).toBe(null);
 
-    changeSelect({ from: 'Timing Data', to: 'Retained Allocations' });
+    changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
 
     // After changing to retained allocations, they do.
     getByText('Total Size (bytes)');
@@ -674,7 +674,7 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
 
   it('matches the snapshot for retained allocations', function() {
     const { container, changeSelect } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Retained Allocations' });
+    changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -642,6 +642,418 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
 </div>
 `;
 
+exports[`ProfileCallTreeView with balanced native allocations matches the snapshot for deallocated memory 1`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label>
+          Summarize:
+           
+          <select
+            class="stackSettingsSelect"
+          >
+            <option
+              title="Summarize using sampled stacks of executed code over time"
+              value="timing"
+            >
+              Timing Data
+            </option>
+            <option
+              title="Summarize using bytes of memory that were allocated, and never freed in the current preview selection"
+              value="native-retained-allocations"
+            >
+              Retained Memory
+            </option>
+            <option
+              title="Summarize using bytes of memory allocated"
+              value="native-allocations"
+            >
+              Allocated Memory
+            </option>
+            <option
+              title="Summarize using bytes of memory deallocated, by the site where the memory was allocated"
+              value="native-deallocations-memory"
+            >
+              Deallocated Memory
+            </option>
+            <option
+              title="Summarize using bytes of memory deallocated, by the site where the memory was deallocated"
+              value="native-deallocations-sites"
+            >
+              Deallocation Sites
+            </option>
+          </select>
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+           Invert call stack
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      data-index="0"
+      title="Complete \\"Empty\\""
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete "Empty"
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalTimePercent"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalTime"
+      >
+        Total Size (bytes)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn selfTime"
+      >
+        Self (bytes)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-8"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 64px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="-100%"
+                >
+                  -100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="-15"
+                >
+                  -15
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="-3"
+                >
+                  -3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="-80%"
+                >
+                  -80%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="-12"
+                >
+                  -12
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="-5"
+                >
+                  -5
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTimePercent"
+                  title="-47%"
+                >
+                  -47%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalTime"
+                  title="-7"
+                >
+                  -7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn selfTime"
+                  title="-7"
+                >
+                  -7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 64px; width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, total size is -15 bytes (-100%), self size is -3 bytes"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, total size is -12 bytes (-80%), self size is -5 bytes"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd dim"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="C, total size is -7 bytes (-47%), self size is -7 bytes"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even dim"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProfileCallTreeView with balanced native allocations matches the snapshot for retained allocations 1`] = `
 <div
   aria-labelledby="calltree-tab-button"
@@ -722,6 +1134,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
               value="native-allocations"
             >
               Allocated Memory
+            </option>
+            <option
+              title="Summarize using bytes of memory deallocated, by the site where the memory was allocated"
+              value="native-deallocations-memory"
+            >
+              Deallocated Memory
             </option>
             <option
               title="Summarize using bytes of memory deallocated, by the site where the memory was deallocated"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -712,22 +712,22 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
               Timing Data
             </option>
             <option
-              title="Summarize using bytes of memory that were allocated, and never freed while profiling"
+              title="Summarize using bytes of memory that were allocated, and never freed in the current preview selection"
               value="native-retained-allocations"
             >
-              Retained Allocations
+              Retained Memory
             </option>
             <option
               title="Summarize using bytes of memory allocated"
               value="native-allocations"
             >
-              Allocations
+              Allocated Memory
             </option>
             <option
-              title="Summarize using bytes of memory deallocated"
-              value="native-deallocations"
+              title="Summarize using bytes of memory deallocated, by the site where the memory was deallocated"
+              value="native-deallocations-sites"
             >
-              Deallocations
+              Deallocation Sites
             </option>
           </select>
         </label>
@@ -1369,13 +1369,13 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
               title="Summarize using bytes of memory allocated"
               value="native-allocations"
             >
-              Allocations
+              Allocated Memory
             </option>
             <option
-              title="Summarize using bytes of memory deallocated"
-              value="native-deallocations"
+              title="Summarize using bytes of memory deallocated, by the site where the memory was deallocated"
+              value="native-deallocations-sites"
             >
-              Deallocations
+              Deallocation Sites
             </option>
           </select>
         </label>
@@ -2017,13 +2017,13 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
               title="Summarize using bytes of memory allocated"
               value="native-allocations"
             >
-              Allocations
+              Allocated Memory
             </option>
             <option
-              title="Summarize using bytes of memory deallocated"
-              value="native-deallocations"
+              title="Summarize using bytes of memory deallocated, by the site where the memory was deallocated"
+              value="native-deallocations-sites"
             >
-              Deallocations
+              Deallocation Sites
             </option>
           </select>
         </label>

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1375,7 +1375,7 @@ describe('transform native deallocations', function() {
   it('can render a normal call tree', function() {
     const { profile } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
-    dispatch(changeCallTreeSummaryStrategy('native-deallocations'));
+    dispatch(changeCallTreeSummaryStrategy('native-deallocations-sites'));
 
     expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
       [
@@ -1398,7 +1398,7 @@ describe('transform native deallocations', function() {
       funcNamesDict: { Fjs },
     } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
-    dispatch(changeCallTreeSummaryStrategy('native-deallocations'));
+    dispatch(changeCallTreeSummaryStrategy('native-deallocations-sites'));
     dispatch(
       addTransformToStack(threadIndex, {
         type: 'focus-function',

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -57,8 +57,8 @@ describe('Native allocation call trees', function() {
       ]);
     });
 
-    it('can create a call tree from deallocations only', function() {
-      const { getState } = setup('balanced', 'native-deallocations');
+    it('can create a call tree from deallocation sites only', function() {
+      const { getState } = setup('balanced', 'native-deallocations-sites');
       const callTree = selectedThreadSelectors.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
@@ -71,6 +71,17 @@ describe('Native allocation call trees', function() {
         '    - C (total: -22, self: —)',
         '      - D (total: -22, self: —)',
         '        - E (total: -22, self: -22)',
+      ]);
+    });
+
+    it('can create a call tree from deallocated memory', function() {
+      const { getState } = setup('balanced', 'native-deallocations-memory');
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+
+      expect(formatTree(callTree)).toEqual([
+        '- A (total: -15, self: -3)',
+        '  - B (total: -12, self: -5)',
+        '    - C (total: -7, self: -7)',
       ]);
     });
 
@@ -111,7 +122,7 @@ describe('Native allocation call trees', function() {
     });
 
     it('can create a call tree from deallocations only', function() {
-      const { getState } = setup('unbalanced', 'native-deallocations');
+      const { getState } = setup('unbalanced', 'native-deallocations-sites');
       const callTree = selectedThreadSelectors.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -88,7 +88,8 @@ export type CallTreeSummaryStrategy =
   | 'js-allocations'
   | 'native-retained-allocations'
   | 'native-allocations'
-  | 'native-deallocations';
+  | 'native-deallocations-memory'
+  | 'native-deallocations-sites';
 
 /**
  * This type determines what kind of information gets sanitized from published profiles.


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-2372--perf-html.netlify.com/public/90e838a880c9b2c56c4ef9a7464c237c618a05e1)

There is a serious limitation in the current memory summarizing. When looking at deallocations, it shows the site *where the memory was deallocated*, not the original site where that memory was allocated. This make it difficult when creating a preview selection over a CC or GC event to know where that memory came from.

This patch does two things. It adds that summary strategy, and it tweaks the names of the summary reports. I tried to keep them short, but identifiable. This is in preparation for the memory tools lightning talk.

As discussed in our stand-up, I'd like to sneak it in before the All Hands. I'll fast follow-up with documentation updates after landing.