### PR TITLE
Implement a button in the profile viewer to delete a profile

### DIFF
--- a/res/css/photon/confirm-dialog.css
+++ b/res/css/photon/confirm-dialog.css
@@ -45,3 +45,7 @@
   display: flex;
   gap: 8px;
 }
+
+.confirmDialogButtons > .photon-button {
+  flex: auto;
+}

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -40,6 +40,7 @@ import type {
   Action,
   ThunkAction,
   UrlState,
+  UploadedProfileInformation,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 
@@ -293,5 +294,17 @@ export function enableEventDelayTracks(): ThunkAction<boolean> {
     });
 
     return true;
+  };
+}
+
+/**
+ * This caches the profile data in the local state for synchronous access.
+ */
+export function setCurrentProfileUploadedInformation(
+  uploadedProfileInformation: UploadedProfileInformation | null
+): Action {
+  return {
+    type: 'SET_CURRENT_PROFILE_UPLOADED_INFORMATION',
+    uploadedProfileInformation,
   };
 }

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -308,3 +308,9 @@ export function setCurrentProfileUploadedInformation(
     uploadedProfileInformation,
   };
 }
+
+export function profileRemotelyDeleted(): Action {
+  // Ideally we should store the current profile data in a local indexeddb, and
+  // set the URL to /local/<indexeddb-key>.
+  return { type: 'PROFILE_REMOTELY_DELETED' };
+}

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -272,9 +272,8 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
       // Because we want to store the published profile even when the upload
       // generation changed, we store the data here, before the state is fully
       // updated, and we'll have to predict the state inside this function.
-      // Note that this function is asynchronous, we don't await it on purpose.
       // We catch all errors in this function.
