### PR TITLE
Show markers of Java main thread in the timeline

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -173,6 +173,7 @@ class TimelineTrackThread extends PureComponent<Props> {
       (filteredThread.name === 'GeckoMain' ||
         filteredThread.name === 'Compositor' ||
         filteredThread.name === 'Renderer' ||
+        filteredThread.name === 'Java Main Thread' ||
         filteredThread.name.startsWith('MediaDecoderStateMachine')) &&
       processType !== 'plugin';
 


### PR DESCRIPTION
I really don't like this check but also didn't want to change that logic completely without discussing it first (probably we can think about it with the marker API changes, right?). So here's adding another ad-hoc check to make android markers work. They are coming soon!