### PR TITLE
Remove the unused PrePublishedState type

### DIFF
--- a/src/types/state.js
+++ b/src/types/state.js
@@ -175,15 +175,6 @@ export type UploadState = {|
   generation: number,
 |};
 
-/**
- * This holds the state of the profile before it was uploaded.
- */
-export type PrePublishedState = {|
-  +profile: Profile,
-  +urlState: UrlState,
-  +zipFileState: ZipFileState,
-|};
-
 export type PublishState = {|
   +checkedSharingOptions: CheckedSharingOptions,
   +upload: UploadState,


### PR DESCRIPTION
Just a small cleanup PR. We are using the whole State now in the `prePublishedState` and we don't need this type anymore.