### PR TITLE
Show marker context menu in the timeline

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -348,16 +348,10 @@ export function changeRightClickedTrack(
   };
 }
 
-export function setContextMenuVisibility(
-  isVisible: boolean
-): ThunkAction<void> {
-  return (dispatch, getState) => {
-    const selectedThreadIndex = getSelectedThreadIndex(getState());
-    dispatch({
-      type: 'SET_CONTEXT_MENU_VISIBILITY',
-      threadIndex: selectedThreadIndex,
-      isVisible,
-    });
+export function setContextMenuVisibility(isVisible: boolean): Action {
+  return {
+    type: 'SET_CONTEXT_MENU_VISIBILITY',
+    isVisible,
   };
 }
 

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -325,38 +325,36 @@ function viewportNeedsUpdate() {
 }
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
-  mapStateToProps: state => {
-    return {
-      thread: selectedThreadSelectors.getFilteredThread(state),
-      unfilteredThread: selectedThreadSelectors.getThread(state),
-      sampleIndexOffset: selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(
-        state
-      ),
-      maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
-        state
-      ),
-      flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
-      callTree: selectedThreadSelectors.getCallTree(state),
-      timeRange: getCommittedRange(state),
-      previewSelection: getPreviewSelection(state),
-      callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
-      categories: getCategories(state),
-      threadIndex: getSelectedThreadIndex(state),
-      selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
-        state
-      ),
-      rightClickedCallNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(
-        state
-      ),
-      scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
-      interval: getProfileInterval(state),
-      isInverted: getInvertCallstack(state),
-      callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
-        state
-      ),
-      pages: getPageList(state),
-    };
-  },
+  mapStateToProps: state => ({
+    thread: selectedThreadSelectors.getFilteredThread(state),
+    unfilteredThread: selectedThreadSelectors.getThread(state),
+    sampleIndexOffset: selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(
+      state
+    ),
+    maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+      state
+    ),
+    flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
+    callTree: selectedThreadSelectors.getCallTree(state),
+    timeRange: getCommittedRange(state),
+    previewSelection: getPreviewSelection(state),
+    callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+    categories: getCategories(state),
+    threadIndex: getSelectedThreadIndex(state),
+    selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
+      state
+    ),
+    rightClickedCallNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(
+      state
+    ),
+    scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
+    interval: getProfileInterval(state),
+    isInverted: getInvertCallstack(state),
+    callTreeSummaryStrategy: selectedThreadSelectors.getCallTreeSummaryStrategy(
+      state
+    ),
+    pages: getPageList(state),
+  }),
   mapDispatchToProps: {
     changeSelectedCallNode,
     changeRightClickedCallNode,

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -52,7 +52,7 @@ type OwnProps = {|
   +changeRightClickedMarker: ChangeRightClickedMarker,
   +marginLeft: CssPixels,
   +marginRight: CssPixels,
-  +rightClickedMarker: MarkerIndex | null,
+  +rightClickedMarkerIndex: MarkerIndex | null,
   +shouldDisplayTooltips: () => boolean,
 |};
 
@@ -224,7 +224,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
       rowHeight,
       marginLeft,
       marginRight,
-      rightClickedMarker,
+      rightClickedMarkerIndex,
       viewport: { containerWidth, viewportLeft, viewportRight, viewportTop },
     } = this.props;
 
@@ -299,7 +299,8 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
           const markerIndex = markerTiming.index[i];
 
           const isHighlighted =
