### PR TITLE
Allow more zooming in marker chart and other adjustments to ranges

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1238,7 +1238,7 @@ export function updatePreviewSelection(
 export function commitRange(start: number, end: number): Action {
   if (end === start) {
     // Ensure that the duration of the range is non-zero.
-    end = end + 0.0001;
+    end = end + 0.000001; // Adds 1ns
   }
   return {
     type: 'COMMIT_RANGE',

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -31,7 +31,6 @@ import type {
   MarkerIndex,
   MarkerTimingAndBuckets,
   Milliseconds,
-  UnitIntervalOfProfileRange,
   StartEndRange,
   PreviewSelection,
 } from 'firefox-profiler/types';
@@ -62,17 +61,6 @@ type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class MarkerChart extends React.PureComponent<Props> {
   _viewport: HTMLDivElement | null = null;
-  /**
-   * Determine the maximum zoom of the viewport.
-   */
-  getMaximumZoom(): UnitIntervalOfProfileRange {
-    const {
-      timeRange: { start, end },
-      interval,
-    } = this.props;
-    return interval / (end - start);
-  }
-
   _shouldDisplayTooltips = () => this.props.rightClickedMarkerIndex === null;
 
   _takeViewportRef = (viewport: HTMLDivElement | null) => {
@@ -130,7 +118,7 @@ class MarkerChart extends React.PureComponent<Props> {
                 previewSelection,
                 maxViewportHeight,
                 viewportNeedsUpdate,
-                maximumZoom: this.getMaximumZoom(),
+                maximumZoom: 0, // In the marker chart, we can zoom in as much as we want.
                 marginLeft: TIMELINE_MARGIN_LEFT,
                 marginRight: TIMELINE_MARGIN_RIGHT,
                 containerRef: this._takeViewportRef,

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -68,6 +68,9 @@ class MarkerChart extends React.PureComponent<Props> {
       timeRange: { start, end },
     } = this.props;
 
+    // This is set to a very small value, that represents 1ns. We can't set it
+    // to zero unless we revamp how ranges are handled in the app to prevent
+    // less-than-1ns ranges, otherwise we can get stuck at a "0" zoom.
     const ONE_NS = 1e-6;
     return ONE_NS / (end - start);
   }

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -164,8 +164,8 @@ export function stringifyCommittedRanges(
 export function getFormattedTimeLength(length: number): string {
   return formatTimestamp(
     length,
-    /*significantdigits*/ 3,
-    /*maxFractionalDigits*/ 3
+    /*significantdigits*/ 2,
+    /*maxFractionalDigits*/ 2
   );
 }
 

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+import { formatTimestamp } from 'firefox-profiler/utils/format-numbers';
 import type { StartEndRange } from 'firefox-profiler/types';
 
 /**
@@ -161,13 +162,11 @@ export function stringifyCommittedRanges(
 }
 
 export function getFormattedTimeLength(length: number): string {
-  if (length >= 10000) {
-    return `${(length / 1000).toFixed(0)} sec`;
-  }
-  if (length >= 1000) {
-    return `${(length / 1000).toFixed(1)} sec`;
-  }
-  return `${length.toFixed(0)} ms`;
+  return formatTimestamp(
+    length,
+    /*significantdigits*/ 3,
+    /*maxFractionalDigits*/ 3
+  );
 }
 
 export function getCommittedRangeLabels(

--- a/src/test/components/FilterNavigatorBar.test.js
+++ b/src/test/components/FilterNavigatorBar.test.js
@@ -71,7 +71,7 @@ describe('app/ProfileFilterNavigator', () => {
         hasSelection: true,
         isModifying: false,
         selectionStart: 10,
-        selectionEnd: 20,
+        selectionEnd: 10.1,
       })
     );
     expect(container.firstChild).toMatchSnapshot();

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -37,12 +37,12 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] 
   <li
     class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem filterNavigatorBarTransition-enter filterNavigatorBarTransition-enter-active"
     data-index="1"
-    title="40 ms"
+    title="40ms"
   >
     <span
       class="filterNavigatorBarItemContent"
     >
-      40 ms
+      40ms
     </span>
   </li>
 </ol>
@@ -67,22 +67,22 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] 
   <li
     class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem filterNavigatorBarTransition-enter filterNavigatorBarTransition-enter-active"
     data-index="1"
-    title="40 ms"
+    title="40ms"
   >
     <span
       class="filterNavigatorBarItemContent"
     >
-      40 ms
+      40ms
     </span>
   </li>
   <li
     class="filterNavigatorBarItem filterNavigatorBarLeafItem filterNavigatorBarUncommittedItem filterNavigatorBarUncommittedTransition-enter filterNavigatorBarUncommittedTransition-enter-active"
-    title="10 ms"
+    title="100μs"
   >
     <span
       class="filterNavigatorBarItemContent"
     >
-      10 ms
+      100μs
     </span>
   </li>
 </ol>
@@ -105,7 +105,7 @@ exports[`app/ProfileFilterNavigator renders the site hostname as its first eleme
       />
       developer.mozilla.org
        (
-      51 ms
+      51ms
       )
     </span>
   </li>


### PR DESCRIPTION
Please look at individual commits, I labelized the ones that can be skipped as they are from other PRs.

![image](https://user-images.githubusercontent.com/454175/86456949-3641ac00-bd23-11ea-9f1b-5b0d13f345a8.png)

This patch should be fairly simple, and works well with #2627, that's why I included it here.

[deploy preview with the new ranges from #2627](https://deploy-preview-2625--perf-html.netlify.app/public/19c6c045616a3b85f8ad75906ca9c84819f18065/marker-chart/?globalTrackOrder=7-8-0-1-2-3-4-5-6&hiddenGlobalTracks=7-8-0-1-2-3-4-6&hiddenLocalTracksByPid=25532-0-1~32116-1&localTrackOrderByPid=9952-1-2-0~27888-0~25412-0~33820-0~12540-0~25532-0-1~32116-2-0-1~&range=7177m181~7249534u7232~7253471u245~7253524u12~7253524881n482&thread=6&v=5)

Fixes #2623 