### PR TITLE
Support 'blinterp' for JS implementation

### DIFF
--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -61,6 +61,7 @@ class ImplementationBreakdown extends React.PureComponent<ImplementationBreakdow
   _orderedImplementations: $ReadOnlyArray<StackImplementation> = [
     'native',
     'interpreter',
+    'blinterp',
     'baseline',
     'ion',
     'unknown',

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -319,7 +319,12 @@ export function getLeafFuncIndex(path: CallNodePath): IndexIntoFuncTable {
   return path[path.length - 1];
 }
 
-export type JsImplementation = 'interpreter' | 'ion' | 'baseline' | 'unknown';
+export type JsImplementation =
+  | 'interpreter'
+  | 'blinterp'
+  | 'baseline'
+  | 'ion'
+  | 'unknown';
 export type StackImplementation = 'native' | JsImplementation;
 export type BreakdownByImplementation = { [StackImplementation]: Milliseconds };
 export type OneCategoryBreakdown = {|
@@ -368,6 +373,7 @@ export function getJsImplementationForStack(
 
   switch (jsImplementation) {
     case 'baseline':
+    case 'blinterp':
     case 'ion':
       return jsImplementation;
     default:
@@ -2074,11 +2080,12 @@ export function getFriendlyStackTypeName(
   implementation: StackImplementation
 ): string {
   switch (implementation) {
-    case 'ion':
-    case 'baseline':
-      return `JS JIT (${implementation})`;
     case 'interpreter':
       return 'JS interpreter';
+    case 'blinterp':
+    case 'baseline':
+    case 'ion':
+      return `JS JIT (${implementation})`;
     case 'native':
       return 'Native code';
     case 'unknown':


### PR DESCRIPTION
The [Baseline Interpreter](https://hacks.mozilla.org/2019/08/the-baseline-interpreter-a-faster-js-interpreter-in-firefox-70/) is one of our JS implementation forms, but is currently lumped in as "JS Interpreter" in the Profiler. These patch adds mappings for the `blinterp` "implementation" so that updates to the Gecko side can fill in this data. Without the patch they would show up as "uknown".

There is still some discussion about if we should deprecate "implementation" in favour of "subcategory", but this UI label is easy to add so we might as well just do it.