### PR TITLE
Fix the full timeline height calculation and add a test for it

### DIFF
--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -181,6 +181,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                     // The height isn't computed yet, return.
                     return null;
                   }
+                  height += trackThreadHeight + border;
                 }
                 break;
               }

--- a/src/test/components/ProfileViewer.test.js
+++ b/src/test/components/ProfileViewer.test.js
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import ProfileViewer from '../../components/app/ProfileViewer';
+import { render } from 'react-testing-library';
+import { Provider } from 'react-redux';
+import { storeWithProfile } from '../fixtures/stores';
+import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
+import { getBoundingBox } from '../fixtures/utils';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { getTimelineHeight } from '../../selectors/app';
+import mockRaf from '../fixtures/mocks/request-animation-frame';
+
+describe('ProfileViewer', function() {
+  beforeEach(() => {
+    jest.spyOn(ReactDOM, 'findDOMNode').mockImplementation(() => {
+      // findDOMNode uses nominal typing instead of structural (null | Element | Text), so
+      // opt out of the type checker for this mock by returning `any`.
+      const mockEl = ({
+        getBoundingClientRect: () => getBoundingBox(300, 300),
+      }: any);
+      return mockEl;
+    });
+
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(() => getBoundingBox(200, 300));
+
+    const ctx = mockCanvasContext();
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => ctx);
+  });
+
+  it('calculates the full timeline height correctly', () => {
+    // WithSize uses requestAnimationFrame
+    const flushRafCalls = mockRaf();
+    const store = storeWithProfile(getProfileWithNiceTracks());
+
+    render(
+      <Provider store={store}>
+        <ProfileViewer />
+      </Provider>
+    );
+
+    // Flushing the requestAnimationFrame calls so we can see the actual height of tracks.
+    flushRafCalls();
+
+    // Note: You should update this total height if you changed the height calculation algorithm.
+    expect(getTimelineHeight(store.getState())).toBe(1250);
+  });
+});


### PR DESCRIPTION
This was a regression from the PR #2529. We missed it because we weren't testing the track height algorithm. Also added a small test that asserts the height.

[Deploy preview](https://deploy-preview-2537--perf-html.netlify.app//public/91bdb2248d08174f07d9186aabbe1025e5ff9bf1/calltree/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&hiddenLocalTracksByPid=41032-1-2-3-4-5~41035-0~41033-0-1&localTrackOrderByPid=41032-6-0-1-2-3-4-5~41035-0~41033-2-0-1~&thread=11&v=4)