### PR TITLE
Return to official offline-plugin with upstream fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "url": "https://github.com/firefox-devtools/profiler"
   },
   "dependencies": {
-    "@mstange/offline-plugin": "^5.0.6",
     "array-move": "^1.0.0",
     "array-range": "^1.0.1",
     "babel-plugin-dynamic-import-node": "^2.2.0",
@@ -64,6 +63,7 @@
     "memoize-immutable": "^3.0.0",
     "mixedtuplemap": "^1.0.0",
     "namedtuplemap": "^1.0.0",
+    "offline-plugin": "^5.0.7",
     "photon-colors": "3.3.2",
     "prop-types": "^15.7.2",
     "query-string": "^6.3.0",

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -35,10 +35,7 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
   };
 
   _installServiceWorker() {
-    // We use '@mstange/offline-plugin/runtime' here instead of
-    // 'offline-plugin/runtime' because the fork contains the fix from
-    // https://github.com/NekR/offline-plugin/pull/410
-    const runtime = require('@mstange/offline-plugin/runtime');
+    const runtime = require('offline-plugin/runtime');
     runtime.install({
       onInstalled: () => {
         console.log('[ServiceWorker] App is ready for offline usage!');

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render, fireEvent } from 'react-testing-library';
-import serviceWorkerRuntime from '@mstange/offline-plugin/runtime';
+import serviceWorkerRuntime from 'offline-plugin/runtime';
 
 import ServiceWorkerManager from '../../components/app/ServiceWorkerManager';
 import { stateFromLocation } from '../../app-logic/url-handling';
@@ -16,7 +16,7 @@ import { fatalError } from '../../actions/receive-profile';
 import { blankStore } from '../fixtures/stores';
 
 // Mock the offline plugin library.
-jest.mock('@mstange/offline-plugin/runtime', () => ({
+jest.mock('offline-plugin/runtime', () => ({
   install: jest.fn(),
   applyUpdate: jest.fn(),
 }));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const OfflinePlugin = require('@mstange/offline-plugin');
+const OfflinePlugin = require('offline-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const includes = [path.join(__dirname, 'src'), path.join(__dirname, 'res')];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,17 +1096,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@mstange/offline-plugin@^5.0.6":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@mstange/offline-plugin/-/offline-plugin-5.0.6.tgz#23d90b9e33fb5546f4b7082ba62796919e0aabb3"
-  integrity sha512-2q2YTvtL1jNZGndGETv+TJOpWqF8aXEoQp4n4xKZf4HhB2rqMu/gvKuzGhkfftn8RH32tKUQHnHMm/8hUZyTrg==
-  dependencies:
-    deep-extend "^0.5.1"
-    ejs "^2.3.4"
-    loader-utils "0.2.x"
-    minimatch "^3.0.3"
-    slash "^1.0.0"
-
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
@@ -8870,6 +8859,17 @@ octokit-pagination-methods@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
+
+offline-plugin@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/offline-plugin/-/offline-plugin-5.0.7.tgz#26936ad1a7699f4d67e0a095a258972a4ccf1788"
+  integrity sha512-ArMFt4QFjK0wg8B5+R/6tt65u6Dk+Pkx4PAcW5O7mgIF3ywMepaQqFOQgfZD4ybanuGwuJihxUwMRgkzd+YGYw==
+  dependencies:
+    deep-extend "^0.5.1"
+    ejs "^2.3.4"
+    loader-utils "0.2.x"
+    minimatch "^3.0.3"
+    slash "^1.0.0"
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
The release v5.0.7 contains the release that Markus contributed. This
patch makes the change to go back to the official plugin. This will help
ensure that we continue to get all of the security alerts for the
package.

https://github.com/NekR/offline-plugin/releases/tag/v5.0.7

I flagged Markus for review if he's around, if not then Nazim as back-up. I tested it out locally with

```
yarn run build-prod
yarn run serve-static
```