### PR TITLE
Sanitize FileIO marker pathname field

### DIFF
--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -137,7 +137,10 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
               'Include hidden time range'
             )}
             {this._renderCheckbox('includeScreenshots', 'Include screenshots')}
-            {this._renderCheckbox('includeUrls', 'Include resource URLs')}
+            {this._renderCheckbox(
+              'includeUrls',
+              'Include resource URLs and paths'
+            )}
             {this._renderCheckbox(
               'includeExtension',
               'Include extension information'

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -5,6 +5,7 @@
 
 import { getEmptyRawMarkerTable } from './data-structures';
 import { getFriendlyThreadName } from './profile-data';
+import { removeFilePath } from '../utils/string';
 
 import type {
   Thread,
@@ -22,6 +23,7 @@ import type {
   NetworkPayload,
   PrefMarkerPayload,
   InvalidationPayload,
+  FileIoPayload,
 } from '../types/markers';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { StartEndRange } from '../types/units';
@@ -1311,6 +1313,18 @@ export function removePrefMarkerPreferenceValues(
   payload: PrefMarkerPayload
 ): PrefMarkerPayload {
   return { ...payload, prefValue: '' };
+}
+
+/**
+ * Sanitize FileIO marker's filename property if it's non-empty.
+ */
+export function sanitizeFileIOMarkerFilenamePath(
+  payload: FileIoPayload
+): FileIoPayload {
+  return {
+    ...payload,
+    filename: removeFilePath(payload.filename),
+  };
 }
 
 export function getMarkerFullDescription(marker: Marker) {

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -13,6 +13,7 @@ import { removeURLs } from '../utils/string';
 import {
   removeNetworkMarkerURLs,
   removePrefMarkerPreferenceValues,
+  sanitizeFileIOMarkerFilenamePath,
   filterRawMarkerTableToRangeWithMarkersToDelete,
 } from './marker-data';
 import { filterThreadSamplesToRange } from './profile-data';
@@ -219,6 +220,17 @@ function sanitizeThreadPII(
         // Strip the URL from the marker name
         const stringIndex = markerTable.name[i];
         stringArray[stringIndex] = stringArray[stringIndex].replace(/:.*/, '');
+      }
+
+      // Remove the all OS paths from FileIO markers if user wants to remove them.
+      if (
+        PIIToBeRemoved.shouldRemoveUrls &&
+        currentMarker &&
+        currentMarker.type &&
+        currentMarker.type === 'FileIO'
+      ) {
+        // Remove the filename path from marker payload.
+        markerTable.data[i] = sanitizeFileIOMarkerFilenamePath(currentMarker);
       }
 
       // Remove the screenshots if the current thread index is in the

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -796,7 +796,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           name="includeUrls"
           type="checkbox"
         />
-        Include resource URLs
+        Include resource URLs and paths
       </label>
       <label
         class="photon-label menuButtonsPublishDataChoicesLabel"
@@ -898,7 +898,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           name="includeUrls"
           type="checkbox"
         />
-        Include resource URLs
+        Include resource URLs and paths
       </label>
       <label
         class="photon-label menuButtonsPublishDataChoicesLabel"

--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -165,6 +165,9 @@ describe('utils/string', function() {
       // A file in the macOS home dir.
       string = '/Users/username/test.txt';
       expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+      // A file path with spaces.
+      string = '/path/with spaces in it/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
     });
 
     it('should remove windows paths', () => {
@@ -177,15 +180,18 @@ describe('utils/string', function() {
       // A file in the Windows home dir.
       string = 'C:\\Users\\username\\test.txt';
       expect(removeFilePath(string)).toEqual('<PATH>\\test.txt');
+      // A file path with spaces.
+      string = 'C:\\path\\with spaces in it\\test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>\\test.txt');
     });
 
     it('should not remove non paths', () => {
       // It can be an empty string.
       let string = '';
-      expect(removeURLs(string)).toEqual(string);
+      expect(removeFilePath(string)).toEqual(string);
       // Or less likely, something else
       string = 'not a path';
-      expect(removeURLs(string)).toEqual(string);
+      expect(removeFilePath(string)).toEqual(string);
     });
   });
 });

--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import { removeURLs } from '../../utils/string';
+import { removeURLs, removeFilePath } from '../../utils/string';
 
 describe('utils/string', function() {
   describe('removeURLs', function() {
@@ -142,6 +142,50 @@ describe('utils/string', function() {
 
       string = 'moz-extension://foo/bar/index.js';
       expect(removeURLs(string, false)).toEqual(string);
+    });
+  });
+
+  describe('removeFilePath', function() {
+    it('should remove Unix-like paths', () => {
+      // A file in the root dir.
+      let string = '/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+      // A file in a non-root dir.
+      string = '/var/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+      // A file in the Linux home dir.
+      string = 'home/username/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+      // A file in a Unix derived home dir.
+      string = 'users/username/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+      // A file in another Unix derived home dir.
+      string = 'user/username/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+      // A file in the macOS home dir.
+      string = '/Users/username/test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>/test.txt');
+    });
+
+    it('should remove windows paths', () => {
+      // A file in the root dir.
+      let string = `C:\\test.txt`;
+      expect(removeFilePath(string)).toEqual('<PATH>\\test.txt');
+      // A file in a non-root dir.
+      string = 'C:\\Documents\\test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>\\test.txt');
+      // A file in the Windows home dir.
+      string = 'C:\\Users\\username\\test.txt';
+      expect(removeFilePath(string)).toEqual('<PATH>\\test.txt');
+    });
+
+    it('should not remove non paths', () => {
+      // It can be an empty string.
+      let string = '';
+      expect(removeURLs(string)).toEqual(string);
+      // Or less likely, something else
+      string = 'not a path';
+      expect(removeURLs(string)).toEqual(string);
     });
   });
 });

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -29,3 +29,36 @@ export function removeURLs(
   );
   return string.replace(regExp, '$1' + redactedText);
 }
