### PR TITLE
Fix the hiding of non-idle threads that were captured with no sampling mode

### DIFF
--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -611,7 +611,7 @@ function _isThreadIdle(profile: Profile, thread: Thread): boolean {
   }
 
   if (thread.samples.length === 0) {
-    // This is a profile without any sample(taken with no periodic sapling mode)
+    // This is a profile without any sample (taken with no periodic sampling mode)
     // and we can't take a look at the samples to decide whether that thread is
     // active or not. So we are checking if we have a paint marker instead.
     return _isThreadWithNoPaint(thread);
@@ -641,19 +641,13 @@ function _isContentThreadWithNoPaint(thread: Thread): boolean {
 // Returns true if the thread doesn't include any RefreshDriverTick. This
 // indicates they were not painted to, and most likely idle. This is just
 // a heuristic to help users.
-function _isThreadWithNoPaint(thread: Thread): boolean {
+function _isThreadWithNoPaint({ markers, stringTable }: Thread): boolean {
   let isPaintMarkerFound = false;
-  if (thread.stringTable.hasString('RefreshDriverTick')) {
-    const paintStringIndex = thread.stringTable.indexForString(
-      'RefreshDriverTick'
-    );
+  if (stringTable.hasString('RefreshDriverTick')) {
+    const paintStringIndex = stringTable.indexForString('RefreshDriverTick');
 
-    for (
-      let markerIndex = 0;
-      markerIndex < thread.markers.length;
-      markerIndex++
-    ) {
-      if (paintStringIndex === thread.markers.name[markerIndex]) {
+    for (let markerIndex = 0; markerIndex < markers.length; markerIndex++) {
+      if (paintStringIndex === markers.name[markerIndex]) {
         isPaintMarkerFound = true;
         break;
       }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -610,6 +610,13 @@ function _isThreadIdle(profile: Profile, thread: Thread): boolean {
     return false;
   }
 
+  if (thread.samples.length === 0) {
+    // This is a profile without any sample(taken with no periodic sapling mode)
+    // and we can't take a look at the samples to decide whether that thread is
+    // active or not. So we are checking if we have a paint marker instead.
+    return _isThreadWithNoPaint(thread);
+  }
+
   if (_isContentThreadWithNoPaint(thread)) {
     // If content thread doesn't have any paint markers, set it idle if the
     // thread has at least 80% idle samples.
@@ -624,29 +631,36 @@ function _isThreadIdle(profile: Profile, thread: Thread): boolean {
 }
 
 function _isContentThreadWithNoPaint(thread: Thread): boolean {
-  // Hide content threads with no RefreshDriverTick. This indicates they were
-  // not painted to, and most likely idle. This is just a heuristic to help users.
   if (thread.name === 'GeckoMain' && thread.processType === 'tab') {
-    let isPaintMarkerFound = false;
-    if (thread.stringTable.hasString('RefreshDriverTick')) {
-      const paintStringIndex = thread.stringTable.indexForString(
-        'RefreshDriverTick'
-      );
+    return _isThreadWithNoPaint(thread);
+  }
 
-      for (
-        let markerIndex = 0;
-        markerIndex < thread.markers.length;
-        markerIndex++
-      ) {
-        if (paintStringIndex === thread.markers.name[markerIndex]) {
-          isPaintMarkerFound = true;
-          break;
-        }
+  return false;
+}
+
+// Returns true if the thread doesn't include any RefreshDriverTick. This
+// indicates they were not painted to, and most likely idle. This is just
+// a heuristic to help users.
+function _isThreadWithNoPaint(thread: Thread): boolean {
+  let isPaintMarkerFound = false;
+  if (thread.stringTable.hasString('RefreshDriverTick')) {
+    const paintStringIndex = thread.stringTable.indexForString(
+      'RefreshDriverTick'
+    );
+
+    for (
+      let markerIndex = 0;
+      markerIndex < thread.markers.length;
+      markerIndex++
+    ) {
+      if (paintStringIndex === thread.markers.name[markerIndex]) {
+        isPaintMarkerFound = true;
+        break;
       }
     }
-    if (!isPaintMarkerFound) {
-      return true;
-    }
+  }
+  if (!isPaintMarkerFound) {
+    return true;
   }
   return false;
 }

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -8,7 +8,10 @@ import type { Profile } from '../../types/profile';
 import sinon from 'sinon';
 import { oneLineTrim } from 'common-tags';
 
-import { getEmptyProfile } from '../../profile-logic/data-structures';
+import {
+  getEmptyProfile,
+  getEmptySamplesTableWithEventDelay,
+} from '../../profile-logic/data-structures';
 import { getTimeRangeForThread } from '../../profile-logic/profile-data';
 import { viewProfileFromPathInZipFile } from '../../actions/zipped-profiles';
 import { blankStore } from '../fixtures/stores';
@@ -161,6 +164,29 @@ describe('actions/receive-profile', function() {
         'show [process]',
         '  - hide [thread Idle Thread]',
         '  - show [thread Work Thread] SELECTED',
+      ]);
+    });
+
+    it('will show the thread with no samples and with paint markers', function() {
+      const store = blankStore();
+      const { profile } = getProfileWithIdleAndWorkThread();
+
+      addMarkersToThreadWithCorrespondingSamples(profile.threads[0], [
+        [
+          'RefreshDriverTick',
+          0,
+          { type: 'tracing', category: 'Paint', interval: 'start' },
+        ],
+      ]);
+
+      // Clearing up the samples to test the no sampling mode.
+      profile.threads[0].samples = getEmptySamplesTableWithEventDelay();
+
+      store.dispatch(viewProfile(profile));
+      expect(getHumanReadableTracks(store.getState())).toEqual([
+        'show [process]',
+        '  - show [thread Idle Thread] SELECTED',
+        '  - show [thread Work Thread]',
       ]);
     });
 


### PR DESCRIPTION
Fixes #2379.

[Before](https://profiler.firefox.com/public/a3c1d4358fcaa9dffb3dec6686f03e0d0626ebc5) and [After](https://deploy-preview-2380--perf-html.netlify.com/public/a3c1d4358fcaa9dffb3dec6686f03e0d0626ebc5/)