### PR TITLE
Only create the SymbolStore if IndexedDB exists

### DIFF
--- a/src/profile-logic/symbol-store-db.js
+++ b/src/profile-logic/symbol-store-db.js
@@ -90,8 +90,11 @@ export default class SymbolStoreDB {
   }
 
   _setupDB(dbName: string): Promise<IDBDatabase> {
+    const indexedDB: IDBFactory | void = window.indexedDB;
+    if (!indexedDB) {
+      throw new Error('Could not find indexedDB on the window object.');
+    }
     return new Promise((resolve, reject) => {
-      const indexedDB: IDBFactory = window.indexedDB;
       const openReq = indexedDB.open(dbName, 2);
       openReq.onerror = () => {
         if (openReq.error.name === 'VersionError') {

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -8,7 +8,6 @@ import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
 // This module is mocked.
 import copy from 'copy-to-clipboard';
-import fakeIndexedDB from 'fake-indexeddb';
 
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
@@ -51,12 +50,6 @@ beforeEach(() => {
   jest
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
     .mockImplementation(() => getBoundingBox(1000, 2000));
-
-  window.indexedDB = fakeIndexedDB;
-});
-
-afterEach(() => {
-  delete window.indexedDB;
 });
 
 describe('calltree/ProfileCallTreeView', function() {

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -36,6 +36,7 @@ import {
   changeShowTabOnly,
   changeSelectedThread,
 } from '../../actions/profile-view';
+import fakeIndexedDB from 'fake-indexeddb';
 
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import JSZip from 'jszip';
@@ -88,6 +89,16 @@ function simulateSymbolStoreHasNoCache() {
 }
 
 describe('actions/receive-profile', function() {
+  beforeEach(() => {
+    // The SymbolStore requires the use of IndexedDB, ensure that it exists so that
+    // symbolication can happen.
+    window.indexedDB = fakeIndexedDB;
+  });
+
+  afterEach(() => {
+    delete window.indexedDB;
+  });
+
   /**
    * This function allows to observe all state changes in a Redux store while
    * something's going on.

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -29,6 +29,7 @@ import { SymbolsNotFoundError } from '../../profile-logic/errors';
 describe('doSymbolicateProfile', function() {
   const symbolStoreName = 'test-db';
   beforeAll(function() {
+    // The SymbolStore requires IndexedDB, otherwise symbolication will be skipped.
     window.indexedDB = fakeIndexedDB;
     window.IDBKeyRange = FDBKeyRange;
     window.TextDecoder = TextDecoder;

--- a/src/test/unit/symbol-store-db.test.js
+++ b/src/test/unit/symbol-store-db.test.js
@@ -15,6 +15,7 @@ describe('SymbolStoreDB', function() {
   }));
 
   beforeAll(function() {
+    // The SymbolStore requires IndexedDB, otherwise symbolication will be skipped.
     window.indexedDB = fakeIndexedDB;
     window.IDBKeyRange = FDBKeyRange;
   });

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -25,6 +25,7 @@ describe('SymbolStore', function() {
   }
 
   beforeAll(function() {
+    // The SymbolStore requires IndexedDB, otherwise symbolication will be skipped.
     window.indexedDB = fakeIndexedDB;
     window.IDBKeyRange = FDBKeyRange;
     window.TextDecoder = TextDecoder;

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -70,7 +70,10 @@ declare class Window extends EventTarget {
   requestIdleCallback: typeof requestIdleCallback;
   requestAnimationFrame: typeof requestAnimationFrame;
   devicePixelRatio: number;
-  indexedDB: IDBFactory;
+  // The indexedDB is marked as optional, as we should handle the test environment
+  // where this is not available. It can lead to hard to debug promise failure
+  // messages.
+  indexedDB?: IDBFactory;
   IDBKeyRange: IDBKeyRange<>;
   innerWidth: number;
   innerHeight: number;


### PR DESCRIPTION
The test suite was spitting our random promise failure errors on code
whenever the SymbolStore was being accessed without mocking out
IndexedDB. This patch changes the behavior where symbolication is
only attempted if the IndexedDB is actually present. This way
tests don't need random mocking of the IndexedDB value when
it's not really needed. This was happening anytime a Gecko Profile
was being used in a test.

Fixes:
<img width="831" alt="image" src="https://user-images.githubusercontent.com/1588648/76254577-b4c98980-621a-11ea-8e99-5f89d92e11c9.png">
