### PR TITLE
Don't let the flame graph steal focus when searching (Fixes #2381)

### DIFF
--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -80,11 +80,12 @@ type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
   +changeRightClickedCallNode: typeof changeRightClickedCallNode,
 |};
-type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+type OwnProps = {|
+  +viewportRef?: (HTMLDivElement | null) => void,
+|};
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class FlameGraph extends React.PureComponent<Props> {
-  _viewport: HTMLDivElement | null = null;
-
   _onSelectedCallNodeChange = (
     callNodeIndex: IndexIntoCallNodeTable | null
   ) => {
@@ -110,16 +111,6 @@ class FlameGraph extends React.PureComponent<Props> {
   };
 
   _shouldDisplayTooltips = () => this.props.rightClickedCallNodeIndex === null;
-
-  _takeViewportRef = (viewport: HTMLDivElement | null) => {
-    this._viewport = viewport;
-  };
-
-  _focusViewport = () => {
-    if (this._viewport) {
-      this._viewport.focus();
-    }
-  };
 
   /**
    * Is the box for this call node wide enough to be selected?
@@ -246,10 +237,6 @@ class FlameGraph extends React.PureComponent<Props> {
     }
   };
 
-  componentDidMount() {
-    this._focusViewport();
-  }
-
   render() {
     const {
       thread,
@@ -270,6 +257,7 @@ class FlameGraph extends React.PureComponent<Props> {
       interval,
       isInverted,
       pages,
+      viewportRef,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -302,7 +290,7 @@ class FlameGraph extends React.PureComponent<Props> {
               viewportNeedsUpdate,
               marginLeft: 0,
               marginRight: 0,
-              containerRef: this._takeViewportRef,
+              containerRef: viewportRef,
             }}
             // FlameGraphCanvas props
             chartProps={{
@@ -340,7 +328,7 @@ function viewportNeedsUpdate() {
   return false;
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
       thread: selectedThreadSelectors.getFilteredThread(state),

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -80,12 +80,11 @@ type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
   +changeRightClickedCallNode: typeof changeRightClickedCallNode,
 |};
-type OwnProps = {|
-  +viewportRef?: (HTMLDivElement | null) => void,
-|};
-type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class FlameGraph extends React.PureComponent<Props> {
+  _viewport: HTMLDivElement | null = null;
+
   _onSelectedCallNodeChange = (
     callNodeIndex: IndexIntoCallNodeTable | null
   ) => {
@@ -111,6 +110,16 @@ class FlameGraph extends React.PureComponent<Props> {
   };
 
   _shouldDisplayTooltips = () => this.props.rightClickedCallNodeIndex === null;
+
+  _takeViewportRef = (viewport: HTMLDivElement | null) => {
+    this._viewport = viewport;
+  };
+
+  focus = () => {
+    if (this._viewport) {
+      this._viewport.focus();
+    }
+  };
 
   /**
    * Is the box for this call node wide enough to be selected?
@@ -257,7 +266,6 @@ class FlameGraph extends React.PureComponent<Props> {
       interval,
       isInverted,
       pages,
-      viewportRef,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -290,7 +298,7 @@ class FlameGraph extends React.PureComponent<Props> {
               viewportNeedsUpdate,
               marginLeft: 0,
               marginRight: 0,
-              containerRef: viewportRef,
+              containerRef: this._takeViewportRef,
             }}
             // FlameGraphCanvas props
             chartProps={{
@@ -328,7 +336,7 @@ function viewportNeedsUpdate() {
   return false;
 }
 
-export default explicitConnect<OwnProps, StateProps, DispatchProps>({
+export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     return {
       thread: selectedThreadSelectors.getFilteredThread(state),
@@ -366,5 +374,6 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     changeSelectedCallNode,
     changeRightClickedCallNode,
   },
+  options: { forwardRef: true },
   component: FlameGraph,
 });

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -25,9 +25,25 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class MaybeFlameGraph extends React.PureComponent<Props> {
+  _viewport: HTMLDivElement | null = null;
+
   _onSwitchToNormalCallstackClick = () => {
     this.props.changeInvertCallstack(false);
   };
+
+  _takeViewportRef = (viewport: HTMLDivElement | null) => {
+    this._viewport = viewport;
+  };
+
+  _focusViewport = () => {
+    if (this._viewport) {
+      this._viewport.focus();
+    }
+  };
+
+  componentDidMount() {
+    this._focusViewport();
+  }
 
   render() {
     const { maxStackDepth, invertCallstack } = this.props;
@@ -52,7 +68,7 @@ class MaybeFlameGraph extends React.PureComponent<Props> {
         </div>
       );
     }
-    return <FlameGraph />;
+    return <FlameGraph viewportRef={this._takeViewportRef} />;
   }
 }
 

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -25,24 +25,17 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class MaybeFlameGraph extends React.PureComponent<Props> {
-  _viewport: HTMLDivElement | null = null;
+  _flameGraph: {| current: HTMLDivElement | null |} = React.createRef();
 
   _onSwitchToNormalCallstackClick = () => {
     this.props.changeInvertCallstack(false);
   };
 
-  _takeViewportRef = (viewport: HTMLDivElement | null) => {
-    this._viewport = viewport;
-  };
-
-  _focusViewport = () => {
-    if (this._viewport) {
-      this._viewport.focus();
-    }
-  };
-
   componentDidMount() {
-    this._focusViewport();
+    const flameGraph = this._flameGraph.current;
+    if (flameGraph) {
+      flameGraph.focus();
+    }
   }
 
   render() {
@@ -68,7 +61,7 @@ class MaybeFlameGraph extends React.PureComponent<Props> {
         </div>
       );
     }
-    return <FlameGraph viewportRef={this._takeViewportRef} />;
+    return <FlameGraph ref={this._flameGraph} />;
   }
 }
 


### PR DESCRIPTION
I tried adding a test, inputting characters into the search box and checking which element having focus with `document.activeElement`, but I failed to get it working. It doesn't seem to update focus within the test. I'm adding this PR without tests, but let me know if you know of a way testing this.