### PR TITLE
Use appropriate time unit in markers chart

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -812,7 +812,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
               {/* we don't know the duration if the marker is incomplete */}
               {!marker.incomplete
                 ? marker.dur
-                  ? formatTimestamp(marker.dur)
+                  ? formatTimestamp(marker.dur, 3, 1)
                   : '—'
                 : 'unknown duration'}
             </div>

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -13,6 +13,7 @@ import {
   formatSI,
   formatMicroseconds,
   formatMilliseconds,
+  formatTimestamp,
   formatValueTotal,
 } from '../../utils/format-numbers';
 import explicitConnect from '../../utils/connect';
@@ -811,7 +812,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
               {/* we don't know the duration if the marker is incomplete */}
               {!marker.incomplete
                 ? marker.dur
-                  ? formatMilliseconds(marker.dur)
+                  ? formatTimestamp(marker.dur)
                   : '—'
                 : 'unknown duration'}
             </div>

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -107,7 +107,7 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         <div
           class="tooltipTiming"
         >
-          6.0ms
+          6ms
         </div>
         <div
           class="tooltipTitle"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -873,7 +873,7 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
         <div
           class="tooltipTiming"
         >
-          4.0ms
+          4ms
         </div>
         <div
           class="tooltipTitle"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -13,7 +13,7 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
       <div
         class="tooltipTiming"
       >
-        1.0ms
+        1ms
       </div>
       <div
         class="tooltipTitle"
@@ -130,7 +130,7 @@ exports[`TooltipMarker renders properly network markers where content type is bl
       <div
         class="tooltipTiming"
       >
-        1,433ms
+        1.433s
       </div>
       <div
         class="tooltipTitle"
@@ -305,7 +305,7 @@ exports[`TooltipMarker renders properly network markers where content type is mi
       <div
         class="tooltipTiming"
       >
-        1,433ms
+        1.433s
       </div>
       <div
         class="tooltipTitle"
@@ -505,7 +505,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
       <div
         class="tooltipTiming"
       >
-        1,433ms
+        1.433s
       </div>
       <div
         class="tooltipTitle"
@@ -769,7 +769,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
       <div
         class="tooltipTiming"
       >
-        1,433ms
+        1.433s
       </div>
       <div
         class="tooltipTitle"
@@ -959,7 +959,7 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
       <div
         class="tooltipTiming"
       >
-        1,434ms
+        1.434s
       </div>
       <div
         class="tooltipTitle"
@@ -1217,7 +1217,7 @@ exports[`TooltipMarker renders properly redirect network markers 1`] = `
       <div
         class="tooltipTiming"
       >
-        18,726ms
+        18.726s
       </div>
       <div
         class="tooltipTitle"
@@ -1413,7 +1413,7 @@ exports[`TooltipMarker renders tooltips for various markers: ConstructRootFrame-
       <div
         class="tooltipTiming"
       >
-        0.80ms
+        800.00μs
       </div>
       <div
         class="tooltipTitle"
@@ -1460,7 +1460,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
       <div
         class="tooltipTiming"
       >
-        0.80ms
+        800.00μs
       </div>
       <div
         class="tooltipTitle"
@@ -1514,7 +1514,7 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
       <div
         class="tooltipTiming"
       >
-        1.0ms
+        1ms
       </div>
       <div
         class="tooltipTitle"
@@ -1783,7 +1783,7 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
       <div
         class="tooltipTiming"
       >
-        1.0ms
+        1ms
       </div>
       <div
         class="tooltipTitle"
@@ -2833,7 +2833,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
       <div
         class="tooltipTiming"
       >
-        0.50ms
+        500μs
       </div>
       <div
         class="tooltipTitle"
@@ -3070,7 +3070,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
       <div
         class="tooltipTiming"
       >
-        0.50ms
+        500μs
       </div>
       <div
         class="tooltipTitle"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -130,7 +130,7 @@ exports[`TooltipMarker renders properly network markers where content type is bl
       <div
         class="tooltipTiming"
       >
-        1.433s
+        1.4s
       </div>
       <div
         class="tooltipTitle"
@@ -305,7 +305,7 @@ exports[`TooltipMarker renders properly network markers where content type is mi
       <div
         class="tooltipTiming"
       >
-        1.433s
+        1.4s
       </div>
       <div
         class="tooltipTitle"
@@ -505,7 +505,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
       <div
         class="tooltipTiming"
       >
-        1.433s
+        1.4s
       </div>
       <div
         class="tooltipTitle"
@@ -769,7 +769,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
       <div
         class="tooltipTiming"
       >
-        1.433s
+        1.4s
       </div>
       <div
         class="tooltipTitle"
@@ -959,7 +959,7 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
       <div
         class="tooltipTiming"
       >
-        1.434s
+        1.4s
       </div>
       <div
         class="tooltipTitle"
@@ -1217,7 +1217,7 @@ exports[`TooltipMarker renders properly redirect network markers 1`] = `
       <div
         class="tooltipTiming"
       >
-        18.726s
+        18.7s
       </div>
       <div
         class="tooltipTitle"
@@ -1413,7 +1413,7 @@ exports[`TooltipMarker renders tooltips for various markers: ConstructRootFrame-
       <div
         class="tooltipTiming"
       >
-        800.00μs
+        800μs
       </div>
       <div
         class="tooltipTitle"
@@ -1460,7 +1460,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
       <div
         class="tooltipTiming"
       >
-        800.00μs
+        800μs
       </div>
       <div
         class="tooltipTitle"


### PR DESCRIPTION
Use new formatTimestamp function and update snapshots.
Fixes #2619 