### PR TITLE
Refactor sanitize tests to use a setup function

### DIFF
--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -18,172 +18,127 @@ import {
 import { toggleCheckedSharingOptions } from '../../actions/publish';
 
 describe('sanitizePII', function() {
-  function getRemoveProfileInformation(
-    customFields: Object
-  ): RemoveProfileInformation {
-    return {
+  function setup(
+    piiConfig,
+    originalProfile = processProfile(createGeckoProfile())
+  ): * {
+    const PIIToRemove: RemoveProfileInformation = {
       shouldRemoveThreads: new Set(),
       shouldRemoveThreadsWithScreenshots: new Set(),
       shouldRemoveUrls: false,
       shouldFilterToCommittedRange: null,
       shouldRemoveExtensions: false,
       shouldRemovePreferenceValues: false,
-      ...customFields,
+      ...piiConfig,
+    };
+    const sanitizedProfile = sanitizePII(originalProfile, PIIToRemove).profile;
+
+    return {
+      sanitizedProfile,
+      originalProfile,
     };
   }
+
   it('should sanitize the threads if they are provided', function() {
-    const profile = processProfile(createGeckoProfile());
-    // There are 3 threads in the beginning.
-    expect(profile.threads.length).toEqual(3);
-    const PIIToRemove = getRemoveProfileInformation({
+    const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreads: new Set([0, 2]),
     });
-
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
+    // There are 3 threads in the beginning.
+    expect(originalProfile.threads.length).toEqual(3);
     // First and last threads are removed and now there are only 1 thread.
     expect(sanitizedProfile.threads.length).toEqual(1);
   });
 
   it('should sanitize counters if its thread is deleted', function() {
-    const profile = processProfile(createGeckoProfile());
-    const { counters } = profile;
-    expect(counters).not.toEqual(undefined);
-    if (counters === undefined) {
-      return;
-    }
-    expect(counters.length).toEqual(1);
-    // Assuming that the mainThreadIndex of the counter is 0.
-    // If that assertion fails, put back the counter where you moved from.
-    expect(counters[0].mainThreadIndex).toEqual(0);
-
-    const PIIToRemove = getRemoveProfileInformation({
+    const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreads: new Set([0]),
     });
-    const { counters: sanitizedCounters } = sanitizePII(
-      profile,
-      PIIToRemove
-    ).profile;
-    // The counter was for the first thread, it should be deleted now.
-    expect(sanitizedCounters).not.toEqual(undefined);
-    if (sanitizedCounters !== undefined) {
-      expect(sanitizedCounters.length).toEqual(0);
+
+    if (ensureExists(originalProfile.counters)[0].mainThreadIndex !== 0) {
+      throw new Error(
+        'This test assumes the the counters mainThreadIndex is 0'
+      );
     }
+
+    expect(ensureExists(originalProfile.counters).length).toEqual(1);
+    // The counter was for the first thread, it should be deleted now.
+    expect(ensureExists(sanitizedProfile.counters).length).toEqual(0);
   });
 
   it('should not sanitize counters if its thread is not deleted', function() {
-    const profile = processProfile(createGeckoProfile());
-    const { counters } = profile;
-    expect(counters).not.toEqual(undefined);
-    if (counters === undefined) {
-      return;
-    }
-    expect(counters.length).toEqual(1);
-    // Assuming that the mainThreadIndex of the counter is 0.
-    // If that assertion fails, put back the counter where you moved from.
-    expect(counters[0].mainThreadIndex).toEqual(0);
-
-    const PIIToRemove = getRemoveProfileInformation({
+    const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreads: new Set([1, 2]),
     });
-    const { counters: sanitizedCounters } = sanitizePII(
-      profile,
-      PIIToRemove
-    ).profile;
-    // The counter was for the first thread, it should not be deleted now.
-    expect(sanitizedCounters).not.toEqual(undefined);
-    if (sanitizedCounters !== undefined) {
-      expect(sanitizedCounters.length).toEqual(1);
+
+    if (ensureExists(originalProfile.counters)[0].mainThreadIndex !== 0) {
+      throw new Error(
+        'This test assumes the the counters mainThreadIndex is 0'
+      );
     }
+
+    expect(ensureExists(originalProfile.counters).length).toEqual(1);
+    // The counter was for the first thread, it should not be deleted now.
+    expect(ensureExists(sanitizedProfile.counters).length).toEqual(1);
   });
 
   it('should sanitize profiler overhead if its thread is deleted', function() {
-    const profile = processProfile(createGeckoProfile());
-    const { profilerOverhead } = profile;
-    expect(profilerOverhead).not.toEqual(undefined);
-    if (profilerOverhead === undefined) {
-      return;
-    }
-    expect(profilerOverhead.length).toEqual(1);
-    // Assuming that the mainThreadIndex of the profiler overhead is 0.
-    // If that assertion fails, put back the profiler overhead where you moved from.
-    expect(profilerOverhead[0].mainThreadIndex).toEqual(0);
-
-    const PIIToRemove = getRemoveProfileInformation({
+    const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreads: new Set([0]),
     });
-    const { profilerOverhead: sanitizedProfilerOverhead } = sanitizePII(
-      profile,
-      PIIToRemove
-    ).profile;
+    expect(ensureExists(originalProfile.profilerOverhead).length).toEqual(1);
     // The counter was for the first thread, it should be deleted now.
-    expect(sanitizedProfilerOverhead).not.toEqual(undefined);
-    if (sanitizedProfilerOverhead !== undefined) {
-      expect(sanitizedProfilerOverhead.length).toEqual(0);
-    }
+    expect(ensureExists(sanitizedProfile.profilerOverhead).length).toEqual(0);
   });
 
   it('should not sanitize profiler overhead if its thread is not deleted', function() {
-    const profile = processProfile(createGeckoProfile());
-    const { profilerOverhead } = profile;
-    expect(profilerOverhead).not.toEqual(undefined);
-    if (profilerOverhead === undefined) {
-      return;
-    }
-    expect(profilerOverhead.length).toEqual(1);
-    // Assuming that the mainThreadIndex of the counter is 0.
-    // If that assertion fails, put back the counter where you moved from.
-    expect(profilerOverhead[0].mainThreadIndex).toEqual(0);
-
-    const PIIToRemove = getRemoveProfileInformation({
+    const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreads: new Set([1, 2]),
     });
-    const { profilerOverhead: sanitizedProfilerOverhead } = sanitizePII(
-      profile,
-      PIIToRemove
-    ).profile;
-    // The counter was for the first thread, it should not be deleted now.
-    expect(sanitizedProfilerOverhead).not.toEqual(undefined);
-    if (sanitizedProfilerOverhead !== undefined) {
-      expect(sanitizedProfilerOverhead.length).toEqual(1);
-    }
+
+    expect(ensureExists(originalProfile.profilerOverhead).length).toEqual(1);
+    expect(ensureExists(sanitizedProfile.profilerOverhead).length).toEqual(1);
   });
 
   it('should sanitize the screenshots if they are provided', function() {
-    const profile = processProfile(createGeckoProfile());
-    // Checking if we have screenshot markers just in case.
-    let screenshotMarkerFound = false;
-    for (const thread of profile.threads) {
-      for (const data of thread.markers.data) {
-        if (data && data.type === 'CompositorScreenshot') {
-          screenshotMarkerFound = true;
-          break;
-        }
-      }
-    }
-    expect(screenshotMarkerFound).toEqual(true);
-
-    const PIIToRemove = getRemoveProfileInformation({
+    const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreadsWithScreenshots: new Set([0, 1, 2]),
     });
 
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
-    screenshotMarkerFound = false;
-    for (const thread of sanitizedProfile.threads) {
-      for (const data of thread.markers.data) {
-        if (data && data.type === 'CompositorScreenshot') {
-          screenshotMarkerFound = true;
-          break;
+    // Checking if we have screenshot markers just in case.
+    {
+      let screenshotMarkerFound = false;
+      for (const thread of originalProfile.threads) {
+        for (const data of thread.markers.data) {
+          if (data && data.type === 'CompositorScreenshot') {
+            screenshotMarkerFound = true;
+            break;
+          }
         }
       }
+      expect(screenshotMarkerFound).toEqual(true);
     }
-    expect(screenshotMarkerFound).toEqual(false);
+
+    {
+      let screenshotMarkerFound = false;
+      for (const thread of sanitizedProfile.threads) {
+        for (const data of thread.markers.data) {
+          if (data && data.type === 'CompositorScreenshot') {
+            screenshotMarkerFound = true;
+            break;
+          }
+        }
+      }
+      expect(screenshotMarkerFound).toEqual(false);
+    }
   });
 
   it('should sanitize the pages information', function() {
-    const profile = processProfile(createGeckoProfile());
+    const { originalProfile, sanitizedProfile } = setup({
+      shouldRemoveUrls: true,
+    });
 
     // Checking to make sure that we have a http{,s} URI in the pages array.
-    const pageUrl = ensureExists(profile.pages).find(page =>
+    const pageUrl = ensureExists(originalProfile.pages).find(page =>
       page.url.includes('http')
     );
     if (pageUrl === undefined) {
@@ -192,21 +147,18 @@ describe('sanitizePII', function() {
       );
     }
 
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveUrls: true,
-    });
-
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
     for (const page of ensureExists(sanitizedProfile.pages)) {
       expect(page.url.includes(pageUrl.url)).toBe(false);
     }
   });
 
   it('should keep the chrome URIs inside the pages array', function() {
-    const profile = processProfile(createGeckoProfile());
+    const { originalProfile, sanitizedProfile } = setup({
+      shouldRemoveUrls: true,
+    });
 
     // Checking to make sure that we have a chrome URI in the pages array.
-    const chromePageUrl = ensureExists(profile.pages).find(page =>
+    const chromePageUrl = ensureExists(originalProfile.pages).find(page =>
       page.url.includes('chrome://')
     );
     if (chromePageUrl === undefined) {
@@ -214,11 +166,6 @@ describe('sanitizePII', function() {
         "There should be a chrome URL in the 'pages' array in this profile."
       );
     }
-
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveUrls: true,
-    });
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
 
     let includesChromeUrl = false;
     for (const page of ensureExists(sanitizedProfile.pages)) {
@@ -231,12 +178,10 @@ describe('sanitizePII', function() {
   });
 
   it('should sanitize all the URLs inside network markers', function() {
-    const profile = processProfile(createGeckoProfile());
-    const PIIToRemove = getRemoveProfileInformation({
+    const { sanitizedProfile } = setup({
       shouldRemoveUrls: true,
     });
 
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
     for (const thread of sanitizedProfile.threads) {
       const stringArray = thread.stringTable.serializeToArray();
       for (let i = 0; i < thread.markers.length; i++) {
@@ -259,23 +204,24 @@ describe('sanitizePII', function() {
     const unsanitizedNameField =
       'onBeforeRequest https://profiler.firefox.com/ by extension';
     const sanitizedNameField = 'onBeforeRequest https://<URL> by extension';
-    const profile = getProfileWithMarkers([
-      [
-        'Extension Suspend',
-        1,
-        {
-          type: 'Text',
-          startTime: 0,
-          endTime: 1,
-          name: unsanitizedNameField,
-        },
-      ],
-    ]);
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveUrls: true,
-    });
+    const { sanitizedProfile } = setup(
+      {
+        shouldRemoveUrls: true,
+      },
+      getProfileWithMarkers([
+        [
+          'Extension Suspend',
+          1,
+          {
+            type: 'Text',
+            startTime: 0,
+            endTime: 1,
+            name: unsanitizedNameField,
+          },
+        ],
+      ])
+    );
 
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
     const marker = sanitizedProfile.threads[0].markers.data[0];
     if (!marker || marker.type !== 'Text') {
       throw new Error('Expected a Text marker');
@@ -284,12 +230,10 @@ describe('sanitizePII', function() {
   });
 
   it('should sanitize all the URLs inside string table', function() {
-    const profile = processProfile(createGeckoProfile());
-    const PIIToRemove = getRemoveProfileInformation({
+    const { sanitizedProfile } = setup({
       shouldRemoveUrls: true,
     });
 
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
     for (const thread of sanitizedProfile.threads) {
       const stringArray = thread.stringTable.serializeToArray();
       for (const string of stringArray) {
@@ -302,25 +246,18 @@ describe('sanitizePII', function() {
   });
 
   it('should sanitize extensions', function() {
-    const profile = processProfile(createGeckoProfile());
-    expect(profile.meta.extensions).not.toEqual(undefined);
-    // For flow
-    if (profile.meta.extensions !== undefined) {
-      const extensions = profile.meta.extensions;
+    const { originalProfile, sanitizedProfile } = setup({
+      shouldRemoveExtensions: true,
+    });
+    {
+      const extensions = ensureExists(originalProfile.meta.extensions);
       expect(extensions.length).toEqual(3);
       expect(extensions.id.length).toEqual(3);
       expect(extensions.name.length).toEqual(3);
       expect(extensions.baseURL.length).toEqual(3);
     }
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveExtensions: true,
-    });
-
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
-    expect(sanitizedProfile.meta.extensions).not.toEqual(undefined);
-    // For flow
-    if (sanitizedProfile.meta.extensions !== undefined) {
-      const extensions = sanitizedProfile.meta.extensions;
+    {
+      const extensions = ensureExists(sanitizedProfile.meta.extensions);
       expect(extensions.length).toEqual(0);
       expect(extensions.id.length).toEqual(0);
       expect(extensions.name.length).toEqual(0);
@@ -329,26 +266,27 @@ describe('sanitizePII', function() {
   });
 
   it('should not sanitize all the preference values inside preference read markers', function() {
-    const profile = getProfileWithMarkers([
-      [
-        'PreferenceRead',
-        1,
-        {
-          type: 'PreferenceRead',
-          startTime: 0,
-          endTime: 1,
-          prefAccessTime: 0,
-          prefName: 'preferenceName',
-          prefKind: 'preferenceKind',
-          prefType: 'preferenceType',
-          prefValue: 'preferenceValue',
-        },
-      ],
-    ]);
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemovePreferenceValues: false,
-    });
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
+    const { sanitizedProfile } = setup(
+      {
+        shouldRemovePreferenceValues: false,
+      },
+      getProfileWithMarkers([
+        [
+          'PreferenceRead',
+          1,
+          {
+            type: 'PreferenceRead',
+            startTime: 0,
+            endTime: 1,
+            prefAccessTime: 0,
+            prefName: 'preferenceName',
+            prefKind: 'preferenceKind',
+            prefType: 'preferenceType',
+            prefValue: 'preferenceValue',
+          },
+        ],
+      ])
+    );
 
     expect(sanitizedProfile.threads.length).toEqual(1);
 
@@ -366,26 +304,27 @@ describe('sanitizePII', function() {
   });
 
   it('should sanitize all the preference values inside preference read markers', function() {
-    const profile = getProfileWithMarkers([
-      [
-        'PreferenceRead',
-        1,
-        {
-          type: 'PreferenceRead',
-          startTime: 0,
-          endTime: 1,
-          prefAccessTime: 0,
-          prefName: 'preferenceName',
-          prefKind: 'preferenceKind',
-          prefType: 'preferenceType',
-          prefValue: 'preferenceValue',
-        },
-      ],
-    ]);
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemovePreferenceValues: true,
-    });
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
+    const { sanitizedProfile } = setup(
+      {
+        shouldRemovePreferenceValues: true,
+      },
+      getProfileWithMarkers([
+        [
+          'PreferenceRead',
+          1,
+          {
+            type: 'PreferenceRead',
+            startTime: 0,
+            endTime: 1,
+            prefAccessTime: 0,
+            prefName: 'preferenceName',
+            prefKind: 'preferenceKind',
+            prefType: 'preferenceType',
+            prefValue: 'preferenceValue',
+          },
+        ],
+      ])
+    );
 
     expect(sanitizedProfile.threads.length).toEqual(1);
 
@@ -403,12 +342,10 @@ describe('sanitizePII', function() {
   });
 
   it('should not push any null values to marker values by mistake while filtering', function() {
-    const profile = processProfile(createGeckoProfile());
-    const PIIToRemove = getRemoveProfileInformation({
+    const { sanitizedProfile } = setup({
       shouldRemoveThreadsWithScreenshots: new Set([0, 1, 2]),
     });
 
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
     for (const thread of sanitizedProfile.threads) {
       const markersTable = thread.markers;
       for (let i = 0; i < markersTable.length; i++) {
@@ -425,48 +362,49 @@ describe('sanitizePII', function() {
   it('should sanitize the FileIO marker paths', function() {
     const marker1File = 'permissions.sqlite-journal';
     const marker2File = 'CustomizableUI.jsm';
-    const profile = getProfileWithMarkers([
-      [
-        'FileIO',
-        2,
-        {
-          type: 'FileIO',
-          startTime: 1,
-          endTime: 2,
-          source: 'PoisonIOInterposer',
-          filename:
-            '/Users/username/Library/Application Support/Firefox/Profiles/profile-id.default/' +
-            marker1File,
-          operation: 'create/open',
-          cause: {
-            time: 1.0,
-            stack: 0,
+    const { sanitizedProfile } = setup(
+      {
+        shouldRemoveUrls: true,
+      },
+      getProfileWithMarkers([
+        [
+          'FileIO',
+          2,
+          {
+            type: 'FileIO',
+            startTime: 1,
+            endTime: 2,
+            source: 'PoisonIOInterposer',
+            filename:
+              '/Users/username/Library/Application Support/Firefox/Profiles/profile-id.default/' +
+              marker1File,
+            operation: 'create/open',
+            cause: {
+              time: 1.0,
+              stack: 0,
+            },
           },
-        },
-      ],
-      [
-        'FileIO',
-        4,
-        {
-          type: 'FileIO',
-          startTime: 3,
-          endTime: 4,
-          source: 'PoisonIOInterposer',
-          filename:
-            'C:\\Users\\username\\mozilla-central\\obj-mc-dbg\\dist\\bin\\browser\\modules\\' +
-            marker2File,
-          operation: 'create/open',
-          cause: {
-            time: 1.0,
-            stack: 0,
+        ],
+        [
+          'FileIO',
+          4,
+          {
+            type: 'FileIO',
+            startTime: 3,
+            endTime: 4,
+            source: 'PoisonIOInterposer',
+            filename:
+              'C:\\Users\\username\\mozilla-central\\obj-mc-dbg\\dist\\bin\\browser\\modules\\' +
+              marker2File,
+            operation: 'create/open',
+            cause: {
+              time: 1.0,
+              stack: 0,
+            },
           },
-        },
-      ],
-    ]);
-    const PIIToRemove = getRemoveProfileInformation({
-      shouldRemoveUrls: true,
-    });
-    const sanitizedProfile = sanitizePII(profile, PIIToRemove).profile;
+        ],
+      ])
+    );
     expect(sanitizedProfile.threads.length).toEqual(1);
     const thread = sanitizedProfile.threads[0];
     expect(thread.markers.length).toEqual(2);


### PR DESCRIPTION
This is a break out of #2626. I am going to modify the function signature of sanitized markers in #2626, and so I wanted to consolidate the usage of the function to make it much easier.