### PR TITLE
Improve Log marker display.

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1285,6 +1285,7 @@ export function getMarkerFullDescription(marker: Marker) {
           }
         }
         break;
+      case 'Log':
       case 'UserTiming':
         description = data.name;
         break;
@@ -1327,16 +1328,11 @@ export function getMarkerCategory(marker: Marker) {
         category = marker.name;
         break;
       case 'FileIO':
-        category = data.type;
-        break;
+      case 'Log':
       case 'Bailout':
-        category = 'Bailout';
-        break;
       case 'Network':
-        category = 'Network';
-        break;
       case 'Text':
-        category = 'Text';
+        category = data.type;
         break;
       case 'IPC':
         category = data.direction === 'sending' ? 'IPC out' : 'IPC in';

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -78,6 +78,15 @@ describe('MarkerTable', function() {
                 sync: false,
               },
             ],
+            [
+              'LogMessages',
+              170,
+              {
+                type: 'Log',
+                name: 'nsJARChannel::nsJARChannel [this=0x87f1ec80]\n',
+                module: 'nsJarProtocol',
+              },
+            ],
           ]
             // Sort the markers.
             .sort((a, b) => a[1] - b[1])
@@ -139,8 +148,8 @@ describe('MarkerTable', function() {
   it('renders some basic markers and updates when needed', () => {
     const { container, fixedRows, scrolledRows, dispatch } = setup();
 
-    expect(fixedRows()).toHaveLength(4);
-    expect(scrolledRows()).toHaveLength(4);
+    expect(fixedRows()).toHaveLength(5);
+    expect(scrolledRows()).toHaveLength(5);
     expect(container.firstChild).toMatchSnapshot();
 
     /* Check that the table updates properly despite the memoisation. */

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -121,7 +121,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 80px;"
+            style="height: 96px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -222,11 +222,34 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   Text
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn start"
+                  title="0.158s"
+                >
+                  0.158s
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn duration"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn category"
+                  title="Log"
+                >
+                  Log
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 80px; width: 3000px;"
+            style="height: 96px; width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -317,6 +340,28 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewRowColumn treeViewMainColumn name"
                 >
                   setTimeout — 5.5
+                </span>
+              </div>
+              <div
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  nsJARChannel::nsJARChannel [this=0x87f1ec80]
+
                 </span>
               </div>
             </div>


### PR DESCRIPTION
If you run Firefox with the environment variable `MOZ_LOG=somelogmodule:5,profilermarkers`, you get markers with the type "Log": https://perfht.ml/3a7JyGp
This profile was generated with `MOZ_LOG=nsJarProtocol:5,profilermarkers`.

Currently, the content of those logs is not displayed in a nice way. This patch adds more hacky workarounds similar to the existing ones to get the text content that actually matters in the place where we want it. We should probably add some tests but I don't want to spend more time on this.

[Deploy preview](https://deploy-preview-2429--perf-html.netlify.com/public/9d30622def306c550b89f1eac61cad7ae4158209/marker-table/?globalTrackOrder=0-1-2&hiddenGlobalTracks=1-2&hiddenLocalTracksByPid=10887-3-4-0-1-2-5-6-7~10992-0-1~10970-0-1-2&localTrackOrderByPid=10887-3-4-0-1-2-5-6-7~10992-1-0-2~10970-1-0-2~&markerSearch=Log&range=0.0000_4.9979&thread=0&v=4)

Fixes #1633