### PR TITLE
Implement the track hiding mechanism for active tab view

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1194,6 +1194,12 @@ export function changeShowTabOnly(
         undefined,
         true // ignore the hidden tracks by active tab
       );
+
+      if (selectedThreadIndex === null) {
+        // We should revert to the first view, because all the threads are hidden
+        // in the single tab view and we won't be able to see anything there.
+        return;
+      }
     }
 
     dispatch({

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -15,7 +15,7 @@ import {
   getPreviewSelection,
   getComputedHiddenGlobalTracks,
   getComputedHiddenLocalTracks,
-  getActiveTabHiddenGlobalTracks,
+  getActiveTabHiddenGlobalTracksGetter,
 } from '../selectors/profile';
 import {
   getThreadSelectors,
@@ -642,7 +642,7 @@ function _findOtherVisibleThread(
   const globalTracks = getGlobalTracks(getState());
   const globalTrackOrder = getGlobalTrackOrder(getState());
   const globalHiddenTracks = getComputedHiddenGlobalTracks(getState());
-  const activeTabHiddenGlobalTracks = getActiveTabHiddenGlobalTracks(
+  const activeTabHiddenGlobalTracksGetter = getActiveTabHiddenGlobalTracksGetter(
     getState()
   );
 
@@ -661,7 +661,7 @@ function _findOtherVisibleThread(
 
     if (
       transitioningToActiveTab &&
-      activeTabHiddenGlobalTracks.has(globalTrackIndex)
+      activeTabHiddenGlobalTracksGetter().has(globalTrackIndex)
     ) {
       // We are transitioning to the active tab view. We should be able to select
       // the track that is not hidden by it as well.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -13,6 +13,8 @@ import {
   getLocalTrackFromReference,
   getGlobalTrackFromReference,
   getPreviewSelection,
+  getComputedHiddenGlobalTracks,
+  getComputedHiddenLocalTracks,
 } from '../selectors/profile';
 import {
   getThreadSelectors,
@@ -24,7 +26,6 @@ import {
   getHiddenGlobalTracks,
   getGlobalTrackOrder,
   getLocalTrackOrder,
-  getHiddenLocalTracks,
   getSelectedTab,
 } from '../selectors/url-state';
 import {
@@ -382,7 +383,7 @@ export function changeGlobalTrackOrder(globalTrackOrder: TrackIndex[]): Action {
  */
 export function hideGlobalTrack(trackIndex: TrackIndex): ThunkAction<void> {
   return (dispatch, getState) => {
-    const hiddenGlobalTracks = getHiddenGlobalTracks(getState());
+    const hiddenGlobalTracks = getComputedHiddenGlobalTracks(getState());
     if (hiddenGlobalTracks.has(trackIndex)) {
       // This track is already hidden, don't do anything.
       return;
@@ -638,7 +639,7 @@ function _findOtherVisibleThread(
 ): ThreadIndex | null {
   const globalTracks = getGlobalTracks(getState());
   const globalTrackOrder = getGlobalTrackOrder(getState());
-  const globalHiddenTracks = getHiddenGlobalTracks(getState());
+  const globalHiddenTracks = getComputedHiddenGlobalTracks(getState());
 
   for (const globalTrackIndex of globalTrackOrder) {
     const globalTrack = globalTracks[globalTrackIndex];
@@ -659,7 +660,10 @@ function _findOtherVisibleThread(
 
     const localTracks = getLocalTracks(getState(), globalTrack.pid);
     const localTrackOrder = getLocalTrackOrder(getState(), globalTrack.pid);
-    const hiddenLocalTracks = getHiddenLocalTracks(getState(), globalTrack.pid);
+    const hiddenLocalTracks = getComputedHiddenLocalTracks(
+      getState(),
+      globalTrack.pid
+    );
 
     for (const trackIndex of localTrackOrder) {
       const track = localTracks[trackIndex];
@@ -689,7 +693,7 @@ export function hideLocalTrack(
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const localTracks = getLocalTracks(getState(), pid);
-    const hiddenLocalTracks = getHiddenLocalTracks(getState(), pid);
+    const hiddenLocalTracks = getComputedHiddenLocalTracks(getState(), pid);
     const localTrackToHide = localTracks[trackIndexToHide];
     const selectedThreadIndex = getSelectedThreadIndex(getState());
     let nextSelectedThreadIndex: ThreadIndex | null =

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -40,6 +40,10 @@ import {
   initializeHiddenGlobalTracks,
   getVisibleThreads,
 } from '../profile-logic/tracks';
+import {
+  computeActiveTabHiddenGlobalTracks,
+  computeActiveTabHiddenLocalTracksByPid,
+} from '../profile-logic/active-tab';
 import { getProfileOrNull } from '../selectors/profile';
 import { getView } from '../selectors/app';
 import { setDataSource } from './profile-view';
@@ -164,6 +168,11 @@ export function finalizeProfileView(
       hasUrlInfo ? getHiddenGlobalTracks(getState()) : null,
       getLegacyHiddenThreads(getState())
     );
+    // Pre-compute which tracks are not available for the active tab.
+    const activeTabHiddenGlobalTracks = computeActiveTabHiddenGlobalTracks(
+      globalTracks,
+      getState() // we need to access per thread selectors inside
+    );
     const localTracksByPid = computeLocalTracksByPid(profile);
     const localTrackOrderByPid = initializeLocalTrackOrderByPid(
       hasUrlInfo ? getLocalTrackOrderByPid(getState()) : null,
@@ -175,6 +184,11 @@ export function finalizeProfileView(
       localTracksByPid,
       profile,
       getLegacyHiddenThreads(getState())
+    );
+    // Pre-compute which local tracks are not available for the active tab.
+    const activeTabHiddenLocalTracksByPid = computeActiveTabHiddenLocalTracksByPid(
+      localTracksByPid,
+      getState() // we need to access per thread selectors inside
     );
     let visibleThreadIndexes = getVisibleThreads(
       globalTracks,
@@ -235,6 +249,8 @@ export function finalizeProfileView(
       localTracksByPid,
       hiddenLocalTracksByPid,
       localTrackOrderByPid,
+      activeTabHiddenGlobalTracks,
+      activeTabHiddenLocalTracksByPid,
     });
 
     // Note we kick off symbolication only for the profiles we know for sure

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -169,10 +169,11 @@ export function finalizeProfileView(
       getLegacyHiddenThreads(getState())
     );
     // Pre-compute which tracks are not available for the active tab.
-    const activeTabHiddenGlobalTracks = computeActiveTabHiddenGlobalTracks(
-      globalTracks,
-      getState() // we need to access per thread selectors inside
-    );
+    const activeTabHiddenGlobalTracksGetter = () =>
+      computeActiveTabHiddenGlobalTracks(
+        globalTracks,
+        getState() // we need to access per thread selectors inside
+      );
     const localTracksByPid = computeLocalTracksByPid(profile);
     const localTrackOrderByPid = initializeLocalTrackOrderByPid(
       hasUrlInfo ? getLocalTrackOrderByPid(getState()) : null,
@@ -186,10 +187,11 @@ export function finalizeProfileView(
       getLegacyHiddenThreads(getState())
     );
     // Pre-compute which local tracks are not available for the active tab.
-    const activeTabHiddenLocalTracksByPid = computeActiveTabHiddenLocalTracksByPid(
-      localTracksByPid,
-      getState() // we need to access per thread selectors inside
-    );
+    const activeTabHiddenLocalTracksByPidGetter = () =>
+      computeActiveTabHiddenLocalTracksByPid(
+        localTracksByPid,
+        getState() // we need to access per thread selectors inside
+      );
     let visibleThreadIndexes = getVisibleThreads(
       globalTracks,
       hiddenGlobalTracks,
@@ -249,8 +251,8 @@ export function finalizeProfileView(
       localTracksByPid,
       hiddenLocalTracksByPid,
       localTrackOrderByPid,
-      activeTabHiddenGlobalTracks,
-      activeTabHiddenLocalTracksByPid,
+      activeTabHiddenGlobalTracksGetter,
+      activeTabHiddenLocalTracksByPidGetter,
     });
 
     // Note we kick off symbolication only for the profiles we know for sure

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -14,7 +14,6 @@ import {
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import {
   getSelectedThreadIndex,
-  getHiddenGlobalTracks,
   getLocalTrackOrder,
   getSelectedTab,
 } from '../../selectors/url-state';
@@ -27,6 +26,7 @@ import {
   getVisualProgress,
   getPerceptualSpeedIndexProgress,
   getContentfulSpeedIndexProgress,
+  getComputedHiddenGlobalTracks,
 } from '../../selectors/profile';
 import { getThreadSelectors } from '../../selectors/per-thread';
 import './Track.css';
@@ -349,7 +349,7 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
       localTrackOrder,
       localTracks,
       pid,
-      isHidden: getHiddenGlobalTracks(state).has(trackIndex),
+      isHidden: getComputedHiddenGlobalTracks(state).has(trackIndex),
       selectedTab,
       processesWithMemoryTrack: getProcessesWithMemoryTrack(state),
       progressGraphData,

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -20,7 +20,7 @@ import explicitConnect from '../../utils/connect';
 import {
   getLocalTrackName,
   getCounterSelectors,
-  getIsLocalTrackHidden,
+  getComputedHiddenLocalTracks,
 } from '../../selectors/profile';
 import { getThreadSelectors } from '../../selectors/per-thread';
 import TrackThread from './TrackThread';
@@ -190,7 +190,7 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
       trackName: getLocalTrackName(state, pid, trackIndex),
       titleText,
       isSelected,
-      isHidden: getIsLocalTrackHidden(state, pid, trackIndex),
+      isHidden: getComputedHiddenLocalTracks(state, pid).has(trackIndex),
     };
   },
   mapDispatchToProps: {

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import { getThreadSelectors } from '../selectors/per-thread';
+import { assertExhaustiveCheck } from '../utils/flow';
+
+import type { State } from '../types/state';
+import type { ThreadIndex, Pid } from '../types/profile';
+import type {
+  GlobalTrack,
+  LocalTrack,
+  TrackIndex,
+} from '../types/profile-derived';
+
+/**
+ * Take the global tracks and decide which one to hide during the active tab view.
+ * Some global tracks are allowed, some tracks are not, and we have to do some
+ * computations for some('process' type specifically).
+ */
+export function computeActiveTabHiddenGlobalTracks(
+  globalTracks: GlobalTrack[],
+  state: State
+): Set<TrackIndex> {
+  const activeTabHiddenGlobalTracks = new Set();
+
+  for (let trackIndex = 0; trackIndex < globalTracks.length; trackIndex++) {
+    const globalTrack: GlobalTrack = globalTracks[trackIndex];
+    const trackType = globalTrack.type;
+
+    switch (trackType) {
+      case 'screenshots':
+        // Do not hide screenshots.
+        break;
+      case 'visual-progress':
+      case 'perceptual-visual-progress':
+      case 'contentful-visual-progress':
+        // Hide those global track types because we want to hide as much as
+        // possible from web developers for now.
+        activeTabHiddenGlobalTracks.add(trackIndex);
+        break;
+      case 'process': {
+        // Do not display empty tracks if the tab filtered thread is empty.
+        if (
+          globalTrack.mainThreadIndex !== undefined &&
+          globalTrack.mainThreadIndex !== null &&
+          isTabFilteredThreadEmpty(globalTrack.mainThreadIndex, state)
+        ) {
+          // Thread is empty and we should hide it.
+          activeTabHiddenGlobalTracks.add(trackIndex);
+        }
+        break;
+      }
+      default:
+        throw assertExhaustiveCheck(trackType, `Unhandled GlobalTrack type.`);
+    }
+  }
+
+  return activeTabHiddenGlobalTracks;
+}
+
+/**
+ * Take the local tracks and decide which one to hide during the active tab view.
+ * Some tracks are not allowed, and we have to do some computations for some('thread' type specifically).
+ */
+export function computeActiveTabHiddenLocalTracksByPid(
+  localTracksByPid: Map<Pid, LocalTrack[]>,
+  state: State
+): Map<Pid, Set<TrackIndex>> {
+  const activeTabHiddenLocalTracksByPid = new Map();
+
+  for (const [pid, localTracks] of localTracksByPid) {
+    // Pre-put the new Set here, because we should keep the whole processes even though they are empty.
+    const currentLocalTracks = new Set();
+    activeTabHiddenLocalTracksByPid.set(pid, currentLocalTracks);
+    for (let trackIndex = 0; trackIndex < localTracks.length; trackIndex++) {
+      const localTrack = localTracks[trackIndex];
+      const trackType = localTrack.type;
+
+      switch (trackType) {
+        case 'network':
+        case 'memory':
+        case 'ipc': {
+          // Hide those global track types because we want to hide as much as
+          // possible from web developers for now.
+          currentLocalTracks.add(trackIndex);
+          break;
+        }
+        case 'thread': {
+          // We don't want to display empty tracks if the tab filtered thread is empty.
+          if (
+            localTrack.threadIndex !== undefined &&
+            localTrack.threadIndex !== null &&
+            isTabFilteredThreadEmpty(localTrack.threadIndex, state)
+          ) {
+            // Thread is empty and we should hide it.
+            currentLocalTracks.add(trackIndex);
+          }
+          break;
+        }
+        default:
+          throw assertExhaustiveCheck(trackType, `Unhandled LocalTrack type.`);
+      }
+    }
+  }
+
+  return activeTabHiddenLocalTracksByPid;
+}
+
+/**
+ * Checks whether the tab filtered thread is empty or not.
+ * We take a look at the sample and marker data to determine that.
+ */
+function isTabFilteredThreadEmpty(
+  threadIndex: ThreadIndex,
+  state: State
+): boolean {
+  // Have to get the thread selectors to look if the thread is empty or not.
+  const threadSelectors = getThreadSelectors(threadIndex);
+  const tabFilteredThread = threadSelectors.getActiveTabFilteredThread(state);
+  // Check the samples first to see if they are all empty or not.
+  for (const stackIndex of tabFilteredThread.samples.stack) {
+    if (stackIndex !== null) {
+      // Samples are not empty. Do not hide that thread.
+      // We don't have to look at the markers because samples are not empty.
+      return false;
+    }
+  }
+
+  const tabFilteredMarkers = threadSelectors.getActiveTabFilteredMarkerIndexesWithoutGlobals(
+    state
+  );
+  if (tabFilteredMarkers.length > 0) {
+    // Thread has some markers in it. Don't hide and skip to the next global track.
+    return false;
+  }
+
+  return true;
+}

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -190,6 +190,12 @@ export function getTabFilteredMarkerIndexes(
         newMarkers.push(markerIndex);
         continue;
       }
+    } else {
+      if (data && data.type === 'Network') {
+        // Now network markers have innerWindowIDs inside their payloads but those markers
+        // can be inside the main thread and not be related to that specific thread.
+        continue;
+      }
     }
 
     if (data && data.innerWindowID && relevantPages.has(data.innerWindowID)) {

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -170,7 +170,8 @@ export function getSearchFilteredMarkerIndexes(
 export function getTabFilteredMarkerIndexes(
   getMarker: MarkerIndex => Marker,
   markerIndexes: MarkerIndex[],
-  relevantPages: Set<InnerWindowID>
+  relevantPages: Set<InnerWindowID>,
+  includeGlobalMarkers: boolean = true
 ): MarkerIndex[] {
   if (relevantPages.size === 0) {
     return markerIndexes;
@@ -184,9 +185,11 @@ export function getTabFilteredMarkerIndexes(
     // We are checking those before and pushing those markers to the new array.
     // As of now, those markers are:
     // - Jank markers
-    if (name === 'Jank') {
-      newMarkers.push(markerIndex);
-      continue;
+    if (includeGlobalMarkers) {
+      if (name === 'Jank') {
+        newMarkers.push(markerIndex);
+        continue;
+      }
     }
 
     if (data && data.innerWindowID && relevantPages.has(data.innerWindowID)) {

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -594,24 +594,6 @@ export function getLocalTrackName(
 }
 
 /**
- * Some of the local tracks are not allowed for the single tab view because they
- * are too much information for users and we would like to hide as much information
- * as possible to make the UI simpler for web developers.
- */
-export function isLocalTrackAllowedForSingleTabView(localTrack: LocalTrack) {
-  switch (localTrack.type) {
-    case 'thread':
-      return true;
-    case 'network':
-    case 'memory':
-    case 'ipc':
-      return false;
-    default:
-      throw assertExhaustiveCheck(localTrack, 'Unhandled LocalTrack type.');
-  }
-}
-
-/**
  * Determine if a thread is idle, so that it can be hidden. It is really annoying for an
  * end user to load a profile full of empty and idle threads. This function uses
  * various rules to determine if a thread is idle.

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -13,7 +13,11 @@ import * as ProfileData from '../profile-logic/profile-data';
 import { arePathsEqual, PathSet } from '../utils/path';
 
 import type { Profile, Pid } from '../types/profile';
-import type { LocalTrack, GlobalTrack } from '../types/profile-derived';
+import type {
+  LocalTrack,
+  GlobalTrack,
+  TrackIndex,
+} from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
 import type {
   PreviewSelection,
@@ -103,6 +107,39 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.localTracksByPid;
+    default:
+      return state;
+  }
+};
+
+/**
+ * This information is stored, rather than derived via selectors, since the coalesced
+ * function update would force it to be recomputed on every symbolication update
+ * pass. It is valid for the lifetime of the profile.
+ */
+const activeTabHiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
+  state = new Set(),
+  action
+) => {
+  switch (action.type) {
+    case 'VIEW_PROFILE':
+      return action.activeTabHiddenGlobalTracks;
+    default:
+      return state;
+  }
+};
+
+/**
+ * This can be derived like the globalTracks information, but is stored in the state
+ * for the same reason.
+ */
+const activeTabHiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
+  state = new Map(),
+  action
+) => {
+  switch (action.type) {
+    case 'VIEW_PROFILE':
+      return action.activeTabHiddenLocalTracksByPid;
     default:
       return state;
   }
@@ -549,6 +586,8 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
     }),
     globalTracks,
     localTracksByPid,
+    activeTabHiddenGlobalTracks,
+    activeTabHiddenLocalTracksByPid,
     profile,
   })
 );

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -117,13 +117,13 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
  * function update would force it to be recomputed on every symbolication update
  * pass. It is valid for the lifetime of the profile.
  */
-const activeTabHiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
-  state = new Set(),
+const activeTabHiddenGlobalTracksGetter: Reducer<() => Set<TrackIndex>> = (
+  state = () => new Set(),
   action
 ) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
-      return action.activeTabHiddenGlobalTracks;
+      return action.activeTabHiddenGlobalTracksGetter;
     default:
       return state;
   }
@@ -133,13 +133,12 @@ const activeTabHiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
  * This can be derived like the globalTracks information, but is stored in the state
  * for the same reason.
  */
-const activeTabHiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
-  state = new Map(),
-  action
-) => {
+const activeTabHiddenLocalTracksByPidGetter: Reducer<
+  () => Map<Pid, Set<TrackIndex>>
+> = (state = () => new Map(), action) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
-      return action.activeTabHiddenLocalTracksByPid;
+      return action.activeTabHiddenLocalTracksByPidGetter;
     default:
       return state;
   }
@@ -586,8 +585,8 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
     }),
     globalTracks,
     localTracksByPid,
-    activeTabHiddenGlobalTracks,
-    activeTabHiddenLocalTracksByPid,
+    activeTabHiddenGlobalTracksGetter,
+    activeTabHiddenLocalTracksByPidGetter,
     profile,
   })
 );

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -134,6 +134,12 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
       }
       return newThreadIndex;
     }
+    case 'CHANGE_SHOW_TAB_ONLY':
+      if (action.selectedThreadIndex === null) {
+        // Do not change the selected thread if we don't have to.
+        return state;
+      }
+      return action.selectedThreadIndex;
     default:
       return state;
   }

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -5,14 +5,13 @@
 // @flow
 import { createSelector } from 'reselect';
 
+import { getDataSource, getSelectedTab, getShowTabOnly } from './url-state';
 import {
-  getDataSource,
-  getSelectedTab,
-  getHiddenGlobalTracks,
-  getHiddenLocalTracksByPid,
-  getShowTabOnly,
-} from './url-state';
-import { getGlobalTracks, getLocalTracksByPid } from './profile';
+  getGlobalTracks,
+  getLocalTracksByPid,
+  getComputedHiddenGlobalTracks,
+  getComputedHiddenLocalTracksByPid,
+} from './profile';
 import { getZipFileState } from './zipped-profiles.js';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import {
@@ -72,8 +71,8 @@ export const getIsDragAndDropOverlayRegistered: Selector<boolean> = state =>
 export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
   getGlobalTracks,
   getLocalTracksByPid,
-  getHiddenGlobalTracks,
-  getHiddenLocalTracksByPid,
+  getComputedHiddenGlobalTracks,
+  getComputedHiddenLocalTracksByPid,
   getTrackThreadHeights,
   getShowTabOnly,
   (

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -194,7 +194,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
   > = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    ProfileSelectors.getRelevantPagesForActiveTab,
+    ProfileSelectors.getRelevantPagesForCurrentTab,
     MarkerData.getTabFilteredMarkerIndexes
   );
 
@@ -220,6 +220,28 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
         !MarkerData.isMemoryMarker(marker) &&
         !MarkerData.isIPCMarker(marker)
     )
+  );
+
+  /**
+   * This selector applies the tab filter(if in a single tab view) to the full
+   * list of markers but excludes the global markers.
+   * This selector is useful to determine if a thread is completely empty or not
+   * so we can hide it inside active tab view.
+   */
+  const getActiveTabFilteredMarkerIndexesWithoutGlobals: Selector<
+    MarkerIndex[]
+  > = createSelector(
+    getMarkerGetter,
+    getFullMarkerListIndexes,
+    ProfileSelectors.getRelevantPagesForActiveTab,
+    (markerGetter, markerIndexes, relevantPages) => {
+      return MarkerData.getTabFilteredMarkerIndexes(
+        markerGetter,
+        markerIndexes,
+        relevantPages,
+        false // exclude global markers
+      );
+    }
   );
 
   /**
@@ -467,6 +489,7 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getCommittedRangeFilteredMarkerIndexes,
     getCommittedRangeAndTabFilteredMarkerIndexes,
     getCommittedRangeAndTabFilteredMarkerIndexesForHeader,
+    getActiveTabFilteredMarkerIndexesWithoutGlobals,
     getTimelineVerticalMarkerIndexes,
     getFileIoMarkerIndexes,
     getMemoryMarkerIndexes,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -72,8 +72,32 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
 
   const getTabFilteredThread: Selector<Thread> = createSelector(
     getThread,
+    ProfileSelectors.getRelevantPagesForCurrentTab,
+    (thread, relevantPages) => {
+      if (relevantPages.size === 0) {
+        // If this set doesn't have any relevant page, just return the whole thread.
+        return thread;
+      }
+      return ProfileData.filterThreadByTab(thread, relevantPages);
+    }
+  );
+
+  /**
+   * Similar to getTabFilteredThread, but this selector returns the active tab
+   * filtered thread even though we are not in the active tab view at the moment.
+   * This selector is needed to make the hidden track calculations during profile
+   * load time(during viewProfile).
+   */
+  const getActiveTabFilteredThread: Selector<Thread> = createSelector(
+    getThread,
     ProfileSelectors.getRelevantPagesForActiveTab,
-    ProfileData.filterThreadByTab
+    (thread, relevantPages) => {
+      if (relevantPages.size === 0) {
+        // If this set doesn't have any relevant page, just return the whole thread.
+        return thread;
+      }
+      return ProfileData.filterThreadByTab(thread, relevantPages);
+    }
   );
 
   const getRangeFilteredThread: Selector<Thread> = createSelector(
@@ -304,5 +328,6 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
     getHasNativeAllocations,
     getCanShowRetainedMemory,
     getTabFilteredThread,
+    getActiveTabFilteredThread,
   };
 }

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -651,11 +651,10 @@ export const getRelevantPagesForCurrentTab: Selector<
 export const getComputedHiddenGlobalTracks: Selector<
   Set<TrackIndex>
 > = createSelector(
-  UrlState.getProfileSpecificState,
+  UrlState.getHiddenGlobalTracks,
   UrlState.getShowTabOnly,
   getActiveTabHiddenGlobalTracks,
-  (profileSpecific, showTabOnly, activeTabHiddenGlobalTracks) => {
-    const hiddenGlobalTracks = profileSpecific.hiddenGlobalTracks;
+  (hiddenGlobalTracks, showTabOnly, activeTabHiddenGlobalTracks) => {
     if (showTabOnly === null) {
       return hiddenGlobalTracks;
     }
@@ -673,11 +672,10 @@ export const getComputedHiddenGlobalTracks: Selector<
 export const getComputedHiddenLocalTracksByPid: Selector<
   Map<Pid, Set<TrackIndex>>
 > = createSelector(
-  UrlState.getProfileSpecificState,
+  UrlState.getHiddenLocalTracksByPid,
   UrlState.getShowTabOnly,
   getActiveTabHiddenLocalTracksByPid,
-  (profileSpecific, showTabOnly, activeTabHiddenLocalTracksByPid) => {
-    const hiddenLocalTracksByPid = profileSpecific.hiddenLocalTracksByPid;
+  (hiddenLocalTracksByPid, showTabOnly, activeTabHiddenLocalTracksByPid) => {
     if (showTabOnly === null) {
       return hiddenLocalTracksByPid;
     }

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -6,7 +6,7 @@
 import { createSelector } from 'reselect';
 import * as Tracks from '../profile-logic/tracks';
 import * as UrlState from './url-state';
-import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
+import { ensureExists } from '../utils/flow';
 import {
   filterCounterToRange,
   accumulateCounterSamples,
@@ -237,6 +237,9 @@ export const getIPCMarkerCorrelations: Selector<IPCMarkerCorrelations> = createS
  */
 export const getGlobalTracks: Selector<GlobalTrack[]> = state =>
   getProfileView(state).globalTracks;
+export const getActiveTabHiddenGlobalTracks: Selector<
+  Set<TrackIndex>
+> = state => getProfileView(state).activeTabHiddenGlobalTracks;
 
 /**
  * This returns all TrackReferences for global tracks.
@@ -306,6 +309,9 @@ export const getGlobalTrackAndIndexByPid: DangerousSelectorWithArguments<
  */
 export const getLocalTracksByPid: Selector<Map<Pid, LocalTrack[]>> = state =>
   getProfileView(state).localTracksByPid;
+export const getActiveTabHiddenLocalTracksByPid: Selector<
+  Map<Pid, Set<TrackIndex>>
+> = state => getProfileView(state).activeTabHiddenLocalTracksByPid;
 
 /**
  * This selectors performs a simple look up in a Map, throws an error if it doesn't exist,
@@ -417,20 +423,26 @@ export const getLocalTrackName = (
 /**
  * It's a bit hard to deduce the total amount of hidden tracks, as there are both
  * global and local tracks, and they are stored by PID. If a global track is hidden,
- * then all its children are as well. This function walks all of the data to determine
+ * then all its children are as well. Also we need to take into account the tracks
+ * that are hidden by active tab view. We should ignore them because they will not
+ * be visible in the track list. This function walks all of the data to determine
  * the correct hidden counts.
  */
 export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
   getGlobalTracks,
   getLocalTracksByPid,
   UrlState.getHiddenLocalTracksByPid,
+  getActiveTabHiddenLocalTracksByPid,
   UrlState.getHiddenGlobalTracks,
+  getActiveTabHiddenGlobalTracks,
   UrlState.getShowTabOnly,
   (
     globalTracks,
     localTracksByPid,
     hiddenLocalTracksByPid,
+    activeTabHiddenLocalTracksByPid,
     hiddenGlobalTracks,
+    activeTabHiddenGlobalTracks,
     showTabOnly
   ) => {
     let hidden = 0;
@@ -440,6 +452,8 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
     for (const [pid, localTracks] of localTracksByPid) {
       // Look up some of the information.
       const hiddenLocalTracks = hiddenLocalTracksByPid.get(pid) || new Set();
+      const activeTabHiddenLocalTracks =
+        activeTabHiddenLocalTracksByPid.get(pid) || new Set();
       const globalTrackIndex = globalTracks.findIndex(
         track => track.type === 'process' && track.pid === pid
       );
@@ -454,37 +468,44 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
 
       if (hiddenGlobalTracks.has(globalTrackIndex)) {
         // The entire process group is hidden, count all of the tracks.
-        hidden += localTracks.length;
-        if (showTabOnly) {
-          // We hide some of the local tracks by default for single tab view.
-          hidden -= localTracks.filter(
-            track => Tracks.isLocalTrackAllowedForSingleTabView(track) === false
-          ).length;
+        if (showTabOnly !== null) {
+          if (!activeTabHiddenGlobalTracks.has(globalTrackIndex)) {
+            // If we are in active tab view and the current hidden track is not
+            // hidden by that, count its local tracks but also make sure that we
+            // don't count its hidden local tracks that if they are hidden by active tab view.
+            hidden += localTracks.length - activeTabHiddenLocalTracks.size;
+          }
+        } else {
+          hidden += localTracks.length;
         }
       } else {
         // Only count the hidden local tracks.
         hidden += hiddenLocalTracks.size;
-        if (showTabOnly) {
-          // We hide some of the local tracks by default for single tab view.
-          hidden -= localTracks.filter(
-            (track, trackIndex) =>
-              hiddenLocalTracks.has(trackIndex) &&
-              Tracks.isLocalTrackAllowedForSingleTabView(track) === false
+        if (showTabOnly !== null) {
+          // If we are in active tab view, we should remove the count of active
+          // tab hidden tracks since they won't be visible at all.
+          hidden -= [...activeTabHiddenLocalTracks].filter(t =>
+            hiddenLocalTracks.has(t)
           ).length;
         }
       }
       total += localTracks.length;
-      if (showTabOnly) {
-        // We hide some of the local tracks by default for single tab view.
-        total -= localTracks.filter(
-          track => Tracks.isLocalTrackAllowedForSingleTabView(track) === false
-        ).length;
+      if (showTabOnly !== null) {
+        // Again, if we are in active tab view, do not count the tracks that are hidden by active tab view.
+        total -= activeTabHiddenLocalTracks.size;
       }
     }
 
     // Count up the global tracks
-    total += globalTracks.length;
-    hidden += hiddenGlobalTracks.size;
+    if (showTabOnly) {
+      total += globalTracks.length - activeTabHiddenGlobalTracks.size;
+      hidden += [...hiddenGlobalTracks].filter(
+        t => !activeTabHiddenGlobalTracks.has(t)
+      ).length;
+    } else {
+      total += globalTracks.length;
+      hidden += hiddenGlobalTracks.size;
+    }
 
     return { hidden, total };
   }
@@ -575,56 +596,127 @@ export const getPagesMap: Selector<Map<
  * are related to this active tab. This is a fairly simple map element access.
  * The `BrowsingContextID -> Set<InnerWindowID>` construction happens inside
  * the getPageMap selector.
+ * This function returns the Set all the time even though we are not in the active
+ * tab view at the moment. Idaelly you should use the wrapper getRelevantPagesForCurrentTab
+ * function if you want to do something inside the active tab view. This is needed
+ * for only viewProfile function to calculate the hidden tracks during page load,
+ * even though we are not in the active tab view.
  */
 export const getRelevantPagesForActiveTab: Selector<
   Set<InnerWindowID>
 > = createSelector(
   getPagesMap,
-  UrlState.getShowTabOnly,
-  (pagesMap, showTabOnly) => {
-    if (pagesMap === null || pagesMap.size === 0 || showTabOnly === null) {
+  getActiveBrowsingContextID,
+  (pagesMap, activeBrowsingContextID) => {
+    if (
+      pagesMap === null ||
+      pagesMap.size === 0 ||
+      activeBrowsingContextID === null
+    ) {
       // Return an empty set if we want to see everything or that data is not there.
       return new Set();
     }
 
-    const pageSet = pagesMap.get(showTabOnly);
+    const pageSet = pagesMap.get(activeBrowsingContextID);
     return pageSet !== undefined ? pageSet : new Set();
   }
 );
 
-export const getIsLocalTrackHidden: DangerousSelectorWithArguments<
-  boolean,
-  Pid,
-  TrackIndex
-> = (state, pid, trackIndex) => {
-  const hiddenLocalTracks = ensureExists(
-    UrlState.getHiddenLocalTracks(state, pid),
+/**
+ * A simple wrapper for getRelevantPagesForActiveTab.
+ * It returns an empty Set if showTabOnly is null, and returns the real Set if
+ * showTabOnly is assigned already. We should usually use this instead of the
+ * wrapped function. But the wrapped function is helpful to calculate the hidden
+ * tracks by active tab view during the first page load(inside viewProfile function).
+ */
+export const getRelevantPagesForCurrentTab: Selector<
+  Set<InnerWindowID>
+> = createSelector(
+  UrlState.getShowTabOnly,
+  getRelevantPagesForActiveTab,
+  (showTabOnly, relevantPages) => {
+    if (showTabOnly === null) {
+      // Return an empty set if we want to see everything or that data is not there.
+      return new Set();
+    }
+
+    return relevantPages;
+  }
+);
+
+/**
+ * Gets the hidden global tracks from the url and from the active tab view,
+ * then merges those Sets depending on the active tab view status.
+ */
+export const getComputedHiddenGlobalTracks: Selector<
+  Set<TrackIndex>
+> = createSelector(
+  UrlState.getProfileSpecificState,
+  UrlState.getShowTabOnly,
+  getActiveTabHiddenGlobalTracks,
+  (profileSpecific, showTabOnly, activeTabHiddenGlobalTracks) => {
+    const hiddenGlobalTracks = profileSpecific.hiddenGlobalTracks;
+    if (showTabOnly === null) {
+      return hiddenGlobalTracks;
+    }
+
+    // We are in the showTabOnly mode and we need to hide the tracks that don't
+    // belong to the active tab as well.
+    return new Set([...hiddenGlobalTracks, ...activeTabHiddenGlobalTracks]);
+  }
+);
+
+/**
+ * Gets the hidden local tracks from the url and from the active tab view,
+ * then merges those Sets depending on the active tab view status.
+ */
+export const getComputedHiddenLocalTracksByPid: Selector<
+  Map<Pid, Set<TrackIndex>>
+> = createSelector(
+  UrlState.getProfileSpecificState,
+  UrlState.getShowTabOnly,
+  getActiveTabHiddenLocalTracksByPid,
+  (profileSpecific, showTabOnly, activeTabHiddenLocalTracksByPid) => {
+    const hiddenLocalTracksByPid = profileSpecific.hiddenLocalTracksByPid;
+    if (showTabOnly === null) {
+      return hiddenLocalTracksByPid;
+    }
+
+    // We are in the showTabOnly mode and we need to hide the tracks that don't
+    // belong to the active tab as well.
+
+    // We need to deep copy those Maps and Sets here, just in case.
+    const mergedHiddenLocalTracksByPid = new Map();
+    for (const [pid, localTracks] of hiddenLocalTracksByPid) {
+      mergedHiddenLocalTracksByPid.set(pid, new Set([...localTracks]));
+    }
+
+    for (const [pid, localTracks] of activeTabHiddenLocalTracksByPid) {
+      const entry = mergedHiddenLocalTracksByPid.get(pid);
+      if (entry) {
+        mergedHiddenLocalTracksByPid.set(
+          pid,
+          new Set([...entry, ...localTracks])
+        );
+      } else {
+        mergedHiddenLocalTracksByPid.set(pid, new Set([...localTracks]));
+      }
+    }
+
+    return mergedHiddenLocalTracksByPid;
+  }
+);
+
+/**
+ * This selector does a simple lookup in the set of computed hidden tracks for a
+ * PID, and ensures that a TrackIndex is selected correctly. This makes it easier
+ * to avoid doing null checks everywhere.
+ */
+export const getComputedHiddenLocalTracks: DangerousSelectorWithArguments<
+  Set<TrackIndex>,
+  Pid
+> = (state, pid) =>
+  ensureExists(
+    getComputedHiddenLocalTracksByPid(state).get(pid),
     'Unable to get the tracks for the given pid.'
   );
-
-  if (hiddenLocalTracks.has(trackIndex)) {
-    return true;
-  }
-
-  if (UrlState.getShowTabOnly(state)) {
-    const tracks = ensureExists(
-      getLocalTracksByPid(state).get(pid),
-      'A local track was expected to exist for the given pid.'
-    );
-    const trackType = tracks[trackIndex].type;
-    switch (trackType) {
-      case 'network':
-      case 'memory':
-      case 'ipc':
-        // Hide those local track types because we want to hide as much as
-        // possible from web developers for now.
-        return true;
-      case 'thread':
-        break;
-      default:
-        throw assertExhaustiveCheck(trackType, `Unhandled LocalTrack type.`);
-    }
-  }
-
-  return false;
-};

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -11,6 +11,8 @@ import {
   getGlobalTracks,
   getLocalTracksByPid,
   getHasPreferenceMarkers,
+  getComputedHiddenGlobalTracks,
+  getComputedHiddenLocalTracksByPid,
 } from './profile';
 import { compress } from '../utils/gz';
 import { serializeProfile } from '../profile-logic/process-profile';
@@ -20,7 +22,6 @@ import {
   type SanitizeProfileResult,
 } from '../profile-logic/sanitize';
 import prettyBytes from '../utils/pretty-bytes';
-import { getHiddenGlobalTracks, getHiddenLocalTracksByPid } from './url-state';
 import { ensureExists } from '../utils/flow';
 import { formatNumber } from '../utils/format-numbers';
 
@@ -66,8 +67,8 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
   getCheckedSharingOptions,
   getProfile,
   getCommittedRange,
-  getHiddenGlobalTracks,
-  getHiddenLocalTracksByPid,
+  getComputedHiddenGlobalTracks,
+  getComputedHiddenLocalTracksByPid,
   getGlobalTracks,
   getLocalTracksByPid,
   getHasPreferenceMarkers,

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -4,6 +4,7 @@
 // @flow
 
 import * as profileViewSelectors from '../../../selectors/profile';
+// FIXME: they are not reducers, it should be `urlStateSelectors` instead.
 import * as urlStateReducers from '../../../selectors/url-state';
 import {
   getProfileFromTextSamples,
@@ -14,6 +15,7 @@ import { oneLine } from 'common-tags';
 
 import type { Profile } from '../../../types/profile';
 import type { State } from '../../../types/state';
+import { ensureExists } from '../../../utils/flow';
 
 /**
  * This function takes the current timeline tracks, and generates a human readable result
@@ -42,9 +44,20 @@ export function getHumanReadableTracks(state: State): string[] {
   const threads = profileViewSelectors.getThreads(state);
   const globalTracks = profileViewSelectors.getGlobalTracks(state);
   const hiddenGlobalTracks = urlStateReducers.getHiddenGlobalTracks(state);
+  const activeTabHiddenGlobalTracks = profileViewSelectors.getActiveTabHiddenGlobalTracks(
+    state
+  );
   const selectedThreadIndex = urlStateReducers.getSelectedThreadIndex(state);
+  const showTabOnly = urlStateReducers.getShowTabOnly(state);
   const text: string[] = [];
   for (const globalTrackIndex of urlStateReducers.getGlobalTrackOrder(state)) {
+    if (
+      showTabOnly !== null &&
+      activeTabHiddenGlobalTracks.has(globalTrackIndex)
+    ) {
+      // If we are in active tab view, hide this track(and its local tracks) completely,
+      continue;
+    }
     const globalTrack = globalTracks[globalTrackIndex];
     const globalHiddenText = hiddenGlobalTracks.has(globalTrackIndex)
       ? 'hide'
@@ -93,6 +106,19 @@ export function getHumanReadableTracks(state: State): string[] {
           state,
           globalTrack.pid
         );
+        const activeTabHiddenLocalTracks = ensureExists(
+          profileViewSelectors
+            .getActiveTabHiddenLocalTracksByPid(state)
+            .get(globalTrack.pid)
+        );
+
+        if (
+          showTabOnly !== null &&
+          activeTabHiddenLocalTracks.has(trackIndex)
+        ) {
+          // If we are in active tab view, hide this track completely,
+          continue;
+        }
         const hiddenText = hiddenTracks.has(trackIndex) ? 'hide' : 'show';
         const selected =
           track.threadIndex === selectedThreadIndex ? ' SELECTED' : '';

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -44,9 +44,12 @@ export function getHumanReadableTracks(state: State): string[] {
   const threads = profileViewSelectors.getThreads(state);
   const globalTracks = profileViewSelectors.getGlobalTracks(state);
   const hiddenGlobalTracks = urlStateReducers.getHiddenGlobalTracks(state);
-  const activeTabHiddenGlobalTracks = profileViewSelectors.getActiveTabHiddenGlobalTracks(
+  const activeTabHiddenGlobalTracks = profileViewSelectors.getActiveTabHiddenGlobalTracksGetter(
     state
-  );
+  )();
+  const activeTabHiddenLocalTracksByPid = profileViewSelectors.getActiveTabHiddenLocalTracksByPidGetter(
+    state
+  )();
   const selectedThreadIndex = urlStateReducers.getSelectedThreadIndex(state);
   const showTabOnly = urlStateReducers.getShowTabOnly(state);
   const text: string[] = [];
@@ -107,9 +110,7 @@ export function getHumanReadableTracks(state: State): string[] {
           globalTrack.pid
         );
         const activeTabHiddenLocalTracks = ensureExists(
-          profileViewSelectors
-            .getActiveTabHiddenLocalTracksByPid(state)
-            .get(globalTrack.pid)
+          activeTabHiddenLocalTracksByPid.get(globalTrack.pid)
         );
 
         if (

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -63,6 +63,12 @@ Object {
         ],
       },
     ],
+    "configuration": Object {
+      "activeBrowsingContextID": 123123,
+      "capacity": 1000000,
+      "features": Array [],
+      "threads": Array [],
+    },
     "extensions": Object {
       "baseURL": Array [],
       "id": Array [],

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -418,6 +418,12 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function() {
         embedderInnerWindowID: 0,
       },
     ];
+    profile.meta.configuration = {
+      threads: [],
+      features: [],
+      capacity: 1000000,
+      activeBrowsingContextID: browsingContextID,
+    };
     const { getState, dispatch } = storeWithProfile(profile);
 
     if (showTabOnly) {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1468,6 +1468,13 @@ describe('snapshots of selectors/profile', function() {
       },
     ];
 
+    profile.meta.configuration = {
+      threads: [],
+      features: [],
+      capacity: 1000000,
+      activeBrowsingContextID: browsingContextID,
+    };
+
     const [samplesThread] = profile.threads;
 
     // Add innerWindowID for G function
@@ -2784,24 +2791,24 @@ describe('pages and active tab selectors', function() {
     expect(ProfileViewSelectors.getPagesMap(getState())).toEqual(result);
   });
 
-  it('getRelevantPagesForActiveTab will get the correct InnerWindowIDs for the first tab', function() {
+  it('getRelevantPagesForCurrentTab will get the correct InnerWindowIDs for the first tab', function() {
     const { getState } = setup(firstTabBrowsingContextID);
     expect(
-      ProfileViewSelectors.getRelevantPagesForActiveTab(getState())
+      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
     ).toEqual(new Set(fistTabInnerWindowIDs));
   });
 
-  it('getRelevantPagesForActiveTab will get the correct InnerWindowIDs for the second tab', function() {
+  it('getRelevantPagesForCurrentTab will get the correct InnerWindowIDs for the second tab', function() {
     const { getState } = setup(secondTabBrowsingContextID);
     expect(
-      ProfileViewSelectors.getRelevantPagesForActiveTab(getState())
+      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
     ).toEqual(new Set(secondTabInnerWindowIDs));
   });
 
-  it('getRelevantPagesForActiveTab will return an empty set for an ID that is not in the array', function() {
+  it('getRelevantPagesForCurrentTab will return an empty set for an ID that is not in the array', function() {
     const { getState } = setup(99999); // a non-existent BrowsingContextID
     expect(
-      ProfileViewSelectors.getRelevantPagesForActiveTab(getState())
+      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
     ).toEqual(new Set());
   });
 });

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -32,6 +32,7 @@ import {
   getProfilesFromRawUrl,
 } from '../../actions/receive-profile';
 import { SymbolsNotFoundError } from '../../profile-logic/errors';
+import { changeShowTabOnly } from '../../actions/profile-view';
 
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import JSZip from 'jszip';
@@ -42,6 +43,8 @@ import {
 import {
   getProfileFromTextSamples,
   addMarkersToThreadWithCorrespondingSamples,
+  getNetworkMarkers,
+  getScreenshotTrackProfile,
 } from '../fixtures/profiles/processed-profile';
 import { getHumanReadableTracks } from '../fixtures/profiles/tracks';
 import { waitUntilState } from '../fixtures/utils';
@@ -366,6 +369,124 @@ describe('actions/receive-profile', function() {
         'show [process]',
         '  - show [thread Work E]',
       ]);
+    });
+
+    describe('with showTabOnly', function() {
+      const browsingContextID = 123;
+      const innerWindowID = 111111;
+      function setup(profile: ?Profile) {
+        const store = blankStore();
+
+        if (!profile) {
+          profile = getEmptyProfile();
+          profile.threads.push(
+            // This thread should be completely hidden because it doesn't contain anything from the tab.
+            getEmptyThread({
+              name: 'GeckoMain',
+              processType: 'default',
+              pid: 1,
+            }),
+            // This thread shouldn't be hidden because it will have markers with innerWindowID.
+            getEmptyThread({ name: 'GeckoMain', processType: 'tab', pid: 2 }),
+            // This thread should be completely hidden because it doesn't contain anything from the tab.
+            getEmptyThread({ name: 'GeckoMain', processType: 'tab', pid: 3 })
+          );
+        } else {
+          // Appending a thread to test the second all the time
+          profile.threads = [
+            getEmptyThread({
+              name: 'GeckoMain',
+              processType: 'default',
+              pid: 1,
+            }),
+            ...profile.threads,
+          ];
+        }
+
+        profile.meta.configuration = {
+          threads: [],
+          features: [],
+          capacity: 1000000,
+          activeBrowsingContextID: browsingContextID,
+        };
+        profile.pages = [
+          {
+            browsingContextID: browsingContextID,
+            innerWindowID: innerWindowID,
+            url: 'URL',
+            embedderInnerWindowID: 0,
+          },
+        ];
+
+        addMarkersToThreadWithCorrespondingSamples(profile.threads[1], [
+          [
+            'RefreshDriverTick',
+            0,
+            {
+              type: 'tracing',
+              category: 'Navigation',
+              interval: 'start',
+              innerWindowID: innerWindowID,
+            },
+          ],
+          ...getNetworkMarkers({
+            startTime: 1,
+          }),
+        ]);
+
+        store.dispatch(viewProfile(profile));
+        store.dispatch(changeShowTabOnly(browsingContextID));
+
+        return { ...store, profile };
+      }
+
+      it('should calculate the hidden tracks correctly', function() {
+        const { getState } = setup();
+        expect(getHumanReadableTracks(getState())).toEqual([
+          'show [thread GeckoMain tab] SELECTED',
+        ]);
+      });
+
+      it('should not hide screenshot tracks', function() {
+        const profile = getScreenshotTrackProfile();
+        profile.threads[0].name = 'GeckoMain';
+        profile.threads[0].processType = 'tab';
+
+        const { getState } = setup(profile);
+        expect(getHumanReadableTracks(getState())).toEqual([
+          'show [screenshots]',
+          'show [screenshots]',
+          'show [thread GeckoMain tab] SELECTED',
+        ]);
+      });
+
+      it('should calculate the hidden local threads correctly', function() {
+        const { profile } = getProfileFromTextSamples(
+          `work work work`,
+          `work work work`,
+          `work work work`
+        );
+        // There is one main thread and two other threads that belong to the same process.
+        const [threadA, threadB, threadC] = profile.threads;
+        threadA.name = 'GeckoMain';
+        threadA.processType = 'tab';
+        threadA.pid = 111;
+        threadB.name = 'Other1';
+        threadB.processType = 'default';
+        threadB.pid = 111;
+        threadC.name = 'Other2';
+        threadC.processType = 'default';
+        threadC.pid = 111;
+
+        // Other2 should be visible and Other1 should not.
+        threadC.frameTable.innerWindowID[0] = innerWindowID;
+
+        const { getState } = setup(profile);
+        expect(getHumanReadableTracks(getState())).toEqual([
+          'show [thread GeckoMain tab] SELECTED',
+          '  - show [thread Other2]',
+        ]);
+      });
     });
   });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -365,6 +365,7 @@ type UrlStateAction =
       +type: 'CHANGE_SHOW_TAB_ONLY',
       +showTabOnly: BrowsingContextID | null,
       +selectedTab: TabSlug,
+      +selectedThreadIndex: ThreadIndex | null,
     |};
 
 type IconsAction =

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -261,6 +261,8 @@ type ReceiveProfileAction =
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+      +activeTabHiddenGlobalTracks: Set<TrackIndex>,
+      +activeTabHiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -261,8 +261,8 @@ type ReceiveProfileAction =
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
-      +activeTabHiddenGlobalTracks: Set<TrackIndex>,
-      +activeTabHiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
+      +activeTabHiddenGlobalTracksGetter: () => Set<TrackIndex>,
+      +activeTabHiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -56,6 +56,8 @@ export type ProfileViewState = {|
   |},
   +globalTracks: GlobalTrack[],
   +localTracksByPid: Map<Pid, LocalTrack[]>,
+  +activeTabHiddenGlobalTracks: Set<TrackIndex>,
+  +activeTabHiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
   +profile: Profile | null,
 |};
 

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -56,8 +56,8 @@ export type ProfileViewState = {|
   |},
   +globalTracks: GlobalTrack[],
   +localTracksByPid: Map<Pid, LocalTrack[]>,
-  +activeTabHiddenGlobalTracks: Set<TrackIndex>,
-  +activeTabHiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
+  +activeTabHiddenGlobalTracksGetter: () => Set<TrackIndex>,
+  +activeTabHiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
   +profile: Profile | null,
 |};
 


### PR DESCRIPTION
With this PR, we are keeping two additional state for global tracks and local tracks: `activeTabHiddenGlobalTracks` and `activeTabHiddenLocalTracksByPid`. They will help us to figure out the hidden tracks for active tab view.

Previously we had only `getHiddenGlobalTracks` and `getHiddenLocalTracksByPid` selectors inside the UrlState and we were using these to compute everything. That patch adds two additional selectors: `getComputedHiddenGlobalTracks` and `getComputedHiddenLocalTracksByPid`. They return the additional hidden tracks(by active tab) if we are in the active tab view. Otherwise, they return the UrlState only.

Closes #2403.

[Deploy preview](https://deploy-preview-2418--perf-html.netlify.com/public/b919767dac79248386b75350e0000ff8c37ddd2b/calltree/?globalTrackOrder=0-1&hiddenLocalTracksByPid=7738-1-2&localTrackOrderByPid=7738-1-2-0~7790-0-1~&thread=2&v=4)