### PR TITLE
Add ActiveTabGlobalTrack component

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -19,7 +19,8 @@ export const TIMELINE_SETTINGS_HEIGHT = 26;
 
 // Export the value for tests, and for computing the max height of the timeline
 // for the splitter.
-export const TRACK_SCREENSHOT_HEIGHT = 50;
+export const FULL_TRACK_SCREENSHOT_HEIGHT = 50;
+export const ACTIVE_TAB_TRACK_SCREENSHOT_HEIGHT = 30;
 
 // The following values are for network track.
 export const TRACK_NETWORK_ROW_HEIGHT = 5;

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -30,7 +30,6 @@ import type { ConnectedProps } from '../../utils/connect';
 type OwnProps = {|
   +trackReference: GlobalTrackReference,
   +trackIndex: TrackIndex,
-  +style?: Object /* This is used by Reorderable */,
   +setInitialSelected: (el: InitialSelectedTrackReference) => void,
 |};
 
@@ -46,6 +45,11 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
+/**
+ * Global track of active tab timeline view. Differently from the full view,
+ * it shows either screenshot and a single main track for active tab and
+ * resources tracks inside it.
+ */
 class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
   _container: HTMLElement | null = null;
   _isInitialSelectedPane: boolean | null = null;
@@ -96,15 +100,16 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
 
   componentDidMount() {
     if (this._isInitialSelectedPane && this._container !== null) {
+      // Handle the scrolling of the initial selected track into view.
       this.props.setInitialSelected(this._container);
     }
   }
 
   render() {
-    const { isSelected, style } = this.props;
+    const { isSelected } = this.props;
 
     return (
-      <li ref={this._takeContainerRef} className="timelineTrack" style={style}>
+      <li ref={this._takeContainerRef} className="timelineTrack">
         <div
           className={classNames(
             'timelineTrackRow timelineTrackGlobalRow activeTab',

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+import { selectActiveTabTrack } from '../../actions/profile-view';
+import {
+  getSelectedThreadIndex,
+  getSelectedTab,
+} from '../../selectors/url-state';
+import explicitConnect from '../../utils/connect';
+import { getActiveTabGlobalTracks } from '../../selectors/profile';
+import './Track.css';
+import TimelineTrackThread from './TrackThread';
+import TimelineTrackScreenshots from './TrackScreenshots';
+import { assertExhaustiveCheck } from '../../utils/flow';
+
+import type { TabSlug } from '../../app-logic/tabs-handling';
+import type { GlobalTrackReference } from '../../types/actions';
+import type {
+  TrackIndex,
+  ActiveTabGlobalTrack,
+  InitialSelectedTrackReference,
+} from '../../types/profile-derived';
+import type { ConnectedProps } from '../../utils/connect';
+
+type OwnProps = {|
+  +trackReference: GlobalTrackReference,
+  +trackIndex: TrackIndex,
+  +style?: Object /* This is used by Reorderable */,
+  +setInitialSelected: (el: InitialSelectedTrackReference) => void,
+|};
+
+type StateProps = {|
+  +globalTrack: ActiveTabGlobalTrack,
+  +isSelected: boolean,
+  +selectedTab: TabSlug,
+|};
+
+type DispatchProps = {|
+  +selectActiveTabTrack: typeof selectActiveTabTrack,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
+  _container: HTMLElement | null = null;
+  _isInitialSelectedPane: boolean | null = null;
+  _selectCurrentTrack = () => {
+    const { selectActiveTabTrack, trackReference } = this.props;
+    selectActiveTabTrack(trackReference);
+  };
+
+  renderTrack() {
+    const { globalTrack } = this.props;
+    switch (globalTrack.type) {
+      case 'tab': {
+        const { threadIndex } = globalTrack;
+        return (
+          <TimelineTrackThread
+            threadIndex={threadIndex}
+            showMemoryMarkers={false}
+          />
+        );
+      }
+      case 'screenshots': {
+        const { threadIndex, id } = globalTrack;
+        return (
+          <TimelineTrackScreenshots threadIndex={threadIndex} windowId={id} />
+        );
+      }
+      default:
+        console.error(
+          'Unhandled active tab globalTrack type',
+          (globalTrack: empty)
+        );
+        return null;
+    }
+  }
+
+  _takeContainerRef = (el: HTMLElement | null) => {
+    const { isSelected } = this.props;
+    this._container = el;
+
+    if (isSelected) {
+      this.setIsInitialSelectedPane(true);
+    }
+  };
+
+  setIsInitialSelectedPane = (value: boolean) => {
+    this._isInitialSelectedPane = value;
+  };
+
+  componentDidMount() {
+    if (this._isInitialSelectedPane && this._container !== null) {
+      this.props.setInitialSelected(this._container);
+    }
+  }
+
+  render() {
+    const { isSelected, style } = this.props;
+
+    return (
+      <li ref={this._takeContainerRef} className="timelineTrack" style={style}>
+        <div
+          className={classNames(
+            'timelineTrackRow timelineTrackGlobalRow activeTab',
+            {
+              selected: isSelected,
+            }
+          )}
+          onClick={this._selectCurrentTrack}
+        >
+          <div className="timelineTrackTrack">{this.renderTrack()}</div>
+        </div>
+        {/* TODO: Render the resources panel here */}
+      </li>
+    );
+  }
+}
+
+export default explicitConnect<OwnProps, StateProps, DispatchProps>({
+  mapStateToProps: (state, { trackIndex }) => {
+    const globalTracks = getActiveTabGlobalTracks(state);
+    const globalTrack = globalTracks[trackIndex];
+    const selectedTab = getSelectedTab(state);
+
+    // These get assigned based on the track type.
+    let isSelected = false;
+
+    // Run different selectors based on the track type.
+    switch (globalTrack.type) {
+      case 'tab': {
+        // Look up the thread information for the process if it exists.
+        if (globalTrack.threadIndex !== null) {
+          const threadIndex = globalTrack.threadIndex;
+          isSelected =
+            threadIndex === getSelectedThreadIndex(state) &&
+            selectedTab !== 'network-chart';
+        }
+        break;
+      }
+      case 'screenshots':
+        break;
+      default:
+        throw assertExhaustiveCheck(
+          globalTrack,
+          'Unhandled active tab GlobalTrack type.'
+        );
+    }
+
+    return {
+      globalTrack,
+      isSelected,
+      selectedTab,
+    };
+  },
+  mapDispatchToProps: {
+    selectActiveTabTrack,
+  },
+  component: ActiveTabGlobalTrackComponent,
+});

--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.timelineSelection.activeTab {
+  --thread-label-column-width: 0;
+}
+
+.timelineTrack:not(:first-child)
+  .timelineTrackGlobalRow.activeTab
+  .timelineTrackThread {
+  padding-top: 10px;
+  border-top: 1px solid var(--grey-30);
+}

--- a/src/components/timeline/ActiveTabTimeline.js
+++ b/src/components/timeline/ActiveTabTimeline.js
@@ -8,20 +8,33 @@ import * as React from 'react';
 import TimelineRuler from './Ruler';
 import TimelineSelection from './Selection';
 import OverflowEdgeIndicator from './OverflowEdgeIndicator';
+import ActiveTabTimelineGlobalTrack from './ActiveTabGlobalTrack';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
 import { getPanelLayoutGeneration } from '../../selectors/app';
-import { getCommittedRange, getZeroAt } from '../../selectors/profile';
+import {
+  getCommittedRange,
+  getZeroAt,
+  getActiveTabGlobalTracks,
+  getActiveTabGlobalTrackReferences,
+} from '../../selectors/profile';
 
 import './index.css';
+import './ActiveTabTimeline.css';
 
 import type { SizeProps } from '../shared/WithSize';
-import type { InitialSelectedTrackReference } from '../../types/profile-derived';
+import type {
+  ActiveTabGlobalTrack,
+  InitialSelectedTrackReference,
+} from '../../types/profile-derived';
+import type { GlobalTrackReference } from '../../types/actions';
 import type { Milliseconds, StartEndRange } from '../../types/units';
 import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|
   +committedRange: StartEndRange,
+  +globalTracks: ActiveTabGlobalTrack[],
+  +globalTrackReferences: GlobalTrackReference[],
   +panelLayoutGeneration: number,
   +zeroAt: Milliseconds,
 |};
@@ -49,11 +62,18 @@ class ActiveTabTimeline extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { committedRange, zeroAt, width, panelLayoutGeneration } = this.props;
+    const {
+      committedRange,
+      zeroAt,
+      width,
+      panelLayoutGeneration,
+      globalTracks,
+      globalTrackReferences,
+    } = this.props;
 
     return (
       <>
-        <TimelineSelection width={width}>
+        <TimelineSelection width={width} className="activeTab">
           <TimelineRuler
             zeroAt={zeroAt}
             rangeStart={committedRange.start}
@@ -66,7 +86,14 @@ class ActiveTabTimeline extends React.PureComponent<Props, State> {
             initialSelected={this.state.initialSelected}
           >
             <ol className="timelineThreadList">
-              {/* TODO: Add the active tab global tracks here */}
+              {globalTracks.map((globalTrack, trackIndex) => (
+                <ActiveTabTimelineGlobalTrack
+                  key={trackIndex}
+                  trackIndex={trackIndex}
+                  trackReference={globalTrackReferences[trackIndex]}
+                  setInitialSelected={this.setInitialSelected}
+                />
+              ))}
             </ol>
           </OverflowEdgeIndicator>
         </TimelineSelection>
@@ -77,6 +104,8 @@ class ActiveTabTimeline extends React.PureComponent<Props, State> {
 
 export default explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: state => ({
+    globalTracks: getActiveTabGlobalTracks(state),
+    globalTrackReferences: getActiveTabGlobalTrackReferences(state),
     committedRange: getCommittedRange(state),
     zeroAt: getZeroAt(state),
     panelLayoutGeneration: getPanelLayoutGeneration(state),

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -32,6 +32,7 @@ type MouseHandler = (event: MouseEvent) => void;
 type OwnProps = {|
   +width: number,
   +children: React.Node,
+  +className?: string,
 |};
 
 type StateProps = {|
@@ -339,12 +340,12 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { children, previewSelection } = this.props;
+    const { children, previewSelection, className } = this.props;
     const { hoverLocation } = this.state;
 
     return (
       <div
-        className="timelineSelection"
+        className={classNames('timelineSelection', className)}
         ref={this._containerCreated}
         onMouseDown={this._onMouseDown}
         onMouseMove={this._onMouseMove}

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -268,6 +268,10 @@ function isTopmostThread(
     if (
       data &&
       data.innerWindowID &&
+      // Do not look at the network markers because they are not reliable. Some
+      // network markers of an iframe comes from the parent frame. Therefore, their
+      // innerWindowID will be the parent window's innerWindowID.
+      data.type !== 'Network' &&
       topmostInnerWindowIDs.has(data.innerWindowID)
     ) {
       return true;

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -16,7 +16,8 @@ import {
 import { getZipFileState } from './zipped-profiles.js';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import {
-  TRACK_SCREENSHOT_HEIGHT,
+  FULL_TRACK_SCREENSHOT_HEIGHT,
+  ACTIVE_TAB_TRACK_SCREENSHOT_HEIGHT,
   TRACK_NETWORK_HEIGHT,
   TRACK_MEMORY_HEIGHT,
   TRACK_IPC_HEIGHT,
@@ -60,6 +61,18 @@ export const getIsDragAndDropOverlayRegistered: Selector<boolean> = state =>
   getApp(state).isDragAndDropOverlayRegistered;
 
 /**
+ * Height of screenshot track is different depending on the view.
+ */
+export const getScreenshotTrackHeight: Selector<number> = createSelector(
+  getShowTabOnly,
+  showTabOnly => {
+    return showTabOnly === null
+      ? FULL_TRACK_SCREENSHOT_HEIGHT
+      : ACTIVE_TAB_TRACK_SCREENSHOT_HEIGHT;
+  }
+);
+
+/**
  * This selector takes all of the tracks, and deduces the height in CssPixels
  * of the timeline. This is here to calculate the max-height of the timeline
  * for the splitter component.
@@ -77,6 +90,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
   getTrackThreadHeights,
   getActiveTabGlobalTracks,
   getShowTabOnly,
+  getScreenshotTrackHeight,
   (
     globalTracks,
     localTracksByPid,
@@ -84,7 +98,8 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
     hiddenLocalTracksByPid,
     trackThreadHeights,
     activeTabGlobalTracks,
-    showTabOnly
+    showTabOnly,
+    screenshotTrackHeight
   ) => {
     let height = TIMELINE_RULER_HEIGHT;
     const border = 1;
@@ -98,7 +113,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
         if (!hiddenGlobalTracks.has(trackIndex)) {
           switch (globalTrack.type) {
             case 'screenshots':
-              height += TRACK_SCREENSHOT_HEIGHT + border;
+              height += screenshotTrackHeight + border;
               break;
             case 'visual-progress':
             case 'perceptual-visual-progress':
@@ -188,7 +203,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
         if (!hiddenGlobalTracks.has(trackIndex)) {
           switch (globalTrack.type) {
             case 'screenshots':
-              height += TRACK_SCREENSHOT_HEIGHT + border;
+              height += screenshotTrackHeight + border;
               break;
             case 'tab':
               {

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -446,6 +446,16 @@ export const getActiveTabGlobalTrackReferences: Selector<
   }))
 );
 
+/**
+ * This finds an ActiveTabGlobalTrack from its TrackReference. No memoization is needed
+ * as this is a simple value look-up.
+ */
+export const getActiveTabGlobalTrackFromReference: DangerousSelectorWithArguments<
+  ActiveTabGlobalTrack,
+  GlobalTrackReference
+> = (state, trackReference) =>
+  getActiveTabGlobalTracks(state)[trackReference.trackIndex];
+
 export const getActiveTabHiddenGlobalTracksGetter: Selector<
   () => Set<TrackIndex>
 > = state => getActiveTabProfileView(state).hiddenGlobalTracksGetter;

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -17,7 +17,7 @@ import { commitRange } from '../../actions/profile-view';
 import TrackScreenshots from '../../components/timeline/TrackScreenshots';
 import Timeline from '../../components/timeline';
 import { ensureExists } from '../../utils/flow';
-import { TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';
+import { FULL_TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
@@ -165,7 +165,7 @@ function setup(
   jest
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
     .mockImplementation(() => {
-      const rect = getBoundingBox(TRACK_WIDTH, TRACK_SCREENSHOT_HEIGHT);
+      const rect = getBoundingBox(TRACK_WIDTH, FULL_TRACK_SCREENSHOT_HEIGHT);
       // Add some arbitrary X offset.
       rect.left += LEFT;
       rect.right += LEFT;

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -1,8 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global tab track 1`] = `
+<li
+  class="timelineTrack"
+>
+  <div
+    class="timelineTrackRow timelineTrackGlobalRow activeTab"
+  >
+    <div
+      class="timelineTrackTrack"
+    >
+      <div
+        class="timelineTrackThread"
+      >
+        <div
+          class="timelineMarkers"
+          data-testid="TimelineMarkersJank"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
+        </div>
+        <div
+          class="timelineMarkers timelineMarkersGeckoMain"
+          data-testid="TimelineMarkersOverview"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
+        </div>
+        <div
+          class="threadActivityGraph"
+        >
+          <canvas
+            class="threadActivityGraphCanvas threadActivityGraphCanvas"
+            height="300"
+            width="200"
+          />
+        </div>
+        <div
+          class="timelineEmptyThreadIndicator"
+        />
+      </div>
+    </div>
+  </div>
+</li>
+`;
+
 exports[`ActiveTabTimeline should be rendered properly from the Timeline component 1`] = `
 <div
-  class="timelineSelection"
+  class="timelineSelection activeTab"
 >
   <div
     class="timelineRuler"
@@ -35,7 +90,60 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
       >
         <ol
           class="timelineThreadList"
-        />
+        >
+          <li
+            class="timelineTrack"
+          >
+            <div
+              class="timelineTrackRow timelineTrackGlobalRow activeTab selected"
+            >
+              <div
+                class="timelineTrackTrack"
+              >
+                <div
+                  class="timelineTrackThread"
+                >
+                  <div
+                    class="timelineMarkers selected"
+                    data-testid="TimelineMarkersJank"
+                  >
+                    <div
+                      class="react-contextmenu-wrapper"
+                    >
+                      <canvas
+                        class="timelineMarkersCanvas"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="timelineMarkers timelineMarkersGeckoMain selected"
+                    data-testid="TimelineMarkersOverview"
+                  >
+                    <div
+                      class="react-contextmenu-wrapper"
+                    >
+                      <canvas
+                        class="timelineMarkersCanvas"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="threadActivityGraph"
+                  >
+                    <canvas
+                      class="threadActivityGraphCanvas threadActivityGraphCanvas"
+                      height="300"
+                      width="200"
+                    />
+                  </div>
+                  <div
+                    class="timelineEmptyThreadIndicator"
+                  />
+                </div>
+              </div>
+            </div>
+          </li>
+        </ol>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds the global track component for the active tab view. Now it should be possible to see screenshots and the main track in the UI by changing the view.

[Deploy preview](https://deploy-preview-2529--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?showTabOnly1=12&thread=19&v=4)

You can try it out with these dispatches:
```
dispatch(actions.changeViewAndRecomputeProfileData(profile.meta.configuration.activeBrowsingContextID));
and
dispatch(actions.changeViewAndRecomputeProfileData(null));
```