### PR TITLE
[Deploy preview] Inline callstacks demo

### DIFF
--- a/res/img/svg/inlined-icon.svg
+++ b/res/img/svg/inlined-icon.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4f, 2020-05-01)"
+   sodipodi:docname="inlined-icon.svg"
+   id="svg1136"
+   version="1.1"
+   viewBox="0 0 12 12"
+   height="12"
+   width="12">
+  <metadata
+     id="metadata1142">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1140" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg1136"
+     inkscape:window-maximized="0"
+     inkscape:window-y="351"
+     inkscape:window-x="-410"
+     inkscape:cy="7.404878"
+     inkscape:cx="5.2780488"
+     inkscape:zoom="51.25"
+     showgrid="false"
+     id="namedview1138"
+     inkscape:window-height="480"
+     inkscape:window-width="1080"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <rect
+     id="rect1126"
+     ry="1.7"
+     rx="1.7"
+     y="1"
+     x="0"
+     height="11"
+     width="12"
+     fill="#bbb" />
+  <rect
+     id="rect1128"
+     ry="1.7"
+     rx="1.7"
+     y="0"
+     x="0"
+     height="11"
+     width="12"
+     fill="#e7e7e7" />
+  <path
+     style="stroke-width:0.960929"
+     id="path1130"
+     fill="#999999"
+     d="M 3.100002,3.961457 V 2.974 h -1.135 v 0.987457 z m -1.135,0.6751869 V 9 h 1.135 V 4.6366439 Z" />
+  <path
+     style="stroke-width:0.971643"
+     id="path1132"
+     fill="#999999"
+     d="M 3.973,4.5388053 V 9 H 5.178976 V 6.6615406 q 0,-0.6816882 0.220812,-0.9750826 0.220812,-0.302014 0.7133929,-0.302014 0.433133,0 0.6029881,0.2761273 0.1698549,0.2674975 0.1698549,0.8197612 V 9 h 1.205976 V 6.2559792 q 0,-0.4141998 -0.07643,-0.7507296 Q 7.9476299,5.1600912 7.7692799,4.9271088 7.5909309,4.685498 7.2766979,4.5560633 6.9709579,4.418 6.4868689,4.418 6.1046929,4.418 5.739503,4.599208 5.3743139,4.7717874 5.145009,5.1600912 H 5.119539 V 4.5388053 Z" />
+  <path
+     style="stroke-width:0.960929"
+     id="path1134"
+     fill="#999999"
+     d="M 8.9719997,2.974 V 9 H 10.007 V 2.974 Z" />
+</svg>

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -13,6 +13,7 @@ import { SymbolStore } from 'firefox-profiler/profile-logic/symbol-store';
 import {
   symbolicateProfile,
   applySymbolicationStep,
+  StackMapper,
 } from 'firefox-profiler/profile-logic/symbolication';
 import * as MozillaSymbolicationAPI from 'firefox-profiler/profile-logic/mozilla-symbolication-api';
 import { mergeProfilesForDiffing } from 'firefox-profiler/profile-logic/merge-compare';
@@ -718,27 +719,29 @@ export function bulkProcessSymbolicationSteps(
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const { threads } = getProfile(getState());
-    const oldFuncToNewFuncMaps = new Map();
+    const oldFuncToNewFuncsMaps = new Map();
     const symbolicatedThreads = threads.map((oldThread, threadIndex) => {
       const symbolicationSteps = symbolicationStepsPerThread.get(threadIndex);
       if (symbolicationSteps === undefined) {
         return oldThread;
       }
-      const oldFuncToNewFuncMap = new Map();
+      const oldFuncToNewFuncsMap = new Map();
       let thread = oldThread;
+      const stackMapper = new StackMapper();
       for (const symbolicationStep of symbolicationSteps) {
         thread = applySymbolicationStep(
           thread,
           symbolicationStep,
-          oldFuncToNewFuncMap
+          oldFuncToNewFuncsMap,
+          stackMapper
         );
       }
-      oldFuncToNewFuncMaps.set(threadIndex, oldFuncToNewFuncMap);
-      return thread;
+      oldFuncToNewFuncsMaps.set(threadIndex, oldFuncToNewFuncsMap);
+      return stackMapper.applyToThread(thread);
     });
     dispatch({
       type: 'BULK_SYMBOLICATION',
-      oldFuncToNewFuncMaps,
+      oldFuncToNewFuncsMaps,
       symbolicatedThreads,
     });
   };

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -10,7 +10,7 @@ import type { MarkerPhase } from 'firefox-profiler/types';
 export const GECKO_PROFILE_VERSION = 23;
 
 // The current version of the "processed" profile format.
-export const PROCESSED_PROFILE_VERSION = 35;
+export const PROCESSED_PROFILE_VERSION = 36;
 
 // The following are the margin sizes for the left and right of the timeline. Independent
 // components need to share these values.

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -146,6 +146,20 @@
   text-align: left;
 }
 
+.treeBadge {
+  display: inline-block;
+  color: transparent;
+  overflow: hidden;
+  width: 12px;
+  height: 12px;
+  vertical-align: -2px;
+  margin-right: 2px;
+}
+
+.treeBadge.inlined, .treeBadge.divergent-inlining {
+  background: url(../../../res/img/svg/inlined-icon.svg)
+}
+
 .treeRowIndentSpacer {
   flex-shrink: 0;
 }

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -297,6 +297,14 @@ class TreeViewRowScrolledColumns<
             title={displayData.categoryName}
           />
         ) : null}
