### PR TITLE
A few more changes to the message bars component

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "run-p lint-js lint-css",
     "lint-js": "eslint *.js bin src",
     "lint-fix-js": "yarn lint-js --fix",
-    "lint-css": "stylelint 'src/**/*.css' 'res/css/**/*.css'",
+    "lint-css": "stylelint 'src/**/*.css' 'res/**/*.css'",
     "lint-fix-css": "yarn lint-css --fix",
     "prettier-json": "prettier --write src/**/*.json",
     "flow": "flow --max-warnings 0",

--- a/res/css/photon/message-bar.css
+++ b/res/css/photon/message-bar.css
@@ -5,51 +5,66 @@
 /* See https://design.firefox.com/photon/components/message-bars.html */
 .photon-message-bar {
   display: flex;
-  width: 100%;
   min-height: 32px;
   box-sizing: border-box;
   align-items: center;
-  padding: 0 4px;
-  border-radius: 4px;
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 1.4;
-}
 
-.photon-message-bar .photon-button {
-  margin-left: 8px;
-}
-
-.photon-message-bar .photon-message-bar-close-button {
-  width: 24px;
-  height: 24px;
-  margin-left: auto;
-  background: url(../../img/svg/close-dark.svg) no-repeat center / 16px 16px;
-  fill: currentColor;
-}
-
-.photon-message-bar-error {
   /* Note: 32px is: 4px (left padding for the message bar) + 4px (left padding
    * for the icon) + 16px (icon width) + 4px (right padding for the icon) + 4px
    * (space between icon and text) */
   padding: 4px 4px 4px 32px;
 
   /* Note: 8px is: 4px (left padding for the message bar) + 4px (left padding
-   * for the icon) */
-  background: url(../../img/svg/error.svg) no-repeat 8px center / 16px 16px
-    var(--red-60);
+   * for the icon). And same for the top positioning, because we want the icon
+   * to stick at the top when the text is multiline */
+  background: url(../../img/svg/info-icon.svg) no-repeat 8px 8px / 16px 16px
+    var(--grey-20);
+  border-radius: 4px;
+  color: var(--grey-90);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.photon-message-bar-action-button {
+  flex: none;
+  margin: 0 8px;
+}
+
+.photon-message-bar-close-button {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  margin-left: auto;
+  background: url(../../img/svg/close-dark.svg) no-repeat center / 16px 16px;
+}
+
+/* This rule is useful only for message bars that have a close button but no
+ * action button. */
+.photon-message-bar-inner-content {
+  margin-right: 4px;
+}
+
+.photon-message-bar-error {
+  background-color: var(--red-60);
+  background-image: url(../../img/svg/error.svg);
   color: #fff;
 }
 
 .photon-message-bar-warning {
-  padding: 4px 4px 4px 32px;
-  background: url(../../img/svg/warning.svg) no-repeat 8px center / 16px 16px
-    var(--yellow-50);
+  background-color: var(--yellow-50);
+  background-image: url(../../img/svg/warning.svg);
   color: var(--yellow-90);
 }
 
 .photon-message-bar-error .photon-message-bar-close-button {
   background-image: url(../../img/svg/close-light.svg);
+}
+
+/* The default styles for this button are copied from the ghost button, mostly
+ * for ease of usage. */
+.photon-message-bar-close-button:hover {
+  background-color: var(--grey-90-a10);
 }
 
 .photon-message-bar-error .photon-message-bar-action-button,
@@ -63,6 +78,10 @@
   background-color: var(--yellow-60);
 }
 
