### PR TITLE
Add a warning notice about the cloud storage migration happening next week-end

### DIFF
--- a/docs-user/_sidebar.md
+++ b/docs-user/_sidebar.md
@@ -19,3 +19,4 @@
 * [Case Studies](./case-studies.md)
   * [2D canvas and worker messaging](./bunny.md)
   * [Harnessing parallelism](./bunny-2.md)
+* [Cloud Migration](./cloud-migration.md)

--- a/docs-user/cloud-migration.md
+++ b/docs-user/cloud-migration.md
@@ -1,0 +1,32 @@
+# Cloud Migration
+
+We're investing a significant amount of time and effort to improve our
+underlying server-side and cloud architecture.
+
+## Why?
+
+We want that the profiler service is handled by Mozilla's fantastic Cloud Ops
+team so that it's better supported and safer for our users.
+
+## What?
+
+On **February 21 and 22** (they are Friday and Saturday) we want to move all our
+storage data. In Google Cloud Platform we can't just change the ownership of a
+bucket. Instead we need to copy all the data over —twice, if we want to keep the
+same bucket name.
+
+That's why we're planning some downtime on these dates.
+
+## What does that mean for you?
+
+If everything goes according to our plan:
+* On February 21 we'll copy the data one-way. During that day you should still
+  be able to access stored profiles, but won't be able to publish new profiles.
+* On February 22 we'll copy the data to the new location. During that day you
+  won't be able to access existing profiles. Possibly publishing new profiles
+  and accessing them will work.
+
+After the move everything should be back to normal.
+
+**Note that you will still be able to capture profiles locally. Only the sharing
+capability will be affected by the downtime.**

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -17,6 +17,7 @@ import { getHasZipFile } from '../../selectors/zipped-profiles';
 import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
 import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
+import { DowntimeWarning } from './DowntimeWarning';
 
 import type { AppViewState, State } from '../../types/state';
 import type { DataSource } from '../../types/actions';
@@ -95,6 +96,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
   render() {
     return (
       <Fragment>
+        <DowntimeWarning />
         <ServiceWorkerManager />
         {this.renderCurrentRoute()}
       </Fragment>

--- a/src/components/app/DowntimeWarning.js
+++ b/src/components/app/DowntimeWarning.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React, { PureComponent } from 'react';
+
+import { Warning } from '../shared/Warning';
+
+const LOCAL_STORAGE_KEY = 'profileServerMigrationNoticeDismissed2020';
+
+type State = {|
+  wasDismissedInThePast: boolean,
+|};
+
+export class DowntimeWarning extends PureComponent<{||}, State> {
+  state = {
+    wasDismissedInThePast: !!localStorage.getItem(LOCAL_STORAGE_KEY),
+  };
+
+  _onDowntimeActionClick() {
+    window.open('/docs/#/./cloud-migration', '_blank');
+  }
+
+  _onClose() {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'dismissed');
+  }
+
+  render() {
+    // Because this code is planned to be only temporary, let's skip it in tests.
+    if (process.env.NODE_ENV === 'test') {
+      return null;
+    }
+
+    const currentDate = new Date();
+    const feb23Date = new Date(Date.UTC(2020, 1, 23));
+    if (currentDate >= feb23Date) {
+      return null;
+    }
+
+    const feb21Date = new Date(Date.UTC(2020, 1, 21));
+    if (currentDate < feb21Date && this.state.wasDismissedInThePast) {
+      return null;
+    }
+
+    return (
+      <Warning
+        message="The profiler will encounter some downtime on Feb 21 and 22."
+        actionText="More information"
+        actionTitle="Consult more information about the downtime (opens a new tab)"
+        actionOnClick={this._onDowntimeActionClick}
+        onClose={this._onClose}
+      />
+    );
+  }
+}

--- a/src/components/shared/Warning.css
+++ b/src/components/shared/Warning.css
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.warningMessageBarWrapper {
+  /* Position */
+  position: fixed;
+  z-index: 4;
+  top: 0;
+  right: 0;
+  left: 0;
+
+  /* Box */
+  display: flex;
+
+  /* Other */
+  pointer-events: none;
+}
+
+.warningMessageBar {
+  margin: 0 auto;
+  pointer-events: auto;
+}

--- a/src/components/shared/Warning.js
+++ b/src/components/shared/Warning.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React, { PureComponent } from 'react';
+import './Warning.css';
+
+type Props = {|
+  +message: string,
+  +actionText?: string,
+  +actionTitle?: string,
+  +actionOnClick?: () => mixed,
+  +onClose?: () => mixed,
+|};
+
+type State = {|
+  +isNoticeDisplayed: boolean,
+|};
+
+export class Warning extends PureComponent<Props, State> {
+  state = { isNoticeDisplayed: true };
+
+  _onHideClick = () => {
+    this.setState({
+      isNoticeDisplayed: false,
+    });
+
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  };
+
+  render() {
+    if (!this.state.isNoticeDisplayed) {
+      return null;
+    }
+
+    const { message, actionText, actionTitle, actionOnClick } = this.props;
+
+    return (
+      <div className="warningMessageBarWrapper">
+        <div className="photon-message-bar photon-message-bar-warning warningMessageBar">
+          {message}
+          {actionText ? (
+            <button
+              className="photon-button photon-button-micro photon-message-bar-action-button"
+              type="button"
+              title={actionTitle}
+              aria-label={actionTitle}
+              onClick={actionOnClick}
+            >
+              {actionText}
+            </button>
+          ) : null}
+          <button
+            className="photon-button photon-message-bar-close-button"
+            type="button"
+            aria-label="Hide the message"
+            title="Hide the message"
+            onClick={this._onHideClick}
+          />
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
[deploy preview for Home](https://deploy-preview-2410--perf-html.netlify.com/)
[deploy preview with a profile](https://deploy-preview-2410--perf-html.netlify.com/public/49b82737e16b5adedafe6bd87cdd4553d3d8c14d/network-chart/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12083-0~11945-0~11862-0~12533-0~12298-0~12118-0~12149-0~12629-0~11798-0~11755-0-1~&thread=11&v=4)

Screenshot:
![screenshot](https://user-images.githubusercontent.com/454175/74660394-5880c600-5196-11ea-8cd5-5326ec80da42.png)

When there's both the service worker reload notice and this warning:
![image](https://user-images.githubusercontent.com/454175/74660523-91209f80-5196-11ea-8f5d-87b5996e7c86.png)
The service worker reload notice doesn't cover the warning completely because it doesn't use the same style (see #2408) and is slightly less high, but I believe it's ok.