### PR TITLE
Switch the first element of breadcrumbs to website favicon + hostname + root range on single tab view

### DIFF
--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -4,20 +4,69 @@
 
 // @flow
 
+import React from 'react';
 import explicitConnect from '../../utils/connect';
 import { popCommittedRanges } from '../../actions/profile-view';
-import { getPreviewSelection } from '../../selectors/profile';
+import {
+  getPreviewSelection,
+  getProfileFilterPageData,
+  getProfileRootRange,
+} from '../../selectors/profile';
 import { getCommittedRangeLabels } from '../../selectors/url-state';
 import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import FilterNavigatorBar from '../shared/FilterNavigatorBar';
+import Icon from '../shared/Icon';
 
 import type { ElementProps } from 'react';
+import type { ProfileFilterPageData } from '../../types/profile-derived';
+import type { StartEndRange } from '../../types/units';
 
-type Props = ElementProps<typeof FilterNavigatorBar>;
+type Props = {|
+  +filterPageData: ProfileFilterPageData | null,
+  +rootRange: StartEndRange,
+  ...ElementProps<typeof FilterNavigatorBar>,
+|};
 type DispatchProps = {|
   +onPop: $PropertyType<Props, 'onPop'>,
 |};
 type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
+
+class ProfileFilterNavigatorBar extends React.PureComponent<Props> {
+  render() {
+    const {
+      className,
+      items,
+      selectedItem,
+      uncommittedItem,
+      onPop,
+      filterPageData,
+      rootRange,
+    } = this.props;
+
+    let firstItem;
+    if (filterPageData) {
+      firstItem = (
+        <>
+          <Icon iconUrl={filterPageData.favicon} />
+          {filterPageData.hostname} (
+          {getFormattedTimeLength(rootRange.end - rootRange.start)})
+        </>
+      );
+    } else {
+      firstItem = 'Full Range';
+    }
+
+    return (
+      <FilterNavigatorBar
+        className={className}
+        items={[firstItem, ...items]}
+        selectedItem={selectedItem}
+        uncommittedItem={uncommittedItem}
+        onPop={onPop}
+      />
+    );
+  }
+}
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
@@ -28,15 +77,21 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
           previewSelection.selectionEnd - previewSelection.selectionStart
         )
       : undefined;
+    const filterPageData = getProfileFilterPageData(state);
+    const rootRange = getProfileRootRange(state);
     return {
       className: 'profileFilterNavigator',
       items: items,
-      selectedItem: items.length - 1,
+      // Do not remove 1 from the length because we are going to increment this
+      // array's length by adding the first element.
+      selectedItem: items.length,
       uncommittedItem,
+      filterPageData,
+      rootRange,
     };
   },
   mapDispatchToProps: {
     onPop: popCommittedRanges,
   },
-  component: FilterNavigatorBar,
+  component: ProfileFilterNavigatorBar,
 });

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -5,6 +5,7 @@
 // @flow
 
 import React from 'react';
