### PR TITLE
Slightly change the error message when the node version is incorrect,…

### DIFF
--- a/bin/pre-install.js
+++ b/bin/pre-install.js
@@ -54,7 +54,7 @@ function checkNode(agents /*: AgentsVersion */) {
   const expectedNodeVersion = parseExpectedNodeVersion();
   if (versionCompare(nodeVersion, expectedNodeVersion) < 0) {
     console.error(
-      `This project expects at least Node version ${expectedNodeVersion}.`
+      `This project expects at least Node version ${expectedNodeVersion} but version ${nodeVersion} is currently used.`
     );
     console.error(
       'You can use a tool like `nvm` to install and manage installed node versions.'


### PR DESCRIPTION
… to show the current node version

This is a very simple change. I found this easier to work with when I worked on the v10 -> v12 node migration.