### PR TITLE
Move timeline track context menu inside the timeline

### DIFF
--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -25,7 +25,6 @@ import { getIsSidebarOpen } from '../../selectors/app';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerContextMenu from '../shared/MarkerContextMenu';
-import TimelineTrackContextMenu from '../timeline/TrackContextMenu';
 import { toValidTabSlug } from '../../utils/flow';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -107,7 +106,6 @@ class ProfileViewer extends PureComponent<Props> {
         </ErrorBoundary>
         <CallNodeContextMenu />
         <MarkerContextMenu />
-        <TimelineTrackContextMenu />
       </div>
     );
   }

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -32,6 +32,7 @@ import {
   TIMELINE_MARGIN_RIGHT,
   TIMELINE_SETTINGS_HEIGHT,
 } from '../../app-logic/constants';
+import TimelineTrackContextMenu from './TrackContextMenu';
 
 import './index.css';
 
@@ -293,6 +294,7 @@ class Timeline extends React.PureComponent<Props, State> {
             </Reorderable>
           </OverflowEdgeIndicator>
         </TimelineSelection>
+        <TimelineTrackContextMenu />
       </>
     );
   }


### PR DESCRIPTION
I'm working on the timeline right now and there are some unrelated but necessary commits inside that I can land independently. So to reduce the complexity of the bigger PR, I wanted to extract and land these before that. This is a pretty small PR, but there will be some other PRs after this.

This is a prerequisite of the main PR for #2423.