### PR TITLE
Fixing the sidebar of the marker table

### DIFF
--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -1,4 +1,4 @@
-.backtrace {
+.tooltip .backtrace {
   --gradient-height: calc(var(--max-height) - 5em);
 
   /* Box */


### PR DESCRIPTION
Using the class 'backtrace' only when its a tooltip to fix the display of sidebar of the marker table