### PR TITLE
Remove extraneous package.json information

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "firefox-profiler",
-  "version": "0.0.1",
-  "description": "Firefox Profiler",
-  "main": "src/index.js",
+  "private": true,
   "scripts": {
     "build:clean": "rimraf dist && mkdirp dist",
     "build:quiet": "yarn build:clean && cross-env NODE_ENV=development webpack",
@@ -40,7 +37,6 @@
     "test-lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
     "test-debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
   },
-  "author": "Markus Stange <mstange@themasta.com>",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
A lot of the fields right now are pretending that we are publishing to npm. This patch trims down to only ones that give real information, and makes it so that we can't accidentally publish to npm.

It adds the private field (since we aren't publishing to npm)
https://docs.npmjs.com/files/package.json#private

It removes extraneous fields:
 * `name` - Used for publishing.
 * `version` - This is pretty much a lie
 * `description` - Only used on npm search
 * `main` - Used by node, not by webpack
 * `author` - Hah, not just Markus anymore.