### PR TITLE
Add symbolication status to the meta info, plus a button to re-symbolicate

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -44,7 +44,7 @@ import {
   computeActiveTabHiddenGlobalTracks,
   computeActiveTabHiddenLocalTracksByPid,
 } from '../profile-logic/active-tab';
-import { getProfileOrNull } from '../selectors/profile';
+import { getProfileOrNull, getProfile } from '../selectors/profile';
 import { getView } from '../selectors/app';
 import { setDataSource } from './profile-view';
 
@@ -261,6 +261,19 @@ export function finalizeProfileView(
       const symbolStore = getSymbolStore(dispatch, geckoProfiler);
       await doSymbolicateProfile(dispatch, profile, symbolStore);
     }
+  };
+}
+
+/**
+ * Symbolication normally happens when a profile is first loaded. This function
+ * provides the ability to kick off symbolication again after it has already been
+ * attempted once.
+ */
+export function resymbolicateProfile(): ThunkAction<Promise<void>> {
+  return async (dispatch, getState) => {
+    const symbolStore = getSymbolStore(dispatch);
+    const profile = getProfile(getState());
+    await doSymbolicateProfile(dispatch, profile, symbolStore);
   };
 }
 

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -10,17 +10,71 @@ import { MetaOverheadStatistics } from './MetaOverheadStatistics';
 import { formatBytes } from '../../../utils/format-numbers';
 
 import type { Profile, ProfileMeta } from '../../../types/profile';
+import type { SymbolicationStatus } from '../../../types/state';
+import { typeof resymbolicateProfile } from '../../../actions/receive-profile';
+import { assertExhaustiveCheck } from '../../../utils/flow';
 
 import './MetaInfo.css';
 
 type Props = {
   profile: Profile,
+  symbolicationStatus: SymbolicationStatus,
+  resymbolicateProfile: resymbolicateProfile,
 };
 
 /**
  * This component formats the profile's meta information into a dropdown panel.
  */
 export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
+  /**
+   * This method provides information about the symbolication status, and a button
+   * to re-trigger symbolication.
+   */
+  renderSymbolication() {
+    const { profile, symbolicationStatus, resymbolicateProfile } = this.props;
+    const isSymbolicated = profile.meta.symbolicated;
+
+    switch (symbolicationStatus) {
+      case 'DONE':
+        return (
+          <>
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Symbols:</span>
+              {isSymbolicated
+                ? 'Profile is symbolicated'
+                : 'Profile is not symbolicated'}
+            </div>
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel"></span>
+              <button
+                onClick={resymbolicateProfile}
+                type="button"
+                className="photon-button photon-button-micro"
+              >
+                {isSymbolicated
+                  ? 'Re-symbolicate profile'
+                  : 'Symbolicate profile'}
+              </button>
+            </div>
+          </>
+        );
+      case 'SYMBOLICATING':
+        return (
+          <div className="metaInfoRow">
+            <span className="metaInfoLabel">Symbols:</span>
+            {isSymbolicated
+              ? 'Attempting to re-symbolicate profile'
+              : 'Currently symbolicating profile'}
+          </div>
+        );
+      default:
+        throw assertExhaustiveCheck(
+          symbolicationStatus,
+          'Unhandled SymbolicationStatus.'
+        );
+    }
+  }
+
   render() {
     const { meta, profilerOverhead } = this.props.profile;
     const { configuration } = meta;
@@ -80,6 +134,7 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
                   </div>
                 </>
               ) : null}
+              {this.renderSymbolication()}
             </div>
             <h2 className="arrowPanelSubTitle">Application</h2>
             <div className="arrowPanelSection">

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -7,7 +7,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
-import { getProfile, getProfileRootRange } from '../../../selectors/profile';
+import {
+  getProfile,
+  getProfileRootRange,
+  getSymbolicationStatus,
+} from '../../../selectors/profile';
 import { getDataSource } from '../../../selectors/url-state';
 import { getIsNewlyPublished } from '../../../selectors/app';
 import { MenuButtonsMetaInfo } from './MetaInfo';
