### PR TITLE
Switch if-else statement into a switch-case to make the following changes more readable

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -230,73 +230,89 @@ export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
     let selectedThreadIndex = null;
     let selectedTab = currentlySelectedTab;
 
-    if (trackReference.type === 'global') {
-      // Handle the case of global tracks.
-      const globalTrack = getGlobalTrackFromReference(
-        getState(),
-        trackReference
-      );
+    switch (trackReference.type) {
+      case 'global': {
+        // Handle the case of global tracks.
+        const globalTrack = getGlobalTrackFromReference(
+          getState(),
+          trackReference
+        );
 
-      // Go through each type, and determine the selected slug and thread index.
-      switch (globalTrack.type) {
-        case 'process': {
-          if (globalTrack.mainThreadIndex === null) {
-            // Do not allow selecting process tracks without a thread index.
+        // Go through each type, and determine the selected slug and thread index.
+        switch (globalTrack.type) {
+          case 'process': {
+            if (globalTrack.mainThreadIndex === null) {
+              // Do not allow selecting process tracks without a thread index.
+              return;
+            }
+            selectedThreadIndex = globalTrack.mainThreadIndex;
+            // Ensure a relevant thread-based tab is used.
+            if (selectedTab === 'network-chart') {
+              selectedTab = getLastVisibleThreadTabSlug(getState());
+            }
+            break;
+          }
+          case 'screenshots':
+          case 'visual-progress':
+          case 'perceptual-visual-progress':
+          case 'contentful-visual-progress':
+            // Do not allow selecting these tracks.
             return;
-          }
-          selectedThreadIndex = globalTrack.mainThreadIndex;
-          // Ensure a relevant thread-based tab is used.
-          if (selectedTab === 'network-chart') {
-            selectedTab = getLastVisibleThreadTabSlug(getState());
-          }
-          break;
+          default:
+            throw assertExhaustiveCheck(
+              globalTrack,
+              `Unhandled GlobalTrack type.`
+            );
         }
-        case 'screenshots':
-        case 'visual-progress':
-        case 'perceptual-visual-progress':
-        case 'contentful-visual-progress':
-          // Do not allow selecting these tracks.
-          return;
-        default:
-          throw assertExhaustiveCheck(
-            globalTrack,
-            `Unhandled GlobalTrack type.`
-          );
+        break;
       }
-    } else {
-      // Handle the case of local tracks.
-      const localTrack = getLocalTrackFromReference(getState(), trackReference);
+      case 'local': {
+        // Handle the case of local tracks.
+        const localTrack = getLocalTrackFromReference(
+          getState(),
+          trackReference
+        );
 
-      // Go through each type, and determine the tab slug and thread index.
-      switch (localTrack.type) {
-        case 'thread': {
-          // Ensure a relevant thread-based tab is used.
-          selectedThreadIndex = localTrack.threadIndex;
-          if (selectedTab === 'network-chart') {
-            selectedTab = getLastVisibleThreadTabSlug(getState());
+        // Go through each type, and determine the tab slug and thread index.
+        switch (localTrack.type) {
+          case 'thread': {
+            // Ensure a relevant thread-based tab is used.
+            selectedThreadIndex = localTrack.threadIndex;
+            if (selectedTab === 'network-chart') {
+              selectedTab = getLastVisibleThreadTabSlug(getState());
+            }
+            break;
           }
-          break;
+          case 'network':
+            selectedThreadIndex = localTrack.threadIndex;
+            selectedTab = 'network-chart';
+            break;
+          case 'ipc':
+            selectedThreadIndex = localTrack.threadIndex;
+            selectedTab = 'marker-chart';
+            break;
+          case 'memory': {
+            const { counterIndex } = localTrack;
+            const counterSelectors = getCounterSelectors(counterIndex);
+            const counter = counterSelectors.getCommittedRangeFilteredCounter(
+              getState()
+            );
+            selectedThreadIndex = counter.mainThreadIndex;
+            break;
+          }
+          default:
+            throw assertExhaustiveCheck(
+              localTrack,
+              `Unhandled LocalTrack type.`
+            );
         }
-        case 'network':
-          selectedThreadIndex = localTrack.threadIndex;
-          selectedTab = 'network-chart';
-          break;
-        case 'ipc':
-          selectedThreadIndex = localTrack.threadIndex;
-          selectedTab = 'marker-chart';
-          break;
-        case 'memory': {
-          const { counterIndex } = localTrack;
-          const counterSelectors = getCounterSelectors(counterIndex);
-          const counter = counterSelectors.getCommittedRangeFilteredCounter(
-            getState()
-          );
-          selectedThreadIndex = counter.mainThreadIndex;
-          break;
-        }
-        default:
-          throw assertExhaustiveCheck(localTrack, `Unhandled LocalTrack type.`);
+        break;
       }
+      default:
+        throw assertExhaustiveCheck(
+          trackReference,
+          'Unhandled TrackReference type'
+        );
     }
 
     const doesNextTrackHaveSelectedTab = getThreadSelectors(selectedThreadIndex)


### PR DESCRIPTION
Pretty small refactoring PR that doesn't change any UI or behavior. This is the same code except it's now a switch case, and we assert at the end to make sure. The diff looks complicated because of the indentation changes. It was making one of my following PR more complicated to understand, so wanted to move it to a PR instead.


You can append the `w=1` query string to the diff to make github ignore the whitespace changes. Like that: https://github.com/firefox-devtools/profiler/pull/2488/files?w=1

This is the place we are changing in the overall changes commit: https://github.com/canova/perf.html/commit/6f824f0325f2e6fc37ba6d1b4bf8e0694aeff7dc#diff-b1f2126428eca56f3e400532a6de3d28L233