### PR TITLE
Consolidate relative "types" paths to "firefox-profiler/types"

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -15,11 +15,15 @@ import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';
 
-import type { Profile, ThreadIndex } from '../types/profile';
-import type { CssPixels } from '../types/units';
-import type { Action, ThunkAction } from '../types/store';
+import type {
+  Profile,
+  ThreadIndex,
+  CssPixels,
+  Action,
+  ThunkAction,
+  UrlState,
+} from 'firefox-profiler/types';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState } from '../types/state';
 
 export function changeSelectedTab(selectedTab: TabSlug): ThunkAction<void> {
   return (dispatch, getState) => {

--- a/src/actions/icons.js
+++ b/src/actions/icons.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Action, ThunkAction } from '../types/store';
+import type { Action, ThunkAction } from 'firefox-profiler/types';
 
 export function iconHasLoaded(icon: string): Action {
   return {

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -47,18 +47,19 @@ import type {
   TimelineType,
   DataSource,
   ActiveTabTrackReference,
-} from '../types/actions';
-import type { State } from '../types/state';
-import type { Action, ThunkAction } from '../types/store';
-import type { ThreadIndex, Pid, IndexIntoSamplesTable } from '../types/profile';
-import type {
+  State,
+  Action,
+  ThunkAction,
+  ThreadIndex,
+  Pid,
+  IndexIntoSamplesTable,
   CallNodePath,
   CallNodeInfo,
   IndexIntoCallNodeTable,
   TrackIndex,
   MarkerIndex,
-} from '../types/profile-derived';
-import type { Transform } from '../types/transforms';
+  Transform,
+} from 'firefox-profiler/types';
 
 /**
  * This file contains actions that pertain to changing the view on the profile, including

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -19,11 +19,14 @@ import { ensureExists } from '../utils/flow';
 import { extractProfileTokenFromJwt } from '../utils/jwt';
 import { setHistoryReplaceState } from '../app-logic/url-handling';
 
-import type { Action, ThunkAction } from '../types/store';
-import type { CheckedSharingOptions } from '../types/actions';
-import type { StartEndRange } from '../types/units';
-import type { ThreadIndex } from '../types/profile';
-import type { State } from '../types/state';
+import type {
+  Action,
+  ThunkAction,
+  CheckedSharingOptions,
+  StartEndRange,
+  ThreadIndex,
+  State,
+} from 'firefox-profiler/types';
 
 export function toggleCheckedSharingOptions(
   slug: $Keys<CheckedSharingOptions>

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -52,19 +52,23 @@ import { computeActiveTabTracks } from '../profile-logic/active-tab';
 import { setDataSource } from './profile-view';
 import { GOOGLE_STORAGE_BUCKET } from 'firefox-profiler/app-logic/constants';
 
-import type { RequestedLib, ImplementationFilter } from '../types/actions';
-import type { TransformStacksPerThread } from '../types/transforms';
-import type { Action, ThunkAction, Dispatch } from '../types/store';
-import type { TimelineTrackOrganization } from '../types/state';
 import type {
+  RequestedLib,
+  ImplementationFilter,
+  TransformStacksPerThread,
+  Action,
+  ThunkAction,
+  Dispatch,
+  TimelineTrackOrganization,
   Profile,
   ThreadIndex,
   BrowsingContextID,
   Page,
   InnerWindowID,
   Pid,
-} from '../types/profile';
-import type { OriginsTimelineRoot } from '../types/profile-derived';
+  OriginsTimelineRoot,
+} from 'firefox-profiler/types';
+
 import type { SymbolicationStepInfo } from '../profile-logic/symbolication';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 

--- a/src/actions/zipped-profiles.js
+++ b/src/actions/zipped-profiles.js
@@ -7,7 +7,7 @@ import { getZipFileTable, getZipFileState } from '../selectors/zipped-profiles';
 import { unserializeProfileOfArbitraryFormat } from '../profile-logic/process-profile';
 import { loadProfile } from './receive-profile';
 
-import type { Action, ThunkAction } from '../types/store';
+import type { Action, ThunkAction } from 'firefox-profiler/types';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 
 export function changeSelectedZipFile(

--- a/src/app-logic/create-store.js
+++ b/src/app-logic/create-store.js
@@ -8,7 +8,7 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
 import reducers from '../reducers';
-import type { Store } from '../types/store';
+import type { Store } from 'firefox-profiler/types';
 
 /**
  * Isolate the store creation into a function, so that it can be used outside of the

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -19,16 +19,18 @@ import {
 } from '../utils/flow';
 import { toValidCallTreeSummaryStrategy } from '../profile-logic/profile-data';
 import { oneLine } from 'common-tags';
-import type { UrlState, TimelineTrackOrganization } from '../types/state';
-import type { DataSource } from '../types/actions';
 import type {
+  UrlState,
+  TimelineTrackOrganization,
+  DataSource,
   Pid,
   Profile,
   Thread,
   IndexIntoStackTable,
   BrowsingContextID,
-} from '../types/profile';
-import type { TrackIndex, CallNodePath } from '../types/profile-derived';
+  TrackIndex,
+  CallNodePath,
+} from 'firefox-profiler/types';
 
 export const CURRENT_URL_VERSION = 4;
 

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -19,8 +19,8 @@ import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import type { AppViewState, State } from '../../types/state';
-import type { DataSource } from '../../types/actions';
+import type { AppViewState, State, DataSource } from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 const ERROR_MESSAGES: { [string]: string } = Object.freeze({

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -9,8 +9,12 @@ import ArrowPanel from '../../shared/ArrowPanel';
 import { MetaOverheadStatistics } from './MetaOverheadStatistics';
 import { formatBytes, formatTimestamp } from '../../../utils/format-numbers';
 
-import type { Profile, ProfileMeta } from '../../../types/profile';
-import type { SymbolicationStatus } from '../../../types/state';
+import type {
+  Profile,
+  ProfileMeta,
+  SymbolicationStatus,
+} from 'firefox-profiler/types';
+
 import { typeof resymbolicateProfile } from '../../../actions/receive-profile';
 import { assertExhaustiveCheck } from '../../../utils/flow';
 

--- a/src/components/app/MenuButtons/MetaOverheadStatistics.js
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.js
@@ -9,7 +9,7 @@ import {
   formatPercent,
 } from '../../../utils/format-numbers';
 
-import type { ProfilerOverhead } from '../../../types/profile';
+import type { ProfilerOverhead } from 'firefox-profiler/types';
 
 import './MetaOverheadStatistics.css';
 

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -33,10 +33,12 @@ import { assertExhaustiveCheck } from '../../../utils/flow';
 
 import explicitConnect, { type ConnectedProps } from '../../../utils/connect';
 
-import type { Profile } from '../../../types/profile';
-import type { CheckedSharingOptions } from '../../../types/actions';
-import type { StartEndRange } from '../../../types/units';
-import type { UploadPhase } from '../../../types/state';
+import type {
+  Profile,
+  CheckedSharingOptions,
+  StartEndRange,
+  UploadPhase,
+} from 'firefox-profiler/types';
 
 require('./Publish.css');
 

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -31,11 +31,15 @@ import {
 
 import { resymbolicateProfile } from '../../../actions/receive-profile';
 
-import type { StartEndRange } from '../../../types/units';
-import type { Profile } from '../../../types/profile';
-import type { DataSource } from '../../../types/actions';
+import type {
+  StartEndRange,
+  Profile,
+  DataSource,
+  UploadPhase,
+  SymbolicationStatus,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../../utils/connect';
-import type { UploadPhase, SymbolicationStatus } from '../../../types/state';
 
 require('./index.css');
 

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -19,8 +19,10 @@ import FilterNavigatorBar from '../shared/FilterNavigatorBar';
 import Icon from '../shared/Icon';
 
 import type { ElementProps } from 'react';
-import type { ProfileFilterPageData } from '../../types/profile-derived';
-import type { StartEndRange } from '../../types/units';
+import type {
+  ProfileFilterPageData,
+  StartEndRange,
+} from 'firefox-profiler/types';
 
 type Props = {|
   +filterPageData: ProfileFilterPageData | null,

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -21,7 +21,7 @@ import {
 } from '../../selectors/url-state';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { DataSource } from '../../types/actions';
+import type { DataSource } from 'firefox-profiler/types';
 
 type StateProps = {|
   +dataSource: DataSource,

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -11,8 +11,8 @@ import { ProfileRootMessage } from './ProfileRootMessage';
 import { getView } from '../../selectors/app';
 import { getDataSource } from '../../selectors/url-state';
 
-import type { AppViewState, State } from '../../types/state';
-import type { DataSource } from '../../types/actions';
+import type { AppViewState, State, DataSource } from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 const LOADING_MESSAGES: { [string]: string } = Object.freeze({

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -28,9 +28,8 @@ import { getIconsWithClassNames } from '../../selectors/icons';
 import { BackgroundImageStyleDef } from '../shared/StyleDef';
 import classNames from 'classnames';
 
-import type { CssPixels } from '../../types/units';
+import type { CssPixels, IconWithClassName } from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
-import type { IconWithClassName } from '../../types/state';
 
 require('./ProfileViewer.css');
 

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -11,7 +11,7 @@ import { ErrorBoundary } from './ErrorBoundary';
 import { AppViewRouter } from './AppViewRouter';
 import { ProfileLoader } from './ProfileLoader';
 
-import type { Store } from '../../types/store';
+import type { Store } from 'firefox-profiler/types';
 
 type RootProps = {
   store: Store,

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -12,8 +12,11 @@ import { getView } from '../../selectors/app';
 import { getSymbolicationStatus } from '../../selectors/profile';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { DataSource } from '../../types/actions';
-import type { Phase, SymbolicationStatus } from '../../types/state';
+import type {
+  DataSource,
+  Phase,
+  SymbolicationStatus,
+} from 'firefox-profiler/types';
 
 import './ServiceWorkerManager.css';
 

--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -11,7 +11,7 @@ import {
 } from '../../selectors/profile';
 import explicitConnect from '../../utils/connect';
 
-import type { RequestedLib } from '../../types/actions';
+import type { RequestedLib } from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
 function englishSgPlLibrary(count) {

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -30,7 +30,7 @@ import type {
   ConnectedProps,
   WrapFunctionInDispatch,
 } from '../../utils/connect';
-import type { UrlState, Phase, UrlSetupPhase } from '../../types/state';
+import type { UrlState, Phase, UrlSetupPhase } from 'firefox-profiler/types';
 
 type StateProps = {|
   +phase: Phase,

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -28,7 +28,7 @@ import TreeView from '../shared/TreeView';
 import ProfileViewer from './ProfileViewer';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { ZipFileState } from '../../types/state';
+import type { ZipFileState } from 'firefox-profiler/types';
 import type {
   ZipFileTable,
   ZipDisplayData,

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -29,18 +29,17 @@ import {
 } from '../../actions/profile-view';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import type { State } from '../../types/state';
-import type { CallTree } from '../../profile-logic/call-tree';
 import type {
+  State,
   ImplementationFilter,
   CallTreeSummaryStrategy,
-} from '../../types/actions';
-import type { ThreadIndex } from '../../types/profile';
-import type {
+  ThreadIndex,
   CallNodeInfo,
   IndexIntoCallNodeTable,
   CallNodeDisplayData,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+import type { CallTree } from '../../profile-logic/call-tree';
+
 import type { Column } from '../shared/TreeView';
 import type { ConnectedProps } from '../../utils/connect';
 

--- a/src/components/calltree/CallTreeEmptyReasons.js
+++ b/src/components/calltree/CallTreeEmptyReasons.js
@@ -10,8 +10,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { Thread } from '../../types/profile';
-import type { State } from '../../types/store';
+import type { Thread, State } from 'firefox-profiler/types';
 
 type StateProps = {|
   threadName: string,

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -16,21 +16,25 @@ import { TooltipCallNode } from '../tooltip/CallNode';
 import { getTimingsForCallNodeIndex } from '../../profile-logic/profile-data';
 import MixedTupleMap from 'mixedtuplemap';
 
-import type { Thread, CategoryList, PageList } from '../../types/profile';
-import type { CssPixels, Milliseconds } from '../../types/units';
+import type {
+  Thread,
+  CategoryList,
+  PageList,
+  CssPixels,
+  Milliseconds,
+  CallNodeInfo,
+  IndexIntoCallNodeTable,
+  CallTreeSummaryStrategy,
+} from 'firefox-profiler/types';
+
 import type {
   FlameGraphTiming,
   FlameGraphDepth,
   IndexIntoFlameGraphTiming,
 } from '../../profile-logic/flame-graph';
 
-import type {
-  CallNodeInfo,
-  IndexIntoCallNodeTable,
-} from '../../types/profile-derived';
 import type { CallTree } from '../../profile-logic/call-tree';
 import type { Viewport } from '../shared/chart/Viewport';
-import type { CallTreeSummaryStrategy } from '../../types/actions';
 
 export type OwnProps = {|
   +thread: Thread,

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -26,17 +26,20 @@ import {
   changeRightClickedCallNode,
 } from '../../actions/profile-view';
 
-import type { Thread, CategoryList, PageList } from '../../types/profile';
-import type { Milliseconds, StartEndRange } from '../../types/units';
-import type { FlameGraphTiming } from '../../profile-logic/flame-graph';
 import type {
+  Thread,
+  CategoryList,
+  PageList,
+  Milliseconds,
+  StartEndRange,
   PreviewSelection,
   CallTreeSummaryStrategy,
-} from '../../types/actions';
-import type {
   CallNodeInfo,
   IndexIntoCallNodeTable,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+
+import type { FlameGraphTiming } from '../../profile-logic/flame-graph';
+
 import type { CallTree } from '../../profile-logic/call-tree';
 
 import type { ConnectedProps } from '../../utils/connect';

--- a/src/components/flame-graph/FlameGraphEmptyReasons.js
+++ b/src/components/flame-graph/FlameGraphEmptyReasons.js
@@ -10,8 +10,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { Thread } from '../../types/profile';
-import type { State } from '../../types/store';
+import type { Thread, State } from 'firefox-profiler/types';
 
 type StateProps = {|
   threadName: string,

--- a/src/components/js-tracer/Canvas.js
+++ b/src/components/js-tracer/Canvas.js
@@ -25,13 +25,12 @@ import type {
   CssPixels,
   UnitIntervalOfProfileRange,
   DevicePixels,
-} from '../../types/units';
-import type {
   ThreadIndex,
   IndexIntoJsTracerEvents,
   JsTracerTable,
-} from '../../types/profile';
-import type { JsTracerTiming } from '../../types/profile-derived';
+  JsTracerTiming,
+} from 'firefox-profiler/types';
+
 import type { Viewport } from '../shared/chart/Viewport';
 import type { WrapFunctionInDispatch } from '../../utils/connect';
 

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -22,14 +22,17 @@ import { updatePreviewSelection } from '../../actions/profile-view';
 import { ensureExists } from '../../utils/flow';
 
 import type { UniqueStringArray } from '../../utils/unique-string-array';
-import type { JsTracerTable, ThreadIndex, Profile } from '../../types/profile';
-import type { JsTracerTiming } from '../../types/profile-derived';
 import type {
+  JsTracerTable,
+  ThreadIndex,
+  Profile,
+  JsTracerTiming,
   UnitIntervalOfProfileRange,
   CssPixels,
   StartEndRange,
-} from '../../types/units';
-import type { PreviewSelection } from '../../types/actions';
+  PreviewSelection,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');

--- a/src/components/js-tracer/EmptyReasons.js
+++ b/src/components/js-tracer/EmptyReasons.js
@@ -10,7 +10,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { State } from '../../types/store';
+import type { State } from 'firefox-profiler/types';
 
 type StateProps = {|
   +threadName: string,

--- a/src/components/js-tracer/index.js
+++ b/src/components/js-tracer/index.js
@@ -17,7 +17,11 @@ import {
 } from '../../selectors/url-state';
 import { updatePreviewSelection } from '../../actions/profile-view';
 
-import type { Profile, JsTracerTable, ThreadIndex } from '../../types/profile';
+import type {
+  Profile,
+  JsTracerTable,
+  ThreadIndex,
+} from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -23,13 +23,12 @@ import type {
   Milliseconds,
   CssPixels,
   UnitIntervalOfProfileRange,
-} from '../../types/units';
-import type { ThreadIndex } from '../../types/profile';
-import type {
+  ThreadIndex,
   Marker,
   MarkerTimingAndBuckets,
   MarkerIndex,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+
 import type { Viewport } from '../shared/chart/Viewport';
 import type { WrapFunctionInDispatch } from '../../utils/connect';
 type MarkerDrawingInformation = {

--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -10,7 +10,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { State } from '../../types/store';
+import type { State } from 'firefox-profiler/types';
 
 type StateProps = {|
   +threadName: string,

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -30,13 +30,12 @@ import type {
   Marker,
   MarkerIndex,
   MarkerTimingAndBuckets,
-} from '../../types/profile-derived';
-import type {
   Milliseconds,
   UnitIntervalOfProfileRange,
   StartEndRange,
-} from '../../types/units';
-import type { PreviewSelection } from '../../types/actions';
+  PreviewSelection,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');

--- a/src/components/marker-table/MarkerTableEmptyReasons.js
+++ b/src/components/marker-table/MarkerTableEmptyReasons.js
@@ -10,7 +10,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { State } from '../../types/store';
+import type { State } from 'firefox-profiler/types';
 
 type StateProps = {|
   +threadName: string,

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -29,9 +29,13 @@ import {
 
 import './index.css';
 
-import type { ThreadIndex } from '../../types/profile';
-import type { Marker, MarkerIndex } from '../../types/profile-derived';
-import type { Milliseconds } from '../../types/units';
+import type {
+  ThreadIndex,
+  Marker,
+  MarkerIndex,
+  Milliseconds,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type MarkerDisplayData = {|

--- a/src/components/network-chart/NetworkChartEmptyReasons.js
+++ b/src/components/network-chart/NetworkChartEmptyReasons.js
@@ -11,7 +11,7 @@ import { oneLine } from 'common-tags';
 
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { State } from '../../types/store';
+import type { State } from 'firefox-profiler/types';
 
 type StateProps = {|
   +threadName: string,

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -19,10 +19,15 @@ import {
   TIMELINE_MARGIN_RIGHT,
 } from '../../app-logic/constants';
 
-import type { CssPixels, Milliseconds, StartEndRange } from '../../types/units';
-import type { ThreadIndex } from '../../types/profile';
-import type { Marker, MarkerIndex } from '../../types/profile-derived';
-import type { NetworkPayload } from '../../types/markers';
+import type {
+  CssPixels,
+  Milliseconds,
+  StartEndRange,
+  ThreadIndex,
+  Marker,
+  MarkerIndex,
+  NetworkPayload,
+} from 'firefox-profiler/types';
 
 // This regexp is used to split a pathname into a directory path and a filename.
 // On purpose, when there's no "real" filename, the filename will contain the

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -24,9 +24,13 @@ import { getSelectedThreadIndex } from '../../selectors/url-state';
 import { changeRightClickedMarker } from '../../actions/profile-view';
 
 import type { SizeProps } from '../shared/WithSize';
-import type { NetworkPayload } from '../../types/markers';
-import type { Marker, MarkerIndex } from '../../types/profile-derived';
-import type { StartEndRange } from '../../types/units';
+import type {
+  NetworkPayload,
+  Marker,
+  MarkerIndex,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');

--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -11,8 +11,11 @@ import {
   convertStackToCallNodePath,
 } from '../../profile-logic/profile-data';
 
-import type { Thread, IndexIntoStackTable } from '../../types/profile';
-import type { ImplementationFilter } from '../../types/actions';
+import type {
+  Thread,
+  IndexIntoStackTable,
+  ImplementationFilter,
+} from 'firefox-profiler/types';
 
 require('./Backtrace.css');
 

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -28,16 +28,18 @@ import {
   assertExhaustiveCheck,
 } from '../../utils/flow';
 
-import type { TransformType } from '../../types/transforms';
-import type { ImplementationFilter } from '../../types/actions';
-import type { TabSlug } from '../../app-logic/tabs-handling';
-import type { ConnectedProps } from '../../utils/connect';
 import type {
+  TransformType,
+  ImplementationFilter,
   IndexIntoCallNodeTable,
   CallNodeInfo,
   CallNodePath,
-} from '../../types/profile-derived';
-import type { Thread, ThreadIndex } from '../../types/profile';
+  Thread,
+  ThreadIndex,
+} from 'firefox-profiler/types';
+
+import type { TabSlug } from '../../app-logic/tabs-handling';
+import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|
   +thread: Thread | null,

--- a/src/components/shared/Draggable.js
+++ b/src/components/shared/Draggable.js
@@ -5,7 +5,7 @@
 // @flow
 
 import * as React from 'react';
-import type { Milliseconds } from '../../types/units';
+import type { Milliseconds } from 'firefox-profiler/types';
 
 export type OnMove = (
   originalValue: { +selectionEnd: Milliseconds, +selectionStart: Milliseconds },

--- a/src/components/shared/Icon.js
+++ b/src/components/shared/Icon.js
@@ -9,7 +9,7 @@ import explicitConnect from '../../utils/connect';
 import { getIconClassName } from '../../selectors/icons';
 import { iconStartLoading } from '../../actions/icons';
 
-import type { CallNodeDisplayData } from '../../types/profile-derived';
+import type { CallNodeDisplayData } from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps =

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -18,15 +18,18 @@ import {
 import { getRightClickedMarkerInfo } from '../../selectors/right-clicked-marker';
 import copy from 'copy-to-clipboard';
 
-import type { Marker } from '../../types/profile-derived';
-import type { StartEndRange } from '../../types/units';
 import type {
+  Marker,
+  StartEndRange,
   PreviewSelection,
   ImplementationFilter,
-} from '../../types/actions';
+  IndexIntoStackTable,
+  Thread,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 import { getImplementationFilter } from '../../selectors/url-state';
-import type { IndexIntoStackTable, Thread } from '../../types/profile';
+
 import { filterCallNodePathByImplementation } from '../../profile-logic/transforms';
 import {
   convertStackToCallNodePath,

--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -8,7 +8,7 @@ import type {
   IndexIntoSamplesTable,
   CategoryList,
   Thread,
-} from '../../types/profile';
+} from 'firefox-profiler/types';
 import Backtrace from './Backtrace';
 import { getCategoryPairLabel } from '../../profile-logic/profile-data';
 

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -32,7 +32,7 @@ import './StackSettings.css';
 import type {
   ImplementationFilter,
   CallTreeSummaryStrategy,
-} from '../../types/actions';
+} from 'firefox-profiler/types';
 
 type OwnProps = {|
   +hideInvertCallstack?: true,

--- a/src/components/shared/TransformNavigator.js
+++ b/src/components/shared/TransformNavigator.js
@@ -9,7 +9,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import FilterNavigatorBar from './FilterNavigatorBar';
 import { popTransformsFromStack } from '../../actions/profile-view';
 
-import type { State } from '../../types/state';
+import type { State } from 'firefox-profiler/types';
 import type { ElementProps } from 'react';
 
 import './TransformNavigator.css';

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -11,7 +11,7 @@ import VirtualList from './VirtualList';
 
 import ContextMenuTrigger from './ContextMenuTrigger';
 
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 /**
  * This number is used to decide how many lines the selection moves when the

--- a/src/components/shared/VirtualList.js
+++ b/src/components/shared/VirtualList.js
@@ -37,7 +37,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import range from 'array-range';
 
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 type RenderItem<Item> = (Item, number, number) => React.Node;
 

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -10,7 +10,7 @@ import explicitConnect from '../../utils/connect';
 import { getProfileName, getDataSource } from '../../selectors/url-state';
 import { getProfile } from '../../selectors/profile';
 
-import type { Profile, ProfileMeta } from '../../types/profile';
+import type { Profile, ProfileMeta } from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|

--- a/src/components/shared/WithSize.js
+++ b/src/components/shared/WithSize.js
@@ -5,7 +5,7 @@
 
 import * as React from 'react';
 import { findDOMNode } from 'react-dom';
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 type State = {|
   width: CssPixels,

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -8,7 +8,7 @@ import { timeCode } from '../../../utils/time-code';
 import classNames from 'classnames';
 import Tooltip from '../../tooltip/Tooltip';
 
-import type { CssPixels, DevicePixels } from '../../../types/units';
+import type { CssPixels, DevicePixels } from 'firefox-profiler/types';
 
 type Props<HoveredItem> = {|
   +containerWidth: CssPixels,

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -17,8 +17,9 @@ import type {
   CssPixels,
   UnitIntervalOfProfileRange,
   StartEndRange,
-} from '../../../types/units';
-import type { PreviewSelection } from '../../../types/actions';
+  PreviewSelection,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../../utils/connect';
 import {
   getObjectValuesAsUnion,

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -17,9 +17,11 @@ import type {
   Thread,
   CategoryList,
   IndexIntoSamplesTable,
-} from '../../../types/profile';
-import type { SelectedState } from '../../../types/profile-derived';
-import type { Milliseconds, CssPixels } from '../../../types/units';
+  SelectedState,
+  Milliseconds,
+  CssPixels,
+} from 'firefox-profiler/types';
+
 import type {
   CategoryDrawStyles,
   ActivityFillGraphQuerier,

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -12,13 +12,11 @@ import type {
   IndexIntoSamplesTable,
   IndexIntoCategoryList,
   Thread,
-} from '../../../types/profile';
-import type { SelectedState } from '../../../types/profile-derived';
-import type {
+  SelectedState,
   Milliseconds,
   DevicePixels,
   CssPixels,
-} from '../../../types/units';
+} from 'firefox-profiler/types';
 
 /**
  * This type contains the values that were used to render the ThreadActivityGraph's React

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -20,12 +20,10 @@ import type {
   Thread,
   CategoryList,
   IndexIntoSamplesTable,
-} from '../../../types/profile';
-import type { Milliseconds } from '../../../types/units';
-import type {
+  Milliseconds,
   CallNodeInfo,
   IndexIntoCallNodeTable,
-} from '../../../types/profile-derived';
+} from 'firefox-profiler/types';
 
 type Props = {|
   +className: string,

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -21,12 +21,14 @@ import {
 import CanSelectContent from './CanSelectContent';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { ThreadIndex, CategoryList } from '../../types/profile';
 import type {
+  ThreadIndex,
+  CategoryList,
   CallNodeTable,
   IndexIntoCallNodeTable,
-} from '../../types/profile-derived';
-import type { Milliseconds } from '../../types/units';
+  Milliseconds,
+} from 'firefox-profiler/types';
+
 import type {
   BreakdownByImplementation,
   BreakdownByCategory,

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -12,8 +12,7 @@ import { getSelectedThreadIndex } from '../../selectors/url-state';
 import { TooltipMarker } from '../tooltip/Marker';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { ThreadIndex } from '../../types/profile';
-import type { Marker } from '../../types/profile-derived';
+import type { ThreadIndex, Marker } from 'firefox-profiler/types';
 
 type StateProps = {|
   +selectedThreadIndex: ThreadIndex,

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -28,19 +28,16 @@ import type {
   CategoryList,
   PageList,
   ThreadIndex,
-} from '../../types/profile';
-import type { UserTimingMarkerPayload } from '../../types/markers';
-import type {
+  UserTimingMarkerPayload,
   CallNodeInfo,
   IndexIntoCallNodeTable,
   CombinedTimingRows,
-} from '../../types/profile-derived';
-import type {
   Milliseconds,
   CssPixels,
   DevicePixels,
   UnitIntervalOfProfileRange,
-} from '../../types/units';
+} from 'firefox-profiler/types';
+
 import type {
   StackTimingDepth,
   IndexIntoStackTiming,

--- a/src/components/stack-chart/StackChartEmptyReasons.js
+++ b/src/components/stack-chart/StackChartEmptyReasons.js
@@ -10,8 +10,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
-import type { Thread } from '../../types/profile';
-import type { State } from '../../types/store';
+import type { Thread, State } from 'firefox-profiler/types';
 
 type StateProps = {|
   threadName: string,

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -36,20 +36,21 @@ import {
 
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 
-import type { Thread, CategoryList, PageList } from '../../types/profile';
 import type {
+  Thread,
+  CategoryList,
+  PageList,
   CallNodeInfo,
   IndexIntoCallNodeTable,
   CombinedTimingRows,
   MarkerIndex,
   Marker,
-} from '../../types/profile-derived';
-import type {
   Milliseconds,
   UnitIntervalOfProfileRange,
   StartEndRange,
-} from '../../types/units';
-import type { PreviewSelection } from '../../types/actions';
+  PreviewSelection,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 require('./index.css');

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -23,13 +23,14 @@ import ActiveTabResourcesPanel from './ActiveTabResourcesPanel';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';
-import type { GlobalTrackReference } from '../../types/actions';
 import type {
+  GlobalTrackReference,
   TrackIndex,
   ActiveTabGlobalTrack,
   InitialSelectedTrackReference,
   ActiveTabResourceTrack,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -15,12 +15,13 @@ import explicitConnect from '../../utils/connect';
 import TrackThread from './TrackThread';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
-import type { ActiveTabTrackReference } from '../../types/actions';
 import type {
+  ActiveTabTrackReference,
   TrackIndex,
   ActiveTabResourceTrack,
   InitialSelectedTrackReference,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -17,7 +17,7 @@ import type { SizeProps } from '../shared/WithSize';
 import type {
   ActiveTabResourceTrack,
   InitialSelectedTrackReference,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|

--- a/src/components/timeline/ActiveTabTimeline.js
+++ b/src/components/timeline/ActiveTabTimeline.js
@@ -26,9 +26,11 @@ import type { SizeProps } from '../shared/WithSize';
 import type {
   ActiveTabGlobalTrack,
   InitialSelectedTrackReference,
-} from '../../types/profile-derived';
-import type { GlobalTrackReference } from '../../types/actions';
-import type { Milliseconds, StartEndRange } from '../../types/units';
+  GlobalTrackReference,
+  Milliseconds,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|

--- a/src/components/timeline/EmptyThreadIndicator.js
+++ b/src/components/timeline/EmptyThreadIndicator.js
@@ -8,8 +8,12 @@ import { withSize } from '../shared/WithSize';
 import DivWithTooltip from '../tooltip/DivWithTooltip';
 import { oneLine } from 'common-tags';
 
-import type { Thread } from '../../types/profile';
-import type { Milliseconds, StartEndRange } from '../../types/units';
+import type {
+  Thread,
+  Milliseconds,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { SizeProps } from '../shared/WithSize';
 
 import './EmptyThreadIndicator.css';

--- a/src/components/timeline/FullTimeline.js
+++ b/src/components/timeline/FullTimeline.js
@@ -43,19 +43,19 @@ import {
 } from '../../actions/profile-view';
 import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
 
-import type { BrowsingContextID } from '../../types/profile';
 import type {
+  BrowsingContextID,
   TrackIndex,
   GlobalTrack,
   InitialSelectedTrackReference,
-} from '../../types/profile-derived';
-import type { TimelineTrackOrganization } from '../../types/state';
-import type {
+  TimelineTrackOrganization,
   GlobalTrackReference,
   TimelineType,
   HiddenTrackCount,
-} from '../../types/actions';
-import type { Milliseconds, StartEndRange } from '../../types/units';
+  Milliseconds,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -38,14 +38,16 @@ import Reorderable from '../shared/Reorderable';
 import { TRACK_PROCESS_BLANK_HEIGHT } from '../../app-logic/constants';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';
-import type { GlobalTrackReference } from '../../types/actions';
-import type { Pid, ProgressGraphData } from '../../types/profile';
 import type {
+  GlobalTrackReference,
+  Pid,
+  ProgressGraphData,
   TrackIndex,
   GlobalTrack,
   LocalTrack,
   InitialSelectedTrackReference,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -27,9 +27,13 @@ import TrackThread from './TrackThread';
 import TrackNetwork from './TrackNetwork';
 import { TrackMemory } from './TrackMemory';
 import { TrackIPC } from './TrackIPC';
-import type { TrackReference } from '../../types/actions';
-import type { Pid } from '../../types/profile';
-import type { TrackIndex, LocalTrack } from '../../types/profile-derived';
+import type {
+  TrackReference,
+  Pid,
+  TrackIndex,
+  LocalTrack,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -19,11 +19,16 @@ import { changeRightClickedMarker } from '../../actions/profile-view';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import './Markers.css';
 
-import type { Milliseconds, CssPixels } from '../../types/units';
-import type { Marker, MarkerIndex } from '../../types/profile-derived';
+import type {
+  Milliseconds,
+  CssPixels,
+  Marker,
+  MarkerIndex,
+  ThreadIndex,
+} from 'firefox-profiler/types';
+
 import type { SizeProps } from '../shared/WithSize';
 import type { ConnectedProps } from '../../utils/connect';
-import type { ThreadIndex } from '../../types/profile';
 
 // Exported for tests.
 export const MIN_MARKER_WIDTH = 0.3;

--- a/src/components/timeline/OriginsTimeline.js
+++ b/src/components/timeline/OriginsTimeline.js
@@ -23,13 +23,16 @@ import { getFriendlyThreadName } from '../../profile-logic/profile-data';
 import { changeSelectedThread } from '../../actions/profile-view';
 
 import type { SizeProps } from '../shared/WithSize';
-import type { Thread, ThreadIndex } from '../../types/profile';
 import type {
+  Thread,
+  ThreadIndex,
   InitialSelectedTrackReference,
   OriginsTimeline,
   OriginsTimelineTrack,
-} from '../../types/profile-derived';
-import type { Milliseconds, StartEndRange } from '../../types/units';
+  Milliseconds,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 import './OriginsTimeline.css';

--- a/src/components/timeline/OverflowEdgeIndicator.js
+++ b/src/components/timeline/OverflowEdgeIndicator.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import type { InitialSelectedTrackReference } from '../../types/profile-derived';
+import type { InitialSelectedTrackReference } from 'firefox-profiler/types';
 
 import './OverflowEdgeIndicator.css';
 

--- a/src/components/timeline/Ruler.js
+++ b/src/components/timeline/Ruler.js
@@ -9,7 +9,7 @@ import { TIMELINE_RULER_HEIGHT } from '../../app-logic/constants';
 
 import './Ruler.css';
 
-import type { Milliseconds, CssPixels } from '../../types/units';
+import type { Milliseconds, CssPixels } from 'firefox-profiler/types';
 
 type Props = {|
   +zeroAt: Milliseconds,

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -23,8 +23,13 @@ import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import './Selection.css';
 
 import type { OnMove } from '../shared/Draggable';
-import type { Milliseconds, CssPixels, StartEndRange } from '../../types/units';
-import type { PreviewSelection } from '../../types/actions';
+import type {
+  Milliseconds,
+  CssPixels,
+  StartEndRange,
+  PreviewSelection,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type MouseHandler = (event: MouseEvent) => void;

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -35,14 +35,16 @@ import {
 } from '../../selectors/url-state';
 import classNames from 'classnames';
 
-import type { Thread, ThreadIndex, Pid } from '../../types/profile';
 import type {
+  Thread,
+  ThreadIndex,
+  Pid,
   TrackIndex,
   GlobalTrack,
   LocalTrack,
-} from '../../types/profile-derived';
-import type { State } from '../../types/state';
-import type { TrackReference } from '../../types/actions';
+  State,
+  TrackReference,
+} from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
 

--- a/src/components/timeline/TrackIPC.js
+++ b/src/components/timeline/TrackIPC.js
@@ -11,8 +11,8 @@ import { TimelineMarkersIPC } from './Markers';
 import { updatePreviewSelection } from '../../actions/profile-view';
 import { TRACK_IPC_MARKERS_HEIGHT } from '../../app-logic/constants';
 
-import type { ThreadIndex } from '../../types/profile';
-import type { Milliseconds } from '../../types/units';
+import type { ThreadIndex, Milliseconds } from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 import './TrackIPC.css';

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -19,8 +19,12 @@ import {
   TRACK_MEMORY_LINE_WIDTH,
 } from '../../app-logic/constants';
 
-import type { CounterIndex, ThreadIndex } from '../../types/profile';
-import type { Milliseconds } from '../../types/units';
+import type {
+  CounterIndex,
+  ThreadIndex,
+  Milliseconds,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 import './TrackMemory.css';

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -24,9 +24,12 @@ import type {
   Counter,
   Thread,
   ThreadIndex,
-} from '../../types/profile';
-import type { AccumulatedCounterSamples } from '../../types/profile-derived';
-import type { Milliseconds, CssPixels, StartEndRange } from '../../types/units';
+  AccumulatedCounterSamples,
+  Milliseconds,
+  CssPixels,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { SizeProps } from '../shared/WithSize';
 import type { ConnectedProps } from '../../utils/connect';
 

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -20,13 +20,15 @@ import {
   TRACK_NETWORK_HEIGHT,
 } from '../../app-logic/constants';
 
-import type { ThreadIndex, PageList } from '../../types/profile';
 import type {
+  ThreadIndex,
+  PageList,
   Marker,
   MarkerIndex,
   MarkerTiming,
-} from '../../types/profile-derived';
-import type { Milliseconds } from '../../types/units';
+  Milliseconds,
+} from 'firefox-profiler/types';
+
 import type { SizeProps } from '../shared/WithSize';
 import type { ConnectedProps } from '../../utils/connect';
 

--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -15,10 +15,14 @@ import { getThreadSelectors } from '../../selectors/per-thread';
 import { withSize, type SizeProps } from '../shared/WithSize';
 import { createPortal } from 'react-dom';
 
-import type { ScreenshotPayload } from '../../types/markers';
-import type { ThreadIndex, Thread } from '../../types/profile';
-import type { Marker } from '../../types/profile-derived';
-import type { Milliseconds } from '../../types/units';
+import type {
+  ScreenshotPayload,
+  ThreadIndex,
+  Thread,
+  Marker,
+  Milliseconds,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 import { ensureExists } from '../../utils/flow';

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -40,20 +40,21 @@ import { reportTrackThreadHeight } from '../../actions/app';
 import EmptyThreadIndicator from './EmptyThreadIndicator';
 import './TrackThread.css';
 
-import type { TimelineType } from '../../types/actions';
 import type {
+  TimelineType,
   Thread,
   ThreadIndex,
   CategoryList,
   IndexIntoSamplesTable,
-} from '../../types/profile';
-import type { Milliseconds, StartEndRange } from '../../types/units';
-import type {
+  Milliseconds,
+  StartEndRange,
   CallNodeInfo,
   IndexIntoCallNodeTable,
   SelectedState,
-} from '../../types/profile-derived';
-import type { State, TimelineTrackOrganization } from '../../types/state';
+  State,
+  TimelineTrackOrganization,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type OwnProps = {|

--- a/src/components/timeline/TrackVisualProgress.js
+++ b/src/components/timeline/TrackVisualProgress.js
@@ -14,8 +14,8 @@ import {
   TRACK_VISUAL_PROGRESS_HEIGHT,
 } from '../../app-logic/constants';
 
-import type { ProgressGraphData } from '../../types/profile';
-import type { Milliseconds } from '../../types/units';
+import type { ProgressGraphData, Milliseconds } from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 import './TrackVisualProgress.css';

--- a/src/components/timeline/TrackVisualProgressGraph.js
+++ b/src/components/timeline/TrackVisualProgressGraph.js
@@ -13,8 +13,12 @@ import Tooltip from '../tooltip/Tooltip';
 import bisection from 'bisection';
 import { BLUE_50, BLUE_60 } from 'photon-colors';
 
-import type { ProgressGraphData } from '../../types/profile';
-import type { Milliseconds, CssPixels } from '../../types/units';
+import type {
+  ProgressGraphData,
+  Milliseconds,
+  CssPixels,
+} from 'firefox-profiler/types';
+
 import type { SizeProps } from '../shared/WithSize';
 import type { ConnectedProps } from '../../utils/connect';
 

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -10,9 +10,12 @@ import { displayNiceUrl } from '../../utils';
 import { formatSeconds } from '../../utils/format-numbers';
 
 import type { SizeProps } from '../shared/WithSize';
-import type { PageList } from '../../types/profile';
-import type { Marker, MarkerIndex } from '../../types/profile-derived';
-import type { Milliseconds } from '../../types/units';
+import type {
+  PageList,
+  Marker,
+  MarkerIndex,
+  Milliseconds,
+} from 'firefox-profiler/types';
 
 import './VerticalIndicators.css';
 

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -13,7 +13,7 @@ import OriginsTimelineView from '../timeline/OriginsTimeline';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
 import type { ConnectedProps } from '../../utils/connect';
-import type { TimelineTrackOrganization } from '../../types/state';
+import type { TimelineTrackOrganization } from 'firefox-profiler/types';
 
 type StateProps = {|
   +timelineTrackOrganization: TimelineTrackOrganization,

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -14,15 +14,18 @@ import {
 } from '../../profile-logic/profile-data';
 
 import type { CallTree } from '../../profile-logic/call-tree';
-import type { Thread, CategoryList, PageList } from '../../types/profile';
 import type {
+  Thread,
+  CategoryList,
+  PageList,
   IndexIntoCallNodeTable,
   CallNodeDisplayData,
   CallNodeInfo,
-} from '../../types/profile-derived';
+  Milliseconds,
+  CallTreeSummaryStrategy,
+} from 'firefox-profiler/types';
+
 import type { TimingsForPath } from '../../profile-logic/profile-data';
-import type { Milliseconds } from '../../types/units';
-import type { CallTreeSummaryStrategy } from '../../types/actions';
 
 import './CallNode.css';
 

--- a/src/components/tooltip/DivWithTooltip.js
+++ b/src/components/tooltip/DivWithTooltip.js
@@ -5,7 +5,7 @@
 // @flow
 import * as React from 'react';
 import Tooltip from './Tooltip';
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 type Props = {
   +tooltip: React.Node,

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -30,11 +30,17 @@ import Backtrace from '../shared/Backtrace';
 
 import { bailoutTypeInformation } from '../../profile-logic/marker-info';
 
-import type { Milliseconds, Microseconds } from '../../types/units';
-import type { Marker } from '../../types/profile-derived';
-import type { ImplementationFilter } from '../../types/actions';
-import type { Thread, ThreadIndex, PageList } from '../../types/profile';
-import type { PhaseTimes } from '../../types/markers';
+import type {
+  Milliseconds,
+  Microseconds,
+  Marker,
+  ImplementationFilter,
+  Thread,
+  ThreadIndex,
+  PageList,
+  PhaseTimes,
+} from 'firefox-profiler/types';
+
 import type { ConnectedProps } from '../../utils/connect';
 
 type PhaseTimeTuple = {| name: string, time: Microseconds |};

--- a/src/components/tooltip/NetworkMarker.js
+++ b/src/components/tooltip/NetworkMarker.js
@@ -18,8 +18,7 @@ import {
   formatMilliseconds,
 } from '../../utils/format-numbers';
 
-import type { NetworkPayload } from '../../types/markers';
-import type { Milliseconds } from '../../types/units';
+import type { NetworkPayload, Milliseconds } from 'firefox-profiler/types';
 
 import './NetworkMarker.css';
 

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -5,7 +5,7 @@
 // @flow
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 import { ensureExists } from '../../utils/flow';
 require('./Tooltip.css');

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -7,19 +7,17 @@ import { getThreadSelectors } from '../selectors/per-thread';
 import { isMainThread } from './tracks';
 import { ensureExists } from '../utils/flow';
 
-import type { State } from '../types/state';
 import type {
+  State,
   ThreadIndex,
   Profile,
   InnerWindowID,
   Page,
   Thread,
-} from '../types/profile';
-import type {
   ActiveTabGlobalTrack,
   ActiveTabResourceTrack,
-} from '../types/profile-derived';
-import type { ScreenshotPayload } from '../types/markers';
+  ScreenshotPayload,
+} from 'firefox-profiler/types';
 
 const ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER = {
   screenshots: 0,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -20,16 +20,15 @@ import type {
   SamplesTable,
   JsAllocationsTable,
   NativeAllocationsTable,
-} from '../types/profile';
-import type {
   CallNodeTable,
   IndexIntoCallNodeTable,
   CallNodeInfo,
   CallNodeData,
   CallNodeDisplayData,
-} from '../types/profile-derived';
-import type { CallTreeSummaryStrategy } from '../types/actions';
-import type { Milliseconds } from '../types/units';
+  CallTreeSummaryStrategy,
+  Milliseconds,
+} from 'firefox-profiler/types';
+
 import ExtensionIcon from '../../res/img/svg/extension.svg';
 import { formatCallNodeNumber, formatPercent } from '../utils/format-numbers';
 import { assertExhaustiveCheck } from '../utils/flow';

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { StartEndRange } from '../types/units';
+import type { StartEndRange } from 'firefox-profiler/types';
 
 /**
  * Users can make preview range selections on the profile, and then can commit these

--- a/src/profile-logic/comparison.js
+++ b/src/profile-logic/comparison.js
@@ -48,11 +48,11 @@ import type {
   ResourceTable,
   StackTable,
   SamplesTable,
-} from '../types/profile';
-import type { UrlState } from '../types/state';
-import type { ImplementationFilter } from '../types/actions';
-import type { TransformStacksPerThread } from '../types/transforms';
-import type { Milliseconds } from '../types/units';
+  UrlState,
+  ImplementationFilter,
+  TransformStacksPerThread,
+  Milliseconds,
+} from 'firefox-profiler/types';
 
 /**
  * This function is the entry point for this file. From a list of profile

--- a/src/profile-logic/convert-markers.js
+++ b/src/profile-logic/convert-markers.js
@@ -9,8 +9,9 @@ import type {
   GCMajorMarkerPayload_Gecko,
   GCMajorCompleted,
   PhaseTimes,
-} from '../types/markers';
-import type { Milliseconds, Microseconds } from '../types/units';
+  Milliseconds,
+  Microseconds,
+} from 'firefox-profiler/types';
 
 export function upgradeGCMinorMarker(marker8: Object): GCMinorMarkerPayload {
   if ('nursery' in marker8) {

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -24,7 +24,7 @@ import type {
   ExtensionTable,
   CategoryList,
   JsTracerTable,
-} from '../types/profile';
+} from 'firefox-profiler/types';
 
 /**
  * This module collects all of the creation of new empty profile data structures.

--- a/src/profile-logic/errors.js
+++ b/src/profile-logic/errors.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { RequestedLib } from '../types/actions';
+import type { RequestedLib } from 'firefox-profiler/types';
 
 // Used during the symbolication process to express that we couldn't find
 // symbols for a specific library

--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { UnitIntervalOfProfileRange } from '../types/units';
-import type { Thread } from '../types/profile';
 import type {
+  UnitIntervalOfProfileRange,
   CallNodeInfo,
   CallNodeTable,
   IndexIntoCallNodeTable,
-} from '../types/profile-derived';
+  Thread,
+} from 'firefox-profiler/types';
 import type { CallTreeCountsAndTimings } from './call-tree';
 
 export type FlameGraphDepth = number;

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -9,7 +9,7 @@ import type {
   IndexIntoFuncTable,
   IndexIntoStackTable,
   IndexIntoResourceTable,
-} from '../../types/profile';
+} from 'firefox-profiler/types';
 
 import {
   getEmptyProfile,

--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -19,9 +19,10 @@ import type {
   IndexIntoStackTable,
   SamplesTable,
   CategoryList,
-} from '../types/profile';
-import type { JsTracerTiming } from '../types/profile-derived';
-import type { Microseconds } from '../types/units';
+  JsTracerTiming,
+  Microseconds,
+} from 'firefox-profiler/types';
+
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { JsImplementation } from '../profile-logic/profile-data';
 

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -15,9 +15,8 @@ import type {
   IndexIntoRawMarkerTable,
   IndexIntoCategoryList,
   InnerWindowID,
-} from '../types/profile';
-import type { Marker, MarkerIndex } from '../types/profile-derived';
-import type {
+  Marker,
+  MarkerIndex,
   IPCPairData,
   BailoutPayload,
   NetworkPayload,
@@ -25,9 +24,10 @@ import type {
   InvalidationPayload,
   FileIoPayload,
   TextMarkerPayload,
-} from '../types/markers';
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { UniqueStringArray } from '../utils/unique-string-array';
-import type { StartEndRange } from '../types/units';
 
 /**
  * Jank instances are created from responsiveness values. Responsiveness is a profiler

--- a/src/profile-logic/marker-styles.js
+++ b/src/profile-logic/marker-styles.js
@@ -4,7 +4,7 @@
 // @flow
 import * as colors from 'photon-colors';
 
-import type { CssPixels } from '../types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 type MarkerStyles = {
   +[styleName: string]: {|

--- a/src/profile-logic/marker-timing.js
+++ b/src/profile-logic/marker-timing.js
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-import type { CategoryList } from '../types/profile';
 import type {
+  CategoryList,
   DOMEventMarkerPayload,
   UserTimingMarkerPayload,
   MarkerPayload,
   TextMarkerPayload,
-} from '../types/markers';
-import type {
   Marker,
   MarkerIndex,
   MarkerTiming,
   MarkerTimingAndBuckets,
-} from '../types/profile-derived';
+} from 'firefox-profiler/types';
 
 // Arbitrarily set an upper limit for adding marker depths, avoiding an infinite loop.
 const MAX_STACKING_DEPTH = 300;

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -58,14 +58,10 @@ import type {
   JsAllocationsTable,
   ProfilerOverhead,
   NativeAllocationsTable,
-} from '../types/profile';
-import type {
   Milliseconds,
   Microseconds,
   Address,
   MemoryOffset,
-} from '../types/units';
-import type {
   GeckoProfile,
   GeckoSubprocessProfile,
   GeckoThread,
@@ -74,8 +70,6 @@ import type {
   GeckoSampleStruct,
   GeckoStackStruct,
   GeckoProfilerOverhead,
-} from '../types/gecko-profile';
-import type {
   GCSliceMarkerPayload,
   GCMajorMarkerPayload,
   MarkerPayload,
@@ -84,7 +78,7 @@ import type {
   GCMajorCompleted,
   GCMajorCompleted_Gecko,
   GCMajorAborted,
-} from '../types/markers';
+} from 'firefox-profiler/types';
 
 type RegExpResult = null | string[];
 /**

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -36,8 +36,6 @@ import type {
   BalancedNativeAllocationsTable,
   IndexIntoFrameTable,
   PageList,
-} from '../types/profile';
-import type {
   CallNodeInfo,
   CallNodeTable,
   CallNodePath,
@@ -45,16 +43,17 @@ import type {
   AccumulatedCounterSamples,
   SelectedState,
   ProfileFilterPageData,
-} from '../types/profile-derived';
-import { assertExhaustiveCheck } from '../utils/flow';
-
-import type { Milliseconds, StartEndRange } from '../types/units';
-import { timeCode } from '../utils/time-code';
-import { hashPath } from '../utils/path';
-import type {
+  Milliseconds,
+  StartEndRange,
   ImplementationFilter,
   CallTreeSummaryStrategy,
-} from '../types/actions';
+} from 'firefox-profiler/types';
+
+import { assertExhaustiveCheck } from '../utils/flow';
+
+import { timeCode } from '../utils/time-code';
+import { hashPath } from '../utils/path';
+
 import bisection from 'bisection';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -18,9 +18,13 @@ import {
   sanitizeTextMarker,
 } from './marker-data';
 import { filterThreadSamplesToRange } from './profile-data';
-import type { Profile, Thread, ThreadIndex } from '../types/profile';
-import type { RemoveProfileInformation } from '../types/profile-derived';
-import type { StartEndRange } from '../types/units';
+import type {
+  Profile,
+  Thread,
+  ThreadIndex,
+  RemoveProfileInformation,
+  StartEndRange,
+} from 'firefox-profiler/types';
 
 export type SanitizeProfileResult = {|
   +profile: Profile,

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Thread } from '../types/profile';
-import type { Milliseconds } from '../types/units';
 import type {
+  Thread,
+  Milliseconds,
   CallNodeInfo,
   CallNodeTable,
   IndexIntoCallNodeTable,
-} from '../types/profile-derived';
+} from 'firefox-profiler/types';
 /**
  * The StackTimingByDepth data structure organizes stack frames by their depth, and start
  * and end times. This optimizes sample data for Stack Chart views. It

--- a/src/profile-logic/symbol-store-db.js
+++ b/src/profile-logic/symbol-store-db.js
@@ -12,7 +12,7 @@ import type {
   IDBObjectStore,
   IDBIndex,
   IDBKeyRange,
-} from '../types/indexeddb';
+} from 'firefox-profiler/types';
 
 // Contains a symbol table, which can be used to map addresses to strings.
 // Symbol tables of this format are created within Firefox's implementation of

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -7,7 +7,7 @@ import SymbolStoreDB from './symbol-store-db';
 import { SymbolsNotFoundError } from './errors';
 import bisection from 'bisection';
 
-import type { RequestedLib } from '../types/actions';
+import type { RequestedLib } from 'firefox-profiler/types';
 import type { SymbolTableAsTuple } from './symbol-store-db';
 
 export type LibSymbolicationRequest = {

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -14,8 +14,10 @@ import type {
   IndexIntoFuncTable,
   IndexIntoFrameTable,
   IndexIntoResourceTable,
-} from '../types/profile';
-import type { MemoryOffset, Address } from '../types/units';
+  MemoryOffset,
+  Address,
+} from 'firefox-profiler/types';
+
 import type {
   AbstractSymbolStore,
   AddressResult,

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -3,13 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { ScreenshotPayload } from '../types/markers';
-import type { Profile, Thread, ThreadIndex, Pid } from '../types/profile';
 import type {
+  ScreenshotPayload,
+  Profile,
+  Thread,
+  ThreadIndex,
+  Pid,
   GlobalTrack,
   LocalTrack,
   TrackIndex,
-} from '../types/profile-derived';
+} from 'firefox-profiler/types';
+
 import { defaultThreadOrder, getFriendlyThreadName } from './profile-data';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -30,18 +30,14 @@ import type {
   IndexIntoFuncTable,
   IndexIntoStackTable,
   IndexIntoResourceTable,
-} from '../types/profile';
-import type {
   CallNodePath,
   CallNodeTable,
   StackType,
-} from '../types/profile-derived';
-import type { ImplementationFilter } from '../types/actions';
-import type {
+  ImplementationFilter,
   Transform,
   TransformType,
   TransformStack,
-} from '../types/transforms';
+} from 'firefox-profiler/types';
 
 /**
  * This file contains the functions and logic for working with and applying transforms

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -13,8 +13,8 @@ import type {
   IsSidebarOpenPerPanelState,
   Reducer,
   UrlSetupPhase,
-} from '../types/state';
-import type { ThreadIndex } from '../types/profile';
+  ThreadIndex,
+} from 'firefox-profiler/types';
 
 const view: Reducer<AppViewState> = (
   state = { phase: 'INITIALIZING' },

--- a/src/reducers/icons.js
+++ b/src/reducers/icons.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Reducer } from '../types/state';
+import type { Reducer } from 'firefox-profiler/types';
 
 const favicons: Reducer<Set<string>> = (state = new Set(), action) => {
   switch (action.type) {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,7 +10,7 @@ import icons from './icons';
 import zippedProfiles from './zipped-profiles';
 import publish from './publish';
 import { combineReducers } from 'redux';
-import type { Reducer, State } from '../types/state';
+import type { Reducer, State } from 'firefox-profiler/types';
 
 /**
  * This function provides a mechanism to swap out to an old state that we have

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -8,28 +8,25 @@ import * as Transforms from '../profile-logic/transforms';
 import * as ProfileData from '../profile-logic/profile-data';
 import { arePathsEqual, PathSet } from '../utils/path';
 
-import type { Profile, Pid } from '../types/profile';
 import type {
+  Profile,
+  Pid,
   LocalTrack,
   GlobalTrack,
   ActiveTabGlobalTrack,
   OriginsTimeline,
   ActiveTabResourceTrack,
-} from '../types/profile-derived';
-import type { StartEndRange } from '../types/units';
-import type {
+  StartEndRange,
   PreviewSelection,
   RequestedLib,
   TrackReference,
-} from '../types/actions';
-import type {
   Reducer,
   ProfileViewState,
   SymbolicationStatus,
   ThreadViewOptions,
   RightClickedCallNode,
   RightClickedMarker,
-} from '../types/state';
+} from 'firefox-profiler/types';
 
 const profile: Reducer<Profile | null> = (state = null, action) => {
   switch (action.type) {

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -6,14 +6,14 @@
 import { combineReducers } from 'redux';
 import { getShouldSanitizeByDefault } from '../profile-logic/sanitize';
 
-import type { CheckedSharingOptions } from '../types/actions';
 import type {
+  CheckedSharingOptions,
   PublishState,
   UploadState,
   UploadPhase,
   Reducer,
   State,
-} from '../types/state';
+} from 'firefox-profiler/types';
 
 function _getDefaultSharingOptions(): CheckedSharingOptions {
   return {

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -7,21 +7,21 @@ import { combineReducers } from 'redux';
 import { oneLine } from 'common-tags';
 import { objectEntries } from '../utils/flow';
 
-import type { ThreadIndex, Pid } from '../types/profile';
-import type { TrackIndex } from '../types/profile-derived';
-import type { StartEndRange } from '../types/units';
-import type { TransformStacksPerThread } from '../types/transforms';
 import type {
+  ThreadIndex,
+  Pid,
+  TrackIndex,
+  StartEndRange,
+  TransformStacksPerThread,
   DataSource,
   ImplementationFilter,
   CallTreeSummaryStrategy,
   TimelineType,
-} from '../types/actions';
-import type {
   UrlState,
   Reducer,
   TimelineTrackOrganization,
-} from '../types/state';
+} from 'firefox-profiler/types';
+
 import type { TabSlug } from '../app-logic/tabs-handling';
 
 /*

--- a/src/reducers/zipped-profiles.js
+++ b/src/reducers/zipped-profiles.js
@@ -12,7 +12,7 @@ import type {
   ZipFileState,
   Reducer,
   ZippedProfilesState,
-} from '../types/state';
+} from 'firefox-profiler/types';
 
 /**
  * This reducer contains all of the state that deals with loading in profiles from

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -35,10 +35,14 @@ import {
 } from '../app-logic/constants';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { AppState, AppViewState, UrlSetupPhase } from '../types/state';
-import type { Selector } from '../types/store';
-import type { CssPixels } from '../types/units';
-import type { ThreadIndex } from '../types/profile';
+import type {
+  AppState,
+  AppViewState,
+  UrlSetupPhase,
+  Selector,
+  CssPixels,
+  ThreadIndex,
+} from 'firefox-profiler/types';
 
 /**
  * Simple selectors into the app state.

--- a/src/selectors/icons.js
+++ b/src/selectors/icons.js
@@ -4,8 +4,12 @@
 
 // @flow
 import { createSelector } from 'reselect';
-import type { IconWithClassName, IconState } from '../types/state';
-import type { Selector, DangerousSelectorWithArguments } from '../types/store';
+import type {
+  IconWithClassName,
+  IconState,
+  Selector,
+  DangerousSelectorWithArguments,
+} from 'firefox-profiler/types';
 
 /**
  * A simple selector into the icon state.

--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -8,14 +8,16 @@ import { createSelector } from 'reselect';
 import { tabSlugs, type TabSlug } from '../../app-logic/tabs-handling';
 import { getTimelineTrackOrganization } from '../url-state';
 
-import type { Selector } from '../../types/store';
-import type { $ReturnType } from '../../types/utils';
-import type { Thread, JsTracerTable } from '../../types/profile';
 import type {
+  Selector,
+  $ReturnType,
+  Thread,
+  JsTracerTable,
   MarkerTimingRows,
   CombinedTimingRows,
   MarkerTiming,
-} from '../../types/profile-derived';
+} from 'firefox-profiler/types';
+
 import type {
   StackTiming,
   StackTimingByDepth,

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -23,8 +23,8 @@ import {
 } from './composed';
 import * as ProfileSelectors from '../profile';
 
-import type { ThreadIndex } from '../../types/profile';
-import type { Selector } from '../../types/store';
+import type { ThreadIndex, Selector } from 'firefox-profiler/types';
+
 import type { TimingsForPath } from '../../profile-logic/profile-data';
 
 /**

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -12,15 +12,16 @@ import * as MarkerTimingLogic from '../../profile-logic/marker-timing';
 import * as ProfileSelectors from '../profile';
 import { getRightClickedMarkerInfo } from '../right-clicked-marker';
 
-import type { RawMarkerTable, ThreadIndex } from '../../types/profile';
 import type {
+  RawMarkerTable,
+  ThreadIndex,
   MarkerIndex,
   Marker,
   MarkerTiming,
   MarkerTimingAndBuckets,
-} from '../../types/profile-derived';
-import type { Selector } from '../../types/store';
-import type { $ReturnType } from '../../types/utils';
+  Selector,
+  $ReturnType,
+} from 'firefox-profiler/types';
 
 /**
  * Infer the return type from the getMarkerSelectorsPerThread function. This

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -22,17 +22,16 @@ import type {
   NativeAllocationsTable,
   IndexIntoCategoryList,
   IndexIntoSamplesTable,
-} from '../../types/profile';
-import type {
   CallNodeInfo,
   CallNodePath,
   IndexIntoCallNodeTable,
   SelectedState,
-} from '../../types/profile-derived';
-import type { StartEndRange } from '../../types/units';
-import type { Selector } from '../../types/store';
-import type { $ReturnType } from '../../types/utils';
-import type { CallTreeSummaryStrategy } from '../../types/actions';
+  StartEndRange,
+  Selector,
+  $ReturnType,
+  CallTreeSummaryStrategy,
+} from 'firefox-profiler/types';
+
 import type { ThreadSelectorsPerThread } from './thread';
 
 /**

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -18,14 +18,15 @@ import type {
   JsTracerTable,
   SamplesTable,
   NativeAllocationsTable,
-} from '../../types/profile';
-import type { Selector } from '../../types/store';
-import type { ThreadViewOptions } from '../../types/state';
-import type { TransformStack } from '../../types/transforms';
+  Selector,
+  ThreadViewOptions,
+  TransformStack,
+  JsTracerTiming,
+  $ReturnType,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
 import type { UniqueStringArray } from '../../utils/unique-string-array';
-import type { JsTracerTiming } from '../../types/profile-derived';
-import type { $ReturnType } from '../../types/utils';
-import type { StartEndRange } from '../../types/units';
 
 /**
  * Infer the return type from the getThreadSelectorsPerThread function. This

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -34,8 +34,6 @@ import type {
   InnerWindowID,
   BrowsingContextID,
   Page,
-} from '../types/profile';
-import type {
   LocalTrack,
   TrackIndex,
   GlobalTrack,
@@ -44,9 +42,8 @@ import type {
   ActiveTabGlobalTrack,
   OriginsTimeline,
   ActiveTabResourceTrack,
-} from '../types/profile-derived';
-import type { Milliseconds, StartEndRange } from '../types/units';
-import type {
+  Milliseconds,
+  StartEndRange,
   GlobalTrackReference,
   LocalTrackReference,
   TrackReference,
@@ -54,17 +51,16 @@ import type {
   HiddenTrackCount,
   ActiveTabGlobalTrackReference,
   ActiveTabResourceTrackReference,
-} from '../types/actions';
-import type { Selector, DangerousSelectorWithArguments } from '../types/store';
-import type {
+  Selector,
+  DangerousSelectorWithArguments,
   State,
   ProfileViewState,
   SymbolicationStatus,
   FullProfileViewState,
   ActiveTabProfileViewState,
   OriginsViewState,
-} from '../types/state';
-import type { $ReturnType } from '../types/utils';
+  $ReturnType,
+} from 'firefox-profiler/types';
 
 export const getProfileView: Selector<ProfileViewState> = state =>
   state.profileView;

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -31,10 +31,10 @@ import type {
   UploadState,
   UploadPhase,
   State,
-} from '../types/state';
-import type { Selector } from '../types/store';
-import type { CheckedSharingOptions } from '../types/actions';
-import type { RemoveProfileInformation } from '../types/profile-derived';
+  Selector,
+  CheckedSharingOptions,
+  RemoveProfileInformation,
+} from 'firefox-profiler/types';
 
 export const getPublishState: Selector<PublishState> = state => state.publish;
 

--- a/src/selectors/right-clicked-call-node.js
+++ b/src/selectors/right-clicked-call-node.js
@@ -7,9 +7,11 @@ import { createSelector } from 'reselect';
 
 import { getProfileViewOptions } from './profile';
 
-import type { ThreadIndex } from '../types/profile';
-import type { CallNodePath } from '../types/profile-derived';
-import type { Selector } from '../types/store';
+import type {
+  ThreadIndex,
+  CallNodePath,
+  Selector,
+} from 'firefox-profiler/types';
 
 export type RightClickedCallNodeInfo = {|
   +threadIndex: ThreadIndex,

--- a/src/selectors/right-clicked-marker.js
+++ b/src/selectors/right-clicked-marker.js
@@ -6,9 +6,11 @@
 import { createSelector } from 'reselect';
 import { getProfileViewOptions } from './profile';
 
-import type { ThreadIndex } from '../types/profile';
-import type { MarkerIndex } from '../types/profile-derived';
-import type { Selector } from '../types/store';
+import type {
+  ThreadIndex,
+  MarkerIndex,
+  Selector,
+} from 'firefox-profiler/types';
 
 export type RightClickedMarkerInfo = {|
   +threadIndex: ThreadIndex,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -9,20 +9,24 @@ import { ensureExists } from '../utils/flow';
 import { urlFromState } from '../app-logic/url-handling';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
 
-import type { ThreadIndex, Pid } from '../types/profile';
-import type { TransformStack } from '../types/transforms';
 import type {
+  ThreadIndex,
+  Pid,
+  TransformStack,
   Action,
   TimelineType,
   DataSource,
   ImplementationFilter,
   CallTreeSummaryStrategy,
-} from '../types/actions';
+  UrlState,
+  TimelineTrackOrganization,
+  Selector,
+  DangerousSelectorWithArguments,
+  StartEndRange,
+  TrackIndex,
+} from 'firefox-profiler/types';
+
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState, TimelineTrackOrganization } from '../types/state';
-import type { Selector, DangerousSelectorWithArguments } from '../types/store';
-import type { StartEndRange } from '../types/units';
-import type { TrackIndex } from '../types/profile-derived';
 
 import urlStateReducer from '../reducers/url-state';
 

--- a/src/selectors/zipped-profiles.js
+++ b/src/selectors/zipped-profiles.js
@@ -8,8 +8,12 @@ import { getProfileUrl } from './url-state';
 import { ensureExists } from '../utils/flow';
 import * as ZipFiles from '../profile-logic/zip-files';
 
-import type { ZipFileState, ZippedProfilesState } from '../types/state';
-import type { Selector } from '../types/store';
+import type {
+  ZipFileState,
+  ZippedProfilesState,
+  Selector,
+} from 'firefox-profiler/types';
+
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type JSZip from 'jszip';
 

--- a/src/test/components/CallTreeSidebar.test.js
+++ b/src/test/components/CallTreeSidebar.test.js
@@ -22,7 +22,7 @@ import {
   getMergedProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
 
-import type { CallNodePath } from 'firefox-profiler/types/profile-derived';
+import type { CallNodePath } from 'firefox-profiler/types';
 
 describe('CallTreeSidebar', function() {
   function setup() {

--- a/src/test/components/CallTreeSidebar.test.js
+++ b/src/test/components/CallTreeSidebar.test.js
@@ -22,7 +22,7 @@ import {
   getMergedProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
 
-import type { CallNodePath } from '../../types/profile-derived';
+import type { CallNodePath } from 'firefox-profiler/types/profile-derived';
 
 describe('CallTreeSidebar', function() {
   function setup() {

--- a/src/test/components/EmptyThreadIndicator.test.js
+++ b/src/test/components/EmptyThreadIndicator.test.js
@@ -16,7 +16,7 @@ import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profil
 import { getBoundingBox } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
-import type { StartEndRange } from '../../types/units';
+import type { StartEndRange } from 'firefox-profiler/types/units';
 
 describe('EmptyThreadIndicator', function() {
   beforeEach(() => {

--- a/src/test/components/EmptyThreadIndicator.test.js
+++ b/src/test/components/EmptyThreadIndicator.test.js
@@ -16,7 +16,7 @@ import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profil
 import { getBoundingBox } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
-import type { StartEndRange } from 'firefox-profiler/types/units';
+import type { StartEndRange } from 'firefox-profiler/types';
 
 describe('EmptyThreadIndicator', function() {
   beforeEach(() => {

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -37,7 +37,7 @@ import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { getInvertCallstack } from '../../selectors/url-state';
 import { ensureExists } from '../../utils/flow';
 
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 const GRAPH_WIDTH = 200;
 const GRAPH_HEIGHT = 300;

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -37,7 +37,7 @@ import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { getInvertCallstack } from '../../selectors/url-state';
 import { ensureExists } from '../../utils/flow';
 
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 const GRAPH_WIDTH = 200;
 const GRAPH_HEIGHT = 300;

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -4,10 +4,12 @@
 
 // @flow
 
-import type { TrackReference } from 'firefox-profiler/types/actions';
-import type { Store } from 'firefox-profiler/types/store';
-import type { ThreadIndex } from 'firefox-profiler/types/profile';
-import type { LocalTrack } from 'firefox-profiler/types/profile-derived';
+import type {
+  TrackReference,
+  Store,
+  ThreadIndex,
+  LocalTrack,
+} from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -4,10 +4,10 @@
 
 // @flow
 
-import type { TrackReference } from '../../types/actions';
-import type { Store } from '../../types/store';
-import type { ThreadIndex } from '../../types/profile';
-import type { LocalTrack } from '../../types/profile-derived';
+import type { TrackReference } from 'firefox-profiler/types/actions';
+import type { Store } from 'firefox-profiler/types/store';
+import type { ThreadIndex } from 'firefox-profiler/types/profile';
+import type { LocalTrack } from 'firefox-profiler/types/profile-derived';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -32,8 +32,10 @@ import {
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
-import type { UserTimingMarkerPayload } from 'firefox-profiler/types/markers';
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type {
+  UserTimingMarkerPayload,
+  CssPixels,
+} from 'firefox-profiler/types';
 
 const MARKERS = [
   ['Marker A', 0, { startTime: 0, endTime: 10 }],

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -32,8 +32,8 @@ import {
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
-import type { UserTimingMarkerPayload } from '../../types/markers';
-import type { CssPixels } from '../../types/units';
+import type { UserTimingMarkerPayload } from 'firefox-profiler/types/markers';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 const MARKERS = [
   ['Marker A', 0, { startTime: 0, endTime: 10 }],

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -18,8 +18,8 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { processProfile } from '../../profile-logic/process-profile';
-import type { Profile } from '../../types/profile';
-import type { SymbolicationStatus } from '../../types/state';
+import type { Profile } from 'firefox-profiler/types/profile';
+import type { SymbolicationStatus } from 'firefox-profiler/types/state';
 
 // Mocking SymbolStoreDB
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -18,8 +18,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { processProfile } from '../../profile-logic/process-profile';
-import type { Profile } from 'firefox-profiler/types/profile';
-import type { SymbolicationStatus } from 'firefox-profiler/types/state';
+import type { Profile, SymbolicationStatus } from 'firefox-profiler/types';
 
 // Mocking SymbolStoreDB
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -38,7 +38,7 @@ import {
   addTransformToStack,
 } from '../../actions/profile-view';
 
-import type { Profile } from '../../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 beforeEach(() => {
   // Mock out the 2d canvas for the loupe view.

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -38,7 +38,7 @@ import {
   addTransformToStack,
 } from '../../actions/profile-view';
 
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile } from 'firefox-profiler/types';
 
 beforeEach(() => {
   // Mock out the 2d canvas for the loupe view.

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -45,9 +45,11 @@ import {
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 
-import type { Profile } from 'firefox-profiler/types/profile';
-import type { UserTimingMarkerPayload } from 'firefox-profiler/types/markers';
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type {
+  Profile,
+  UserTimingMarkerPayload,
+  CssPixels,
+} from 'firefox-profiler/types';
 
 jest.useFakeTimers();
 

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -45,9 +45,9 @@ import {
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 
-import type { Profile } from '../../types/profile';
-import type { UserTimingMarkerPayload } from '../../types/markers';
-import type { CssPixels } from '../../types/units';
+import type { Profile } from 'firefox-profiler/types/profile';
+import type { UserTimingMarkerPayload } from 'firefox-profiler/types/markers';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 jest.useFakeTimers();
 

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -4,8 +4,11 @@
 
 // @flow
 
-import type { Profile, IndexIntoSamplesTable } from 'firefox-profiler/types/profile';
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type {
+  Profile,
+  IndexIntoSamplesTable,
+  CssPixels,
+} from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -4,8 +4,8 @@
 
 // @flow
 
-import type { Profile, IndexIntoSamplesTable } from '../../types/profile';
-import type { CssPixels } from '../../types/units';
+import type { Profile, IndexIntoSamplesTable } from 'firefox-profiler/types/profile';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -16,7 +16,7 @@ import ReactDOM from 'react-dom';
 import { getTimelineTrackOrganization } from '../../selectors/url-state';
 import { getRightClickedTrack } from '../../selectors/profile';
 
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile } from 'firefox-profiler/types';
 
 function _getProfileWithDroppedSamples(): Profile {
   const { profile } = getProfileFromTextSamples(

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -16,7 +16,7 @@ import ReactDOM from 'react-dom';
 import { getTimelineTrackOrganization } from '../../selectors/url-state';
 import { getRightClickedTrack } from '../../selectors/profile';
 
-import type { Profile } from '../../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 function _getProfileWithDroppedSamples(): Profile {
   const { profile } = getProfileFromTextSamples(

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -28,7 +28,7 @@ import {
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { ensureExists } from '../../utils/flow';
 
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type { CssPixels } from 'firefox-profiler/types';
 
 function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   const flushRafCalls = mockRaf();

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -28,7 +28,7 @@ import {
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { ensureExists } from '../../utils/flow';
 
-import type { CssPixels } from '../../types/units';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   const flushRafCalls = mockRaf();

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -4,8 +4,8 @@
 
 // @flow
 
-import type { IndexIntoSamplesTable } from '../../types/profile';
-import type { CssPixels } from '../../types/units';
+import type { IndexIntoSamplesTable } from 'firefox-profiler/types/profile';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -4,8 +4,7 @@
 
 // @flow
 
-import type { IndexIntoSamplesTable } from 'firefox-profiler/types/profile';
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type { IndexIntoSamplesTable, CssPixels } from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -7,7 +7,7 @@ import type {
   Profile,
   Thread,
   IndexIntoRawMarkerTable,
-} from '../../types/profile';
+} from 'firefox-profiler/types/profile';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -7,7 +7,7 @@ import type {
   Profile,
   Thread,
   IndexIntoRawMarkerTable,
-} from 'firefox-profiler/types/profile';
+} from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile, FileIoPayload } from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
@@ -34,8 +34,6 @@ import {
   getProfileFromTextSamples,
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
-
-import type { FileIoPayload } from 'firefox-profiler/types/markers';
 
 // The graph is 400 pixels wide based on the getBoundingBox mock. Each stack is 100
 // pixels wide. Use the value 50 to click in the middle of this stack, and

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Profile } from '../../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
@@ -35,7 +35,7 @@ import {
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 
-import type { FileIoPayload } from '../../types/markers';
+import type { FileIoPayload } from 'firefox-profiler/types/markers';
 
 // The graph is 400 pixels wide based on the getBoundingBox mock. Each stack is 100
 // pixels wide. Use the value 50 to click in the middle of this stack, and

--- a/src/test/components/TrackVisualProgress.test.js
+++ b/src/test/components/TrackVisualProgress.test.js
@@ -4,8 +4,8 @@
 
 // @flow
 
-import type { IndexIntoSamplesTable } from '../../types/profile';
-import type { CssPixels } from '../../types/units';
+import type { IndexIntoSamplesTable } from 'firefox-profiler/types/profile';
+import type { CssPixels } from 'firefox-profiler/types/units';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/TrackVisualProgress.test.js
+++ b/src/test/components/TrackVisualProgress.test.js
@@ -4,8 +4,7 @@
 
 // @flow
 
-import type { IndexIntoSamplesTable } from 'firefox-profiler/types/profile';
-import type { CssPixels } from 'firefox-profiler/types/units';
+import type { IndexIntoSamplesTable, CssPixels } from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -24,7 +24,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
-import type { Milliseconds } from 'firefox-profiler/types/units';
+import type { Milliseconds } from 'firefox-profiler/types';
 
 // The following define the magic values used for the mocked bounding box of the
 // the rendered component.

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -24,7 +24,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
-import type { Milliseconds } from '../../types/units';
+import type { Milliseconds } from 'firefox-profiler/types/units';
 
 // The following define the magic values used for the mocked bounding box of the
 // the rendered component.

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -8,7 +8,7 @@ import type {
   SamplesTable,
   FrameTable,
   Profile,
-} from '../../../types/profile';
+} from 'firefox-profiler/types/profile';
 
 import {
   getEmptyThread,

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -8,7 +8,7 @@ import type {
   SamplesTable,
   FrameTable,
   Profile,
-} from 'firefox-profiler/types/profile';
+} from 'firefox-profiler/types';
 
 import {
   getEmptyThread,

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { Lib, ProfilerOverheadStats } from '../../../types/profile';
+import type { Lib, ProfilerOverheadStats } from 'firefox-profiler/types/profile';
 
 import type {
   GeckoProfile,
@@ -14,7 +14,7 @@ import type {
   GeckoCounter,
   GeckoMarkerStack,
   GeckoProfilerOverhead,
-} from '../../../types/gecko-profile';
+} from 'firefox-profiler/types/gecko-profile';
 
 import { GECKO_PROFILE_VERSION } from '../../../app-logic/constants';
 

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { Lib, ProfilerOverheadStats } from 'firefox-profiler/types/profile';
-
 import type {
+  Lib,
+  ProfilerOverheadStats,
   GeckoProfile,
   GeckoSubprocessProfile,
   GeckoProfileFullMeta,
@@ -14,7 +14,7 @@ import type {
   GeckoCounter,
   GeckoMarkerStack,
   GeckoProfilerOverhead,
-} from 'firefox-profiler/types/gecko-profile';
+} from 'firefox-profiler/types';
 
 import { GECKO_PROFILE_VERSION } from '../../../app-logic/constants';
 

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -26,15 +26,13 @@ import type {
   JsTracerTable,
   Counter,
   BrowsingContextID,
-} from 'firefox-profiler/types/profile';
-import type {
   MarkerPayload,
   NetworkPayload,
   NavigationMarkerPayload,
   IPCMarkerPayload,
   UserTimingMarkerPayload,
-} from 'firefox-profiler/types/markers';
-import type { Milliseconds } from 'firefox-profiler/types/units';
+  Milliseconds,
+} from 'firefox-profiler/types';
 
 // Array<[MarkerName, Milliseconds, Data]>
 type MarkerName = string;

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -26,15 +26,15 @@ import type {
   JsTracerTable,
   Counter,
   BrowsingContextID,
-} from '../../../types/profile';
+} from 'firefox-profiler/types/profile';
 import type {
   MarkerPayload,
   NetworkPayload,
   NavigationMarkerPayload,
   IPCMarkerPayload,
   UserTimingMarkerPayload,
-} from '../../../types/markers';
-import type { Milliseconds } from '../../../types/units';
+} from 'firefox-profiler/types/markers';
+import type { Milliseconds } from 'firefox-profiler/types/units';
 
 // Array<[MarkerName, Milliseconds, Data]>
 type MarkerName = string;

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -12,9 +12,12 @@ import {
 import { storeWithProfile } from '../stores';
 import { oneLine } from 'common-tags';
 
-import type { OriginsTimelineTrack } from 'firefox-profiler/types/profile-derived';
-import type { Profile } from 'firefox-profiler/types/profile';
-import type { State } from 'firefox-profiler/types/state';
+import type {
+  OriginsTimelineTrack,
+  Profile,
+  State,
+} from 'firefox-profiler/types';
+
 import { assertExhaustiveCheck } from '../../../utils/flow';
 import { getFriendlyThreadName } from '../../../profile-logic/profile-data';
 

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -12,9 +12,9 @@ import {
 import { storeWithProfile } from '../stores';
 import { oneLine } from 'common-tags';
 
-import type { OriginsTimelineTrack } from '../../../types/profile-derived';
-import type { Profile } from '../../../types/profile';
-import type { State } from '../../../types/state';
+import type { OriginsTimelineTrack } from 'firefox-profiler/types/profile-derived';
+import type { Profile } from 'firefox-profiler/types/profile';
+import type { State } from 'firefox-profiler/types/state';
 import { assertExhaustiveCheck } from '../../../utils/flow';
 import { getFriendlyThreadName } from '../../../profile-logic/profile-data';
 

--- a/src/test/fixtures/stores.js
+++ b/src/test/fixtures/stores.js
@@ -9,8 +9,8 @@ import { createGeckoProfileWithJsTimings } from './profiles/gecko-profile';
 import { processProfile } from '../../profile-logic/process-profile';
 import { getProfileFromTextSamples } from './profiles/processed-profile';
 
-import type { Store } from '../../types/store';
-import type { Profile } from '../../types/profile';
+import type { Store } from 'firefox-profiler/types/store';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 export function blankStore() {
   return createStore();

--- a/src/test/fixtures/stores.js
+++ b/src/test/fixtures/stores.js
@@ -9,8 +9,7 @@ import { createGeckoProfileWithJsTimings } from './profiles/gecko-profile';
 import { processProfile } from '../../profile-logic/process-profile';
 import { getProfileFromTextSamples } from './profiles/processed-profile';
 
-import type { Store } from 'firefox-profiler/types/store';
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Store, Profile } from 'firefox-profiler/types';
 
 export function blankStore() {
   return createStore();

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -3,8 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { CallTree } from '../../profile-logic/call-tree';
-import type { IndexIntoCallNodeTable } from 'firefox-profiler/types/profile-derived';
-import type { Store, State } from 'firefox-profiler/types/store';
+import type {
+  IndexIntoCallNodeTable,
+  Store,
+  State,
+} from 'firefox-profiler/types';
+
 import { ensureExists } from '../../utils/flow';
 import { fireEvent, type RenderResult } from 'react-testing-library';
 

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { CallTree } from '../../profile-logic/call-tree';
-import type { IndexIntoCallNodeTable } from '../../types/profile-derived';
-import type { Store, State } from '../../types/store';
+import type { IndexIntoCallNodeTable } from 'firefox-profiler/types/profile-derived';
+import type { Store, State } from 'firefox-profiler/types/store';
 import { ensureExists } from '../../utils/flow';
 import { fireEvent, type RenderResult } from 'react-testing-library';
 

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -7,7 +7,7 @@ import { createImageMock } from '../fixtures/mocks/image';
 import { blankStore } from '../fixtures/stores';
 import * as iconsAccessors from '../../selectors/icons';
 import * as iconsActions from '../../actions/icons';
-import type { CallNodeDisplayData } from 'firefox-profiler/types/profile-derived';
+import type { CallNodeDisplayData } from 'firefox-profiler/types';
 
 describe('actions/icons', function() {
   const validIcons = [

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -7,7 +7,7 @@ import { createImageMock } from '../fixtures/mocks/image';
 import { blankStore } from '../fixtures/stores';
 import * as iconsAccessors from '../../selectors/icons';
 import * as iconsActions from '../../actions/icons';
-import type { CallNodeDisplayData } from '../../types/profile-derived';
+import type { CallNodeDisplayData } from 'firefox-profiler/types/profile-derived';
 
 describe('actions/icons', function() {
   const validIcons = [

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -18,7 +18,7 @@ import {
   type TestDefinedJsTracerEvent,
 } from '../fixtures/profiles/processed-profile';
 
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile } from 'firefox-profiler/types';
 
 describe('jsTracerFixed', function() {
   function fixTiming(events: *) {

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -18,7 +18,7 @@ import {
   type TestDefinedJsTracerEvent,
 } from '../fixtures/profiles/processed-profile';
 
-import type { Profile } from '../../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 describe('jsTracerFixed', function() {
   function fixTiming(events: *) {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { TrackReference } from 'firefox-profiler/types/actions';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import {
@@ -46,9 +45,12 @@ import {
 } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
-import type { Milliseconds } from 'firefox-profiler/types/units';
 import type { BreakdownByCategory } from '../../profile-logic/profile-data';
-import type { BrowsingContextID } from 'firefox-profiler/types/profile';
+import type {
+  TrackReference,
+  Milliseconds,
+  BrowsingContextID,
+} from 'firefox-profiler/types';
 
 describe('call node paths on implementation filter change', function() {
   const {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { TrackReference } from '../../types/actions';
+import type { TrackReference } from 'firefox-profiler/types/actions';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import {
@@ -46,9 +46,9 @@ import {
 } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
-import type { Milliseconds } from '../../types/units';
+import type { Milliseconds } from 'firefox-profiler/types/units';
 import type { BreakdownByCategory } from '../../profile-logic/profile-data';
-import type { BrowsingContextID } from '../../types/profile';
+import type { BrowsingContextID } from 'firefox-profiler/types/profile';
 
 describe('call node paths on implementation filter change', function() {
   const {

--- a/src/test/store/profile-view.test.js.orig
+++ b/src/test/store/profile-view.test.js.orig
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { TrackReference } from '../../types/actions';
+import type { TrackReference } from 'firefox-profiler/types/actions';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import {
@@ -40,9 +40,9 @@ import {
 } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
-import type { Milliseconds } from '../../types/units';
+import type { Milliseconds } from 'firefox-profiler/types/units';
 import type { BreakdownByCategory } from '../../profile-logic/profile-data';
-import type { BrowsingContextID } from '../../types/profile';
+import type { BrowsingContextID } from 'firefox-profiler/types/profile';
 
 describe('call node paths on implementation filter change', function() {
   const {

--- a/src/test/store/profile-view.test.js.orig
+++ b/src/test/store/profile-view.test.js.orig
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { TrackReference } from 'firefox-profiler/types/actions';
+import type { TrackReference } from 'firefox-profiler/types';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import {
@@ -40,9 +40,9 @@ import {
 } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
-import type { Milliseconds } from 'firefox-profiler/types/units';
+import type { Milliseconds } from 'firefox-profiler/types';
 import type { BreakdownByCategory } from '../../profile-logic/profile-data';
-import type { BrowsingContextID } from 'firefox-profiler/types/profile';
+import type { BrowsingContextID } from 'firefox-profiler/types';
 
 describe('call node paths on implementation filter change', function() {
   const {

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -43,7 +43,7 @@ import {
   hideGlobalTrack,
 } from '../../actions/profile-view';
 
-import type { Store } from '../../types/store';
+import type { Store } from 'firefox-profiler/types/store';
 
 // Mocks:
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -43,7 +43,7 @@ import {
   hideGlobalTrack,
 } from '../../actions/profile-view';
 
-import type { Store } from 'firefox-profiler/types/store';
+import type { Store } from 'firefox-profiler/types';
 
 // Mocks:
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile } from 'firefox-profiler/types';
 
 import { oneLineTrim } from 'common-tags';
 

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { Profile } from '../../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 import { oneLineTrim } from 'common-tags';
 

--- a/src/test/types/markers.js
+++ b/src/test/types/markers.js
@@ -8,8 +8,8 @@
 import type {
   $ReplaceCauseWithStack,
   CauseBacktrace,
-} from '../../types/markers';
-import type { GeckoMarkerStack } from '../../types/gecko-profile';
+} from 'firefox-profiler/types/markers';
+import type { GeckoMarkerStack } from 'firefox-profiler/types/gecko-profile';
 
 type ObjectWithCause = {| a: number, cause: CauseBacktrace |};
 type ObjectWithOptionalCause = {| a: number, cause?: CauseBacktrace |};

--- a/src/test/types/markers.js
+++ b/src/test/types/markers.js
@@ -8,8 +8,8 @@
 import type {
   $ReplaceCauseWithStack,
   CauseBacktrace,
-} from 'firefox-profiler/types/markers';
-import type { GeckoMarkerStack } from 'firefox-profiler/types/gecko-profile';
+  GeckoMarkerStack,
+} from 'firefox-profiler/types';
 
 type ObjectWithCause = {| a: number, cause: CauseBacktrace |};
 type ObjectWithOptionalCause = {| a: number, cause?: CauseBacktrace |};

--- a/src/test/types/react-redux.js
+++ b/src/test/types/react-redux.js
@@ -17,7 +17,7 @@ import type {
   ThunkAction,
   Dispatch,
   GetState,
-} from 'firefox-profiler/types/store';
+} from 'firefox-profiler/types';
 /* eslint-disable no-unused-vars, react/prefer-stateless-function, flowtype/no-unused-expressions */
 
 // Use this any value to create fake variables as a type. Consider using

--- a/src/test/types/react-redux.js
+++ b/src/test/types/react-redux.js
@@ -17,7 +17,7 @@ import type {
   ThunkAction,
   Dispatch,
   GetState,
-} from '../../types/store';
+} from 'firefox-profiler/types/store';
 /* eslint-disable no-unused-vars, react/prefer-stateless-function, flowtype/no-unused-expressions */
 
 // Use this any value to create fake variables as a type. Consider using

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -17,8 +17,8 @@ import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getThreadWithMarkers } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
 