@@ -25,11 +29,13 @@ import {
   getHasPrePublishedState,
 } from '../../../selectors/publish';
 
+import { resymbolicateProfile } from '../../../actions/receive-profile';
+
 import type { StartEndRange } from '../../../types/units';
 import type { Profile } from '../../../types/profile';
 import type { DataSource } from '../../../types/actions';
 import type { ConnectedProps } from '../../../utils/connect';
-import type { UploadPhase } from '../../../types/state';
+import type { UploadPhase, SymbolicationStatus } from '../../../types/state';
 
 require('./index.css');
 
@@ -48,12 +54,14 @@ type StateProps = {|
   +isNewlyPublished: boolean,
   +uploadPhase: UploadPhase,
   +hasPrePublishedState: boolean,
+  +symbolicationStatus: SymbolicationStatus,
 |};
 
 type DispatchProps = {|
   +dismissNewlyPublished: typeof dismissNewlyPublished,
   +revertToPrePublishedState: typeof revertToPrePublishedState,
   +abortUpload: typeof abortUpload,
+  +resymbolicateProfile: typeof resymbolicateProfile,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -143,11 +151,15 @@ class MenuButtons extends React.PureComponent<Props> {
   }
 
   render() {
-    const { profile } = this.props;
+    const { profile, symbolicationStatus, resymbolicateProfile } = this.props;
     return (
       <>
         {/* Place the info button outside of the menu buttons to allow it to shrink. */}
-        <MenuButtonsMetaInfo profile={profile} />
+        <MenuButtonsMetaInfo
+          profile={profile}
+          symbolicationStatus={symbolicationStatus}
+          resymbolicateProfile={resymbolicateProfile}
+        />
         <div className="menuButtons">
           {this._renderRevertProfile()}
           {this._renderPublishPanel()}
@@ -175,11 +187,13 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     isNewlyPublished: getIsNewlyPublished(state),
     uploadPhase: getUploadPhase(state),
     hasPrePublishedState: getHasPrePublishedState(state),
+    symbolicationStatus: getSymbolicationStatus(state),
   }),
   mapDispatchToProps: {
     dismissNewlyPublished,
     revertToPrePublishedState,
     abortUpload,
+    resymbolicateProfile,
   },
   component: MenuButtons,
 });

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -134,6 +134,29 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
               </ul>
             </div>
           </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Symbols:
+            </span>
+            Profile is not symbolicated
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            />
+            <button
+              class="photon-button photon-button-micro"
+              type="button"
+            >
+              Symbolicate profile
+            </button>
+          </div>
         </div>
         <h2
           class="arrowPanelSubTitle"
@@ -457,6 +480,29 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
               Profile Version:
             </span>
             28
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Symbols:
+            </span>
+            Profile is not symbolicated
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoLabel"
+            />
+            <button
+              class="photon-button photon-button-micro"
+              type="button"
+            >
+              Symbolicate profile
+            </button>
           </div>
         </div>
         <h2

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
+exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
 <div
   class="buttonWithPanel menuButtonsMetaInfoButton open"
 >
@@ -394,7 +394,7 @@ exports[`app/MenuButtons <MenuButtonsMetaInfo> matches the snapshot 1`] = `
 </div>
 `;
 
-exports[`app/MenuButtons <MenuButtonsMetaInfo> with no statistics object should not make the app crash 1`] = `
+exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app crash 1`] = `
 <div
   class="buttonWithPanel menuButtonsMetaInfoButton open"
 >


### PR DESCRIPTION
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/1588648/76255268-e858e380-621b-11ea-99d0-d2b197cbd840.png">

Example profile:
https://deploy-preview-2448--perf-html.netlify.com/public/6a5142c47da73320ff5491488996c2948207cae9/calltree/?globalTrackOrder=0-1-2-3-4-5&localTrackOrderByPid=5620-1-2-0~3824-1-0~7960-1-0~2932-1-0~6316-1-0~10324-1-2-0~&thread=1&timelineType=stack&v=4

This introduces a lot of warnings about unhandled promise rejections in the tests. These are fixed in #2447.