### PR TITLE
Loop up the unfiltered stack table to find the JS implementation

### DIFF
--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -378,7 +378,7 @@ function _parseTextSamples(textSamples: string): Array<string[]> {
   });
 }
 
-const JIT_IMPLEMENTATIONS = ['ion', 'baseline'];
+const JIT_IMPLEMENTATIONS = ['ion', 'baseline', 'blinterp'];
 
 function _findJitTypeFromFuncName(funcNameWithModifier: string): string | null {
   const findJitTypeResult = /\[jit:([^\]]+)\]/.exec(funcNameWithModifier);
@@ -387,8 +387,13 @@ function _findJitTypeFromFuncName(funcNameWithModifier: string): string | null {
     jitType = findJitTypeResult[1];
   }
 
-  if (jitType && JIT_IMPLEMENTATIONS.includes(jitType)) {
-    return jitType;
+  if (jitType) {
+    if (JIT_IMPLEMENTATIONS.includes(jitType)) {
+      return jitType;
+    }
+    throw new Error(
+      `The jitType '${jitType}' is unknown to this tool. Is it a typo or should you update the list of possible values?`
+    );
   }
 
   return null;

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1884,6 +1884,12 @@ describe('getTimingsForSidebar', () => {
     }));
   }
 
+  const EMPTY_TIMING = {
+    value: 0,
+    breakdownByImplementation: null,
+    breakdownByCategory: null,
+  };
+
   describe('in a non-inverted tree', function() {
     it('returns good timings for a root node', () => {
       const {
@@ -1892,50 +1898,31 @@ describe('getTimingsForSidebar', () => {
       } = setup();
 
       // This is a root node: it should have no self time but all the total time.
+      // Also, because the function is only present once in the tree, forPath
+      // and forFunc timings are the same, so we're extracting them in one
+      // object for a better readability.
       const timings = getTimingsForPath([A]);
+
+      const expectedTiming = {
+        selfTime: EMPTY_TIMING,
+        totalTime: {
+          value: 5,
+          breakdownByImplementation: { native: 2, baseline: 1, ion: 2 },
+          breakdownByCategory: withSingleSubcategory([
+            1, // Idle
+            0, // Other
+            1, // Layout
+            3, // JavaScript
+            0,
+            0,
+            0,
+            0,
+          ]),
+        },
+      };
       expect(timings).toEqual({
-        forPath: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
-          totalTime: {
-            value: 5,
-            breakdownByImplementation: { native: 2, baseline: 1, ion: 2 },
-            breakdownByCategory: withSingleSubcategory([
-              1, // Idle
-              0, // Other
-              1, // Layout
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
-        forFunc: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
-          totalTime: {
-            value: 5,
-            breakdownByImplementation: { native: 2, baseline: 1, ion: 2 },
-            breakdownByCategory: withSingleSubcategory([
-              1, // Idle
-              0, // Other
-              1, // Layout
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
+        forPath: expectedTiming,
+        forFunc: expectedTiming,
         rootTime: 5,
       });
     });
@@ -2029,68 +2016,45 @@ describe('getTimingsForSidebar', () => {
       // This is a node that has both children and some self time. So it should
       // have some running time that's different than the self time.
       const timings = getTimingsForPath([A, B, H]);
-      expect(timings).toEqual({
-        forPath: {
-          selfTime: {
-            value: 1,
-            breakdownByImplementation: { native: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-          totalTime: {
-            value: 2,
-            breakdownByImplementation: { native: 2 },
 
-            breakdownByCategory: withSingleSubcategory([
-              1, // Idle
-              0,
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
+      // This node is present only once in the tree, so its forPath and forFunc
+      // timing values are identical. Extracting them provides a better
+      // readability.
+      const expectedTiming = {
+        selfTime: {
+          value: 1,
+          breakdownByImplementation: { native: 1 },
+          breakdownByCategory: withSingleSubcategory([
+            0,
+            0,
+            1, // Layout
+            0,
+            0,
+            0,
+            0,
+            0,
+          ]),
         },
-        forFunc: {
-          selfTime: {
-            value: 1,
-            breakdownByImplementation: { native: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-          totalTime: {
-            value: 2,
-            breakdownByImplementation: { native: 2 },
-            breakdownByCategory: withSingleSubcategory([
-              1, // Idle
-              0,
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
+        totalTime: {
+          value: 2,
+          breakdownByImplementation: { native: 2 },
+
+          breakdownByCategory: withSingleSubcategory([
+            1, // Idle
+            0,
+            1, // Layout
+            0,
+            0,
+            0,
+            0,
+            0,
+          ]),
         },
+      };
+
+      expect(timings).toEqual({
+        forPath: expectedTiming,
+        forFunc: expectedTiming,
         rootTime: 5,
       });
     });
@@ -2157,11 +2121,7 @@ describe('getTimingsForSidebar', () => {
         // same timing results for forPath and forFunc. So we extract the
         // expectation to make this a bit more readable.
         const expectedTiming = {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
+          selfTime: EMPTY_TIMING,
           totalTime: {
             value: 4,
             breakdownByImplementation: {
@@ -2386,58 +2346,36 @@ describe('getTimingsForSidebar', () => {
         funcNamesDict: { Ejs },
       } = setupForInvertedTree();
       const timings = getTimingsForPath([Ejs]);
+
+      // A root node will have the same values for total and selftime. Also this
+      // function is present once so forPath and forFunc will have the same
+      // values.
+      const expectedTiming = {
+        value: 3,
+        breakdownByImplementation: { ion: 2, baseline: 1 },
+        breakdownByCategory: withSingleSubcategory([
+          0, // Idle
+          0, // Other
+          0, // Layout
+          3, // JavaScript
+          0,
+          0,
+          0,
+          0,
+        ]),
+      };
       expect(timings).toEqual({
         forPath: {
           selfTime: {
+            // Inverted trees have an empty breakdown for the selftime because
+            // it's always the same values as for totaltime, or 0. For a root
+            // node, the value is non-0 though.
+            ...EMPTY_TIMING,
             value: 3,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
           },
-          totalTime: {
-            value: 3,
-            breakdownByImplementation: { ion: 2, baseline: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0, // Idle
-              0, // Other
-              0, // Layout
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
+          totalTime: expectedTiming,
         },
-        forFunc: {
-          selfTime: {
-            value: 3,
-            breakdownByImplementation: { ion: 2, baseline: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              0,
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-          totalTime: {
-            value: 3,
-            breakdownByImplementation: { ion: 2, baseline: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              0,
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
+        forFunc: { selfTime: expectedTiming, totalTime: expectedTiming },
         rootTime: 5,
       });
     });
@@ -2450,11 +2388,7 @@ describe('getTimingsForSidebar', () => {
       const timings = getTimingsForPath([Ejs, D, Cjs, B]);
       expect(timings).toEqual({
         forPath: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
+          selfTime: EMPTY_TIMING,
           totalTime: {
             value: 2,
             breakdownByImplementation: { ion: 1, baseline: 1 },
@@ -2471,11 +2405,7 @@ describe('getTimingsForSidebar', () => {
           },
         },
         forFunc: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
+          selfTime: EMPTY_TIMING,
           totalTime: {
             value: 5,
             breakdownByImplementation: {
@@ -2510,9 +2440,8 @@ describe('getTimingsForSidebar', () => {
       expect(timings).toEqual({
         forPath: {
           selfTime: {
+            ...EMPTY_TIMING,
             value: 1,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
           },
           totalTime: {
             value: 1,
@@ -2566,11 +2495,7 @@ describe('getTimingsForSidebar', () => {
       timings = getTimingsForPath([I, H]);
       expect(timings).toEqual({
         forPath: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
+          selfTime: EMPTY_TIMING,
           totalTime: {
             value: 1,
             breakdownByImplementation: { native: 1 },
@@ -2628,11 +2553,7 @@ describe('getTimingsForSidebar', () => {
       const timings = getTimingsForPath([H, B, A]);
       expect(timings).toEqual({
         forPath: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
+          selfTime: EMPTY_TIMING,
           totalTime: {
             value: 1,
             breakdownByImplementation: { native: 1 },
@@ -2649,11 +2570,7 @@ describe('getTimingsForSidebar', () => {
           },
         },
         forFunc: {
-          selfTime: {
-            value: 0,
-            breakdownByImplementation: null,
-            breakdownByCategory: null,
-          },
+          selfTime: EMPTY_TIMING,
           totalTime: {
             value: 5,
             breakdownByImplementation: { native: 2, ion: 2, baseline: 1 },
@@ -2759,11 +2676,11 @@ describe('getTimingsForSidebar', () => {
         expect(timings).toEqual({
           forPath: {
             selfTime: {
-              value: 1,
               // selftime breakdowns are always empty for inverted trees because
               // they're the same than the total time.
-              breakdownByImplementation: null,
-              breakdownByCategory: null,
+              ...EMPTY_TIMING,
+              // But root nodes have self time value of course!
+              value: 1,
             },
             totalTime: expectedTiming,
           },
@@ -2802,11 +2719,11 @@ describe('getTimingsForSidebar', () => {
         expect(timings).toEqual({
           forPath: {
             selfTime: {
-              value: 1,
               // selftime breakdowns are always empty for inverted trees because
               // they're the same than the total time.
-              breakdownByImplementation: null,
-              breakdownByCategory: null,
+              ...EMPTY_TIMING,
+              // But root nodes have a selftime value
+              value: 1,
             },
             totalTime: expectedTiming,
           },
@@ -2825,11 +2742,7 @@ describe('getTimingsForSidebar', () => {
 
         expect(timings).toEqual({
           forPath: {
-            selfTime: {
-              value: 0,
-              breakdownByImplementation: null,
-              breakdownByCategory: null,
-            },
+            selfTime: EMPTY_TIMING,
             totalTime: {
               value: 1,
               breakdownByImplementation: {
@@ -2927,11 +2840,7 @@ describe('getTimingsForSidebar', () => {
       } = setup();
       const timings = getTimingsForPath([A]);
       expect(timings.forPath).toEqual({
-        selfTime: {
-          breakdownByCategory: null,
-          breakdownByImplementation: null,
-          value: 0,
-        },
+        selfTime: EMPTY_TIMING,
         totalTime: {
           breakdownByCategory: withSingleSubcategory([0, 0, -1, 1, 0, 0, 0, 0]), // Idle, Other, Layout, JavaScript, etc.
           breakdownByImplementation: {


### PR DESCRIPTION
This patch does 3 things:
1. Uses the unfiltered thread to find the JS implementation information. This was already the case for the category information.
2. Finds the right JS implementation for native stacks with the category "JavaScript" by looping up the call tree.
3. Reorganizes and add more comments so that hopefully this algorithm is easier to follow.

It also adds tests, and simplifies existing tests.

Direct links to test the patch:
* [production](https://profiler.firefox.com/public/be1cd82911e8cd282563f420ef9218472d51fd27/calltree/?globalTrackOrder=0&localTrackOrderByPid=9636-0-1~&thread=0&v=4)
* [deploy preview](https://deploy-preview-2590--perf-html.netlify.app/public/be1cd82911e8cd282563f420ef9218472d51fd27/calltree/?globalTrackOrder=0&localTrackOrderByPid=9636-0-1~&thread=0&v=4)

The result is directly visible if you select the `(root)` and look at the breakdowns: on the production deploy, using "all stacks" there's no "interpreter" nor "blinterp" results in the breakdown, but the deploy preview has them. Also when switching to the "native stacks" implementation filter, you should still see a valid implementation breakdown.
Another way to look at it is that the "native" result should equal the sum all non-JavaScript categories.
Lastly the breakdowns in the JS view vs All stacks should be very similar (could be somewhat different because of some merges happening).

Another example from #1798 using the flame graph, easily visible by hovering the JS stacks:
* [production](https://profiler.firefox.com/public/671cf336e06a20333fbbfa599c76e0f496410cc0/flame-graph/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10&hiddenLocalTracksByPid=7814-2-0&localTrackOrderByPid=7814-1-2-0~8868-0~2413-0~10453-0~5302-0~863-0~588-0~4829-0~6209-0~567-0~10361-0-1~&range=4.7958_5.8327~5.0623_5.2124&thread=0&v=4)
* [deploy preview](https://deploy-preview-2590--perf-html.netlify.app/public/671cf336e06a20333fbbfa599c76e0f496410cc0/flame-graph/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10&hiddenLocalTracksByPid=7814-2-0&localTrackOrderByPid=7814-1-2-0~8868-0~2413-0~10453-0~5302-0~863-0~588-0~4829-0~6209-0~567-0~10361-0-1~&range=4.7958_5.8327~5.0623_5.2124&thread=0&v=4)


This is probably a good idea to look at the commits separately. Most notably you'll see that no existing test is failing with the new code. This means that this case wasn't exercised at all (I believe this was implemented before we had categories at all). Hopefully the new tests exercise it properly.

Tell me what you think!

Fixes #1798 

