### PR TITLE
[deploy-preview] Show frame addresses for native functions in the sidebar, as a breakdown for self time.

### DIFF
--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1444,11 +1444,13 @@ exports[`snapshots of selectors/profile matches the last stored run of selectedN
 Object {
   "forFunc": Object {
     "selfTime": Object {
+      "breakdownByAddress": null,
       "breakdownByCategory": null,
       "breakdownByImplementation": null,
       "value": 0,
     },
     "totalTime": Object {
+      "breakdownByAddress": null,
       "breakdownByCategory": Array [
         Object {
           "entireCategoryValue": 0,
@@ -1507,11 +1509,13 @@ Object {
   },
   "forPath": Object {
     "selfTime": Object {
+      "breakdownByAddress": null,
       "breakdownByCategory": null,
       "breakdownByImplementation": null,
       "value": 0,
     },
     "totalTime": Object {
+      "breakdownByAddress": null,
       "breakdownByCategory": Array [
         Object {
           "entireCategoryValue": 0,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1887,9 +1887,11 @@ describe('getTimingsForSidebar', () => {
             value: 0,
             breakdownByImplementation: null,
             breakdownByCategory: null,
+            breakdownByAddress: null,
           },
           totalTime: {
             value: 5,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2, baseline: 1, ion: 2 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -1908,9 +1910,11 @@ describe('getTimingsForSidebar', () => {
             value: 0,
             breakdownByImplementation: null,
             breakdownByCategory: null,
+            breakdownByAddress: null,
           },
           totalTime: {
             value: 5,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2, baseline: 1, ion: 2 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -1947,6 +1951,7 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 1, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0, // Idle
@@ -1961,6 +1966,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 1, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0, // Idle
@@ -1977,6 +1983,7 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 3,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -1991,6 +1998,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 3,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2021,6 +2029,7 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2035,6 +2044,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2 },
 
             breakdownByCategory: withSingleSubcategory([
@@ -2052,6 +2062,7 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2066,6 +2077,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -2106,6 +2118,7 @@ describe('getTimingsForSidebar', () => {
       expect(timings.rootTime).toEqual(2);
       expect(timings.forPath.totalTime).toEqual({
         value: 2,
+        breakdownByAddress: null,
         breakdownByImplementation: { native: 1, ion: 1 },
         breakdownByCategory: withSingleSubcategory([
           1, // Idle
@@ -2148,11 +2161,13 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 3,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 3,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0, // Idle
@@ -2169,6 +2184,7 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 3,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2183,6 +2199,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 3,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2210,11 +2227,13 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 0,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { ion: 1, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2231,11 +2250,13 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 0,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 5,
+            breakdownByAddress: null,
             breakdownByImplementation: {
               ion: 2,
               baseline: 1,
@@ -2269,11 +2290,13 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2290,6 +2313,7 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2304,6 +2328,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -2326,11 +2351,13 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 0,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -2347,6 +2374,7 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2361,6 +2389,7 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: {
             value: 2,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -2388,11 +2417,13 @@ describe('getTimingsForSidebar', () => {
         forPath: {
           selfTime: {
             value: 0,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 1,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
               0,
@@ -2409,11 +2440,13 @@ describe('getTimingsForSidebar', () => {
         forFunc: {
           selfTime: {
             value: 0,
+            breakdownByAddress: null,
             breakdownByImplementation: null,
             breakdownByCategory: null,
           },
           totalTime: {
             value: 5,
+            breakdownByAddress: null,
             breakdownByImplementation: { native: 2, ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
               1, // Idle
@@ -2454,6 +2487,7 @@ describe('getTimingsForSidebar', () => {
       expect(timings.rootTime).toEqual(2);
       expect(timings.forPath.totalTime).toEqual({
         value: 1,
+        breakdownByAddress: null,
         breakdownByImplementation: { ion: 1 },
         breakdownByCategory: withSingleSubcategory([
           0, // Idle
@@ -2510,10 +2544,12 @@ describe('getTimingsForSidebar', () => {
       expect(timings.forPath).toEqual({
         selfTime: {
           breakdownByCategory: null,
+          breakdownByAddress: null,
           breakdownByImplementation: null,
           value: 0,
         },
         totalTime: {
+          breakdownByAddress: null,
           breakdownByCategory: withSingleSubcategory([0, 0, -1, 1, 0, 0, 0, 0]), // Idle, Other, Layout, JavaScript, etc.
           breakdownByImplementation: {
             native: 0,


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-2526--perf-html.netlify.app/public/19c6c045616a3b85f8ad75906ca9c84819f18065/calltree/?globalTrackOrder=7-8-0-1-2-3-4-5-6&hiddenGlobalTracks=7-8-0-1-2-3-4-6&hiddenLocalTracksByPid=25532-0-1~32116-1&localTrackOrderByPid=9952-1-2-0~27888-0~25412-0~33820-0~12540-0~25532-0-1~32116-2-0-1~&range=1.4712_2.4635&thread=6&v=4)

For C++ functions with a lot of self time, it is interesting to know which instructions and which C++ source code lines took up the time. At the moment we do not expose that information.

This change is a first step towards that: It exposes the raw frame address data in the UI.
This is not a great approach - for the vast majority of people, this information is not useful. But I'd like to have a way to show it on demand. Any ideas for how to do that?

For now I'm just putting this up as a [deploy preview] PR so that I can make use of it whenever I need this information.

<img width="1552" alt="Screen Shot 2020-04-28 at 4 05 54 PM" src="https://user-images.githubusercontent.com/961291/80532449-2d6edb80-896a-11ea-9642-237eb67815ae.png">

Having the raw frame addresses allows interested developers to do the following:
 - Look up which instructions are at those addresses, with a debugger or other tools,
 - Symbolicate those addresses themselves, for trouble-shooting symbolication problems, or
 - Find file and line number information about the addresses.

Once we get filename and line number information from the symbol server, we should add a similar breakdown to the sidebar for those.