### PR TITLE
Fixing the sidebar of the marker table

### DIFF
--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -18,19 +18,19 @@
   /* The gradient is defined towards the bottom so that we hide the end of the
    * backtrace only when the element is tall enough, which is when the backtrace
    * is long. */
-
-  mask-image: linear-gradient(
-    to bottom,
-    white,
-    white var(--gradient-height),
-    transparent
-  );
+  
   -webkit-mask-image: linear-gradient(
     to bottom,
     white,
     white var(--gradient-height),
     transparent
   );  
+  mask-image: linear-gradient(
+    to bottom,
+    white,
+    white var(--gradient-height),
+    transparent
+  );
 }
 
 .backtraceStackFrame {

--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -2,31 +2,35 @@
   --gradient-height: calc(var(--max-height) - 5em);
 
   /* Box */
-  overflow: hidden;
   max-width: 35em;
-  max-height: var(--max-height);
   padding: 0;
   margin: 5px;
 
   /* Other */
   font-size: 0.9em;
   line-height: 1.5;
+}
+
+.tooltip .backtrace {
+  overflow: hidden;
+  max-height: var(--max-height);
 
   /* The gradient is defined towards the bottom so that we hide the end of the
    * backtrace only when the element is tall enough, which is when the backtrace
    * is long. */
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    white,
-    white var(--gradient-height),
-    transparent
-  );
+
   mask-image: linear-gradient(
     to bottom,
     white,
     white var(--gradient-height),
     transparent
   );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    white,
+    white var(--gradient-height),
+    transparent
+  );  
 }
 
 .backtraceStackFrame {

--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -18,13 +18,13 @@
   /* The gradient is defined towards the bottom so that we hide the end of the
    * backtrace only when the element is tall enough, which is when the backtrace
    * is long. */
-  
+
   -webkit-mask-image: linear-gradient(
     to bottom,
     white,
     white var(--gradient-height),
     transparent
-  );  
+  );
   mask-image: linear-gradient(
     to bottom,
     white,


### PR DESCRIPTION
Using overflow, max-height, mask-image and -webkit-mask-image only when it is a tooltip.
To fix the display of sidebar of the marker table
Issue #2452