### PR TITLE
Handle either JWT tokens or bare profile hashes coming from the server

### DIFF
--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -16,7 +16,7 @@ import {
 import { getDataSource } from '../selectors/url-state';
 import { viewProfile } from './receive-profile';
 import { ensureExists } from '../utils/flow';
-import * as Jwt from '../utils/jwt';
+import { extractProfileTokenFromJwt } from '../utils/jwt';
 import { setHistoryReplaceState } from '../app-logic/url-handling';
 
 import type { Action, ThunkAction } from '../types/store';
@@ -66,37 +66,6 @@ export function updateUploadProgress(uploadProgress: number): Action {
  */
 export function uploadFailed(error: mixed): Action {
   return { type: 'UPLOAD_FAILED', error };
-}
-
-/**
- * This function returns a profile token from a JWT token, if the passed string
- * looks like a JWT token. Otherwise it just returns the passed string because
- * this would be the hash directly, as returned by a previous version of the
- * server.
- * In the future when the server will be migrated we'll be able to remove this
- * fallback.
- */
-function extractProfileTokenFromJwt(hashOrToken: string): string {
-  if (Jwt.isValidJwtToken(hashOrToken)) {
-    // This is a JWT token, let's extract the hash out of it.
-    const jwtPayload = Jwt.extractAndDecodePayload(hashOrToken);
-    if (!jwtPayload) {
-      throw new Error(
-        `The JWT token that's been returned by the server is incorrect.`
-      );
-    }
-
-    const { profileToken } = jwtPayload;
-    if (!profileToken) {
-      throw new Error(
-        `The JWT token returned by the server doesn't contain a profile token.`
-      );
-    }
-    return profileToken;
-  }
-
-  // Then this is a good old hash.
-  return hashOrToken;
 }
 
 /**

--- a/src/test/unit/jwt.test.js
+++ b/src/test/unit/jwt.test.js
@@ -71,3 +71,28 @@ describe('jwt/extractAndDecodePayload', () => {
     expect(Jwt.extractAndDecodePayload(fixture)).toBe(null);
   });
 });
+
+describe('jwt/extractProfileTokenFromJwt', () => {
+  // Main use cases are tested in the store/publish.test.js. In this unit test
+  // we'll focus on error cases.
+
+  it('errors when passing a badly formed token', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // This looks like a JWT token but it's clearly incorrect.
+    const incorrectBase64 = 'A.B.C';
+    expect(() => Jwt.extractProfileTokenFromJwt(incorrectBase64)).toThrow();
+
+    // This is the same one as in a previous test.
+    const incorrectJSON = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.c3RyaW5n.dCi-PvNARK1DvRcqTtkVaimRLFJTY_a7LZqSruor1Uw`;
+    expect(() => Jwt.extractProfileTokenFromJwt(incorrectJSON)).toThrow();
+  });
+
+  it(`errors when the token doesn't have the needed property`, () => {
+    // This token's payload is { "name": "John Doe" }
+    const tokenWithoutProfileToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UifQ.DjwRE2jZhren2Wt37t5hlVru6Myq4AhpGLiiefF69u8`;
+    expect(() =>
+      Jwt.extractProfileTokenFromJwt(tokenWithoutProfileToken)
+    ).toThrow();
+  });
+});

--- a/src/test/unit/jwt.test.js
+++ b/src/test/unit/jwt.test.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import * as Jwt from '../../utils/jwt';
+
+// This is a valid token taken from jwt.io.
+// It was carefully chosen to contain both - and _ characters, that are
+// special to the Base64URL encoding.
+const completeToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiP34_fj9-In0.KIumXQmDxL1bJ0RGNV2-mm-8h0LEQATKbtHUsCHMGcg`;
+
+describe('jwt/isValidJwtToken', () => {
+  it('returns true for valid jwt tokens', () => {
+    expect(Jwt.isValidJwtToken(completeToken)).toBe(true);
+  });
+
+  it('returns false for incomplete tokens', () => {
+    const fixture = completeToken.slice(completeToken.indexOf('.') + 1);
+
+    expect(Jwt.isValidJwtToken(fixture)).toBe(false);
+  });
+
+  const fixtures = [
+    // This one is invalid for both encodings base64 and base64url
+    '|ODe.iOIZ.X;oD',
+
+    // These ones are valid base64 values, but invalid base64url
+    'a+hD.b1sc.cSre',
+    'a/4a.bRcZ.c81Z',
+
+    // This one is valid base64url but uses a padding character, that's not
+    // used with JWT.
+    'SOE=.SUY5.4ScA',
+  ];
+
+  fixtures.forEach(fixture => {
+    it(`returns false for invalid base64url value: ${fixture}`, () => {
+      expect(Jwt.isValidJwtToken(fixture)).toBe(false);
+    });
+  });
+});
+
+describe('jwt/decodeJwtBase64Url', () => {
+  it('decodes base64url values', () => {
+    const fixture = 'eyJuYW1lIjoiP34_fj9-In0';
+    const expected = '{"name":"?~?~?~"}';
+    expect(Jwt.decodeJwtBase64Url(fixture)).toEqual(expected);
+  });
+});
+
+describe('jwt/extractAndDecodePayload', () => {
+  it('decodes jwt payloads', () => {
+    const expected = { name: '?~?~?~' };
+    expect(Jwt.extractAndDecodePayload(completeToken)).toEqual(expected);
+  });
+
+  it(`returns null when the payload isn't a JSON`, () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const fixture = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.c3RyaW5n.dCi-PvNARK1DvRcqTtkVaimRLFJTY_a7LZqSruor1Uw`;
+
+    expect(Jwt.extractAndDecodePayload(fixture)).toBe(null);
+  });
+
+  it(`returns null when the payload isn't a valid token`, () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const fixture = `ABCD`;
+
+    expect(Jwt.extractAndDecodePayload(fixture)).toBe(null);
+  });
+});

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -46,3 +46,34 @@ export function decodeJwtBase64Url(base64UrlEncodedValue: string): string {
 
   return atob(base64EncodedValue);
 }
+
+/**
+ * This function returns a profile token from a JWT token, if the passed string
+ * looks like a JWT token. Otherwise it just returns the passed string because
+ * this would be the hash directly, as returned by a previous version of the
+ * server.
+ * In the future when the server will be migrated we'll be able to remove this
+ * fallback.
+ */
+export function extractProfileTokenFromJwt(hashOrToken: string): string {
+  if (isValidJwtToken(hashOrToken)) {
+    // This is a JWT token, let's extract the hash out of it.
+    const jwtPayload = extractAndDecodePayload(hashOrToken);
+    if (!jwtPayload) {
+      throw new Error(
+        `The JWT token that's been returned by the server is incorrect.`
+      );
+    }
+
+    const { profileToken } = jwtPayload;
+    if (!profileToken) {
+      throw new Error(
+        `The JWT token returned by the server doesn't contain a profile token.`
+      );
+    }
+    return profileToken;
+  }
+
+  // Then this is a good old hash.
+  return hashOrToken;
+}

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This file provides simple utils to deal with JWT tokens.
+
+export function extractAndDecodePayload(jwtToken: string): any {
+  if (!isValidJwtToken(jwtToken)) {
+    console.error('The token is an invalid JWT token.');
+    return null;
+  }
+
+  try {
+    const payload = jwtToken.split('.')[1];
+    const decodedPayload = decodeJwtBase64Url(payload);
+    const jsonPayload = JSON.parse(decodedPayload);
+
+    return jsonPayload;
+  } catch (e) {
+    console.error(
+      `We got an unexpected error when trying to decode the JWT token '${jwtToken}':`,
+      e
+    );
+    return null;
+  }
+}
+
+// This uses the base64url characters, that is base64 characters where + is
+// replaced by -, and / is replaced by _. Moreover the padding character isn't
+// used with JWT.
+const JWT_TOKEN_RE = /^(?:[a-zA-Z0-9_-])+\.(?:[a-zA-Z0-9_-])+\.(?:[a-zA-Z0-9_-])+$/;
+export function isValidJwtToken(jwtToken: string): boolean {
+  return JWT_TOKEN_RE.test(jwtToken);
+}
+
+export function decodeJwtBase64Url(base64UrlEncodedValue: string): string {
+  // In the base64url variant used in JWT, the padding "=" character is removed.
+  // But atob doesn't mind, so we don't need to recover the missing padding like
+  // most implementations do.
+
+  // We do need to convert the string to a "normal" base64 encoding though.
+  const base64EncodedValue = base64UrlEncodedValue
+    .replace('-', '+')
+    .replace('_', '/');
+
+  return atob(base64EncodedValue);
+}

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -26,9 +26,13 @@ export function extractAndDecodePayload(jwtToken: string): any {
   }
 }
 
-// This uses the base64url characters, that is base64 characters where + is
-// replaced by -, and / is replaced by _. Moreover the padding character isn't
-// used with JWT.
+// A JWT token is composed of 3 parts, separated by a period.
+// These parts all use the base64url characters, that is base64 characters where
+// "+" is replaced by "-", and "/" is replaced by "_". Moreover the padding
+// character "=" isn't used with JWT.
+// Here is an example:
+// eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiP34_fj9-In0.KIumXQmDxL1bJ0RGNV2-mm-8h0LEQATKbtHUsCHMGcg
+//                  ╰ header                        ╰ payload                     ╰ signature
 const JWT_TOKEN_RE = /^(?:[a-zA-Z0-9_-])+\.(?:[a-zA-Z0-9_-])+\.(?:[a-zA-Z0-9_-])+$/;
 export function isValidJwtToken(jwtToken: string): boolean {
   return JWT_TOKEN_RE.test(jwtToken);


### PR DESCRIPTION
This PR implements the logic to extract a profile token (aka the profile hash) out of a JWT token returned by the server. But with this change we still support the old server's method of returning the hash directly.

This is split in 2 commits to make it maybe easier to look at. Each commit contains the corresponding tests.