### PR TITLE
Add active tab resource track component

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -236,6 +236,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
   _onMouseUp = (event: SyntheticMouseEvent<>) => {
     const sample = this._getSampleAtMouseEvent(event);
     if (sample !== null) {
+      event.stopPropagation();
       this.props.onSampleClick(sample);
     }
   };

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -231,6 +231,7 @@ class StackGraph extends PureComponent<Props> {
         return;
       }
 
+      e.stopPropagation();
       this.props.onSampleClick(sampleIndex);
     }
   };

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -28,7 +28,7 @@ import type {
   TrackIndex,
   ActiveTabGlobalTrack,
   InitialSelectedTrackReference,
-  LocalTrack,
+  ActiveTabResourceTrack,
 } from '../../types/profile-derived';
 import type { ConnectedProps } from '../../utils/connect';
 
@@ -42,7 +42,7 @@ type StateProps = {|
   +globalTrack: ActiveTabGlobalTrack,
   +isSelected: boolean,
   +selectedTab: TabSlug,
-  +resourceTracks: LocalTrack[],
+  +resourceTracks: ActiveTabResourceTrack[],
 |};
 
 type DispatchProps = {|
@@ -73,6 +73,7 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
           <TimelineTrackThread
             threadIndex={threadIndex}
             showMemoryMarkers={false}
+            trackType="expanded"
           />
         );
       }

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+import { selectActiveTabTrack } from '../../actions/profile-view';
+import {
+  getSelectedThreadIndex,
+  getSelectedTab,
+} from '../../selectors/url-state';
+import explicitConnect from '../../utils/connect';
+import TrackThread from './TrackThread';
+import { assertExhaustiveCheck } from '../../utils/flow';
+
+import type { ActiveTabTrackReference } from '../../types/actions';
+import type {
+  TrackIndex,
+  ActiveTabResourceTrack,
+} from '../../types/profile-derived';
+import type { ConnectedProps } from '../../utils/connect';
+
+type OwnProps = {|
+  +resourceTrack: ActiveTabResourceTrack,
+  +trackIndex: TrackIndex,
+  +setIsInitialSelectedPane: (value: boolean) => void,
+|};
+
+type StateProps = {|
+  +isSelected: boolean,
+|};
+
+type DispatchProps = {|
+  +selectActiveTabTrack: typeof selectActiveTabTrack,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+type State = {|
+  isOpen: boolean,
+  prevIsSelected?: boolean,
+|};
+
+class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isOpen: props.isSelected,
+    };
+  }
+
+  _onMouseUp = (event: MouseEvent) => {
+    const { isSelected } = this.props;
+    const { isOpen } = this.state;
+
+    if (event.button === 0) {
+      // Don't allow clicks on the threads list to steal focus from the tree view.
+      event.preventDefault();
+      if (isSelected || !isOpen) {
+        // We have two different states for selected tracks and open tracks because
+        // non selected tracks also can stay opened. We can only close the track if
+        // the track is already selected.
+        this.setState(prevState => {
+          return { isOpen: !prevState.isOpen };
+        });
+      }
+      this.props.selectActiveTabTrack(this._getTrackReference());
+    }
+  };
+
+  _getTrackReference(): ActiveTabTrackReference {
+    const { trackIndex } = this.props;
+    return { type: 'resource', trackIndex };
+  }
+
+  renderTrack() {
+    const { resourceTrack } = this.props;
+    const { isOpen } = this.state;
+    switch (resourceTrack.type) {
+      case 'sub-frame':
+      case 'thread':
+        return (
+          <TrackThread
+            threadIndex={resourceTrack.threadIndex}
+            trackType={isOpen ? 'expanded' : 'condensed'}
+          />
+        );
+      default:
+        console.error('Unhandled resourceTrack type', (resourceTrack: empty));
+        return null;
+    }
+  }
+
+  componentDidMount() {
+    const { isSelected } = this.props;
+    if (isSelected) {
+      this.props.setIsInitialSelectedPane(true);
+    }
+  }
+
+  render() {
+    const { isSelected, resourceTrack } = this.props;
+    const { isOpen } = this.state;
+
+    let trackLabel;
+    switch (resourceTrack.type) {
+      case 'sub-frame':
+        trackLabel = 'Frame:';
+        break;
+      case 'thread':
+        trackLabel = 'Thread:';
+        break;
+      default:
+        throw assertExhaustiveCheck(
+          resourceTrack,
+          `Unhandled ActiveTabResourceTrack type.`
+        );
+    }
+
+    return (
+      <li className="timelineTrack timelineTrackResource">
+        {/* This next div is used to mirror the structure of the TimelineGlobalTrack */}
+        <div
+          className={classNames('timelineTrackRow timelineTrackResourceRow', {
+            selected: isSelected,
+            opened: isOpen,
+          })}
+          onMouseUp={this._onMouseUp}
+        >
+          <div className="timelineTrackResourceLabel">
+            <span>{trackLabel}</span> {resourceTrack.name}
+          </div>
+          <div className="timelineTrackTrack">{this.renderTrack()}</div>
+        </div>
+      </li>
+    );
+  }
+}
+
+export default explicitConnect<OwnProps, StateProps, DispatchProps>({
+  mapStateToProps: (state, { resourceTrack }) => {
+    const threadIndex = resourceTrack.threadIndex;
+    const selectedThreadIndex = getSelectedThreadIndex(state);
+    const selectedTab = getSelectedTab(state);
+    const isSelected =
+      threadIndex === selectedThreadIndex && selectedTab !== 'network-chart';
+
+    return {
+      isSelected,
+    };
+  },
+  mapDispatchToProps: {
+    selectActiveTabTrack,
+  },
+  component: ActiveTabResourceTrackComponent,
+});

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -11,13 +11,14 @@ import { withSize } from '../shared/WithSize';
 import { getIsActiveTabResourcesPanelOpen } from '../../selectors/url-state';
 import { toggleResourcesPanel } from '../../actions/app';
 import { ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT } from '../../app-logic/constants';
