### PR TITLE
Increase the permalink's input width so that new permalinks are completely visible

### DIFF
--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -42,7 +42,7 @@
 }
 
 .menuButtonsPermalinkTextField {
-  width: 14em;
+  width: 16em;
   height: 19px;
   padding: 0 4px;
   margin: 5px -5px;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/454175/83001565-3a83f680-a00c-11ea-9c2c-793c4ad442de.png)
[link to profile](https://profiler.firefox.com/public/24a9fdbdab160a8b11390de381f1c8b334f50f24/calltree/?globalTrackOrder=5-0-2-3-4-1&hiddenGlobalTracks=2-3-4&implementation=js&localTrackOrderByPid=3823-0~&thread=2&v=4)

after:
![image](https://user-images.githubusercontent.com/454175/83001506-23450900-a00c-11ea-95cd-d881dcd6c3da.png)
[link to profile](https://deploy-preview-2566--perf-html.netlify.com/public/24a9fdbdab160a8b11390de381f1c8b334f50f24/calltree/?globalTrackOrder=5-0-2-3-4-1&hiddenGlobalTracks=2-3-4&implementation=js&localTrackOrderByPid=3823-0~&thread=2&v=4)
