### PR TITLE
Select the main track when we close the resources panel in active tab view

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -3,11 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getSelectedTab, getDataSource } from '../selectors/url-state';
+import {
+  getSelectedTab,
+  getDataSource,
+  getIsActiveTabResourcesPanelOpen,
+} from '../selectors/url-state';
 import { getTrackThreadHeights } from '../selectors/app';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';
+import { selectActiveTabMainTrack } from './profile-view';
+
 import type { Profile, ThreadIndex } from '../types/profile';
 import type { CssPixels } from '../types/units';
 import type { Action, ThunkAction } from '../types/store';
@@ -185,6 +191,16 @@ export function unregisterDragAndDropOverlay(): Action {
 /**
  * Toggle the active tab resources panel
  */
-export function toggleResourcesPanel(): Action {
-  return { type: 'TOGGLE_RESOURCES_PANEL' };
+export function toggleResourcesPanel(): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const isResourcesPanelOpen = getIsActiveTabResourcesPanelOpen(getState());
+    if (isResourcesPanelOpen) {
+      // If it was open when we dispatched that action, it means we are closing this panel.
+      // We would like to also select the main track when we close this panel.
+      dispatch(selectActiveTabMainTrack());
+    }
+
+    // Toggle the resources panel eventually.
+    dispatch({ type: 'TOGGLE_RESOURCES_PANEL' });
+  };
 }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -15,6 +15,7 @@ import {
   getPreviewSelection,
   getActiveTabGlobalTrackFromReference,
   getActiveTabResourceTrackFromReference,
+  getActiveTabGlobalTracks,
 } from '../selectors/profile';
 import {
   getThreadSelectors,
@@ -477,6 +478,31 @@ export function selectActiveTabTrack(
       selectedThreadIndex,
       selectedTab,
     });
+  };
+}
+
+/**
+ * An action for selecting the main track of active tab view directly.
+ * This is handy for some cases where we need to select the main track
+ * without actually clicking on it (e.g. closing event of resources panel).
+ */
+export function selectActiveTabMainTrack(): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const globalTracks = getActiveTabGlobalTracks(getState());
+    const mainTrackIndex = globalTracks.findIndex(
+      track => track.type === 'tab'
+    );
+
+    if (mainTrackIndex === -1) {
+      throw new Error('Failed to find the main track index in active tab view');
+    }
+
+    dispatch(
+      selectActiveTabTrack({
+        type: 'global',
+        trackIndex: mainTrackIndex,
+      })
+    );
   };
 }
 

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -15,7 +15,6 @@ import {
   getPreviewSelection,
   getActiveTabGlobalTrackFromReference,
   getActiveTabResourceTrackFromReference,
-  getActiveTabGlobalTracks,
 } from '../selectors/profile';
 import {
   getThreadSelectors,
@@ -478,31 +477,6 @@ export function selectActiveTabTrack(
       selectedThreadIndex,
       selectedTab,
     });
-  };
-}
-
-/**
- * An action for selecting the main track of active tab view directly.
- * This is handy for some cases where we need to select the main track
- * without actually clicking on it (e.g. closing event of resources panel).
- */
-export function selectActiveTabMainTrack(): ThunkAction<void> {
-  return (dispatch, getState) => {
-    const globalTracks = getActiveTabGlobalTracks(getState());
-    const mainTrackIndex = globalTracks.findIndex(
-      track => track.type === 'tab'
-    );
-
-    if (mainTrackIndex === -1) {
-      throw new Error('Failed to find the main track index in active tab view');
-    }
-
-    dispatch(
-      selectActiveTabTrack({
-        type: 'global',
-        trackIndex: mainTrackIndex,
-      })
-    );
   };
 }
 

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -127,6 +127,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'HIDE_LOCAL_TRACK':
     case 'SHOW_LOCAL_TRACK':
     case 'ISOLATE_LOCAL_TRACK':
+    case 'TOGGLE_RESOURCES_PANEL':
     // Committed range changes: (fallthrough)
     case 'COMMIT_RANGE':
     case 'POP_COMMITTED_RANGES':

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -121,6 +121,7 @@ const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
     case 'HIDE_GLOBAL_TRACK':
     case 'HIDE_LOCAL_TRACK':
     case 'ISOLATE_LOCAL_TRACK':
+    case 'TOGGLE_RESOURCES_PANEL':
       // Only switch to non-null selected threads.
       return (action.selectedThreadIndex: ThreadIndex);
     case 'SANITIZED_PROFILE_PUBLISHED': {

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -166,10 +166,12 @@ describe('ActiveTabTimeline', function() {
       const { profile, ...pageInfo } = addActiveTabInformationToProfile(
         getProfileWithNiceTracks()
       );
+      const mainThreadIndex = 0;
+      const resourceThreadIndex = 1;
       // Setting the first thread as parent track and the second as the iframe track.
-      profile.threads[0].frameTable.innerWindowID[0] =
+      profile.threads[mainThreadIndex].frameTable.innerWindowID[0] =
         pageInfo.parentInnerWindowIDsWithChildren;
-      profile.threads[1].frameTable.innerWindowID[0] =
+      profile.threads[resourceThreadIndex].frameTable.innerWindowID[0] =
         pageInfo.iframeInnerWindowIDsWithChild;
       const store = storeWithProfile(profile);
       store.dispatch(
@@ -203,6 +205,8 @@ describe('ActiveTabTimeline', function() {
         store,
         getResourcesPanelHeader,
         getResourceFrameTrack,
+        mainThreadIndex,
+        resourceThreadIndex,
       };
     }
 
@@ -229,6 +233,30 @@ describe('ActiveTabTimeline', function() {
 
       fireEvent.click(resourcesPanelHeader);
       expect(getResourceFrameTrack()).toBeTruthy();
+    });
+
+    it('selects the main track when panel is being closed', () => {
+      const {
+        getResourcesPanelHeader,
+        getResourceFrameTrack,
+        getState,
+        mainThreadIndex,
+        resourceThreadIndex,
+      } = setup();
+      // At first, make sure the main thread is selected.
+      expect(getSelectedThreadIndex(getState())).toBe(mainThreadIndex);
+
+      // 1. Open the panel.
+      fireEvent.click(getResourcesPanelHeader());
+      // 2. Select the reource track.
+      fireEvent.mouseUp(ensureExists(getResourceFrameTrack()));
+      // Selected thread should be the resource now.
+      expect(getSelectedThreadIndex(getState())).toBe(resourceThreadIndex);
+
+      // 3. Close the panel.
+      fireEvent.click(getResourcesPanelHeader());
+      // Now the main thread should be selected again.
+      expect(getSelectedThreadIndex(getState())).toBe(mainThreadIndex);
     });
   });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -388,7 +388,10 @@ type UrlStateAction =
       +type: 'SET_DATA_SOURCE',
       +dataSource: DataSource,
     |}
-  | {| +type: 'TOGGLE_RESOURCES_PANEL' |};
+  | {|
+      +type: 'TOGGLE_RESOURCES_PANEL',
+      +selectedThreadIndex: ThreadIndex,
+    |};
 
 type IconsAction =
   | {| +type: 'ICON_HAS_LOADED', +icon: string |}


### PR DESCRIPTION
Before this PR, when we close the resources panel, the selected thread was still the hidden resource track. It's kinda weird because that track is no longer visible. With this PR, we are being more consistent with the timeline since it's automatically selecting the main thread when we close the resources panel.

[Deploy preview](https://deploy-preview-2584--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?ctxId=12&resources&thread=7&v=4&view=active-tab)