+import memoize from 'memoize-immutable';
 import explicitConnect from '../../utils/connect';
 import { popCommittedRanges } from '../../actions/profile-view';
 import {
@@ -32,6 +33,13 @@ type DispatchProps = {|
 type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
 
 class ProfileFilterNavigatorBar extends React.PureComponent<Props> {
+  _getItemsWithFirstElement = memoize(
+    (firstItem, items) => [firstItem, ...items],
+    {
+      limit: 1,
+    }
+  );
+
   render() {
     const {
       className,
@@ -56,10 +64,14 @@ class ProfileFilterNavigatorBar extends React.PureComponent<Props> {
       firstItem = 'Full Range';
     }
 
+    const itemsWithFirstElement = this._getItemsWithFirstElement(
+      firstItem,
+      items
+    );
     return (
       <FilterNavigatorBar
         className={className}
-        items={[firstItem, ...items]}
+        items={itemsWithFirstElement}
         selectedItem={selectedItem}
         uncommittedItem={uncommittedItem}
         onPop={onPop}

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -24,10 +24,13 @@ import {
   getIsHidingStaleProfile,
   getHasSanitizedProfile,
 } from '../../selectors/publish';
+import { getIconsWithClassNames } from '../../selectors/icons';
+import { BackgroundImageStyleDef } from '../shared/StyleDef';
 import classNames from 'classnames';
 
 import type { CssPixels } from '../../types/units';
 import type { ConnectedProps } from '../../utils/connect';
+import type { IconWithClassName } from '../../types/state';
 
 require('./ProfileViewer.css');
 
@@ -39,6 +42,7 @@ type StateProps = {|
   +isUploading: boolean,
   +isHidingStaleProfile: boolean,
   +hasSanitizedProfile: boolean,
+  +icons: IconWithClassName[],
 |};
 
 type DispatchProps = {|
@@ -60,6 +64,7 @@ class ProfileViewer extends PureComponent<Props> {
       uploadProgress,
       isHidingStaleProfile,
       hasSanitizedProfile,
+      icons,
     } = this.props;
 
     return (
@@ -69,6 +74,13 @@ class ProfileViewer extends PureComponent<Props> {
           profileViewerWrapperBackground: hasSanitizedProfile,
         })}
       >
+        {icons.map(({ className, icon }) => (
+          <BackgroundImageStyleDef
+            className={className}
+            url={icon}
+            key={className}
+          />
+        ))}
         <div
           className={classNames({
             profileViewer: true,
@@ -141,6 +153,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     isUploading: getUploadPhase(state) === 'uploading',
     isHidingStaleProfile: getIsHidingStaleProfile(state),
     hasSanitizedProfile: getHasSanitizedProfile(state),
+    icons: getIconsWithClassNames(state),
   }),
   mapDispatchToProps: {
     returnToZipFileList,

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -7,7 +7,7 @@ import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import TreeView from '../shared/TreeView';
 import CallTreeEmptyReasons from './CallTreeEmptyReasons';
-import NodeIcon from '../shared/NodeIcon';
+import Icon from '../shared/Icon';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   getInvertCallstack,
@@ -77,13 +77,13 @@ class CallTreeComponent extends PureComponent<Props> {
     { propName: 'totalTimePercent', title: '' },
     { propName: 'totalTime', title: 'Running Time (ms)' },
     { propName: 'selfTime', title: 'Self (ms)' },
-    { propName: 'icon', title: '', component: NodeIcon },
+    { propName: 'icon', title: '', component: Icon },
   ];
   _fixedColumnsAllocations: Column[] = [
     { propName: 'totalTimePercent', title: '' },
     { propName: 'totalTime', title: 'Total Size (bytes)' },
     { propName: 'selfTime', title: 'Self (bytes)' },
-    { propName: 'icon', title: '', component: NodeIcon },
+    { propName: 'icon', title: '', component: Icon },
   ];
   _mainColumn: Column = { propName: 'name', title: '' };
   _appendageColumn: Column = { propName: 'lib', title: '' };

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -21,7 +21,6 @@ import {
   getPreviewSelection,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getIconsWithClassNames } from '../../selectors/icons';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
@@ -30,7 +29,7 @@ import {
 } from '../../actions/profile-view';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import type { IconWithClassName, State } from '../../types/state';
+import type { State } from '../../types/state';
 import type { CallTree } from '../../profile-logic/call-tree';
 import type {
   ImplementationFilter,
@@ -58,7 +57,6 @@ type StateProps = {|
   +disableOverscan: boolean,
   +invertCallstack: boolean,
   +implementationFilter: ImplementationFilter,
-  +icons: IconWithClassName[],
   +callNodeMaxDepth: number,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
 |};
@@ -232,7 +230,6 @@ class CallTreeComponent extends PureComponent<Props> {
         ref={this._takeTreeViewRef}
         contextMenuId="CallNodeContextMenu"
         maxNodeDepth={callNodeMaxDepth}
-        icons={this.props.icons}
         rowHeight={16}
         indentWidth={10}
       />
@@ -260,7 +257,6 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     disableOverscan: getPreviewSelection(state).isModifying,
     invertCallstack: getInvertCallstack(state),
     implementationFilter: getImplementationFilter(state),
-    icons: getIconsWithClassNames(state),
     callNodeMaxDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
     callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
       state

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -25,8 +25,6 @@ import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
 } from '../../actions/profile-view';
-import { getIconsWithClassNames } from '../../selectors/icons';
-import { BackgroundImageStyleDef } from '../shared/StyleDef';
 
 import type { Thread, CategoryList, PageList } from '../../types/profile';
 import type { Milliseconds } from '../../types/units';
@@ -40,7 +38,6 @@ import type {
   IndexIntoCallNodeTable,
 } from '../../types/profile-derived';
 import type { CallTree } from '../../profile-logic/call-tree';
-import type { IconWithClassName } from '../../types/state';
 
 import type { ConnectedProps } from '../../utils/connect';
 
@@ -70,7 +67,6 @@ type StateProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +scrollToSelectionGeneration: number,
-  +icons: IconWithClassName[],
   +categories: CategoryList,
   +interval: Milliseconds,
   +isInverted: boolean,
@@ -261,7 +257,6 @@ class FlameGraph extends React.PureComponent<Props> {
       selectedCallNodeIndex,
       scrollToSelectionGeneration,
       callTreeSummaryStrategy,
-      icons,
       categories,
       interval,
       isInverted,
@@ -272,13 +267,6 @@ class FlameGraph extends React.PureComponent<Props> {
 
     return (
       <div className="flameGraphContent" onKeyDown={this._handleKeyDown}>
-        {icons.map(({ className, icon }) => (
-          <BackgroundImageStyleDef
-            className={className}
-            url={icon}
-            key={className}
-          />
-        ))}
         <ContextMenuTrigger
           id="CallNodeContextMenu"
           attributes={{
@@ -361,7 +349,6 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
         state
       ),
       scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
-      icons: getIconsWithClassNames(state),
       interval: getProfileInterval(state),
       isInverted: getInvertCallstack(state),
       callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -38,6 +38,7 @@
 }
 
 .filterNavigatorBarItemContent {
+  display: flex;
   overflow: hidden;
 
   /* These lines are mostly to override the default browser styles for `<button>`.
@@ -51,6 +52,10 @@
   line-height: normal;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.filterNavigatorBarItemContent > .nodeIcon {
+  margin-inline-end: 5px;
 }
 
 .filterNavigatorBarLeafItem {

--- a/src/components/shared/FilterNavigatorBar.js
+++ b/src/components/shared/FilterNavigatorBar.js
@@ -4,20 +4,20 @@
 
 // @flow
 
-import React, { PureComponent } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import './FilterNavigatorBar.css';
 
 type Props = {|
   +className: string,
-  +items: string[],
+  +items: $ReadOnlyArray<React.Node>,
   +onPop: number => *,
   +selectedItem: number,
   +uncommittedItem?: string,
 |};
 
-class FilterNavigatorBar extends PureComponent<Props> {
+class FilterNavigatorBar extends React.PureComponent<Props> {
   _onLiClick = (e: SyntheticMouseEvent<HTMLLIElement>) => {
     const element = e.currentTarget;
     const index = parseInt(element.dataset.index, 10) || 0;

--- a/src/components/shared/Icon.js
+++ b/src/components/shared/Icon.js
@@ -33,7 +33,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
-class NodeIcon extends PureComponent<Props> {
+class Icon extends PureComponent<Props> {
   constructor(props: Props) {
     super(props);
     if (props.icon) {
@@ -64,5 +64,5 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     };
   },
   mapDispatchToProps: { iconStartLoading },
-  component: NodeIcon,
+  component: Icon,
 });

--- a/src/components/shared/NodeIcon.js
+++ b/src/components/shared/NodeIcon.js
@@ -6,15 +6,21 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-import { getIconClassNameForCallNode } from '../../selectors/icons';
+import { getIconClassName } from '../../selectors/icons';
 import { iconStartLoading } from '../../actions/icons';
 
 import type { CallNodeDisplayData } from '../../types/profile-derived';
 import type { ConnectedProps } from '../../utils/connect';
 
-type OwnProps = {|
-  +displayData: CallNodeDisplayData,
-|};
+type OwnProps =
+  | {|
+      // This prop is used by call tree.
+      +displayData: CallNodeDisplayData,
+    |}
+  | {|
+      // This prop is for other parts of the profiler.
+      +iconUrl: string | null,
+    |};
 
 type StateProps = {|
   +className: string,
@@ -47,10 +53,16 @@ class NodeIcon extends PureComponent<Props> {
 }
 
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
-  mapStateToProps: (state, { displayData }) => ({
-    className: getIconClassNameForCallNode(state, displayData),
-    icon: displayData.icon,
-  }),
+  mapStateToProps: (state, ownProps) => {
+    const icon = ownProps.displayData
+      ? ownProps.displayData.icon
+      : ownProps.iconUrl;
+
+    return {
+      className: getIconClassName(state, icon),
+      icon,
+    };
+  },
   mapDispatchToProps: { iconStartLoading },
   component: NodeIcon,
 });

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -8,11 +8,9 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import VirtualList from './VirtualList';
-import { BackgroundImageStyleDef } from './StyleDef';
 
 import ContextMenuTrigger from './ContextMenuTrigger';
 
-import type { IconWithClassName } from '../../types/state';
 import type { CssPixels } from '../../types/units';
 
 /**
@@ -333,7 +331,6 @@ type TreeViewProps<DisplayData> = {|
   +highlightRegExp?: RegExp | null,
   +appendageColumn?: Column,
   +disableOverscan?: boolean,
-  +icons?: IconWithClassName[],
   +contextMenu?: React.Element<any>,
   +contextMenuId?: string,
   +maxNodeDepth: number,
@@ -696,21 +693,12 @@ class TreeView<DisplayData: Object> extends React.PureComponent<
       disableOverscan,
       contextMenu,
       contextMenuId,
-      icons,
       maxNodeDepth,
       rowHeight,
       selectedNodeId,
     } = this.props;
     return (
       <div className="treeView">
-        {icons &&
-          icons.map(({ className, icon }) => (
-            <BackgroundImageStyleDef
-              className={className}
-              url={icon}
-              key={className}
-            />
-          ))}
         <TreeViewHeader fixedColumns={fixedColumns} mainColumn={mainColumn} />
         <ContextMenuTrigger
           id={contextMenuId}

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { getStackType } from '../../profile-logic/transforms';
 import { objectEntries } from '../../utils/flow';
 import { formatCallNodeNumber } from '../../utils/format-numbers';
-import NodeIcon from '../shared/NodeIcon';
+import Icon from '../shared/Icon';
 import {
   getFriendlyStackTypeName,
   getCategoryPairLabel,
@@ -285,7 +285,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           <div className="tooltipTitle">{funcName}</div>
           <div className="tooltipIcon">
             {displayData && displayData.icon ? (
-              <NodeIcon displayData={displayData} />
+              <Icon displayData={displayData} />
             ) : null}
           </div>
         </div>

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -70,6 +70,5 @@ export function getCommittedRangeLabels(
   const labels = committedRanges.map(range =>
     getFormattedTimeLength(range.end - range.start)
   );
-  labels.unshift('Full Range');
   return labels;
 }

--- a/src/selectors/icons.js
+++ b/src/selectors/icons.js
@@ -6,7 +6,6 @@
 import { createSelector } from 'reselect';
 import type { IconWithClassName, IconState } from '../types/state';
 import type { Selector, DangerousSelectorWithArguments } from '../types/store';
-import type { CallNodeDisplayData } from '../types/profile-derived';
 
 /**
  * A simple selector into the icon state.
@@ -15,18 +14,16 @@ export const getIcons: Selector<IconState> = state => state.icons;
 
 /**
  * In order to load icons without multiple requests, icons are created through
- * CSS. This function gets the CSS class name for a call node. This function
+ * CSS. This function gets the CSS class name for a icon url. This function
  * does not perform any memoization, and updates every time. It could be updated
  * to memoize.
  */
-export const getIconClassNameForCallNode: DangerousSelectorWithArguments<
+export const getIconClassName: DangerousSelectorWithArguments<
   string,
-  CallNodeDisplayData
-> = (state, displayData) => {
+  string | null
+> = (state, icon) => {
   const icons = getIcons(state);
-  return displayData.icon !== null && icons.has(displayData.icon)
-    ? _classNameFromUrl(displayData.icon)
-    : '';
+  return icon !== null && icons.has(icon) ? _classNameFromUrl(icon) : '';
 };
 
 /**

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -10,6 +10,7 @@ import { ensureExists } from '../utils/flow';
 import {
   filterCounterToRange,
   accumulateCounterSamples,
+  extractProfileFilterPageData,
 } from '../profile-logic/profile-data';
 import {
   IPCMarkerCorrelations,
@@ -38,6 +39,7 @@ import type {
   TrackIndex,
   GlobalTrack,
   AccumulatedCounterSamples,
+  ProfileFilterPageData,
 } from '../types/profile-derived';
 import type { Milliseconds, StartEndRange } from '../types/units';
 import type {
@@ -719,3 +721,16 @@ export const getComputedHiddenLocalTracks: DangerousSelectorWithArguments<
     getComputedHiddenLocalTracksByPid(state).get(pid),
     'Unable to get the tracks for the given pid.'
   );
+
+/**
+ * Extracts the data of the first page on the tab filtered profile.
+ * Currently we assume that we don't change the origin of webpages while
+ * profiling in web developer preset. That's why we are simply getting the
+ * first page we find that belongs to the active tab. Returns null if profiler
+ * is not in the single tab view at the moment.
+ */
+export const getProfileFilterPageData: Selector<ProfileFilterPageData | null> = createSelector(
+  getPageList,
+  getRelevantPagesForCurrentTab,
+  extractProfileFilterPageData
+);

--- a/src/test/components/FilterNavigatorBar.test.js
+++ b/src/test/components/FilterNavigatorBar.test.js
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+
+import ProfileFilterNavigator from '../../components/app/ProfileFilterNavigator';
+import * as ProfileView from '../../actions/profile-view';
+import { storeWithProfile } from '../fixtures/stores';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+
+describe('app/ProfileFilterNavigator', () => {
+  const browsingContextID = 123123;
+  function setup() {
+    const { profile } = getProfileFromTextSamples(`
+      A  A  A
+      B  B  B
+      C  C  H
+      D  F  I
+      E  G
+      `);
+    // Add page for active tab.
+    profile.pages = [
+      {
+        browsingContextID: browsingContextID,
+        innerWindowID: 1,
+        url: 'https://developer.mozilla.org/en-US/',
+        embedderInnerWindowID: 0,
+      },
+    ];
+    profile.meta.configuration = {
+      threads: [],
+      features: [],
+      capacity: 1000000,
+      activeBrowsingContextID: browsingContextID,
+    };
+
+    // Change the root range for testing.
+    const samples = profile.threads[0].samples;
+    samples.time[samples.length - 1] = 50;
+
+    const store = storeWithProfile(profile);
+    const renderResult = render(
+      <Provider store={store}>
+        <ProfileFilterNavigator />
+      </Provider>
+    );
+
+    return {
+      ...store,
+      ...renderResult,
+    };
+  }
+
+  it('renders ProfileFilterNavigator properly', () => {
+    const { container, dispatch } = setup();
+    // Just root range
+    expect(container.firstChild).toMatchSnapshot();
+
+    // With committed range
+    dispatch(ProfileView.commitRange(0, 40));
+    expect(container.firstChild).toMatchSnapshot();
+
+    // With preview selection
+    dispatch(
+      ProfileView.updatePreviewSelection({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 10,
+        selectionEnd: 20,
+      })
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('displays the "Full Range" text as its first element', () => {
+    const { queryByText } = setup();
+    expect(queryByText('Full Range')).toBeTruthy();
+  });
+
+  it('renders the site hostname as its first element in the single tab view', () => {
+    const { dispatch, container } = setup();
+    dispatch(ProfileView.changeShowTabOnly(browsingContextID));
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('displays the site hostname as its first element in the single tab view', () => {
+    const { dispatch, queryByText } = setup();
+    dispatch(ProfileView.changeShowTabOnly(browsingContextID));
+    expect(queryByText('Full Range')).toBeFalsy();
+    // Using regexp because searching for a partial text.
+    expect(queryByText(/developer\.mozilla\.org/)).toBeTruthy();
+  });
+});

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 1`] = `
+<ol
+  class="filterNavigatorBar profileFilterNavigator"
+>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    data-index="0"
+    title="Full Range"
+  >
+    <span
+      class="filterNavigatorBarItemContent"
+    >
+      Full Range
+    </span>
+  </li>
+</ol>
+`;
+
+exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] = `
+<ol
+  class="filterNavigatorBar profileFilterNavigator"
+>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarBeforeSelectedItem"
+    data-index="0"
+    title="Full Range"
+  >
+    <button
+      class="filterNavigatorBarItemContent"
+      type="button"
+    >
+      Full Range
+    </button>
+  </li>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem filterNavigatorBarTransition-enter filterNavigatorBarTransition-enter-active"
+    data-index="1"
+    title="40 ms"
+  >
+    <span
+      class="filterNavigatorBarItemContent"
+    >
+      40 ms
+    </span>
+  </li>
+</ol>
+`;
+
+exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] = `
+<ol
+  class="filterNavigatorBar profileFilterNavigator"
+>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarBeforeSelectedItem"
+    data-index="0"
+    title="Full Range"
+  >
+    <button
+      class="filterNavigatorBarItemContent"
+      type="button"
+    >
+      Full Range
+    </button>
+  </li>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem filterNavigatorBarTransition-enter filterNavigatorBarTransition-enter-active"
+    data-index="1"
+    title="40 ms"
+  >
+    <span
+      class="filterNavigatorBarItemContent"
+    >
+      40 ms
+    </span>
+  </li>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarLeafItem filterNavigatorBarUncommittedItem filterNavigatorBarUncommittedTransition-enter filterNavigatorBarUncommittedTransition-enter-active"
+    title="10 ms"
+  >
+    <span
+      class="filterNavigatorBarItemContent"
+    >
+      10 ms
+    </span>
+  </li>
+</ol>
+`;
+
+exports[`app/ProfileFilterNavigator renders the site hostname as its first element in the single tab view 1`] = `
+<ol
+  class="filterNavigatorBar profileFilterNavigator"
+>
+  <li
+    class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    data-index="0"
+    title="[object Object]"
+  >
+    <span
+      class="filterNavigatorBarItemContent"
+    >
+      <div
+        class="nodeIcon "
+      />
+      developer.mozilla.org
+       (
+      51 ms
+      )
+    </span>
+  </li>
+</ol>
+`;

--- a/src/test/fixtures/stores.js
+++ b/src/test/fixtures/stores.js
@@ -27,6 +27,7 @@ export function storeWithProfile(profile?: Profile): Store {
 }
 
 export function storeWithSimpleProfile(): Store {
+  // FIXME: These samples need to be seperated by two spaces instead of one.
   const { profile } = getProfileFromTextSamples(`
     A A A
     B B B

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -60,10 +60,10 @@ describe('actions/icons', function() {
       expect(initialState.size).toEqual(0);
     });
 
-    it('getIconClassNameForCallNode returns an empty string for any icon', function() {
-      const subject = iconsAccessors.getIconClassNameForCallNode(
+    it('getIconClassName returns an empty string for any icon', function() {
+      const subject = iconsAccessors.getIconClassName(
         getInitialState(),
-        _createCallNodeWithIcon(validIcons[0])
+        _createCallNodeWithIcon(validIcons[0]).icon
       );
       expect(subject).toBe('');
     });
@@ -104,9 +104,9 @@ describe('actions/icons', function() {
       );
 
       validIcons.forEach((icon, i) => {
-        subject = iconsAccessors.getIconClassNameForCallNode(
+        subject = iconsAccessors.getIconClassName(
           state,
-          _createCallNodeWithIcon(icon)
+          _createCallNodeWithIcon(icon).icon
         );
         expect(subject).toEqual(expectedClasses[i]);
       });
@@ -128,9 +128,9 @@ describe('actions/icons', function() {
       let subject = iconsAccessors.getIcons(state);
       expect([...subject]).toEqual([]);
 
-      subject = iconsAccessors.getIconClassNameForCallNode(
+      subject = iconsAccessors.getIconClassName(
         state,
-        _createCallNodeWithIcon(invalidIcon)
+        _createCallNodeWithIcon(invalidIcon).icon
       );
       expect(subject).toBe('');
 

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -246,3 +246,11 @@ export type SelectedState =
  * to scroll the initially selected track into view once the page is loaded.
  */
 export type InitialSelectedTrackReference = HTMLElement;
+
+/**
+ * Page data for ProfileFilterNavigator component.
+ */
+export type ProfileFilterPageData = {|
+  hostname: string,
+  favicon: string,
+|};


### PR DESCRIPTION
This PR changes the first element of breadcrumbs to favicon + hostname + root range. Instead of "Full Range" text on single tab view. There is no difference for non-single-tab view.
Here's a screenshot of new navigation bar:
<img width="345" alt="Screen Shot 2020-03-05 at 6 33 05 PM" src="https://user-images.githubusercontent.com/466239/76008337-c73c7e00-5f0f-11ea-9c74-d566a75dd328.png">

[Deploy preview](https://deploy-preview-2439--perf-html.netlify.com/public/b919767dac79248386b75350e0000ff8c37ddd2b/calltree/?globalTrackOrder=0-1&hiddenLocalTracksByPid=7738-2-0~7790-0&implementation=js&localTrackOrderByPid=7738-1-2-0~7790-0-1~&range=0.7394_9.7602&showTabOnly=1156&thread=2&v=4)

Separated each task to its own commit, hope it's easy to review.
Closes #2420.