### PR TITLE
Enable marker table sidebar by default

### DIFF
--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -82,6 +82,7 @@ function _getSidebarInitialState() {
   const state = {};
   tabSlugs.forEach(tabSlug => (state[tabSlug] = false));
   state.calltree = true;
+  state['marker-table'] = true;
   return state;
 }
 

--- a/src/test/components/MarkerSidebar.test.js
+++ b/src/test/components/MarkerSidebar.test.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { render } from 'react-testing-library';
+
+import MarkerSidebar from '../../components/sidebar/MarkerSidebar';
+import { changeSelectedMarker } from '../../actions/profile-view';
+
+import { storeWithProfile } from '../fixtures/stores';
+import { getMarkerTableProfile } from '../fixtures/profiles/processed-profile';
+
+describe('MarkerSidebar', function() {
+  function setup() {
+    const profile = getMarkerTableProfile();
+    const store = storeWithProfile(profile);
+
+    const renderResult = render(
+      <Provider store={store}>
+        <MarkerSidebar />
+      </Provider>
+    );
+    return {
+      ...renderResult,
+      ...store,
+      profile,
+    };
+  }
+
+  it('matches the snapshots when displaying data about the currently selected node', () => {
+    const { dispatch, profile, container } = setup();
+
+    dispatch(
+      changeSelectedMarker(
+        0,
+        profile.threads[0].markers.data.findIndex(data => data?.type === 'IPC')
+      )
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/test/components/MarkerSidebar.test.js
+++ b/src/test/components/MarkerSidebar.test.js
@@ -37,7 +37,9 @@ describe('MarkerSidebar', function() {
     dispatch(
       changeSelectedMarker(
         0,
-        profile.threads[0].markers.data.findIndex(data => data?.type === 'IPC')
+        profile.threads[0].markers.data.findIndex(
+          data => data && data.type === 'IPC'
+        )
       )
     );
 

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -18,7 +18,10 @@ import {
 import { ensureExists } from '../../utils/flow';
 
 import { storeWithProfile } from '../fixtures/stores';
-import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
+import {
+  getProfileWithMarkers,
+  getMarkerTableProfile,
+} from '../fixtures/profiles/processed-profile';
 import { getBoundingBox } from '../fixtures/utils';
 
 describe('MarkerTable', function() {
@@ -28,69 +31,9 @@ describe('MarkerTable', function() {
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(() => getBoundingBox(2000, 1000));
 
-    // These were all taken from real-world values.
-    const profile = getProfileWithMarkers(
-      markers !== undefined
-        ? markers
-        : [
-            [
-              'UserTiming',
-              12.5,
-              {
-                type: 'UserTiming',
-                startTime: 12.5,
-                endTime: 12.5,
-                name: 'foobar',
-                entryType: 'mark',
-              },
-            ],
-            [
-              'NotifyDidPaint',
-              14.5,
-              {
-                type: 'tracing',
-                category: 'Paint',
-                interval: 'start',
-              },
-            ],
-            [
-              'setTimeout',
-              165.87091900000001,
-              {
-                type: 'Text',
-                startTime: 165.87091900000001,
-                endTime: 165.871503,
-                name: '5.5',
-              },
-            ],
-            [
-              'IPC',
-              120,
-              {
-                type: 'IPC',
-                startTime: 120,
-                endTime: 120,
-                otherPid: 2222,
-                messageType: 'PContent::Msg_PreferenceUpdate',
-                messageSeqno: 1,
-                side: 'parent',
-                direction: 'sending',
-                sync: false,
-              },
-            ],
-            [
-              'LogMessages',
-              170,
-              {
-                type: 'Log',
-                name: 'nsJARChannel::nsJARChannel [this=0x87f1ec80]\n',
-                module: 'nsJarProtocol',
-              },
-            ],
-          ]
-            // Sort the markers.
-            .sort((a, b) => a[1] - b[1])
-    );
+    const profile = markers
+      ? getProfileWithMarkers(markers)
+      : getMarkerTableProfile();
 
     const store = storeWithProfile(profile);
     const renderResult = render(

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MarkerSidebar matches the snapshots when displaying data about the currently selected node 1`] = `
+<aside
+  class="sidebar sidebar-marker-table"
+>
+  <div
+    class="sidebar-contents-wrapper"
+  >
+    <div
+      class="tooltipMarker"
+    >
+      <div
+        class="tooltipHeader"
+      >
+        <div
+          class="tooltipOneLine"
+        >
+          <div
+            class="tooltipTiming"
+          >
+            unknown duration
+          </div>
+          <div
+            class="tooltipTitle"
+          >
+            IPC — sent to 2222
+          </div>
+        </div>
+        <div
+          class="tooltipDetails"
+        >
+          <div
+            class="tooltipLabel"
+          >
+            Thread
+            :
+          </div>
+          Empty
+        </div>
+      </div>
+      <div
+        class="tooltipDetails"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Type
+          :
+        </div>
+        PContent::Msg_PreferenceUpdate
+        <div
+          class="tooltipLabel"
+        >
+          Sync
+          :
+        </div>
+        false
+      </div>
+    </div>
+  </div>
+</aside>
+`;

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -124,10 +124,80 @@ export function getProfileWithMarkers(
   ...markersPerThread: TestDefinedMarkers[]
 ): Profile {
   const profile = getEmptyProfile();
+  if (markersPerThread.length === 0) {
+    throw new Error(
+      'getProfileWithMarkers expected to get at least one list of markers.'
+    );
+  }
   profile.threads = markersPerThread.map(testDefinedMarkers =>
     getThreadWithMarkers(testDefinedMarkers)
   );
   return profile;
+}
+
+/**
+ * This profile is useful for marker table tests. The markers were taken from
+ * real-world values.
+ */
+export function getMarkerTableProfile() {
+  return getProfileWithMarkers(
+    [
+      [
+        'UserTiming',
+        12.5,
+        {
+          type: 'UserTiming',
+          startTime: 12.5,
+          endTime: 12.5,
+          name: 'foobar',
+          entryType: 'mark',
+        },
+      ],
+      [
+        'NotifyDidPaint',
+        14.5,
+        {
+          type: 'tracing',
+          category: 'Paint',
+          interval: 'start',
+        },
+      ],
+      [
+        'setTimeout',
+        165.87091900000001,
+        {
+          type: 'Text',
+          startTime: 165.87091900000001,
+          endTime: 165.871503,
+          name: '5.5',
+        },
+      ],
+      [
+        'IPC',
+        120,
+        {
+          type: 'IPC',
+          startTime: 120,
+          endTime: 120,
+          otherPid: 2222,
+          messageType: 'PContent::Msg_PreferenceUpdate',
+          messageSeqno: 1,
+          side: 'parent',
+          direction: 'sending',
+          sync: false,
+        },
+      ],
+      [
+        'LogMessages',
+        170,
+        {
+          type: 'Log',
+          name: 'nsJARChannel::nsJARChannel [this=0x87f1ec80]\n',
+          module: 'nsJarProtocol',
+        },
+      ],
+    ].sort((a, b) => a[1] - b[1])
+  );
 }
 
 export function getProfileWithNamedThreads(threadNames: string[]): Profile {

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -88,6 +88,31 @@ describe('app actions', function() {
   });
 
   describe('isSidebarOpen', function() {
+    it('has certain sidebars open by default', function() {
+      const { dispatch, getState } = storeWithSimpleProfile();
+
+      dispatch(AppActions.changeSelectedTab('calltree'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+
+      dispatch(AppActions.changeSelectedTab('flame-graph'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+
+      dispatch(AppActions.changeSelectedTab('stack-chart'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+
+      dispatch(AppActions.changeSelectedTab('marker-chart'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+
+      dispatch(AppActions.changeSelectedTab('marker-table'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+
+      dispatch(AppActions.changeSelectedTab('network-chart'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+
+      dispatch(AppActions.changeSelectedTab('js-tracer'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+    });
+
     it('can change the state of the sidebar', function() {
       const { dispatch, getState } = storeWithSimpleProfile();
       expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);


### PR DESCRIPTION
This enables the marker table sidebar to be on by default. It also adds a few tests in this area.