### PR TITLE
[deploy preview] Hardcode the symbolication server to http://127.0.0.1:3000/.

### DIFF
--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -118,7 +118,7 @@ export function requestSymbols(
     ),
   };
 
-  const jsonPromise = fetch('https://symbols.mozilla.org/symbolicate/v5', {
+  const jsonPromise = fetch('http://127.0.0.1:3000/symbolicate/v5', {
     body: JSON.stringify(body),
     method: 'POST',
     mode: 'cors',


### PR DESCRIPTION
I made this PR so that I would get a deploy preview that I can use for [`perfrecord`](https://github.com/mstange/perfrecord/).

We should come up with a proper way to specify a symbol server in the URL.