### PR TITLE
Only show user-timing checkbox in stack-chart

### DIFF
--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -15,6 +15,7 @@ import {
 import {
   getImplementationFilter,
   getInvertCallstack,
+  getSelectedTab,
   getShowUserTimings,
   getCurrentSearchString,
 } from '../../selectors/url-state';
@@ -41,6 +42,7 @@ type OwnProps = {|
 type StateProps = {|
   +implementationFilter: ImplementationFilter,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
+  +selectedTab: string,
   +invertCallstack: boolean,
   +showUserTimings: boolean,
   +currentSearchString: string,
@@ -123,6 +125,7 @@ class StackSettings extends PureComponent<Props> {
   render() {
     const {
       invertCallstack,
+      selectedTab,
       showUserTimings,
       hideInvertCallstack,
       currentSearchString,
@@ -202,7 +205,7 @@ class StackSettings extends PureComponent<Props> {
               </label>
             </li>
           )}
-          {
+          {selectedTab !== 'stack-chart' ? null : (
             <li className="stackSettingsListItem">
               <label className="photon-label photon-label-micro stackSettingsLabel">
                 <input
@@ -214,7 +217,7 @@ class StackSettings extends PureComponent<Props> {
                 {' Show user timing'}
               </label>
             </li>
-          }
+          )}
         </ul>
         <PanelSearch
           className="stackSettingsSearchField"
@@ -231,6 +234,7 @@ class StackSettings extends PureComponent<Props> {
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     invertCallstack: getInvertCallstack(state),
+    selectedTab: getSelectedTab(state),
     showUserTimings: getShowUserTimings(state),
     implementationFilter: getImplementationFilter(state),
     currentSearchString: getCurrentSearchString(state),

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -26,6 +26,7 @@ import {
   commitRange,
   changeImplementationFilter,
 } from '../../actions/profile-view';
+import { changeSelectedTab } from '../../actions/app';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
@@ -366,6 +367,8 @@ function setup(profile: Profile, funcNames: string[] = []): * {
     .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
 
   const store = storeWithProfile(profile);
+  store.dispatch(changeSelectedTab('stack-chart'));
+
   const renderResult = render(
     <Provider store={store}>
       <>

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -243,19 +243,6 @@ exports[`FlameGraph matches the snapshot 1`] = `
           Native
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -91,19 +91,6 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -758,19 +745,6 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -1417,19 +1391,6 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             type="checkbox"
           />
            Invert call stack
-        </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
         </label>
       </li>
     </ul>
@@ -2080,19 +2041,6 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -2711,19 +2659,6 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -2857,19 +2792,6 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -3001,19 +2923,6 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
             type="checkbox"
           />
            Invert call stack
-        </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
         </label>
       </li>
     </ul>
@@ -3202,19 +3111,6 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
             type="checkbox"
           />
            Invert call stack
-        </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
         </label>
       </li>
     </ul>
@@ -3833,19 +3729,6 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -4460,19 +4343,6 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="checkbox"
           />
            Invert call stack
-        </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
         </label>
       </li>
     </ul>
@@ -5091,19 +4961,6 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -5673,19 +5530,6 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="checkbox"
           />
            Invert call stack
-        </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
         </label>
       </li>
     </ul>
@@ -6259,19 +6103,6 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -6724,19 +6555,6 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"
@@ -7187,19 +7005,6 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="checkbox"
           />
            Invert call stack
-        </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -62,19 +62,6 @@ exports[`StackSettings matches the snapshot 1`] = `
            Invert call stack
         </label>
       </li>
-      <li
-        class="stackSettingsListItem"
-      >
-        <label
-          class="photon-label photon-label-micro stackSettingsLabel"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-           Show user timing
-        </label>
-      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"


### PR DESCRIPTION
Previously, we were showing the user timings checkbox in all tabs, now we only show it in the stack chart.