### PR TITLE
Remove the "show active tab only" checkbox for now 

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -100,7 +100,7 @@ type BaseQuery = {|
   hiddenThreads: string, // "0-1"
   profiles: string[],
   profileName: string,
-  showTabOnly: BrowsingContextID,
+  showTabOnly1: BrowsingContextID,
 |};
 
 type CallTreeQuery = {|
@@ -192,7 +192,7 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     profiles: urlState.profilesToCompare || undefined,
     v: CURRENT_URL_VERSION,
     profileName: urlState.profileName || undefined,
-    showTabOnly: urlState.showTabOnly || undefined,
+    showTabOnly1: urlState.showTabOnly || undefined,
   };
 
   // Add the parameter hiddenGlobalTracks only when needed.
@@ -365,8 +365,8 @@ export function stateFromLocation(
   }
 
   let showTabOnly = null;
-  if (query.showTabOnly && Number.isInteger(Number(query.showTabOnly))) {
-    showTabOnly = Number(query.showTabOnly);
+  if (query.showTabOnly1 && Number.isInteger(Number(query.showTabOnly1))) {
+    showTabOnly = Number(query.showTabOnly1);
   }
 
   return {

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -257,11 +257,18 @@ class Timeline extends React.PureComponent<Props, State> {
             hiddenTrackCount={hiddenTrackCount}
             changeRightClickedTrack={changeRightClickedTrack}
           />
-          <TimelineSettingsActiveTabView
-            activeBrowsingContextID={activeBrowsingContextID}
-            showTabOnly={showTabOnly}
-            changeShowTabOnly={changeShowTabOnly}
-          />
+          {/*
+            Removing the active tab view checkbox for now.
+            TODO: Bring it back once we are done with the new active tab UI implementation.
+           */}
+          {/* eslint-disable-next-line no-constant-condition */}
+          {true ? null : (
+            <TimelineSettingsActiveTabView
+              activeBrowsingContextID={activeBrowsingContextID}
+              showTabOnly={showTabOnly}
+              changeShowTabOnly={changeShowTabOnly}
+            />
+          )}
         </div>
         <TimelineSelection width={timelineWidth}>
           <TimelineRuler

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -113,7 +113,10 @@ describe('Timeline', function() {
     delete window.devicePixelRatio;
   });
 
-  describe('TimelineSettingsActiveTabView', function() {
+  // These tests are disabled for now because active tab view checkbox is disabled for now.
+  // TODO: Enable it again once we have that checbox back.
+  // eslint-disable-next-line jest/no-disabled-tests
+  describe.skip('TimelineSettingsActiveTabView', function() {
     it('"Show active tab only" checkbox should not present in a profile without active tab metadata', () => {
       const ctx = mockCanvasContext();
       jest

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -388,12 +388,12 @@ describe('showTabOnly', function() {
     dispatch(changeShowTabOnly(showTabOnly));
     const urlState = urlStateReducers.getUrlState(getState());
     const { query } = urlStateToUrlObject(urlState);
-    expect(query.showTabOnly).toBe(showTabOnly);
+    expect(query.showTabOnly1).toBe(showTabOnly);
   });
 
   it('reflects in the state from URL', function() {
     const { getState } = _getStoreWithURL({
-      search: '?showTabOnly=123',
+      search: '?showTabOnly1=123',
     });
     expect(urlStateReducers.getShowTabOnly(getState())).toBe(123);
   });


### PR DESCRIPTION
This PR:
 - Removes the "show active tab only" checkbox
We are currently in a transition from the old timeline to a simpler timeline with a different UI. To be able to land this gradually, we are removing this and we are going to bring it back once the timeline is complete.
- Changes the query string variable to`showTabOnly1`
So we can still use it to enter manually, but older profiles will redirect to the full view for now. Once we are done with the implementation we can change that back to `showTabOnly` or something nicer.

