### PR TITLE
Cleanup after the new active tab timeline component

### DIFF
--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -92,7 +92,6 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
 const globalTracks: Reducer<GlobalTrack[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
-    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.globalTracks;
     default:
       return state;
@@ -109,7 +108,6 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
-    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.localTracksByPid;
     default:
       return state;
@@ -126,8 +124,6 @@ const activeTabHiddenGlobalTracksGetter: Reducer<() => Set<TrackIndex>> = (
   action
 ) => {
   switch (action.type) {
-    case 'VIEW_ACTIVE_TAB_PROFILE':
-      return action.activeTabHiddenGlobalTracksGetter;
     default:
       return state;
   }
@@ -141,8 +137,6 @@ const activeTabHiddenLocalTracksByPidGetter: Reducer<
   () => Map<Pid, Set<TrackIndex>>
 > = (state = () => new Map(), action) => {
   switch (action.type) {
-    case 'VIEW_ACTIVE_TAB_PROFILE':
-      return action.activeTabHiddenLocalTracksByPidGetter;
     default:
       return state;
   }

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -619,9 +619,11 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
       rightClickedCallNode,
       rightClickedMarker,
     }),
-    globalTracks,
-    localTracksByPid,
     profile,
+    full: combineReducers({
+      globalTracks,
+      localTracksByPid,
+    }),
     activeTab: combineReducers({
       hiddenGlobalTracksGetter: activeTabHiddenGlobalTracksGetter,
       hiddenLocalTracksByPidGetter: activeTabHiddenLocalTracksByPidGetter,

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -286,7 +286,6 @@ const showJsTracerSummary: Reducer<boolean> = (state = false, action) => {
 const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
-    case 'VIEW_ACTIVE_TAB_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
       return action.globalTrackOrder;
     case 'SANITIZED_PROFILE_PUBLISHED':
@@ -304,7 +303,6 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
-    case 'VIEW_ACTIVE_TAB_PROFILE':
     case 'ISOLATE_LOCAL_TRACK':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
@@ -335,7 +333,6 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
-    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.hiddenLocalTracksByPid;
     case 'HIDE_LOCAL_TRACK': {
       const hiddenLocalTracksByPid = new Map(state);
@@ -371,7 +368,6 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
-    case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -54,12 +54,15 @@ import type {
   State,
   ProfileViewState,
   SymbolicationStatus,
+  FullProfileViewState,
   ActiveTabProfileViewState,
 } from '../types/state';
 import type { $ReturnType } from '../types/utils';
 
 export const getProfileView: Selector<ProfileViewState> = state =>
   state.profileView;
+export const getFullProfileView: Selector<FullProfileViewState> = state =>
+  getProfileView(state).full;
 export const getActiveTabProfileView: Selector<ActiveTabProfileViewState> = state =>
   getProfileView(state).activeTab;
 
@@ -237,7 +240,7 @@ export const getIPCMarkerCorrelations: Selector<IPCMarkerCorrelations> = createS
  * They're uniquely referenced by a TrackReference.
  */
 export const getGlobalTracks: Selector<GlobalTrack[]> = state =>
-  getProfileView(state).globalTracks;
+  getFullProfileView(state).globalTracks;
 
 /**
  * This returns all TrackReferences for global tracks.
@@ -304,7 +307,7 @@ export const getGlobalTrackAndIndexByPid: DangerousSelectorWithArguments<
  * This returns a map of local tracks from a pid.
  */
 export const getLocalTracksByPid: Selector<Map<Pid, LocalTrack[]>> = state =>
-  getProfileView(state).localTracksByPid;
+  getFullProfileView(state).localTracksByPid;
 
 /**
  * This selectors performs a simple look up in a Map, throws an error if it doesn't exist,
@@ -316,7 +319,7 @@ export const getLocalTracks: DangerousSelectorWithArguments<
   Pid
 > = (state, pid) =>
   ensureExists(
-    getProfileView(state).localTracksByPid.get(pid),
+    getFullProfileView(state).localTracksByPid.get(pid),
     'Unable to get the tracks for the given pid.'
   );
 

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -200,7 +200,8 @@ describe('timeline/TrackContextMenu', function() {
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    it('network track will be hidden when a number is set for showTabOnly', () => {
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('network track will be hidden when a number is set for showTabOnly', () => {
       const { dispatch, container } = setupGlobalTrack(
         getNetworkTrackProfile(),
         0

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -13,7 +13,6 @@ import {
   changeSelectedThread,
   changeRightClickedTrack,
 } from '../../actions/profile-view';
-import { changeViewAndRecomputeProfileData } from '../../actions/receive-profile';
 import TrackContextMenu from '../../components/timeline/TrackContextMenu';
 import { getGlobalTracks, getLocalTracks } from '../../selectors/profile';
 import {
@@ -195,19 +194,6 @@ describe('timeline/TrackContextMenu', function() {
 
     it('network track will be displayed when a number is not set for showTabOnly', () => {
       const { container } = setupGlobalTrack(getNetworkTrackProfile(), 0);
-      // We can't use getHumanReadableTracks here because that function doesn't
-      // use the functions used by context menu directly and gives us wrong results.
-      expect(container.firstChild).toMatchSnapshot();
-    });
-
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('network track will be hidden when a number is set for showTabOnly', () => {
-      const { dispatch, container } = setupGlobalTrack(
-        getNetworkTrackProfile(),
-        0
-      );
-      // parameter doesn't matter here, it can be anything except null.
-      dispatch(changeViewAndRecomputeProfileData(111));
       // We can't use getHumanReadableTracks here because that function doesn't
       // use the functions used by context menu directly and gives us wrong results.
       expect(container.firstChild).toMatchSnapshot();

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -225,47 +225,6 @@ exports[`timeline/TrackContextMenu selected global track network track will be d
 </nav>
 `;
 
-exports[`timeline/TrackContextMenu selected global track network track will be hidden when a number is set for showTabOnly 1`] = `
-<nav
-  class="react-contextmenu timeline-context-menu"
-  role="menu"
-  style="position: fixed; opacity: 0; pointer-events: none;"
-  tabindex="-1"
->
-  <div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
-      role="menuitem"
-      tabindex="-1"
-      title="Process 0 (Process ID: 0)"
-    >
-      <span>
-        Process 0
-      </span>
-      <span
-        class="timelineTrackContextMenuSpacer"
-      />
-      <span
-        class="timelineTrackContextMenuPid"
-      >
-        (
-        0
-        )
-      </span>
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Empty
-    </div>
-  </div>
-</nav>
-`;
-
 exports[`timeline/TrackContextMenu selected local track matches the snapshot of a local track 1`] = `
 <nav
   class="react-contextmenu timeline-context-menu"

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -506,14 +506,8 @@ describe('actions/receive-profile', function() {
         return { ...store, profile };
       }
 
-      it('should calculate the hidden tracks correctly', function() {
-        const { getState } = setup();
-        expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain tab]',
-        ]);
-      });
-
-      it('should not hide screenshot tracks', function() {
+      // eslint-disable-next-line jest/no-disabled-tests
+      it.skip('should not hide screenshot tracks', function() {
         const profile = getScreenshotTrackProfile();
         profile.threads[0].name = 'GeckoMain';
         profile.threads[0].processType = 'tab';
@@ -523,34 +517,6 @@ describe('actions/receive-profile', function() {
           'show [screenshots]',
           'show [screenshots]',
           'show [thread GeckoMain tab]',
-        ]);
-      });
-
-      it('should calculate the hidden local threads correctly', function() {
-        const { profile } = getProfileFromTextSamples(
-          `work  work  work`,
-          `work  work  work`,
-          `work  work  work`
-        );
-        // There is one main thread and two other threads that belong to the same process.
-        const [threadA, threadB, threadC] = profile.threads;
-        threadA.name = 'GeckoMain';
-        threadA.processType = 'tab';
-        threadA.pid = 111;
-        threadB.name = 'Other1';
-        threadB.processType = 'default';
-        threadB.pid = 111;
-        threadC.name = 'Other2';
-        threadC.processType = 'default';
-        threadC.pid = 111;
-
-        // Other2 should be visible and Other1 should not.
-        threadC.frameTable.innerWindowID[0] = innerWindowID;
-
-        const { getState } = setup(profile);
-        expect(getHumanReadableTracks(getState())).toEqual([
-          'show [thread GeckoMain tab]',
-          '  - show [thread Other2]',
         ]);
       });
     });

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -418,7 +418,8 @@ describe('showTabOnly', function() {
     expect(urlStateReducers.getShowTabOnly(getState())).toBe(null);
   });
 
-  it('should use the finalizeActiveTabProfileView path and initialize active tab profile view state', function() {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should use the finalizeActiveTabProfileView path and initialize active tab profile view state', function() {
     const { getState } = _getStoreWithURL({
       search: '?showTabOnly1=123',
     });

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -418,6 +418,9 @@ describe('showTabOnly', function() {
     expect(urlStateReducers.getShowTabOnly(getState())).toBe(null);
   });
 
+  // TODO: This test is disabled for now because we don't initizalize anything inside
+  // the finalizeActiveTabProfileView function yet. This will be enabled back once
+  // we have some active tab specific states (like active tab global track or resouces tracks).
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should use the finalizeActiveTabProfileView path and initialize active tab profile view state', function() {
     const { getState } = _getStoreWithURL({

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -265,14 +265,6 @@ type ReceiveProfileAction =
   | {|
       +type: 'VIEW_ACTIVE_TAB_PROFILE',
       +selectedThreadIndex: ThreadIndex,
-      +globalTracks: GlobalTrack[],
-      +globalTrackOrder: TrackIndex[],
-      +hiddenGlobalTracks: Set<TrackIndex>,
-      +localTracksByPid: Map<Pid, LocalTrack[]>,
-      +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
-      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
-      +activeTabHiddenGlobalTracksGetter: () => Set<TrackIndex>,
-      +activeTabHiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
       +showTabOnly?: BrowsingContextID | null,
     |}
   | {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -57,7 +57,10 @@ export type RightClickedMarker = {|
  * NOTE: This state is empty for now, but will be used later, do not remove.
  * globalTracks and localTracksByPid states will be here in the future.
  */
-export type FullProfileViewState = {||};
+export type FullProfileViewState = {|
+  globalTracks: GlobalTrack[],
+  localTracksByPid: Map<Pid, LocalTrack[]>,
+|};
 
 /**
  * Active tab profile view state
@@ -84,12 +87,8 @@ export type ProfileViewState = {
     rightClickedCallNode: RightClickedCallNode | null,
     rightClickedMarker: RightClickedMarker | null,
   |},
-  globalTracks: GlobalTrack[],
-  localTracksByPid: Map<Pid, LocalTrack[]>,
   +profile: Profile | null,
-  // NOTE: Currently commented out to fix the flow warnings, but will be used soon.
-  // Do not remove.
-  // +full: FullProfileViewState,
+  +full: FullProfileViewState,
   +activeTab: ActiveTabProfileViewState,
 };
 


### PR DESCRIPTION
I was working on the active tab global track PR but realized that it's getting bigger than I expected and decided to split this part. This PR,
1. Moves the  global track and local tracks to full view.
2. Removes full view states from the active tab action to prepare for the new action items like active tab global track.
3. Removes some invalid tests(we no longer care about hidden tracks for active tab). And skips some of them for now so we can re-enable once we have active tab global tracks, and resource tracks.

[Example profile](https://deploy-preview-2505--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/)