-import type { Thread } from '../../types/profile';
-import type { Milliseconds } from '../../types/units';
+import type { Thread } from 'firefox-profiler/types/profile';
+import type { Milliseconds } from 'firefox-profiler/types/units';
 
 describe('deriveMarkersFromRawMarkerTable', function() {
   function setup() {

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -17,8 +17,7 @@ import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getThreadWithMarkers } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
 
-import type { Thread } from 'firefox-profiler/types/profile';
-import type { Milliseconds } from 'firefox-profiler/types/units';
+import type { Thread, Milliseconds } from 'firefox-profiler/types';
 
 describe('deriveMarkersFromRawMarkerTable', function() {
   function setup() {

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -17,7 +17,7 @@ import {
   updatePreviewSelection,
 } from '../../actions/profile-view';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import type { CallTreeSummaryStrategy } from 'firefox-profiler/types/actions';
+import type { CallTreeSummaryStrategy } from 'firefox-profiler/types';
 
 /**
  * Test that the NativeAllocationTable structure can by used with all of the call tree

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -17,7 +17,7 @@ import {
   updatePreviewSelection,
 } from '../../actions/profile-view';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import type { CallTreeSummaryStrategy } from '../../types/actions';
+import type { CallTreeSummaryStrategy } from 'firefox-profiler/types/actions';
 
 /**
  * Test that the NativeAllocationTable structure can by used with all of the call tree

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -20,8 +20,8 @@ import { ensureExists } from '../../utils/flow';
 import type {
   JsAllocationPayload_Gecko,
   NativeAllocationPayload_Gecko,
-} from '../../types/markers';
-import type { GeckoThread } from '../../types/gecko-profile';
+} from 'firefox-profiler/types/markers';
+import type { GeckoThread } from 'firefox-profiler/types/gecko-profile';
 
 describe('extract functions and resource from location strings', function() {
   // These location strings are turned into the proper funcs.

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -20,8 +20,8 @@ import { ensureExists } from '../../utils/flow';
 import type {
   JsAllocationPayload_Gecko,
   NativeAllocationPayload_Gecko,
-} from 'firefox-profiler/types/markers';
-import type { GeckoThread } from 'firefox-profiler/types/gecko-profile';
+  GeckoThread,
+} from 'firefox-profiler/types';
 
 describe('extract functions and resource from location strings', function() {
   // These location strings are turned into the proper funcs.

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -36,7 +36,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { funcHasRecursiveCall } from '../../profile-logic/transforms';
 
-import type { Thread, IndexIntoStackTable } from '../../types/profile';
+import type { Thread, IndexIntoStackTable } from 'firefox-profiler/types/profile';
 
 describe('unique-string-array', function() {
   const u = new UniqueStringArray(['foo', 'bar', 'baz']);

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -36,7 +36,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { funcHasRecursiveCall } from '../../profile-logic/transforms';
 
-import type { Thread, IndexIntoStackTable } from 'firefox-profiler/types/profile';
+import type { Thread, IndexIntoStackTable } from 'firefox-profiler/types';
 
 describe('unique-string-array', function() {
   const u = new UniqueStringArray(['foo', 'bar', 'baz']);

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -22,7 +22,7 @@ import {
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { formatTree, formatTreeIncludeCategories } from '../fixtures/utils';
 
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile } from 'firefox-profiler/types';
 
 function callTreeFromProfile(
   profile: Profile,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -22,7 +22,7 @@ import {
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { formatTree, formatTreeIncludeCategories } from '../fixtures/utils';
 
-import type { Profile } from '../../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 
 function callTreeFromProfile(
   profile: Profile,

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -8,7 +8,7 @@ import { sanitizePII } from '../../profile-logic/sanitize';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
-import type { RemoveProfileInformation } from '../../types/profile-derived';
+import type { RemoveProfileInformation } from 'firefox-profiler/types/profile-derived';
 import { storeWithProfile } from '../fixtures/stores';
 import { getHasPreferenceMarkers } from '../../selectors/profile';
 import {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -8,7 +8,7 @@ import { sanitizePII } from '../../profile-logic/sanitize';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
-import type { RemoveProfileInformation } from 'firefox-profiler/types/profile-derived';
+import type { RemoveProfileInformation } from 'firefox-profiler/types';
 import { storeWithProfile } from '../fixtures/stores';
 import { getHasPreferenceMarkers } from '../../selectors/profile';
 import {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -25,7 +25,7 @@ import {
   viewProfile,
   changeTimelineTrackOrganization,
 } from '../actions/receive-profile';
-import type { Profile } from '../types/profile';
+import type { Profile } from 'firefox-profiler/types/profile';
 import getProfile from './fixtures/profiles/call-nodes';
 import queryString from 'query-string';
 import {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -25,7 +25,7 @@ import {
   viewProfile,
   changeTimelineTrackOrganization,
 } from '../actions/receive-profile';
-import type { Profile } from 'firefox-profiler/types/profile';
+import type { Profile } from 'firefox-profiler/types';
 import getProfile from './fixtures/profiles/call-nodes';
 import queryString from 'query-string';
 import {

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -28,8 +28,8 @@ import type { TemporaryError } from '../utils/errors';
 import type { Transform, TransformStacksPerThread } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState, UploadState, State } from '../types/state';
-import type { CssPixels, StartEndRange } from '../types/units';
+import type { UrlState, UploadState, State } from './state';
+import type { CssPixels, StartEndRange } from './units';
 
 export type DataSource =
   | 'none'

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+export * from './actions';
+export * from './gecko-profile';
+export * from './indexeddb';
+export * from './markers';
+export * from './profile-derived';
+export * from './profile';
+export * from './state';
+export * from './store';
+export * from './transforms';
+export * from './units';
+export * from './utils';

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -5,7 +5,12 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
-import type { Dispatch, State, ThunkAction, Action } from '../types/store';
+import type {
+  Dispatch,
+  State,
+  ThunkAction,
+  Action,
+} from 'firefox-profiler/types';
 
 type MapStateToProps<OwnProps: Object, StateProps: Object> = (
   state: State,

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -4,7 +4,7 @@
 // @flow
 
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { TransformType } from '../types/transforms';
+import type { TransformType } from 'firefox-profiler/types';
 
 /**
  * This file contains utils that help Flow understand things better. Occasionally

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -7,7 +7,11 @@
 import memoize from 'memoize-immutable';
 import NamedTupleMap from 'namedtuplemap';
 
-import type { Microseconds, Milliseconds, Nanoseconds } from '../types/units';
+import type {
+  Microseconds,
+  Milliseconds,
+  Nanoseconds,
+} from 'firefox-profiler/types';
 
 // Calling `toLocalestring` repeatedly in a tight loop can be a performance
 // problem. It's much better to reuse an instance of `Intl.NumberFormat`.

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { CallNodePath } from '../types/profile-derived';
+import type { CallNodePath } from 'firefox-profiler/types';
 
 export function arePathsEqual(a: CallNodePath, b: CallNodePath): boolean {
   if (a === b) {

--- a/src/utils/unique-string-array.js
+++ b/src/utils/unique-string-array.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { IndexIntoStringTable } from '../types/profile';
+import type { IndexIntoStringTable } from 'firefox-profiler/types';
 
 export class UniqueStringArray {
   _array: string[];

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { stripIndent } from 'common-tags';
-import type { GetState, Dispatch } from '../types/store';
+import type { GetState, Dispatch } from 'firefox-profiler/types';
 import { selectorsForConsole } from 'firefox-profiler/selectors';
 import actions from '../actions';
 


### PR DESCRIPTION
@canova I flagged you for review of the diffs
@julienw I wanted to loop you into this, but with Nazim being the main reviewer.

This is going to be a large diff, but it's also mostly an automated change through search/replace and `eslint --fix` to de-duplicate import statements. My thought here is that commits with `Simplify types paths ...` in the title can be skimmed in the review as it's an automated change with Flow agreeing. I think both of you should manually test that this setup works in your editors so we're not caught by surprises.

This change is motivated by the marker 2.0 front-end changes, and how annoying dealing with types changing locations is. My thought is, like selectors, our types are pretty much global entries. It's nice to have them broken into separate files while working on them, but importing them I don't really care.

Feel free to chat with me on Riot about these changes before reviewing.