### PR TITLE
 Better formatting for the interval tag in the profile info dialog

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -97,7 +97,7 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
               {meta.interval ? (
                 <div className="metaInfoRow">
                   <span className="metaInfoLabel">Interval:</span>
-                  {meta.interval}ms
+                  {_formatInterval(meta.interval)}
                 </div>
               ) : null}
               {meta.preprocessedProfileVersion ? (
@@ -289,4 +289,16 @@ function _formatLabel(meta: ProfileMeta): string {
     os = meta.oscpu || '';
   }
   return product + (version ? ` (${version})` : '') + (os ? ` ${os}` : '');
+}
+
+function _formatInterval(interval: number): string {
+    // Format in the most precise base (milliseconds, microseconds, or
+    // nanoseconds), to avoid cases where intervals are displayed with
+    // too many leading zeroes to be useful.
+    if (interval >= 1.0) {
+        return interval + "ms";
+    } else if (interval * 1000 >= 1.0) {
+        return (interval * 1000) + "μs";
+    }
+    return (interval * 1000000) + "ns";
 }

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -292,13 +292,13 @@ function _formatLabel(meta: ProfileMeta): string {
 }
 
 function _formatInterval(interval: number): string {
-    // Format in the most precise base (milliseconds, microseconds, or
-    // nanoseconds), to avoid cases where intervals are displayed with
-    // too many leading zeroes to be useful.
-    if (interval >= 1.0) {
-        return interval + "ms";
-    } else if (interval * 1000 >= 1.0) {
-        return (interval * 1000) + "μs";
-    }
-    return (interval * 1000000) + "ns";
+  // Format in the most precise base (milliseconds, microseconds, or
+  // nanoseconds), to avoid cases where intervals are displayed with
+  // too many leading zeroes to be useful.
+  if (interval >= 1.0) {
+    return interval + 'ms';
+  } else if (interval * 1000 >= 1.0) {
+    return interval * 1000 + 'μs';
+  }
+  return interval * 1000000 + 'ns';
 }

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import ButtonWithPanel from '../../shared/ButtonWithPanel';
 import ArrowPanel from '../../shared/ArrowPanel';
 import { MetaOverheadStatistics } from './MetaOverheadStatistics';
-import { formatBytes } from '../../../utils/format-numbers';
+import { formatBytes, formatTimestamp } from '../../../utils/format-numbers';
 
 import type { Profile, ProfileMeta } from '../../../types/profile';
 import type { SymbolicationStatus } from '../../../types/state';
@@ -97,7 +97,7 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
               {meta.interval ? (
                 <div className="metaInfoRow">
                   <span className="metaInfoLabel">Interval:</span>
-                  {_formatInterval(meta.interval)}
+                  {formatTimestamp(meta.interval, 4, 1)}
                 </div>
               ) : null}
               {meta.preprocessedProfileVersion ? (
@@ -289,16 +289,4 @@ function _formatLabel(meta: ProfileMeta): string {
     os = meta.oscpu || '';
   }
   return product + (version ? ` (${version})` : '') + (os ? ` ${os}` : '');
-}
-
-function _formatInterval(interval: number): string {
-  // Format in the most precise base (milliseconds, microseconds, or
-  // nanoseconds), to avoid cases where intervals are displayed with
-  // too many leading zeroes to be useful.
-  if (interval >= 1.0) {
-    return interval + 'ms';
-  } else if (interval * 1000 >= 1.0) {
-    return interval * 1000 + 'μs';
-  }
-  return interval * 1000000 + 'ns';
 }

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -51,8 +51,7 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
             >
               Interval:
             </span>
-            1
-            ms
+            1ms
           </div>
           <div
             class="metaInfoRow"
@@ -468,8 +467,7 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
             >
               Interval:
             </span>
-            1
-            ms
+            1ms
           </div>
           <div
             class="metaInfoRow"

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -51,7 +51,7 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
             >
               Interval:
             </span>
-            1ms
+            1.0ms
           </div>
           <div
             class="metaInfoRow"
@@ -467,7 +467,7 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
             >
               Interval:
             </span>
-            1ms
+            1.0ms
           </div>
           <div
             class="metaInfoRow"

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -51,7 +51,7 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
             >
               Interval:
             </span>
-            1.0ms
+            1ms
           </div>
           <div
             class="metaInfoRow"
@@ -467,7 +467,7 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
             >
               Interval:
             </span>
-            1.0ms
+            1ms
           </div>
           <div
             class="metaInfoRow"

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -168,21 +168,29 @@ export function formatTimestamp(
 ) {
   // Format in the closest base (seconds, milliseconds, microseconds, or nanoseconds),
   // to avoid cases where times are displayed with too many leading zeroes to be useful.
-  if (time > 1000) {
-    return formatSeconds(time, significantDigits, maxFractionalDigits);
+  if (time >= 1000) {
+    return formatSeconds(
+      time,
+      significantDigits,
+      Number.isInteger(time / 1000) ? 0 : maxFractionalDigits
+    );
   } else if (time >= 1) {
-    return formatMilliseconds(time, significantDigits, maxFractionalDigits);
+    return formatMilliseconds(
+      time,
+      significantDigits,
+      Number.isInteger(time) ? 0 : maxFractionalDigits
+    );
   } else if (time * 1000 >= 1) {
     return formatMicroseconds(
       time * 1000,
       significantDigits,
-      maxFractionalDigits
+      Number.isInteger(time * 1000) ? 0 : maxFractionalDigits
     );
   }
   return formatNanoseconds(
     time * 1000 * 1000,
     significantDigits,
-    maxFractionalDigits
+    Number.isInteger(time * 1000 * 1000) ? 0 : maxFractionalDigits
   );
 }
 

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -161,6 +161,31 @@ export function formatSeconds(
   );
 }
 
+export function formatTimestamp(
+  time: Milliseconds,
+  significantDigits: number = 5,
+  maxFractionalDigits: number = 3
+) {
+  // Format in the closest base (seconds, milliseconds, microseconds, or nanoseconds),
+  // to avoid cases where times are displayed with too many leading zeroes to be useful.
+  if (time > 1000) {
+    return formatSeconds(time, significantDigits, maxFractionalDigits);
+  } else if (time >= 1) {
+    return formatMilliseconds(time, significantDigits, maxFractionalDigits);
+  } else if (time * 1000 >= 1) {
+    return formatMicroseconds(
+      time * 1000,
+      significantDigits,
+      maxFractionalDigits
+    );
+  }
+  return formatNanoseconds(
+    time * 1000 * 1000,
+    significantDigits,
+    maxFractionalDigits
+  );
+}
+
 /*
  * Format a value and a total to the form "v/t (p%)".  For example this can
  * be used to print "7MB/10MB (70%)"  fornatNum is a function to format the


### PR DESCRIPTION
The current formatting approach doesn't handle leading zeroes well (intervals less than 1ms).  This changes the display to show in whichever is closer of ms, us, or ns.