### PR TITLE
Active tab resources panel

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -181,3 +181,10 @@ export function registerDragAndDropOverlay(): Action {
 export function unregisterDragAndDropOverlay(): Action {
   return { type: 'UNREGISTER_DRAG_AND_DROP_OVERLAY' };
 }
+
+/**
+ * Toggle the active tab resources panel
+ */
+export function toggleResourcesPanel(): Action {
+  return { type: 'TOGGLE_RESOURCES_PANEL' };
+}

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -51,3 +51,6 @@ export const JS_TRACER_MAXIMUM_CHART_ZOOM = 0.001;
 // The following values are for the visual progress tracks.
 export const TRACK_VISUAL_PROGRESS_HEIGHT = 40;
 export const TRACK_VISUAL_PROGRESS_LINE_WIDTH = 2;
+
+// Height of the active tab resources panel header.
+export const ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT = 20;

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -95,7 +95,9 @@ type FullProfileSpecificBaseQuery = {|
 |};
 
 // Base query that only applies to active tab profile view.
-type ActiveTabProfileSpecificBaseQuery = {||};
+type ActiveTabProfileSpecificBaseQuery = {|
+  resourcesOpen: null | void,
+|};
 
 // Base query that only applies to origins profile view.
 type OriginsProfileSpecificBaseQuery = {||};
@@ -265,6 +267,10 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     }
     case 'active-tab': {
       baseQuery = ({}: ActiveTabProfileSpecificBaseQueryShape);
+
+      baseQuery.resourcesOpen = urlState.profileSpecific.activeTab.resourcesOpen
+        ? null
+        : undefined;
       break;
     }
     case 'origins':
@@ -528,9 +534,9 @@ export function stateFromLocation(
           ? query.hiddenThreads.split('-').map(index => Number(index))
           : null,
       },
-      // Currently this is commented out because it's empty and redux doesn't allow
-      // empty objects without reducers. Uncomment it after adding a state in it.
-      // activeTab: {},
+      activeTab: {
+        resourcesOpen: query.resourcesOpen !== undefined,
+      },
     },
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -96,7 +96,7 @@ type FullProfileSpecificBaseQuery = {|
 
 // Base query that only applies to active tab profile view.
 type ActiveTabProfileSpecificBaseQuery = {|
-  resourcesOpen: null | void,
+  resources: null | void,
 |};
 
 // Base query that only applies to origins profile view.
@@ -268,7 +268,7 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     case 'active-tab': {
       baseQuery = ({}: ActiveTabProfileSpecificBaseQueryShape);
 
-      baseQuery.resourcesOpen = urlState.profileSpecific.activeTab
+      baseQuery.resources = urlState.profileSpecific.activeTab
         .isResourcesPanelOpen
         ? null
         : undefined;
@@ -536,7 +536,7 @@ export function stateFromLocation(
           : null,
       },
       activeTab: {
-        isResourcesPanelOpen: query.resourcesOpen !== undefined,
+        isResourcesPanelOpen: query.resources !== undefined,
       },
     },
   };

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -268,7 +268,8 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     case 'active-tab': {
       baseQuery = ({}: ActiveTabProfileSpecificBaseQueryShape);
 
-      baseQuery.resourcesOpen = urlState.profileSpecific.activeTab.resourcesOpen
+      baseQuery.resourcesOpen = urlState.profileSpecific.activeTab
+        .isResourcesPanelOpen
         ? null
         : undefined;
       break;
@@ -535,7 +536,7 @@ export function stateFromLocation(
           : null,
       },
       activeTab: {
-        resourcesOpen: query.resourcesOpen !== undefined,
+        isResourcesPanelOpen: query.resourcesOpen !== undefined,
       },
     },
   };

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -8,7 +8,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../utils/connect';
 import { withSize } from '../shared/WithSize';
-import { getIsActiveTabResourcesOpen } from '../../selectors/url-state';
+import { getIsActiveTabResourcesPanelOpen } from '../../selectors/url-state';
 import { toggleResourcesPanel } from '../../actions/app';
 import { ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT } from '../../app-logic/constants';
 
