### PR TITLE
Display thread name of FileIO markers if present

### DIFF
--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -727,3 +727,18 @@ export const getProfileFilterPageData: Selector<ProfileFilterPageData | null> = 
   getRelevantInnerWindowIDsForCurrentTab,
   extractProfileFilterPageData
 );
+
+/**
+ * Get the map of Thread ID -> Thread Name for easy access.
+ */
+export const getThreadIdToNameMap: Selector<
+  Map<number, string>
+> = createSelector(getThreads, threads => {
+  const threadIdToNameMap = new Map();
+  for (const thread of threads) {
+    if (thread.tid !== undefined) {
+      threadIdToNameMap.set(thread.tid, thread.name);
+    }
+  }
+  return threadIdToNameMap;
+});

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -37,7 +37,7 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
         Occurring Thread
         :
       </div>
-      Renderer (123456)
+      Renderer (TID: 123456)
     </div>
   </div>
   <div

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1411,10 +1411,17 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-main th
       <div
         class="tooltipLabel"
       >
-        Thread
+        Recording Thread
         :
       </div>
       Main Thread
+      <div
+        class="tooltipLabel"
+      >
+        Occurring Thread ID
+        :
+      </div>
+      123
     </div>
   </div>
   <div
@@ -1434,13 +1441,6 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-main th
       :
     </div>
     PoisonIOInterposer
-    <div
-      class="tooltipLabel"
-    >
-      Thread ID
-      :
-    </div>
-    123
     <div
       class="tooltipLabel"
     >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1,5 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 1`] = `
+<div
+  class="tooltipMarker propClass"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1.0ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        FileIO (non-main thread)
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Recording Thread
+        :
+      </div>
+      Empty
+      <div
+        class="tooltipLabel"
+      >
+        Occurring Thread
+        :
+      </div>
+      Renderer (123456)
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Operation
+      :
+    </div>
+    create/open
+    <div
+      class="tooltipLabel"
+    >
+      Source
+      :
+    </div>
+    PoisonIOInterposer
+    <div
+      class="tooltipLabel"
+    >
+      Filename
+      :
+    </div>
+    /foo/bar
+  </div>
+  <div
+    class="tooltipDetailsBackTrace"
+  >
+    <ol
+      class="backtrace"
+      style="--max-height: 30em;"
+    >
+      <li
+        class="backtraceStackFrame"
+      >
+        nsRefreshDriver::AddStyleFlushObserver
+        <em
+          class="backtraceStackFrameOrigin"
+        />
+      </li>
+      <li
+        class="backtraceStackFrame"
+      >
+        mozilla::GeckoRestyleManager::PostRestyleEvent
+        <em
+          class="backtraceStackFrameOrigin"
+        />
+      </li>
+      <li
+        class="backtraceStackFrame"
+      >
+        XREMain::XRE_main
+        <em
+          class="backtraceStackFrameOrigin"
+        />
+      </li>
+      <li
+        class="backtraceStackFrame"
+      >
+        XRE_main
+        <em
+          class="backtraceStackFrameOrigin"
+        />
+      </li>
+      <li
+        class="backtraceStackFrame"
+      >
+        _main
+        <em
+          class="backtraceStackFrameOrigin"
+        />
+      </li>
+    </ol>
+  </div>
+</div>
+`;
+
 exports[`TooltipMarker renders properly network markers where content type is blank 1`] = `
 <div
   class="tooltipMarker propClass"
@@ -1384,7 +1501,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
 </div>
 `;
 
-exports[`TooltipMarker renders tooltips for various markers: FileIO (non-main thread)-114 1`] = `
+exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profiled thread)-114 1`] = `
 <div
   class="tooltipMarker propClass"
 >
@@ -1402,7 +1519,7 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-main th
       <div
         class="tooltipTitle"
       >
-        FileIO (non-main thread)
+        FileIO (non-profiled thread)
       </div>
     </div>
     <div


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-2564--perf-html.netlify.app/public/9893be6a76fc42736ba313e4cba393c6d7cc0f1e/marker-chart/?globalTrackOrder=1-2-0&hiddenLocalTracksByPid=13498-0-2-3-4&localTrackOrderByPid=13498-5-6-0-1-2-3-4~&markerSearch=FileIO%20%28non-main&thread=0&v=4)