### PR TITLE
Split the profile specific url state into two for full and active tab views

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -468,6 +468,8 @@ export function stateFromLocation(
           ? query.hiddenThreads.split('-').map(index => Number(index))
           : null,
       },
+      // Currently this is commented out because it's empty and redux doesn't allow
+      // empty objects without reducers. Uncomment it after adding a state in it.
       // activeTab: {},
     },
   };

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -464,6 +464,8 @@ const profileSpecific = combineReducers({
   networkSearchString,
   transforms,
   full: fullProfileSpecific,
+  // Currently this is commented out because it's empty and redux doesn't allow
+  // empty objects without reducers. Uncomment it after adding a state in it.
   // activeTab: activeTabProfileSpecific,
 });
 

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -427,24 +427,14 @@ const showTabOnly: Reducer<BrowsingContextID | null> = (
 };
 
 /**
- * These values are specific to an individual profile.
+ * These values are specific to an individual full profile.
  */
-const profileSpecific = combineReducers({
-  selectedThread,
+const fullProfileSpecific = combineReducers({
   globalTrackOrder,
   hiddenGlobalTracks,
   hiddenLocalTracksByPid,
   localTrackOrderByPid,
-  implementation,
-  lastSelectedCallTreeSummaryStrategy,
-  invertCallstack,
-  showUserTimings,
   showJsTracerSummary,
-  committedRanges,
-  callTreeSearchString,
-  markersSearchString,
-  networkSearchString,
-  transforms,
   timelineType,
   // The timeline tracks used to be hidden and sorted by thread indexes, rather than
   // track indexes. The only way to migrate this information to tracks-based data is to
@@ -452,6 +442,29 @@ const profileSpecific = combineReducers({
   // process. These value are only set by the locationToState function.
   legacyThreadOrder: (state: ThreadIndex[] | null = null) => state,
   legacyHiddenThreads: (state: ThreadIndex[] | null = null) => state,
+});
+
+/**
+ * These values are specific to an individual active tab profile.
+ */
+// const activeTabProfileSpecific = combineReducers({});
+
+/**
+ * These values are specific to an individual profile.
+ */
+const profileSpecific = combineReducers({
+  selectedThread,
+  implementation,
+  lastSelectedCallTreeSummaryStrategy,
+  invertCallstack,
+  showUserTimings,
+  committedRanges,
+  callTreeSearchString,
+  markersSearchString,
+  networkSearchString,
+  transforms,
+  full: fullProfileSpecific,
+  // activeTab: activeTabProfileSpecific,
 });
 
 /**

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -33,6 +33,8 @@ export const getUrlState: Selector<UrlState> = (state): UrlState =>
   state.urlState;
 export const getProfileSpecificState: Selector<*> = state =>
   getUrlState(state).profileSpecific;
+export const getFullProfileSpecificState: Selector<*> = state =>
+  getProfileSpecificState(state).full;
 export const getDataSource: Selector<DataSource> = state =>
   getUrlState(state).dataSource;
 export const getHash: Selector<string> = state => getUrlState(state).hash;
@@ -55,7 +57,7 @@ export const getInvertCallstack: Selector<boolean> = state =>
 export const getShowUserTimings: Selector<boolean> = state =>
   getProfileSpecificState(state).showUserTimings;
 export const getShowJsTracerSummary: Selector<boolean> = state =>
-  getProfileSpecificState(state).showJsTracerSummary;
+  getFullProfileSpecificState(state).showJsTracerSummary;
 
 /**
  * Raw search strings, before any splitting has been performed.
@@ -77,25 +79,25 @@ export const getSelectedThreadIndex: Selector<ThreadIndex> = state =>
     'Attempted to get a thread index before a profile was loaded.'
   );
 export const getTimelineType: Selector<TimelineType> = state =>
-  getProfileSpecificState(state).timelineType;
+  getFullProfileSpecificState(state).timelineType;
 
 /**
  * Simple selectors for tracks and track order.
  */
 export const getLegacyThreadOrder: Selector<ThreadIndex[] | null> = state =>
-  getProfileSpecificState(state).legacyThreadOrder;
+  getFullProfileSpecificState(state).legacyThreadOrder;
 export const getLegacyHiddenThreads: Selector<ThreadIndex[] | null> = state =>
-  getProfileSpecificState(state).legacyHiddenThreads;
+  getFullProfileSpecificState(state).legacyHiddenThreads;
 export const getGlobalTrackOrder: Selector<TrackIndex[]> = state =>
-  getProfileSpecificState(state).globalTrackOrder;
+  getFullProfileSpecificState(state).globalTrackOrder;
 export const getHiddenGlobalTracks: Selector<Set<TrackIndex>> = state =>
-  getProfileSpecificState(state).hiddenGlobalTracks;
+  getFullProfileSpecificState(state).hiddenGlobalTracks;
 export const getHiddenLocalTracksByPid: Selector<
   Map<Pid, Set<TrackIndex>>
-> = state => getProfileSpecificState(state).hiddenLocalTracksByPid;
+> = state => getFullProfileSpecificState(state).hiddenLocalTracksByPid;
 export const getLocalTrackOrderByPid: Selector<
   Map<Pid, TrackIndex[]>
-> = state => getProfileSpecificState(state).localTrackOrderByPid;
+> = state => getFullProfileSpecificState(state).localTrackOrderByPid;
 
 /**
  * This selector does a simple lookup in the set of hidden tracks for a PID, and ensures

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -328,6 +328,9 @@ describe('search strings', function() {
       dispatch(changeSelectedTab(tabSlug));
       const urlState = urlStateReducers.getUrlState(getState());
       const { query } = urlStateToUrlObject(urlState);
+      if (!query.search) {
+        throw new Error('Could not find the search query string');
+      }
       expect(query.search).toBe(callTreeSearchString);
     });
   });
@@ -343,6 +346,9 @@ describe('search strings', function() {
       dispatch(changeSelectedTab(tabSlug));
       const urlState = urlStateReducers.getUrlState(getState());
       const { query } = urlStateToUrlObject(urlState);
+      if (!query.markerSearch) {
+        throw new Error('Could not find the markerSearch query string');
+      }
       expect(query.markerSearch).toBe(markerSearchString);
     });
   });
@@ -356,6 +362,9 @@ describe('search strings', function() {
     dispatch(changeSelectedTab('network-chart'));
     const urlState = urlStateReducers.getUrlState(getState());
     const { query } = urlStateToUrlObject(urlState);
+    if (!query.networkSearch) {
+      throw new Error('Could not find the networkSearch query string');
+    }
     expect(query.networkSearch).toBe(networkSearchString);
   });
 });

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -432,6 +432,22 @@ describe('showTabOnly', function() {
     const hiddenLocalTracksByPid = activeTabHiddenLocalTracksByPidGetter();
     expect(hiddenLocalTracksByPid.size).toBe(1);
   });
+
+  it('should remove other full view url states if present', function() {
+    const { getState } = _getStoreWithURL({
+      search:
+        '?showTabOnly1=123&globalTrackOrder=3-2-1-0&hiddenGlobalTracks=4-5&hiddenLocalTracksByPid=111-1&thread=0',
+    });
+
+    const newUrl = new URL(
+      urlFromState(urlStateReducers.getUrlState(getState())),
+      'https://profiler.firefox.com'
+    );
+    // The url states that are relevant to full view should be stripped out.
+    expect(newUrl.search).toEqual(
+      `?showTabOnly1=123&thread=0&v=${CURRENT_URL_VERSION}`
+    );
+  });
 });
 
 describe('url upgrading', function() {

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -192,25 +192,43 @@ export type ZippedProfilesState = {
   expandedZipFileIndexes: Array<IndexIntoZipFileTable | null>,
 };
 
-export type ProfileSpecificUrlState = {|
-  selectedThread: ThreadIndex | null,
+/**
+ * Full profile specific url state
+ * They should not be used from the active tab view.
+ */
+export type FullProfileSpecificUrlState = {|
   globalTrackOrder: TrackIndex[],
   hiddenGlobalTracks: Set<TrackIndex>,
   hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
   localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+  showJsTracerSummary: boolean,
+  timelineType: TimelineType,
+  legacyThreadOrder: ThreadIndex[] | null,
+  legacyHiddenThreads: ThreadIndex[] | null,
+|};
+
+/**
+ * Active tab profile specific url state
+ * They should not be used from the full view.
+ * NOTE: This state is empty for now, but will be used later, do not remove.
+ */
+export type ActiveTabSpecificProfileUrlState = {||};
+
+export type ProfileSpecificUrlState = {|
+  selectedThread: ThreadIndex | null,
   implementation: ImplementationFilter,
   lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy,
   invertCallstack: boolean,
   showUserTimings: boolean,
-  showJsTracerSummary: boolean,
   committedRanges: StartEndRange[],
   callTreeSearchString: string,
   markersSearchString: string,
   networkSearchString: string,
   transforms: TransformStacksPerThread,
-  timelineType: TimelineType,
-  legacyThreadOrder: ThreadIndex[] | null,
-  legacyHiddenThreads: ThreadIndex[] | null,
+  full: FullProfileSpecificUrlState,
+  // NOTE: Currently commented out to fix the flow warnings, but will be used soon.
+  // Do not remove.
+  // activeTab: ActiveTabSpecificProfileUrlState,
 |};
 
 export type UrlState = {|


### PR DESCRIPTION
This PR only changes the store and url handling. It does **not** change the actions, so currently even though they are inside the full view, we also use them inside the active tab view code(since the timeline is still the same)

It's mostly preparation for the next PRs but there is an observable change as well. If showTabOnly is present in the url, full view query strings can't be present at the same time.

[Example profile](https://deploy-preview-2486--perf-html.netlify.com/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/)

Since we disabled the checkbox, if you want to see the non-refresh view change, you can use these in the console: 
```
dispatch(actions.changeViewAndRecomputeProfileData(profile.meta.configuration.activeBrowsingContextID));
```
or (to switch back to full view):
```
dispatch(actions.changeViewAndRecomputeProfileData(null));
```
You can see the overall code here(includes this PR + one single commit that contains the rest of the work): https://github.com/canova/perf.html/tree/timeline-resources-merged