### PR TITLE
Split the profile view state and profile loading mechanism

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -49,12 +49,7 @@ import type {
 } from '../types/actions';
 import type { State } from '../types/state';
 import type { Action, ThunkAction } from '../types/store';
-import type {
-  ThreadIndex,
-  Pid,
-  IndexIntoSamplesTable,
-  BrowsingContextID,
-} from '../types/profile';
+import type { ThreadIndex, Pid, IndexIntoSamplesTable } from '../types/profile';
 import type {
   CallNodePath,
   CallNodeInfo,
@@ -1166,42 +1161,6 @@ export function changeProfileName(profileName: string): Action {
   return {
     type: 'CHANGE_PROFILE_NAME',
     profileName,
-  };
-}
-
-export function changeShowTabOnly(
-  showTabOnly: BrowsingContextID | null
-): ThunkAction<void> {
-  return (dispatch, getState) => {
-    let selectedTab = getSelectedTab(getState());
-
-    if (showTabOnly !== null && selectedTab === 'network-chart') {
-      selectedTab = getLastVisibleThreadTabSlug(getState());
-    }
-
-    let selectedThreadIndex = null;
-    if (showTabOnly !== null) {
-      // Select the first visible thread when we are transitioning to tab only view.
-      selectedThreadIndex = _findOtherVisibleThread(
-        getState,
-        undefined, // Do not filter out any track.
-        undefined,
-        true // ignore the hidden tracks by active tab
-      );
-
-      if (selectedThreadIndex === null) {
-        // We should revert to the first view, because all the threads are hidden
-        // in the single tab view and we won't be able to see anything there.
-        return;
-      }
-    }
-
-    dispatch({
-      type: 'CHANGE_SHOW_TAB_ONLY',
-      showTabOnly,
-      selectedTab,
-      selectedThreadIndex,
-    });
   };
 }
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -25,6 +25,7 @@ import {
   getLocalTrackOrderByPid,
   getLegacyThreadOrder,
   getLegacyHiddenThreads,
+  getShowTabOnly,
 } from '../selectors/url-state';
 import {
   stateFromLocation,
@@ -152,7 +153,143 @@ export function finalizeProfileView(
     // The selectedThreadIndex is only null for new profiles that haven't
     // been seen before. If it's non-null, then there is profile view information
     // encoded into the URL.
-    let selectedThreadIndex = getSelectedThreadIndexOrNull(getState());
+    const selectedThreadIndex = getSelectedThreadIndexOrNull(getState());
+
+    if (selectedThreadIndex !== null && getShowTabOnly(getState()) !== null) {
+      // The url state says this is an active tab view. We should compute and
+      // initialize the state relevant to that state.
+      dispatch(finalizeActiveTabProfileView(profile, selectedThreadIndex));
+    } else {
+      // The url state says this is a full view. We should compute and initialize
+      // the state relevant to that state.
+      dispatch(finalizeFullProfileView(profile, selectedThreadIndex));
+    }
+
+    // Note we kick off symbolication only for the profiles we know for sure
+    // that they weren't symbolicated.
+    if (profile.meta.symbolicated === false) {
+      const symbolStore = getSymbolStore(dispatch, geckoProfiler);
+      if (symbolStore) {
+        // Only symbolicate if a symbol store is available. In tests we may not
+        // have access to IndexedDB.
+        await doSymbolicateProfile(dispatch, profile, symbolStore);
+      }
+    }
+  };
+}
+
+/**
+ * Finalize the profile state for full view.
+ * This function will take the view information from the URL, such as hiding and sorting
+ * information, and it will validate it against the profile. If there is no pre-existing
+ * view information, this function will compute the defaults.
+ */
+export function finalizeFullProfileView(
+  profile: Profile,
+  selectedThreadIndex: ThreadIndex | null
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const hasUrlInfo = selectedThreadIndex !== null;
+
+    const globalTracks = computeGlobalTracks(profile);
+    const globalTrackOrder = initializeGlobalTrackOrder(
+      globalTracks,
+      hasUrlInfo ? getGlobalTrackOrder(getState()) : null,
+      getLegacyThreadOrder(getState())
+    );
+    let hiddenGlobalTracks = initializeHiddenGlobalTracks(
+      globalTracks,
+      profile,
+      globalTrackOrder,
+      hasUrlInfo ? getHiddenGlobalTracks(getState()) : null,
+      getLegacyHiddenThreads(getState())
+    );
+    const localTracksByPid = computeLocalTracksByPid(profile);
+    const localTrackOrderByPid = initializeLocalTrackOrderByPid(
+      hasUrlInfo ? getLocalTrackOrderByPid(getState()) : null,
+      localTracksByPid,
+      getLegacyThreadOrder(getState())
+    );
+    let hiddenLocalTracksByPid = initializeHiddenLocalTracksByPid(
+      hasUrlInfo ? getHiddenLocalTracksByPid(getState()) : null,
+      localTracksByPid,
+      profile,
+      getLegacyHiddenThreads(getState())
+    );
+    let visibleThreadIndexes = getVisibleThreads(
+      globalTracks,
+      hiddenGlobalTracks,
+      localTracksByPid,
+      hiddenLocalTracksByPid
+    );
+
+    // This validity check can't be extracted into a separate function, as it needs
+    // to update a lot of the local variables in this function.
+    if (visibleThreadIndexes.length === 0) {
+      // All threads are hidden, since this can't happen normally, revert them all.
+      visibleThreadIndexes = profile.threads.map(
+        (_, threadIndex) => threadIndex
+      );
+      hiddenGlobalTracks = new Set();
+      const newHiddenTracksByPid = new Map();
+      for (const [pid] of hiddenLocalTracksByPid) {
+        newHiddenTracksByPid.set(pid, new Set());
+      }
+      hiddenLocalTracksByPid = newHiddenTracksByPid;
+    }
+
+    selectedThreadIndex = initializeSelectedThreadIndex(
+      selectedThreadIndex,
+      visibleThreadIndexes,
+      profile
+    );
+
+    // If all of the local tracks were hidden for a process, and the main thread was
+    // not recorded for that process, hide the (empty) process track as well.
+    for (const [pid, localTracks] of localTracksByPid) {
+      const hiddenLocalTracks = hiddenLocalTracksByPid.get(pid);
+      if (!hiddenLocalTracks) {
+        continue;
+      }
+      if (hiddenLocalTracks.size === localTracks.length) {
+        // All of the local tracks were hidden.
+        const globalTrackIndex = globalTracks.findIndex(
+          globalTrack =>
+            globalTrack.type === 'process' &&
+            globalTrack.pid === pid &&
+            globalTrack.mainThreadIndex === null
+        );
+        if (globalTrackIndex !== -1) {
+          // An empty global track was found, hide it.
+          hiddenGlobalTracks.add(globalTrackIndex);
+        }
+      }
+    }
+
+    dispatch({
+      type: 'VIEW_FULL_PROFILE',
+      selectedThreadIndex,
+      globalTracks,
+      globalTrackOrder,
+      hiddenGlobalTracks,
+      localTracksByPid,
+      hiddenLocalTracksByPid,
+      localTrackOrderByPid,
+    });
+  };
+}
+
+/**
+ * Finalize the profile state for active tab view.
+ * This function will take the view information from the URL, such as hiding and sorting
+ * information, and it will validate it against the profile. If there is no pre-existing
+ * view information, this function will compute the defaults.
+ */
+export function finalizeActiveTabProfileView(
+  profile: Profile,
+  selectedThreadIndex: ThreadIndex
+): ThunkAction<void> {
+  return (dispatch, getState) => {
     const hasUrlInfo = selectedThreadIndex !== null;
 
     const globalTracks = computeGlobalTracks(profile);
@@ -243,7 +380,7 @@ export function finalizeProfileView(
     }
 
     dispatch({
-      type: 'VIEW_FULL_PROFILE',
+      type: 'VIEW_ACTIVE_TAB_PROFILE',
       selectedThreadIndex,
       globalTracks,
       globalTrackOrder,
@@ -254,17 +391,6 @@ export function finalizeProfileView(
       activeTabHiddenGlobalTracksGetter,
       activeTabHiddenLocalTracksByPidGetter,
     });
-
-    // Note we kick off symbolication only for the profiles we know for sure
-    // that they weren't symbolicated.
-    if (profile.meta.symbolicated === false) {
-      const symbolStore = getSymbolStore(dispatch, geckoProfiler);
-      if (symbolStore) {
-        // Only symbolicate if a symbol store is available. In tests we may not
-        // have access to IndexedDB.
-        await doSymbolicateProfile(dispatch, profile, symbolStore);
-      }
-    }
   };
 }
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -243,7 +243,7 @@ export function finalizeProfileView(
     }
 
     dispatch({
-      type: 'VIEW_PROFILE',
+      type: 'VIEW_FULL_PROFILE',
       selectedThreadIndex,
       globalTracks,
       globalTrackOrder,

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -54,6 +54,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
     switch (phase) {
       case 'INITIALIZING':
       case 'PROFILE_LOADED':
+      case 'DATA_RELOAD':
         return <ProfileLoaderAnimation />;
       case 'FATAL_ERROR': {
         const message =

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -42,8 +42,8 @@ import {
   changeGlobalTrackOrder,
   changeTimelineType,
   changeRightClickedTrack,
-  changeShowTabOnly,
 } from '../../actions/profile-view';
+import { changeViewAndRecomputeProfileData } from '../../actions/receive-profile';
 
 import type { BrowsingContextID } from '../../types/profile';
 import type {
@@ -76,7 +76,7 @@ type DispatchProps = {|
   +changeGlobalTrackOrder: typeof changeGlobalTrackOrder,
   +changeTimelineType: typeof changeTimelineType,
   +changeRightClickedTrack: typeof changeRightClickedTrack,
-  +changeShowTabOnly: typeof changeShowTabOnly,
+  +changeViewAndRecomputeProfileData: typeof changeViewAndRecomputeProfileData,
 |};
 
 type Props = {|
@@ -168,18 +168,18 @@ class TimelineSettingsHiddenTracks extends React.PureComponent<{|
 class TimelineSettingsActiveTabView extends React.PureComponent<{|
   +activeBrowsingContextID: BrowsingContextID | null,
   +showTabOnly: BrowsingContextID | null,
-  +changeShowTabOnly: typeof changeShowTabOnly,
+  +changeViewAndRecomputeProfileData: typeof changeViewAndRecomputeProfileData,
 |}> {
   _toggleShowTabOnly = () => {
     const {
       showTabOnly,
-      changeShowTabOnly,
+      changeViewAndRecomputeProfileData,
       activeBrowsingContextID,
     } = this.props;
     if (showTabOnly === null) {
-      changeShowTabOnly(activeBrowsingContextID);
+      changeViewAndRecomputeProfileData(activeBrowsingContextID);
     } else {
-      changeShowTabOnly(null);
+      changeViewAndRecomputeProfileData(null);
     }
   };
 
@@ -235,7 +235,7 @@ class Timeline extends React.PureComponent<Props, State> {
       changeRightClickedTrack,
       activeBrowsingContextID,
       showTabOnly,
-      changeShowTabOnly,
+      changeViewAndRecomputeProfileData,
     } = this.props;
 
     // Do not include the left and right margins when computing the timeline width.
@@ -266,7 +266,9 @@ class Timeline extends React.PureComponent<Props, State> {
             <TimelineSettingsActiveTabView
               activeBrowsingContextID={activeBrowsingContextID}
               showTabOnly={showTabOnly}
-              changeShowTabOnly={changeShowTabOnly}
+              changeViewAndRecomputeProfileData={
+                changeViewAndRecomputeProfileData
+              }
             />
           )}
         </div>
@@ -324,7 +326,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     changeGlobalTrackOrder,
     changeTimelineType,
     changeRightClickedTrack,
-    changeShowTabOnly,
+    changeViewAndRecomputeProfileData,
   },
   component: withSize<Props>(Timeline),
 });

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -42,6 +42,8 @@ const view: Reducer<AppViewState> = (
       return { phase: 'TRANSITIONING_FROM_STALE_PROFILE' };
     case 'PROFILE_LOADED':
       return { phase: 'PROFILE_LOADED' };
+    case 'DATA_RELOAD':
+      return { phase: 'DATA_RELOAD' };
     case 'RECEIVE_ZIP_FILE':
     case 'VIEW_FULL_PROFILE':
     case 'VIEW_ACTIVE_TAB_PROFILE':
@@ -146,7 +148,6 @@ const lastVisibleThreadTabSlug: Reducer<TabSlug> = (
   switch (action.type) {
     case 'SELECT_TRACK':
     case 'CHANGE_SELECTED_TAB':
-    case 'CHANGE_SHOW_TAB_ONLY':
       if (action.selectedTab !== 'network-chart') {
         return action.selectedTab;
       }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -43,7 +43,7 @@ const view: Reducer<AppViewState> = (
     case 'PROFILE_LOADED':
       return { phase: 'PROFILE_LOADED' };
     case 'RECEIVE_ZIP_FILE':
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return { phase: 'DATA_LOADED' };
     default:
       return state;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -44,6 +44,7 @@ const view: Reducer<AppViewState> = (
       return { phase: 'PROFILE_LOADED' };
     case 'RECEIVE_ZIP_FILE':
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return { phase: 'DATA_LOADED' };
     default:
       return state;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -92,6 +92,7 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
 const globalTracks: Reducer<GlobalTrack[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.globalTracks;
     default:
       return state;
@@ -108,6 +109,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.localTracksByPid;
     default:
       return state;
@@ -124,7 +126,7 @@ const activeTabHiddenGlobalTracksGetter: Reducer<() => Set<TrackIndex>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.activeTabHiddenGlobalTracksGetter;
     default:
       return state;
@@ -139,7 +141,7 @@ const activeTabHiddenLocalTracksByPidGetter: Reducer<
   () => Map<Pid, Set<TrackIndex>>
 > = (state = () => new Map(), action) => {
   switch (action.type) {
-    case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.activeTabHiddenLocalTracksByPidGetter;
     default:
       return state;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -622,7 +622,7 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
     globalTracks,
     localTracksByPid,
     profile,
-    activeTabProfile: combineReducers({
+    activeTab: combineReducers({
       hiddenGlobalTracksGetter: activeTabHiddenGlobalTracksGetter,
       hiddenLocalTracksByPidGetter: activeTabHiddenLocalTracksByPidGetter,
     }),

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -620,9 +620,11 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
     }),
     globalTracks,
     localTracksByPid,
-    activeTabHiddenGlobalTracksGetter,
-    activeTabHiddenLocalTracksByPidGetter,
     profile,
+    activeTabProfile: combineReducers({
+      hiddenGlobalTracksGetter: activeTabHiddenGlobalTracksGetter,
+      hiddenLocalTracksByPidGetter: activeTabHiddenLocalTracksByPidGetter,
+    }),
   })
 );
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -452,7 +452,6 @@ const scrollToSelectionGeneration: Reducer<number> = (state = 0, action) => {
     case 'HIDE_GLOBAL_TRACK':
     case 'HIDE_LOCAL_TRACK':
     case 'CHANGE_SELECTED_MARKER':
-    case 'CHANGE_SHOW_TAB_ONLY':
       return state + 1;
     default:
       return state;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -91,7 +91,7 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
  */
 const globalTracks: Reducer<GlobalTrack[]> = (state = [], action) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return action.globalTracks;
     default:
       return state;
@@ -107,7 +107,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return action.localTracksByPid;
     default:
       return state;
@@ -124,7 +124,7 @@ const activeTabHiddenGlobalTracksGetter: Reducer<() => Set<TrackIndex>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return action.activeTabHiddenGlobalTracksGetter;
     default:
       return state;
@@ -139,7 +139,7 @@ const activeTabHiddenLocalTracksByPidGetter: Reducer<
   () => Map<Pid, Set<TrackIndex>>
 > = (state = () => new Map(), action) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return action.activeTabHiddenLocalTracksByPidGetter;
     default:
       return state;

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -180,7 +180,7 @@ const isHidingStaleProfile: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'HIDE_STALE_PROFILE':
       return true;
-    case 'VIEW_PROFILE': // TODO: should this be PROFILE_LOADED?
+    case 'VIEW_FULL_PROFILE':
       return false;
     default:
       return state;

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -181,6 +181,7 @@ const isHidingStaleProfile: Reducer<boolean> = (state = false, action) => {
     case 'HIDE_STALE_PROFILE':
       return true;
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return false;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -111,6 +111,7 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
     case 'CHANGE_SELECTED_THREAD':
     case 'SELECT_TRACK':
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'HIDE_GLOBAL_TRACK':
@@ -292,6 +293,7 @@ const showJsTracerSummary: Reducer<boolean> = (state = false, action) => {
 const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
       return action.globalTrackOrder;
     case 'SANITIZED_PROFILE_PUBLISHED':
@@ -309,6 +311,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
     case 'ISOLATE_LOCAL_TRACK':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
@@ -339,6 +342,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.hiddenLocalTracksByPid;
     case 'HIDE_LOCAL_TRACK': {
       const hiddenLocalTracksByPid = new Map(state);
@@ -374,6 +378,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -83,7 +83,6 @@ const selectedTab: Reducer<TabSlug> = (state = 'calltree', action) => {
   switch (action.type) {
     case 'CHANGE_SELECTED_TAB':
     case 'SELECT_TRACK':
-    case 'CHANGE_SHOW_TAB_ONLY':
       return action.selectedTab;
     default:
       return state;
@@ -135,12 +134,6 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
       }
       return newThreadIndex;
     }
-    case 'CHANGE_SHOW_TAB_ONLY':
-      if (action.selectedThreadIndex === null) {
-        // Do not change the selected thread if we don't have to.
-        return state;
-      }
-      return action.selectedThreadIndex;
     default:
       return state;
   }
@@ -421,8 +414,13 @@ const showTabOnly: Reducer<BrowsingContextID | null> = (
   action
 ) => {
   switch (action.type) {
-    case 'CHANGE_SHOW_TAB_ONLY':
-      return action.showTabOnly;
+    case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
+      if (action.showTabOnly !== undefined) {
+        // Do not change the state if it's undefined.
+        return action.showTabOnly;
+      }
+      return state;
     default:
       return state;
   }

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -110,7 +110,7 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
   switch (action.type) {
     case 'CHANGE_SELECTED_THREAD':
     case 'SELECT_TRACK':
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'HIDE_GLOBAL_TRACK':
@@ -291,7 +291,7 @@ const showJsTracerSummary: Reducer<boolean> = (state = false, action) => {
 
 const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
       return action.globalTrackOrder;
     case 'SANITIZED_PROFILE_PUBLISHED':
@@ -308,7 +308,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
     case 'ISOLATE_LOCAL_TRACK':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
@@ -338,7 +338,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return action.hiddenLocalTracksByPid;
     case 'HIDE_LOCAL_TRACK': {
       const hiddenLocalTracksByPid = new Map(state);
@@ -373,7 +373,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/reducers/zipped-profiles.js
+++ b/src/reducers/zipped-profiles.js
@@ -87,6 +87,7 @@ const zipFile: Reducer<ZipFileState> = (
             pathInZipFile: ensureExists(state.pathInZipFile),
           });
     case 'VIEW_FULL_PROFILE':
+    case 'VIEW_ACTIVE_TAB_PROFILE':
       // Only process this as a change if a zip file is actually loaded.
       return state.phase === 'NO_ZIP_FILE'
         ? state

--- a/src/reducers/zipped-profiles.js
+++ b/src/reducers/zipped-profiles.js
@@ -86,7 +86,7 @@ const zipFile: Reducer<ZipFileState> = (
             zip: ensureExists(state.zip),
             pathInZipFile: ensureExists(state.pathInZipFile),
           });
-    case 'VIEW_PROFILE':
+    case 'VIEW_FULL_PROFILE':
       // Only process this as a change if a zip file is actually loaded.
       return state.phase === 'NO_ZIP_FILE'
         ? state

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -238,9 +238,6 @@ export const getIPCMarkerCorrelations: Selector<IPCMarkerCorrelations> = createS
  */
 export const getGlobalTracks: Selector<GlobalTrack[]> = state =>
   getProfileView(state).globalTracks;
-export const getActiveTabHiddenGlobalTracksGetter: Selector<
-  () => Set<TrackIndex>
-> = state => getActiveTabProfileView(state).hiddenGlobalTracksGetter;
 
 /**
  * This returns all TrackReferences for global tracks.
@@ -308,9 +305,6 @@ export const getGlobalTrackAndIndexByPid: DangerousSelectorWithArguments<
  */
 export const getLocalTracksByPid: Selector<Map<Pid, LocalTrack[]>> = state =>
   getProfileView(state).localTracksByPid;
-export const getActiveTabHiddenLocalTracksByPidGetter: Selector<
-  () => Map<Pid, Set<TrackIndex>>
-> = state => getActiveTabProfileView(state).hiddenLocalTracksByPidGetter;
 
 /**
  * This selectors performs a simple look up in a Map, throws an error if it doesn't exist,
@@ -417,6 +411,17 @@ export const getLocalTrackName = (
     getLocalTrackNamesByPid(state).get(pid),
     'Could not find the track names from the given pid'
   )[trackIndex];
+
+/**
+ * Active tab profile selectors
+ */
+export const getActiveTabHiddenGlobalTracksGetter: Selector<
+  () => Set<TrackIndex>
+> = state => getActiveTabProfileView(state).hiddenGlobalTracksGetter;
+
+export const getActiveTabHiddenLocalTracksByPidGetter: Selector<
+  () => Map<Pid, Set<TrackIndex>>
+> = state => getActiveTabProfileView(state).hiddenLocalTracksByPidGetter;
 
 /**
  * It's a bit hard to deduce the total amount of hidden tracks, as there are both

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -54,11 +54,14 @@ import type {
   State,
   ProfileViewState,
   SymbolicationStatus,
+  ActiveTabProfileViewState,
 } from '../types/state';
 import type { $ReturnType } from '../types/utils';
 
 export const getProfileView: Selector<ProfileViewState> = state =>
   state.profileView;
+export const getActiveTabProfileView: Selector<ActiveTabProfileViewState> = state =>
+  getProfileView(state).activeTabProfile;
 
 /**
  * Profile View Options
@@ -237,7 +240,7 @@ export const getGlobalTracks: Selector<GlobalTrack[]> = state =>
   getProfileView(state).globalTracks;
 export const getActiveTabHiddenGlobalTracksGetter: Selector<
   () => Set<TrackIndex>
-> = state => getProfileView(state).activeTabHiddenGlobalTracksGetter;
+> = state => getActiveTabProfileView(state).hiddenGlobalTracksGetter;
 
 /**
  * This returns all TrackReferences for global tracks.
@@ -307,7 +310,7 @@ export const getLocalTracksByPid: Selector<Map<Pid, LocalTrack[]>> = state =>
   getProfileView(state).localTracksByPid;
 export const getActiveTabHiddenLocalTracksByPidGetter: Selector<
   () => Map<Pid, Set<TrackIndex>>
-> = state => getProfileView(state).activeTabHiddenLocalTracksByPidGetter;
+> = state => getActiveTabProfileView(state).hiddenLocalTracksByPidGetter;
 
 /**
  * This selectors performs a simple look up in a Map, throws an error if it doesn't exist,

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -61,7 +61,7 @@ import type { $ReturnType } from '../types/utils';
 export const getProfileView: Selector<ProfileViewState> = state =>
   state.profileView;
 export const getActiveTabProfileView: Selector<ActiveTabProfileViewState> = state =>
-  getProfileView(state).activeTabProfile;
+  getProfileView(state).activeTab;
 
 /**
  * Profile View Options

--- a/src/test/components/FilterNavigatorBar.test.js
+++ b/src/test/components/FilterNavigatorBar.test.js
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux';
 
 import ProfileFilterNavigator from '../../components/app/ProfileFilterNavigator';
 import * as ProfileView from '../../actions/profile-view';
+import * as ReceiveProfile from '../../actions/receive-profile';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
@@ -83,13 +84,17 @@ describe('app/ProfileFilterNavigator', () => {
 
   it('renders the site hostname as its first element in the single tab view', () => {
     const { dispatch, container } = setup();
-    dispatch(ProfileView.changeShowTabOnly(browsingContextID));
+    dispatch(
+      ReceiveProfile.changeViewAndRecomputeProfileData(browsingContextID)
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('displays the site hostname as its first element in the single tab view', () => {
     const { dispatch, queryByText } = setup();
-    dispatch(ProfileView.changeShowTabOnly(browsingContextID));
+    dispatch(
+      ReceiveProfile.changeViewAndRecomputeProfileData(browsingContextID)
+    );
     expect(queryByText('Full Range')).toBeFalsy();
     // Using regexp because searching for a partial text.
     expect(queryByText(/developer\.mozilla\.org/)).toBeTruthy();

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -12,8 +12,8 @@ import { ensureExists } from '../../utils/flow';
 import {
   changeSelectedThread,
   changeRightClickedTrack,
-  changeShowTabOnly,
 } from '../../actions/profile-view';
+import { changeViewAndRecomputeProfileData } from '../../actions/receive-profile';
 import TrackContextMenu from '../../components/timeline/TrackContextMenu';
 import { getGlobalTracks, getLocalTracks } from '../../selectors/profile';
 import {
@@ -206,7 +206,7 @@ describe('timeline/TrackContextMenu', function() {
         0
       );
       // parameter doesn't matter here, it can be anything except null.
-      dispatch(changeShowTabOnly(111));
+      dispatch(changeViewAndRecomputeProfileData(111));
       // We can't use getHumanReadableTracks here because that function doesn't
       // use the functions used by context menu directly and gives us wrong results.
       expect(container.firstChild).toMatchSnapshot();

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -108,16 +108,15 @@ export function getHumanReadableTracks(state: State): string[] {
           state,
           globalTrack.pid
         );
-        const activeTabHiddenLocalTracks = ensureExists(
-          activeTabHiddenLocalTracksByPid.get(globalTrack.pid)
-        );
 
-        if (
-          showTabOnly !== null &&
-          activeTabHiddenLocalTracks.has(trackIndex)
-        ) {
-          // If we are in active tab view, hide this track completely,
-          continue;
+        if (showTabOnly !== null) {
+          const activeTabHiddenLocalTracks = ensureExists(
+            activeTabHiddenLocalTracksByPid.get(globalTrack.pid)
+          );
+          if (activeTabHiddenLocalTracks.has(trackIndex)) {
+            // If we are in active tab view, hide this track completely,
+            continue;
+          }
         }
         const hiddenText = hiddenTracks.has(trackIndex) ? 'hide' : 'show';
         const selected =

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -9,7 +9,7 @@ import {
   getProfileWithMarkers,
   getNetworkTrackProfile,
 } from '../fixtures/profiles/processed-profile';
-import { changeShowTabOnly } from '../../actions/profile-view';
+import { changeViewAndRecomputeProfileData } from '../../actions/receive-profile';
 
 describe('selectors/getMarkerChartTimingAndBuckets', function() {
   function getMarkerChartTimingAndBuckets(testMarkers) {
@@ -427,7 +427,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function() {
     const { getState, dispatch } = storeWithProfile(profile);
 
     if (showTabOnly) {
-      dispatch(changeShowTabOnly(browsingContextID));
+      dispatch(changeViewAndRecomputeProfileData(browsingContextID));
     }
     const markerIndexes = selectedThreadSelectors.getCommittedRangeAndTabFilteredMarkerIndexes(
       getState()

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -29,7 +29,10 @@ import { assertSetContainsOnly } from '../fixtures/custom-assertions';
 
 import * as App from '../../actions/app';
 import * as ProfileView from '../../actions/profile-view';
-import { viewProfile } from '../../actions/receive-profile';
+import {
+  viewProfile,
+  changeViewAndRecomputeProfileData,
+} from '../../actions/receive-profile';
 import * as ProfileViewSelectors from '../../selectors/profile';
 import * as UrlStateSelectors from '../../selectors/url-state';
 import { getRightClickedCallNodeInfo } from '../../selectors/right-clicked-call-node';
@@ -1658,7 +1661,7 @@ describe('snapshots of selectors/profile', function() {
   it('matches the last stored run of selectedThreadSelector.getTabFilteredThread', function() {
     const { getState, dispatch } = setupStore();
 
-    dispatch(ProfileView.changeShowTabOnly(browsingContextID));
+    dispatch(changeViewAndRecomputeProfileData(browsingContextID));
     expect(
       selectedThreadSelectors.getTabFilteredThread(getState())
     ).toMatchSnapshot();
@@ -2938,7 +2941,7 @@ describe('pages and active tab selectors', function() {
     profile.threads.push(getEmptyThread());
 
     const { dispatch, getState } = storeWithProfile(profile);
-    dispatch(ProfileView.changeShowTabOnly(activeBrowsingContextID));
+    dispatch(changeViewAndRecomputeProfileData(activeBrowsingContextID));
     return { profile, dispatch, getState };
   }
 

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -30,12 +30,9 @@ import {
   retrieveProfilesToCompare,
   _fetchProfile,
   getProfilesFromRawUrl,
+  changeViewAndRecomputeProfileData,
 } from '../../actions/receive-profile';
 import { SymbolsNotFoundError } from '../../profile-logic/errors';
-import {
-  changeShowTabOnly,
-  changeSelectedThread,
-} from '../../actions/profile-view';
 import fakeIndexedDB from 'fake-indexeddb';
 
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
@@ -450,7 +447,7 @@ describe('actions/receive-profile', function() {
 
         store.dispatch(viewProfile(profile));
         if (dispatchToShowTabOnly) {
-          store.dispatch(changeShowTabOnly(browsingContextID));
+          store.dispatch(changeViewAndRecomputeProfileData(browsingContextID));
         }
 
         return { ...store, profile };
@@ -459,7 +456,7 @@ describe('actions/receive-profile', function() {
       it('should calculate the hidden tracks correctly', function() {
         const { getState } = setup();
         expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain tab] SELECTED',
+          'show [thread GeckoMain tab]',
         ]);
       });
 
@@ -472,7 +469,7 @@ describe('actions/receive-profile', function() {
         expect(getHumanReadableTracks(getState())).toEqual([
           'show [screenshots]',
           'show [screenshots]',
-          'show [thread GeckoMain tab] SELECTED',
+          'show [thread GeckoMain tab]',
         ]);
       });
 
@@ -499,57 +496,8 @@ describe('actions/receive-profile', function() {
 
         const { getState } = setup(profile);
         expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain tab] SELECTED',
-          '  - show [thread Other2]',
-        ]);
-      });
-
-      it('should select the first visible thread during changeShowTabOnly action', function() {
-        const { profile } = getProfileFromTextSamples(
-          `work  work  work`,
-          `work  work  work`
-        );
-        // There is one main thread and two other threads that belong to the same process.
-        const [threadA, threadB] = profile.threads;
-        threadA.name = 'GeckoMain';
-        threadA.processType = 'tab';
-        threadA.pid = 111;
-        threadB.name = 'Other';
-        threadB.processType = 'default';
-        threadB.pid = 111;
-
-        // Other should be visible
-        threadB.frameTable.innerWindowID[0] = innerWindowID;
-
-        const { getState, dispatch } = setup(profile, false);
-
-        // Select the first thread
-        dispatch(changeSelectedThread(0));
-        // First thread should be selected. This will be hidden after the next dispatch.
-        expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain default] SELECTED',
           'show [thread GeckoMain tab]',
-          '  - show [network GeckoMain]',
-          '  - show [thread Other]',
-        ]);
-
-        // Switch to active tab view.
-        dispatch(changeShowTabOnly(browsingContextID));
-
-        // Now first visible thread should be selected. This was a breaking action.
-        expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain tab] SELECTED',
-          '  - show [thread Other]',
-        ]);
-
-        // Switching back again.
-        dispatch(changeShowTabOnly(null));
-        // Now the selected thread should not change, since this is not a breaking action.
-        expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain default]',
-          'show [thread GeckoMain tab] SELECTED',
-          '  - show [network GeckoMain] SELECTED',
-          '  - show [thread Other]',
+          '  - show [thread Other2]',
         ]);
       });
     });

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -382,7 +382,7 @@ describe('actions/receive-profile', function() {
       ]);
     });
 
-    describe('with showTabOnly', function() {
+    describe('finalizeActiveTabProfileView', function() {
       const browsingContextID = 123;
       const innerWindowID = 111111;
       function setup(profile: ?Profile, dispatchToShowTabOnly: boolean = true) {
@@ -500,6 +500,59 @@ describe('actions/receive-profile', function() {
           '  - show [thread Other2]',
         ]);
       });
+    });
+  });
+
+  describe('changeViewAndRecomputeProfileData', function() {
+    const browsingContextID = 123;
+    const innerWindowID = 111111;
+    function setup(initializeShowTabOnly: boolean = false) {
+      const store = blankStore();
+      const profile = getEmptyProfile();
+
+      profile.threads.push(
+        getEmptyThread({ name: 'GeckoMain', processType: 'tab', pid: 1 })
+      );
+
+      profile.meta.configuration = {
+        threads: [],
+        features: [],
+        capacity: 1000000,
+        activeBrowsingContextID: browsingContextID,
+      };
+      profile.pages = [
+        {
+          browsingContextID: browsingContextID,
+          innerWindowID: innerWindowID,
+          url: 'URL',
+          embedderInnerWindowID: 0,
+        },
+      ];
+
+      store.dispatch(viewProfile(profile));
+      if (initializeShowTabOnly) {
+        store.dispatch(changeViewAndRecomputeProfileData(browsingContextID));
+      }
+
+      return { ...store, profile };
+    }
+
+    it('should be able to switch to active tab view from the full view', function() {
+      const { dispatch, getState } = setup();
+      expect(UrlStateSelectors.getShowTabOnly(getState())).toBe(null);
+      dispatch(changeViewAndRecomputeProfileData(browsingContextID));
+      expect(UrlStateSelectors.getShowTabOnly(getState())).toBe(
+        browsingContextID
+      );
+    });
+
+    it('should be able to switch to full view from the active tab', function() {
+      const { dispatch, getState } = setup(true);
+      expect(UrlStateSelectors.getShowTabOnly(getState())).toBe(
+        browsingContextID
+      );
+      dispatch(changeViewAndRecomputeProfileData(null));
+      expect(UrlStateSelectors.getShowTabOnly(getState())).toBe(null);
     });
   });
 

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -11,7 +11,6 @@ import {
   changeMarkersSearchString,
   changeNetworkSearchString,
   changeProfileName,
-  changeShowTabOnly,
 } from '../actions/profile-view';
 import { changeSelectedTab, changeProfilesToCompare } from '../actions/app';
 import {
@@ -22,7 +21,10 @@ import {
   upgradeLocationToCurrentVersion,
 } from '../app-logic/url-handling';
 import { blankStore } from './fixtures/stores';
-import { viewProfile } from '../actions/receive-profile';
+import {
+  viewProfile,
+  changeViewAndRecomputeProfileData,
+} from '../actions/receive-profile';
 import type { Profile } from '../types/profile';
 import getProfile from './fixtures/profiles/call-nodes';
 import queryString from 'query-string';
@@ -385,7 +387,7 @@ describe('showTabOnly', function() {
     const { getState, dispatch } = _getStoreWithURL();
     const showTabOnly = 123;
 
-    dispatch(changeShowTabOnly(showTabOnly));
+    dispatch(changeViewAndRecomputeProfileData(showTabOnly));
     const urlState = urlStateReducers.getUrlState(getState());
     const { query } = urlStateToUrlObject(urlState);
     expect(query.showTabOnly1).toBe(showTabOnly);

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -35,6 +35,10 @@ import {
 import { getProfileFromTextSamples } from './fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../selectors/per-thread';
 import { uintArrayToString } from '../utils/uintarray-encoding';
+import {
+  getActiveTabHiddenGlobalTracksGetter,
+  getActiveTabHiddenLocalTracksByPidGetter,
+} from '../selectors/profile';
 
 function _getStoreWithURL(
   settings: {
@@ -403,6 +407,21 @@ describe('showTabOnly', function() {
   it('returns null when showTabOnly is not specified', function() {
     const { getState } = _getStoreWithURL();
     expect(urlStateReducers.getShowTabOnly(getState())).toBe(null);
+  });
+
+  it('should use the finalizeActiveTabProfileView path and initialize active tab profile view state', function() {
+    const { getState } = _getStoreWithURL({
+      search: '?showTabOnly1=123',
+    });
+    expect(getActiveTabHiddenGlobalTracksGetter(getState())).toBeInstanceOf(
+      Function
+    );
+    const activeTabHiddenLocalTracksByPidGetter = getActiveTabHiddenLocalTracksByPidGetter(
+      getState()
+    );
+    expect(activeTabHiddenLocalTracksByPidGetter).toBeInstanceOf(Function);
+    const hiddenLocalTracksByPid = activeTabHiddenLocalTracksByPidGetter();
+    expect(hiddenLocalTracksByPid.size).toBe(1);
   });
 });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -260,6 +260,16 @@ type ReceiveProfileAction =
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+    |}
+  | {|
+      +type: 'VIEW_ACTIVE_TAB_PROFILE',
+      +selectedThreadIndex: ThreadIndex,
+      +globalTracks: GlobalTrack[],
+      +globalTrackOrder: TrackIndex[],
+      +hiddenGlobalTracks: Set<TrackIndex>,
+      +localTracksByPid: Map<Pid, LocalTrack[]>,
+      +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
+      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
       +activeTabHiddenGlobalTracksGetter: () => Set<TrackIndex>,
       +activeTabHiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
     |}

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -252,7 +252,7 @@ type ReceiveProfileAction =
       +transformStacks: ?TransformStacksPerThread,
     |}
   | {|
-      +type: 'VIEW_PROFILE',
+      +type: 'VIEW_FULL_PROFILE',
       +selectedThreadIndex: ThreadIndex,
       +globalTracks: GlobalTrack[],
       +globalTrackOrder: TrackIndex[],

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -260,6 +260,7 @@ type ReceiveProfileAction =
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+      +showTabOnly?: BrowsingContextID | null,
     |}
   | {|
       +type: 'VIEW_ACTIVE_TAB_PROFILE',
@@ -272,6 +273,10 @@ type ReceiveProfileAction =
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
       +activeTabHiddenGlobalTracksGetter: () => Set<TrackIndex>,
       +activeTabHiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
+      +showTabOnly?: BrowsingContextID | null,
+    |}
+  | {|
+      +type: 'DATA_RELOAD',
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}
@@ -369,12 +374,6 @@ type UrlStateAction =
   | {|
       +type: 'SET_DATA_SOURCE',
       +dataSource: DataSource,
-    |}
-  | {|
-      +type: 'CHANGE_SHOW_TAB_ONLY',
-      +showTabOnly: BrowsingContextID | null,
-      +selectedTab: TabSlug,
-      +selectedThreadIndex: ThreadIndex | null,
     |};
 
 type IconsAction =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -51,7 +51,27 @@ export type RightClickedMarker = {|
   +markerIndex: MarkerIndex,
 |};
 
-export type ProfileViewState = {|
+/**
+ * Full profile view state
+ * They should not be used from the active tab view.
+ * NOTE: This state is empty for now, but will be used later, do not remove.
+ * globalTracks and localTracksByPid states will be here in the future.
+ */
+export type FullProfileViewState = {||};
+
+/**
+ * Active tab profile view state
+ * They should not be used from the full view.
+ */
+export type ActiveTabProfileViewState = {|
+  hiddenGlobalTracksGetter: () => Set<TrackIndex>,
+  hiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
+|};
+
+/**
+ * Profile view state
+ */
+export type ProfileViewState = {
   +viewOptions: {|
     perThread: ThreadViewOptions[],
     symbolicationStatus: SymbolicationStatus,
@@ -64,12 +84,14 @@ export type ProfileViewState = {|
     rightClickedCallNode: RightClickedCallNode | null,
     rightClickedMarker: RightClickedMarker | null,
   |},
-  +globalTracks: GlobalTrack[],
-  +localTracksByPid: Map<Pid, LocalTrack[]>,
-  +activeTabHiddenGlobalTracksGetter: () => Set<TrackIndex>,
-  +activeTabHiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
+  globalTracks: GlobalTrack[],
+  localTracksByPid: Map<Pid, LocalTrack[]>,
   +profile: Profile | null,
-|};
+  // NOTE: Currently commented out to fix the flow warnings, but will be used soon.
+  // Do not remove.
+  // +fullProfile: FullProfileViewState,
+  +activeTabProfile: ActiveTabProfileViewState,
+};
 
 export type AppViewState =
   | {| +phase: 'ROUTE_NOT_FOUND' |}
@@ -178,6 +200,27 @@ export type ZippedProfilesState = {
   expandedZipFileIndexes: Array<IndexIntoZipFileTable | null>,
 };
 
+export type ProfileSpecificUrlState = {|
+  selectedThread: ThreadIndex | null,
+  globalTrackOrder: TrackIndex[],
+  hiddenGlobalTracks: Set<TrackIndex>,
+  hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
+  localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+  implementation: ImplementationFilter,
+  lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy,
+  invertCallstack: boolean,
+  showUserTimings: boolean,
+  showJsTracerSummary: boolean,
+  committedRanges: StartEndRange[],
+  callTreeSearchString: string,
+  markersSearchString: string,
+  networkSearchString: string,
+  transforms: TransformStacksPerThread,
+  timelineType: TimelineType,
+  legacyThreadOrder: ThreadIndex[] | null,
+  legacyHiddenThreads: ThreadIndex[] | null,
+|};
+
 export type UrlState = {|
   +dataSource: DataSource,
   // This is used for the "public" dataSource".
@@ -190,26 +233,7 @@ export type UrlState = {|
   +pathInZipFile: string | null,
   +profileName: string,
   +showTabOnly: BrowsingContextID | null,
-  +profileSpecific: {|
-    selectedThread: ThreadIndex | null,
-    globalTrackOrder: TrackIndex[],
-    hiddenGlobalTracks: Set<TrackIndex>,
-    hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
-    localTrackOrderByPid: Map<Pid, TrackIndex[]>,
-    implementation: ImplementationFilter,
-    lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy,
-    invertCallstack: boolean,
-    showUserTimings: boolean,
-    showJsTracerSummary: boolean,
-    committedRanges: StartEndRange[],
-    callTreeSearchString: string,
-    markersSearchString: string,
-    networkSearchString: string,
-    transforms: TransformStacksPerThread,
-    timelineType: TimelineType,
-    legacyThreadOrder: ThreadIndex[] | null,
-    legacyHiddenThreads: ThreadIndex[] | null,
-  |},
+  +profileSpecific: ProfileSpecificUrlState,
 |};
 
 export type IconState = Set<string>;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -98,6 +98,7 @@ export type AppViewState =
   | {| +phase: 'TRANSITIONING_FROM_STALE_PROFILE' |}
   | {| +phase: 'PROFILE_LOADED' |}
   | {| +phase: 'DATA_LOADED' |}
+  | {| +phase: 'DATA_RELOAD' |}
   | {| +phase: 'FATAL_ERROR', +error: Error |}
   | {|
       +phase: 'INITIALIZING',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -89,8 +89,8 @@ export type ProfileViewState = {
   +profile: Profile | null,
   // NOTE: Currently commented out to fix the flow warnings, but will be used soon.
   // Do not remove.
-  // +fullProfile: FullProfileViewState,
-  +activeTabProfile: ActiveTabProfileViewState,
+  // +full: FullProfileViewState,
+  +activeTab: ActiveTabProfileViewState,
 };
 
 export type AppViewState =


### PR DESCRIPTION
This PR splits the profile view state into two(`FullProfileViewState` and `ActiveTabProfileViewState`) and splits the profile loading mechanism into two depending on their url state (`finalizeFullProfileView` and `finalizeActiveTabProfileView`).

Split the PR into smaller commits, probably it's best to look commit by commit.

[Example profile](https://deploy-preview-2478--perf-html.netlify.com/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/)

Since we disabled the checkbox, to manually test the profile loading mechanism without reloading, you should dispatch an event in the console like this: 
```
dispatch(actions.changeViewAndRecomputeProfileData(profile.meta.configuration.activeBrowsingContextID));
```
or (to switch back to full view):
```
dispatch(actions.changeViewAndRecomputeProfileData(null));
```

This doesn't split the url state yet. Next PR will be about splitting the url state.

You can see the overall code here(includes this PR + one single commit that contains the rest of the work): https://github.com/canova/perf.html/tree/timeline-resources-merged