### PR TITLE
Do not sanitize chrome URIs inside the pages array

### DIFF
--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -48,15 +48,14 @@ export function sanitizePII(
   // Flow mistakenly thinks that PIIToBeRemoved could be null in the reduce functions
   // below, so instead re-bind it here.
   const PIIToBeRemoved = maybePIIToBeRemoved;
-  let urlCounter = 0;
   const oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex> = new Map();
 
   let pages;
   if (profile.pages) {
     if (PIIToBeRemoved.shouldRemoveUrls) {
-      pages = profile.pages.map(page =>
+      pages = profile.pages.map((page, pageIndex) =>
         Object.assign({}, page, {
-          url: 'Page #' + urlCounter++,
+          url: removeURLs(page.url, true, `<Page #${pageIndex}>`),
         })
       );
     } else {

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -91,6 +91,12 @@ export function createGeckoSubprocessProfile(
         url: 'https://github.com/rustwasm/wasm-bindgen/issues/5',
         embedderInnerWindowID: 0,
       },
+      {
+        browsingContextID: 111111,
+        innerWindowID: 2,
+        url: 'chrome://browser/content/browser.xhtml',
+        embedderInnerWindowID: 0,
+      },
     ],
     threads: [
       {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -183,16 +183,13 @@ describe('sanitizePII', function() {
     const profile = processProfile(createGeckoProfile());
 
     // Checking to make sure that we have a http{,s} URI in the pages array.
-    let pageUrl = null;
-    for (const page of ensureExists(profile.pages)) {
-      if (page.url.includes('http')) {
-        pageUrl = page.url;
-      }
-    }
-    expect(pageUrl).not.toBe(null);
-    if (pageUrl === null) {
-      // This makes flow happy when we need to use pageUrl next.
-      return;
+    const pageUrl = ensureExists(profile.pages).find(page =>
+      page.url.includes('http')
+    );
+    if (pageUrl === undefined) {
+      throw new Error(
+        "There should be an http URL in the 'pages' array in this profile."
+      );
     }
 
     const PIIToRemove = getRemoveProfileInformation({
@@ -201,7 +198,7 @@ describe('sanitizePII', function() {
 
     const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
     for (const page of ensureExists(sanitizedProfile.pages)) {
-      expect(page.url.includes(pageUrl)).toBe(false);
+      expect(page.url.includes(pageUrl.url)).toBe(false);
     }
   });
 
@@ -209,16 +206,13 @@ describe('sanitizePII', function() {
     const profile = processProfile(createGeckoProfile());
 
     // Checking to make sure that we have a chrome URI in the pages array.
-    let chromePageUrl = null;
-    for (const page of ensureExists(profile.pages)) {
-      if (page.url.includes('chrome://')) {
-        chromePageUrl = page.url;
-      }
-    }
-    expect(chromePageUrl).not.toBe(null);
-    if (chromePageUrl === null) {
-      // This makes flow happy when we need to use chromePageUrl next.
-      return;
+    const chromePageUrl = ensureExists(profile.pages).find(page =>
+      page.url.includes('chrome://')
+    );
+    if (chromePageUrl === undefined) {
+      throw new Error(
+        "There should be a chrome URL in the 'pages' array in this profile."
+      );
     }
 
     const PIIToRemove = getRemoveProfileInformation({
@@ -228,7 +222,7 @@ describe('sanitizePII', function() {
 
     let includesChromeUrl = false;
     for (const page of ensureExists(sanitizedProfile.pages)) {
-      if (page.url.includes(chromePageUrl)) {
+      if (page.url.includes(chromePageUrl.url)) {
         includesChromeUrl = true;
         break;
       }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -11,7 +11,8 @@
  */
 export function removeURLs(
   string: string,
-  removeExtensions: boolean = true
+  removeExtensions: boolean = true,
+  redactedText: string = '<URL>'
 ): string {
   const rmExtensions = removeExtensions ? '|moz-extension' : '';
   const regExp = new RegExp(
@@ -26,5 +27,5 @@ export function removeURLs(
     //    Matches 'http', 'https', 'ftp', 'file' and optionally 'moz-extension' protocols.
     'gi'
   );
-  return string.replace(regExp, '$1<URL>');
+  return string.replace(regExp, '$1' + redactedText);
 }


### PR DESCRIPTION
Currently we are blindly sanitizing the pages array, which is not great since we are losing all the internal URIs. This patch makes use of `removeUrl` utility function we have to make sure we are only removing the necessary ones.

[Deploy preview](https://deploy-preview-2569--perf-html.netlify.app/public/7c3daf5943e8773806f0c15b4a5a71b8107bf65c/calltree/?globalTrackOrder=6-0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-4&hiddenLocalTracksByPid=47111-0-2-3-4&localTrackOrderByPid=47111-5-6-0-1-2-3-4~47126-0~47121-0~47123-0~47124-0~47122-0-1~&thread=0&v=4) (this profile has unsanitized pages, so you can re-publish with sanitizing to see the result)

STR:
- Open the deploy preview
- Check from the console that we have page urls with this `profile.pages`.
- Publish with "Include resource URLs" unchecked.
- Check again from the console that URLs are sanitized except the internal ones like `chrome://...` or `about:...`.

Fixes #2563.