### PR TITLE
Add a custom symbol server URL as a URL parameter

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -50,3 +50,5 @@ export const JS_TRACER_MAXIMUM_CHART_ZOOM = 0.001;
 // The following values are for the visual progress tracks.
 export const TRACK_VISUAL_PROGRESS_HEIGHT = 40;
 export const TRACK_VISUAL_PROGRESS_LINE_WIDTH = 2;
+
+export const SYMBOL_STORE_URL = 'https://symbols.mozilla.org/symbolicate/v5';

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -107,6 +107,7 @@ type BaseQuery = {|
   transforms: string,
   profiles: string[],
   profileName: string,
+  symbolServer: string,
   showTabOnly1: BrowsingContextID,
   ...FullProfileSpecificBaseQuery,
   ...ActiveTabProfileSpecificBaseQuery,
@@ -265,6 +266,7 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     v: CURRENT_URL_VERSION,
     profileName: urlState.profileName || undefined,
     showTabOnly1: urlState.showTabOnly || undefined,
+    symbolServer: urlState.symbolServerUrl || undefined,
   }: BaseQueryShape);
 
   // Depending on which panel is active, also show tab-specific query parameters.
@@ -431,6 +433,7 @@ export function stateFromLocation(
     pathInZipFile: query.file || null,
     profileName: query.profileName,
     showTabOnly: showTabOnly,
+    symbolServerUrl: query.symbolServer || null,
     profileSpecific: {
       implementation,
       lastSelectedCallTreeSummaryStrategy: toValidCallTreeSummaryStrategy(

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -105,7 +105,8 @@ function _ensureIsAPIResult(result: any): APIResult {
 // to indicate failure status for each library independently. Under the hood,
 // only one request is made to the server.
 export function requestSymbols(
-  requests: LibSymbolicationRequest[]
+  requests: LibSymbolicationRequest[],
+  symbolsUrl: string
 ): Array<Promise<Map<number, AddressResult>>> {
   const addressArrays = requests.map(({ addresses }) => Array.from(addresses));
   const body = {
@@ -118,7 +119,7 @@ export function requestSymbols(
     ),
   };
 
-  const jsonPromise = fetch('https://symbols.mozilla.org/symbolicate/v5', {
+  const jsonPromise = fetch(symbolsUrl, {
     body: JSON.stringify(body),
     method: 'POST',
     mode: 'cors',

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -426,6 +426,10 @@ const showTabOnly: Reducer<BrowsingContextID | null> = (
   }
 };
 
+const symbolServerUrl: Reducer<string | null> = (state = null) => {
+  return state;
+};
+
 /**
  * These values are specific to an individual full profile.
  */
@@ -511,6 +515,7 @@ const urlStateReducer: Reducer<UrlState> = wrapReducerInResetter(
     profileSpecific,
     profileName,
     showTabOnly,
+    symbolServerUrl,
   })
 );
 

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -8,6 +8,7 @@ import { createSelector } from 'reselect';
 import { ensureExists } from '../utils/flow';
 import { urlFromState } from '../app-logic/url-handling';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
+import { SYMBOL_STORE_URL } from '../app-logic/constants';
 
 import type { ThreadIndex, Pid, BrowsingContextID } from '../types/profile';
 import type { TransformStack } from '../types/transforms';
@@ -254,4 +255,30 @@ export const getProfileName: Selector<null | string> = createSelector(
 export const getCommittedRangeLabels: Selector<string[]> = createSelector(
   getAllCommittedRanges,
   CommittedRanges.getCommittedRangeLabels
+);
+
+export const getSymbolStoreUrl: Selector<string> = createSelector(
+  getUrlState,
+  ({ symbolServerUrl }) => {
+    if (!symbolServerUrl) {
+      return SYMBOL_STORE_URL;
+    }
+    const allowedHostnames = new Set(['localhost', 'symbols.mozilla.org']);
+    try {
+      const url = new URL(symbolServerUrl);
+      if (allowedHostnames.has(url.hostname)) {
+        return symbolServerUrl;
+      }
+      console.error(
+        `The symbol server URL was not in the list of allowed domains, defaulting to ${SYMBOL_STORE_URL}`
+      );
+      return SYMBOL_STORE_URL;
+    } catch (error) {
+      console.error(
+        `The symbol server URL was not valid, defaulting to ${SYMBOL_STORE_URL}`,
+        error
+      );
+      return SYMBOL_STORE_URL;
+    }
+  }
 );

--- a/src/test/__snapshots__/url-handling.test.js.snap
+++ b/src/test/__snapshots__/url-handling.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`symbolServerUrl will error when switching to an invalid host 1`] = `
+Array [
+  Array [
+    "The symbol server URL was not valid, defaulting to https://symbols.mozilla.org/symbolicate/v5",
+    [TypeError: Invalid URL: invalid],
+  ],
+]
+`;
+
+exports[`symbolServerUrl will error when switching to an unknown host 1`] = `
+Array [
+  Array [
+    "The symbol server URL was not in the list of allowed domains, defaulting to https://symbols.mozilla.org/symbolicate/v5",
+  ],
+]
+`;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -244,6 +244,7 @@ export type UrlState = {|
   +profileName: string,
   +showTabOnly: BrowsingContextID | null,
   +profileSpecific: ProfileSpecificUrlState,
+  +symbolServerUrl: string | null,
 |};
 
 export type IconState = Set<string>;


### PR DESCRIPTION
This PR adds the ability to set a custom symbol server URL. I was being a little cautious and there is an allow list to restrict which URLs we accept. See [Bug 1628073](https://bugzilla.mozilla.org/show_bug.cgi?id=1628073) for where I'm planning on using it.