-            rightClickedMarker === markerIndex || hoveredItem === markerIndex;
+            rightClickedMarkerIndex === markerIndex ||
+            hoveredItem === markerIndex;
 
           if (isHighlighted) {
             highlightedMarkers.push({ x, y, w, h, uncutWidth, text });

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -55,7 +55,7 @@ type StateProps = {|
   +interval: Milliseconds,
   +threadIndex: number,
   +previewSelection: PreviewSelection,
-  +rightClickedMarker: MarkerIndex | null,
+  +rightClickedMarkerIndex: MarkerIndex | null,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -73,7 +73,7 @@ class MarkerChart extends React.PureComponent<Props> {
     return interval / (end - start);
   }
 
-  _shouldDisplayTooltips = () => this.props.rightClickedMarker === null;
+  _shouldDisplayTooltips = () => this.props.rightClickedMarkerIndex === null;
 
   _takeViewportRef = (viewport: HTMLDivElement | null) => {
     this._viewport = viewport;
@@ -99,7 +99,7 @@ class MarkerChart extends React.PureComponent<Props> {
       previewSelection,
       updatePreviewSelection,
       changeRightClickedMarker,
-      rightClickedMarker,
+      rightClickedMarkerIndex,
     } = this.props;
 
     // The viewport needs to know about the height of what it's drawing, calculate
@@ -147,7 +147,7 @@ class MarkerChart extends React.PureComponent<Props> {
                 threadIndex,
                 marginLeft: TIMELINE_MARGIN_LEFT,
                 marginRight: TIMELINE_MARGIN_RIGHT,
-                rightClickedMarker,
+                rightClickedMarkerIndex,
                 shouldDisplayTooltips: this._shouldDisplayTooltips,
               }}
             />
@@ -179,7 +179,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
       interval: getProfileInterval(state),
       threadIndex: getSelectedThreadIndex(state),
       previewSelection: getPreviewSelection(state),
-      rightClickedMarker: selectedThreadSelectors.getRightClickedMarkerIndex(
+      rightClickedMarkerIndex: selectedThreadSelectors.getRightClickedMarkerIndex(
         state
       ),
     };

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -133,7 +133,7 @@ type StateProps = {|
   +getMarker: MarkerIndex => Marker,
   +markerIndexes: MarkerIndex[],
   +selectedMarker: MarkerIndex | null,
-  +rightClickedMarker: MarkerIndex | null,
+  +rightClickedMarkerIndex: MarkerIndex | null,
   +zeroAt: Milliseconds,
   +scrollToSelectionGeneration: number,
 |};
@@ -197,7 +197,7 @@ class MarkerTable extends PureComponent<Props> {
       markerIndexes,
       zeroAt,
       selectedMarker,
-      rightClickedMarker,
+      rightClickedMarkerIndex,
     } = this.props;
     const tree = this.getMarkerTree(getMarker, markerIndexes, zeroAt);
     return (
@@ -220,7 +220,7 @@ class MarkerTable extends PureComponent<Props> {
             onRightClickSelection={this._onRightClickSelection}
             onExpandedNodesChange={this._onExpandedNodeIdsChange}
             selectedNodeId={selectedMarker}
-            rightClickedNodeId={rightClickedMarker}
+            rightClickedNodeId={rightClickedMarkerIndex}
             expandedNodeIds={this._expandedNodeIds}
             ref={this._takeTreeViewRef}
             contextMenuId="MarkerContextMenu"
@@ -242,7 +242,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
       state
     ),
     selectedMarker: selectedThreadSelectors.getSelectedMarkerIndex(state),
-    rightClickedMarker: selectedThreadSelectors.getRightClickedMarkerIndex(
+    rightClickedMarkerIndex: selectedThreadSelectors.getRightClickedMarkerIndex(
       state
     ),
     zeroAt: getZeroAt(state),

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -172,20 +172,18 @@ class NetworkChart extends React.PureComponent<Props> {
  */
 const ConnectedComponent = explicitConnect<OwnProps, StateProps, DispatchProps>(
   {
-    mapStateToProps: state => {
-      return {
-        markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
-          state
-        ),
-        getMarker: selectedThreadSelectors.getMarkerGetter(state),
-        rightClickedMarkerIndex: selectedThreadSelectors.getRightClickedMarkerIndex(
-          state
-        ),
-        timeRange: getPreviewSelectionRange(state),
-        disableOverscan: getPreviewSelection(state).isModifying,
-        threadIndex: getSelectedThreadIndex(state),
-      };
-    },
+    mapStateToProps: state => ({
+      markerIndexes: selectedThreadSelectors.getSearchFilteredNetworkMarkerIndexes(
+        state
+      ),
+      getMarker: selectedThreadSelectors.getMarkerGetter(state),
+      rightClickedMarkerIndex: selectedThreadSelectors.getRightClickedMarkerIndex(
+        state
+      ),
+      timeRange: getPreviewSelectionRange(state),
+      disableOverscan: getPreviewSelection(state).isModifying,
+      threadIndex: getSelectedThreadIndex(state),
+    }),
     mapDispatchToProps: { changeRightClickedMarker },
     component: NetworkChart,
   }

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -7,7 +7,6 @@ import React, { PureComponent, Fragment } from 'react';
 import { MenuItem } from 'react-contextmenu';
 import ContextMenu from '../shared/ContextMenu';
 import explicitConnect from '../../utils/connect';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { funcHasRecursiveCall } from '../../profile-logic/transforms';
 import { getFunctionName } from '../../profile-logic/function-info';
 import copy from 'copy-to-clipboard';
@@ -18,10 +17,11 @@ import {
 } from '../../actions/profile-view';
 import {
   getSelectedTab,
-  getSelectedThreadIndex,
   getImplementationFilter,
   getInvertCallstack,
 } from '../../selectors/url-state';
+import { getRightClickedCallNodeInfo } from '../../selectors/right-clicked-call-node';
+import { getThreadSelectors } from '../../selectors/per-thread';
 
 import {
   convertToTransformType,
@@ -31,22 +31,22 @@ import {
 import type { TransformType } from '../../types/transforms';
 import type { ImplementationFilter } from '../../types/actions';
 import type { TabSlug } from '../../app-logic/tabs-handling';
+import type { ConnectedProps } from '../../utils/connect';
 import type {
   IndexIntoCallNodeTable,
   CallNodeInfo,
   CallNodePath,
 } from '../../types/profile-derived';
 import type { Thread, ThreadIndex } from '../../types/profile';
-import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|
-  +thread: Thread,
-  +threadIndex: ThreadIndex,
-  +callNodeInfo: CallNodeInfo,
+  +thread: Thread | null,
+  +threadIndex: ThreadIndex | null,
+  +callNodeInfo: CallNodeInfo | null,
+  +rightClickedCallNodePath: CallNodePath | null,
+  +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +implementation: ImplementationFilter,
   +inverted: boolean,
-  +callNodePath: CallNodePath | null,
-  +callNodeIndex: IndexIntoCallNodeTable | null,
   +selectedTab: TabSlug,
 |};
 
@@ -100,17 +100,19 @@ class CallNodeContextMenu extends PureComponent<Props> {
   };
 
   _getFunctionName(): string {
-    const {
-      callNodeIndex,
-      thread: { stringTable, funcTable },
-      callNodeInfo: { callNodeTable },
-    } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-    if (callNodeIndex === null) {
+    if (rightClickedCallNodeInfo === null) {
       throw new Error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
     }
+
+    const {
+      callNodeIndex,
+      thread: { stringTable, funcTable },
+      callNodeInfo: { callNodeTable },
+    } = rightClickedCallNodeInfo;
 
     const funcIndex = callNodeTable.func[callNodeIndex];
     const isJS = funcTable.isJS[funcIndex];
@@ -135,17 +137,19 @@ class CallNodeContextMenu extends PureComponent<Props> {
   }
 
   copyUrl(): void {
-    const {
-      callNodeIndex,
-      thread: { stringTable, funcTable },
-      callNodeInfo: { callNodeTable },
-    } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-    if (callNodeIndex === null) {
+    if (rightClickedCallNodeInfo === null) {
       throw new Error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
     }
+
+    const {
+      callNodeIndex,
+      thread: { stringTable, funcTable },
+      callNodeInfo: { callNodeTable },
+    } = rightClickedCallNodeInfo;
 
     const funcIndex = callNodeTable.func[callNodeIndex];
     const stringIndex = funcTable.fileName[funcIndex];
@@ -156,18 +160,19 @@ class CallNodeContextMenu extends PureComponent<Props> {
   }
 
   copyStack(): void {
-    const {
-      callNodeIndex,
-      thread: { stringTable, funcTable },
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-      callNodeInfo: { callNodeTable },
-    } = this.props;
-
-    if (callNodeIndex === null) {
+    if (rightClickedCallNodeInfo === null) {
       throw new Error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
     }
+
+    const {
+      callNodeIndex,
+      thread: { stringTable, funcTable },
+      callNodeInfo: { callNodeTable },
+    } = rightClickedCallNodeInfo;
 
     let stack = '';
     let curCallNodeIndex = callNodeIndex;
@@ -213,21 +218,16 @@ class CallNodeContextMenu extends PureComponent<Props> {
   };
 
   addTransformToStack(type: TransformType): void {
-    const {
-      addTransformToStack,
-      threadIndex,
-      implementation,
-      callNodePath,
-      inverted,
-      thread,
-    } = this.props;
+    const { addTransformToStack, implementation, inverted } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-    if (callNodePath === null) {
+    if (rightClickedCallNodeInfo === null) {
       throw new Error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
     }
 
+    const { threadIndex, callNodePath, thread } = rightClickedCallNodeInfo;
     const selectedFunc = callNodePath[callNodePath.length - 1];
 
     switch (type) {
@@ -299,32 +299,37 @@ class CallNodeContextMenu extends PureComponent<Props> {
   }
 
   expandAll(): void {
-    const {
-      expandAllCallNodeDescendants,
-      threadIndex,
-      callNodeIndex,
-      callNodeInfo,
-    } = this.props;
-    if (callNodeIndex === null) {
+    const { expandAllCallNodeDescendants } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
+
+    if (rightClickedCallNodeInfo === null) {
       throw new Error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
     }
+
+    const {
+      threadIndex,
+      callNodeIndex,
+      callNodeInfo,
+    } = rightClickedCallNodeInfo;
 
     expandAllCallNodeDescendants(threadIndex, callNodeIndex, callNodeInfo);
   }
 
   getNameForSelectedResource(): string | null {
-    const {
-      callNodePath,
-      thread: { funcTable, stringTable, resourceTable, libs },
-    } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-    if (callNodePath === null) {
+    if (rightClickedCallNodeInfo === null) {
       throw new Error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
     }
+
+    const {
+      callNodePath,
+      thread: { funcTable, stringTable, resourceTable, libs },
+    } = rightClickedCallNodeInfo;
 
     const funcIndex = callNodePath[callNodePath.length - 1];
     if (funcIndex === undefined) {
@@ -353,19 +358,23 @@ class CallNodeContextMenu extends PureComponent<Props> {
    * Determine if this CallNode represent a recursive function call.
    */
   isRecursiveCall(): boolean {
-    const { callNodePath, thread, implementation } = this.props;
+    const { implementation } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-    if (callNodePath === null) {
+    if (rightClickedCallNodeInfo === null) {
       console.error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
       return false;
     }
 
+    const { callNodePath, thread } = rightClickedCallNodeInfo;
     const funcIndex = callNodePath[callNodePath.length - 1];
+
     if (funcIndex === undefined) {
       return false;
     }
+
     // Do the easy thing first, see if this function was called by itself.
     if (callNodePath[callNodePath.length - 2] === funcIndex) {
       return true;
@@ -375,21 +384,56 @@ class CallNodeContextMenu extends PureComponent<Props> {
     return funcHasRecursiveCall(thread, implementation, funcIndex);
   }
 
-  renderContextMenuContents() {
+  getRightClickedCallNodeInfo(): null | {|
+    +thread: Thread,
+    +threadIndex: ThreadIndex,
+    +callNodeInfo: CallNodeInfo,
+    +callNodePath: CallNodePath,
+    +callNodeIndex: IndexIntoCallNodeTable,
+  |} {
     const {
-      callNodeIndex,
-      inverted,
-      thread: { funcTable },
-      callNodeInfo: { callNodeTable },
-      selectedTab,
+      thread,
+      threadIndex,
+      callNodeInfo,
+      rightClickedCallNodePath,
+      rightClickedCallNodeIndex,
     } = this.props;
 
-    if (callNodeIndex === null) {
+    if (
+      thread &&
+      typeof threadIndex === 'number' &&
+      callNodeInfo &&
+      rightClickedCallNodePath &&
+      typeof rightClickedCallNodeIndex === 'number'
+    ) {
+      return {
+        thread,
+        threadIndex,
+        callNodeInfo,
+        callNodePath: rightClickedCallNodePath,
+        callNodeIndex: rightClickedCallNodeIndex,
+      };
+    }
+
+    return null;
+  }
+
+  renderContextMenuContents() {
+    const { inverted, selectedTab } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
+
+    if (rightClickedCallNodeInfo === null) {
       console.error(
         "The context menu assumes there is a selected call node and there wasn't one."
       );
       return <div />;
     }
+
+    const {
+      callNodeIndex,
+      thread: { funcTable },
+      callNodeInfo: { callNodeTable },
+    } = rightClickedCallNodeInfo;
 
     const funcIndex = callNodeTable.func[callNodeIndex];
     const isJS = funcTable.isJS[funcIndex];
@@ -483,9 +527,9 @@ class CallNodeContextMenu extends PureComponent<Props> {
   }
 
   render() {
-    const { callNodeIndex } = this.props;
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
-    if (callNodeIndex === null) {
+    if (rightClickedCallNodeInfo === null) {
       return null;
     }
 
@@ -502,16 +546,38 @@ class CallNodeContextMenu extends PureComponent<Props> {
 }
 
 export default explicitConnect<{||}, StateProps, DispatchProps>({
-  mapStateToProps: state => ({
-    thread: selectedThreadSelectors.getFilteredThread(state),
-    threadIndex: getSelectedThreadIndex(state),
-    callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
-    implementation: getImplementationFilter(state),
-    inverted: getInvertCallstack(state),
-    callNodePath: selectedThreadSelectors.getRightClickedCallNodePath(state),
-    callNodeIndex: selectedThreadSelectors.getRightClickedCallNodeIndex(state),
-    selectedTab: getSelectedTab(state),
-  }),
+  mapStateToProps: state => {
+    const rightClickedCallNodeInfo = getRightClickedCallNodeInfo(state);
+
+    let thread = null;
+    let threadIndex = null;
+    let callNodeInfo = null;
+    let rightClickedCallNodePath = null;
+    let rightClickedCallNodeIndex = null;
+
+    if (rightClickedCallNodeInfo !== null) {
+      const selectors = getThreadSelectors(
+        rightClickedCallNodeInfo.threadIndex
+      );
+
+      thread = selectors.getThread(state);
+      threadIndex = rightClickedCallNodeInfo.threadIndex;
+      callNodeInfo = selectors.getCallNodeInfo(state);
+      rightClickedCallNodePath = rightClickedCallNodeInfo.callNodePath;
+      rightClickedCallNodeIndex = selectors.getRightClickedCallNodeIndex(state);
+    }
+
+    return {
+      thread,
+      threadIndex,
+      callNodeInfo,
+      rightClickedCallNodePath,
+      rightClickedCallNodeIndex,
+      implementation: getImplementationFilter(state),
+      inverted: getInvertCallstack(state),
+      selectedTab: getSelectedTab(state),
+    };
+  },
   mapDispatchToProps: {
     addTransformToStack,
     expandAllCallNodeDescendants,

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -35,6 +35,7 @@ import {
 } from '../../actions/profile-view';
 
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
+
 import type { Thread, CategoryList, PageList } from '../../types/profile';
 import type {
   CallNodeInfo,

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -63,8 +63,8 @@ export const getThreadSelectors = (
     // selectors for their own definition.
     selectors = {
       ...selectors,
-      ...getStackAndSampleSelectorsPerThread(selectors),
-      ...getMarkerSelectorsPerThread(selectors),
+      ...getStackAndSampleSelectorsPerThread(selectors, threadIndex),
+      ...getMarkerSelectorsPerThread(selectors, threadIndex),
     };
     // 3. Other selectors that need selectors from different files to be defined.
     _threadSelectorsCache[threadIndex] = {

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -10,8 +10,9 @@ import * as UrlState from '../url-state';
 import * as MarkerData from '../../profile-logic/marker-data';
 import * as MarkerTimingLogic from '../../profile-logic/marker-timing';
 import * as ProfileSelectors from '../profile';
+import { getRightClickedMarkerInfo } from '../right-clicked-marker';
 
-import type { RawMarkerTable } from '../../types/profile';
+import type { RawMarkerTable, ThreadIndex } from '../../types/profile';
 import type {
   MarkerIndex,
   Marker,
@@ -33,7 +34,10 @@ export type MarkerSelectorsPerThread = $ReturnType<
 /**
  * Create the selectors for a thread that have to do with either markers.
  */
-export function getMarkerSelectorsPerThread(threadSelectors: *) {
+export function getMarkerSelectorsPerThread(
+  threadSelectors: *,
+  threadIndex: ThreadIndex
+) {
   const _getRawMarkerTable: Selector<RawMarkerTable> = state =>
     threadSelectors.getThread(state).markers;
 
@@ -457,26 +461,26 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     return getMarker(selectedMarkerIndex);
   };
 
-  /**
-   * This returns the marker index for the currently right clicked marker.
-   */
-  const getRightClickedMarkerIndex: Selector<MarkerIndex | null> = state =>
-    threadSelectors.getViewOptions(state).rightClickedMarker;
+  const getRightClickedMarkerIndex: Selector<null | MarkerIndex> = createSelector(
+    getRightClickedMarkerInfo,
+    rightClickedMarkerInfo => {
+      if (
+        rightClickedMarkerInfo !== null &&
+        rightClickedMarkerInfo.threadIndex === threadIndex
+      ) {
+        return rightClickedMarkerInfo.markerIndex;
+      }
 
-  /**
-   * From the previous value, this returns the full marker object for the
-   * selected marker.
-   */
-  const getRightClickedMarker: Selector<Marker | null> = state => {
-    const getMarker = getMarkerGetter(state);
-    const rightClickedMarkerIndex = getRightClickedMarkerIndex(state);
-
-    if (rightClickedMarkerIndex === null) {
       return null;
     }
+  );
 
-    return getMarker(rightClickedMarkerIndex);
-  };
+  const getRightClickedMarker: Selector<null | Marker> = createSelector(
+    getMarkerGetter,
+    getRightClickedMarkerIndex,
+    (getMarker, markerIndex) =>
+      typeof markerIndex === 'number' ? getMarker(markerIndex) : null
+  );
 
   return {
     getMarkerGetter,
@@ -503,10 +507,10 @@ export function getMarkerSelectorsPerThread(threadSelectors: *) {
     getPreviewFilteredMarkerIndexes,
     getSelectedMarkerIndex,
     getSelectedMarker,
-    getRightClickedMarkerIndex,
-    getRightClickedMarker,
     getIsNetworkChartEmptyInFullRange,
     getUserTimingMarkerIndexes,
     getUserTimingMarkerTiming,
+    getRightClickedMarkerIndex,
+    getRightClickedMarker,
   };
 }

--- a/src/selectors/right-clicked-call-node.js
+++ b/src/selectors/right-clicked-call-node.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { createSelector } from 'reselect';
+
+import { getProfileViewOptions } from './profile';
+
+import type { ThreadIndex } from '../types/profile';
+import type { CallNodePath } from '../types/profile-derived';
+import type { Selector } from '../types/store';
+
+export type RightClickedCallNodeInfo = {|
+  +threadIndex: ThreadIndex,
+  +callNodePath: CallNodePath,
+|};
+
+export const getRightClickedCallNodeInfo: Selector<RightClickedCallNodeInfo | null> = createSelector(
+  getProfileViewOptions,
+  viewOptions => viewOptions.rightClickedCallNode
+);

--- a/src/selectors/right-clicked-marker.js
+++ b/src/selectors/right-clicked-marker.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { createSelector } from 'reselect';
+import { getProfileViewOptions } from './profile';
+
+import type { ThreadIndex } from '../types/profile';
+import type { MarkerIndex } from '../types/profile-derived';
+import type { Selector } from '../types/store';
+
+export type RightClickedMarkerInfo = {|
+  +threadIndex: ThreadIndex,
+  +markerIndex: MarkerIndex,
+|};
+
+export const getRightClickedMarkerInfo: Selector<RightClickedMarkerInfo | null> = createSelector(
+  getProfileViewOptions,
+  viewOptions => viewOptions.rightClickedMarker
+);

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -4,90 +4,193 @@
 
 // @flow
 import * as React from 'react';
+
+// This module is mocked.
+import copy from 'copy-to-clipboard';
+
 import {
   TimelineMarkersOverview,
   MIN_MARKER_WIDTH,
 } from '../../components/timeline/Markers';
-import { render } from 'react-testing-library';
+import MarkerContextMenu from '../../components/shared/MarkerContextMenu';
+import { overlayFills } from '../../profile-logic/marker-styles';
+import { render, fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
-import ReactDOM from 'react-dom';
-import { getBoundingBox } from '../fixtures/utils';
+import {
+  getBoundingBox,
+  getMouseEvent,
+  addRootOverlayElement,
+  removeRootOverlayElement,
+} from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { ensureExists } from '../../utils/flow';
 
-describe('TimelineMarkers', function() {
-  beforeEach(() => {
-    jest.spyOn(ReactDOM, 'findDOMNode').mockImplementation(() => {
-      // findDOMNode uses nominal typing instead of structural (null | Element | Text), so
-      // opt out of the type checker for this mock by returning `any`.
-      const mockEl = ({
-        getBoundingClientRect: () => getBoundingBox(200, 300),
-      }: any);
-      return mockEl;
-    });
-  });
+import type { CssPixels } from '../../types/units';
 
-  it('renders correctly', () => {
-    const flushRafCalls = mockRaf();
-    window.devicePixelRatio = 1;
-    const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(200, 300));
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
+function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
+  const flushRafCalls = mockRaf();
+  const ctx = mockCanvasContext();
 
-    const profile = getProfileWithMarkers([
-      ['Marker A', 0, { startTime: 0, endTime: 10 }],
-      ['Marker B', 0, { startTime: 0, endTime: 10 }],
-      ['Marker C', 5, { startTime: 5, endTime: 15 }],
-      [
-        'BHR-detected hang',
-        5,
-        { type: 'BHR-detected hang', startTime: 2, endTime: 13 },
-      ],
-      [
-        'LongTask',
-        6,
-        {
-          type: 'MainThreadLongTask',
-          category: 'LongTask',
-          startTime: 2,
-          endTime: 6,
-        },
-      ],
-      [
-        'LongIdleTask',
-        8,
-        {
-          type: 'MainThreadLongTask',
-          category: 'LongTask',
-          startTime: 6,
-          endTime: 8,
-        },
-      ],
-    ]);
+  jest
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation(() => ctx);
 
-    const { container } = render(
-      <Provider store={storeWithProfile(profile)}>
-        <TimelineMarkersOverview
-          rangeStart={0}
-          rangeEnd={15}
-          threadIndex={0}
-          onSelect={() => {}}
-        />
-      </Provider>
-    );
+  // Ideally we'd want this only on the Canvas and on ChartViewport, but this is
+  // a lot easier to mock this everywhere.
+  jest
+    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => getBoundingBox(200, 300));
 
+  function flushRafTwice() {
     // We need to flush twice since when the first flush is run, it
     // will request more code to be run in later animation frames.
     flushRafCalls();
     flushRafCalls();
+  }
 
-    const drawCalls = ctx.__flushDrawLog();
+  function flushDrawLog() {
+    return ctx.__flushDrawLog();
+  }
+
+  const profile = getProfileWithMarkers(...markersPerThread);
+
+  const renderResult = render(
+    <Provider store={storeWithProfile(profile)}>
+      <>
+        <TimelineMarkersOverview
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          threadIndex={0}
+          onSelect={() => {}}
+        />
+        <MarkerContextMenu />
+      </>
+    </Provider>
+  );
+
+  flushRafTwice();
+
+  function getContextMenu() {
+    return ensureExists(
+      renderResult.container.querySelector('.react-contextmenu'),
+      `Couldn't find the context menu.`
+    );
+  }
+
+  function clickOnMenuItem(stringOrRegexp) {
+    fireEvent.click(renderResult.getByText(stringOrRegexp));
+  }
+
+  function fireMouseEvent(eventName, options) {
+    fireEvent(
+      ensureExists(
+        renderResult.container.querySelector('canvas'),
+        `Couldn't find the canvas element`
+      ),
+      getMouseEvent(eventName, options)
+    );
+  }
+
+  function getPositioningOptions({ x, y }) {
+    // These positioning options will be sent to all our mouse events. Note
+    // that the values aren't really consistent, especially offsetY and
+    // pageY shouldn't be the same, but in the context of our test this will
+    // be good enough.
+    // pageX/Y values control the position of the tooltip so it's not super
+    // important.
+    // offsetX/Y are more important as they're used to find which node is
+    // actually clicked.
+    const positioningOptions = {
+      offsetX: x,
+      offsetY: y,
+      clientX: x,
+      clientY: y,
+      pageX: x,
+      pageY: y,
+    };
+
+    return positioningOptions;
+  }
+
+  // Note to a future developer: the x/y values can be derived from the
+  // array returned by ctx.__flushDrawLog().
+  function rightClick(where: { x: CssPixels, y: CssPixels }) {
+    const positioningOptions = getPositioningOptions(where);
+    const clickOptions = {
+      ...positioningOptions,
+      button: 2,
+      buttons: 2,
+    };
+
+    // Because different components listen to different events, we trigger
+    // all the right events, to be as close as possible to the real stuff.
+    fireMouseEvent('mousemove', positioningOptions);
+    fireMouseEvent('mousedown', clickOptions);
+    fireMouseEvent('mouseup', clickOptions);
+    fireMouseEvent('contextmenu', clickOptions);
+
+    flushRafTwice();
+  }
+
+  function mouseOver(where: { x: CssPixels, y: CssPixels }) {
+    const positioningOptions = getPositioningOptions(where);
+    fireMouseEvent('mousemove', positioningOptions);
+    flushRafTwice();
+  }
+
+  return {
+    flushDrawLog,
+    flushRafTwice,
+    rightClick,
+    mouseOver,
+    getContextMenu,
+    clickOnMenuItem,
+    ...renderResult,
+  };
+}
+
+describe('TimelineMarkers', function() {
+  it('renders correctly', () => {
+    window.devicePixelRatio = 1;
+
+    const { container, flushDrawLog } = setupWithMarkers(
+      { rangeStart: 0, rangeEnd: 15 },
+      [
+        ['Marker A', 0, { startTime: 0, endTime: 10 }],
+        ['Marker B', 0, { startTime: 0, endTime: 10 }],
+        ['Marker C', 5, { startTime: 5, endTime: 15 }],
+        [
+          'BHR-detected hang',
+          5,
+          { type: 'BHR-detected hang', startTime: 2, endTime: 13 },
+        ],
+        [
+          'LongTask',
+          6,
+          {
+            type: 'MainThreadLongTask',
+            category: 'LongTask',
+            startTime: 2,
+            endTime: 6,
+          },
+        ],
+        [
+          'LongIdleTask',
+          8,
+          {
+            type: 'MainThreadLongTask',
+            category: 'LongTask',
+            startTime: 6,
+            endTime: 8,
+          },
+        ],
+      ]
+    );
+
+    const drawCalls = flushDrawLog();
 
     expect(container.firstChild).toMatchSnapshot();
     expect(drawCalls).toMatchSnapshot();
@@ -96,42 +199,20 @@ describe('TimelineMarkers', function() {
   });
 
   it('does not render several dot markers in the same position', () => {
-    const flushRafCalls = mockRaf();
     window.devicePixelRatio = 2;
-    const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(200, 300));
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
-    const markers = [
-      // 2 very close dot markers. They shouldn't be drawn both together.
-      ['Marker A', 5000, null],
-      ['Marker B', 5001, null],
-      // This is a longer marker starting at the same place, it should always be drawn
-      ['Marker C', 5001, { startTime: 5001, endTime: 7000 }],
-    ];
-    const profile = getProfileWithMarkers(markers);
-
-    render(
-      <Provider store={storeWithProfile(profile)}>
-        <TimelineMarkersOverview
-          rangeStart={0}
-          rangeEnd={15000}
-          threadIndex={0}
-          onSelect={() => {}}
-        />
-      </Provider>
+    const { flushDrawLog } = setupWithMarkers(
+      { rangeStart: 0, rangeEnd: 15000 },
+      [
+        // 2 very close dot markers. They shouldn't be drawn both together.
+        ['Marker A', 5000, null],
+        ['Marker B', 5001, null],
+        // This is a longer marker starting at the same place, it should always be drawn
+        ['Marker C', 5001, { startTime: 5001, endTime: 7000 }],
+      ]
     );
 
-    // We need to flush twice since when the first flush is run, it
-    // will request more code to be run in later animation frames.
-    flushRafCalls();
-    flushRafCalls();
-
-    const drawCalls = ctx.__flushDrawLog();
+    const drawCalls = flushDrawLog();
 
     // We filter on height to get only 1 relevant fillRect operation for each marker.
     const fillRectOperations = drawCalls.filter(
@@ -147,5 +228,96 @@ describe('TimelineMarkers', function() {
     ).toBe(true);
 
     delete window.devicePixelRatio;
+  });
+
+  describe('displays context menus', () => {
+    beforeEach(() => {
+      // Always use fake timers when dealing with context menus.
+      jest.useFakeTimers();
+      // We will be hovering over element with a tooltip. It requires root overlay
+      // element to be present in DOM
+      addRootOverlayElement();
+    });
+
+    afterEach(removeRootOverlayElement);
+
+    it('when right clicking on a marker', () => {
+      const { rightClick, getContextMenu, clickOnMenuItem } = setupWithMarkers(
+        { rangeStart: 0, rangeEnd: 10 },
+        [['Marker A', 0, { startTime: 0, endTime: 10 }]]
+      );
+
+      // The "Marker A" marker is drawn from 0,0 to 5,200.
+      rightClick({ x: 50, y: 2 });
+
+      jest.runAllTimers();
+
+      expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
+
+      clickOnMenuItem('Copy');
+
+      expect(copy).toHaveBeenLastCalledWith('Marker A');
+      expect(getContextMenu()).not.toHaveClass('react-contextmenu--visible');
+
+      jest.runAllTimers();
+
+      expect(document.querySelector('react-contextmenu')).toBeFalsy();
+    });
+
+    it('when right clicking on markers in a sequence', () => {
+      const { rightClick, getContextMenu, clickOnMenuItem } = setupWithMarkers(
+        { rangeStart: 0, rangeEnd: 10 },
+        [
+          ['Marker A', 0, { startTime: 0, endTime: 3 }],
+          ['Marker B', 0, { startTime: 6, endTime: 10 }],
+        ]
+      );
+
+      // The "Marker A" marker is drawn from 0,0 to 5,60.
+      rightClick({ x: 30, y: 2 });
+      jest.runAllTimers();
+
+      // The "Marker B" marker is drawn from 0,120 to 5,200.
+      rightClick({ x: 160, y: 2 });
+      jest.runAllTimers();
+
+      expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
+
+      clickOnMenuItem('Copy');
+      expect(copy).toHaveBeenLastCalledWith('Marker B');
+
+      expect(getContextMenu()).not.toHaveClass('react-contextmenu--visible');
+
+      jest.runAllTimers();
+      expect(document.querySelector('react-contextmenu')).toBeFalsy();
+    });
+
+    it('and still highlights other markers when hovering them', () => {
+      const {
+        rightClick,
+        mouseOver,
+        flushDrawLog,
+        getContextMenu,
+      } = setupWithMarkers({ rangeStart: 0, rangeEnd: 10 }, [
+        ['Marker A', 0, { startTime: 0, endTime: 3 }],
+        ['Marker B', 0, { startTime: 6, endTime: 10 }],
+      ]);
+
+      // The "Marker A" marker is drawn from 0,0 to 5,60.
+      rightClick({ x: 30, y: 2 });
+      expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
+
+      flushDrawLog();
+      // The "Marker B" marker is drawn from 0,120 to 5,200.
+      mouseOver({ x: 160, y: 1 });
+
+      const drawCalls = flushDrawLog();
+
+      // Expect that we have one marker with hovered color
+      const callsWithHoveredColor = drawCalls.filter(
+        ([, argument]) => argument === overlayFills.HOVERED
+      );
+      expect(callsWithHoveredColor).toHaveLength(1);
+    });
   });
 });

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -35,25 +35,37 @@ process: \\"tab\\" (222)"
           class="timelineMarkers timelineMarkersMemory"
           data-testid="TimelineMarkersMemory"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="timelineMarkers"
           data-testid="TimelineMarkersJank"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="timelineMarkers timelineMarkersGeckoMain"
           data-testid="TimelineMarkersOverview"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="threadActivityGraph"
@@ -101,9 +113,13 @@ process: \\"tab\\" (222)"
               class="timelineMarkers selected"
               data-testid="TimelineMarkersJank"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-              />
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <canvas
+                  class="timelineMarkersCanvas"
+                />
+              </div>
             </div>
             <div
               class="threadActivityGraph"
@@ -149,9 +165,13 @@ process: \\"tab\\" (222)"
               class="timelineMarkers"
               data-testid="TimelineMarkersJank"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-              />
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <canvas
+                  class="timelineMarkersCanvas"
+                />
+              </div>
             </div>
             <div
               class="threadActivityGraph"
@@ -229,9 +249,13 @@ process: \\"default\\" (5555)"
               class="timelineMarkers"
               data-testid="TimelineMarkersJank"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-              />
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <canvas
+                  class="timelineMarkersCanvas"
+                />
+              </div>
             </div>
             <div
               class="threadActivityGraph"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -29,9 +29,13 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
           class="timelineMarkers timelineMarkersMemory"
           data-testid="TimelineMarkersMemory"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="timelineTrackMemoryGraph"
@@ -141,9 +145,13 @@ process: \\"tab\\" (222)"
           class="timelineMarkers"
           data-testid="TimelineMarkersJank"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
         <div
           class="threadActivityGraph"
@@ -190,9 +198,13 @@ exports[`timeline/LocalTrack with an IPC track matches the snapshot of the IPC t
           class="timelineMarkers timelineMarkersIPC"
           data-testid="TimelineMarkersIPC"
         >
-          <canvas
-            class="timelineMarkersCanvas"
-          />
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -2532,9 +2532,13 @@ exports[`ThreadActivityGraph matches the component snapshot 1`] = `
     class="timelineMarkers selected"
     data-testid="TimelineMarkersJank"
   >
-    <canvas
-      class="timelineMarkersCanvas"
-    />
+    <div
+      class="react-contextmenu-wrapper"
+    >
+      <canvas
+        class="timelineMarkersCanvas"
+      />
+    </div>
   </div>
   <div
     class="threadActivityGraph"

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -5,11 +5,15 @@ exports[`TimelineMarkers renders correctly 1`] = `
   class="timelineMarkers selected"
   data-testid="TimelineMarkersOverview"
 >
-  <canvas
-    class="timelineMarkersCanvas"
-    height="300"
-    width="200"
-  />
+  <div
+    class="react-contextmenu-wrapper"
+  >
+    <canvas
+      class="timelineMarkersCanvas"
+      height="300"
+      width="200"
+    />
+  </div>
 </div>
 `;
 

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -148,9 +148,13 @@ exports[`TrackMemory matches the component snapshot 1`] = `
     class="timelineMarkers timelineMarkersMemory selected"
     data-testid="TimelineMarkersMemory"
   >
-    <canvas
-      class="timelineMarkersCanvas"
-    />
+    <div
+      class="react-contextmenu-wrapper"
+    >
+      <canvas
+        class="timelineMarkersCanvas"
+      />
+    </div>
   </div>
   <div
     class="timelineTrackMemoryGraph"

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -53,9 +53,13 @@ exports[`timeline/TrackThread matches the snapshot for the component 1`] = `
     class="timelineMarkers selected"
     data-testid="TimelineMarkersJank"
   >
-    <canvas
-      class="timelineMarkersCanvas"
-    />
+    <div
+      class="react-contextmenu-wrapper"
+    >
+      <canvas
+        class="timelineMarkersCanvas"
+      />
+    </div>
   </div>
   <div
     class="threadStackGraph"

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -3605,8 +3605,6 @@ Object {
       ],
     },
   },
-  "rightClickedCallNodePath": null,
-  "rightClickedMarker": null,
   "selectedCallNodePath": Array [
     0,
     1,

--- a/src/test/store/profile-view.test.js.orig
+++ b/src/test/store/profile-view.test.js.orig
@@ -32,8 +32,6 @@ import * as ProfileView from '../../actions/profile-view';
 import { viewProfile } from '../../actions/receive-profile';
 import * as ProfileViewSelectors from '../../selectors/profile';
 import * as UrlStateSelectors from '../../selectors/url-state';
-import { getRightClickedCallNodeInfo } from '../../selectors/right-clicked-call-node';
-import { getRightClickedMarkerInfo } from '../../selectors/right-clicked-marker';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import {
   selectedThreadSelectors,
@@ -2760,98 +2758,6 @@ describe('visual metrics selectors', function() {
     expect(getContentfulSpeedIndexProgress(getState())).toEqual(
       ContentfulSpeedIndexProgress
     );
-  });
-});
-
-describe('right clicked call node info', () => {
-  function setup() {
-    const profile = getProfileFromTextSamples(`
-      A
-      B
-      C
-    `);
-
-    return storeWithProfile(profile.profile);
-  }
-
-  it('should be empty on store creation', () => {
-    const { getState } = setup();
-
-    expect(getRightClickedCallNodeInfo(getState())).toBeNull();
-  });
-
-  it('sets right clicked call node info when right clicked call node action is dispatched', () => {
-    const { dispatch, getState } = setup();
-
-    expect(getRightClickedCallNodeInfo(getState())).toBeNull();
-
-    dispatch(ProfileView.changeRightClickedCallNode(0, [0, 1]));
-
-    expect(getRightClickedCallNodeInfo(getState())).toEqual({
-      threadIndex: 0,
-      callNodePath: [0, 1],
-    });
-  });
-
-  it('resets right clicked call node when context menu is hidden', () => {
-    const { dispatch, getState } = setup();
-
-    dispatch(ProfileView.changeRightClickedCallNode(0, [0, 1]));
-
-    expect(getRightClickedCallNodeInfo(getState())).toEqual({
-      threadIndex: 0,
-      callNodePath: [0, 1],
-    });
-
-    dispatch(ProfileView.setContextMenuVisibility(false));
-
-    expect(getRightClickedCallNodeInfo(getState())).toBeNull();
-  });
-});
-
-describe('right clicked marker info', () => {
-  function setup() {
-    const profile = getProfileWithMarkers([
-      ['a', 0, null],
-      ['b', 1, null],
-      ['c', 2, null],
-    ]);
-
-    return storeWithProfile(profile);
-  }
-
-  it('should be empty on store creation', () => {
-    const { getState } = setup();
-
-    expect(getRightClickedMarkerInfo(getState())).toBeNull();
-  });
-
-  it('sets right clicked marker info when right clicked marker action is dispatched', () => {
-    const { dispatch, getState } = setup();
-
-    expect(getRightClickedMarkerInfo(getState())).toBeNull();
-
-    dispatch(ProfileView.changeRightClickedMarker(0, 0));
-
-    expect(getRightClickedMarkerInfo(getState())).toEqual({
-      threadIndex: 0,
-      markerIndex: 0,
-    });
-  });
-
-  it('resets right clicked marker when context menu is hidden', () => {
-    const { dispatch, getState } = setup();
-
-    dispatch(ProfileView.changeRightClickedMarker(0, 1));
-
-    expect(getRightClickedMarkerInfo(getState())).toEqual({
-      threadIndex: 0,
-      markerIndex: 1,
-    });
-
-    dispatch(ProfileView.setContextMenuVisibility(false));
-
-    expect(getRightClickedMarkerInfo(getState())).toBeNull();
   });
 });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -221,7 +221,6 @@ type ProfileAction =
   | {|
       +type: 'SET_CONTEXT_MENU_VISIBILITY',
       +isVisible: boolean,
-      +threadIndex: ThreadIndex,
     |}
   | {|
       +type: 'INCREMENT_PANEL_LAYOUT_GENERATION',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -37,10 +37,18 @@ export type Reducer<T> = (T | void, Action) => T;
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {|
   +selectedCallNodePath: CallNodePath,
-  +rightClickedCallNodePath: CallNodePath | null,
   +expandedCallNodePaths: PathSet,
   +selectedMarker: MarkerIndex | null,
-  +rightClickedMarker: MarkerIndex | null,
+|};
+
+export type RightClickedCallNode = {|
+  +threadIndex: ThreadIndex,
+  +callNodePath: CallNodePath,
+|};
+
+export type RightClickedMarker = {|
+  +threadIndex: ThreadIndex,
+  +markerIndex: MarkerIndex,
 |};
 
 export type ProfileViewState = {|
@@ -53,6 +61,8 @@ export type ProfileViewState = {|
     focusCallTreeGeneration: number,
     rootRange: StartEndRange,
     rightClickedTrack: TrackReference | null,
+    rightClickedCallNode: RightClickedCallNode | null,
+    rightClickedMarker: RightClickedMarker | null,
   |},
   +globalTracks: GlobalTrack[],
   +localTracksByPid: Map<Pid, LocalTrack[]>,


### PR DESCRIPTION
This is simply #2305 squashed and rebased on top of #2467. No other change was done so I plan to land this without a review once #2467 lands.

[deploy preview for the problematic profile](https://deploy-preview-2468--perf-html.netlify.com/public/c78aeffd46f820c8e7337c20b4e16bd104cd556e/calltree/?globalTrackOrder=0&localTrackOrderByPid=30853-0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25-26-27-28-29-30-31-32-33-34-35-36-37-38-39-40-41-42-43-44-45-46-47-48-49-50-51-52-53-54-55-56-57-58-59-60-61-62-63-64-65-66-67-68-69-70-71-72-73-74-75-76-77-78-79-80-81-82-83-84-85-86-87-88-89-90-91-92-93-94-95-96-97-98-99-100-101-102-103-104-105-106-107-108-109-110-111-112-113-114-115-116-117-118-119-120-121-122-123-124-125~&thread=0&timelineType=stack&v=4)
[deploy preview for a normal profile](https://deploy-preview-2468--perf-html.netlify.com/public/bf89d8af7ead8296ab59ad51a0b25acef7d18425/marker-chart/?globalTrackOrder=9-0-1-2-3-4-5-6-7-8&hiddenGlobalTracks=1-2-3-4-5-7&hiddenLocalTracksByPid=29369-1&localTrackOrderByPid=4411-1-0~29588-0~29567-0~19549-0~19528-0~30211-0~29369-2-0-1~29522-0~29476-0~&thread=11&v=4)