### PR TITLE
Prototype some marker schema for Markers 2.0, with the memory timeline

### DIFF
--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -413,10 +413,18 @@ export function getMarkerSelectorsPerThread(
   /**
    * This returns only memory markers.
    */
-  const getMemoryMarkerIndexes: Selector<MarkerIndex[]> = createSelector(
+  const getMemoryMarkerIndexes: Selector<
+    MarkerIndex[]
+  > = createSelector(
     getMarkerGetter,
     getCommittedRangeAndTabFilteredMarkerIndexes,
-    filterMarkerIndexesCreator(MarkerData.isMemoryMarker)
+    ProfileSelectors.getTimelineMemoryMarkerTypes,
+    (getMarker, markerIndexes, timelineMemoryMarkerTypes) =>
+      MarkerData.filterMarkerByTypes(
+        getMarker,
+        markerIndexes,
+        timelineMemoryMarkerTypes
+      )
   );
 
   /**

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -6,6 +6,7 @@
 import { createSelector } from 'reselect';
 import * as Tracks from '../profile-logic/tracks';
 import * as UrlState from './url-state';
+import * as MarkerData from '../profile-logic/marker-data';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 import {
   filterCounterToRange,
@@ -62,6 +63,7 @@ import type {
   ActiveTabTimeline,
   ActiveTabMainTrack,
   $ReturnType,
+  MarkerSchema,
 } from 'firefox-profiler/types';
 
 export const getProfileView: Selector<ProfileViewState> = state =>
@@ -169,6 +171,43 @@ export const getContentfulSpeedIndexProgress: Selector<
 > = state => getVisualMetrics(state).ContentfulSpeedIndexProgress;
 export const getProfilerConfiguration: Selector<?ProfilerConfiguration> = state =>
   getMeta(state).configuration;
+
+/**
+ * TODO - These will eventually be stored in the profile, but for now
+ * define them here.
+ */
+export const getMarkerSchema: Selector<MarkerSchema[]> = () => [
+  {
+    name: 'GCSlice',
+    label: 'GCSlice',
+    display: ['marker-chart', 'marker-table', 'timeline-memory'],
+    data: [],
+  },
+  {
+    name: 'GCMajor',
+    label: 'GCMajor',
+    display: ['marker-chart', 'marker-table', 'timeline-memory'],
+    data: [],
+  },
+  {
+    name: 'GCMinor',
+    label: 'GCMinor',
+    display: ['marker-chart', 'marker-table', 'timeline-memory'],
+    data: [],
+  },
+  {
+    name: 'CC',
+    label: 'Cycle Collect',
+    display: ['marker-chart', 'marker-table', 'timeline-memory'],
+    data: [],
+  },
+];
+
+export const getTimelineMemoryMarkerTypes: Selector<
+  Set<string>
+> = createSelector(getMarkerSchema, markerSchema =>
+  MarkerData.getMarkerTypesForDisplay(markerSchema, 'timeline-memory')
+);
 
 export const getActiveBrowsingContextID: Selector<BrowsingContextID | null> = state => {
   const configuration = getProfilerConfiguration(state);

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -7,6 +7,50 @@ import type { Milliseconds, Microseconds, Seconds, Bytes } from './units';
 import type { GeckoMarkerStack } from './gecko-profile';
 import type { IndexIntoStackTable, IndexIntoStringTable } from './profile';
 
+// Provide different formatting options for strings.
+export type MarkerFormatType =
+  | 'string' // "Label: Some String"
+  | 'bytes' // "Label: 5mb"
+  | 'seconds' // "Label: 5s"
+  | 'milliseconds' // "Label: 5ms"
+  | 'microseconds' // "Label: 5μs"
+  | 'nanoseconds' // "Label: 5ns"
+  | 'integer' // "Label: 5323"
+  | 'number' // "Label: 52.23"
+  | 'percentage' // "Label: 50%"
+  | 'stack' // Prints a full stack trace using the value.
+  | 'url'; // Show the URL, and handle sanitization
+
+// A list of all the valid locations to surface this marker.
+// We can be free to add more UI areas.
+export type MarkerDisplayLocation =
+  | 'marker-chart'
+  | 'marker-table'
+  | 'timeline'
+  // In the timeline, this is a section that breaks out markers that are related
+  // to memory.
+  | 'timeline-memory'
+  | 'stack-chart';
+
+export type MarkerSchema = {
+  // The unique identifier for this marker.
+  name: string, // e.g. "GCMajor-complete"
+
+  // The label of how this marker should be displayed in the UI.
+  // TODO - It would be nice to support printf-like features here
+  label: string, // e.g. "GCMajor"
+
+  // The locations to display
+  display: MarkerDisplayLocation[],
+
+  data: Array<{
+    key: string,
+    label: string,
+    format: MarkerFormatType,
+    searchable?: boolean,
+  }>,
+};
+
 /**
  * Markers can include a stack. These are converted to a cause backtrace, which includes
  * the time the stack was taken. Sometimes this cause can be async, and triggered before


### PR DESCRIPTION
edit: Ok, I would like to land this as an initial base for future work. It seems like the start of a reasonable approach. My next patch will be marker tooltips which is... more invasive. I think this will help focus some of the schema efforts with some of the initial wiring. I'd like to refine the actual schema implementation as follow-up, given the current feedback. I only rebased this patch and added a few more comments.

Resolves #2731.

This patch only handles a simpler case of the memory marker timeline, pictured here. There should be no behavior changes.

> <img width="631" alt="image" src="https://user-images.githubusercontent.com/1588648/91482783-3ade9880-e86c-11ea-91c8-7f13f0d7fbad.png">

Before: https://share.firefox.dev/3b6OzRd
After: [deploy preview](https://deploy-preview-2565--perf-html.netlify.app//public/d99f716701bea4da595043fdd7bff3122f2b8cbe/calltree/?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=5-0-1-2-3&localTrackOrderByPid=85196-1-2-0~85200-0~85203-0~85199-0~85198-0-1~&range=1770m1103&thread=5&v=5)


----

Original message: I'm trying to figure out an incremental approach for handling these changes.