+.photon-message-bar-close-button:hover:active {
+  background-color: var(--grey-90-a20);
+}
+
 .photon-message-bar-error .photon-message-bar-action-button:hover,
 .photon-message-bar-error .photon-message-bar-close-button:hover:active {
   background-color: var(--red-80);
@@ -71,6 +90,7 @@
 .photon-message-bar-warning .photon-message-bar-action-button:hover,
 .photon-message-bar-warning .photon-message-bar-close-button:hover:active {
   background-color: var(--yellow-70);
+  color: #fff;
 }
 
 .photon-message-bar-error .photon-message-bar-action-button:hover:active {

--- a/res/photon/index.html
+++ b/res/photon/index.html
@@ -136,15 +136,34 @@
     </div>
 
     <h2>Photon Message Bars</h2>
-    <div class="row">
-      <h3>Photon Message Bar Generic</h3>
-      <pre>
+    <p>These components work well both when taking all the available space or
+    when they're smaller (sized in a flex component for example).</p>
+
+    <h3>Photon Message Bar Generic</h3>
+      <div class="row">
+        <pre>
 &lt;div class="photon-message-bar"&gt;
   This is a non-dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
 &lt;/div&gt;
+        </pre>
+        <div class="photon-message-bar">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+        <div class="photon-message-bar sized-to-content">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <pre>
 &lt;div class="photon-message-bar"&gt;
   This is a dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
@@ -154,45 +173,7 @@
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
 &lt;/div&gt;
-&lt;div class="photon-message-bar"&gt;
-  &lt;div class='photon-message-bar-inner-content'&gt;
-    This is a dismissable message bar.
-  &lt;/div&gt;
-  &lt;button class="photon-button photon-message-bar-close-button" type="button"
-    aria-label="Hide the message" title="Hide the message"&gt;
-  &lt;/button&gt;
-&lt;/div&gt;
-      </pre>
-      <div class="photon-message-bar">
-        This is a non-dismissable message bar.
-        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-          Call to action
-        </button>
-      </div>
-      <div class="photon-message-bar">
-        This is a dismissable message bar.
-        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-          Call to action
-        </button>
-        <button class="photon-button photon-message-bar-close-button" type="button"
-          aria-label="Hide the message" title="Hide the message">
-        </button>
-      </div>
-      <div class="photon-message-bar">
-        <div class='photon-message-bar-inner-content'>
-          This is a dismissable message bar.
-        </div>
-        <button class="photon-button photon-message-bar-close-button" type="button"
-          aria-label="Hide the message" title="Hide the message">
-        </button>
-      </div>
-      <div class='flex-container'>
-        <div class="photon-message-bar">
-          This is a non-dismissable message bar.
-          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-            Call to action
-          </button>
-        </div>
+        </pre>
         <div class="photon-message-bar">
           This is a dismissable message bar.
           <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
@@ -202,7 +183,36 @@
             aria-label="Hide the message" title="Hide the message">
           </button>
         </div>
+        <div class="photon-message-bar sized-to-content">
+          This is a dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <pre>
+&lt;div class="photon-message-bar"&gt;
+  &lt;div class='photon-message-bar-inner-content'&gt;
+    This is a dismissable message bar.
+  &lt;/div&gt;
+  &lt;button class="photon-button photon-message-bar-close-button" type="button"
+    aria-label="Hide the message" title="Hide the message"&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
+        </pre>
         <div class="photon-message-bar">
+          <div class='photon-message-bar-inner-content'>
+            This is a dismissable message bar.
+          </div>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+        <div class="photon-message-bar sized-to-content">
           <div class='photon-message-bar-inner-content'>
             This is a dismissable message bar.
           </div>
@@ -213,15 +223,31 @@
       </div>
     </div>
   </div>
-    <div class="row">
       <h3>Photon Message Bar Error</h3>
-      <pre>
+      <div class="row">
+        <pre>
 &lt;div class="photon-message-bar photon-message-bar-error"&gt;
   This is a non-dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
 &lt;/div&gt;
+        </pre>
+        <div class="photon-message-bar photon-message-bar-error">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+        <div class="photon-message-bar photon-message-bar-error sized-to-content">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <pre>
 &lt;div class="photon-message-bar photon-message-bar-error"&gt;
   This is a dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
@@ -231,45 +257,7 @@
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
 &lt;/div&gt;
-&lt;div class="photon-message-bar photon-message-bar-error"&gt;
-  &lt;div class='photon-message-bar-inner-content'&gt;
-    This is a dismissable message bar.
-  &lt;/div&gt;
-  &lt;button class="photon-button photon-message-bar-close-button" type="button"
-    aria-label="Hide the message" title="Hide the message"&gt;
-  &lt;/button&gt;
-&lt;/div&gt;
-      </pre>
-      <div class="photon-message-bar photon-message-bar-error">
-        This is a non-dismissable message bar.
-        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-          Call to action
-        </button>
-      </div>
-      <div class="photon-message-bar photon-message-bar-error">
-        This is a dismissable message bar.
-        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-          Call to action
-        </button>
-        <button class="photon-button photon-message-bar-close-button" type="button"
-          aria-label="Hide the message" title="Hide the message">
-        </button>
-      </div>
-      <div class="photon-message-bar photon-message-bar-error">
-        <div class='photon-message-bar-inner-content'>
-          This is a dismissable message bar.
-        </div>
-        <button class="photon-button photon-message-bar-close-button" type="button"
-          aria-label="Hide the message" title="Hide the message">
-        </button>
-      </div>
-      <div class='flex-container'>
-        <div class="photon-message-bar photon-message-bar-error">
-          This is a non-dismissable message bar.
-          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-            Call to action
-          </button>
-        </div>
+        </pre>
         <div class="photon-message-bar photon-message-bar-error">
           This is a dismissable message bar.
           <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
@@ -279,7 +267,36 @@
             aria-label="Hide the message" title="Hide the message">
           </button>
         </div>
+        <div class="photon-message-bar photon-message-bar-error sized-to-content">
+          This is a dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <pre>
+&lt;div class="photon-message-bar photon-message-bar-error"&gt;
+  &lt;div class='photon-message-bar-inner-content'&gt;
+    This is a dismissable message bar.
+  &lt;/div&gt;
+  &lt;button class="photon-button photon-message-bar-close-button" type="button"
+    aria-label="Hide the message" title="Hide the message"&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
+        </pre>
         <div class="photon-message-bar photon-message-bar-error">
+          <div class='photon-message-bar-inner-content'>
+            This is a dismissable message bar.
+          </div>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+        <div class="photon-message-bar photon-message-bar-error sized-to-content">
           <div class='photon-message-bar-inner-content'>
             This is a dismissable message bar.
           </div>
@@ -291,15 +308,31 @@
     </div>
   </div>
 
-    <div class="row">
-      <h3>Photon Message Bar Warning</h3>
-      <pre>
+  <h3>Photon Message Bar Warning</h3>
+  <div class="row">
+    <pre>
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
   This is a non-dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
 &lt;/div&gt;
+    </pre>
+    <div class="photon-message-bar photon-message-bar-warning">
+      This is a non-dismissable message bar.
+      <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+        Call to action
+      </button>
+    </div>
+    <div class="photon-message-bar photon-message-bar-warning sized-to-content">
+      This is a non-dismissable message bar.
+      <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+        Call to action
+      </button>
+    </div>
+  </div>
+  <div class="row">
+    <pre>
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
   This is a dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
@@ -309,6 +342,28 @@
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
 &lt;/div&gt;
+    </pre>
+      <div class="photon-message-bar photon-message-bar-warning">
+        This is a dismissable message bar.
+        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+          Call to action
+        </button>
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
+      </div>
+      <div class="photon-message-bar photon-message-bar-warning sized-to-content">
+        This is a dismissable message bar.
+        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+          Call to action
+        </button>
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
+      </div>
+    </div>
+    <div class="row">
+      <pre>
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
   &lt;div class='photon-message-bar-inner-content'&gt;
     This is a dismissable message bar.
@@ -319,21 +374,6 @@
 &lt;/div&gt;
       </pre>
       <div class="photon-message-bar photon-message-bar-warning">
-        This is a non-dismissable message bar.
-        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-          Call to action
-        </button>
-      </div>
-      <div class="photon-message-bar photon-message-bar-warning">
-        This is a dismissable message bar.
-        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-          Call to action
-        </button>
-        <button class="photon-button photon-message-bar-close-button" type="button"
-          aria-label="Hide the message" title="Hide the message">
-        </button>
-      </div>
-      <div class="photon-message-bar photon-message-bar-warning">
         <div class='photon-message-bar-inner-content'>
           This is a dismissable message bar.
         </div>
@@ -341,30 +381,13 @@
           aria-label="Hide the message" title="Hide the message">
         </button>
       </div>
-      <div class='flex-container'>
-        <div class="photon-message-bar photon-message-bar-warning">
-          This is a non-dismissable message bar.
-          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-            Call to action
-          </button>
-        </div>
-        <div class="photon-message-bar photon-message-bar-warning">
+      <div class="photon-message-bar photon-message-bar-warning sized-to-content">
+        <div class='photon-message-bar-inner-content'>
           This is a dismissable message bar.
-          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
-            Call to action
-          </button>
-          <button class="photon-button photon-message-bar-close-button" type="button"
-            aria-label="Hide the message" title="Hide the message">
-          </button>
         </div>
-        <div class="photon-message-bar photon-message-bar-warning">
-          <div class='photon-message-bar-inner-content'>
-            This is a dismissable message bar.
-          </div>
-          <button class="photon-button photon-message-bar-close-button" type="button"
-            aria-label="Hide the message" title="Hide the message">
-          </button>
-        </div>
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
       </div>
     </div>
   </body>

--- a/res/photon/index.html
+++ b/res/photon/index.html
@@ -8,6 +8,7 @@
     <h1>Photon Styling Examples</h1>
     <p>This page has examples for the profiler’s implementation of the <a href="https://design.firefox.com/photon/">Photon design spec</a>.</p>
 
+    <h2>Photon Buttons</h2>
     <div class="row">
       <h3>Photon Button</h3>
       <pre>&lt;button type="button" class="photon-button"&gt;Photon Button&lt;/button&gt;</pre>
@@ -37,6 +38,8 @@
       <pre>&lt;button type="button" class="photon-button photon-button-ghost photon-button-test-image"&gt;&lt;/button&gt;</pre>
       <button type="button" class="photon-button photon-button-ghost photon-button-test-image"></button>
     </div>
+
+    <h2>Photon inputs</h2>
 
     <div class="row">
       <h3>Photon Input</h3>
@@ -132,6 +135,84 @@
       </label>
     </div>
 
+    <h2>Photon Message Bars</h2>
+    <div class="row">
+      <h3>Photon Message Bar Generic</h3>
+      <pre>
+&lt;div class="photon-message-bar"&gt;
+  This is a non-dismissable message bar.
+  &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
+    Call to action
+  &lt;/button&gt;
+&lt;/div&gt;
+&lt;div class="photon-message-bar"&gt;
+  This is a dismissable message bar.
+  &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
+    Call to action
+  &lt;/button&gt;
+  &lt;button class="photon-button photon-message-bar-close-button" type="button"
+    aria-label="Hide the message" title="Hide the message"&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
+&lt;div class="photon-message-bar"&gt;
+  &lt;div class='photon-message-bar-inner-content'&gt;
+    This is a dismissable message bar.
+  &lt;/div&gt;
+  &lt;button class="photon-button photon-message-bar-close-button" type="button"
+    aria-label="Hide the message" title="Hide the message"&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
+      </pre>
+      <div class="photon-message-bar">
+        This is a non-dismissable message bar.
+        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+          Call to action
+        </button>
+      </div>
+      <div class="photon-message-bar">
+        This is a dismissable message bar.
+        <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+          Call to action
+        </button>
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
+      </div>
+      <div class="photon-message-bar">
+        <div class='photon-message-bar-inner-content'>
+          This is a dismissable message bar.
+        </div>
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
+      </div>
+      <div class='flex-container'>
+        <div class="photon-message-bar">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+        <div class="photon-message-bar">
+          This is a dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+        <div class="photon-message-bar">
+          <div class='photon-message-bar-inner-content'>
+            This is a dismissable message bar.
+          </div>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
     <div class="row">
       <h3>Photon Message Bar Error</h3>
       <pre>
@@ -151,7 +232,9 @@
   &lt;/button&gt;
 &lt;/div&gt;
 &lt;div class="photon-message-bar photon-message-bar-error"&gt;
-  This is a dismissable message bar.
+  &lt;div class='photon-message-bar-inner-content'&gt;
+    This is a dismissable message bar.
+  &lt;/div&gt;
   &lt;button class="photon-button photon-message-bar-close-button" type="button"
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
@@ -173,7 +256,9 @@
         </button>
       </div>
       <div class="photon-message-bar photon-message-bar-error">
-        This is a dismissable message bar.
+        <div class='photon-message-bar-inner-content'>
+          This is a dismissable message bar.
+        </div>
         <button class="photon-button photon-message-bar-close-button" type="button"
           aria-label="Hide the message" title="Hide the message">
         </button>
@@ -195,7 +280,9 @@
           </button>
         </div>
         <div class="photon-message-bar photon-message-bar-error">
-          This is a dismissable message bar.
+          <div class='photon-message-bar-inner-content'>
+            This is a dismissable message bar.
+          </div>
           <button class="photon-button photon-message-bar-close-button" type="button"
             aria-label="Hide the message" title="Hide the message">
           </button>
@@ -223,7 +310,9 @@
   &lt;/button&gt;
 &lt;/div&gt;
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
-  This is a dismissable message bar.
+  &lt;div class='photon-message-bar-inner-content'&gt;
+    This is a dismissable message bar.
+  &lt;/div&gt;
   &lt;button class="photon-button photon-message-bar-close-button" type="button"
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
@@ -245,7 +334,9 @@
         </button>
       </div>
       <div class="photon-message-bar photon-message-bar-warning">
-        This is a dismissable message bar.
+        <div class='photon-message-bar-inner-content'>
+          This is a dismissable message bar.
+        </div>
         <button class="photon-button photon-message-bar-close-button" type="button"
           aria-label="Hide the message" title="Hide the message">
         </button>
@@ -267,7 +358,9 @@
           </button>
         </div>
         <div class="photon-message-bar photon-message-bar-warning">
-          This is a dismissable message bar.
+          <div class='photon-message-bar-inner-content'>
+            This is a dismissable message bar.
+          </div>
           <button class="photon-button photon-message-bar-close-button" type="button"
             aria-label="Hide the message" title="Hide the message">
           </button>

--- a/res/photon/index.html
+++ b/res/photon/index.html
@@ -136,13 +136,13 @@
       <h3>Photon Message Bar Error</h3>
       <pre>
 &lt;div class="photon-message-bar photon-message-bar-error"&gt;
-  This is a non-dismissable message bar
+  This is a non-dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
 &lt;/div&gt;
 &lt;div class="photon-message-bar photon-message-bar-error"&gt;
-  This is a dismissable message bar
+  This is a dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
@@ -150,15 +150,21 @@
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
 &lt;/div&gt;
+&lt;div class="photon-message-bar photon-message-bar-error"&gt;
+  This is a dismissable message bar.
+  &lt;button class="photon-button photon-message-bar-close-button" type="button"
+    aria-label="Hide the message" title="Hide the message"&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
       </pre>
       <div class="photon-message-bar photon-message-bar-error">
-        This is a non-dismissable message bar
+        This is a non-dismissable message bar.
         <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
           Call to action
         </button>
       </div>
       <div class="photon-message-bar photon-message-bar-error">
-        This is a dismissable message bar
+        This is a dismissable message bar.
         <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
           Call to action
         </button>
@@ -166,19 +172,49 @@
           aria-label="Hide the message" title="Hide the message">
         </button>
       </div>
+      <div class="photon-message-bar photon-message-bar-error">
+        This is a dismissable message bar.
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
+      </div>
+      <div class='flex-container'>
+        <div class="photon-message-bar photon-message-bar-error">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+        <div class="photon-message-bar photon-message-bar-error">
+          This is a dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+        <div class="photon-message-bar photon-message-bar-error">
+          This is a dismissable message bar.
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+      </div>
     </div>
+  </div>
 
     <div class="row">
       <h3>Photon Message Bar Warning</h3>
       <pre>
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
-  This is a non-dismissable message bar
+  This is a non-dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
 &lt;/div&gt;
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
-  This is a dismissable message bar
+  This is a dismissable message bar.
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
@@ -186,21 +222,56 @@
     aria-label="Hide the message" title="Hide the message"&gt;
   &lt;/button&gt;
 &lt;/div&gt;
+&lt;div class="photon-message-bar photon-message-bar-warning"&gt;
+  This is a dismissable message bar.
+  &lt;button class="photon-button photon-message-bar-close-button" type="button"
+    aria-label="Hide the message" title="Hide the message"&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
       </pre>
       <div class="photon-message-bar photon-message-bar-warning">
-        This is a non-dismissable message bar
+        This is a non-dismissable message bar.
         <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
           Call to action
         </button>
       </div>
       <div class="photon-message-bar photon-message-bar-warning">
-        This is a dismissable message bar
+        This is a dismissable message bar.
         <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
           Call to action
         </button>
         <button class="photon-button photon-message-bar-close-button" type="button"
           aria-label="Hide the message" title="Hide the message">
         </button>
+      </div>
+      <div class="photon-message-bar photon-message-bar-warning">
+        This is a dismissable message bar.
+        <button class="photon-button photon-message-bar-close-button" type="button"
+          aria-label="Hide the message" title="Hide the message">
+        </button>
+      </div>
+      <div class='flex-container'>
+        <div class="photon-message-bar photon-message-bar-warning">
+          This is a non-dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+        </div>
+        <div class="photon-message-bar photon-message-bar-warning">
+          This is a dismissable message bar.
+          <button class="photon-button photon-button-micro photon-message-bar-action-button" type="button">
+            Call to action
+          </button>
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
+        <div class="photon-message-bar photon-message-bar-warning">
+          This is a dismissable message bar.
+          <button class="photon-button photon-message-bar-close-button" type="button"
+            aria-label="Hide the message" title="Hide the message">
+          </button>
+        </div>
       </div>
     </div>
   </body>

--- a/res/photon/style.css
+++ b/res/photon/style.css
@@ -29,12 +29,6 @@ html {
   margin-bottom: 5px;
 }
 
-.flex-container {
-  display: flex;
-  flex-direction: column;
-}
-
-/* This makes these bars as small as possible */
-.flex-container .photon-message-bar {
-  margin-right: auto;
+.sized-to-content {
+  width: max-content;
 }

--- a/res/photon/style.css
+++ b/res/photon/style.css
@@ -1,12 +1,13 @@
-body, html {
+body,
+html {
   font: message-box;
   font-size: 11px;
 }
 
 .row {
   padding: 0 3em 2em;
-  margin: 3em 0;
   border-left: 2px solid var(--grey-30);
+  margin: 3em 0;
 }
 
 .row pre {

--- a/res/photon/style.css
+++ b/res/photon/style.css
@@ -22,3 +22,19 @@ html {
   background-position: 50%;
   background-repeat: no-repeat;
 }
+
+/* Give nearby message bars some room so that they can breathe a bit. */
+.photon-message-bar {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.flex-container {
+  display: flex;
+  flex-direction: column;
+}
+
+/* This makes these bars as small as possible */
+.flex-container .photon-message-bar {
+  margin-right: auto;
+}


### PR DESCRIPTION
This is a follow-up to my previous patch for the message bars. When I started using them I realized they had a few problems that I try to fix it, hopefully completely this time.

* the icon now stays at the top when the text is multiline.
* better behavior when the available space is small: buttons don't shrink anymore, and the closing button always has some margin.
* added the "generic" style.

In a future patch (maybe a "good first issue" :) ), I'd like to use the generic style for the service worker notice. In the past I did this notice following photon guidelines but without thinking of making it reusable.

It might be easier to look at the individual commits.
