### PR TITLE
Sanitize the Text marker payloads just in case they have URLs inside the name fields

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -5,7 +5,7 @@
 
 import { getEmptyRawMarkerTable } from './data-structures';
 import { getFriendlyThreadName } from './profile-data';
-import { removeFilePath } from '../utils/string';
+import { removeFilePath, removeURLs } from '../utils/string';
 
 import type {
   Thread,
@@ -24,6 +24,7 @@ import type {
   PrefMarkerPayload,
   InvalidationPayload,
   FileIoPayload,
+  TextMarkerPayload,
 } from '../types/markers';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { StartEndRange } from '../types/units';
@@ -1324,6 +1325,18 @@ export function sanitizeFileIOMarkerFilenamePath(
   return {
     ...payload,
     filename: removeFilePath(payload.filename),
+  };
+}
+
+/**
+ * Sanitize Text marker's name property for potential URLs.
+ */
+export function sanitizeTextMarker(
+  payload: TextMarkerPayload
+): TextMarkerPayload {
+  return {
+    ...payload,
+    name: removeURLs(payload.name),
   };
 }
 

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -15,6 +15,7 @@ import {
   removePrefMarkerPreferenceValues,
   sanitizeFileIOMarkerFilenamePath,
   filterRawMarkerTableToRangeWithMarkersToDelete,
+  sanitizeTextMarker,
 } from './marker-data';
 import { filterThreadSamplesToRange } from './profile-data';
 import type { Profile, Thread, ThreadIndex } from '../types/profile';
@@ -231,6 +232,16 @@ function sanitizeThreadPII(
       ) {
         // Remove the filename path from marker payload.
         markerTable.data[i] = sanitizeFileIOMarkerFilenamePath(currentMarker);
+      }
+
+      if (
+        PIIToBeRemoved.shouldRemoveUrls &&
+        currentMarker &&
+        currentMarker.type &&
+        currentMarker.type === 'Text'
+      ) {
+        // Sanitize all the name fields of text markers in case they contain URLs.
+        markerTable.data[i] = sanitizeTextMarker(currentMarker);
       }
 
       // Remove the screenshots if the current thread index is in the

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -255,6 +255,34 @@ describe('sanitizePII', function() {
     }
   });
 
+  it('should sanitize the URLs inside text markers', function() {
+    const unsanitizedNameField =
+      'onBeforeRequest https://profiler.firefox.com/ by extension';
+    const sanitizedNameField = 'onBeforeRequest https://<URL> by extension';
+    const profile = getProfileWithMarkers([
+      [
+        'Extension Suspend',
+        1,
+        {
+          type: 'Text',
+          startTime: 0,
+          endTime: 1,
+          name: unsanitizedNameField,
+        },
+      ],
+    ]);
+    const PIIToRemove = getRemoveProfileInformation({
+      shouldRemoveUrls: true,
+    });
+
+    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
+    const marker = sanitizedProfile.threads[0].markers.data[0];
+    if (!marker || marker.type !== 'Text') {
+      throw new Error('Expected a Text marker');
+    }
+    expect(marker.name).toBe(sanitizedNameField);
+  });
+
   it('should sanitize all the URLs inside string table', function() {
     const profile = processProfile(createGeckoProfile());
     const PIIToRemove = getRemoveProfileInformation({


### PR DESCRIPTION
It looks like we have some URLs inside the Text markers. Marker 2.0 will fix it but, still it's good to do this before it comes.