### PR TITLE
Extract the meta info formatting to a separate file

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -93,7 +93,7 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
       <ButtonWithPanel
         className="menuButtonsMetaInfoButton"
         buttonClassName="menuButtonsMetaInfoButtonButton"
-        label={_formatMetainfoString(meta) || 'Profile information'}
+        label={_formatMetaInfoString(meta) || 'Profile information'}
         panel={
           <ArrowPanel className="arrowPanelOpenMetaInfo">
             <h2 className="arrowPanelSubTitle">Profile Information</h2>
@@ -264,7 +264,7 @@ function _formatDate(timestamp: number): string {
   return timestampDate;
 }
 
-function _formatMetainfoString(meta: ProfileMeta) {
+function _formatMetaInfoString(meta: ProfileMeta) {
   const productAndVersion = formatProductAndVersion(meta);
   const os = formatPlatform(meta);
   return productAndVersion + (os ? ` – ${os}` : '');

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -8,6 +8,10 @@ import ButtonWithPanel from '../../shared/ButtonWithPanel';
 import ArrowPanel from '../../shared/ArrowPanel';
 import { MetaOverheadStatistics } from './MetaOverheadStatistics';
 import { formatBytes, formatTimestamp } from '../../../utils/format-numbers';
+import {
+  formatProductAndVersion,
+  formatPlatform,
+} from '../../../profile-logic/profile-metainfo';
 
 import type {
   Profile,
@@ -20,11 +24,11 @@ import { assertExhaustiveCheck } from '../../../utils/flow';
 
 import './MetaInfo.css';
 
-type Props = {
-  profile: Profile,
-  symbolicationStatus: SymbolicationStatus,
-  resymbolicateProfile: resymbolicateProfile,
-};
+type Props = {|
+  +profile: Profile,
+  +symbolicationStatus: SymbolicationStatus,
+  +resymbolicateProfile: resymbolicateProfile,
+|};
 
 /**
  * This component formats the profile's meta information into a dropdown panel.
@@ -83,11 +87,13 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
     const { meta, profilerOverhead } = this.props.profile;
     const { configuration } = meta;
 
+    const platformInformation = formatPlatform(meta);
+
     return (
       <ButtonWithPanel
         className="menuButtonsMetaInfoButton"
         buttonClassName="menuButtonsMetaInfoButtonButton"
-        label={_formatLabel(meta) || 'Profile information'}
+        label={_formatMetainfoString(meta) || 'Profile information'}
         panel={
           <ArrowPanel className="arrowPanelOpenMetaInfo">
             <h2 className="arrowPanelSubTitle">Profile Information</h2>
@@ -144,14 +150,8 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
             <div className="arrowPanelSection">
               {meta.product ? (
                 <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Name:</span>
-                  {meta.product}
-                </div>
-              ) : null}
-              {meta.misc ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Version:</span>
-                  {_formatVersionNumber(meta.misc)}
+                  <span className="metaInfoLabel">Name and version:</span>
+                  {formatProductAndVersion(meta)}
                 </div>
               ) : null}
               {meta.updateChannel ? (
@@ -194,16 +194,10 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
             </div>
             <h2 className="arrowPanelSubTitle">Platform</h2>
             <div className="arrowPanelSection">
-              {meta.platform ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Platform:</span>
-                  {meta.platform}
-                </div>
-              ) : null}
-              {meta.oscpu ? (
+              {platformInformation ? (
                 <div className="metaInfoRow">
                   <span className="metaInfoLabel">OS:</span>
-                  {meta.oscpu}
+                  {platformInformation}
                 </div>
               ) : null}
               {meta.abi ? (
@@ -270,27 +264,8 @@ function _formatDate(timestamp: number): string {
   return timestampDate;
 }
 
-function _formatVersionNumber(version?: string): string | null {
-  const regex = /[0-9]+.+[0-9]/gi;
-
-  if (version) {
-    const match = version.match(regex);
-    if (match) {
-      return match.toString();
-    }
-  }
-  return null;
-}
-
-function _formatLabel(meta: ProfileMeta): string {
-  const product = meta.product || '';
-  const version = _formatVersionNumber(meta.misc) || '';
-  let os;
-  // To displaying Android Version instead of Linux for Android developers.
-  if (meta.platform !== undefined && meta.platform.match(/android/i)) {
-    os = meta.platform;
-  } else {
-    os = meta.oscpu || '';
-  }
-  return product + (version ? ` (${version})` : '') + (os ? ` ${os}` : '');
+function _formatMetainfoString(meta: ProfileMeta) {
+  const productAndVersion = formatProductAndVersion(meta);
+  const os = formatPlatform(meta);
+  return productAndVersion + (os ? ` – ${os}` : '');
 }

--- a/src/components/shared/WindowTitle.js
+++ b/src/components/shared/WindowTitle.js
@@ -9,8 +9,12 @@ import explicitConnect from '../../utils/connect';
 
 import { getProfileName, getDataSource } from '../../selectors/url-state';
 import { getProfile } from '../../selectors/profile';
+import {
+  formatProductAndVersion,
+  formatPlatform,
+} from '../../profile-logic/profile-metainfo';
 
-import type { Profile, ProfileMeta } from 'firefox-profiler/types';
+import type { Profile } from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
 type StateProps = {|
@@ -21,6 +25,8 @@ type StateProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 
+const SEPARATOR = ' – ';
+
 class WindowTitle extends PureComponent<Props> {
   // This component updates window title in the form of:
   // profile name - version - platform - date time - data source - 'Firefox profiler'
@@ -30,17 +36,18 @@ class WindowTitle extends PureComponent<Props> {
     let title = '';
 
     if (profileName) {
-      title = title.concat(profileName, ' - ');
+      title += profileName + SEPARATOR;
     }
-    title = title.concat(_formatVersion(meta), ' - ');
-    if (meta.oscpu) {
-      title = title.concat(_formatPlatform(meta), ' - ');
+    title += formatProductAndVersion(meta) + SEPARATOR;
+    const os = formatPlatform(meta);
+    if (os) {
+      title += os + SEPARATOR;
     }
-    title = title.concat(_formatDateTime(meta.startTime));
+    title += _formatDateTime(meta.startTime);
     if (dataSource === 'public') {
-      title = title.concat(' (', dataSource, ')');
+      title += ` (${dataSource})`;
     }
-    title = title.concat(' - ', 'Firefox profiler');
+    title += SEPARATOR + 'Firefox profiler';
     document.title = title;
   }
 
@@ -55,39 +62,6 @@ class WindowTitle extends PureComponent<Props> {
   render() {
     return null;
   }
-}
-
-function _formatVersionNumber(version?: string): string | null {
-  const regex = /[0-9]+.+[0-9]/gi;
-
-  if (version) {
-    const match = version.match(regex);
-    if (match) {
-      return match.toString();
-    }
-  }
-
-  return null;
-}
-
-function _formatVersion(meta: ProfileMeta): string {
-  const product = meta.product || '';
-  const version = _formatVersionNumber(meta.misc) || '';
-  const versionLabel = product + ' ' + version + ' ';
-
-  return versionLabel;
-}
-
-function _formatPlatform(meta: ProfileMeta): string {
-  let os;
-  // To display Android Version instead of Linux for Android developers.
-  if (meta.platform !== undefined && meta.platform.match(/android/i)) {
-    os = meta.platform;
-  } else {
-    os = meta.oscpu || '';
-  }
-
-  return os;
 }
 
 function _formatDateTime(timestamp: number): string {

--- a/src/profile-logic/profile-metainfo.js
+++ b/src/profile-logic/profile-metainfo.js
@@ -10,7 +10,7 @@
 // The function uses a permissive regexp to support more use cases (like having
 // the version directly without the prefix `rv:`). Also we remove the `.0` at
 // the end of the version if present because this gives no added value.
-export function formatVersionNumber(version?: string): string {
+function formatVersionNumber(version?: string): string {
   if (version) {
     const regex = /[\d.]+$/; // Matches any group of number and dots at the end of the string.
     const match = regex.exec(version);
@@ -42,6 +42,10 @@ export function formatProductAndVersion(meta: {
   return product + (version ? ' ' + version : '');
 }
 
+// This function will extract a nice string out of the meta information. This is
+// very inconsistent depending on the OS so we have very different code for each
+// of them. We may need to tweak this further when we'll deal with importers
+// too.
 export function formatPlatform(meta: {
   +platform?: string,
   +oscpu?: string,

--- a/src/profile-logic/profile-metainfo.js
+++ b/src/profile-logic/profile-metainfo.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// This extracts the version number out of the 'misc' value we have in the
+// profile.
+// The 'misc' value looks like `rv:<version>`, we want to return the version.
+// The function uses a permissive regexp to support more use cases (like having
+// the version directly without the prefix `rv:`). Also we remove the `.0` at
+// the end of the version if present because this gives no added value.
+export function formatVersionNumber(version?: string): string {
+  if (version) {
+    const regex = /[\d.]+$/; // Matches any group of number and dots at the end of the string.
+    const match = regex.exec(version);
+    if (match) {
+      return match[0];
+    }
+  }
+  return '';
+}
+
+// This removes the ending `.0` in version strings, if present.
+function removeUselessEndZeroInVersion(version: string): string {
+  if (version.endsWith('.0')) {
+    // Remove useless `.0` at the end of Firefox versions.
+    return version.slice(0, -2);
+  }
+  return version;
+}
+
+// This returns a string to identify the product and its version out of the meta
+// information, eg `Firefox 77` of `Firefox Preview 78`.
+export function formatProductAndVersion(meta: {
+  +product: string,
+  +misc?: string,
+}): string {
+  const product = meta.product || '';
+  const version = removeUselessEndZeroInVersion(formatVersionNumber(meta.misc));
+
+  return product + (version ? ' ' + version : '');
+}
+
+export function formatPlatform(meta: {
+  +platform?: string,
+  +oscpu?: string,
+  +toolkit?: string,
+}): string {
+  switch (meta.toolkit) {
+    case 'android':
+      // Typically `platform` contains 'Android <version>'.
+      // `oscpu` contains the same thing as a normal Linux so this isn't
+      // interesting in this case.
+      return meta.platform
+        ? removeUselessEndZeroInVersion(meta.platform)
+        : 'Android';
+    case 'cocoa':
+      // Typically `oscpu` contains 'Intel Mac OS X <version>'.
+      // We're doing the replacement in 2 steps just in case we get `macOS`
+      // already in the string in the future.
+      return meta.oscpu
+        ? meta.oscpu.replace(/^Intel /, '').replace(/^Mac OS X/, 'macOS')
+        : 'macOS';
+    case 'windows': {
+      // Typically `oscpu` contains 'Windows NT 10.0; Win64; x64'
+      // This oddly looking regexp removes everything after (and including) the
+      // first semicolon.
+      return meta.oscpu
+        ? removeUselessEndZeroInVersion(
+            meta.oscpu.replace(/;.*$/, '').replace(/ NT/, '')
+          )
+        : 'Windows';
+    }
+    case 'gtk':
+      // Typically `oscpu` contains 'Linux x86_64'.
+      // We slice instead of always returning Linux for other Unixes. But we
+      // haven't really tried them.
+      return meta.oscpu
+        ? meta.oscpu.slice(0, meta.oscpu.indexOf(' '))
+        : 'Linux';
+    default:
+      return meta.oscpu || '';
+  }
+}

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -298,7 +298,7 @@ describe('<MenuButtonsMetaInfo>', function() {
     };
 
     const { container, getByValue } = setup(profile);
-    const metaInfoButton = getByValue('Firefox (48.0) Intel Mac OS X 10.11');
+    const metaInfoButton = getByValue('Firefox 48 – macOS 10.11');
     fireEvent.click(metaInfoButton);
     jest.runAllTimers();
 
@@ -318,7 +318,7 @@ describe('<MenuButtonsMetaInfo>', function() {
 
     const { getByValue, container } = setup(profile);
 
-    const metaInfoButton = getByValue('Firefox (48.0) Intel Mac OS X 10.11');
+    const metaInfoButton = getByValue('Firefox 48 – macOS 10.11');
     fireEvent.click(metaInfoButton);
     jest.runAllTimers();
 

--- a/src/test/components/WindowTitle.test.js
+++ b/src/test/components/WindowTitle.test.js
@@ -28,14 +28,18 @@ describe('WindowTitle', () => {
     );
 
     expect(document.title).toBe(
-      'Firefox - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+      'Firefox – 1/1/1970, 12:00:00 AM UTC – Firefox profiler'
     );
   });
 
   it('shows platform details in the window title if it is available', () => {
     const profile = getEmptyProfile();
     profile.threads.push(getEmptyThread());
-    profile.meta.oscpu = 'Intel Mac OS X 10.14';
+    Object.assign(profile.meta, {
+      oscpu: 'Intel Mac OS X 10.14',
+      platform: 'Macintosh',
+      toolkit: 'cocoa',
+    });
     const store = storeWithProfile(profile);
     render(
       <Provider store={store}>
@@ -44,14 +48,18 @@ describe('WindowTitle', () => {
     );
 
     expect(document.title).toBe(
-      'Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+      'Firefox – macOS 10.14 – 1/1/1970, 12:00:00 AM UTC – Firefox profiler'
     );
   });
 
   it('shows profile name in the window title if it is available', () => {
     const profile = getEmptyProfile();
     profile.threads.push(getEmptyThread());
-    profile.meta.oscpu = 'Intel Mac OS X 10.14';
+    Object.assign(profile.meta, {
+      oscpu: 'Intel Mac OS X 10.14',
+      platform: 'Macintosh',
+      toolkit: 'cocoa',
+    });
     const store = storeWithProfile(profile);
     store.dispatch(changeProfileName('good profile'));
     render(
@@ -61,12 +69,12 @@ describe('WindowTitle', () => {
     );
 
     expect(document.title).toBe(
-      'good profile - Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+      'good profile – Firefox – macOS 10.14 – 1/1/1970, 12:00:00 AM UTC – Firefox profiler'
     );
 
     store.dispatch(changeProfileName('awesome profile'));
     expect(document.title).toBe(
-      'awesome profile - Firefox - Intel Mac OS X 10.14 - 1/1/1970, 12:00:00 AM UTC - Firefox profiler'
+      'awesome profile – Firefox – macOS 10.14 – 1/1/1970, 12:00:00 AM UTC – Firefox profiler'
     );
   });
 });

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -10,7 +10,7 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
     <input
       class="buttonWithPanelButton menuButtonsMetaInfoButtonButton"
       type="button"
-      value="Firefox (48.0) Intel Mac OS X 10.11"
+      value="Firefox 48 – macOS 10.11"
     />
   </div>
   <div
@@ -171,19 +171,9 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
             <span
               class="metaInfoLabel"
             >
-              Name:
+              Name and version:
             </span>
-            Firefox
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Version:
-            </span>
-            48.0
+            Firefox 48
           </div>
           <div
             class="metaInfoRow"
@@ -258,19 +248,9 @@ exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
             <span
               class="metaInfoLabel"
             >
-              Platform:
-            </span>
-            Macintosh
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
               OS:
             </span>
-            Intel Mac OS X 10.11
+            macOS 10.11
           </div>
           <div
             class="metaInfoRow"
@@ -426,7 +406,7 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
     <input
       class="buttonWithPanelButton menuButtonsMetaInfoButtonButton"
       type="button"
-      value="Firefox (48.0) Intel Mac OS X 10.11"
+      value="Firefox 48 – macOS 10.11"
     />
   </div>
   <div
@@ -517,19 +497,9 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
             <span
               class="metaInfoLabel"
             >
-              Name:
+              Name and version:
             </span>
-            Firefox
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Version:
-            </span>
-            48.0
+            Firefox 48
           </div>
           <div
             class="metaInfoRow"
@@ -604,19 +574,9 @@ exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app
             <span
               class="metaInfoLabel"
             >
-              Platform:
-            </span>
-            Macintosh
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
               OS:
             </span>
-            Intel Mac OS X 10.11
+            macOS 10.11
           </div>
           <div
             class="metaInfoRow"

--- a/src/test/unit/profile-metainfo.test.js
+++ b/src/test/unit/profile-metainfo.test.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import {
+  formatProductAndVersion,
+  formatPlatform,
+} from 'firefox-profiler/profile-logic/profile-metainfo';
+
+import { getEmptyProfile } from '../../profile-logic/data-structures';
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+describe('profile-metainfo', () => {
+  function setup(metaOverride) {
+    const profile = getEmptyProfile();
+    Object.assign(profile.meta, metaOverride);
+    return profile;
+  }
+  describe('formatProductAndVersion', () => {
+    it('can format Firefox releases', () => {
+      const profile = setup({
+        product: 'Firefox',
+        misc: 'rv:61.0',
+      });
+
+      expect(formatProductAndVersion(profile.meta)).toBe('Firefox 61');
+    });
+
+    it('can format Firefox ESR releases', () => {
+      const profile = setup({
+        product: 'Firefox',
+        misc: 'rv:61.15',
+      });
+
+      expect(formatProductAndVersion(profile.meta)).toBe('Firefox 61.15');
+    });
+
+    it('can format Firefox chemspill versions', () => {
+      const profile = setup({
+        product: 'Firefox',
+        misc: 'rv:61.0.5',
+      });
+
+      expect(formatProductAndVersion(profile.meta)).toBe('Firefox 61.0.5');
+    });
+
+    it('can format Fenix versions', () => {
+      const profile = setup({
+        product: 'Firefox Preview',
+        misc: 'rv:77.0',
+      });
+      expect(formatProductAndVersion(profile.meta)).toBe('Firefox Preview 77');
+    });
+  });
+
+  describe('formatPlatform', () => {
+    it('can format MacOS information', () => {
+      const profile = setup({
+        oscpu: 'Intel Mac OS X 10.14',
+        platform: 'Macintosh',
+        toolkit: 'cocoa',
+      });
+      expect(formatPlatform(profile.meta)).toBe('macOS 10.14');
+    });
+
+    it('can format Windows information', () => {
+      const profile = setup({
+        oscpu: 'Windows NT 10.0; Win64; x64',
+        platform: 'Windows',
+        toolkit: 'windows',
+      });
+      expect(formatPlatform(profile.meta)).toBe('Windows 10');
+    });
+
+    it('can format Linux information', () => {
+      const profile = setup({
+        oscpu: 'Linux x86_64',
+        platform: 'X11',
+        toolkit: 'gtk',
+      });
+      expect(formatPlatform(profile.meta)).toBe('Linux');
+    });
+
+    it('can format Android information', () => {
+      const profile = setup({
+        oscpu: 'Linux armv7l',
+        platform: 'Android 7.0',
+        toolkit: 'android',
+      });
+      expect(formatPlatform(profile.meta)).toBe('Android 7');
+    });
+  });
+});

--- a/src/test/unit/profile-metainfo.test.js
+++ b/src/test/unit/profile-metainfo.test.js
@@ -10,12 +10,6 @@ import {
 
 import { getEmptyProfile } from '../../profile-logic/data-structures';
 
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-// @flow
-
 describe('profile-metainfo', () => {
   function setup(metaOverride) {
     const profile = getEmptyProfile();

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -674,7 +674,7 @@ export type ProfileMeta = {|
   // The current platform, as taken from the user agent string.
   // See https://searchfox.org/mozilla-central/rev/819cd31a93fd50b7167979607371878c4d6f18e8/netwerk/protocol/http/nsHttpHandler.cpp#992
   platform?:
-    | 'Android'
+    | 'Android' // It usually has the version embedded in the string
     | 'Windows'
     | 'Macintosh'
     // X11 is used for historic reasons, but this value means that it is a Unix platform.


### PR DESCRIPTION
I'll be using these new functions when displaying the information about saved profiles.

Deploy previews:
* windows: [deployed](https://profiler.firefox.com/public/19c6c045616a3b85f8ad75906ca9c84819f18065/calltree/?globalTrackOrder=7-8-0-1-2-3-4-5-6&hiddenGlobalTracks=7-8-0-1-2-3-4-6&hiddenLocalTracksByPid=25532-0-1~32116-1&localTrackOrderByPid=9952-1-2-0~27888-0~25412-0~33820-0~12540-0~25532-0-1~32116-2-0-1~&range=1.4712_2.4635&thread=6&v=4) / [preview](https://deploy-preview-2617--perf-html.netlify.app/public/19c6c045616a3b85f8ad75906ca9c84819f18065/calltree/?globalTrackOrder=7-8-0-1-2-3-4-5-6&hiddenGlobalTracks=7-8-0-1-2-3-4-6&hiddenLocalTracksByPid=25532-0-1~32116-1&localTrackOrderByPid=9952-1-2-0~27888-0~25412-0~33820-0~12540-0~25532-0-1~32116-2-0-1~&range=1.4712_2.4635&thread=6&v=4)
* linux: [deployed](https://profiler.firefox.com/public/2b38186f16b0ab99e3c691b2b04869543b40e504/flame-graph/?globalTrackOrder=0-1&localTrackOrderByPid=4176-1-2-0~6176-0-1~&thread=2&v=4) / [preview](https://deploy-preview-2617--perf-html.netlify.app/public/2b38186f16b0ab99e3c691b2b04869543b40e504/flame-graph/?globalTrackOrder=0-1&localTrackOrderByPid=4176-1-2-0~6176-0-1~&thread=2&v=4)
* mac: [deployed](https://profiler.firefox.com/public/1c77f550d099ab67995681cf835ae589dd88e714/calltree/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=58998-0~&search=%20const&thread=0&v=4) / [preview](https://deploy-preview-2617--perf-html.netlify.app/public/1c77f550d099ab67995681cf835ae589dd88e714/calltree/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=58998-0~&search=%20const&thread=0&v=4)
* Fennec: [deployed](https://profiler.firefox.com/public/7d90e10269fd7e04d2266ef7794270048232e6b1/calltree/?globalTrackOrder=0&localTrackOrderByPid=21342-2-0-1~&thread=0&v=3) / [preview](https://deploy-preview-2617--perf-html.netlify.app/public/7d90e10269fd7e04d2266ef7794270048232e6b1/calltree/?globalTrackOrder=0&localTrackOrderByPid=21342-2-0-1~&thread=0&v=3)
* Fenix: [deployed](https://profiler.firefox.com/public/f6be20bf40b6807d64a146f91a370fe309e96ebf/calltree/?globalTrackOrder=0-1-2&hiddenGlobalTracks=2&hiddenLocalTracksByPid=12212-0~11901-0&localTrackOrderByPid=11854-2-3-0-1~12212-0~11901-1-0~&thread=0&v=4) / [preview](https://deploy-preview-2617--perf-html.netlify.app/public/f6be20bf40b6807d64a146f91a370fe309e96ebf/calltree/?globalTrackOrder=0-1-2&hiddenGlobalTracks=2&hiddenLocalTracksByPid=12212-0~11901-0&localTrackOrderByPid=11854-2-3-0-1~12212-0~11901-1-0~&thread=0&v=4)

Look at both the profile info summary, and also inside the summary itself.