### PR TITLE
Remove some warnings we have at load time

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -559,9 +559,12 @@ export function deriveMarkersFromRawMarkerTable(
             });
           }
         } else {
-          console.error(
-            `'data.interval' holds the invalid value '${data.interval}' in marker index ${i}. This should not normally happen.`
-          );
+          if (data.interval !== undefined) {
+            // Undefined values are valid, but others are unexpected.
+            console.error(
+              `'data.interval' holds the invalid value '${data.interval}' in marker index ${i}. This should not normally happen.`
+            );
+          }
           matchedMarkers.push({
             start: time,
             dur: 0,
@@ -910,9 +913,12 @@ export function* filterRawMarkerTableToRangeIndexGenerator(
             }
           }
         } else {
-          console.error(
-            `'data.interval' holds the invalid value '${data.interval}' in marker index ${i}. This should not normally happen.`
-          );
+          if (data.interval !== undefined) {
+            // Undefined  values are valid, but others are unexpected.
+            console.error(
+              `'data.interval' holds the invalid value '${data.interval}' in marker index ${i}. This should not normally happen.`
+            );
+          }
           if (isTimeInRange(time)) {
             yield i;
           }

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -163,7 +163,7 @@ describe('deriveMarkersFromRawMarkerTable', function() {
       title: null,
     });
   });
-  it('should handle arbitrary event markers correctly', function() {
+  it('should handle arbitrary tracing markers correctly', function() {
     const { markers } = setup();
     expect(markers[9]).toMatchObject({
       start: 21,
@@ -172,9 +172,6 @@ describe('deriveMarkersFromRawMarkerTable', function() {
       title: null,
       data: { category: 'ArbitraryCategory', type: 'tracing' },
     });
-    // Such a marker is unexpected, so we output an error to the console in this
-    // case.
-    expect(console.error).toHaveBeenCalled();
   });
 
   // Note that the network markers are also extensively tested below in the part
@@ -418,8 +415,8 @@ describe('filterRawMarkerTableToRange', () => {
   });
 
   it('filters tracing markers', () => {
-    // Note: these tracing markers define the same set of markers as in the
-    // previous test.
+    // Note: these tracing markers define mostly the same set of markers as in the
+    // previous test. Only the marker without an interval value has been added.
     const markers = [
       ['0', 0, { type: 'tracing', interval: 'start' }],
       ['1', 1, { type: 'tracing', interval: 'start' }],
@@ -431,6 +428,7 @@ describe('filterRawMarkerTableToRange', () => {
       ['0', 4, { type: 'tracing', interval: 'end' }],
       ['5', 5, { type: 'tracing', interval: 'start' }],
       ['5', 5, { type: 'tracing', interval: 'end' }],
+      ['5.5', 5.5, { type: 'tracing' }], // No interval value
       ['6', 6, { type: 'tracing', interval: 'start' }],
       ['4', 6, { type: 'tracing', interval: 'end' }],
       ['7', 7, { type: 'tracing', interval: 'start' }],
@@ -463,6 +461,7 @@ describe('filterRawMarkerTableToRange', () => {
       '3',
       '4',
       '5',
+      '5.5',
     ]);
   });
 

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -8,7 +8,7 @@
  * please change the CSS variables as well.
  *
  * Firefox Colors v1.0.3
- * https://github.com/FirefoxUX/design-tokens/tree/master/colors
+ * https://github.com/FirefoxUX/photon-colors/blob/master/photon-colors.js
  */
 
 export const MAGENTA_50 = '#ff1ad9';
@@ -87,7 +87,7 @@ type ColorStyles = {|
  * that already have their category colors saved into the profile.
  *
  * Category color names come from:
- * https://searchfox.org/mozilla-central/rev/0b8ed772d24605d7cb44c1af6d59e4ca023bd5f5/tools/profiler/core/platform.cpp#1593-1627
+ * https://searchfox.org/mozilla-central/rev/9193635dca8cfdcb68f114306194ffc860456044/js/public/ProfilingCategory.h#33
  */
 export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
   switch (colorName) {
@@ -140,7 +140,7 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedFillStyle: GREY_30,
         unselectedFillStyle: GREY_30 + '60',
         selectedTextColor: '#000',
-        gravity: 8,
+        gravity: 9,
       };
     case 'blue':
       return {
@@ -156,6 +156,13 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedTextColor: '#fff',
         gravity: 7,
       };
+    case 'lightgreen':
+      return {
+        selectedFillStyle: GREEN_50,
+        unselectedFillStyle: GREEN_50 + '60',
+        selectedTextColor: '#fff',
+        gravity: 8,
+      };
     default:
       console.error(
         `Unknown color name '${colorName}' encountered. Consider updating this code to handle it.`
@@ -164,7 +171,7 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedFillStyle: GREY_30,
         unselectedFillStyle: GREY_30 + '60',
         selectedTextColor: '#000',
-        gravity: 8,
+        gravity: 9,
       };
   }
 }


### PR DESCRIPTION
I've seen these errors in the console often while working on profiles: tracing markers without an interval, and category with the color "lightgreen".
The first was used sometimes before already, but is now [used a lot more by WebRender markers ](https://searchfox.org/mozilla-central/search?q=symbol:E_%3CT_TracingKind%3E_TRACING_EVENT&redirect=false).
The second is [used for IPC frames](https://searchfox.org/mozilla-central/rev/9193635dca8cfdcb68f114306194ffc860456044/js/public/ProfilingCategory.h#93) for some time.

[master](https://profiler.firefox.com/public/f9320c052daf3127f2181e38b3d0a4eb83b5e3cf/calltree/?globalTrackOrder=13-0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6-8-11&hiddenLocalTracksByPid=5144-1&localTrackOrderByPid=19215-1-2-0~5663-0~5142-0~5287-0~5336-0~5282-0~6227-0~5391-0~6296-0~5625-0-1~6268-0-1~5238-0-1~5144-2-0-1~&thread=1&v=4)
[deploy preview](https://deploy-preview-2555--perf-html.netlify.com/public/f9320c052daf3127f2181e38b3d0a4eb83b5e3cf/calltree/?globalTrackOrder=13-0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6-8-11&hiddenLocalTracksByPid=5144-1&localTrackOrderByPid=19215-1-2-0~5663-0~5142-0~5287-0~5336-0~5282-0~6227-0~5391-0~6296-0~5625-0-1~6268-0-1~5238-0-1~5144-2-0-1~&thread=1&v=4)

I admit I haven't tried with a profile that _does have_ an IPC frame.