### PR TITLE
Scroll to the resource track in active tab view

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -51,6 +51,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
   _resizeListener = () => this.forceUpdate();
   _categoryDrawStyles: null | CategoryDrawStyles = null;
   _fillsQuerier: null | ActivityFillGraphQuerier = null;
+  _container: HTMLElement | null = null;
 
   state = {
     hoveredSample: null,
@@ -89,13 +90,27 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
     }
   }
 
+  _stopPropagation(e: TransitionEvent) {
+    e.stopPropagation();
+  }
+
   componentDidMount() {
     window.addEventListener('resize', this._resizeListener);
     this.forceUpdate(); // for initial size
+    const container = this._container;
+    if (container !== null) {
+      // Stop the propagation of transitionend so we won't fire multiple events
+      // on the active tab resource track `transitionend` event.
+      container.addEventListener('transitionend', this._stopPropagation);
+    }
   }
 
   componentWillUnmount() {
     window.removeEventListener('resize', this._resizeListener);
+    const container = this._container;
+    if (container !== null) {
+      container.removeEventListener('transitionend', this._stopPropagation);
+    }
   }
 
   /**
@@ -241,6 +256,10 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
     }
   };
 
+  _takeContainerRef = (el: HTMLElement | null) => {
+    this._container = el;
+  };
+
   render() {
     this._renderCanvas();
     const { fullThread, categories } = this.props;
@@ -250,6 +269,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
         className={this.props.className}
         onMouseMove={this._onMouseMove}
         onMouseLeave={this._onMouseLeave}
+        ref={this._takeContainerRef}
       >
         <canvas
           className={classNames(

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -46,6 +46,10 @@ type State = {
   mouseY: CssPixels,
 };
 
+function _stopPropagation(e: TransitionEvent) {
+  e.stopPropagation();
+}
+
 class ThreadActivityGraph extends React.PureComponent<Props, State> {
   _canvas: null | HTMLCanvasElement = null;
   _resizeListener = () => this.forceUpdate();
@@ -90,10 +94,6 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
     }
   }
 
-  _stopPropagation(e: TransitionEvent) {
-    e.stopPropagation();
-  }
-
   componentDidMount() {
     window.addEventListener('resize', this._resizeListener);
     this.forceUpdate(); // for initial size
@@ -101,7 +101,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
     if (container !== null) {
       // Stop the propagation of transitionend so we won't fire multiple events
       // on the active tab resource track `transitionend` event.
-      container.addEventListener('transitionend', this._stopPropagation);
+      container.addEventListener('transitionend', _stopPropagation);
     }
   }
 
@@ -109,7 +109,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
     window.removeEventListener('resize', this._resizeListener);
     const container = this._container;
     if (container !== null) {
-      container.removeEventListener('transitionend', this._stopPropagation);
+      container.removeEventListener('transitionend', _stopPropagation);
     }
   }
 

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -35,7 +35,10 @@ import type { ConnectedProps } from '../../utils/connect';
 type OwnProps = {|
   +trackReference: GlobalTrackReference,
   +trackIndex: TrackIndex,
-  +setInitialSelected: (el: InitialSelectedTrackReference) => void,
+  +setInitialSelected: (
+    el: InitialSelectedTrackReference,
+    forceScroll?: boolean
+  ) => void,
 |};
 
 type StateProps = {|

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -93,12 +93,17 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
   }
 
   renderResourcesPanel() {
-    const { resourceTracks } = this.props;
+    const { resourceTracks, setInitialSelected } = this.props;
     if (resourceTracks.length === 0) {
       return null;
     }
 
-    return <ActiveTabResourcesPanel resourceTracks={resourceTracks} />;
+    return (
+      <ActiveTabResourcesPanel
+        resourceTracks={resourceTracks}
+        setInitialSelected={setInitialSelected}
+      />
+    );
   }
 
   _takeContainerRef = (el: HTMLElement | null) => {

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -98,12 +98,7 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
       return null;
     }
 
-    return (
-      <ActiveTabResourcesPanel
-        resourceTracks={resourceTracks}
-        setIsInitialSelectedPane={this.setIsInitialSelectedPane}
-      />
-    );
+    return <ActiveTabResourcesPanel resourceTracks={resourceTracks} />;
   }
 
   _takeContainerRef = (el: HTMLElement | null) => {
@@ -111,12 +106,8 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
     this._container = el;
 
     if (isSelected) {
-      this.setIsInitialSelectedPane(true);
+      this._isInitialSelectedPane = true;
     }
-  };
-
-  setIsInitialSelectedPane = (value: boolean) => {
-    this._isInitialSelectedPane = value;
   };
 
   componentDidMount() {

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -104,24 +104,31 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    if (this._isInitialSelectedPane && this._container !== null) {
-      // Handle the scrolling of the initial selected track into view.
-      this.props.setInitialSelected(this._container);
+    const container = this._container;
+    if (container !== null) {
+      if (this._isInitialSelectedPane) {
+        // Handle the scrolling of the initial selected track into view.
+        this.props.setInitialSelected(container);
+      }
+
+      // Add an event listener for the end of transition so we can make sure
+      // opened tracks are still in the viewport.
+      container.addEventListener('transitionend', this._scrollIfNecessary);
     }
   }
 
-  componentDidUpdate(_, prevState) {
-    const { setInitialSelected } = this.props;
-
-    if (!prevState.isOpen && this.state.isOpen && this._container !== null) {
-      // Scroll to the expanded resource track after it's fully opened.
-      setTimeout(() => {
-        if (this._container !== null) {
-          setInitialSelected(this._container, true);
-        }
-      }, 200); // We need to wait for the transition.
+  componentWillUnmount() {
+    const container = this._container;
+    if (container !== null) {
+      container.removeEventListener('transitionend', this._scrollIfNecessary);
     }
   }
+
+  _scrollIfNecessary = () => {
+    if (this.state.isOpen && this._container !== null) {
+      this.props.setInitialSelected(this._container, true);
+    }
+  };
 
   _takeContainerRef = (el: HTMLElement | null) => {
     const { isSelected } = this.props;

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -25,7 +25,6 @@ import type { ConnectedProps } from '../../utils/connect';
 type OwnProps = {|
   +resourceTrack: ActiveTabResourceTrack,
   +trackIndex: TrackIndex,
-  +setIsInitialSelectedPane: (value: boolean) => void,
 |};
 
 type StateProps = {|
@@ -90,13 +89,6 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
       default:
         console.error('Unhandled resourceTrack type', (resourceTrack: empty));
         return null;
-    }
-  }
-
-  componentDidMount() {
-    const { isSelected } = this.props;
-    if (isSelected) {
-      this.props.setIsInitialSelectedPane(true);
     }
   }
 

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -26,7 +26,10 @@ import type { ConnectedProps } from '../../utils/connect';
 type OwnProps = {|
   +resourceTrack: ActiveTabResourceTrack,
   +trackIndex: TrackIndex,
-  +setInitialSelected: (el: InitialSelectedTrackReference) => void,
+  +setInitialSelected: (
+    el: InitialSelectedTrackReference,
+    forceScroll?: boolean
+  ) => void,
 |};
 
 type StateProps = {|
@@ -104,6 +107,19 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
     if (this._isInitialSelectedPane && this._container !== null) {
       // Handle the scrolling of the initial selected track into view.
       this.props.setInitialSelected(this._container);
+    }
+  }
+
+  componentDidUpdate(_, prevState) {
+    const { setInitialSelected } = this.props;
+
+    if (!prevState.isOpen && this.state.isOpen && this._container !== null) {
+      // Scroll to the expanded resource track after it's fully opened.
+      setTimeout(() => {
+        if (this._container !== null) {
+          setInitialSelected(this._container, true);
+        }
+      }, 200); // We need to wait for the transition.
     }
   }
 

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -19,12 +19,14 @@ import type { ActiveTabTrackReference } from '../../types/actions';
 import type {
   TrackIndex,
   ActiveTabResourceTrack,
+  InitialSelectedTrackReference,
 } from '../../types/profile-derived';
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|
   +resourceTrack: ActiveTabResourceTrack,
   +trackIndex: TrackIndex,
+  +setInitialSelected: (el: InitialSelectedTrackReference) => void,
 |};
 
 type StateProps = {|
@@ -43,6 +45,8 @@ type State = {|
 |};
 
 class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
+  _container: HTMLElement | null = null;
+  _isInitialSelectedPane: boolean | null = null;
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -92,6 +96,26 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
     }
   }
 
+  setIsInitialSelectedPane = (value: boolean) => {
+    this._isInitialSelectedPane = value;
+  };
+
+  componentDidMount() {
+    if (this._isInitialSelectedPane && this._container !== null) {
+      // Handle the scrolling of the initial selected track into view.
+      this.props.setInitialSelected(this._container);
+    }
+  }
+
+  _takeContainerRef = (el: HTMLElement | null) => {
+    const { isSelected } = this.props;
+    this._container = el;
+
+    if (isSelected) {
+      this.setIsInitialSelectedPane(true);
+    }
+  };
+
   render() {
     const { isSelected, resourceTrack } = this.props;
     const { isOpen } = this.state;
@@ -112,7 +136,10 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
     }
 
     return (
-      <li className="timelineTrack timelineTrackResource">
+      <li
+        ref={this._takeContainerRef}
+        className="timelineTrack timelineTrackResource"
+      >
         {/* This next div is used to mirror the structure of the TimelineGlobalTrack */}
         <div
           className={classNames('timelineTrackRow timelineTrackResourceRow', {

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -14,11 +14,15 @@ import { ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT } from '../../app-logic/con
 import ActiveTabTimelineResourceTrack from './ActiveTabResourceTrack';
 
 import type { SizeProps } from '../shared/WithSize';
-import type { ActiveTabResourceTrack } from '../../types/profile-derived';
+import type {
+  ActiveTabResourceTrack,
+  InitialSelectedTrackReference,
+} from '../../types/profile-derived';
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|
   +resourceTracks: ActiveTabResourceTrack[],
+  +setInitialSelected: (el: InitialSelectedTrackReference) => void,
 |};
 
 type StateProps = {|
@@ -40,6 +44,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
       resourceTracks,
       toggleResourcesPanel,
       isActiveTabResourcesPanelOpen,
+      setInitialSelected,
     } = this.props;
     return (
       <div
@@ -63,6 +68,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
                 key={trackIndex}
                 resourceTrack={resourceTrack}
                 trackIndex={trackIndex}
+                setInitialSelected={setInitialSelected}
               />
             ))}
           </ol>

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -19,7 +19,6 @@ import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|
   +resourceTracks: ActiveTabResourceTrack[],