+import ActiveTabTimelineResourceTrack from './ActiveTabResourceTrack';
 
 import type { SizeProps } from '../shared/WithSize';
-import type { LocalTrack } from '../../types/profile-derived';
+import type { ActiveTabResourceTrack } from '../../types/profile-derived';
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|
-  +resourceTracks: LocalTrack[],
+  +resourceTracks: ActiveTabResourceTrack[],
   +setIsInitialSelectedPane: (value: boolean) => void,
 |};
 
@@ -40,6 +41,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
       resourceTracks,
       toggleResourcesPanel,
       isActiveTabResourcesPanelOpen,
+      setIsInitialSelectedPane,
     } = this.props;
     return (
       <div
@@ -58,7 +60,14 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
         </div>
         {isActiveTabResourcesPanelOpen ? (
           <ol className="timelineResourceTracks">
-            {/* TODO: Add the Resource tracks here */}
+            {resourceTracks.map((resourceTrack, trackIndex) => (
+              <ActiveTabTimelineResourceTrack
+                key={trackIndex}
+                resourceTrack={resourceTrack}
+                trackIndex={trackIndex}
+                setIsInitialSelectedPane={setIsInitialSelectedPane}
+              />
+            ))}
           </ol>
         ) : null}
       </div>

--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -49,25 +49,30 @@
   flex-direction: column;
 }
 
-.timelineTrackResourceRow .timelineTrackThreadMarkers {
-  width: 100%;
-}
-
 .timelineTrackResourceRow .threadActivityGraph,
 .timelineTrackResourceRow .timelineMarkers {
   transition: height 0.2s;
 }
 
+/* Set the marker height of the closed resources to 3px */
 .timelineTrackResourceRow:not(.opened) .timelineMarkers {
   height: 3px;
 }
 
+/**
+ * Double the marker height of markers when they are open, except the main marker
+ * row, because it should be heigher (it's set by the full timeline css).
+ */
 .timelineTrackResourceRow.opened
   .timelineMarkers:not(.timelineMarkersGeckoMain)
   canvas {
   height: 6px;
 }
 
+/**
+ * This is the main markers section. Since it has additional marker rows,
+ * we need to set it a heigher value.
+ */
 .timelineTrackResourceRow .timelineMarkersGeckoMain {
   height: 9px;
 }
