### PR TITLE
Dispatch a fatal error when the URL upgrading fails

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -14,6 +14,7 @@ import { getActiveTabGlobalTracks } from '../selectors/profile';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';
+import { fatalError } from './errors';
 
 import type {
   Profile,
@@ -105,6 +106,14 @@ export function setupInitialUrlState(
     try {
       urlState = stateFromLocation(location, profile);
     } catch (e) {
+      if (e.name === 'UrlUpgradeError') {
+        // The error is an URL upgrade error, let's fire a fatal error.
+        // If there's a service worker update, the class `ServiceWorkerManager`
+        // will automatically reload in case the new code knows how to handle
+        // this URL version.
+        dispatch(fatalError(e));
+        return;
+      }
       // The location could not be parsed, show a 404 instead.
       console.error(e);
       dispatch(show404(location.pathname + location.search));

--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+//
+import type { Action } from 'firefox-profiler/types';
+
+export function fatalError(error: Error): Action {
+  return {
+    type: 'FATAL_ERROR',
+    error,
+  };
+}

--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-//
+
+// This file contains actions related to error handling.
+
 import type { Action } from 'firefox-profiler/types';
 
 export function fatalError(error: Error): Action {

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -50,6 +50,7 @@ import {
 } from '../profile-logic/tracks';
 import { computeActiveTabTracks } from '../profile-logic/active-tab';
 import { setDataSource } from './profile-view';
+import { fatalError } from './errors';
 import { GOOGLE_STORAGE_BUCKET } from 'firefox-profiler/app-logic/constants';
 
 import type {
@@ -893,13 +894,6 @@ export async function doSymbolicateProfile(
   await Promise.all(completionPromises);
 
   dispatch(doneSymbolicating());
-}
-
-export function fatalError(error: Error): Action {
-  return {
-    type: 'FATAL_ERROR',
-    error,
-  };
 }
 
 export function retrieveProfileFromAddon(): ThunkAction<Promise<void>> {

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -592,6 +592,10 @@ function parseLocalTrackOrder(rawText: string): Map<Pid, TrackIndex[]> {
   return localTrackOrderByPid;
 }
 
+class UrlUpgradeError extends Error {
+  name = 'UrlUpgradeError';
+}
+
 type ProcessedLocation = {|
   pathname: string,
   hash: string,
@@ -613,7 +617,7 @@ export function upgradeLocationToCurrentVersion(
   }
 
   if (urlVersion > CURRENT_URL_VERSION) {
-    throw new Error(
+    throw new UrlUpgradeError(
       `Unable to parse a url of version ${urlVersion}, most likely profiler.firefox.com needs to be refreshed. ` +
         `The most recent version understood by this version of profiler.firefox.com is version ${CURRENT_URL_VERSION}.\n` +
         'You can try refreshing this page in case profiler.firefox.com has updated in the meantime.'

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -595,7 +595,8 @@ function parseLocalTrackOrder(rawText: string): Map<Pid, TrackIndex[]> {
 // This Error class is used in other codepaths to detect the specific error of
 // URL upgrading and react differently when this happens, compared to other
 // errors.
-class UrlUpgradeError extends Error {
+// Exported for tests.
+export class UrlUpgradeError extends Error {
   name = 'UrlUpgradeError';
 }
 

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -592,6 +592,9 @@ function parseLocalTrackOrder(rawText: string): Map<Pid, TrackIndex[]> {
   return localTrackOrderByPid;
 }
 
+// This Error class is used in other codepaths to detect the specific error of
+// URL upgrading and react differently when this happens, compared to other
+// errors.
 class UrlUpgradeError extends Error {
   name = 'UrlUpgradeError';
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -61,6 +61,8 @@ const urlSetupPhase: Reducer<UrlSetupPhase> = (
   switch (action.type) {
     case 'START_FETCHING_PROFILES':
       return 'loading-profile';
+    case 'ROUTE_NOT_FOUND':
+    case 'FATAL_ERROR':
     case 'URL_SETUP_DONE':
       return 'done';
     default:

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -32,10 +32,11 @@ import { render } from 'react-testing-library';
 import { AppViewRouter } from '../../components/app/AppViewRouter';
 import { ProfileLoader } from '../../components/app/ProfileLoader';
 import { updateUrlState, changeProfilesToCompare } from '../../actions/app';
+import { fatalError } from '../../actions/errors';
+
 // Because this module is mocked but we want the real actions in the test, we
 // use `jest.requireActual` here.
 const {
-  fatalError,
   temporaryError,
   viewProfile,
   waitingForProfileFromAddon,

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -12,11 +12,12 @@ import ServiceWorkerManager from '../../components/app/ServiceWorkerManager';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import { updateUrlState } from '../../actions/app';
 import {
-  fatalError,
   viewProfile,
   startSymbolicating,
   doneSymbolicating,
 } from '../../actions/receive-profile';
+import { fatalError } from '../../actions/errors';
+
 import { ensureExists } from '../../utils/flow';
 
 import { blankStore } from '../fixtures/stores';

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -19,6 +19,7 @@ import {
   urlFromState,
   CURRENT_URL_VERSION,
   upgradeLocationToCurrentVersion,
+  UrlUpgradeError,
 } from '../app-logic/url-handling';
 import { blankStore } from './fixtures/stores';
 import {
@@ -474,11 +475,11 @@ describe('showTabOnly', function() {
 });
 
 describe('url upgrading', function() {
-  /**
-   * Originally transform stacks were called call tree filters. This test asserts that
-   * the upgrade process works correctly.
-   */
   describe('version 1: legacy URL serialized call tree filters', function() {
+    /**
+     * Originally transform stacks were called call tree filters. This test asserts that
+     * the upgrade process works correctly.
+     */
     it('can upgrade callTreeFilters to transforms', function() {
       const { getState } = _getStoreWithURL({
         search:
@@ -802,7 +803,7 @@ describe('url upgrading', function() {
   });
 
   // More general checks
-  it("won't run if the version is specified", function() {
+  it("won't run if the current version is specified", function() {
     const { getState } = _getStoreWithURL({
       pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/markers/',
       v: CURRENT_URL_VERSION, // This is the default, but still using it here to make it explicit
@@ -818,6 +819,14 @@ describe('url upgrading', function() {
     expect(urlStateReducers.getSelectedTab(getState())).not.toBe(
       'marker-table'
     );
+  });
+
+  it('throws a specific error if a more recent version is specified', function() {
+    expect(() =>
+      _getStoreWithURL({
+        v: CURRENT_URL_VERSION + 1,
+      })
+    ).toThrow(UrlUpgradeError);
   });
 });
 


### PR DESCRIPTION
While working on #2627 where I upgrade the URL version, I've seen that when the URL can't be upgraded because the requested version isn't supported by the current code, nothing was shown to the user, only an explanation was displayed in the console.

This code tries to fix that in 2 ways:
1. Both FATAL_ERROR  and ROUTE_NOT_FOUND will set the url setup as "done", which will remove the loading page.
2. Using FATAL_ERROR for the initial setup makes that the error is properly shown in the UI, and also some code in ServiceWorkerManager will try to recover if there's an update. This is the code in `ServiceWorkerManager` that reloads the page when there's a service worker update: https://github.com/firefox-devtools/profiler/blob/6a61d5547faef8111af708d652bdb0bc925efa44/src/components/app/ServiceWorkerManager.js#L219-L226

I didn't use FATAL_ERROR everywhere URL ugprading can happen, because I believe ROUTE_NOT_ROUND can be valid in some of the cases too. I especially wanted to fix the initial load.

See the difference between:
* [this deploy preview](https://deploy-preview-2630--perf-html.netlify.app/public/2b38186f16b0ab99e3c691b2b04869543b40e504/flame-graph/?globalTrackOrder=0-1&localTrackOrderByPid=4176-1-2-0~6176-0-1~&thread=2&v=5)
* [same thing on production](https://profiler.firefox.com/public/2b38186f16b0ab99e3c691b2b04869543b40e504/flame-graph/?globalTrackOrder=0-1&localTrackOrderByPid=4176-1-2-0~6176-0-1~&thread=2&v=5)

I'm not comfortable with existing tests that could exercise this, do you have some idea?

@canova I'm requesting a review from you because I think you worked with URL handling lately. Tell me if you're not comfortable with that and I can ask Greg instead :-)