### PR TITLE
Correctly reset rightClickedTrack on 'x/x tracks visible' button click

### DIFF
--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -130,7 +130,7 @@ class TimelineSettingsHiddenTracks extends React.PureComponent<{|
 |}> {
   _showMenu = (event: SyntheticMouseEvent<HTMLElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();
-    changeRightClickedTrack(null);
+    this.props.changeRightClickedTrack(null);
     showMenu({
       data: null,
       id: 'TimelineTrackContextMenu',

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -14,6 +14,7 @@ import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { getBoundingBox } from '../fixtures/utils';
 import ReactDOM from 'react-dom';
 import { getShowTabOnly } from '../../selectors/url-state';
+import { getRightClickedTrack } from '../../selectors/profile';
 
 import type { Profile } from '../../types/profile';
 
@@ -153,6 +154,34 @@ describe('Timeline', function() {
 
       fireEvent.click(getByText('Show active tab only'));
       expect(getShowTabOnly(store.getState())).toEqual(null);
+    });
+  });
+
+  describe('TimelineSettingsHiddenTracks', () => {
+    it('resets "rightClickedTrack" state when clicked', () => {
+      const profile = _getProfileWithDroppedSamples();
+      const ctx = mockCanvasContext();
+      jest
+        .spyOn(HTMLCanvasElement.prototype, 'getContext')
+        .mockImplementation(() => ctx);
+
+      const store = storeWithProfile(profile);
+      const { getByText } = render(
+        <Provider store={store}>
+          <Timeline />
+        </Provider>
+      );
+
+      expect(getRightClickedTrack(store.getState())).toEqual(null);
+
+      fireEvent.mouseDown(getByText('Process 0'), { button: 2 });
+      expect(getRightClickedTrack(store.getState())).toEqual({
+        trackIndex: 0,
+        type: 'global',
+      });
+
+      fireEvent.click(getByText('/ tracks visible'));
+      expect(getRightClickedTrack(store.getState())).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
Closes #2399 

The issue was due the fact we were calling the action creator directly instead of the bound one from the props.