@@ -22,7 +22,7 @@ type OwnProps = {|
 |};
 
 type StateProps = {|
-  isActiveTabResourcesOpen: boolean,
+  isActiveTabResourcesPanelOpen: boolean,
 |};
 
 type DispatchProps = {|
@@ -39,7 +39,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
     const {
       resourceTracks,
       toggleResourcesPanel,
-      isActiveTabResourcesOpen,
+      isActiveTabResourcesPanelOpen,
     } = this.props;
     return (
       <div
@@ -51,12 +51,12 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
         <div
           onClick={toggleResourcesPanel}
           className={classNames('timelineResourcesHeader', {
-            opened: isActiveTabResourcesOpen,
+            opened: isActiveTabResourcesPanelOpen,
           })}
         >
           Resources ({resourceTracks.length})
         </div>
-        {isActiveTabResourcesOpen ? (
+        {isActiveTabResourcesPanelOpen ? (
           <ol className="timelineResourceTracks">
             {/* TODO: Add the Resource tracks here */}
           </ol>
@@ -68,7 +68,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
 
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
-    isActiveTabResourcesOpen: getIsActiveTabResourcesOpen(state),
+    isActiveTabResourcesPanelOpen: getIsActiveTabResourcesPanelOpen(state),
   }),
   mapDispatchToProps: { toggleResourcesPanel },
   component: withSize<Props>(ActiveTabResourcesPanel),

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import classNames from 'classnames';
+import explicitConnect from '../../utils/connect';
+import { withSize } from '../shared/WithSize';
+import { getIsActiveTabResourcesOpen } from '../../selectors/url-state';
+import { toggleResourcesPanel } from '../../actions/app';
+import { ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT } from '../../app-logic/constants';
+
+import type { SizeProps } from '../shared/WithSize';
+import type { LocalTrack } from '../../types/profile-derived';
+import type { ConnectedProps } from '../../utils/connect';
+
+type OwnProps = {|
+  +resourceTracks: LocalTrack[],
+  +setIsInitialSelectedPane: (value: boolean) => void,
+|};
+
+type StateProps = {|
+  isActiveTabResourcesOpen: boolean,
+|};
+
+type DispatchProps = {|
+  +toggleResourcesPanel: typeof toggleResourcesPanel,
+|};
+
+type Props = {|
+  ...SizeProps,
+  ...ConnectedProps<OwnProps, StateProps, DispatchProps>,
+|};
+
+class ActiveTabResourcesPanel extends React.PureComponent<Props> {
+  render() {
+    const {
+      resourceTracks,
+      toggleResourcesPanel,
+      isActiveTabResourcesOpen,
+    } = this.props;
+    return (
+      <div
+        className="timelineResources"
+        style={{
+          '--resources-header-height': `${ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT}px`,
+        }}
+      >
+        <div
+          onClick={toggleResourcesPanel}
+          className={classNames('timelineResourcesHeader', {
+            opened: isActiveTabResourcesOpen,
+          })}
+        >
+          Resources ({resourceTracks.length})
+        </div>
+        {isActiveTabResourcesOpen ? (
+          <ol className="timelineResourceTracks">
+            {/* TODO: Add the Resource tracks here */}
+          </ol>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+export default explicitConnect<OwnProps, StateProps, DispatchProps>({
+  mapStateToProps: state => ({
+    isActiveTabResourcesOpen: getIsActiveTabResourcesOpen(state),
+  }),
+  mapDispatchToProps: { toggleResourcesPanel },
+  component: withSize<Props>(ActiveTabResourcesPanel),
+});

--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -12,3 +12,44 @@
   padding-top: 10px;
   border-top: 1px solid var(--grey-30);
 }
+
+/* Active tab timeline resources panel */
+.timelineResources {
+  background-color: #fff;
+}
+
+.timelineResourcesHeader {
+  position: relative;
+  height: var(--resources-header-height);
+  padding-left: 20px;
+  cursor: default;
+  font-size: 12px;
+  line-height: var(--resources-header-height);
+}
+
+.timelineResourcesHeader::before {
+  position: absolute;
+  top: calc(50% - 5px);
+  left: 8px;
+  width: 0;
+  height: 0;
+
+  /* Drawing the arrow */
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 5px solid #979797;
+  content: '';
+  transition: transform 0.2s;
+}
+
+.timelineResourcesHeader.opened::before {
+  /* Rotating the arrow if the panel is opened */
+  transform: rotate(90deg);
+}
+
+.timelineResourceTracks {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -436,7 +436,7 @@ const timelineTrackOrganization: Reducer<TimelineTrackOrganization> = (
 /**
  * Active tab resources panel open/close state.
  */
-const resourcesOpen: Reducer<boolean> = (state = false, action) => {
+const isResourcesPanelOpen: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'TOGGLE_RESOURCES_PANEL':
       return !state;
@@ -467,7 +467,7 @@ const fullProfileSpecific = combineReducers({
  * These values are specific to an individual active tab profile.
  */
 const activeTabProfileSpecific = combineReducers({
-  resourcesOpen,
+  isResourcesPanelOpen,
 });
 
 /**

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -430,6 +430,22 @@ const timelineTrackOrganization: Reducer<TimelineTrackOrganization> = (
 };
 
 /**
+ * Active tab specific profile url states
+ */
+
+/**
+ * Active tab resources panel open/close state.
+ */
+const resourcesOpen: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'TOGGLE_RESOURCES_PANEL':
+      return !state;
+    default:
+      return state;
+  }
+};
+
+/**
  * These values are specific to an individual full profile.
  */
 const fullProfileSpecific = combineReducers({
@@ -450,7 +466,9 @@ const fullProfileSpecific = combineReducers({
 /**
  * These values are specific to an individual active tab profile.
  */
-// const activeTabProfileSpecific = combineReducers({});
+const activeTabProfileSpecific = combineReducers({
+  resourcesOpen,
+});
 
 /**
  * These values are specific to an individual profile.
@@ -467,9 +485,7 @@ const profileSpecific = combineReducers({
   networkSearchString,
   transforms,
   full: fullProfileSpecific,
-  // Currently this is commented out because it's empty and redux doesn't allow
-  // empty objects without reducers. Uncomment it after adding a state in it.
-  // activeTab: activeTabProfileSpecific,
+  activeTab: activeTabProfileSpecific,
 });
 
 /**

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -16,6 +16,7 @@ import {
   getGlobalTracks,
   getLocalTracksByPid,
   getActiveTabGlobalTracks,
+  getActiveTabResourceTracks,
 } from './profile';
 import { getZipFileState } from './zipped-profiles.js';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
@@ -29,6 +30,7 @@ import {
   TIMELINE_RULER_HEIGHT,
   TIMELINE_SETTINGS_HEIGHT,
   TRACK_VISUAL_PROGRESS_HEIGHT,
+  ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT,
 } from '../app-logic/constants';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -103,6 +105,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
   getHiddenLocalTracksByPid,
   getTrackThreadHeights,
   getActiveTabGlobalTracks,
+  getActiveTabResourceTracks,
   getScreenshotTrackHeight,
   (
     timelineTrackOrganization,
@@ -112,6 +115,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
     hiddenLocalTracksByPid,
     trackThreadHeights,
     activeTabGlobalTracks,
+    activeTabResourceTracks,
     screenshotTrackHeight
   ) => {
     let height = TIMELINE_RULER_HEIGHT;
@@ -121,6 +125,12 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
         return height + 500;
       }
       case 'active-tab': {
+        if (activeTabResourceTracks.length > 0) {
+          // Active tab resources panel has a header and we should also add its
+          // height if there is a panel there.
+          height += ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT;
+        }
+
         for (const [
           trackIndex,
           globalTrack,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -35,6 +35,9 @@ export const getProfileSpecificState: Selector<*> = state =>
   getUrlState(state).profileSpecific;
 export const getFullProfileSpecificState: Selector<*> = state =>
   getProfileSpecificState(state).full;
+export const getActiveTabProfileSpecificState: Selector<*> = state =>
+  getProfileSpecificState(state).activeTab;
+
 export const getDataSource: Selector<DataSource> = state =>
   getUrlState(state).dataSource;
 export const getHash: Selector<string> = state => getUrlState(state).hash;
@@ -58,6 +61,12 @@ export const getShowJsTracerSummary: Selector<boolean> = state =>
   getFullProfileSpecificState(state).showJsTracerSummary;
 export const getTimelineTrackOrganization: Selector<TimelineTrackOrganization> = state =>
   getUrlState(state).timelineTrackOrganization;
+
+/**
+ * Active tab specific url state selectors
+ */
+export const getIsActiveTabResourcesOpen: Selector<boolean> = state =>
+  getActiveTabProfileSpecificState(state).resourcesOpen;
 
 /**
  * Raw search strings, before any splitting has been performed.

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -65,8 +65,8 @@ export const getTimelineTrackOrganization: Selector<TimelineTrackOrganization> =
 /**
  * Active tab specific url state selectors
  */
-export const getIsActiveTabResourcesOpen: Selector<boolean> = state =>
-  getActiveTabProfileSpecificState(state).resourcesOpen;
+export const getIsActiveTabResourcesPanelOpen: Selector<boolean> = state =>
+  getActiveTabProfileSpecificState(state).isResourcesPanelOpen;
 
 /**
  * Raw search strings, before any splitting has been performed.

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -154,9 +154,9 @@ describe('ActiveTabTimeline', function() {
     });
 
     it('does not display the resources panel if there are no resource tracks', () => {
-      const { getState, container } = setup();
+      const { getState, queryByText } = setup();
       expect(getActiveTabResourceTracks(getState()).length).toBe(0);
-      expect(container.querySelector('.timelineResourcesHeader')).toBeFalsy();
+      expect(queryByText(/Resources/)).toBe(null);
     });
   });
 
@@ -189,12 +189,8 @@ describe('ActiveTabTimeline', function() {
         </Provider>
       );
 
-      const { container } = renderResult;
-      const getResourcesPanelHeader = () =>
-        ensureExists(
-          container.querySelector('.timelineResourcesHeader'),
-          `Couldn't find the resources panel header with selector .timelineResourcesHeader`
-        );
+      const { getByText } = renderResult;
+      const getResourcesPanelHeader = () => getByText(/Resources/);
 
       return {
         ...renderResult,
@@ -214,6 +210,9 @@ describe('ActiveTabTimeline', function() {
 
     it('is closed by default', () => {
       const { getResourcesPanelHeader } = setup();
+      // TODO: Currently it's not possible to test this without accessing the class
+      // directly but this is not ideal for testing. We should assert user-like actions
+      // instead when we have content in this panel.
       expect(getResourcesPanelHeader().classList.contains('opened')).toBe(
         false
       );
@@ -222,6 +221,9 @@ describe('ActiveTabTimeline', function() {
     it('clicking on the header opens the resources panel', () => {
       const { getResourcesPanelHeader } = setup();
       const resourcesPanelHeader = getResourcesPanelHeader();
+      // TODO: Currently it's not possible to test this without accessing the class
+      // directly but this is not ideal for testing. We should assert user-like actions
+      // instead when we have content in this panel.
       expect(resourcesPanelHeader.classList.contains('opened')).toBe(false);
 
       fireEvent.click(resourcesPanelHeader);

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -8,6 +8,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import Timeline from '../../components/timeline';
 import ActiveTabGlobalTrack from '../../components/timeline/ActiveTabGlobalTrack';
+import ActiveTabResourcesPanel from '../../components/timeline/ActiveTabResourcesPanel';
 import { render, fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
@@ -16,7 +17,10 @@ import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
 import { getBoundingBox } from '../fixtures/utils';
 import { addActiveTabInformationToProfile } from '../fixtures/profiles/processed-profile';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
-import { getActiveTabGlobalTracks } from '../../selectors/profile';
+import {
+  getActiveTabGlobalTracks,
+  getActiveTabResourceTracks,
+} from '../../selectors/profile';
 import { getSelectedThreadIndex } from '../../selectors/url-state';
 import { changeSelectedThread } from '../../actions/profile-view';
 import { ensureExists } from '../../utils/flow';
@@ -147,6 +151,81 @@ describe('ActiveTabTimeline', function() {
       expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
       fireEvent.click(getGlobalTrackRow());
       expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
+    });
+
+    it('does not display the resources panel if there are no resource tracks', () => {
+      const { getState, container } = setup();
+      expect(getActiveTabResourceTracks(getState()).length).toBe(0);
+      expect(container.querySelector('.timelineResourcesHeader')).toBeFalsy();
+    });
+  });
+
+  describe('ActiveTabResourcesPanel', function() {
+    function setup() {
+      const { profile, ...pageInfo } = addActiveTabInformationToProfile(
+        getProfileWithNiceTracks()
+      );
+      // Setting the first thread as parent track and the second as the iframe track.
+      profile.threads[0].frameTable.innerWindowID[0] =
+        pageInfo.parentInnerWindowIDsWithChildren;
+      profile.threads[1].frameTable.innerWindowID[0] =
+        pageInfo.iframeInnerWindowIDsWithChild;
+      const store = storeWithProfile(profile);
+      store.dispatch(
+        changeTimelineTrackOrganization({
+          type: 'active-tab',
+          browsingContextID: pageInfo.firstTabBrowsingContextID,
+        })
+      );
+      const { getState, dispatch } = store;
+      const resourceTracks = getActiveTabResourceTracks(getState());
+
+      const renderResult = render(
+        <Provider store={store}>
+          <ActiveTabResourcesPanel
+            resourceTracks={resourceTracks}
+            setIsInitialSelectedPane={() => {}}
+          />
+        </Provider>
+      );
+
+      const { container } = renderResult;
+      const getResourcesPanelHeader = () =>
+        ensureExists(
+          container.querySelector('.timelineResourcesHeader'),
+          `Couldn't find the resources panel header with selector .timelineResourcesHeader`
+        );
+
+      return {
+        ...renderResult,
+        ...pageInfo,
+        dispatch,
+        getState,
+        profile,
+        store,
+        getResourcesPanelHeader,
+      };
+    }
+
+    it('matches the snapshot of a resources panel', () => {
+      const { container } = setup();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('is closed by default', () => {
+      const { getResourcesPanelHeader } = setup();
+      expect(getResourcesPanelHeader().classList.contains('opened')).toBe(
+        false
+      );
+    });
+
+    it('clicking on the header opens the resources panel', () => {
+      const { getResourcesPanelHeader } = setup();
+      const resourcesPanelHeader = getResourcesPanelHeader();
+      expect(resourcesPanelHeader.classList.contains('opened')).toBe(false);
+
+      fireEvent.click(resourcesPanelHeader);
+      expect(resourcesPanelHeader.classList.contains('opened')).toBe(true);
     });
   });
 });

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -55,6 +55,21 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
 </li>
 `;
 
+exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a resources panel 1`] = `
+<div
+  class="timelineResources"
+  style="--resources-header-height: 20px;"
+>
+  <div
+    class="timelineResourcesHeader"
+  >
+    Resources (
+    1
+    )
+  </div>
+</div>
+`;
+
 exports[`ActiveTabTimeline should be rendered properly from the Timeline component 1`] = `
 <div
   class="timelineSelection activeTab"

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -376,7 +376,8 @@ type UrlStateAction =
   | {|
       +type: 'SET_DATA_SOURCE',
       +dataSource: DataSource,
-    |};
+    |}
+  | {| +type: 'TOGGLE_RESOURCES_PANEL' |};
 
 type IconsAction =
   | {| +type: 'ICON_HAS_LOADED', +icon: string |}

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -219,7 +219,7 @@ export type FullProfileSpecificUrlState = {|
  * They should not be used from the full view.
  */
 export type ActiveTabSpecificProfileUrlState = {|
-  resourcesOpen: boolean,
+  isResourcesPanelOpen: boolean,
 |};
 
 export type ProfileSpecificUrlState = {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -217,9 +217,10 @@ export type FullProfileSpecificUrlState = {|
 /**
  * Active tab profile specific url state
  * They should not be used from the full view.
- * NOTE: This state is empty for now, but will be used later, do not remove.
  */
-export type ActiveTabSpecificProfileUrlState = {||};
+export type ActiveTabSpecificProfileUrlState = {|
+  resourcesOpen: boolean,
+|};
 
 export type ProfileSpecificUrlState = {|
   selectedThread: ThreadIndex | null,
@@ -233,9 +234,7 @@ export type ProfileSpecificUrlState = {|
   networkSearchString: string,
   transforms: TransformStacksPerThread,
   full: FullProfileSpecificUrlState,
-  // NOTE: Currently commented out to fix the flow warnings, but will be used soon.
-  // Do not remove.
-  // activeTab: ActiveTabSpecificProfileUrlState,
+  activeTab: ActiveTabSpecificProfileUrlState,
 |};
 
 /**


### PR DESCRIPTION
This PR adds the resources panel itself to the active tab view but doesn't add the resource tracks themselves. 

[Example profile](https://deploy-preview-2542--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?ctxId=12&thread=19&v=4&view=active-tab)