### PR TITLE
Fix the transform key changes during publish of sanitized profile

### DIFF
--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -199,7 +199,7 @@ const transforms: Reducer<TransformStacksPerThread> = (state = {}, action) => {
       // This may no longer be valid because of PII sanitization.
       const newTransforms = {};
       for (const [threadIndex, transformStack] of objectEntries(state)) {
-        const newThreadIndex = oldThreadIndexToNew.get(threadIndex);
+        const newThreadIndex = oldThreadIndexToNew.get(Number(threadIndex));
         if (newThreadIndex !== undefined) {
           newTransforms[newThreadIndex] = transformStack;
         }


### PR DESCRIPTION
Since Object.entries returns the key values as string only, the numeric
keys of oldThreadIndexToNew were getting converted into strings.
Therefore we had to cast those indexes back to numbers.

Bug STR:
1. Load [this profile](https://profiler.firefox.com/public/b919767dac79248386b75350e0000ff8c37ddd2b/calltree/?globalTrackOrder=0-1&hiddenLocalTracksByPid=7738-0&localTrackOrderByPid=7738-1-2-0~7790-0-1~&thread=2&transforms=f-combined-012345~ff-9~mcn-combined-9abh&v=4) (note that the Compositor thread is hidden, and the added transforms are on the next thread. Compositor's thread index is 1 and Web Content's index is 2.)
2. Uncheck the "Include hidden threads" checkbox and re-publish the profile.
3. Now Compositor thread is removed, but see that the transforms are no longer there.

Expected Result: Transforms should still be there.

Fixes #2461.