### PR TITLE
Add a webconsole API to persist tooltips in order to aid in inspecting and debugging

### DIFF
--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -348,9 +348,13 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
   };
 
   _hoverOut = () => {
-    this.setState({
-      hovered: false,
-    });
+    // This persistTooltips property is part of the web console API. It helps
+    // in being able to inspect and debug tooltips.
+    if (!window.persistTooltips) {
+      this.setState({
+        hovered: false,
+      });
+    }
   };
 
   _onMouseDown = (e: SyntheticMouseEvent<>) => {

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -224,7 +224,12 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
         pageX: event.pageX,
         pageY: event.pageY,
       });
-    } else if (this.state.hoveredItem !== null) {
+    } else if (
+      this.state.hoveredItem !== null &&
+      // This persistTooltips property is part of the web console API. It helps
+      // in being able to inspect and debug tooltips.
+      !window.persistTooltips
+    ) {
       this.setState({
         hoveredItem: null,
       });
@@ -232,7 +237,12 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
   };
 
   _onMouseOut = () => {
-    if (this.state.hoveredItem !== null) {
+    if (
+      this.state.hoveredItem !== null &&
+      // This persistTooltips property is part of the web console API. It helps
+      // in being able to inspect and debug tooltips.
+      !window.persistTooltips
+    ) {
       this.setState({ hoveredItem: null });
     }
   };

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -354,7 +354,12 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
         mouseX: event.pageX,
         mouseY: event.pageY,
       });
-    } else if (this.state.hoveredItem !== null) {
+    } else if (
+      this.state.hoveredItem !== null &&
+      // This persistTooltips property is part of the web console API. It helps
+      // in being able to inspect and debug tooltips.
+      !window.persistTooltips
+    ) {
       this.setState({
         hoveredItem: null,
       });
@@ -415,9 +420,13 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
   };
 
   _onMouseOut = () => {
-    this.setState({
-      hoveredItem: null,
-    });
+    // This persistTooltips property is part of the web console API. It helps
+    // in being able to inspect and debug tooltips.
+    if (!window.persistTooltips) {
+      this.setState({
+        hoveredItem: null,
+      });
+    }
   };
 
   componentDidMount() {

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -47,6 +47,13 @@ type Props = {|
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
 |};
 
+// For debugging purposes, allow tooltips to persist. This aids in inspecting
+// the DOM structure.
+window.persistTooltips = false;
+if (process.env.NODE_ENV === 'development') {
+  console.log('To debug tooltips, set window.persistTooltips to true.');
+}
+
 /**
  * This class collects the tooltip rendering for anything that cares about call nodes.
  * This includes the Flame Graph and Stack Chart.

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -47,13 +47,6 @@ type Props = {|
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
 |};
 
-// For debugging purposes, allow tooltips to persist. This aids in inspecting
-// the DOM structure.
-window.persistTooltips = false;
-if (process.env.NODE_ENV === 'development') {
-  console.log('To debug tooltips, set window.persistTooltips to true.');
-}
-
 /**
  * This class collects the tooltip rendering for anything that cares about call nodes.
  * This includes the Flame Graph and Stack Chart.

--- a/src/components/tooltip/DivWithTooltip.js
+++ b/src/components/tooltip/DivWithTooltip.js
@@ -39,7 +39,11 @@ export default class DivWithTooltip extends React.PureComponent<Props, State> {
   };
 
   _onMouseLeave = () => {
-    this.setState({ isMouseOver: false });
+    // This persistTooltips property is part of the web console API. It helps
+    // in being able to inspect and debug tooltips.
+    if (!window.persistTooltips) {
+      this.setState({ isMouseOver: false });
+    }
     document.removeEventListener('mousemove', this._onMouseMove, false);
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import createStore from './app-logic/create-store';
 import {
   addDataToWindowObject,
   logFriendlyPreamble,
+  logDevelopmentTips,
 } from './utils/window-console';
 import { ensureExists } from './utils/flow';
 
@@ -54,4 +55,7 @@ addDataToWindowObject(store.getState, store.dispatch);
 if (process.env.NODE_ENV === 'production') {
   // Don't clutter the console in development mode.
   logFriendlyPreamble();
+}
+if (process.env.NODE_ENV === 'development') {
+  logDevelopmentTips();
 }

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -36,6 +36,10 @@ declare class Window {
     install: Object => {},
   };
 
+  // For debugging purposes, allow tooltips to persist. This aids in inspecting
+  // the DOM structure.
+  persistTooltips?: boolean;
+
   // WebChannel events.
   // https://searchfox.org/mozilla-central/source/toolkit/modules/WebChannel.jsm
   addEventListener: $PropertyType<EventTarget, 'addEventListener'> &

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -63,6 +63,10 @@ export function addDataToWindowObject(
   target.selectors = selectorsForConsole;
   target.dispatch = dispatch;
   target.actions = actions;
+
+  // For debugging purposes, allow tooltips to persist. This aids in inspecting
+  // the DOM structure.
+  target.persistTooltips = false;
 }
 
 export function logFriendlyPreamble() {
@@ -150,4 +154,8 @@ export function logFriendlyPreamble() {
     link,
     reset
   );
+}
+
+export function logDevelopmentTips() {
+  console.log('To debug tooltips, set window.persistTooltips to true.');
 }


### PR DESCRIPTION
This is a break out PR from #2558. I didn't include a new test for the feature, as it didn't regress any existing tests, and it's really a development-only convenience. I updated the implementation based on your comments, centralizing it with the other web console APIs. I also hadn't included the timeline tooltips, so they are included now.