### PR TITLE
Remove the static information from the function name, when copying, s…

### DIFF
--- a/src/profile-logic/function-info.js
+++ b/src/profile-logic/function-info.js
@@ -11,8 +11,15 @@
  * it will return the original string.
  */
 export function stripFunctionArguments(functionCall: string): string {
-  // Remove known data that can appear at the end of the string
-  const s = functionCall.replace(/ \[clone [^]+\]$/, '').replace(/ const$/, '');
+  // Remove known data that can appear at the start or the end of the string
+  const s = functionCall
+    // example: "(anonymous namespace)::get_registry() [clone .8847]"
+    .replace(/ \[clone [^]+\]$/, '')
+    // example: "SkPath::internalGetConvexity() const"
+    .replace(/ const$/, '')
+    // example:" static nsThread::ThreadFunc(void*)"
+    .replace(/^static /, '');
+
   if (s[s.length - 1] !== ')') {
     return functionCall;
   }
@@ -27,11 +34,11 @@ export function stripFunctionArguments(functionCall: string): string {
     } else if (s[i] === '(') {
       depth--;
       if (depth === 0) {
-        return functionCall.substr(0, i);
+        return s.substr(0, i);
       }
     }
   }
-  return functionCall;
+  return s;
 }
 
 export function removeTemplateInformation(functionName: string) {

--- a/src/test/unit/function-info.test.js
+++ b/src/test/unit/function-info.test.js
@@ -34,6 +34,11 @@ describe('strip-function-arguments', function() {
   it('should do nothing if not a function call', function() {
     expect(stripFunctionArguments('(root)')).toEqual('(root)');
   });
+  it('should remove also the storage class', function() {
+    expect(
+      stripFunctionArguments('static nsThread::ThreadFunc(void*)')
+    ).toEqual('nsThread::ThreadFunc');
+  });
 });
 
 describe('remove-template-information', function() {
@@ -62,7 +67,9 @@ describe('remove-template-information', function() {
 describe('get-function-name', function() {
   it('should get the function name', function() {
     expect(
-      getFunctionName('ns::Foo<0>::fn(bool (*)(JS::Handle<JSObject*>)) const')
+      getFunctionName(
+        'static ns::Foo<0>::fn(bool (*)(JS::Handle<JSObject*>)) const'
+      )
     ).toEqual('ns::Foo::fn');
   });
 });


### PR DESCRIPTION
…earching or in sidebar

This also came from a discussion with @padenot, tell me what you think!

[production](https://profiler.firefox.com/public/c1d0b127624cfa840947ff5a7502f978ecb7d0e2/calltree/?globalTrackOrder=0-1-2&hiddenGlobalTracks=0-1&hiddenLocalTracksByPid=2216-1-2~5544-9-10-0-1-3-4-5-6-7-8&localTrackOrderByPid=10820-1-2-0~2216-5-0-1-2-3-4~5544-9-10-0-1-2-3-4-5-6-7-8~&search=static&thread=11&v=4)
[deploy preview](https://deploy-preview-2496--perf-html.netlify.com/public/c1d0b127624cfa840947ff5a7502f978ecb7d0e2/calltree/?globalTrackOrder=0-1-2&hiddenGlobalTracks=0-1&hiddenLocalTracksByPid=2216-1-2~5544-9-10-0-1-3-4-5-6-7-8&localTrackOrderByPid=10820-1-2-0~2216-5-0-1-2-3-4~5544-9-10-0-1-2-3-4-5-6-7-8~&search=static&thread=11&v=4)

To see the difference, you can select the line that has a search highlight and look at the sidebar title. Or rightclick and select "look up the function name in searchfox".