### PR TITLE
 Support smaller ranges in the URL 

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -776,8 +776,11 @@ const _upgraders = {
     // We changed how the ranges are serialized to the URLs. Before it was the
     // pair of start/end in seconds unit with 4 digits, now this is a pair of
     // start/duration, where start and duration are both integers expressed with
-    // a specific unit: for example 10000000u500 is a range from 10000000 microseconds
-    // (that is 10s) to 10s + 500 µs.
+    // a specific unit.
+    // For example we'll convert from 1.2345_2.3456 (that is: a range starting
+    // at 1.2345s and ending at 2.3456s) to 1234m1112 (a range starting at
+    // 1234ms and ending after 1112ms). You notice that the range is slightly
+    // bigger, because this accounts for the loss of precision.
     if (!query.range) {
       return;
     }
@@ -785,6 +788,7 @@ const _upgraders = {
     query.range = query.range
       .split('~')
       .map(committedRange => {
+        // This regexp captures two (positive or negative) numbers, separated by a `_`.
         const m = committedRange.match(/^(-?[0-9.]+)_(-?[0-9.]+)$/);
         if (!m) {
           console.error(

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -787,13 +787,23 @@ const _upgraders = {
       .map(committedRange => {
         const m = committedRange.match(/^(-?[0-9.]+)_(-?[0-9.]+)$/);
         if (!m) {
+          console.error(
+            `The range "${committedRange}" couldn't be parsed, ignoring.`
+          );
           return null;
         }
         const start = Number(m[1]) * 1000;
         const end = Number(m[2]) * 1000;
+        if (isNaN(start) || isNaN(end)) {
+          console.error(
+            `The range "${committedRange}" couldn't be parsed, ignoring.`
+          );
+          return null;
+        }
+
         return stringifyStartEnd({ start, end });
       })
-      .filter(committedRange => committedRange)
+      .filter(Boolean)
       .join('~');
   },
 };

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -12,8 +12,10 @@ import type { StartEndRange } from 'firefox-profiler/types';
  */
 
 /**
- * Parse URL encoded committed ranges with the form: "start-end~start-end", where
- * `start` and `end` are positive or negative float numbers.
+ * Parse URL encoded committed ranges with the form:
+ * "<start><unit><duration>~<start><unit><duration>", where `start` and
+ * `duration` are both integer numbers expressed with the specified unit.
+ * `start` can be negative.
  */
 export function parseCommittedRanges(
   stringValue: string = ''
@@ -21,37 +23,115 @@ export function parseCommittedRanges(
   if (!stringValue) {
     return [];
   }
-  return stringValue.split('~').map(s => {
-    const m = s.match(/(-?[0-9.]+)_(-?[0-9.]+)/);
-    if (!m) {
-      return { start: 0, end: 1000 };
-    }
+  return (
+    stringValue
+      .split('~')
+      .map(s => {
+        // Strings look like: 12345m25, which means the start is at 12'345ms, and
+        // the duration is 25ms. All values are integer.
+        // For microseconds: 12345678u25: the start is at 12'345'678µs, and the
+        // duration is 25µs.
+        // For nanoseconds: 12345678901n25: the start is at 12'345'678'901ns, and the
+        // duration is 25ns.
+        const m = s.match(/^(-?[0-9]+)([mun])([0-9]+)$/);
+        if (!m) {
+          // Flow doesn't like that we return null, but that's OK
+          // because we filter it out in the last operation.
+          // $FlowExpectError
+          return null;
+        }
 
-    const m1 = Number(m[1]);
-    let m2 = Number(m[2]);
+        // Let's convert values to milliseconds.
+        const start = Number(m[1]);
+        const durationUnit = m[2];
+        const duration = Number(m[3]);
 
-    if (m2 === m1) {
-      // Ensure that the duration of the range is non-zero.
-      m2 = m2 + 0.0001;
+        let startInMs;
+        let endInMs;
+        switch (durationUnit) {
+          case 'm':
+            // values are in milliseconds.
+            startInMs = start;
+            endInMs = start + duration;
+            break;
+          case 'u':
+            // values are in microseconds.
+            startInMs = start / 1000;
+            endInMs = (start + duration) / 1000;
+            break;
+          case 'n':
+            // values are in nanoseconds.
+            startInMs = start / 1000000;
+            endInMs = (start + duration) / 1000000;
+            break;
+          default:
+            throw new Error(
+              `We couldn't recognize the unit ${durationUnit}, which can't happen because the regexp wouldn't match.`
+            );
+        }
+
+        if (startInMs === endInMs) {
+          // Duration could be 0 at first, or float operations rounding errors could
+          // also produce this: make sure that we have a non-empty range.
+          endInMs += 0.0001;
+        }
+
+        return { start: startInMs, end: endInMs };
+      })
+      // Filter out possible null values coming from bad inputs.
+      .filter(value => value)
+  );
+}
+
+// This function returns a string representation of the pair { start, end } in
+// the form of the start + a duration: "<start><unit><duration>". We may lose
+// some precision, which is OK. We just need to take care that the resulting
+// range is close in length _and_ includes the requested range.
+// Note that start and end inputs are in milliseconds.
+export function stringifyStartEnd({ start, end }: StartEndRange): string {
+  // Let's work in integer nanoseconds for calculations, and with string
+  // manipulations, so that we avoid rounding errors due to floats.
+  const startInNs = Math.floor(start * 1000000);
+  const endInNs = Math.ceil(end * 1000000);
+
+  const durationInNs = endInNs - startInNs;
+  const strDurationInNs = String(durationInNs);
+
+  let result;
+  if (durationInNs > 9000000) {
+    // If the initial duration is more than 9ms, we'll output milliseconds
+    const startInMs = String(startInNs).slice(0, -6);
+    let durationInMs = strDurationInNs.slice(0, -6);
+    if (!strDurationInNs.endsWith('000000')) {
+      // We round up the duration, this is like Math.ceil on integer parts.
+      durationInMs = Number(durationInMs) + 1;
     }
-    return { start: m1 * 1000, end: m2 * 1000 };
-  });
+    result = `${startInMs}m${durationInMs}`;
+  } else if (durationInNs > 9000) {
+    // If the initial duration is more than 9µs, we'll output microseconds
+    const startInUs = String(startInNs).slice(0, -3);
+    let durationInUs = strDurationInNs.slice(0, -3);
+    if (!strDurationInNs.endsWith('000')) {
+      // We round up the duration, this is like Math.ceil on integer parts.
+      durationInUs = Number(durationInUs) + 1;
+    }
+    result = `${startInUs}u${durationInUs}`;
+  } else if (durationInNs === 0) {
+    result = `${startInNs}n1`;
+  } else {
+    result = `${startInNs}n${strDurationInNs}`;
+  }
+
+  return result;
 }
 
 /**
- * Stringify committed ranges into the following form: "start-end~start-end", where
- * `start` and `end` are float numbers.
+ * Stringify committed ranges into the following form: "start-end~start-end".
  */
 export function stringifyCommittedRanges(
   arrayValue: StartEndRange[] = []
 ): string {
-  return arrayValue
-    .map(({ start, end }) => {
-      const startStr = (start / 1000).toFixed(4);
-      const endStr = (end / 1000).toFixed(4);
-      return `${startStr}_${endStr}`;
-    })
-    .join('~');
+  return arrayValue.map(stringifyStartEnd).join('~');
 }
 
 export function getFormattedTimeLength(length: number): string {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -508,7 +508,11 @@ describe('committed ranges', function() {
       dispatch(commitRange(1514, 1514));
       const urlState = urlStateReducers.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
-      expect(queryString).toMatch(/range=1514000000n(?!0)/); // 1.514s + something non zero
+      // In the following regexp we want to especially assert that the duration
+      // isn't 0. That's why there's this negative look-ahead assertion.
+      // Therefore here we're matching a start at 1.514s, and a non-zero
+      // duration.
+      expect(queryString).toMatch(/range=1514000000n(?!0)/);
     });
 
     it('serializes when there are several ranges', () => {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -27,7 +27,7 @@ import {
   viewProfile,
   changeTimelineTrackOrganization,
 } from '../actions/receive-profile';
-import type { Profile } from 'firefox-profiler/types';
+import type { Profile, StartEndRange } from 'firefox-profiler/types';
 import getProfile from './fixtures/profiles/call-nodes';
 import queryString from 'query-string';
 import {
@@ -475,16 +475,16 @@ describe('showTabOnly', function() {
   });
 });
 
-describe('ranges', function() {
-  describe('are serializing correctly', () => {
-    it('when there is no range', () => {
+describe('committed ranges', function() {
+  describe('serialization', () => {
+    it('serializes when there is no range', () => {
       const { getState } = _getStoreWithURL();
       const urlState = urlStateReducers.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).not.toContain(`range=`);
     });
 
-    it('when there is 1 range', () => {
+    it('serializes when there is 1 range', () => {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1514.587845, 25300));
@@ -493,7 +493,7 @@ describe('ranges', function() {
       expect(queryString).toContain(`range=1514m23786`); // 1.514s + 23786ms
     });
 
-    it('when rounding down the start', () => {
+    it('serializes when rounding down the start', () => {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1510.58, 1519.59));
@@ -502,7 +502,7 @@ describe('ranges', function() {
       expect(queryString).toContain(`range=1510m10`); // 1.510s + 10ms
     });
 
-    it('when the duration is 0', () => {
+    it('serializes when the duration is 0', () => {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1514, 1514));
@@ -511,7 +511,7 @@ describe('ranges', function() {
       expect(queryString).toMatch(/range=1514000000n(?!0)/); // 1.514s + something non zero
     });
 
-    it('when there are several ranges', () => {
+    it('serializes when there are several ranges', () => {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1514.587845, 25300));
@@ -524,7 +524,7 @@ describe('ranges', function() {
       expect(queryString).toContain(`range=1514m23786~1800000u100`);
     });
 
-    it('when there is a small range', () => {
+    it('serializes when there is a small range', () => {
       const { getState, dispatch } = _getStoreWithURL();
       dispatch(commitRange(1000.08, 1000.09));
       const urlState = urlStateReducers.getUrlState(getState());
@@ -532,7 +532,7 @@ describe('ranges', function() {
       expect(queryString).toContain(`range=1000080u10`); // 1s and 80µs + 10µs
     });
 
-    it('when there is a very small range', () => {
+    it('serializes when there is a very small range', () => {
       const { getState, dispatch } = _getStoreWithURL();
       dispatch(commitRange(1000.00008, 1000.0001));
       const urlState = urlStateReducers.getUrlState(getState());
@@ -541,13 +541,13 @@ describe('ranges', function() {
     });
   });
 
-  describe('are deserializing correctly', () => {
-    it('when there is no range', () => {
+  describe('parsing', () => {
+    it('deserializes when there is no range', () => {
       const { getState } = _getStoreWithURL();
       expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([]);
     });
 
-    it('when there is 1 range', () => {
+    it('deserializes when there is 1 range', () => {
       const { getState } = _getStoreWithURL({
         search: '?range=1600m5000',
       });
@@ -556,7 +556,7 @@ describe('ranges', function() {
       ]);
     });
 
-    it('when there are several ranges', () => {
+    it('deserializes when there are several ranges', () => {
       const { getState } = _getStoreWithURL({
         search: '?range=1600m5000~2245m24',
       });
@@ -566,7 +566,7 @@ describe('ranges', function() {
       ]);
     });
 
-    it('when there is a small range', () => {
+    it('deserializes when there is a small range', () => {
       const { getState } = _getStoreWithURL({
         search: '?range=1678900u100',
       });
@@ -575,7 +575,7 @@ describe('ranges', function() {
       ]);
     });
 
-    it('when there is a very small range', () => {
+    it('deserializes when there is a very small range', () => {
       const { getState } = _getStoreWithURL({
         search: '?range=1678123900n100',
       });
@@ -585,6 +585,69 @@ describe('ranges', function() {
       );
       expect(committedRange.start).toBeCloseTo(1678.1239);
       expect(committedRange.end).toBeCloseTo(1678.124);
+    });
+
+    it('is permissive with invalid input', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { getState } = _getStoreWithURL({
+        search: '?range=invalid~2245m24',
+      });
+      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+        { start: 2245, end: 2269 },
+      ]);
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('serializing and parsing', () => {
+    function getQueryStringForRanges(
+      ranges: $ReadOnlyArray<StartEndRange>
+    ): string {
+      const { getState, dispatch } = _getStoreWithURL();
+
+      ranges.forEach(({ start, end }) => dispatch(commitRange(start, end)));
+
+      const urlState = urlStateReducers.getUrlState(getState());
+      const queryString = getQueryStringFromUrlState(urlState);
+      return queryString;
+    }
+
+    function setup(ranges: $ReadOnlyArray<StartEndRange>) {
+      const queryString = getQueryStringForRanges(ranges);
+
+      return _getStoreWithURL({
+        search: '?' + queryString,
+      });
+    }
+
+    it('can parse the serialized values', () => {
+      const { getState } = setup([
+        { start: 1514.587845, end: 25300 },
+        { start: 1800, end: 1800.1 },
+        { start: 1800.00008, end: 1800.0001 },
+      ]);
+
+      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+        { start: 1514, end: 25300 },
+        { start: 1800, end: 1800.1 },
+        { start: 1800.00008, end: 1800.0001 },
+      ]);
+    });
+
+    it('will round values near the threshold', () => {
+      const { getState } = setup([{ start: 50000, end: 50009.9 }]);
+
+      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+        { start: 50000, end: 50010 },
+      ]);
+    });
+
+    it('supports negative start values', () => {
+      const { getState } = setup([{ start: -1000, end: 1000 }]);
+
+      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+        { start: -1000, end: 1000 },
+      ]);
     });
   });
 });
@@ -953,6 +1016,22 @@ describe('url upgrading', function() {
         { start: 245, end: 18470 },
         { start: 1451, end: 1453 },
       ]);
+    });
+
+    it('is permissive with invalid input', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { getState } = _getStoreWithURL({
+        // The first range has several dots, the second range is fully invalid,
+        // only the 3rd range is valid.
+        search: '?range=0.24.5_18.470~invalid~1.451_1.453',
+        v: 4,
+      });
+
+      const committedRanges = urlStateReducers.getAllCommittedRanges(
+        getState()
+      );
+      expect(committedRanges).toEqual([{ start: 1451, end: 1453 }]);
+      expect(console.error).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Please only look at the last commit, as the first one is #2613.

This changes how we serialize the ranges to the URL. Previously it was `<start>_<end>`, where values were in seconds, and rounded with 4 digits. Now it is `<start><unit><duration>`, where `start`and `duration` are expressed either in milliseconds (unit 'm'), microseconds (unit 'u') or nanoseconds (unit 'n'), and are always integers.

I first did an implementation keeping the value in seconds, because this is what is displayed in the UI. But there were all sorts of rounding errors making the URL a bit messy, so I decided to switch to integers.

This change supports the PR #2625, but we could already select very small ranges with the mouse in the timeline. Saving an URL like the first one isn't possible on profiler.firefox.com currently.

[deploy preview with new ranges](https://deploy-preview-2627--perf-html.netlify.app/public/19c6c045616a3b85f8ad75906ca9c84819f18065/marker-chart/?globalTrackOrder=7-8-0-1-2-3-4-5-6&hiddenGlobalTracks=7-8-0-1-2-3-4-6&hiddenLocalTracksByPid=25532-0-1~32116-1&implementation=js&localTrackOrderByPid=9952-1-2-0~27888-0~25412-0~33820-0~12540-0~25532-0-1~32116-2-0-1~&range=7177m181~7249534u7232~7253471u245~7253524u12&thread=6&v=5)
[deploy preview with old ranges](https://deploy-preview-2627--perf-html.netlify.app/public/96b0f5d1275c1327f6a95b065c919da611638116/marker-chart/?globalTrackOrder=9-0-1-2-3-4-5-6-7-8&hiddenGlobalTracks=1-2-3-4-5-6-7&localTrackOrderByPid=3823-1-2-0~18964-0~6000-0~11889-0~6120-0~6350-0~15276-0~6043-0~19082-0~&range=0.1127_0.1241~0.1161_0.1191~0.1168_0.1178&thread=9&v=4) (to test upgrading) / [compare with the deployed version](https://profiler.firefox.com/public/96b0f5d1275c1327f6a95b065c919da611638116/marker-chart/?globalTrackOrder=9-0-1-2-3-4-5-6-7-8&hiddenGlobalTracks=1-2-3-4-5-6-7&localTrackOrderByPid=3823-1-2-0~18964-0~6000-0~11889-0~6120-0~6350-0~15276-0~6043-0~19082-0~&range=0.1127_0.1241~0.1161_0.1191~0.1168_0.1178&thread=9&v=4)