### PR TITLE
Don't install yarn on appveyor anymore because they use a good enough…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,9 @@ environment:
 platform: x64 # flow needs 64b platforms
 # Install scripts. (runs after repo cloning)
 install:
-  # 1. Yarn 1.9.4 is preinstalled, but we need a newer version, so let's install it.
-  # Go to https://www.appveyor.com/docs/windows-images-software/#tools to check if a
-  # newer version is preinstalled in the future.
-  - choco install yarn
-  # 2. Select the right node
+  # 1. Select the right node
   - ps: Install-Product node $env:nodejs_version $env:platform
-  # 3. Setup the project
+  # 2. Setup the project
   - yarn install --frozen-lockfile
 
 # Post-install test scripts.


### PR DESCRIPTION
… one now

Version 1.21.1 [is now installed by default](https://www.appveyor.com/docs/windows-images-software/#tools), which is the one that chocolatey was trying to install. This is also the reason why appveyor was failing lately.