### PR TITLE
Compute active tab global tracks

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -41,9 +41,14 @@ import {
   initializeHiddenGlobalTracks,
   getVisibleThreads,
 } from '../profile-logic/tracks';
-import { getProfileOrNull, getProfile } from '../selectors/profile';
+import {
+  getProfileOrNull,
+  getProfile,
+  getRelevantPagesForActiveTab,
+} from '../selectors/profile';
 import { getView } from '../selectors/app';
 import { setDataSource } from './profile-view';
+import { computeActiveTabTracks } from '../profile-logic/active-tab';
 
 import type {
   FunctionsUpdatePerThread,
@@ -289,11 +294,20 @@ export function finalizeActiveTabProfileView(
   selectedThreadIndex: ThreadIndex,
   showTabOnly?: BrowsingContextID | null
 ): ThunkAction<void> {
-  return dispatch => {
+  return (dispatch, getState) => {
+    const relevantPages = getRelevantPagesForActiveTab(getState());
+    const { globalTracks, resourceTracks } = computeActiveTabTracks(
+      profile,
+      relevantPages,
+      getState()
+    );
+
+    // TODO: check the selectedThreadIndex and select the proper one if it's out of bound.
+
     dispatch({
       type: 'VIEW_ACTIVE_TAB_PROFILE',
-      globalTracks: [],
-      resourceTracks: [],
+      globalTracks,
+      resourceTracks,
       selectedThreadIndex,
       showTabOnly,
     });

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -292,6 +292,8 @@ export function finalizeActiveTabProfileView(
   return dispatch => {
     dispatch({
       type: 'VIEW_ACTIVE_TAB_PROFILE',
+      globalTracks: [],
+      resourceTracks: [],
       selectedThreadIndex,
       showTabOnly,
     });

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -5,14 +5,29 @@
 
 import { getThreadSelectors } from '../selectors/per-thread';
 import { assertExhaustiveCheck } from '../utils/flow';
+import { isMainThread } from './tracks';
 
 import type { State } from '../types/state';
-import type { ThreadIndex, Pid } from '../types/profile';
+import type {
+  ThreadIndex,
+  Pid,
+  Profile,
+  InnerWindowID,
+  Page,
+  Thread,
+} from '../types/profile';
 import type {
   GlobalTrack,
+  ActiveTabGlobalTrack,
   LocalTrack,
   TrackIndex,
 } from '../types/profile-derived';
+import type { ScreenshotPayload } from '../types/markers';
+
+const ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER = {
+  screenshots: 0,
+  tab: 1,
+};
 
 /**
  * Take the global tracks and decide which one to hide during the active tab view.
@@ -137,4 +152,127 @@ function isTabFilteredThreadEmpty(
   }
 
   return true;
+}
+
+/**
+ * Take a profile and figure out what active tab GlobalTracks it contains.
+ * The returned array should contain only one thread and screenshot tracks
+ */
+export function computeActiveTabTracks(
+  profile: Profile,
+  relevantPages: Page[],
+  state: State
+): {| globalTracks: ActiveTabGlobalTrack[], resourceTracks: LocalTrack[] |} {
+  // Global tracks that are certainly global tracks.
+  const globalTracks: ActiveTabGlobalTrack[] = [];
+  const resourceTracks = [];
+  const topmostInnerWindowIDs = getTopmostInnerWindowIDs(relevantPages);
+
+  for (
+    let threadIndex = 0;
+    threadIndex < profile.threads.length;
+    threadIndex++
+  ) {
+    const thread = profile.threads[threadIndex];
+    const { markers, stringTable } = thread;
+
+    if (isMainThread(thread)) {
+      // This is a main thread, there is a possibility that it can be a global
+      // track, check if the thread contains active tab data and add it to candidates if it does.
+
+      if (isTopmostThread(thread, topmostInnerWindowIDs)) {
+        // This is a topmost thread, add it to global tracks.
+        globalTracks.push({
+          type: 'tab',
+          threadIndex: threadIndex,
+        });
+      } else {
+        if (!isTabFilteredThreadEmpty(threadIndex, state)) {
+          resourceTracks.push({ type: 'thread', threadIndex });
+        }
+      }
+    } else {
+      // This is not a main thread, it's not possible that this can be a global
+      // track. Find out if that thread contains the active tab data, and add it
+      // as a resource track if it does.
+      if (!isTabFilteredThreadEmpty(threadIndex, state)) {
+        resourceTracks.push({ type: 'thread', threadIndex });
+      }
+    }
+
+    // Check for screenshots.
+    const windowIDs: Set<string> = new Set();
+    if (stringTable.hasString('CompositorScreenshot')) {
+      const screenshotNameIndex = stringTable.indexForString(
+        'CompositorScreenshot'
+      );
+      for (let markerIndex = 0; markerIndex < markers.length; markerIndex++) {
+        if (markers.name[markerIndex] === screenshotNameIndex) {
+          // Coerce the payload to a screenshot one. Don't do a runtime check that
+          // this is correct.
+          const data: ScreenshotPayload = (markers.data[markerIndex]: any);
+          windowIDs.add(data.windowID);
+        }
+      }
+      for (const id of windowIDs) {
+        globalTracks.push({ type: 'screenshots', id, threadIndex });
+      }
+    }
+  }
+
+  // When adding a new track type, this sort ensures that the newer tracks are added
+  // at the end so that the global track indexes are stable and backwards compatible.
+  globalTracks.sort(
+    // In place sort!
+    (a, b) =>
+      ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER[a.type] -
+      ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER[b.type]
+  );
+
+  return { globalTracks, resourceTracks };
+}
+
+/**
+ * Gets the relevant pages and returns a set of InnerWindowIDs of topmost frames.
+ */
+function getTopmostInnerWindowIDs(relevantPages: Page[]): Set<InnerWindowID> {
+  const topmostInnerWindowIDs = [];
+
+  for (const page of relevantPages) {
+    if (page.embedderInnerWindowID === 0) {
+      topmostInnerWindowIDs.push(page.innerWindowID);
+    }
+  }
+
+  return new Set(topmostInnerWindowIDs);
+}
+
+/**
+ * Check if the thread is a topmost thread or not.
+ * Topmost thread means the thread that belongs to the browser tab itself and not the iframe.
+ */
+function isTopmostThread(
+  thread: Thread,
+  topmostInnerWindowIDs: Set<InnerWindowID>
+): boolean {
+  const { frameTable, markers } = thread;
+  for (let frameIndex = 0; frameIndex < frameTable.length; frameIndex++) {
+    const innerWindowID = frameTable.innerWindowID[frameIndex];
+    if (innerWindowID !== null && topmostInnerWindowIDs.has(innerWindowID)) {
+      return true;
+    }
+  }
+
+  for (let markerIndex = 0; markerIndex < markers.length; markerIndex++) {
+    const data = markers.data[markerIndex];
+    if (
+      data &&
+      data.innerWindowID &&
+      topmostInnerWindowIDs.has(data.innerWindowID)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -223,7 +223,7 @@ export function computeLocalTracksByPid(
       localTracksByPid.set(pid, tracks);
     }
 
-    if (!_isMainThread(thread)) {
+    if (!isMainThread(thread)) {
       // This thread has not been added as a GlobalTrack, so add it as a local track.
       tracks.push({ type: 'thread', threadIndex });
     }
@@ -290,7 +290,7 @@ export function computeGlobalTracks(profile: Profile): GlobalTrack[] {
   ) {
     const thread = profile.threads[threadIndex];
     const { pid, markers, stringTable } = thread;
-    if (_isMainThread(thread)) {
+    if (isMainThread(thread)) {
       // This is a main thread, a global track needs to be created or updated with
       // the main thread info.
       let globalTrack = globalTracksByPid.get(pid);
@@ -765,7 +765,7 @@ function _findDefaultThread(threads: Thread[]): Thread | null {
   return threads[defaultThreadIndex];
 }
 
-function _isMainThread(thread: Thread): boolean {
+export function isMainThread(thread: Thread): boolean {
   return (
     thread.name === 'GeckoMain' ||
     // If the pid is a string, then it's not one that came from the system.

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -17,6 +17,7 @@ import type {
   LocalTrack,
   GlobalTrack,
   TrackIndex,
+  ActiveTabGlobalTrack,
 } from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
 import type {
@@ -109,6 +110,36 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
       return action.localTracksByPid;
+    default:
+      return state;
+  }
+};
+
+/**
+ * This information is stored, rather than derived via selectors, since the coalesced
+ * function update would force it to be recomputed on every symbolication update
+ * pass. It is valid for the lifetime of the profile.
+ */
+const activeTabGlobalTracks: Reducer<ActiveTabGlobalTrack[]> = (
+  state = [],
+  action
+) => {
+  switch (action.type) {
+    case 'VIEW_ACTIVE_TAB_PROFILE':
+      return action.globalTracks;
+    default:
+      return state;
+  }
+};
+
+/**
+ * This can be derived like the globalTracks information, but is stored in the state
+ * for the same reason.
+ */
+const activeTabResourceTracks: Reducer<LocalTrack[]> = (state = [], action) => {
+  switch (action.type) {
+    case 'VIEW_ACTIVE_TAB_PROFILE':
+      return action.resourceTracks;
     default:
       return state;
   }
@@ -619,6 +650,8 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
       localTracksByPid,
     }),
     activeTab: combineReducers({
+      globalTracks: activeTabGlobalTracks,
+      resourceTracks: activeTabResourceTracks,
       hiddenGlobalTracksGetter: activeTabHiddenGlobalTracksGetter,
       hiddenLocalTracksByPidGetter: activeTabHiddenLocalTracksByPidGetter,
     }),

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -201,7 +201,7 @@ export function getMarkerSelectorsPerThread(
   > = createSelector(
     getMarkerGetter,
     getCommittedRangeFilteredMarkerIndexes,
-    ProfileSelectors.getRelevantPagesForCurrentTab,
+    ProfileSelectors.getRelevantInnerWindowIDsForCurrentTab,
     MarkerData.getTabFilteredMarkerIndexes
   );
 
@@ -240,7 +240,7 @@ export function getMarkerSelectorsPerThread(
   > = createSelector(
     getMarkerGetter,
     getFullMarkerListIndexes,
-    ProfileSelectors.getRelevantPagesForActiveTab,
+    ProfileSelectors.getRelevantInnerWindowIDsForActiveTab,
     (markerGetter, markerIndexes, relevantPages) => {
       return MarkerData.getTabFilteredMarkerIndexes(
         markerGetter,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -72,7 +72,7 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
 
   const getTabFilteredThread: Selector<Thread> = createSelector(
     getThread,
-    ProfileSelectors.getRelevantPagesForCurrentTab,
+    ProfileSelectors.getRelevantInnerWindowIDsForCurrentTab,
     (thread, relevantPages) => {
       if (relevantPages.size === 0) {
         // If this set doesn't have any relevant page, just return the whole thread.
@@ -90,7 +90,7 @@ export function getThreadSelectorsPerThread(threadIndex: ThreadIndex): * {
    */
   const getActiveTabFilteredThread: Selector<Thread> = createSelector(
     getThread,
-    ProfileSelectors.getRelevantPagesForActiveTab,
+    ProfileSelectors.getRelevantInnerWindowIDsForActiveTab,
     (thread, relevantPages) => {
       if (relevantPages.size === 0) {
         // If this set doesn't have any relevant page, just return the whole thread.

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -636,7 +636,7 @@ export const getPagesMap: Selector<Map<
  * for only viewProfile function to calculate the hidden tracks during page load,
  * even though we are not in the active tab view.
  */
-export const getRelevantPagesForActiveTab: Selector<
+export const getRelevantInnerWindowIDsForActiveTab: Selector<
   Set<InnerWindowID>
 > = createSelector(
   getPagesMap,
@@ -657,17 +657,17 @@ export const getRelevantPagesForActiveTab: Selector<
 );
 
 /**
- * A simple wrapper for getRelevantPagesForActiveTab.
+ * A simple wrapper for getRelevantInnerWindowIDsForActiveTab.
  * It returns an empty Set if showTabOnly is null, and returns the real Set if
  * showTabOnly is assigned already. We should usually use this instead of the
  * wrapped function. But the wrapped function is helpful to calculate the hidden
  * tracks by active tab view during the first page load(inside viewProfile function).
  */
-export const getRelevantPagesForCurrentTab: Selector<
+export const getRelevantInnerWindowIDsForCurrentTab: Selector<
   Set<InnerWindowID>
 > = createSelector(
   UrlState.getShowTabOnly,
-  getRelevantPagesForActiveTab,
+  getRelevantInnerWindowIDsForActiveTab,
   (showTabOnly, relevantPages) => {
     if (showTabOnly === null) {
       // Return an empty set if we want to see everything or that data is not there.
@@ -769,6 +769,6 @@ export const getComputedHiddenLocalTracks: DangerousSelectorWithArguments<
  */
 export const getProfileFilterPageData: Selector<ProfileFilterPageData | null> = createSelector(
   getPageList,
-  getRelevantPagesForCurrentTab,
+  getRelevantInnerWindowIDsForCurrentTab,
   extractProfileFilterPageData
 );

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -40,6 +40,7 @@ import type {
   GlobalTrack,
   AccumulatedCounterSamples,
   ProfileFilterPageData,
+  ActiveTabGlobalTrack,
 } from '../types/profile-derived';
 import type { Milliseconds, StartEndRange } from '../types/units';
 import type {
@@ -418,6 +419,32 @@ export const getLocalTrackName = (
 /**
  * Active tab profile selectors
  */
+
+/**
+ * Returns global tracks for the active tab view.
+ */
+export const getActiveTabGlobalTracks: Selector<
+  ActiveTabGlobalTrack[]
+> = state => getActiveTabProfileView(state).globalTracks;
+
+/**
+ * Returns resource tracks for the active tab view.
+ */
+export const getActiveTabResourceTracks: Selector<LocalTrack[]> = state =>
+  getActiveTabProfileView(state).resourceTracks;
+
+/**
+ * This returns all TrackReferences for global tracks.
+ */
+export const getActiveTabGlobalTrackReferences: Selector<
+  GlobalTrackReference[]
+> = createSelector(getActiveTabGlobalTracks, globalTracks =>
+  globalTracks.map((globalTrack, trackIndex) => ({
+    type: 'global',
+    trackIndex,
+  }))
+);
+
 export const getActiveTabHiddenGlobalTracksGetter: Selector<
   () => Set<TrackIndex>
 > = state => getActiveTabProfileView(state).hiddenGlobalTracksGetter;

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -5,6 +5,7 @@
 // @flow
 
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import Timeline from '../../components/timeline';
 import { render } from 'react-testing-library';
 import { Provider } from 'react-redux';
@@ -12,9 +13,24 @@ import { storeWithProfile } from '../fixtures/stores';
 import { processProfile } from '../../profile-logic/process-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { changeViewAndRecomputeProfileData } from '../../actions/receive-profile';
+import { getBoundingBox } from '../fixtures/utils';
 
 describe('ActiveTabTimeline', function() {
   const browsingContextID = 123123;
+  beforeEach(() => {
+    jest.spyOn(ReactDOM, 'findDOMNode').mockImplementation(() => {
+      // findDOMNode uses nominal typing instead of structural (null | Element | Text), so
+      // opt out of the type checker for this mock by returning `any`.
+      const mockEl = ({
+        getBoundingClientRect: () => getBoundingBox(300, 300),
+      }: any);
+      return mockEl;
+    });
+
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(() => getBoundingBox(200, 300));
+  });
 
   it('should be rendered properly from the Timeline component', () => {
     const profile = processProfile(createGeckoProfile());

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1100,6 +1100,17 @@ export function getProfileWithBalancedNativeAllocations(): * {
   return { profile, funcNamesDict };
 }
 
+/**
+ * Add pages array and activeTabBrowsingContextID to the given profile.
+ * Pages array has the following relationship:
+ * Tab #1                           Tab #2
+ * --------------                --------------
+ * Page #1                        Page #4
+ * |- Page #2                     |
+ * |  |- Page #3                  Page #6
+ * |
+ * Page #5
+ */
 export function addActiveTabInformationToProfile(
   profile: Profile,
   activeBrowsingContextID?: BrowsingContextID
@@ -1122,14 +1133,7 @@ export function addActiveTabInformationToProfile(
       ? firstTabBrowsingContextID
       : activeBrowsingContextID;
 
-  // Add a pages array with the following relationship:
-  // Tab #1                           Tab #2
-  // --------------                --------------
-  // Page #1                        Page #4
-  // |- Page #2                     |
-  // |  |- Page #3                  Page #6
-  // |
-  // Page #5
+  // Add the pages array
   profile.pages = [
     // A top most page in the first tab
     {

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -25,6 +25,7 @@ import type {
   CategoryList,
   JsTracerTable,
   Counter,
+  BrowsingContextID,
 } from '../../../types/profile';
 import type {
   MarkerPayload,
@@ -1097,4 +1098,100 @@ export function getProfileWithBalancedNativeAllocations(): * {
   }
 
   return { profile, funcNamesDict };
+}
+
+export function addActiveTabInformationToProfile(
+  profile: Profile,
+  activeBrowsingContextID?: BrowsingContextID
+): * {
+  const firstTabBrowsingContextID = 1;
+  const secondTabBrowsingContextID = 4;
+  const parentInnerWindowIDsWithChildren = 11111111111;
+  const iframeInnerWindowIDsWithChild = 11111111112;
+  const fistTabInnerWindowIDs = [
+    parentInnerWindowIDsWithChildren,
+    iframeInnerWindowIDsWithChild,
+    11111111113,
+    11111111115,
+  ];
+  const secondTabInnerWindowIDs = [11111111114, 11111111116];
+
+  // Default to first tab browsingContextID if not given
+  activeBrowsingContextID =
+    activeBrowsingContextID === undefined
+      ? firstTabBrowsingContextID
+      : activeBrowsingContextID;
+
+  // Add a pages array with the following relationship:
+  // Tab #1                           Tab #2
+  // --------------                --------------
+  // Page #1                        Page #4
+  // |- Page #2                     |
+  // |  |- Page #3                  Page #6
+  // |
+  // Page #5
+  profile.pages = [
+    // A top most page in the first tab
+    {
+      browsingContextID: firstTabBrowsingContextID,
+      innerWindowID: parentInnerWindowIDsWithChildren,
+      url: 'Page #1',
+      embedderInnerWindowID: 0,
+    },
+    // An iframe page inside the previous page
+    {
+      browsingContextID: 2,
+      innerWindowID: iframeInnerWindowIDsWithChild,
+      url: 'Page #2',
+      embedderInnerWindowID: parentInnerWindowIDsWithChildren,
+    },
+    // Another iframe page inside the previous iframe
+    {
+      browsingContextID: 3,
+      innerWindowID: fistTabInnerWindowIDs[2],
+      url: 'Page #3',
+      embedderInnerWindowID: iframeInnerWindowIDsWithChild,
+    },
+    // A top most frame from the second tab
+    {
+      browsingContextID: secondTabBrowsingContextID,
+      innerWindowID: secondTabInnerWindowIDs[0],
+      url: 'Page #4',
+      embedderInnerWindowID: 0,
+    },
+    // Another top most frame from the first tab
+    // Their browsingContextIDs are the same because of that.
+    {
+      browsingContextID: firstTabBrowsingContextID,
+      innerWindowID: fistTabInnerWindowIDs[3],
+      url: 'Page #5',
+      embedderInnerWindowID: 0,
+    },
+    // Another top most frame from the second tab
+    {
+      browsingContextID: secondTabBrowsingContextID,
+      innerWindowID: secondTabInnerWindowIDs[1],
+      url: 'Page #4',
+      embedderInnerWindowID: 0,
+    },
+  ];
+
+  // Set the active BrowsingContext ID.
+  profile.meta.configuration = {
+    activeBrowsingContextID,
+    capacity: 1,
+    features: [],
+    threads: [],
+  };
+
+  return {
+    profile,
+    firstTabBrowsingContextID,
+    secondTabBrowsingContextID,
+    parentInnerWindowIDsWithChildren,
+    iframeInnerWindowIDsWithChild,
+    activeBrowsingContextID,
+    fistTabInnerWindowIDs,
+    secondTabInnerWindowIDs,
+  };
 }

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -14,7 +14,7 @@ import { oneLine } from 'common-tags';
 
 import type { Profile } from '../../../types/profile';
 import type { State } from '../../../types/state';
-import { ensureExists } from '../../../utils/flow';
+import { assertExhaustiveCheck } from '../../../utils/flow';
 
 /**
  * This function takes the current timeline tracks, and generates a human readable result
@@ -43,23 +43,9 @@ export function getHumanReadableTracks(state: State): string[] {
   const threads = profileViewSelectors.getThreads(state);
   const globalTracks = profileViewSelectors.getGlobalTracks(state);
   const hiddenGlobalTracks = urlStateSelectors.getHiddenGlobalTracks(state);
-  const activeTabHiddenGlobalTracks = profileViewSelectors.getActiveTabHiddenGlobalTracksGetter(
-    state
-  )();
-  const activeTabHiddenLocalTracksByPid = profileViewSelectors.getActiveTabHiddenLocalTracksByPidGetter(
-    state
-  )();
   const selectedThreadIndex = urlStateSelectors.getSelectedThreadIndex(state);
-  const showTabOnly = urlStateSelectors.getShowTabOnly(state);
   const text: string[] = [];
   for (const globalTrackIndex of urlStateSelectors.getGlobalTrackOrder(state)) {
-    if (
-      showTabOnly !== null &&
-      activeTabHiddenGlobalTracks.has(globalTrackIndex)
-    ) {
-      // If we are in active tab view, hide this track(and its local tracks) completely,
-      continue;
-    }
     const globalTrack = globalTracks[globalTrackIndex];
     const globalHiddenText = hiddenGlobalTracks.has(globalTrackIndex)
       ? 'hide'
@@ -109,15 +95,6 @@ export function getHumanReadableTracks(state: State): string[] {
           globalTrack.pid
         );
 
-        if (showTabOnly !== null) {
-          const activeTabHiddenLocalTracks = ensureExists(
-            activeTabHiddenLocalTracksByPid.get(globalTrack.pid)
-          );
-          if (activeTabHiddenLocalTracks.has(trackIndex)) {
-            // If we are in active tab view, hide this track completely,
-            continue;
-          }
-        }
         const hiddenText = hiddenTracks.has(trackIndex) ? 'hide' : 'show';
         const selected =
           track.threadIndex === selectedThreadIndex ? ' SELECTED' : '';
@@ -204,4 +181,46 @@ export function getStoreWithMemoryTrack(pid: number = 222): * {
     throw new Error('Expected a memory track.');
   }
   return { store, ...store, profile, trackReference, localTrack, threadIndex };
+}
+
+/**
+ * This function takes the current active tab timeline tracks, and generates a
+ * human readable result that makes it easy to assert the shape and structure
+ * of the tracks in tests.
+ *
+ * Usage:
+ *
+ * expect(getHumanReadableTracks(getState())).toEqual([
+ *  'screenshots',
+ *  'main track [tab]',
+ * ]);
+ *
+ */
+export function getHumanReadableActiveTabTracks(state: State): string[] {
+  const globalTracks = profileViewSelectors.getActiveTabGlobalTracks(state);
+  const selectedThreadIndex = urlStateSelectors.getSelectedThreadIndex(state);
+  const text: string[] = [];
+
+  for (const globalTrack of globalTracks) {
+    switch (globalTrack.type) {
+      case 'tab': {
+        const selected =
+          globalTrack.threadIndex === selectedThreadIndex ? ' SELECTED' : '';
+        text.push(`main track [tab]${selected}`);
+        // TODO: Add resource tracks
+        break;
+      }
+      case 'screenshots': {
+        text.push(`${globalTrack.type}`);
+        break;
+      }
+      default:
+        throw assertExhaustiveCheck(
+          globalTrack,
+          'Unhandled ActiveTabGlobalTrack.'
+        );
+    }
+  }
+
+  return text;
 }

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import { changeViewAndRecomputeProfileData } from '../../actions/receive-profile';
+import {
+  getHumanReadableActiveTabTracks,
+  getProfileWithNiceTracks,
+} from '../fixtures/profiles/tracks';
+import {
+  getScreenshotTrackProfile,
+  addActiveTabInformationToProfile,
+} from '../fixtures/profiles/processed-profile';
+import { storeWithProfile } from '../fixtures/stores';
+
+describe('ActiveTab', function() {
+  function setup(p = getProfileWithNiceTracks()) {
+    const { profile, ...pageInfo } = addActiveTabInformationToProfile(p);
+    // Add the innerWindowIDs so we can compute the first thread as main track.
+    profile.threads[0].frameTable.innerWindowID[0] =
+      pageInfo.parentInnerWindowIDsWithChildren;
+    if (profile.threads[0].frameTable.length < 1) {
+      profile.threads[0].frameTable.length = 1;
+    }
+
+    const { dispatch, getState } = storeWithProfile(profile);
+    dispatch(
+      changeViewAndRecomputeProfileData(pageInfo.activeBrowsingContextID)
+    );
+
+    return {
+      // Store:
+      dispatch,
+      getState,
+      // BrowsingContextIDs and InnerWindowIDs of pages:
+      ...pageInfo,
+    };
+  }
+
+  describe('global tracks', function() {
+    it('can initialize with active tab information', function() {
+      const { getState } = setup();
+      expect(getHumanReadableActiveTabTracks(getState())).toEqual([
+        'main track [tab] SELECTED',
+      ]);
+    });
+
+    it('can extract a screenshots track', function() {
+      const profile = getScreenshotTrackProfile();
+      profile.threads[0].name = 'GeckoMain';
+      const { getState } = setup(profile);
+      expect(getHumanReadableActiveTabTracks(getState())).toEqual([
+        'screenshots',
+        'screenshots',
+        'main track [tab] SELECTED',
+      ]);
+    });
+  });
+});

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -2955,24 +2955,24 @@ describe('pages and active tab selectors', function() {
     expect(ProfileViewSelectors.getPagesMap(getState())).toEqual(result);
   });
 
-  it('getRelevantPagesForCurrentTab will get the correct InnerWindowIDs for the first tab', function() {
+  it('getRelevantInnerWindowIDsForCurrentTab will get the correct InnerWindowIDs for the first tab', function() {
     const { getState } = setup(firstTabBrowsingContextID);
     expect(
-      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
+      ProfileViewSelectors.getRelevantInnerWindowIDsForCurrentTab(getState())
     ).toEqual(new Set(fistTabInnerWindowIDs));
   });
 
-  it('getRelevantPagesForCurrentTab will get the correct InnerWindowIDs for the second tab', function() {
+  it('getRelevantInnerWindowIDsForCurrentTab will get the correct InnerWindowIDs for the second tab', function() {
     const { getState } = setup(secondTabBrowsingContextID);
     expect(
-      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
+      ProfileViewSelectors.getRelevantInnerWindowIDsForCurrentTab(getState())
     ).toEqual(new Set(secondTabInnerWindowIDs));
   });
 
-  it('getRelevantPagesForCurrentTab will return an empty set for an ID that is not in the array', function() {
+  it('getRelevantInnerWindowIDsForCurrentTab will return an empty set for an ID that is not in the array', function() {
     const { getState } = setup(99999); // a non-existent BrowsingContextID
     expect(
-      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
+      ProfileViewSelectors.getRelevantInnerWindowIDsForCurrentTab(getState())
     ).toEqual(new Set());
   });
 });

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -2945,14 +2945,16 @@ describe('pages and active tab selectors', function() {
     return { profile, dispatch, getState };
   }
 
-  it('getPagesMap will construct the whole map correctly', function() {
+  it('getInnerWindowIDSetByBrowsingContextID will construct the whole map correctly', function() {
     const { getState } = setup(firstTabBrowsingContextID); // the given argument is not important for this test
     const objectResult = [
       [firstTabBrowsingContextID, new Set(fistTabInnerWindowIDs)],
       [secondTabBrowsingContextID, new Set(secondTabInnerWindowIDs)],
     ];
     const result = new Map(objectResult);
-    expect(ProfileViewSelectors.getPagesMap(getState())).toEqual(result);
+    expect(
+      ProfileViewSelectors.getInnerWindowIDSetByBrowsingContextID(getState())
+    ).toEqual(result);
   });
 
   it('getRelevantInnerWindowIDsForCurrentTab will get the correct InnerWindowIDs for the first tab', function() {

--- a/src/test/store/profile-view.test.js.orig
+++ b/src/test/store/profile-view.test.js.orig
@@ -2858,24 +2858,24 @@ describe('pages and active tab selectors', function() {
     expect(ProfileViewSelectors.getPagesMap(getState())).toEqual(result);
   });
 
-  it('getRelevantPagesForCurrentTab will get the correct InnerWindowIDs for the first tab', function() {
+  it('getRelevantInnerWindowIDsForCurrentTab will get the correct InnerWindowIDs for the first tab', function() {
     const { getState } = setup(firstTabBrowsingContextID);
     expect(
-      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
+      ProfileViewSelectors.getRelevantInnerWindowIDsForCurrentTab(getState())
     ).toEqual(new Set(fistTabInnerWindowIDs));
   });
 
-  it('getRelevantPagesForCurrentTab will get the correct InnerWindowIDs for the second tab', function() {
+  it('getRelevantInnerWindowIDsForCurrentTab will get the correct InnerWindowIDs for the second tab', function() {
     const { getState } = setup(secondTabBrowsingContextID);
     expect(
-      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
+      ProfileViewSelectors.getRelevantInnerWindowIDsForCurrentTab(getState())
     ).toEqual(new Set(secondTabInnerWindowIDs));
   });
 
-  it('getRelevantPagesForCurrentTab will return an empty set for an ID that is not in the array', function() {
+  it('getRelevantInnerWindowIDsForCurrentTab will return an empty set for an ID that is not in the array', function() {
     const { getState } = setup(99999); // a non-existent BrowsingContextID
     expect(
-      ProfileViewSelectors.getRelevantPagesForCurrentTab(getState())
+      ProfileViewSelectors.getRelevantInnerWindowIDsForCurrentTab(getState())
     ).toEqual(new Set());
   });
 });

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -32,12 +32,15 @@ import {
   getHumanReadableTracks,
   getProfileWithNiceTracks,
 } from './fixtures/profiles/tracks';
-import { getProfileFromTextSamples } from './fixtures/profiles/processed-profile';
+import {
+  getProfileFromTextSamples,
+  addActiveTabInformationToProfile,
+} from './fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../selectors/per-thread';
 import { uintArrayToString } from '../utils/uintarray-encoding';
 import {
-  getActiveTabHiddenGlobalTracksGetter,
-  getActiveTabHiddenLocalTracksByPidGetter,
+  getActiveTabGlobalTracks,
+  getActiveTabResourceTracks,
 } from '../selectors/profile';
 
 function _getStoreWithURL(
@@ -418,23 +421,36 @@ describe('showTabOnly', function() {
     expect(urlStateReducers.getShowTabOnly(getState())).toBe(null);
   });
 
-  // TODO: This test is disabled for now because we don't initizalize anything inside
-  // the finalizeActiveTabProfileView function yet. This will be enabled back once
-  // we have some active tab specific states (like active tab global track or resouces tracks).
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should use the finalizeActiveTabProfileView path and initialize active tab profile view state', function() {
-    const { getState } = _getStoreWithURL({
-      search: '?showTabOnly1=123',
-    });
-    expect(getActiveTabHiddenGlobalTracksGetter(getState())).toBeInstanceOf(
-      Function
+  it('should use the finalizeActiveTabProfileView path and initialize active tab profile view state', function() {
+    const {
+      profile,
+      parentInnerWindowIDsWithChildren,
+      iframeInnerWindowIDsWithChild,
+    } = addActiveTabInformationToProfile(getProfileWithNiceTracks());
+    profile.threads[0].frameTable.innerWindowID[0] = parentInnerWindowIDsWithChildren;
+    profile.threads[1].frameTable.innerWindowID[0] = iframeInnerWindowIDsWithChild;
+    const { getState } = _getStoreWithURL(
+      {
+        search: '?showTabOnly1=123',
+      },
+      profile
     );
-    const activeTabHiddenLocalTracksByPidGetter = getActiveTabHiddenLocalTracksByPidGetter(
-      getState()
-    );
-    expect(activeTabHiddenLocalTracksByPidGetter).toBeInstanceOf(Function);
-    const hiddenLocalTracksByPid = activeTabHiddenLocalTracksByPidGetter();
-    expect(hiddenLocalTracksByPid.size).toBe(1);
+    const globalTracks = getActiveTabGlobalTracks(getState());
+    expect(globalTracks.length).toBe(1);
+    expect(globalTracks).toEqual([
+      {
+        type: 'tab',
+        threadIndex: 0,
+      },
+    ]);
+    // TODO: Resource track type will be changed soon.
+    const resourceTracks = getActiveTabResourceTracks(getState());
+    expect(resourceTracks).toEqual([
+      {
+        type: 'thread',
+        threadIndex: 1,
+      },
+    ]);
   });
 
   it('should remove other full view url states if present', function() {

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -20,6 +20,7 @@ import type {
   LocalTrack,
   TrackIndex,
   MarkerIndex,
+  ActiveTabGlobalTrack,
 } from './profile-derived';
 import type { TemporaryError } from '../utils/errors';
 import type { Transform, TransformStacksPerThread } from './transforms';
@@ -76,6 +77,7 @@ export type LocalTrackReference = {|
   +trackIndex: TrackIndex,
   +pid: Pid,
 |};
+
 export type TrackReference = GlobalTrackReference | LocalTrackReference;
 
 export type RequestedLib = {|
@@ -265,6 +267,8 @@ type ReceiveProfileAction =
   | {|
       +type: 'VIEW_ACTIVE_TAB_PROFILE',
       +selectedThreadIndex: ThreadIndex,
+      +globalTracks: ActiveTabGlobalTrack[],
+      +resourceTracks: LocalTrack[],
       +showTabOnly?: BrowsingContextID | null,
     |}
   | {|

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -203,6 +203,16 @@ export type Track = GlobalTrack | LocalTrack;
 export type TrackIndex = number;
 
 /**
+ * Active tab view tracks
+ */
+export type ActiveTabGlobalTrack =
+  | {| +type: 'tab', +threadIndex: ThreadIndex |}
+  | {| +type: 'screenshots', +id: string, +threadIndex: ThreadIndex |};
+
+// TODO: add resource track type
+export type ActiveTabTrack = ActiveTabGlobalTrack;
+
+/**
  * Type that holds the values of personally identifiable information that user
  * wants to remove.
  */

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -25,6 +25,7 @@ import type {
   LocalTrack,
   TrackIndex,
   MarkerIndex,
+  ActiveTabGlobalTrack,
 } from './profile-derived';
 import type { Attempt } from '../utils/errors';
 import type { TransformStacksPerThread } from './transforms';
@@ -67,6 +68,9 @@ export type FullProfileViewState = {|
  * They should not be used from the full view.
  */
 export type ActiveTabProfileViewState = {|
+  globalTracks: ActiveTabGlobalTrack[],
+  // TODO: Add a better refined type for resource tracks.
+  resourceTracks: LocalTrack[],
   hiddenGlobalTracksGetter: () => Set<TrackIndex>,
   hiddenLocalTracksByPidGetter: () => Map<Pid, Set<TrackIndex>>,
 |};


### PR DESCRIPTION
This PR adds the computation of global tracks. But doesn't change the UI. It's possible to check the state from command line or with the test.
It also adds the resource tracks field but it's not complete yet and it's type is not completely refined (still uses `LocalTrack`). Will be change when we have a proper resource track support.

[Example profile](https://deploy-preview-2518--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/) 
Dispatches:
```
dispatch(actions.changeViewAndRecomputeProfileData(profile.meta.configuration.activeBrowsingContextID));
and
dispatch(actions.changeViewAndRecomputeProfileData(null));
```