### PR TITLE
Change the dataSource check to a switch in the router

### DIFF
--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -17,6 +17,7 @@ import { getHasZipFile } from '../../selectors/zipped-profiles';
 import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
 import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
+import { assertExhaustiveCheck } from '../../utils/flow';
 
 import type { AppViewState, State } from '../../types/state';
 import type { DataSource } from '../../types/actions';
@@ -44,13 +45,28 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
   renderCurrentRoute() {
     const { view, dataSource, profilesToCompare, hasZipFile } = this.props;
     const phase = view.phase;
-    if (dataSource === 'none') {
-      return <Home />;
+
+    // We're using a switch to assert that all values for the dataSource has
+    // been checked. This is useful when we add a new dataSource, as Flow will
+    // error here if we forget to update this code.
+    switch (dataSource) {
+      case 'none':
+        return <Home />;
+      case 'compare':
+        if (profilesToCompare === null) {
+          return <CompareHome />;
+        }
+        break;
+      case 'from-addon':
+      case 'from-file':
+      case 'local':
+      case 'public':
+      case 'from-url':
+        break;
+      default:
+        throw assertExhaustiveCheck(dataSource);
     }
 
-    if (dataSource === 'compare' && profilesToCompare === null) {
-      return <CompareHome />;
-    }
     switch (phase) {
       case 'INITIALIZING':
       case 'PROFILE_LOADED':


### PR DESCRIPTION
This is a simple change that will make adding new dataSources easier. There should be no user-visible change.

[deploy preview](https://deploy-preview-2491--perf-html.netlify.com/public/a48e69780e84edab57dd2a029bd8b6b34ba0419b/calltree/?globalTrackOrder=0-1-2-3&hiddenGlobalTracks=0-1-2&hiddenLocalTracksByPid=17686-0&localTrackOrderByPid=17606-1-0~17686-0~&range=5.3162_35.9437&thread=4&v=4)