### PR TITLE
Propagate tree order samples comparator into ThreadActivityGraph.

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -34,7 +34,7 @@ export type Props = {|
   +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
   +categories: CategoryList,
   +samplesSelectedStates: null | SelectedState[],
-  +treeOrderSampleComparator?: (
+  +treeOrderSampleComparator: (
     IndexIntoSamplesTable,
     IndexIntoSamplesTable
   ) => number,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -72,6 +72,10 @@ type StateProps = {|
   +timelineType: TimelineType,
   +hasFileIoMarkers: boolean,
   +samplesSelectedStates: null | SelectedState[],
+  +treeOrderSampleComparator: (
+    IndexIntoSamplesTable,
+    IndexIntoSamplesTable
+  ) => number,
 |};
 
 type DispatchProps = {|
@@ -137,6 +141,7 @@ class TimelineTrackThread extends PureComponent<Props> {
       hasFileIoMarkers,
       showMemoryMarkers,
       samplesSelectedStates,
+      treeOrderSampleComparator,
     } = this.props;
 
     const processType = filteredThread.processType;
@@ -191,6 +196,7 @@ class TimelineTrackThread extends PureComponent<Props> {
             onSampleClick={this._onSampleClick}
             categories={categories}
             samplesSelectedStates={samplesSelectedStates}
+            treeOrderSampleComparator={treeOrderSampleComparator}
           />
         ) : (
           <ThreadStackGraph
@@ -242,6 +248,9 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
       timelineType: getTimelineType(state),
       hasFileIoMarkers: selectors.getFileIoMarkerIndexes(state).length !== 0,
       samplesSelectedStates: selectors.getSamplesSelectedStatesInFilteredThread(
+        state
+      ),
+      treeOrderSampleComparator: selectors.getTreeOrderComparatorInFilteredThread(
         state
       ),
     };


### PR DESCRIPTION
This fixes hit testing in the activity graph; the call tree structure
needs to be known so that clicking a pixel in the graph selects a sample
whose call node will light up that pixel in the graph.

Fixes #2498.

Writing a test for this would probably be a nightmare. By making the prop a required prop, at least the type system should now provide some level of protection against this breaking.

Julien's comment:
* [problem on master](https://profiler.firefox.com/public/30a29ff05af419c04db467b5285495e392884e84/calltree/?globalTrackOrder=0&localTrackOrderByPid=11745-0~&thread=0&v=4)
* [deploy preview](https://deploy-preview-2500--perf-html.netlify.app/public/30a29ff05af419c04db467b5285495e392884e84/calltree/?globalTrackOrder=0&localTrackOrderByPid=11745-0~&thread=0&v=4)