+
+/**
+ * Take an absolute file path string and sanitize it except the last file name segment.
+ *
+ * Note: Do not use this function if the string not only contains a file path but
+ * also contains more text. This function is intended to use only for path strings.
+ */
+export function removeFilePath(
+  filePath: string,
+  redactedText: string = '<PATH>'
+): string {
+  let pathSeparator = null;
+
+  // Figure out which separator the path uses.
+  if (filePath.includes('/')) {
+    // This is a Unix-like path.
+    pathSeparator = '/';
+  } else if (filePath.includes('\\')) {
+    // This is a Windows path.
+    pathSeparator = '\\';
+  }
+
+  if (pathSeparator === null) {
+    // There is no path separator, which means it's either not a file path or empty.
+    return filePath;
+  }
+
+  return (
+    redactedText +
+    pathSeparator +
+    filePath.substring(filePath.lastIndexOf(pathSeparator) + 1)
+  );
+}

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -42,13 +42,17 @@ export function removeFilePath(
 ): string {
   let pathSeparator = null;
 
-  // Figure out which separator the path uses.
-  if (filePath.includes('/')) {
+  // Figure out which separator the path uses and the last separator index.
+  let lastSeparatorIndex = filePath.lastIndexOf('/');
+  if (lastSeparatorIndex !== -1) {
     // This is a Unix-like path.
     pathSeparator = '/';
-  } else if (filePath.includes('\\')) {
-    // This is a Windows path.
-    pathSeparator = '\\';
+  } else {
+    lastSeparatorIndex = filePath.lastIndexOf('\\');
+    if (lastSeparatorIndex !== -1) {
+      // This is a Windows path.
+      pathSeparator = '\\';
+    }
   }
 
   if (pathSeparator === null) {
@@ -56,9 +60,5 @@ export function removeFilePath(
     return filePath;
   }
 
-  return (
-    redactedText +
-    pathSeparator +
-    filePath.substring(filePath.lastIndexOf(pathSeparator) + 1)
-  );
+  return redactedText + pathSeparator + filePath.slice(lastSeparatorIndex + 1);
 }


### PR DESCRIPTION
This PR adds the sanitization for FileIO markers. Removes the OS paths but keeps the filename so we can still understand what is being accessed.

[Deploy preview to test the publish](https://deploy-preview-2583--perf-html.netlify.app/public/42de3e8912bb912fdcff0aff4ef31707c9fa30aa/marker-chart/?globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=2-4&hiddenLocalTracksByPid=2591108-1-3-4~2578984-1&localTrackOrderByPid=2591108-6-7-0-1-2-3-4-5~2582860-1-0~2589752-1-0~2578984-3-0-1-2~2590420-1-0~2585264-1-0~2591672-1-0~&markerSearch=fileio&thread=0&v=4)

Looks like we had an issue about this already. Fixes #2297.