-      persistJustUploadedProfileInformationToDb(
+      await persistJustUploadedProfileInformationToDb(
         hash,
         hashOrToken === hash ? null : hashOrToken,
         sanitizedInformation,

--- a/src/app-logic/uploaded-profiles-db.js
+++ b/src/app-logic/uploaded-profiles-db.js
@@ -165,9 +165,15 @@ export async function listAllUploadedProfileInformationFromDb(): Promise<
  */
 export async function retrieveUploadedProfileInformationFromDb(
   profileToken: string
-): Promise<UploadedProfileInformation | void> {
+): Promise<UploadedProfileInformation | null> {
+  if (!profileToken) {
+    // If this is the empty string, let's skip the lookup.
+    return null;
+  }
+
   const db = await open();
-  return db.get(OBJECTSTORE_NAME, profileToken);
+  const result = await db.get(OBJECTSTORE_NAME, profileToken);
+  return result || null;
 }
 
 /**

--- a/src/components/app/CurrentProfileUploadedInformationLoader.js
+++ b/src/components/app/CurrentProfileUploadedInformationLoader.js
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// This component is responsible for caching the stored profile data in the
+// redux state.  This will control whether we can delete this profile.
+
+// Implementation note:
+// This is done as a separate component than where the deletion button is
+// rendered, so that the button doesn't flick, because the access to the stored
+// profile data is asynchronous. It also nicely splits the responsibilities.
+// Also this isn't in a thunk action to make it independent from any other
+// change. It only depends on the current hash being changed.
+
+import { PureComponent } from 'react';
+
+import { getHash } from 'firefox-profiler/selectors/url-state';
+import { setCurrentProfileUploadedInformation } from 'firefox-profiler/actions/app';
+
+import { retrieveUploadedProfileInformationFromDb } from 'firefox-profiler/app-logic/uploaded-profiles-db';
+import explicitConnect from 'firefox-profiler/utils/connect';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type StateProps = {|
+  +hash: string,
+|};
+
+type DispatchProps = {|
+  +setCurrentProfileUploadedInformation: typeof setCurrentProfileUploadedInformation,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+class CurrentProfileUploadedInformationLoaderImpl extends PureComponent<Props> {
+  async updateCurrentProfileInformationState() {
+    // In tests we don't always have the indexeddb object. To avoid that we have
+    // to add it to a lot of tests, let's bail out in this case.
+    if (process.env.NODE_ENV === 'test' && window.indexedDB === undefined) {
+      return;
+    }
+
+    const { hash, setCurrentProfileUploadedInformation } = this.props;
+    const uploadedProfileInformation = await retrieveUploadedProfileInformationFromDb(
+      hash
+    );
+
+    // The previous action is asynchronous, so let's make sure the current hash
+    // is still the one we retrieved the information for.
+    if (this.props.hash === hash) {
+      setCurrentProfileUploadedInformation(uploadedProfileInformation || null);
+    }
+  }
+
+  componentDidMount() {
+    this.updateCurrentProfileInformationState();
+  }
+
+  componentDidUpdate() {
+    this.updateCurrentProfileInformationState();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export const CurrentProfileUploadedInformationLoader = explicitConnect<
+  {||},
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: state => ({
+    hash: getHash(state),
+  }),
+  mapDispatchToProps: { setCurrentProfileUploadedInformation },
+  component: CurrentProfileUploadedInformationLoaderImpl,
+});

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -127,7 +127,6 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
 
     return (
       <>
-        <h2 className="metaInfoSubTitle">Profile Information</h2>
         <div className="metaInfoSection">
           {meta.startTime ? (
             <div className="metaInfoRow">

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -107,3 +107,40 @@
 .menuButtonsRevertToFullView::before {
   background-image: url(firefox-profiler-res/img/svg/maximize-dark-12.svg);
 }
+
+.profileInfoUploadedActions {
+  padding: 8px 0 8px 40px; /* The 40px padding leaves the room for the cloud image */
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  font-size: 13px;
+}
+
+.profileInfoUploadedLabel {
+  padding-right: 8px;
+  color: var(--grey-50);
+}
+
+.profileInfoUploadedDate {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.profileInfoUploadedDate::before {
+  position: absolute;
+  left: -40px;
+  display: block;
+  width: 32px;
+  height: 32px;
+  background: url(firefox-profiler-res/img/svg/cloud-dark-12.svg) no-repeat left /
+    32px;
+  content: '';
+  opacity: 0.5;
+}
+
+.profileInfoUploadedActionsButtons {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+  gap: 8px;
+}

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -32,7 +32,11 @@ import {
   ProfileDeleteSuccess,
 } from 'firefox-profiler/components/app/ProfileDeleteButton';
 import { revertToPrePublishedState } from 'firefox-profiler/actions/publish';
-import { dismissNewlyPublished } from 'firefox-profiler/actions/app';
+import {
+  dismissNewlyPublished,
+  profileRemotelyDeleted,
+} from 'firefox-profiler/actions/app';
+
 import {
   getAbortFunction,
   getUploadPhase,
@@ -74,6 +78,7 @@ type DispatchProps = {|
   +dismissNewlyPublished: typeof dismissNewlyPublished,
   +revertToPrePublishedState: typeof revertToPrePublishedState,
   +changeTimelineTrackOrganization: typeof changeTimelineTrackOrganization,
+  +profileRemotelyDeleted: typeof profileRemotelyDeleted,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -98,10 +103,10 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
       case 'from-addon':
       case 'unpublished':
       case 'from-file':
+      case 'local':
         return 'local';
       case 'none':
       case 'uploaded-recordings':
-      case 'local':
         throw new Error(`The datasource ${dataSource} shouldn't happen here.`);
       default:
         throw assertExhaustiveCheck(dataSource);
@@ -115,6 +120,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
   };
 
   _onProfileDeleted = () => {
+    this.props.profileRemotelyDeleted();
     this.setState({
       metaInfoPanelState: 'profile-deleted',
     });
@@ -367,6 +373,7 @@ export const MenuButtons = explicitConnect<OwnProps, StateProps, DispatchProps>(
       dismissNewlyPublished,
       revertToPrePublishedState,
       changeTimelineTrackOrganization,
+      profileRemotelyDeleted,
     },
     component: MenuButtonsImpl,
   }

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -211,6 +211,10 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
       }
 
       case 'profile-deleted':
+        // Note that <ProfileDeletePanel> can also render <ProfileDeleteSuccess>
+        // in some situations. However it's not suitable for this case, because
+        // we still have to pass jwtToken / profileToken, and we don't have
+        // these values anymore when we're in this state.
         return <ProfileDeleteSuccess />;
 
       default:

--- a/src/components/app/ProfileDeleteButton.js
+++ b/src/components/app/ProfileDeleteButton.js
@@ -114,7 +114,7 @@ type PanelState = {|
   +error: Error | null,
 |};
 
-class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
+export class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
   state = { error: null, status: 'idle' };
 
   onConfirmDeletion = async () => {
@@ -172,11 +172,7 @@ class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
     const { status } = this.state;
 
     if (status === 'deleted') {
-      return (
-        <p className="profileDeleteButtonSuccess">
-          Successfully deleted uploaded data.
-        </p>
-      );
+      return <ProfileDeleteSuccess />;
     }
 
     return (
@@ -206,4 +202,12 @@ class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
       </div>
     );
   }
+}
+
+export function ProfileDeleteSuccess(_props: {||}) {
+  return (
+    <p className="profileDeleteButtonSuccess">
+      Successfully deleted uploaded data.
+    </p>
+  );
 }

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -10,6 +10,7 @@ import explicitConnect from 'firefox-profiler/utils/connect';
 import { DetailsContainer } from './DetailsContainer';
 import { ProfileFilterNavigator } from './ProfileFilterNavigator';
 import { MenuButtons } from './MenuButtons';
+import { CurrentProfileUploadedInformationLoader } from './CurrentProfileUploadedInformationLoader';
 import { WindowTitle } from 'firefox-profiler/components/shared/WindowTitle';
 import { SymbolicationStatusOverlay } from './SymbolicationStatusOverlay';
 import { ProfileName } from './ProfileName';
@@ -141,6 +142,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
           <SymbolicationStatusOverlay />
           <BeforeUnloadManager />
           <DebugWarning />
+          <CurrentProfileUploadedInformationLoader />
         </div>
       </KeyboardShortcut>
     );

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -16,6 +16,7 @@ import type {
   ThreadsKey,
   ExperimentalFlags,
   CssPixels,
+  UploadedProfileInformation,
 } from 'firefox-profiler/types';
 
 const view: Reducer<AppViewState> = (
@@ -246,6 +247,27 @@ const eventDelayTracks: Reducer<boolean> = (state = false, action) => {
 };
 
 /**
+ * This keeps the information about the upload for the current profile, if any.
+ * This is retrieved from the IndexedDB for published profiles information in
+ * CurrentProfileUploadedInformationLoader.
+ * This will be null if the currently loaded profile doesn't come from the
+ * public store (for example if this comes from Firefox and hasn't been uploaded
+ * yet) or if this profile hasn't been uploaded by this user and we don't have
+ * its uploaded information in the IndexedDB.
+ */
+const currentProfileUploadedInformation: Reducer<UploadedProfileInformation | null> = (
+  state = null,
+  action
+) => {
+  switch (action.type) {
+    case 'SET_CURRENT_PROFILE_UPLOADED_INFORMATION':
+      return action.uploadedProfileInformation;
+    default:
+      return state;
+  }
+};
+
+/**
  * Experimental features that are mostly disabled by default. You need to enable
  * them from the DevTools console with `experimental.enable<feature-camel-case>()`,
  * e.g. `experimental.enableEventDelayTracks()`.
@@ -268,6 +290,7 @@ const appStateReducer: Reducer<AppState> = combineReducers({
   isDragAndDropDragging,
   isDragAndDropOverlayRegistered,
   experimental,
+  currentProfileUploadedInformation,
 });
 
 export default appStateReducer;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -46,6 +46,8 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
       return 'public';
     case 'TRIGGER_LOADING_FROM_URL':
       return 'from-url';
+    case 'PROFILE_REMOTELY_DELETED':
+      return 'unpublished';
     case 'SET_DATA_SOURCE':
       return action.dataSource;
     default:
@@ -58,6 +60,8 @@ const hash: Reducer<string> = (state = '', action) => {
     case 'PROFILE_PUBLISHED':
     case 'SANITIZED_PROFILE_PUBLISHED':
       return action.hash;
+    case 'PROFILE_REMOTELY_DELETED':
+      return '';
     default:
       return state;
   }

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -36,7 +36,6 @@ import {
   ACTIVE_TAB_TIMELINE_MARGIN_LEFT,
 } from '../app-logic/constants';
 
-import type { TabSlug } from '../app-logic/tabs-handling';
 import type {
   AppState,
   AppViewState,
@@ -45,7 +44,9 @@ import type {
   CssPixels,
   ThreadsKey,
   ExperimentalFlags,
+  UploadedProfileInformation,
 } from 'firefox-profiler/types';
+import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 
 /**
  * Simple selectors into the app state.
@@ -77,6 +78,9 @@ export const getIsDragAndDropDragging: Selector<boolean> = state =>
   getApp(state).isDragAndDropDragging;
 export const getIsDragAndDropOverlayRegistered: Selector<boolean> = state =>
   getApp(state).isDragAndDropOverlayRegistered;
+
+export const getCurrentProfileUploadedInformation: Selector<UploadedProfileInformation | null> = state =>
+  getApp(state).currentProfileUploadedInformation;
 
 /**
  * Height of screenshot track is different depending on the view.

--- a/src/test/components/CurrentProfileUploadedInformationLoader.test.js
+++ b/src/test/components/CurrentProfileUploadedInformationLoader.test.js
@@ -51,6 +51,12 @@ describe('app/CurrentProfileUploadedInformationLoader', () => {
 
   // eslint-disable-next-line jest/expect-expect
   it('bails out if there is no indexedDB object', async () => {
+    // In tests we don't always have the indexeddb object for simplicity.
+    // Because this component is used high in the component tree it may be
+    // inserted in tests that don't want to test this behavior. Therefore the
+    // component will bail out if the indexedDB object is missing. This test
+    // tests for this behavior.
+
     window.indexedDB = undefined;
     const { nextTick } = setup();
 

--- a/src/test/components/CurrentProfileUploadedInformationLoader.test.js
+++ b/src/test/components/CurrentProfileUploadedInformationLoader.test.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, waitFor } from '@testing-library/react';
+
+import { CurrentProfileUploadedInformationLoader } from 'firefox-profiler/components/app/CurrentProfileUploadedInformationLoader';
+import { getCurrentProfileUploadedInformation } from 'firefox-profiler/selectors/app';
+import { updateUrlState } from 'firefox-profiler/actions/app';
+
+import { persistUploadedProfileInformationToDb } from 'firefox-profiler/app-logic/uploaded-profiles-db';
+import { stateFromLocation } from 'firefox-profiler/app-logic/url-handling';
+
+import { blankStore } from 'firefox-profiler/test/fixtures/stores';
+
+import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
+autoMockIndexedDB();
+
+describe('app/CurrentProfileUploadedInformationLoader', () => {
+  function setup() {
+    const store = blankStore();
+    const renderResult = render(
+      <Provider store={store}>
+        <CurrentProfileUploadedInformationLoader />
+      </Provider>
+    );
+
+    function nextTick() {
+      return new Promise(resolve => setTimeout(resolve));
+    }
+
+    function navigateToHash(hash: string) {
+      const newUrlState = stateFromLocation({
+        pathname: `/public/${hash}/calltree`,
+        search: '',
+        hash: '',
+      });
+      store.dispatch(updateUrlState(newUrlState));
+    }
+
+    return {
+      ...renderResult,
+      ...store,
+      nextTick,
+      navigateToHash,
+    };
+  }
+
+  // eslint-disable-next-line jest/expect-expect
+  it('bails out if there is no indexedDB object', async () => {
+    window.indexedDB = undefined;
+    const { nextTick } = setup();
+
+    // All IndexedDB behavior is asynchronous, and errors themselves will be
+    // rejected promises that the test runner will catch. That's why we have to
+    // wait a bit to be sure that there's no error.
+    await nextTick();
+  });
+
+  it('populates the state if a known hash is loaded, resets it otherwise', async () => {
+    const uploadedProfileInformation = {
+      profileToken: 'MACOSX',
+      jwtToken: null,
+      publishedDate: new Date('5 Jul 2020 11:00'), // This is the future!
+      name: 'MacOS X profile',
+      preset: null,
+      originHostname: 'https://mozilla.org',
+      meta: {
+        product: 'Firefox',
+        platform: 'Macintosh',
+        toolkit: 'cocoa',
+        misc: 'rv:62.0',
+        oscpu: 'Intel Mac OS X 10.12',
+      },
+      urlPath: '/public/MACOSX/marker-chart/',
+      publishedRange: { start: 2000, end: 40000 },
+    };
+
+    await persistUploadedProfileInformationToDb(uploadedProfileInformation);
+
+    const { navigateToHash, getState } = setup();
+    navigateToHash('MACOSX');
+    await waitFor(() =>
+      expect(getCurrentProfileUploadedInformation(getState())).toEqual(
+        uploadedProfileInformation
+      )
+    );
+
+    // Then navigate to some unknown hash
+    navigateToHash('UNKNOWN_HASH');
+    await waitFor(() =>
+      expect(getCurrentProfileUploadedInformation(getState())).toBe(null)
+    );
+  });
+});

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -362,7 +362,7 @@ describe('ListOfPublishedProfiles', () => {
       fireFullClick(getConfirmDeleteButton());
       await findByText(/successfully/i);
       expect(await retrieveUploadedProfileInformationFromDb(profileToken)).toBe(
-        undefined
+        null
       );
 
       // Clicking elsewhere should make the successful message disappear.

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -4,7 +4,8 @@
 
 // @flow
 import * as React from 'react';
-import { MenuButtons } from '../../components/app/MenuButtons';
+import { MenuButtons } from 'firefox-profiler/components/app/MenuButtons';
+import { CurrentProfileUploadedInformationLoader } from 'firefox-profiler/components/app/CurrentProfileUploadedInformationLoader';
 import {
   render,
   fireEvent,
@@ -13,9 +14,14 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { storeWithProfile, blankStore } from '../fixtures/stores';
 import { TextEncoder } from 'util';
-import { stateFromLocation } from '../../app-logic/url-handling';
+
+import { stateFromLocation } from 'firefox-profiler/app-logic/url-handling';
+import { processGeckoProfile } from 'firefox-profiler/profile-logic/process-profile';
+import {
+  persistUploadedProfileInformationToDb,
+  retrieveUploadedProfileInformationFromDb,
+} from 'firefox-profiler/app-logic/uploaded-profiles-db';
 import { updateUrlState } from 'firefox-profiler/actions/app';
 import {
   changeTimelineTrackOrganization,
@@ -31,8 +37,8 @@ import {
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
-import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { fireFullClick } from '../fixtures/utils';
+import { storeWithProfile, blankStore } from '../fixtures/stores';
 
 import type { Profile } from 'firefox-profiler/types';
 
@@ -42,8 +48,11 @@ import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexedd
 autoMockIndexedDB();
 
 // We mock profile-store but we want the real error, so that we can simulate it.
-import { uploadBinaryProfileData } from '../../profile-logic/profile-store';
-jest.mock('../../profile-logic/profile-store');
+import {
+  uploadBinaryProfileData,
+  deleteProfileOnServer,
+} from 'firefox-profiler/profile-logic/profile-store';
+jest.mock('firefox-profiler/profile-logic/profile-store');
 const { UploadAbortedError } = jest.requireActual(
   '../../profile-logic/profile-store'
 );
@@ -108,7 +117,10 @@ describe('app/MenuButtons', function() {
 
     const renderResult = render(
       <Provider store={store}>
-        <MenuButtons />
+        <>
+          <CurrentProfileUploadedInformationLoader />
+          <MenuButtons />
+        </>
       </Provider>
     );
 
@@ -428,6 +440,137 @@ describe('app/MenuButtons', function() {
       } = await setupForMetaInfoPanel(profile);
       displayMetaInfoPanel();
       expect(getMetaInfoPanel()).toMatchSnapshot();
+    });
+
+    describe('deleting a profile', () => {
+      const FAKE_HASH = 'FAKE_HASH';
+      const FAKE_PROFILE_DATA = {
+        profileToken: FAKE_HASH,
+        jwtToken: null,
+        publishedDate: new Date('4 Jul 2020 13:00 GMT'),
+        name: 'PROFILE',
+        preset: null,
+        originHostname: 'https://mozilla.org',
+        meta: {
+          product: 'Firefox',
+          platform: 'Macintosh',
+          toolkit: 'cocoa',
+          misc: 'rv:62.0',
+          oscpu: 'Intel Mac OS X 10.12',
+        },
+        urlPath: '/public/MACOSX/marker-chart/',
+        publishedRange: { start: 2000, end: 40000 },
+      };
+
+      async function addUploadedProfileInformation(
+        uploadedProfileInformationOverrides
+      ) {
+        const uploadedProfileInformation = {
+          ...FAKE_PROFILE_DATA,
+          ...uploadedProfileInformationOverrides,
+        };
+        await persistUploadedProfileInformationToDb(uploadedProfileInformation);
+      }
+
+      async function setupForDeletion() {
+        const { profile } = createSimpleProfile();
+        const setupResult = await setupForMetaInfoPanel(profile);
+        const { navigateToHash, displayMetaInfoPanel } = setupResult;
+        navigateToHash(FAKE_HASH);
+        displayMetaInfoPanel();
+
+        return setupResult;
+      }
+
+      test('does not display the delete button if the profile is public but without uploaded data', async () => {
+        const { getMetaInfoPanel } = await setupForDeletion();
+        // We wait a bit using the "find" flavor of the queries because this is
+        // reached asynchronously.
+        await expect(screen.findByText('Uploaded:')).rejects.toThrow();
+        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+        expect(getMetaInfoPanel()).toMatchSnapshot();
+      });
+
+      test('displays the delete button if we have the uploaded data but no JWT token', async () => {
+        await addUploadedProfileInformation();
+        const { getMetaInfoPanel } = await setupForDeletion();
+        expect(await screen.findByText('Uploaded:')).toBeInTheDocument();
+        expect(screen.getByText('Delete')).toBeDisabled();
+        expect(getMetaInfoPanel()).toMatchSnapshot();
+      });
+
+      test('displays the delete button if we have the uploaded data and some JWT token', async () => {
+        await addUploadedProfileInformation({ jwtToken: 'FAKE_TOKEN' });
+        const { getMetaInfoPanel } = await setupForDeletion();
+        expect(await screen.findByText('Uploaded:')).toBeInTheDocument();
+        expect(screen.getByText('Delete')).toBeEnabled();
+        expect(getMetaInfoPanel()).toMatchSnapshot();
+      });
+
+      test('clicking on the button shows the confirmation', async () => {
+        await addUploadedProfileInformation({ jwtToken: 'FAKE_TOKEN' });
+        const { getMetaInfoPanel } = await setupForDeletion();
+        fireFullClick(await screen.findByText('Delete'));
+        expect(screen.getByText(/are you sure/i)).toBeEnabled();
+        expect(screen.getByText('Cancel')).toBeInTheDocument();
+        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(getMetaInfoPanel()).toMatchSnapshot();
+      });
+
+      test('clicking on the "cancel" button will move back to the profile information', async () => {
+        await addUploadedProfileInformation({ jwtToken: 'FAKE_TOKEN' });
+        await setupForDeletion();
+        fireFullClick(await screen.findByText('Delete'));
+
+        // Canceling should move back to the previous
+        fireFullClick(screen.getByText('Cancel'));
+
+        // We're back at the profile information panel.
+        expect(screen.getByText('Profile Information')).toBeInTheDocument();
+      });
+
+      test('dismissing the panel will move back to the profile information when opened again', async () => {
+        await addUploadedProfileInformation({ jwtToken: 'FAKE_TOKEN' });
+        const { displayMetaInfoPanel } = await setupForDeletion();
+        fireFullClick(await screen.findByText('Delete'));
+
+        // Dismissing by clicking elsewhere
+        fireFullClick(ensureExists(document.body));
+        jest.runAllTimers();
+
+        // We're back at the profile information panel if we open the panel again.
+        displayMetaInfoPanel();
+        expect(screen.getByText('Profile Information')).toBeInTheDocument();
+      });
+
+      test('confirming the delete should delete on the server and in the db', async () => {
+        await addUploadedProfileInformation({ jwtToken: 'FAKE_TOKEN' });
+        const {
+          getMetaInfoPanel,
+          displayMetaInfoPanel,
+        } = await setupForDeletion();
+        fireFullClick(await screen.findByText('Delete'));
+        fireFullClick(screen.getByText('Delete'));
+        await screen.findByText(/successfully/i);
+        // This has been deleted from the server.
+        expect(deleteProfileOnServer).toHaveBeenCalledWith({
+          profileToken: FAKE_HASH,
+          jwtToken: 'FAKE_TOKEN',
+        });
+        // This has been deleted from the DB.
+        expect(await retrieveUploadedProfileInformationFromDb(FAKE_HASH)).toBe(
+          null
+        );
+        expect(getMetaInfoPanel()).toMatchSnapshot();
+
+        // Dismissing the metainfo panel and displaying it again should show the
+        // initial panel now.
+        fireFullClick(ensureExists(document.body));
+        jest.runAllTimers();
+        displayMetaInfoPanel();
+        expect(screen.getByText('Profile Information')).toBeInTheDocument();
+        expect(screen.queryByText('Uploaded:')).not.toBeInTheDocument();
+      });
     });
 
     describe('symbolication', function() {

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,65 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
-<div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Profile Information
-  </h2>
+<div
+  class="arrowPanel open metaInfoPanel"
+>
   <div
-    class="metaInfoSection"
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
   >
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
-      >
-        Recording started:
-      </span>
-      toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Interval:
-      </span>
-      1ms
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Profile Version:
-      </span>
-      33
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Buffer Capacity:
-      </span>
-      16.0KB
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Buffer Duration:
-      </span>
-      20 seconds
-    </div>
+      Profile Information
+    </h2>
     <div
       class="metaInfoSection"
     >
@@ -69,23 +24,9 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         <span
           class="metaInfoLabel"
         >
-          Features
-          :
+          Recording started:
         </span>
-        <ul
-          class="metaInfoList"
-        >
-          <li
-            class="metaInfoListItem"
-          >
-            js
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            threads
-          </li>
-        </ul>
+        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
       </div>
       <div
         class="metaInfoRow"
@@ -93,7 +34,171 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         <span
           class="metaInfoLabel"
         >
-          Threads Filter
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Capacity:
+        </span>
+        16.0KB
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Duration:
+        </span>
+        20 seconds
+      </div>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Features
+            :
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              js
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              threads
+            </li>
+          </ul>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Threads Filter
+            :
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              GeckoMain
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              DOM Worker
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is not symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox 48
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        nightly
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build ID:
+        </span>
+        20181126165837
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build Type:
+        </span>
+        Debug
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Extensions
           :
         </span>
         <ul
@@ -102,470 +207,383 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
           <li
             class="metaInfoListItem"
           >
-            GeckoMain
+            Form Autofill
           </li>
           <li
             class="metaInfoListItem"
           >
-            DOM Worker
+            Firefox Screenshots
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Gecko Profiler
           </li>
         </ul>
       </div>
     </div>
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
-      >
-        Symbols:
-      </span>
-      Profile is not symbolicated
-    </div>
+      Platform
+    </h2>
     <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      />
-      <button
-        class="photon-button photon-button-micro"
-        type="button"
-      >
-        Symbolicate profile
-      </button>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Application
-  </h2>
-  <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Name and version:
-      </span>
-      Firefox 48
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Update Channel:
-      </span>
-      nightly
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build ID:
-      </span>
-      20181126165837
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build Type:
-      </span>
-      Debug
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Extensions
-        :
-      </span>
-      <ul
-        class="metaInfoList"
-      >
-        <li
-          class="metaInfoListItem"
-        >
-          Form Autofill
-        </li>
-        <li
-          class="metaInfoListItem"
-        >
-          Firefox Screenshots
-        </li>
-        <li
-          class="metaInfoListItem"
-        >
-          Gecko Profiler
-        </li>
-      </ul>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Platform
-  </h2>
-  <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        OS:
-      </span>
-      macOS 10.11
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        ABI:
-      </span>
-      x86_64-gcc3
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        CPU:
-      </span>
-      4 physical cores
-      , 
-      8 logical cores
-    </div>
-  </div>
-  <details>
-    <summary
-      class="arrowPanelSubTitle"
-    >
-      Profiler Overhead
-    </summary>
-    <div
-      class="arrowPanelSection"
+      class="metaInfoSection"
     >
       <div
-        class="metaInfoGrid"
+        class="metaInfoRow"
       >
-        <div />
-        <div>
-          Mean
-        </div>
-        <div>
-          Max
-        </div>
-        <div>
-          Min
-        </div>
-        <div>
-          Overhead
-        </div>
-        <div>
-          227μs
-        </div>
-        <div>
-          410μs
-        </div>
-        <div>
-          38μs
-        </div>
-        <div>
-          Cleaning
-        </div>
-        <div>
-          54μs
-        </div>
-        <div>
-          100μs
-        </div>
-        <div>
-          7.0μs
-        </div>
-        <div>
-          Counter
-        </div>
-        <div>
-          59μs
-        </div>
-        <div>
-          105μs
-        </div>
-        <div>
-          12μs
-        </div>
-        <div>
-          Interval
-        </div>
-        <div>
-          857μs
-        </div>
-        <div>
-          1,000μs
-        </div>
-        <div>
-          0.000μs
-        </div>
-        <div>
-          Lockings
-        </div>
-        <div>
-          49μs
-        </div>
-        <div>
-          95μs
-        </div>
-        <div>
-          2.0μs
-        </div>
+        <span
+          class="metaInfoLabel"
+        >
+          OS:
+        </span>
+        macOS 10.11
       </div>
       <div
         class="metaInfoRow"
       >
         <span
-          class="metaInfoWideLabel"
+          class="metaInfoLabel"
         >
-          Overhead Durations:
+          ABI:
         </span>
-        <span
-          class="metaInfoValueRight"
-        >
-          1,586μs
-        </span>
+        x86_64-gcc3
       </div>
       <div
         class="metaInfoRow"
       >
         <span
-          class="metaInfoWideLabel"
+          class="metaInfoLabel"
         >
-          Overhead Percentage:
+          CPU:
         </span>
-        <span
-          class="metaInfoValueRight"
-        >
-          26,433%
-        </span>
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoWideLabel"
-        >
-          Profiled Duration:
-        </span>
-        <span
-          class="metaInfoValueRight"
-        >
-          6.0μs
-        </span>
+        4 physical cores
+        , 
+        8 logical cores
       </div>
     </div>
-  </details>
+    <details>
+      <summary
+        class="arrowPanelSubTitle"
+      >
+        Profiler Overhead
+      </summary>
+      <div
+        class="arrowPanelSection"
+      >
+        <div
+          class="metaInfoGrid"
+        >
+          <div />
+          <div>
+            Mean
+          </div>
+          <div>
+            Max
+          </div>
+          <div>
+            Min
+          </div>
+          <div>
+            Overhead
+          </div>
+          <div>
+            227μs
+          </div>
+          <div>
+            410μs
+          </div>
+          <div>
+            38μs
+          </div>
+          <div>
+            Cleaning
+          </div>
+          <div>
+            54μs
+          </div>
+          <div>
+            100μs
+          </div>
+          <div>
+            7.0μs
+          </div>
+          <div>
+            Counter
+          </div>
+          <div>
+            59μs
+          </div>
+          <div>
+            105μs
+          </div>
+          <div>
+            12μs
+          </div>
+          <div>
+            Interval
+          </div>
+          <div>
+            857μs
+          </div>
+          <div>
+            1,000μs
+          </div>
+          <div>
+            0.000μs
+          </div>
+          <div>
+            Lockings
+          </div>
+          <div>
+            49μs
+          </div>
+          <div>
+            95μs
+          </div>
+          <div>
+            2.0μs
+          </div>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead Durations:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            1,586μs
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead Percentage:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            26,433%
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Profiled Duration:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            6.0μs
+          </span>
+        </div>
+      </div>
+    </details>
+  </div>
 </div>
 `;
 
 exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
-<div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Profile Information
-  </h2>
+<div
+  class="arrowPanel open metaInfoPanel"
+>
   <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Recording started:
-      </span>
-      toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Interval:
-      </span>
-      1ms
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Profile Version:
-      </span>
-      33
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Symbols:
-      </span>
-      Profile is not symbolicated
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      />
-      <button
-        class="photon-button photon-button-micro"
-        type="button"
-      >
-        Symbolicate profile
-      </button>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Application
-  </h2>
+    class="arrowPanelArrow"
+  />
   <div
-    class="metaInfoSection"
+    class="arrowPanelContent"
   >
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
-      >
-        Name and version:
-      </span>
-      Firefox 48
-    </div>
+      Profile Information
+    </h2>
     <div
-      class="metaInfoRow"
+      class="metaInfoSection"
     >
-      <span
-        class="metaInfoLabel"
+      <div
+        class="metaInfoRow"
       >
-        Update Channel:
-      </span>
-      nightly
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build ID:
-      </span>
-      20181126165837
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build Type:
-      </span>
-      Debug
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Extensions
-        :
-      </span>
-      <ul
-        class="metaInfoList"
-      >
-        <li
-          class="metaInfoListItem"
+        <span
+          class="metaInfoLabel"
         >
-          Form Autofill
-        </li>
-        <li
-          class="metaInfoListItem"
+          Recording started:
+        </span>
+        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
         >
-          Firefox Screenshots
-        </li>
-        <li
-          class="metaInfoListItem"
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
         >
-          Gecko Profiler
-        </li>
-      </ul>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Platform
-  </h2>
-  <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
       >
-        OS:
-      </span>
-      macOS 10.11
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is not symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
       >
-        ABI:
-      </span>
-      x86_64-gcc3
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Symbolicate profile
+        </button>
+      </div>
     </div>
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
       >
-        CPU:
-      </span>
-      4 physical cores
-      , 
-      8 logical cores
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox 48
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        nightly
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build ID:
+        </span>
+        20181126165837
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build Type:
+        </span>
+        Debug
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Extensions
+          :
+        </span>
+        <ul
+          class="metaInfoList"
+        >
+          <li
+            class="metaInfoListItem"
+          >
+            Form Autofill
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Firefox Screenshots
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Gecko Profiler
+          </li>
+        </ul>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          OS:
+        </span>
+        macOS 10.11
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          ABI:
+        </span>
+        x86_64-gcc3
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          CPU:
+        </span>
+        4 physical cores
+        , 
+        8 logical cores
+      </div>
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,5 +1,426 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile clicking on the button shows the confirmation 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <div
+      class="confirmDialog"
+    >
+      <h2
+        class="confirmDialogTitle"
+      >
+        Delete 
+        PROFILE
+      </h2>
+      <div
+        class="confirmDialogContent"
+      >
+        Are you sure you want to delete uploaded data for this profile? Links that were previously shared will no longer work.
+      </div>
+      <div
+        class="confirmDialogButtons"
+      >
+        <input
+          class="photon-button photon-button-default"
+          type="button"
+          value="Cancel"
+        />
+        <input
+          class="photon-button photon-button-destructive"
+          type="button"
+          value="Delete"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile confirming the delete should delete on the server and in the db 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <p
+      class="profileDeleteButtonSuccess"
+    >
+      Successfully deleted uploaded data.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete button if we have the uploaded data and some JWT token 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="profileInfoUploadedActions"
+    >
+      <div
+        class="profileInfoUploadedDate"
+      >
+        <span
+          class="profileInfoUploadedLabel"
+        >
+          Uploaded:
+        </span>
+        toLocaleString Sat, 04 Jul 2020 13:00:00 GMT
+      </div>
+      <div
+        class="profileInfoUploadedActionsButtons"
+      >
+        <button
+          class="photon-button photon-button-default photon-button-micro"
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Re-symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        release
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    />
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete button if we have the uploaded data but no JWT token 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="profileInfoUploadedActions"
+    >
+      <div
+        class="profileInfoUploadedDate"
+      >
+        <span
+          class="profileInfoUploadedLabel"
+        >
+          Uploaded:
+        </span>
+        toLocaleString Sat, 04 Jul 2020 13:00:00 GMT
+      </div>
+      <div
+        class="profileInfoUploadedActionsButtons"
+      >
+        <button
+          class="photon-button photon-button-default photon-button-micro"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Re-symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        release
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    />
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile does not display the delete button if the profile is public but without uploaded data 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Re-symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        release
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    />
+  </div>
+</div>
+`;
+
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,50 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MetaInfoPanel> Full View Button is present when we are in the active tab view 1`] = `
-<div>
-  <button
-    class="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertToFullView"
-    type="button"
-  >
-    Full View
-  </button>
-  <div
-    class="buttonWithPanel"
-  >
-    <button
-      aria-expanded="false"
-      class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-local"
-      type="button"
-    >
-      Local Profile
-    </button>
-  </div>
-  <div
-    class="buttonWithPanel"
-  >
-    <button
-      aria-expanded="false"
-      class="buttonWithPanelButton menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon"
-      type="button"
-    >
-      Upload
-    </button>
-  </div>
-  <a
-    class="menuButtonsButton menuButtonsButton-hasLeftBorder"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs
-    <i
-      class="open-in-new"
-    />
-  </a>
-</div>
-`;
-
-exports[`<MetaInfoPanel> matches the snapshot 1`] = `
+exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 <div>
   <h2
     class="metaInfoSubTitle"
@@ -429,7 +385,7 @@ exports[`<MetaInfoPanel> matches the snapshot 1`] = `
 </div>
 `;
 
-exports[`<MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
+exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
 <div>
   <h2
     class="metaInfoSubTitle"
@@ -1114,5 +1070,49 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       </button>
     </div>
   </form>
+</div>
+`;
+
+exports[`app/MenuButtons Full View Button is present when we are in the active tab view 1`] = `
+<div>
+  <button
+    class="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertToFullView"
+    type="button"
+  >
+    Full View
+  </button>
+  <div
+    class="buttonWithPanel"
+  >
+    <button
+      aria-expanded="false"
+      class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-local"
+      type="button"
+    >
+      Local Profile
+    </button>
+  </div>
+  <div
+    class="buttonWithPanel"
+  >
+    <button
+      aria-expanded="false"
+      class="buttonWithPanelButton menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon"
+      type="button"
+    >
+      Upload
+    </button>
+  </div>
+  <a
+    class="menuButtonsButton menuButtonsButton-hasLeftBorder"
+    href="/docs/"
+    target="_blank"
+    title="Open the documentation in a new window"
+  >
+    Docs
+    <i
+      class="open-in-new"
+    />
+  </a>
 </div>
 `;

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -750,7 +750,7 @@ describe('attemptToPublish', function() {
       const firstRequestData = await retrieveUploadedProfileInformationFromDb(
         BARE_PROFILE_TOKEN
       );
-      expect(firstRequestData).toBe(undefined);
+      expect(firstRequestData).toBe(null);
 
       // And now, checking that we can retrieve this data when retrieving the
       // full list. The second profile comes first because it was answered

--- a/src/test/unit/uploaded-profiles-db.test.js
+++ b/src/test/unit/uploaded-profiles-db.test.js
@@ -85,7 +85,7 @@ describe('uploaded-profiles-db', function() {
 
     await deleteUploadedProfileInformationFromDb('PROFILE-2');
     expect(await retrieveUploadedProfileInformationFromDb('PROFILE-2')).toBe(
-      undefined
+      null
     );
     expect(await listAllUploadedProfileInformationFromDb()).toEqual([
       expect.objectContaining({ profileToken: 'PROFILE-3' }),

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -427,6 +427,9 @@ type UrlStateAction =
   | {|
       +type: 'TOGGLE_RESOURCES_PANEL',
       +selectedThreadIndexes: Set<ThreadIndex>,
+    |}
+  | {|
+      +type: 'PROFILE_REMOTELY_DELETED',
     |};
 
 type IconsAction =

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -28,7 +28,12 @@ import type { TemporaryError } from '../utils/errors';
 import type { Transform, TransformStacksPerThread } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState, UploadState, State } from './state';
+import type {
+  UrlState,
+  UploadState,
+  State,
+  UploadedProfileInformation,
+} from './state';
 import type { CssPixels, StartEndRange, Milliseconds } from './units';
 
 export type DataSource =
@@ -484,6 +489,11 @@ type DragAndDropAction =
       +type: 'UNREGISTER_DRAG_AND_DROP_OVERLAY',
     |};
 
+type CurrentProfileUploadedInformationAction = {|
+  +type: 'SET_CURRENT_PROFILE_UPLOADED_INFORMATION',
+  +uploadedProfileInformation: UploadedProfileInformation | null,
+|};
+
 export type Action =
   | ProfileAction
   | ReceiveProfileAction
@@ -492,4 +502,5 @@ export type Action =
   | UrlStateAction
   | IconsAction
   | PublishAction
-  | DragAndDropAction;
+  | DragAndDropAction
+  | CurrentProfileUploadedInformationAction;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -34,8 +34,15 @@ import type { TransformStacksPerThread } from './transforms';
 import type JSZip from 'jszip';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { PathSet } from '../utils/path.js';
+import type { UploadedProfileInformation as ImportedUploadedProfileInformation } from 'firefox-profiler/app-logic/uploaded-profiles-db';
 
 export type Reducer<T> = (T | void, Action) => T;
+
+// This type is defined in uploaded-profiles-db.js because it is very tied to
+// the data stored in our local IndexedDB, and we don't want to change it
+// lightly, without changing the DB code.
+// We reexport this type here mostly for easier access.
+export type UploadedProfileInformation = ImportedUploadedProfileInformation;
 
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {|
@@ -180,6 +187,7 @@ export type AppState = {|
   +isDragAndDropDragging: boolean,
   +isDragAndDropOverlayRegistered: boolean,
   +experimental: ExperimentalFlags,
+  +currentProfileUploadedInformation: UploadedProfileInformation | null,
 |};
 
 export type UploadPhase =


### PR DESCRIPTION
This is now ready for review.
Fixes #2443.

![image](https://user-images.githubusercontent.com/454175/102091327-fb3dbb80-3e1e-11eb-9791-a64576f983f6.png)
![image](https://user-images.githubusercontent.com/454175/102091391-0d1f5e80-3e1f-11eb-8a37-6755aa4e1b37.png)
![image](https://user-images.githubusercontent.com/454175/102091421-17415d00-3e1f-11eb-8c55-744b0adaf912.png)

This pull request implements several things, but do not review the first commit, as this is a squashed version of PR #3102. Then:
1. A commit implements a "preloading" mechanism. The goal is to store to the redux state the "uploaded information" about the currently loaded profile, as retrieved from the indexed db. This way we can access it synchronously.
2. A few commits reorganize the test file for menu buttons. The goal is to highlight the important changes in the later commits by splitting them out.
3. One commit will implement actually adding the delete button. It is conditioned by the availability of the preloaded data. When deleting a profile, the datasource is moved to "unpublished" (this is the next commit).
4. At last in the last commit, I'm implementing a lot of tests to cover this new functionality.

I tested this a lot but please test it more :-)

#### Deploy previews
* [home page](https://deploy-preview-2639--perf-html.netlify.app/) (should have no change, but can be useful to access recordings)
* [link to a profile](https://deploy-preview-2639--perf-html.netlify.app/public/d4hkzng1fj4grv69n2a2k368sh4ayad2sq45wxg/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&range=634m1689~1144m610&thread=11&v=5) that you can re-upload to have local uploaded information for a profile

