### PR TITLE
Do no use localized numbers as CSS values, and clamp the upload progress value

### DIFF
--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -23,6 +23,7 @@ import {
   getDownloadSize,
   getCompressedProfileBlob,
   getUploadPhase,
+  getUploadProgress,
   getUploadProgressString,
   getUploadError,
   getShouldSanitizeByDefault,
@@ -52,7 +53,8 @@ type StateProps = {|
   +compressedProfileBlobPromise: Promise<Blob>,
   +downloadFileName: string,
   +uploadPhase: UploadPhase,
-  +uploadProgress: string,
+  +uploadProgress: number,
+  +uploadProgressString: string,
   +shouldSanitizeByDefault: boolean,
   +error: mixed,
 |};
@@ -184,6 +186,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
   _renderUploadPanel() {
     const {
       uploadProgress,
+      uploadProgressString,
       abortUpload,
       downloadFileName,
       compressedProfileBlobPromise,
@@ -200,12 +203,12 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
             Publishing profile…
           </div>
           <div className="menuButtonsPublishUploadPercentage">
-            {uploadProgress}
+            {uploadProgressString}
           </div>
           <div className="menuButtonsPublishUploadBar">
             <div
               className="menuButtonsPublishUploadBarInner"
-              style={{ width: uploadProgress }}
+              style={{ width: `${uploadProgress * 100}%` }}
             />
           </div>
         </div>
@@ -294,7 +297,8 @@ export const MenuButtonsPublish = explicitConnect<
     downloadFileName: getFilenameString(state),
     compressedProfileBlobPromise: getCompressedProfileBlob(state),
     uploadPhase: getUploadPhase(state),
-    uploadProgress: getUploadProgressString(state),
+    uploadProgress: getUploadProgress(state),
+    uploadProgressString: getUploadProgressString(state),
     error: getUploadError(state),
     shouldSanitizeByDefault: getShouldSanitizeByDefault(state),
   }),

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -19,7 +19,7 @@ import SplitterLayout from 'react-splitter-layout';
 import { invalidatePanelLayout } from '../../actions/app';
 import { getTimelineHeight } from '../../selectors/app';
 import {
-  getUploadProgressString,
+  getUploadProgress,
   getUploadPhase,
   getIsHidingStaleProfile,
   getHasSanitizedProfile,
@@ -38,7 +38,7 @@ type StateProps = {|
   +profileName: string | null,
   +hasZipFile: boolean,
   +timelineHeight: CssPixels | null,
-  +uploadProgress: string,
+  +uploadProgress: number,
   +isUploading: boolean,
   +isHidingStaleProfile: boolean,
   +hasSanitizedProfile: boolean,
@@ -119,7 +119,7 @@ class ProfileViewer extends PureComponent<Props> {
             {isUploading ? (
               <div
                 className="menuButtonsPublishUploadBarInner"
-                style={{ width: uploadProgress }}
+                style={{ width: `${uploadProgress * 100}%` }}
               />
             ) : null}
           </div>
@@ -149,7 +149,7 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     profileName: getProfileName(state),
     hasZipFile: getHasZipFile(state),
     timelineHeight: getTimelineHeight(state),
-    uploadProgress: getUploadProgressString(state),
+    uploadProgress: getUploadProgress(state),
     isUploading: getUploadPhase(state) === 'uploading',
     isHidingStaleProfile: getIsHidingStaleProfile(state),
     hasSanitizedProfile: getHasSanitizedProfile(state),

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -205,23 +205,20 @@ export const getUploadPhase: Selector<UploadPhase> = state =>
 export const getUploadGeneration: Selector<number> = state =>
   getUploadState(state).generation;
 
-export const getUploadProgress: Selector<number> = state =>
-  getUploadState(state).uploadProgress;
+export const getUploadProgress: Selector<number> = createSelector(
+  getUploadState,
+  ({ uploadProgress }) =>
+    // Create a minimum value of 0.1 so that there is at least some user feedback
+    // that the upload started.
+    Math.max(uploadProgress, 0.1)
+);
 
 export const getUploadError: Selector<Error | mixed> = state =>
   getUploadState(state).error;
 
 export const getUploadProgressString: Selector<string> = createSelector(
   getUploadProgress,
-  progress =>
-    formatNumber(
-      // Create a minimum value of 0.1 so that there is at least some user feedback
-      // that the upload started.
-      Math.max(progress, 0.1),
-      0,
-      0,
-      'percent'
-    )
+  progress => formatNumber(progress, 0, 0, 'percent')
 );
 
 export const getAbortFunction: Selector<() => void> = state =>

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -4,6 +4,8 @@
 
 // @flow
 import { createSelector } from 'reselect';
+import clamp from 'clamp';
+
 import {
   getProfile,
   getProfileRootRange,
@@ -209,8 +211,10 @@ export const getUploadProgress: Selector<number> = createSelector(
   getUploadState,
   ({ uploadProgress }) =>
     // Create a minimum value of 0.1 so that there is at least some user feedback
-    // that the upload started.
-    Math.max(uploadProgress, 0.1)
+    // that the upload started, and a maximum value of 0.95 so that the user
+    // doesn't wait with a full bar (there's still some work to do after the
+    // uplod succeeds).
+    clamp(uploadProgress, 0.1, 0.95)
 );
 
 export const getUploadError: Selector<Error | mixed> = state =>

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -21,6 +21,7 @@ import {
   getUploadPhase,
   getUploadError,
   getUploadProgress,
+  getUploadProgressString,
   getUploadGeneration,
 } from '../../selectors/publish';
 import {
@@ -242,19 +243,33 @@ describe('attemptToPublish', function() {
     await waitUntilPhase('uploading');
     const updateUploadProgress = getUpdateUploadProgress();
 
-    expect(getUploadProgress(getState())).toEqual(0);
+    // We clamp the value at 0.1 as a minimum.
+    expect(getUploadProgress(getState())).toEqual(0.1);
+    // Note: it's fairly sure that this will fail on Windows environments in
+    // some locale (eg: French) because we don't know how to force a locale in
+    // these environments.
+    expect(getUploadProgressString(getState())).toEqual('10%');
 
     updateUploadProgress(0.2);
     expect(getUploadProgress(getState())).toEqual(0.2);
+    expect(getUploadProgressString(getState())).toEqual('20%');
 
     updateUploadProgress(0.5);
     expect(getUploadProgress(getState())).toEqual(0.5);
+    expect(getUploadProgressString(getState())).toEqual('50%');
+
+    updateUploadProgress(1);
+    // We clamp the value at 0.95 as a maximum.
+    expect(getUploadProgress(getState())).toEqual(0.95);
+    expect(getUploadProgressString(getState())).toEqual('95%');
 
     resolveUpload(JWT_TOKEN);
 
     expect(await publishAttempt).toEqual(true);
 
-    expect(getUploadProgress(getState())).toEqual(0);
+    // We still clamp :-)
+    expect(getUploadProgress(getState())).toEqual(0.1);
+    expect(getUploadProgressString(getState())).toEqual('10%');
   });
 
   it('can reset after a successful upload', async function() {


### PR DESCRIPTION
I had a look at this while discussing with @padenot. Specifically, the progress bar goes to the end, but we're still waiting for something to happen.
So I wanted to change this so that the progress bar never goes to the end: indeed after the upload end, there's still some action to finish. Also possibly (not sure when this can happen) we get the last "progress" event before the upload itself finishes.

While looking at this I realized that we were using localized numbers as CSS values. The direct result is that the progress bar was missing in french locales, where floats use a comma instead of a dot. 
I've seen this before but thought it was a transient problem because uploads were too fast 😓.

There's no test for the 2 components sadly. I didn't want to make some for this quick fix because I didn't want to invest too much time here. I still updated the tests we had for the selectors.

[deploy preview](https://deploy-preview-2490--perf-html.netlify.com/public/a48e69780e84edab57dd2a029bd8b6b34ba0419b/calltree/?v=4)