@@ -77,8 +82,6 @@
 }
 
 .timelineTrackResourceLabel {
-  z-index: 3;
-  top: 0;
   overflow: hidden;
   max-width: calc(100% - 55px);
   padding: 0 5px 0 30px;

--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -28,9 +28,78 @@
 }
 
 .timelineResourcesHeader::before {
-  position: absolute;
   top: calc(50% - 5px);
   left: 8px;
+}
+
+.timelineResourceTracks {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+/* Active tab timeline resource tracks */
+.timelineTrackResource:first-child {
+  border-top: none;
+}
+
+.timelineTrackResourceRow {
+  position: relative;
+  flex-direction: column;
+}
+
+.timelineTrackResourceRow .timelineTrackThreadMarkers {
+  width: 100%;
+}
+
+.timelineTrackResourceRow .threadActivityGraph,
+.timelineTrackResourceRow .timelineMarkers {
+  transition: height 0.2s;
+}
+
+.timelineTrackResourceRow:not(.opened) .timelineMarkers {
+  height: 3px;
+}
+
+.timelineTrackResourceRow.opened
+  .timelineMarkers:not(.timelineMarkersGeckoMain)
+  canvas {
+  height: 6px;
+}
+
+.timelineTrackResourceRow .timelineMarkersGeckoMain {
+  height: 9px;
+}
+
+.timelineTrackResourceRow:not(.opened) .threadActivityGraph {
+  height: 6px;
+}
+
+.timelineTrackResourceLabel {
+  z-index: 3;
+  top: 0;
+  overflow: hidden;
+  max-width: calc(100% - 55px);
+  padding: 0 5px 0 30px;
+  line-height: var(--resources-header-height);
+  pointer-events: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timelineTrackResourceRow.opened .timelineTrackResourceLabel {
+  position: relative;
+}
+
+.timelineTrackResourceLabel::before {
+  top: 5px;
+  left: 20px;
+}
+
+.timelineResourcesHeader::before,
+.timelineTrackResourceLabel::before {
+  position: absolute;
   width: 0;
   height: 0;
 
@@ -42,14 +111,12 @@
   transition: transform 0.2s;
 }
 
-.timelineResourcesHeader.opened::before {
+.timelineResourcesHeader.opened::before,
+.timelineTrackResourceRow.opened .timelineTrackResourceLabel::before {
   /* Rotating the arrow if the panel is opened */
   transform: rotate(90deg);
 }
 
-.timelineResourceTracks {
-  position: relative;
-  padding: 0;
-  margin: 0;
-  list-style: none;
+.timelineTrackResourceLabel span {
+  font-weight: bold;
 }

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -122,6 +122,7 @@ class GlobalTrackComponent extends PureComponent<Props> {
           <TimelineTrackThread
             threadIndex={mainThreadIndex}
             showMemoryMarkers={!processesWithMemoryTrack.has(globalTrack.pid)}
+            trackType="expanded"
           />
         );
       }

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -80,7 +80,12 @@ class LocalTrackComponent extends PureComponent<Props> {
     const { localTrack } = this.props;
     switch (localTrack.type) {
       case 'thread':
-        return <TrackThread threadIndex={localTrack.threadIndex} />;
+        return (
+          <TrackThread
+            threadIndex={localTrack.threadIndex}
+            trackType="expanded"
+          />
+        );
       case 'network':
         return <TrackNetwork threadIndex={localTrack.threadIndex} />;
       case 'memory':

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -389,6 +389,7 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
         mouseUpItem !==
           null /* extra null check because flow doesn't realize it's unnecessary */
       ) {
+        e.stopPropagation();
         const { onSelect, threadIndex } = this.props;
         onSelect(
           threadIndex,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -20,6 +20,7 @@ import {
   getSelectedThreadIndex,
   getTimelineType,
   getInvertCallstack,
+  getTimelineTrackOrganization,
 } from '../../selectors/url-state';
 import {
   TimelineMarkersJank,
@@ -52,11 +53,12 @@ import type {
   IndexIntoCallNodeTable,
   SelectedState,
 } from '../../types/profile-derived';
-import type { State } from '../../types/state';
+import type { State, TimelineTrackOrganization } from '../../types/state';
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|
   +threadIndex: ThreadIndex,
+  +trackType: 'expanded' | 'condensed',
   +showMemoryMarkers?: boolean,
 |};
 
@@ -79,6 +81,7 @@ type StateProps = {|
     IndexIntoSamplesTable,
     IndexIntoSamplesTable
   ) => number,
+  +timelineTrackOrganization: TimelineTrackOrganization,
 |};
 
 type DispatchProps = {|
@@ -160,6 +163,8 @@ class TimelineTrackThread extends PureComponent<Props> {
       showMemoryMarkers,
       samplesSelectedStates,
       treeOrderSampleComparator,
+      trackType,
+      timelineTrackOrganization,
     } = this.props;
 
     const processType = filteredThread.processType;
@@ -173,37 +178,41 @@ class TimelineTrackThread extends PureComponent<Props> {
 
     return (
       <div className="timelineTrackThread">
-        {showMemoryMarkers ? (
-          <TimelineMarkersMemory
-            rangeStart={rangeStart}
-            rangeEnd={rangeEnd}
-            threadIndex={threadIndex}
-            onSelect={this._onMarkerSelect}
-          />
-        ) : null}
-        {hasFileIoMarkers ? (
-          <TimelineMarkersFileIo
-            rangeStart={rangeStart}
-            rangeEnd={rangeEnd}
-            threadIndex={threadIndex}
-            onSelect={this._onMarkerSelect}
-          />
-        ) : null}
-        {displayJank ? (
-          <TimelineMarkersJank
-            rangeStart={rangeStart}
-            rangeEnd={rangeEnd}
-            threadIndex={threadIndex}
-            onSelect={this._onMarkerSelect}
-          />
-        ) : null}
-        {displayMarkers ? (
-          <TimelineMarkersOverview
-            rangeStart={rangeStart}
-            rangeEnd={rangeEnd}
-            threadIndex={threadIndex}
-            onSelect={this._onMarkerSelect}
-          />
+        {timelineTrackOrganization.type !== 'active-tab' ? (
+          <>
+            {showMemoryMarkers ? (
+              <TimelineMarkersMemory
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+            {hasFileIoMarkers ? (
+              <TimelineMarkersFileIo
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+            {displayJank ? (
+              <TimelineMarkersJank
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+            {displayMarkers ? (
+              <TimelineMarkersOverview
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+          </>
         ) : null}
         {timelineType === 'category' && !filteredThread.isJsTracer ? (
           <ThreadActivityGraph
@@ -231,6 +240,42 @@ class TimelineTrackThread extends PureComponent<Props> {
             onSampleClick={this._onSampleClick}
           />
         )}
+        {timelineTrackOrganization.type === 'active-tab' ? (
+          <div className="timelineTrackThreadMarkers">
+            {trackType === 'expanded' && showMemoryMarkers ? (
+              <TimelineMarkersMemory
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+            {trackType === 'expanded' && hasFileIoMarkers ? (
+              <TimelineMarkersFileIo
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+            {displayJank ? (
+              <TimelineMarkersJank
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+            {trackType === 'expanded' && displayMarkers ? (
+              <TimelineMarkersOverview
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                threadIndex={threadIndex}
+                onSelect={this._onMarkerSelect}
+              />
+            ) : null}
+          </div>
+        ) : null}
         <EmptyThreadIndicator
           thread={filteredThread}
           interval={interval}
@@ -274,6 +319,7 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
       treeOrderSampleComparator: selectors.getTreeOrderComparatorInFilteredThread(
         state
       ),
+      timelineTrackOrganization: getTimelineTrackOrganization(state),
     };
   },
   mapDispatchToProps: {

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -14,6 +14,7 @@ import type {
   GlobalTrack,
   ActiveTabGlobalTrack,
   OriginsTimeline,
+  ActiveTabResourceTrack,
 } from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
 import type {
@@ -117,7 +118,10 @@ const activeTabGlobalTracks: Reducer<ActiveTabGlobalTrack[]> = (
  * This can be derived like the globalTracks information, but is stored in the state
  * for the same reason.
  */
-const activeTabResourceTracks: Reducer<LocalTrack[]> = (state = [], action) => {
+const activeTabResourceTracks: Reducer<ActiveTabResourceTrack[]> = (
+  state = [],
+  action
+) => {
   switch (action.type) {
     case 'VIEW_ACTIVE_TAB_PROFILE':
       return action.resourceTracks;

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -43,6 +43,7 @@ import type {
   ProfileFilterPageData,
   ActiveTabGlobalTrack,
   OriginsTimeline,
+  ActiveTabResourceTrack,
 } from '../types/profile-derived';
 import type { Milliseconds, StartEndRange } from '../types/units';
 import type {
@@ -51,6 +52,8 @@ import type {
   TrackReference,
   PreviewSelection,
   HiddenTrackCount,
+  ActiveTabGlobalTrackReference,
+  ActiveTabResourceTrackReference,
 } from '../types/actions';
 import type { Selector, DangerousSelectorWithArguments } from '../types/store';
 import type {
@@ -435,8 +438,9 @@ export const getActiveTabGlobalTracks: Selector<
 /**
  * Returns resource tracks for the active tab view.
  */
-export const getActiveTabResourceTracks: Selector<LocalTrack[]> = state =>
-  getActiveTabProfileView(state).resourceTracks;
+export const getActiveTabResourceTracks: Selector<
+  ActiveTabResourceTrack[]
+> = state => getActiveTabProfileView(state).resourceTracks;
 
 /**
  * This returns all TrackReferences for global tracks.
@@ -456,9 +460,19 @@ export const getActiveTabGlobalTrackReferences: Selector<
  */
 export const getActiveTabGlobalTrackFromReference: DangerousSelectorWithArguments<
   ActiveTabGlobalTrack,
-  GlobalTrackReference
+  ActiveTabGlobalTrackReference
 > = (state, trackReference) =>
   getActiveTabGlobalTracks(state)[trackReference.trackIndex];
+
+/**
+ * This finds an ActiveTabResourceTrack from its TrackReference. No memoization is needed
+ * as this is a simple value look-up.
+ */
+export const getActiveTabResourceTrackFromReference: DangerousSelectorWithArguments<
+  ActiveTabResourceTrack,
+  ActiveTabResourceTrackReference
+> = (state, trackReference) =>
+  getActiveTabResourceTracks(state)[trackReference.trackIndex];
 
 /**
  * Origins profile view selectors.

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -237,7 +237,10 @@ describe('ActiveTabTimeline', function() {
       const { profile, ...pageInfo } = addActiveTabInformationToProfile(
         getProfileWithNiceTracks()
       );
-      // Setting the first thread as parent track, the second and third as the iframe tracks.
+      // Setting the threads with the following relationship:
+      // Page #1 (thread #0)
+      // |- Page #2 (thread #1)
+      //    |- Page #3 (thread #2)
       const threadIndex = 2;
       profile.threads[0].frameTable.innerWindowID[0] =
         pageInfo.parentInnerWindowIDsWithChildren;

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -9,6 +9,7 @@ import ReactDOM from 'react-dom';
 import Timeline from '../../components/timeline';
 import ActiveTabGlobalTrack from '../../components/timeline/ActiveTabGlobalTrack';
 import ActiveTabResourcesPanel from '../../components/timeline/ActiveTabResourcesPanel';
+import ActiveTabResourceTrack from '../../components/timeline/ActiveTabResourceTrack';
 import { render, fireEvent } from 'react-testing-library';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
@@ -189,8 +190,9 @@ describe('ActiveTabTimeline', function() {
         </Provider>
       );
 
-      const { getByText } = renderResult;
+      const { getByText, queryByText } = renderResult;
       const getResourcesPanelHeader = () => getByText(/Resources/);
+      const getResourceFrameTrack = () => queryByText(/Frame:/);
 
       return {
         ...renderResult,
@@ -200,34 +202,122 @@ describe('ActiveTabTimeline', function() {
         profile,
         store,
         getResourcesPanelHeader,
+        getResourceFrameTrack,
       };
     }
 
-    it('matches the snapshot of a resources panel', () => {
+    it('matches the snapshot of a resources panel when closed', () => {
       const { container } = setup();
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    it('matches the snapshot of a resources panel when opened', () => {
+      const { container, getResourcesPanelHeader } = setup();
+      fireEvent.click(getResourcesPanelHeader());
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
     it('is closed by default', () => {
-      const { getResourcesPanelHeader } = setup();
-      // TODO: Currently it's not possible to test this without accessing the class
-      // directly but this is not ideal for testing. We should assert user-like actions
-      // instead when we have content in this panel.
-      expect(getResourcesPanelHeader().classList.contains('opened')).toBe(
-        false
-      );
+      const { getResourceFrameTrack } = setup();
+      expect(getResourceFrameTrack()).toBeFalsy();
     });
 
     it('clicking on the header opens the resources panel', () => {
-      const { getResourcesPanelHeader } = setup();
+      const { getResourcesPanelHeader, getResourceFrameTrack } = setup();
       const resourcesPanelHeader = getResourcesPanelHeader();
-      // TODO: Currently it's not possible to test this without accessing the class
-      // directly but this is not ideal for testing. We should assert user-like actions
-      // instead when we have content in this panel.
-      expect(resourcesPanelHeader.classList.contains('opened')).toBe(false);
+      expect(getResourceFrameTrack()).toBeFalsy();
 
       fireEvent.click(resourcesPanelHeader);
-      expect(resourcesPanelHeader.classList.contains('opened')).toBe(true);
+      expect(getResourceFrameTrack()).toBeTruthy();
+    });
+  });
+
+  describe('ActiveTabResourceTrack', function() {
+    function setup() {
+      const { profile, ...pageInfo } = addActiveTabInformationToProfile(
+        getProfileWithNiceTracks()
+      );
+      // Setting the first thread as parent track, the second and third as the iframe tracks.
+      const threadIndex = 2;
+      profile.threads[0].frameTable.innerWindowID[0] =
+        pageInfo.parentInnerWindowIDsWithChildren;
+      profile.threads[1].frameTable.innerWindowID[0] =
+        pageInfo.iframeInnerWindowIDsWithChild;
+      profile.threads[threadIndex].frameTable.innerWindowID[0] =
+        pageInfo.fistTabInnerWindowIDs[2];
+      profile.threads[threadIndex].name = 'GeckoMain';
+      const store = storeWithProfile(profile);
+      store.dispatch(
+        changeTimelineTrackOrganization({
+          type: 'active-tab',
+          browsingContextID: pageInfo.firstTabBrowsingContextID,
+        })
+      );
+      const { getState, dispatch } = store;
+      const resourceTracks = getActiveTabResourceTracks(getState());
+      const trackIndex = 1;
+      const renderResult = render(
+        <Provider store={store}>
+          <ActiveTabResourceTrack
+            resourceTrack={resourceTracks[1]}
+            trackIndex={trackIndex}
+            setIsInitialSelectedPane={() => {}}
+          />
+        </Provider>
+      );
+
+      const { getByText, container } = renderResult;
+      const resourcePage = ensureExists(profile.pages)[2];
+      const getResourceFrameTrackLabel = () => getByText(resourcePage.url);
+      const getResourceTrackRow = () =>
+        ensureExists(
+          container.querySelector('.timelineTrackResourceRow'),
+          `Couldn't find the track resource row with selector .timelineTrackResourceRow`
+        );
+
+      return {
+        ...renderResult,
+        ...pageInfo,
+        dispatch,
+        getState,
+        profile,
+        store,
+        threadIndex,
+        getResourceFrameTrackLabel,
+        getResourceTrackRow,
+        resourcePage,
+      };
+    }
+
+    describe('with a thread/sub-frame track', function() {
+      it('matches the snapshot of a resource track', () => {
+        const { container } = setup();
+        expect(container.firstChild).toMatchSnapshot();
+      });
+
+      it('has the correct track name', function() {
+        const { queryByText, resourcePage } = setup();
+        expect(queryByText(resourcePage.url)).toBeTruthy();
+      });
+
+      it('starts out not being selected', function() {
+        const { getState, threadIndex } = setup();
+        expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+      });
+
+      it('can select a thread by clicking the label', () => {
+        const { getState, getResourceFrameTrackLabel, threadIndex } = setup();
+        expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+        fireEvent.mouseUp(getResourceFrameTrackLabel());
+        expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
+      });
+
+      it('can select a thread by clicking the row', () => {
+        const { getState, getResourceTrackRow, threadIndex } = setup();
+        expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+        fireEvent.mouseUp(getResourceTrackRow());
+        expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
+      });
     });
   });
 });

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -63,7 +63,7 @@ describe('ThreadActivityGraph', function() {
 
     const renderResult = render(
       <Provider store={store}>
-        <TrackThread threadIndex={0} />
+        <TrackThread threadIndex={0} trackType="expanded" />
       </Provider>
     );
     const { container } = renderResult;

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -100,7 +100,7 @@ describe('timeline/TrackThread', function() {
 
     const renderResult = render(
       <Provider store={store}>
-        <TrackThread threadIndex={threadIndex} />
+        <TrackThread threadIndex={threadIndex} trackType="expanded" />
       </Provider>
     );
     const { container } = renderResult;

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -14,30 +14,6 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
         class="timelineTrackThread"
       >
         <div
-          class="timelineMarkers"
-          data-testid="TimelineMarkersJank"
-        >
-          <div
-            class="react-contextmenu-wrapper"
-          >
-            <canvas
-              class="timelineMarkersCanvas"
-            />
-          </div>
-        </div>
-        <div
-          class="timelineMarkers timelineMarkersGeckoMain"
-          data-testid="TimelineMarkersOverview"
-        >
-          <div
-            class="react-contextmenu-wrapper"
-          >
-            <canvas
-              class="timelineMarkersCanvas"
-            />
-          </div>
-        </div>
-        <div
           class="threadActivityGraph"
         >
           <canvas
@@ -45,6 +21,34 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
             height="300"
             width="200"
           />
+        </div>
+        <div
+          class="timelineTrackThreadMarkers"
+        >
+          <div
+            class="timelineMarkers"
+            data-testid="TimelineMarkersJank"
+          >
+            <div
+              class="react-contextmenu-wrapper"
+            >
+              <canvas
+                class="timelineMarkersCanvas"
+              />
+            </div>
+          </div>
+          <div
+            class="timelineMarkers timelineMarkersGeckoMain"
+            data-testid="TimelineMarkersOverview"
+          >
+            <div
+              class="react-contextmenu-wrapper"
+            >
+              <canvas
+                class="timelineMarkersCanvas"
+              />
+            </div>
+          </div>
         </div>
         <div
           class="timelineEmptyThreadIndicator"
@@ -55,7 +59,63 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
 </li>
 `;
 
-exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a resources panel 1`] = `
+exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track matches the snapshot of a resource track 1`] = `
+<li
+  class="timelineTrack timelineTrackResource"
+>
+  <div
+    class="timelineTrackRow timelineTrackResourceRow"
+  >
+    <div
+      class="timelineTrackResourceLabel"
+    >
+      <span>
+        Frame:
+      </span>
+       
+      Page #3
+    </div>
+    <div
+      class="timelineTrackTrack"
+    >
+      <div
+        class="timelineTrackThread"
+      >
+        <div
+          class="threadActivityGraph"
+        >
+          <canvas
+            class="threadActivityGraphCanvas threadActivityGraphCanvas"
+            height="300"
+            width="200"
+          />
+        </div>
+        <div
+          class="timelineTrackThreadMarkers"
+        >
+          <div
+            class="timelineMarkers"
+            data-testid="TimelineMarkersJank"
+          >
+            <div
+              class="react-contextmenu-wrapper"
+            >
+              <canvas
+                class="timelineMarkersCanvas"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="timelineEmptyThreadIndicator"
+        />
+      </div>
+    </div>
+  </div>
+</li>
+`;
+
+exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a resources panel when closed 1`] = `
 <div
   class="timelineResources"
   style="--resources-header-height: 20px;"
@@ -67,6 +127,78 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
     1
     )
   </div>
+</div>
+`;
+
+exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a resources panel when opened 1`] = `
+<div
+  class="timelineResources"
+  style="--resources-header-height: 20px;"
+>
+  <div
+    class="timelineResourcesHeader opened"
+  >
+    Resources (
+    1
+    )
+  </div>
+  <ol
+    class="timelineResourceTracks"
+  >
+    <li
+      class="timelineTrack timelineTrackResource"
+    >
+      <div
+        class="timelineTrackRow timelineTrackResourceRow"
+      >
+        <div
+          class="timelineTrackResourceLabel"
+        >
+          <span>
+            Frame:
+          </span>
+           
+          Page #2
+        </div>
+        <div
+          class="timelineTrackTrack"
+        >
+          <div
+            class="timelineTrackThread"
+          >
+            <div
+              class="threadActivityGraph"
+            >
+              <canvas
+                class="threadActivityGraphCanvas threadActivityGraphCanvas"
+                height="300"
+                width="200"
+              />
+            </div>
+            <div
+              class="timelineTrackThreadMarkers"
+            >
+              <div
+                class="timelineMarkers"
+                data-testid="TimelineMarkersJank"
+              >
+                <div
+                  class="react-contextmenu-wrapper"
+                >
+                  <canvas
+                    class="timelineMarkersCanvas"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="timelineEmptyThreadIndicator"
+            />
+          </div>
+        </div>
+      </div>
+    </li>
+  </ol>
 </div>
 `;
 
@@ -119,30 +251,6 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                   class="timelineTrackThread"
                 >
                   <div
-                    class="timelineMarkers selected"
-                    data-testid="TimelineMarkersJank"
-                  >
-                    <div
-                      class="react-contextmenu-wrapper"
-                    >
-                      <canvas
-                        class="timelineMarkersCanvas"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    class="timelineMarkers timelineMarkersGeckoMain selected"
-                    data-testid="TimelineMarkersOverview"
-                  >
-                    <div
-                      class="react-contextmenu-wrapper"
-                    >
-                      <canvas
-                        class="timelineMarkersCanvas"
-                      />
-                    </div>
-                  </div>
-                  <div
                     class="threadActivityGraph"
                   >
                     <canvas
@@ -150,6 +258,34 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                       height="300"
                       width="200"
                     />
+                  </div>
+                  <div
+                    class="timelineTrackThreadMarkers"
+                  >
+                    <div
+                      class="timelineMarkers selected"
+                      data-testid="TimelineMarkersJank"
+                    >
+                      <div
+                        class="react-contextmenu-wrapper"
+                      >
+                        <canvas
+                          class="timelineMarkersCanvas"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="timelineMarkers timelineMarkersGeckoMain selected"
+                      data-testid="TimelineMarkersOverview"
+                    >
+                      <div
+                        class="react-contextmenu-wrapper"
+                      >
+                        <canvas
+                          class="timelineMarkersCanvas"
+                        />
+                      </div>
+                    </div>
                   </div>
                   <div
                     class="timelineEmptyThreadIndicator"

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -454,7 +454,8 @@ describe('showTabOnly', function() {
     const resourceTracks = getActiveTabResourceTracks(getState());
     expect(resourceTracks).toEqual([
       {
-        type: 'thread',
+        name: 'Page #2',
+        type: 'sub-frame',
         threadIndex: 1,
       },
     ]);

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -21,6 +21,7 @@ import type {
   MarkerIndex,
   ActiveTabGlobalTrack,
   OriginsTimeline,
+  ActiveTabResourceTrack,
 } from './profile-derived';
 import type { FuncToFuncMap } from '../profile-logic/symbolication';
 import type { TemporaryError } from '../utils/errors';
@@ -72,6 +73,23 @@ export type LocalTrackReference = {|
 |};
 
 export type TrackReference = GlobalTrackReference | LocalTrackReference;
+
+/**
+ * Active tab track references
+ * A TrackReference uniquely identifies a track.
+ */
+export type ActiveTabGlobalTrackReference = {|
+  +type: 'global',
+  +trackIndex: TrackIndex,
+|};
+export type ActiveTabResourceTrackReference = {|
+  +type: 'resource',
+  +trackIndex: TrackIndex,
+|};
+
+export type ActiveTabTrackReference =
+  | ActiveTabGlobalTrackReference
+  | ActiveTabResourceTrackReference;
 
 export type RequestedLib = {|
   +debugName: string,
@@ -267,7 +285,7 @@ type ReceiveProfileAction =
       +type: 'VIEW_ACTIVE_TAB_PROFILE',
       +selectedThreadIndex: ThreadIndex,
       +globalTracks: ActiveTabGlobalTrack[],
-      +resourceTracks: LocalTrack[],
+      +resourceTracks: ActiveTabResourceTrack[],
       +browsingContextID: BrowsingContextID,
     |}
   | {|

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -258,8 +258,19 @@ export type ActiveTabGlobalTrack =
   | {| +type: 'tab', +threadIndex: ThreadIndex |}
   | {| +type: 'screenshots', +id: string, +threadIndex: ThreadIndex |};
 
-// TODO: add resource track type
-export type ActiveTabTrack = ActiveTabGlobalTrack;
+export type ActiveTabResourceTrack =
+  | {|
+      +type: 'sub-frame',
+      +threadIndex: ThreadIndex,
+      +name: string,
+    |}
+  | {|
+      +type: 'thread',
+      +threadIndex: ThreadIndex,
+      +name: string,
+    |};
+
+export type ActiveTabTrack = ActiveTabGlobalTrack | ActiveTabResourceTrack;
 
 /**
  * Type that holds the values of personally identifiable information that user

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -27,6 +27,7 @@ import type {
   MarkerIndex,
   ActiveTabGlobalTrack,
   OriginsTimeline,
+  ActiveTabResourceTrack,
 } from './profile-derived';
 import type { Attempt } from '../utils/errors';
 import type { TransformStacksPerThread } from './transforms';
@@ -74,8 +75,7 @@ export type OriginsViewState = {|
  */
 export type ActiveTabProfileViewState = {|
   globalTracks: ActiveTabGlobalTrack[],
-  // TODO: Add a better refined type for resource tracks.
-  resourceTracks: LocalTrack[],
+  resourceTracks: ActiveTabResourceTrack[],
 |};
 
 /**


### PR DESCRIPTION
This PR adds active tab resources tracks. There are still some problems after this PR, like selected thread logic doesn't properly work (it should open the resources panel if a resource track is selected for example). I will fix these issues in the follow-up PR.

Resource track show/hide mechanism has changed a bit since the first iteration. It was only possible to see one track open at a time before. Now it's possible to open multiple resource tracks. If you want to hide the track you can click one more time, but it should be selected already to be able to hide it. First commit is to make this mechanism work as well. It's stopping the propagation so it can't propagate to our resource mechanism later.

[Example profile](https://deploy-preview-2549--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?ctxId=12&thread=19&v=4&view=active-tab)

Also dispatches to test if you like:
```
dispatch(actions.changeTimelineTrackOrganization({ type: 'active-tab', browsingContextID: profile.meta.configuration.activeBrowsingContextID}));
and
dispatch(actions.changeTimelineTrackOrganization({ type: 'full' }));
```