### PR TITLE
Fix the performance issue on flow server initialization

### DIFF
--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -24,7 +24,7 @@ declare class WebChannelEvent {
   };
 }
 
-declare class Window extends EventTarget {
+declare class Window {
   // Google Analytics
   ga?: GoogleAnalytics;
   // profiler.firefox.com and Gecko Profiler Addon
@@ -53,6 +53,7 @@ declare class Window extends EventTarget {
     ) => void);
 
   // Built-ins.
+  dispatchEvent: $PropertyType<EventTarget, 'dispatchEvent'>;
   getComputedStyle: (
     element: HTMLElement,
     pseudoEl: ?string


### PR DESCRIPTION
Before this patch flow server was taking ~100 seconds to initialize.
After this patch, it takes ~10 seconds to initialize on my machine.
This is most likely because we cannot overload the methods inside the
extended classes(EventTarget in that case). Because it looks like this
performance issue appeared after the `addEventListener` and
`removeEventListener` signature change for webchannels.

This is the EventTarget type in flow:
https://github.com/facebook/flow/blob/2e1987fd9a5e7fa21859dfa6de621c4f4a2162ae/lib/dom.js#L199-L274
`attachEvent` and `detachEvent` methods are non-standards and others are
deprecated already. Only other method that we need is `dispatchEvent`.

This is before the PR:
```
➜  perf.html git:(flow-performance-fix) ✗ yarn flow-stop && yarn flow
yarn run v1.22.0
$ flow stop
Trying to connect to server for `/Users/nazimcanaltinova/projects/perf.html`
Told server for `/Users/nazimcanaltinova/projects/perf.html` to die. Waiting for confirmation...
Successfully killed server for `/Users/nazimcanaltinova/projects/perf.html`
✨  Done in 2.43s.
yarn run v1.22.0
$ flow --max-warnings 0
Launching Flow server for /Users/nazimcanaltinova/projects/perf.html
Spawned flow server (pid=48045)
Logs will go to /private/tmp/flow/zSUserszSnazZimcanaltinovazSprojectszSperf.html.log
Monitor logs will go to /private/tmp/flow/zSUserszSnazZimcanaltinovazSprojectszSperf.html.monitor_log
No errors!
✨  Done in 116.26s.
```

This is after the PR:
```
➜  perf.html git:(flow-performance-fix) ✗ yarn flow-stop && yarn flow
yarn run v1.22.0
$ flow stop
Trying to connect to server for `/Users/nazimcanaltinova/projects/perf.html`
Told server for `/Users/nazimcanaltinova/projects/perf.html` to die. Waiting for confirmation...
Successfully killed server for `/Users/nazimcanaltinova/projects/perf.html`
✨  Done in 2.44s.
yarn run v1.22.0
$ flow --max-warnings 0
Launching Flow server for /Users/nazimcanaltinova/projects/perf.html
Spawned flow server (pid=49934)
Logs will go to /private/tmp/flow/zSUserszSnazZimcanaltinovazSprojectszSperf.html.log
Monitor logs will go to /private/tmp/flow/zSUserszSnazZimcanaltinovazSprojectszSperf.html.monitor_log
No errors!
✨  Done in 11.24s.
```
