### PR TITLE
Update the media thread idle logic for BMO#1641608

### DIFF
--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -641,12 +641,13 @@ function _isThreadIdle(profile: Profile, thread: Thread): boolean {
     );
   }
 
-  if (/^(?:Audio|Media)/.test(thread.name)) {
+  if (/^(?:Audio|Media|GraphRunner)/.test(thread.name)) {
     // This is a media thread: they are usually very idle, but are interesting
     // as soon as there's at least one sample. They're present with the media
     // preset, but not usually captured otherwise.
     // Matched thread names: AudioIPC, MediaPDecoder, MediaTimer, MediaPlayback,
-    // MediaDecoderStateMachine. They're enabled by the media preset.
+    // MediaDecoderStateMachine, GraphRunner. They're enabled by the media
+    // preset.
     return !_hasThreadAtLeastOneNonIdleSample(profile, thread);
   }
 


### PR DESCRIPTION
We're adding `"GraphRunner"` [there](https://bugzilla.mozilla.org/show_bug.cgi?id=1641608) so we want to add it here.