-  +setIsInitialSelectedPane: (value: boolean) => void,
 |};
 
 type StateProps = {|
@@ -41,7 +40,6 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
       resourceTracks,
       toggleResourcesPanel,
       isActiveTabResourcesPanelOpen,
-      setIsInitialSelectedPane,
     } = this.props;
     return (
       <div
@@ -65,7 +63,6 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
                 key={trackIndex}
                 resourceTrack={resourceTrack}
                 trackIndex={trackIndex}
-                setIsInitialSelectedPane={setIsInitialSelectedPane}
               />
             ))}
           </ol>

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -22,7 +22,10 @@ import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|
   +resourceTracks: ActiveTabResourceTrack[],
-  +setInitialSelected: (el: InitialSelectedTrackReference) => void,
+  +setInitialSelected: (
+    el: InitialSelectedTrackReference,
+    forceScroll?: boolean
+  ) => void,
 |};
 
 type StateProps = {|

--- a/src/components/timeline/ActiveTabTimeline.js
+++ b/src/components/timeline/ActiveTabTimeline.js
@@ -67,7 +67,7 @@ class ActiveTabTimeline extends React.PureComponent<Props, State> {
       this.setState(prevState => {
         return {
           initialSelected: el,
-          forceLayoutGeneration: ++prevState.forceLayoutGeneration,
+          forceLayoutGeneration: prevState.forceLayoutGeneration + 1,
         };
       });
     } else {

--- a/src/components/timeline/ActiveTabTimeline.js
+++ b/src/components/timeline/ActiveTabTimeline.js
@@ -46,19 +46,33 @@ type Props = {|
 
 type State = {|
   initialSelected: InitialSelectedTrackReference | null,
+  forceLayoutGeneration: number,
 |};
 
 class ActiveTabTimeline extends React.PureComponent<Props, State> {
   state = {
     initialSelected: null,
+    forceLayoutGeneration: 0,
   };
 
   /**
    * This method collects the initially selected track's HTMLElement. This allows the timeline
    * to scroll the initially selected track into view once the page is loaded.
    */
-  setInitialSelected = (el: InitialSelectedTrackReference) => {
-    this.setState({ initialSelected: el });
+  setInitialSelected = (
+    el: InitialSelectedTrackReference,
+    forceScroll: boolean = false
+  ) => {
+    if (forceScroll) {
+      this.setState(prevState => {
+        return {
+          initialSelected: el,
+          forceLayoutGeneration: ++prevState.forceLayoutGeneration,
+        };
+      });
+    } else {
+      this.setState({ initialSelected: el });
+    }
   };
 
   render() {
@@ -84,6 +98,7 @@ class ActiveTabTimeline extends React.PureComponent<Props, State> {
             className="timelineOverflowEdgeIndicator"
             panelLayoutGeneration={panelLayoutGeneration}
             initialSelected={this.state.initialSelected}
+            forceLayoutGeneration={this.state.forceLayoutGeneration}
           >
             <ol className="timelineThreadList">
               {globalTracks.map((globalTrack, trackIndex) => (

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -32,6 +32,10 @@ type MarkerState = 'PRESSED' | 'HOVERED' | 'NONE';
 
 type MouseEventHandler = (SyntheticMouseEvent<HTMLCanvasElement>) => any;
 
+function _stopPropagation(e: TransitionEvent) {
+  e.stopPropagation();
+}
+
 /**
  * When adding properties to these props, please consider the comment above the component.
  */
@@ -411,23 +415,19 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
     });
   };
 
-  _stopPropagation(e: TransitionEvent) {
-    e.stopPropagation();
-  }
-
   componentDidMount() {
     const container = this._container;
     if (container !== null) {
       // Stop the propagation of transitionend so we won't fire multiple events
       // on the active tab resource track `transitionend` event.
-      container.addEventListener('transitionend', this._stopPropagation);
+      container.addEventListener('transitionend', _stopPropagation);
     }
   }
 
   componentWillUnmount() {
     const container = this._container;
     if (container !== null) {
-      container.removeEventListener('transitionend', this._stopPropagation);
+      container.removeEventListener('transitionend', _stopPropagation);
     }
   }
 

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -280,6 +280,7 @@ type State = {
 };
 
 class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
+  _container: HTMLElement | null = null;
   state = {
     hoveredItem: null,
     mouseDownItem: null,
@@ -410,6 +411,30 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
     });
   };
 
+  _stopPropagation(e: TransitionEvent) {
+    e.stopPropagation();
+  }
+
+  componentDidMount() {
+    const container = this._container;
+    if (container !== null) {
+      // Stop the propagation of transitionend so we won't fire multiple events
+      // on the active tab resource track `transitionend` event.
+      container.addEventListener('transitionend', this._stopPropagation);
+    }
+  }
+
+  componentWillUnmount() {
+    const container = this._container;
+    if (container !== null) {
+      container.removeEventListener('transitionend', this._stopPropagation);
+    }
+  }
+
+  _takeContainerRef = (el: HTMLElement | null) => {
+    this._container = el;
+  };
+
   render() {
     const {
       additionalClassName,
@@ -432,6 +457,7 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
           additionalClassName,
           isSelected ? 'selected' : null
         )}
+        ref={this._takeContainerRef}
       >
         <ContextMenuTrigger id="MarkerContextMenu">
           <TimelineMarkersCanvas

--- a/src/components/timeline/OverflowEdgeIndicator.js
+++ b/src/components/timeline/OverflowEdgeIndicator.js
@@ -15,6 +15,7 @@ type Props = {
   children: React.Node,
   panelLayoutGeneration: number,
   initialSelected: InitialSelectedTrackReference | null,
+  forceLayoutGeneration?: number,
 };
 
 type State = {
@@ -52,14 +53,34 @@ class OverflowEdgeIndicator extends React.PureComponent<Props, State> {
     this._updateIndicatorStatus();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
     this._updateIndicatorStatus();
+    const { initialSelected, forceLayoutGeneration } = this.props;
+    const container = this._container;
+
+    if (
+      forceLayoutGeneration !== undefined &&
+      forceLayoutGeneration !== prevProps.forceLayoutGeneration &&
+      initialSelected &&
+      container !== null
+    ) {
+      // If forceLayoutGeneration exists and incremented, scroll to the selected
+      // element even though it's already scrolled before.
+      const childPosition =
+        initialSelected.offsetTop + initialSelected.offsetHeight;
+      const parentPosition = container.offsetTop + container.offsetHeight;
+
+      if (childPosition > parentPosition) {
+        container.scrollTop = initialSelected.offsetTop;
+      }
+    }
+
     if (
       !this._scrolledToInitialSelected &&
-      this.props.initialSelected &&
+      initialSelected &&
       this._container
     ) {
-      this._container.scrollTop = this.props.initialSelected.offsetTop;
+      this._container.scrollTop = initialSelected.offsetTop;
       this._scrolledToInitialSelected = true;
     }
   }

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -185,10 +185,7 @@ describe('ActiveTabTimeline', function() {
 
       const renderResult = render(
         <Provider store={store}>
-          <ActiveTabResourcesPanel
-            resourceTracks={resourceTracks}
-            setIsInitialSelectedPane={() => {}}
-          />
+          <ActiveTabResourcesPanel resourceTracks={resourceTracks} />
         </Provider>
       );
 
@@ -292,7 +289,6 @@ describe('ActiveTabTimeline', function() {
           <ActiveTabResourceTrack
             resourceTrack={resourceTracks[1]}
             trackIndex={trackIndex}
-            setIsInitialSelectedPane={() => {}}
           />
         </Provider>
       );

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -185,7 +185,10 @@ describe('ActiveTabTimeline', function() {
 
       const renderResult = render(
         <Provider store={store}>
-          <ActiveTabResourcesPanel resourceTracks={resourceTracks} />
+          <ActiveTabResourcesPanel
+            resourceTracks={resourceTracks}
+            setInitialSelected={() => {}}
+          />
         </Provider>
       );
 
@@ -289,6 +292,7 @@ describe('ActiveTabTimeline', function() {
           <ActiveTabResourceTrack
             resourceTrack={resourceTracks[1]}
             trackIndex={trackIndex}
+            setInitialSelected={() => {}}
           />
         </Provider>
       );


### PR DESCRIPTION
This PR:
- Fixes the scrolling to resource track implementation during the initial load.
- Implements scrolling to the resource track if it is outside of view when we expand it.

[Deploy preview](https://deploy-preview-2568--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?ctxId=12&resources&thread=16&v=4&view=active-tab)

Fixes #2562.