+        {displayData.badge.type === 'badge' ? (
+          <span
+            className={`treeBadge ${displayData.badge.name}`}
+            title={displayData.badge.title}
+          >
+            {displayData.badge.alt}
+          </span>
+        ) : null}
         <span
           className={classNames(
             'treeViewRowColumn',

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -161,6 +161,21 @@ export function shallowCloneFuncTable(funcTable: FuncTable): FuncTable {
   };
 }
 
+export function shallowCloneNativeSymbolTable(
+  nativeSymbols: NativeSymbolTable
+): NativeSymbolTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    libIndex: nativeSymbols.libIndex.slice(),
+    address: nativeSymbols.address.slice(),
+    name: nativeSymbols.name.slice(),
+    length: nativeSymbols.length,
+  };
+}
+
 export function getEmptyResourceTable(): ResourceTable {
   return {
     // Important!

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -20,6 +20,7 @@ import type {
   UnbalancedNativeAllocationsTable,
   BalancedNativeAllocationsTable,
   ResourceTable,
+  NativeSymbolTable,
   Profile,
   ExtensionTable,
   CategoryList,
@@ -94,6 +95,8 @@ export function getEmptyFrameTable(): FrameTable {
     category: [],
     subcategory: [],
     func: [],
+    nativeSymbol: [],
+    inlineDepth: [],
     innerWindowID: [],
     implementation: [],
     line: [],
@@ -113,6 +116,8 @@ export function shallowCloneFrameTable(frameTable: FrameTable): FrameTable {
     category: frameTable.category.slice(),
     subcategory: frameTable.subcategory.slice(),
     func: frameTable.func.slice(),
+    nativeSymbol: frameTable.nativeSymbol.slice(),
+    inlineDepth: frameTable.inlineDepth.slice(),
     innerWindowID: frameTable.innerWindowID.slice(),
     implementation: frameTable.implementation.slice(),
     line: frameTable.line.slice(),
@@ -128,7 +133,6 @@ export function getEmptyFuncTable(): FuncTable {
     // If modifying this structure, please update all callers of this function to ensure
     // that they are pushing on correctly to the data structure. These pushes may not
     // be caught by the type system.
-    address: [],
     isJS: [],
     relevantForJS: [],
     name: [],
@@ -146,7 +150,6 @@ export function shallowCloneFuncTable(funcTable: FuncTable): FuncTable {
     // If modifying this structure, please update all callers of this function to ensure
     // that they are pushing on correctly to the data structure. These pushes may not
     // be caught by the type system.
-    address: funcTable.address.slice(),
     isJS: funcTable.isJS.slice(),
     relevantForJS: funcTable.relevantForJS.slice(),
     name: funcTable.name.slice(),
@@ -168,6 +171,19 @@ export function getEmptyResourceTable(): ResourceTable {
     name: [],
     host: [],
     type: [],
+    length: 0,
+  };
+}
+
+export function getEmptyNativeSymbolTable(): NativeSymbolTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    libIndex: [],
+    address: [],
+    name: [],
     length: 0,
   };
 }
@@ -343,6 +359,7 @@ export function getEmptyThread(overrides?: $Shape<Thread>): Thread {
     libs: [],
     funcTable: getEmptyFuncTable(),
     resourceTable: getEmptyResourceTable(),
+    nativeSymbols: getEmptyNativeSymbolTable(),
   };
 
   return {

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -580,7 +580,6 @@ async function processTracingEvents(
           if (funcId === undefined) {
             // The function did not exist.
             funcId = funcTable.length++;
-            funcTable.address.push(-1);
             funcTable.isJS.push(isJS);
             funcTable.relevantForJS.push(relevantForJS);
             const name = functionName !== '' ? functionName : '(anonymous)';
@@ -619,6 +618,8 @@ async function processTracingEvents(
           frameTable.category[frameIndex] = category;
           frameTable.subcategory[frameIndex] = 0;
           frameTable.func[frameIndex] = funcId;
+          frameTable.nativeSymbol[frameIndex] = null;
+          frameTable.inlineDepth[frameIndex] = 0;
           frameTable.innerWindowID[frameIndex] = 0;
           frameTable.implementation[frameIndex] = null;
           frameTable.line[frameIndex] =

--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -585,7 +585,6 @@ export function convertJsTracerToThreadWithoutSamples(
       if (generatedFuncIndex === undefined) {
         // Create a new function only if the event string is different.
         funcIndex = funcTable.length++;
-        funcTable.address.push(0);
         funcTable.name.push(eventStringIndex);
         funcTable.isJS.push(false);
         funcTable.resource.push(-1);
@@ -635,6 +634,8 @@ export function convertJsTracerToThreadWithoutSamples(
     frameTable.address.push(blankStringIndex);
     frameTable.category.push(otherCategory);
     frameTable.func.push(funcIndex);
+    frameTable.nativeSymbol.push(null);
+    frameTable.inlineDepth.push(0);
     frameTable.innerWindowID.push(0);
     frameTable.implementation.push(implementation);
     frameTable.line.push(line);

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -17,6 +17,7 @@ import {
 import {
   getEmptyProfile,
   getEmptyResourceTable,
+  getEmptyNativeSymbolTable,
   getEmptyFrameTable,
   getEmptyFuncTable,
   getEmptyStackTable,
@@ -45,11 +46,13 @@ import type {
   IndexIntoFuncTable,
   IndexIntoResourceTable,
   IndexIntoLibs,
+  IndexIntoNativeSymbolTable,
   IndexIntoStackTable,
   IndexIntoSamplesTable,
   FuncTable,
   FrameTable,
   Lib,
+  NativeSymbolTable,
   ResourceTable,
   StackTable,
   SamplesTable,
@@ -273,6 +276,10 @@ type TranslationMapForResources = Map<
   IndexIntoResourceTable,
   IndexIntoResourceTable
 >;
+type TranslationMapForNativeSymbols = Map<
+  IndexIntoNativeSymbolTable,
+  IndexIntoNativeSymbolTable
+>;
 type TranslationMapForFrames = Map<IndexIntoFrameTable, IndexIntoFrameTable>;
 type TranslationMapForStacks = Map<IndexIntoStackTable, IndexIntoStackTable>;
 type TranslationMapForLibs = Map<IndexIntoLibs, IndexIntoLibs>;
@@ -377,6 +384,7 @@ function adjustNullableCategories(
  * This combines the library tables for a list of threads. It returns a merged
  * Lib array, along with a translation maps that can be used in other functions
  * when merging lib references in other tables.
+ * The address ranges in the combined lib table are meaningless.
  */
 function combineLibTables(
   threads: $ReadOnlyArray<Thread>
@@ -488,6 +496,69 @@ function combineResourceTables(
 }
 
 /**
+ * This combines the nativeSymbols tables for the threads.
+ */
+function combineNativeSymbolTables(
+  translationMapsForLibs: TranslationMapForLibs[],
+  newStringTable: UniqueStringArray,
+  threads: $ReadOnlyArray<Thread>
+): {
+  nativeSymbols: NativeSymbolTable,
+  translationMaps: TranslationMapForNativeSymbols[],
+} {
+  const mapOfInsertedNativeSymbols: Map<
+    string,
+    IndexIntoNativeSymbolTable
+  > = new Map();
+  const translationMaps = [];
+  const newNativeSymbols = getEmptyNativeSymbolTable();
+
+  threads.forEach((thread, threadIndex) => {
+    const translationMap = new Map();
+    const { nativeSymbols, stringTable } = thread;
+    const libTranslationMap = translationMapsForLibs[threadIndex];
+
+    for (let i = 0; i < nativeSymbols.length; i++) {
+      const libIndex = nativeSymbols.libIndex[i];
+      const newLibIndex = libTranslationMap.get(libIndex);
+      if (newLibIndex === undefined) {
+        throw new Error(stripIndent`
+        We couldn't find the lib of nativeSymbol ${i} in the translation map.
+        This is a programming error.
+        `);
+      }
+
+      const nameIndex = nativeSymbols.name[i];
+      const newName = stringTable.getString(nameIndex);
+      const address = nativeSymbols.address[i];
+
+      // Duplicate search.
+      const nativeSymbolKey = [newLibIndex, newName, address].join('#');
+      const insertedNativeSymbolIndex = mapOfInsertedNativeSymbols.get(
+        nativeSymbolKey
+      );
+      if (insertedNativeSymbolIndex !== undefined) {
+        translationMap.set(i, insertedNativeSymbolIndex);
+        continue;
+      }
+
+      translationMap.set(i, newNativeSymbols.length);
+      mapOfInsertedNativeSymbols.set(nativeSymbolKey, newNativeSymbols.length);
+
+      newNativeSymbols.libIndex.push(newLibIndex);
+      newNativeSymbols.name.push(newStringTable.indexForString(newName));
+      newNativeSymbols.address.push(address);
+
+      newNativeSymbols.length++;
+    }
+
+    translationMaps.push(translationMap);
+  });
+
+  return { nativeSymbols: newNativeSymbols, translationMaps };
+}
+
+/**
  * This combines the function tables for a list of threads. It returns the new
  * function table with the translation maps to be used in subsequent merging
  * functions.
@@ -543,7 +614,6 @@ function combineFuncTables(
       mapOfInsertedFuncs.set(funcKey, newFuncTable.length);
       translationMap.set(i, newFuncTable.length);
 
-      newFuncTable.address.push(funcTable.address[i]);
       newFuncTable.isJS.push(funcTable.isJS[i]);
       newFuncTable.name.push(newStringTable.indexForString(name));
       newFuncTable.resource.push(newResourceIndex);
@@ -573,6 +643,7 @@ function combineFuncTables(
 function combineFrameTables(
   translationMapsForCategories: TranslationMapForCategories[] | null,
   translationMapsForFuncs: TranslationMapForFuncs[],
+  translationMapsForNativeSymbols: TranslationMapForNativeSymbols[],
   newStringTable: UniqueStringArray,
   threads: $ReadOnlyArray<Thread>
 ): { frameTable: FrameTable, translationMaps: TranslationMapForFrames[] } {
@@ -591,6 +662,8 @@ function combineFrameTables(
       const categoryTranslationMap = translationMapsForCategories[threadIndex];
       return categoryTranslationMap.get(category);
     };
+    const nativeSymbolTranslationMap =
+      translationMapsForNativeSymbols[threadIndex];
 
     for (let i = 0; i < frameTable.length; i++) {
       const category = frameTable.category[i];
@@ -616,13 +689,27 @@ function combineFrameTables(
           ? stringTable.getString(implementationIndex)
           : null;
 
+      const nativeSymbol = frameTable.nativeSymbol[i];
+      const newNativeSymbol =
+        nativeSymbol === null
+          ? null
+          : nativeSymbolTranslationMap.get(nativeSymbol);
+      if (newNativeSymbol === undefined) {
+        throw new Error(stripIndent`
+          We couldn't find the nativeSymbol of frame ${i} in the translation map.
+          This is a programming error.
+        `);
+      }
+
       newFrameTable.address.push(frameTable.address[i]);
       newFrameTable.category.push(newCategory);
       // TODO issue #2151: we assume that subcategory strings are the same if
       // the category is the same, and have no translation maps. But we should
       // really implement one.
       newFrameTable.subcategory.push(frameTable.subcategory[i]);
+      newFrameTable.nativeSymbol.push(newNativeSymbol);
       newFrameTable.func.push(newFunc);
+      newFrameTable.inlineDepth.push(frameTable.inlineDepth[i]);
       newFrameTable.innerWindowID.push(frameTable.innerWindowID[i]);
       newFrameTable.implementation.push(
         implementation === null
@@ -841,6 +928,14 @@ function getComparisonThread(
     translationMaps: translationMapsForResources,
   } = combineResourceTables(translationMapsForLibs, newStringTable, threads);
   const {
+    nativeSymbols: newNativeSymbols,
+    translationMaps: translationMapsForNativeSymbols,
+  } = combineNativeSymbolTables(
+    translationMapsForLibs,
+    newStringTable,
+    threads
+  );
+  const {
     funcTable: newFuncTable,
     translationMaps: translationMapsForFuncs,
   } = combineFuncTables(translationMapsForResources, newStringTable, threads);
@@ -850,6 +945,7 @@ function getComparisonThread(
   } = combineFrameTables(
     translationMapsForCategories,
     translationMapsForFuncs,
+    translationMapsForNativeSymbols,
     newStringTable,
     threads
   );
@@ -895,6 +991,7 @@ function getComparisonThread(
     libs: newLibTable,
     funcTable: newFuncTable,
     resourceTable: newResourceTable,
+    nativeSymbols: newNativeSymbols,
   };
 
   return mergedThread;
@@ -919,6 +1016,14 @@ export function mergeThreads(threads: Thread[]): Thread {
     translationMaps: translationMapsForResources,
   } = combineResourceTables(translationMapsForLibs, newStringTable, threads);
   const {
+    nativeSymbols: newNativeSymbols,
+    translationMaps: translationMapsForNativeSymbols,
+  } = combineNativeSymbolTables(
+    translationMapsForLibs,
+    newStringTable,
+    threads
+  );
+  const {
     funcTable: newFuncTable,
     translationMaps: translationMapsForFuncs,
   } = combineFuncTables(translationMapsForResources, newStringTable, threads);
@@ -928,6 +1033,7 @@ export function mergeThreads(threads: Thread[]): Thread {
   } = combineFrameTables(
     null,
     translationMapsForFuncs,
+    translationMapsForNativeSymbols,
     newStringTable,
     threads
   );
@@ -982,6 +1088,7 @@ export function mergeThreads(threads: Thread[]): Thread {
     stringTable: newStringTable,
     libs: newLibTable,
     funcTable: newFuncTable,
+    nativeSymbols: newNativeSymbols,
     resourceTable: newResourceTable,
   };
 

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -294,9 +294,20 @@ async function getResultForLibRequestFromV6Response(
     const address = addressArray[i];
     const info = addressInfo[i];
     if (info.function !== undefined && info.function_offset !== undefined) {
+      let inlineFrames;
+      if (info.inline_stack !== undefined) {
+        inlineFrames = info.inline_stack.map(
+          ({ function_name, file_path, line_number }) => ({
+            functionName: function_name,
+            fileName: file_path,
+            lineNumber: line_number,
+          })
+        );
+      }
       results.set(address, {
         name: info.function,
         functionOffset: parseInt(info.function_offset.substr(2), 16),
+        inlineFrames,
       });
     } else {
       throw new SymbolsNotFoundError(

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -42,6 +42,7 @@ import type {
   IndexIntoSamplesTable,
   IndexIntoStackTable,
   IndexIntoResourceTable,
+  IndexIntoNativeSymbolTable,
   ThreadIndex,
   Category,
   Counter,
@@ -105,6 +106,9 @@ export function getCallNodeInfo(
     const subcategory: Array<IndexIntoSubcategoryListForCategory> = [];
     const innerWindowID: Array<InnerWindowID> = [];
     const depth: Array<number> = [];
+    const sourceFramesInlinedIntoSymbol: Array<
+      IndexIntoNativeSymbolTable | -1 | null
+    > = [];
     let length = 0;
 
     function addCallNode(
@@ -112,7 +116,8 @@ export function getCallNodeInfo(
       funcIndex: IndexIntoFuncTable,
       categoryIndex: IndexIntoCategoryList,
       subcategoryIndex: IndexIntoSubcategoryListForCategory,
-      windowID: InnerWindowID
+      windowID: InnerWindowID,
+      inlinedIntoSymbol: IndexIntoNativeSymbolTable | null
     ) {
       const index = length++;
       prefix[index] = prefixIndex;
@@ -120,6 +125,7 @@ export function getCallNodeInfo(
       category[index] = categoryIndex;
       subcategory[index] = subcategoryIndex;
       innerWindowID[index] = windowID;
+      sourceFramesInlinedIntoSymbol[index] = inlinedIntoSymbol;
       if (prefixIndex === -1) {
         depth[index] = 0;
       } else {
@@ -139,6 +145,10 @@ export function getCallNodeInfo(
       const categoryIndex = stackTable.category[stackIndex];
       const subcategoryIndex = stackTable.subcategory[stackIndex];
       const windowID = frameTable.innerWindowID[frameIndex] || 0;
+      const inlinedIntoSymbol =
+        frameTable.inlineDepth[frameIndex] > 0
+          ? frameTable.nativeSymbol[frameIndex]
+          : null;
       const funcIndex = frameTable.func[frameIndex];
       const prefixCallNodeAndFuncIndex = prefixCallNode * funcCount + funcIndex;
       let callNodeIndex = prefixCallNodeAndFuncToCallNodeMap.get(
@@ -151,19 +161,28 @@ export function getCallNodeInfo(
           funcIndex,
           categoryIndex,
           subcategoryIndex,
-          windowID
+          windowID,
+          inlinedIntoSymbol
         );
         prefixCallNodeAndFuncToCallNodeMap.set(
           prefixCallNodeAndFuncIndex,
           callNodeIndex
         );
-      } else if (category[callNodeIndex] !== categoryIndex) {
-        // Conflicting origin stack categories -> default category + subcategory.
-        category[callNodeIndex] = defaultCategory;
-        subcategory[callNodeIndex] = 0;
-      } else if (subcategory[callNodeIndex] !== subcategoryIndex) {
-        // Conflicting origin stack subcategories -> "Other" subcategory.
-        subcategory[callNodeIndex] = 0;
+      } else {
+        if (
+          sourceFramesInlinedIntoSymbol[callNodeIndex] !== inlinedIntoSymbol
+        ) {
+          // Conflicting inlining: -1.
+          sourceFramesInlinedIntoSymbol[callNodeIndex] = -1;
+        }
+        if (category[callNodeIndex] !== categoryIndex) {
+          // Conflicting origin stack categories -> default category + subcategory.
+          category[callNodeIndex] = defaultCategory;
+          subcategory[callNodeIndex] = 0;
+        } else if (subcategory[callNodeIndex] !== subcategoryIndex) {
+          // Conflicting origin stack subcategories -> "Other" subcategory.
+          subcategory[callNodeIndex] = 0;
+        }
       }
       stackIndexToCallNodeIndex[stackIndex] = callNodeIndex;
     }
@@ -174,6 +193,7 @@ export function getCallNodeInfo(
       category: new Int32Array(category),
       subcategory: new Int32Array(subcategory),
       innerWindowID: new Float64Array(innerWindowID),
+      sourceFramesInlinedIntoSymbol,
       depth,
       length,
     };

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -360,6 +360,7 @@ export class SymbolStore {
               request,
             ])[0];
             const results = await resultsPromise;
+            // console.log(results);
 
             // Did not throw, option 3 was successful!
             successCb(request, results);

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -21,6 +21,15 @@ export type AddressResult = {|
   name: string,
   // The offset (in bytes) between the start of the function and the address.
   functionOffset: number,
+  // An optional inline callstack, ordered from inside to outside. The outermost
+  // function usually matches `name`.
+  inlineFrames?: Array<AddressInlineFrame>,
+|};
+
+type AddressInlineFrame = {|
+  functionName?: string,
+  fileName?: string,
+  lineNumber?: number,
 |};
 
 interface SymbolProvider {

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -29,6 +29,10 @@ interface SymbolProvider {
     requests: LibSymbolicationRequest[]
   ): Promise<Map<number, AddressResult>>[];
 
+  requestSymbolsFromAPI(
+    requests: LibSymbolicationRequest[]
+  ): Promise<Map<number, AddressResult>>[];
+
   // Expensive, should be called if requestSymbolsFromServer was unsuccessful.
   requestSymbolTableFromAddon(lib: RequestedLib): Promise<SymbolTableAsTuple>;
 }
@@ -289,7 +293,7 @@ export class SymbolStore {
     // for this library.
     const libraryPromiseChunks = chunks.map(requests =>
       this._symbolProvider
-        .requestSymbolsFromServer(requests)
+        .requestSymbolsFromAPI(requests)
         .map((resultsPromise, i) => ({
           request: requests[i],
           resultsPromise,

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -425,9 +425,7 @@ export function applySymbolicationStep(
     if (addressResult === undefined) {
       const oldSymbol = stringTable.getString(oldFuncTable.name[oldFrameFunc]);
       addressResult = {
-        functionOffset:
-          oldFrameTable.address[frameIndex] -
-          oldFuncTable.address[oldFrameFunc],
+        functionOffset: 0,
         name: oldSymbol,
       };
     }
@@ -517,7 +515,6 @@ export function applySymbolicationStep(
       funcAddressToCanonicalFuncIndexMap.set(funcAddress, funcIndex);
     }
     // Update the func properties.
-    funcTable.address[funcIndex] = funcAddress;
     funcTable.name[funcIndex] = symbolStringIndex;
   }
 

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -852,7 +852,14 @@ export function applySymbolicationStep(
       `funcTable: +${funcTable.length - oldFuncTable.length}`
   );
 
-  return { ...thread, frameTable, funcTable, stackTable, stringTable };
+  return {
+    ...thread,
+    nativeSymbols,
+    frameTable,
+    funcTable,
+    stackTable,
+    stringTable,
+  };
 }
 
 /**

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -818,6 +818,10 @@ export function collapseResource(
             newFrameTable.category.push(frameTable.category[frameIndex]);
             newFrameTable.subcategory.push(frameTable.subcategory[frameIndex]);
             newFrameTable.func.push(collapsedFuncIndex);
+            newFrameTable.nativeSymbol.push(
+              frameTable.nativeSymbol[frameIndex]
+            );
+            newFrameTable.inlineDepth.push(frameTable.inlineDepth[frameIndex]);
             newFrameTable.line.push(frameTable.line[frameIndex]);
             newFrameTable.column.push(frameTable.column[frameIndex]);
             newFrameTable.innerWindowID.push(
@@ -831,7 +835,6 @@ export function collapseResource(
             );
 
             // Add the psuedo-func
-            newFuncTable.address.push(funcTable.address[funcIndex]);
             newFuncTable.isJS.push(funcTable.isJS[funcIndex]);
             newFuncTable.name.push(resourceNameIndex);
             newFuncTable.resource.push(funcTable.resource[funcIndex]);

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -55,7 +55,6 @@ export default function getProfile(): Profile {
   // Be explicit about table creation so flow errors are really readable.
   const funcTable: FuncTable = {
     name: funcNames,
-    address: Array(funcNames.length).fill(-1),
     isJS: Array(funcNames.length).fill(false),
     resource: Array(funcNames.length).fill(-1),
     relevantForJS: Array(funcNames.length).fill(false),
@@ -88,6 +87,8 @@ export default function getProfile(): Profile {
   const frameTable: FrameTable = {
     func: frameFuncs.map(stringIndex => funcTable.name.indexOf(stringIndex)),
     address: Array(frameFuncs.length).fill(-1),
+    inlineDepth: Array(frameFuncs.length).fill(0),
+    nativeSymbol: Array(frameFuncs.length).fill(null),
     category: Array(frameFuncs.length).fill(null),
     subcategory: Array(frameFuncs.length).fill(null),
     innerWindowID: Array(frameFuncs.length).fill(null),

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -710,9 +710,6 @@ function _buildThreadFromTextOnlyStacks(
   // Create the FuncTable.
   funcNames.forEach(funcName => {
     funcTable.name.push(stringTable.indexForString(funcName));
-    funcTable.address.push(
-      funcName.startsWith('0x') ? parseInt(funcName.substr(2), 16) : -1
-    );
     funcTable.fileName.push(null);
     funcTable.relevantForJS.push(funcName.endsWith('js-relevant'));
     funcTable.isJS.push(_isJsFunctionName(funcName));
@@ -793,10 +790,14 @@ function _buildThreadFromTextOnlyStacks(
 
       if (frameIndex === undefined) {
         frameTable.func.push(funcIndex);
-        frameTable.address.push(funcTable.address[funcIndex]);
+        frameTable.address.push(
+          funcName.startsWith('0x') ? parseInt(funcName.substr(2), 16) : -1
+        );
         frameTable.category.push(category);
         frameTable.subcategory.push(0);
         frameTable.innerWindowID.push(0);
+        frameTable.inlineDepth.push(0);
+        frameTable.nativeSymbol.push(null);
         frameTable.implementation.push(jitTypeIndex);
         frameTable.line.push(null);
         frameTable.column.push(null);

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -42,6 +42,7 @@ describe('actions/icons', function() {
       selfWithUnit: '0 ms',
       name: 'icon',
       lib: 'icon',
+      badge: { type: 'none' },
       isFrameLabel: false,
       categoryName: 'Other',
       categoryColor: 'grey',

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -103,6 +103,13 @@ describe('doSymbolicateProfile', function() {
               request.lib
             );
           }),
+        requestSymbolsFromAPI: requests =>
+          requests.map(async request => {
+            throw new SymbolsNotFoundError(
+              'requestSymbolsFromAPI is not part of this test',
+              request.lib
+            );
+          }),
         requestSymbolTableFromAddon: async lib => {
           if (lib.debugName === 'firefox.pdb') {
             if (symbolicationProviderMode === 'from-addon') {

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -91,11 +91,11 @@ describe('extract functions and resource from location strings', function() {
   };
 
   it('extracts the information for all different types of locations', function() {
-    const [
+    const {
       funcTable,
       resourceTable,
       frameFuncs,
-    ] = extractFuncsAndResourcesFromFrameLocations(
+    } = extractFuncsAndResourcesFromFrameLocations(
       locationIndexes,
       locationIndexes.map(() => false),
       stringTable,
@@ -110,7 +110,6 @@ describe('extract functions and resource from location strings', function() {
 
         const funcName = stringTable.getString(funcTable.name[funcIndex]);
         const resourceIndex = funcTable.resource[funcIndex];
-        const address = funcTable.address[funcIndex];
         const isJS = funcTable.isJS[funcIndex];
         const fileNameIndex = funcTable.fileName[funcIndex];
         const fileName =
@@ -146,7 +145,6 @@ describe('extract functions and resource from location strings', function() {
             funcName,
             isJS,
             resourceIndex,
-            address,
             fileName,
             lineNumber,
             columnNumber,

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -258,11 +258,6 @@ describe('process-profile', function() {
       );
       expect(thread.funcTable.lineNumber[4]).toEqual(34);
       expect(thread.funcTable.columnNumber[4]).toEqual(35);
-      expect(thread.funcTable.address[0]).toEqual(-1);
-      expect(thread.funcTable.address[1]).toEqual(3972);
-      expect(thread.funcTable.address[2]).toEqual(6725);
-      expect(thread.funcTable.address[3]).toEqual(-1);
-      expect(thread.funcTable.address[4]).toEqual(-1);
     });
 
     it('should create one resource per used library', function() {

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -6,6 +6,7 @@ import {
   getContainingLibrary,
   symbolicateProfile,
   applySymbolicationStep,
+  StackMapper,
 } from '../../profile-logic/symbolication';
 import {
   processGeckoProfile,
@@ -626,7 +627,8 @@ describe('symbolication', function() {
           symbolicatedProfile.threads[threadIndex] = applySymbolicationStep(
             symbolicatedProfile.threads[threadIndex],
             symbolicationStepInfo,
-            new Map()
+            new Map(),
+            new StackMapper()
           );
         }
       );

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -57,6 +57,13 @@ describe('SymbolStore', function() {
           );
         })
       ),
+      requestSymbolsFromAPI: requests =>
+        requests.map(async request => {
+          throw new SymbolsNotFoundError(
+            'requestSymbolsFromAPI is not part of this test',
+            request.lib
+          );
+        }),
       requestSymbolTableFromAddon: jest.fn(() =>
         Promise.resolve(exampleSymbolTable)
       ),
@@ -138,6 +145,13 @@ describe('SymbolStore', function() {
           Promise.reject(new Error('this example only supports symbol tables'))
         )
       ),
+      requestSymbolsFromAPI: requests =>
+        requests.map(async request => {
+          throw new SymbolsNotFoundError(
+            'requestSymbolsFromAPI is not part of this test',
+            request.lib
+          );
+        }),
       requestSymbolTableFromAddon: jest.fn(() =>
         Promise.resolve(exampleSymbolTable)
       ),
@@ -196,6 +210,13 @@ describe('SymbolStore', function() {
             })
         );
       }),
+      requestSymbolsFromAPI: requests =>
+        requests.map(async request => {
+          throw new SymbolsNotFoundError(
+            'requestSymbolsFromAPI is not part of this test',
+            request.lib
+          );
+        }),
       requestSymbolTableFromAddon: jest
         .fn()
         .mockResolvedValue(exampleSymbolTable),
@@ -336,6 +357,13 @@ describe('SymbolStore', function() {
           });
         });
       },
+      requestSymbolsFromAPI: requests =>
+        requests.map(async request => {
+          throw new SymbolsNotFoundError(
+            'requestSymbolsFromAPI is not part of this test',
+            request.lib
+          );
+        }),
       requestSymbolTableFromAddon: async ({ debugName, breakpadId }) => {
         expect(debugName).not.toEqual('');
         expect(breakpadId).not.toEqual('');

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -18,7 +18,7 @@ import type {
   ActiveTabTimeline,
   ThreadsKey,
 } from './profile-derived';
-import type { FuncToFuncMap } from '../profile-logic/symbolication';
+import type { FuncToFuncsMap } from '../profile-logic/symbolication';
 import type { TemporaryError } from '../utils/errors';
 import type { Transform, TransformStacksPerThread } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
@@ -277,7 +277,7 @@ type ReceiveProfileAction =
   | {|
       +type: 'BULK_SYMBOLICATION',
       +symbolicatedThreads: Thread[],
-      +oldFuncToNewFuncMaps: Map<ThreadIndex, FuncToFuncMap>,
+      +oldFuncToNewFuncsMaps: Map<ThreadIndex, FuncToFuncsMap>,
     |}
   | {|
       +type: 'DONE_SYMBOLICATING',

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -16,6 +16,7 @@ declare type $GeckoProfiler = {
     debugName: string,
     breakpadId: string
   ) => Promise<SymbolTableAsTuple>,
+  queryAPI?: (url: string, requestJSON: string) => Promise<string>,
 };
 
 declare class WebChannelEvent {

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -131,6 +131,10 @@ export type CallNodeData = {
   selfRelative: number,
 };
 
+export type ExtraBadgeInfo =
+  | { type: 'none' }
+  | { type: 'badge', name: string, alt: string, title: string };
+
 export type CallNodeDisplayData = $Exact<
   $ReadOnly<{
     total: string,
@@ -144,6 +148,7 @@ export type CallNodeDisplayData = $Exact<
     categoryName: string,
     categoryColor: string,
     iconSrc: string | null,
+    badge: ExtraBadgeInfo,
     icon: string | null,
     ariaLabel: string,
   }>

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -11,6 +11,7 @@ import type {
   Pid,
   IndexIntoJsTracerEvents,
   IndexIntoCategoryList,
+  IndexIntoNativeSymbolTable,
   CounterIndex,
   InnerWindowID,
   Page,
@@ -51,6 +52,10 @@ export type CallNodeTable = {
   category: Int32Array, // IndexIntoCallNodeTable -> IndexIntoCategoryList
   subcategory: Int32Array, // IndexIntoCallNodeTable -> IndexIntoSubcategoryListForCategory
   innerWindowID: Float64Array, // IndexIntoCallNodeTable -> InnerWindowID
+  // null: no inlining
+  // IndexIntoNativeSymbolTable: all frames that collapsed into this call node inlined into the same native symbol
+  // -1: divergent: not all frames that collapsed into this call node were inlined, or they are from different symbols
+  sourceFramesInlinedIntoSymbol: Array<IndexIntoNativeSymbolTable | -1 | null>,
   depth: number[],
   length: number,
 };

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -23,6 +23,7 @@ export type IndexIntoStringTable = number;
 export type IndexIntoFuncTable = number;
 export type IndexIntoResourceTable = number;
 export type IndexIntoLibs = number;
+export type IndexIntoNativeSymbolTable = number;
 export type IndexIntoCategoryList = number;
 export type IndexIntoSubcategoryListForCategory = number;
 export type resourceTypeEnum = number;
@@ -275,6 +276,8 @@ export type FrameTable = {|
   category: (IndexIntoCategoryList | null)[],
   subcategory: (IndexIntoSubcategoryListForCategory | null)[],
   func: IndexIntoFuncTable[],
+  inlineDepth: number[], // 0 for "this is the outer function at the address"
+  nativeSymbol: (IndexIntoNativeSymbolTable | null)[],
   // Inner window ID of JS frames. JS frames can be correlated to a Page through this value.
   // It's used to determine which JS frame belongs to which web page so we can display
   // that information and filter for single tab profiling.
@@ -334,14 +337,19 @@ export type FuncTable = {|
   lineNumber: Array<number | null>,
   columnNumber: Array<number | null>,
 
-  // This is relevant for functions of the 'native' stackType only (functions
-  // whose resource is a library).
-  // Stores the library-relative offset of the start of the function, i.e. the
-  // address of the symbol that gave this function its name.
-  // Prior to initial symbolication, it stores the same address as the single
-  // frame that refers to this func, because at that point the actual boundaries
-  // of the true functions are not known.
-  address: Array<Address | -1>,
+  length: number,
+|};
+
+export type NativeSymbolTable = {|
+  // The library that this native symbol is in.
+  libIndex: Array<IndexIntoLibs>,
+  // The library-relative offset of this symbol.
+  address: Array<Address>,
+  // The symbol name, demangled.
+  name: Array<IndexIntoStringTable>,
+
+  // This would be a good spot for a "size" field. But the symbolication API does
+  // not give us information about the size of a function.
 
   length: number,
 |};
@@ -574,6 +582,7 @@ export type Thread = {|
   libs: Lib[],
   funcTable: FuncTable,
   resourceTable: ResourceTable,
+  nativeSymbols: NativeSymbolTable,
   jsTracer?: JsTracerTable,
 |};
 


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-2556--perf-html.netlify.app/public/58bc6a83313314f2af53628947efb07e8af710df/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-7&hiddenLocalTracksByPid=18940-5-6-7-8-9-11-10~59629-1-2~59312-0-1~59627-0-1&localTrackOrderByPid=18940-10-11-0-1-2-3-4-5-6-7-8-9~59631-0~18941-0~52932-0~53147-0~18943-0~59629-1-2-0~18944-0~59312-0-1~59627-0-1~&range=8.7560_20.2980&thread=0&v=4)
[Deploy preview](https://deploy-preview-2556--perf-html.netlify.app/public/b814899c2c2abcd039b7b551aa94f8b1181caa19/calltree/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4&hiddenLocalTracksByPid=60017-1-2-3-4-5-6-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25-26-27~60020-0-1-2~60023-0-1&localTrackOrderByPid=60017-26-27-0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25~60018-0~60032-0~60022-0~60021-0~60020-1-2-0~60023-0-1~&range=18.6575_31.9307&thread=1&v=4)

Same profile: [before](https://deploy-preview-2556--perf-html.netlify.app/public/ba1342c1c692248e6a9372b692a27585c51b4eee/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&hiddenLocalTracksByPid=67859-3-4-1-2~67861-0-1&localTrackOrderByPid=67859-3-4-0-1-2~67860-0~67862-0~67865-0~68166-0~70696-0~67863-0~71317-0-1~67861-2-0-1~&thread=1&transforms=ff-41&v=4) [after](https://deploy-preview-2556--perf-html.netlify.app/public/ac615514a782f70d3209f5cb6939d44d9dfb4dcc/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&hiddenLocalTracksByPid=67859-3-4-1-2~67861-0-1&localTrackOrderByPid=67859-3-4-0-1-2~67860-0~67862-0~67865-0~68166-0~70696-0~67863-0~71317-0-1~67861-2-0-1~&thread=1&transforms=ff-76&v=4)

Another comparison: [before](https://share.firefox.dev/2XH5mW6) [after](https://deploy-preview-2556--perf-html.netlify.app/public/60ebefb59ca0f5c2f54ebacb3e571af8af095db8/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=0-1-2-3-4&hiddenLocalTracksByPid=73273-0-2-4-5-6~73274-0~73277-0~73278-0~73279-0~73275-1-0&localTrackOrderByPid=73273-7-0-1-2-3-4-5-6~73274-1-0~73277-1-0~73278-1-0~73279-1-0~73275-1-0~&thread=16&transforms=ff-519&v=4)

<del>It's not working as great as I hoped it would. There are lots of bad frames in the call stacks. I think the problem is that the return addresses, which are collected during stackwalking, point to the instruction *after* the call instruction.
I'll try to find out how many goats I'd have to sacrifice to have the stackwalkers give me the addresses of the actual call instructions, for all caller frames upstack.</del>

Edit: This is working great now. I just needed to adjust caller addresses by 1 byte upwards. Now all line information and inline stacks in caller functions look correct.