### PR TITLE
Fix some uploader race conditions and leaks

### DIFF
--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -99,17 +99,17 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
 
       // Create an abort function before the first async call, but we won't
       // start the upload until much later.
-      const { abortFunction, startUpload } = uploadBinaryProfileData();
-      const augmentedAbortfunction = () => {
+      const { abortUpload, startUpload } = uploadBinaryProfileData();
+      const abortfunction = () => {
         // We dispatch the action right away, so that the UI is updated.
         // Otherwise if the user pressed "Cancel" during a long process, like
         // the compression, we wouldn't get a feedback until the end.
         // Later on the promise from `startUpload` will get rejected too, and we
         // handle this in the `catch` block.
         dispatch({ type: 'UPLOAD_ABORTED' });
-        abortFunction();
+        abortUpload();
       };
-      dispatch(uploadCompressionStarted(augmentedAbortfunction));
+      dispatch(uploadCompressionStarted(abortfunction));
 
       const gzipData: Uint8Array = await getSanitizedProfileData(
         prePublishedState

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -9,7 +9,6 @@ import classNames from 'classnames';
 import {
   toggleCheckedSharingOptions,
   attemptToPublish,
-  abortUpload,
   resetUploadState,
 } from '../../../actions/publish';
 import {
@@ -18,6 +17,7 @@ import {
   getHasPreferenceMarkers,
 } from '../../../selectors/profile';
 import {
+  getAbortFunction,
   getCheckedSharingOptions,
   getFilenameString,
   getDownloadSize,
@@ -59,12 +59,12 @@ type StateProps = {|
   +uploadProgressString: string,
   +shouldSanitizeByDefault: boolean,
   +error: mixed,
+  +abortFunction: () => mixed,
 |};
 
 type DispatchProps = {|
   +toggleCheckedSharingOptions: typeof toggleCheckedSharingOptions,
   +attemptToPublish: typeof attemptToPublish,
-  +abortUpload: typeof abortUpload,
   +resetUploadState: typeof resetUploadState,
 |};
 
@@ -192,7 +192,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
     const {
       uploadProgress,
       uploadProgressString,
-      abortUpload,
+      abortFunction,
       downloadFileName,
       compressedProfileBlobPromise,
       downloadSizePromise,
@@ -226,7 +226,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
           <button
             type="button"
             className="photon-button photon-button-default menuButtonsPublishButton menuButtonsPublishButtonsCancelUpload"
-            onClick={abortUpload}
+            onClick={abortFunction}
           >
             Cancel Upload
           </button>
@@ -306,11 +306,11 @@ export const MenuButtonsPublish = explicitConnect<
     uploadProgressString: getUploadProgressString(state),
     error: getUploadError(state),
     shouldSanitizeByDefault: getShouldSanitizeByDefault(state),
+    abortFunction: getAbortFunction(state),
   }),
   mapDispatchToProps: {
     toggleCheckedSharingOptions,
     attemptToPublish,
-    abortUpload,
     resetUploadState,
   },
   component: MenuButtonsPublishImpl,

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -19,12 +19,10 @@ import { MenuButtonsPublish } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';
 import ArrowPanel from '../../shared/ArrowPanel';
 import ButtonWithPanel from '../../shared/ButtonWithPanel';
-import {
-  revertToPrePublishedState,
-  abortUpload,
-} from '../../../actions/publish';
+import { revertToPrePublishedState } from '../../../actions/publish';
 import { dismissNewlyPublished } from '../../../actions/app';
 import {
+  getAbortFunction,
   getUploadPhase,
   getHasPrePublishedState,
 } from '../../../selectors/publish';
@@ -59,12 +57,12 @@ type StateProps = {|
   +uploadPhase: UploadPhase,
   +hasPrePublishedState: boolean,
   +symbolicationStatus: SymbolicationStatus,
+  +abortFunction: () => mixed,
 |};
 
 type DispatchProps = {|
   +dismissNewlyPublished: typeof dismissNewlyPublished,
   +revertToPrePublishedState: typeof revertToPrePublishedState,
-  +abortUpload: typeof abortUpload,
   +resymbolicateProfile: typeof resymbolicateProfile,
 |};
 
@@ -77,7 +75,7 @@ class MenuButtons extends React.PureComponent<Props> {
   }
 
   _renderPublishPanel() {
-    const { uploadPhase, dataSource, abortUpload } = this.props;
+    const { uploadPhase, dataSource, abortFunction } = this.props;
 
     const isUploading =
       uploadPhase === 'uploading' || uploadPhase === 'compressing';
@@ -87,7 +85,7 @@ class MenuButtons extends React.PureComponent<Props> {
         <button
           type="button"
           className="buttonWithPanelButton menuButtonsAbortUploadButton"
-          onClick={abortUpload}
+          onClick={abortFunction}
         >
           Cancel Upload
         </button>
@@ -192,11 +190,11 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     uploadPhase: getUploadPhase(state),
     hasPrePublishedState: getHasPrePublishedState(state),
     symbolicationStatus: getSymbolicationStatus(state),
+    abortFunction: getAbortFunction(state),
   }),
   mapDispatchToProps: {
     dismissNewlyPublished,
     revertToPrePublishedState,
-    abortUpload,
     resymbolicateProfile,
   },
   component: MenuButtons,

--- a/src/profile-logic/profile-store.js
+++ b/src/profile-logic/profile-store.js
@@ -12,6 +12,15 @@ const PUBLISHING_ENDPOINT = `${PROFILER_SERVER_ORIGIN}/compressed-store`;
 
 const ACCEPT_HEADER_VALUE = 'application/vnd.firefox-profiler+json;version=1.0';
 
+// This error is used when we get an "abort" event. This happens when we call
+// "abort" expliitely, and so when the user actually cancels the upload.
+// We use a specific class error to distinguish this case from other cases from
+// the caller function.
+// It's exported because we use it in tests.
+export class UploadAbortedError extends Error {
+  name = 'UploadAbortedError';
+}
+
 export function uploadBinaryProfileData(): * {
   const xhr = new XMLHttpRequest();
   let isAborted = false;
@@ -27,7 +36,7 @@ export function uploadBinaryProfileData(): * {
     ): Promise<string> =>
       new Promise((resolve, reject) => {
         if (isAborted) {
-          reject(new Error('The request was already aborted.'));
+          reject(new UploadAbortedError('The request was already aborted.'));
           return;
         }
 
@@ -69,6 +78,12 @@ export function uploadBinaryProfileData(): * {
             errorMessage += ` The error response was: ${xhr.statusText}`;
           }
           reject(new Error(errorMessage));
+        };
+
+        xhr.onabort = () => {
+          reject(
+            new UploadAbortedError('The error has been aborted by the user.')
+          );
         };
 
         xhr.upload.onprogress = e => {

--- a/src/profile-logic/profile-store.js
+++ b/src/profile-logic/profile-store.js
@@ -26,7 +26,7 @@ export function uploadBinaryProfileData(): * {
   let isAborted = false;
 
   return {
-    abortFunction: (): void => {
+    abortUpload: (): void => {
       isAborted = true;
       xhr.abort();
     },

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -122,7 +122,7 @@ const abortFunction: Reducer<() => void> = (state = noop, action) => {
     case 'SANITIZED_PROFILE_PUBLISHED':
     case 'UPLOAD_FAILED':
       return noop;
-    case 'UPLOAD_STARTED':
+    case 'UPLOAD_COMPRESSION_STARTED':
       return action.abortFunction;
     default:
       return state;

--- a/src/reducers/publish.js
+++ b/src/reducers/publish.js
@@ -138,6 +138,7 @@ const generation: Reducer<number> = (state = 0, action) => {
     case 'SANITIZED_PROFILE_PUBLISHED':
     case 'UPLOAD_ABORTED':
     case 'UPLOAD_FAILED':
+    case 'HIDE_STALE_PROFILE':
       // Increment the generation value when exiting out of the profile uploading.
       return state + 1;
     default:

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -60,7 +60,7 @@ describe('app/MenuButtons', function() {
     // Flow doesn't know uploadBinaryProfileData is a jest mock.
     (uploadBinaryProfileData: any).mockImplementation(
       (() => ({
-        abortFunction: () => {
+        abortUpload: () => {
           // In the real implementation, we call xhr.abort, which in turn
           // triggers an "abort" event on the XHR object, which in turn rejects
           // the promise with the error UploadAbortedError. So we do just that

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -53,13 +53,15 @@ describe('app/MenuButtons', function() {
     promise.catch(() => {
       // Node complains if we don't handle a promise/catch, and this one may reject
       // before it's properly handled. Catch it here so that Node doesn't complain.
+      // This won't hide problems in our code because the app code "awaits" the
+      // result of startUpload, so any rejection will be handled there.
     });
 
     // Flow doesn't know uploadBinaryProfileData is a jest mock.
     (uploadBinaryProfileData: any).mockImplementation(
       (() => ({
         abortFunction: () => {
-          // In the real implementation, we call xhr.abort, hwich in turn
+          // In the real implementation, we call xhr.abort, which in turn
           // triggers an "abort" event on the XHR object, which in turn rejects
           // the promise with the error UploadAbortedError. So we do just that
           // here directly, to simulate this.

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -180,6 +180,10 @@ export function waitUntilState(
   store: Store,
   predicate: State => boolean
 ): Promise<void> {
+  if (predicate(store.getState())) {
+    return Promise.resolve();
+  }
+
   return new Promise(resolve => {
     store.subscribe(() => {
       if (predicate(store.getState())) {

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -281,7 +281,9 @@ describe('attemptToPublish', function() {
     expect(await publishAttempt).toEqual(true);
 
     expect(getUploadPhase(getState())).toEqual('uploaded');
-    expect(getUploadGeneration(getState())).toEqual(1);
+    // The generation is incremented twice because of some asynchronous code in
+    // the uploader function.
+    expect(getUploadGeneration(getState())).toEqual(2);
     dispatch(resetUploadState());
     expect(getUploadPhase(getState())).toEqual('local');
   });

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -154,6 +154,8 @@ describe('attemptToPublish', function() {
     promise.catch(() => {
       // Node complains if we don't handle a promise/catch, and this one rejects
       // before it's properly handled. Catch it here so that Node doesn't complain.
+      // This won't hide problems in our code because the app code "awaits" the
+      // result of startUpload, so any rejection will be handled there.
     });
 
     const initUploadProcess: typeof uploadBinaryProfileData = () => ({
@@ -293,7 +295,7 @@ describe('attemptToPublish', function() {
     expect(getUploadPhase(getState())).toEqual('uploaded');
     // The generation is incremented twice because of some asynchronous code in
     // the uploader function.
-    expect(getUploadGeneration(getState())).toEqual(2);
+    expect(getUploadGeneration(getState())).toBeGreaterThan(0);
     dispatch(resetUploadState());
     expect(getUploadPhase(getState())).toEqual('local');
   });

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -159,7 +159,7 @@ describe('attemptToPublish', function() {
     });
 
     const initUploadProcess: typeof uploadBinaryProfileData = () => ({
-      abortFunction() {
+      abortUpload() {
         // In the real implementation, we call xhr.abort, hwich in turn
         // triggers an "abort" event on the XHR object, which in turn rejects
         // the promise with the error UploadAbortedError. So we do just that

--- a/src/test/unit/profile-store.test.js
+++ b/src/test/unit/profile-store.test.js
@@ -155,9 +155,9 @@ describe('profile upload', () => {
   it('can abort the request', async () => {
     const { getLastXhr } = setup();
 
-    const { startUpload, abortFunction } = uploadBinaryProfileData();
+    const { startUpload, abortUpload } = uploadBinaryProfileData();
     startUpload(new Uint8Array(10));
-    abortFunction();
+    abortUpload();
     expect(getLastXhr().abort).toHaveBeenCalled();
   });
 });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -408,7 +408,6 @@ type PublishAction =
     |}
   | {|
       +type: 'UPLOAD_STARTED',
-      +abortFunction: () => void,
     |}
   | {|
       +type: 'UPDATE_UPLOAD_PROGRESS',
@@ -426,6 +425,7 @@ type PublishAction =
     |}
   | {|
       +type: 'UPLOAD_COMPRESSION_STARTED',
+      +abortFunction: () => void,
     |}
   | {|
       +type: 'CHANGE_UPLOAD_STATE',


### PR DESCRIPTION
This fixes a few race conditions in the publishing code.
I doubt they could be hit in real life but this makes tests a bit more difficult to write sometimes.

Also I believe this fixes a real leak when a user cancels an upload.

The 4 commits are fairly independent, they could have been separate PRs but they also make sense together.
The 3rd commit is where there could be bugs because it changes rather extensively how upload cancelation works. I'm less worried about the other commits.

This is the profile I was testing with: [deploy preview](https://deploy-preview-2646--perf-html.netlify.com/public/2b38186f16b0ab99e3c691b2b04869543b40e504/marker-chart/?globalTrackOrder=0-1&localTrackOrderByPid=4176-1-2-0~6176-0-1~&thread=0&v=4)
Things I tried: canceling quickly after publishing while it was still compressing (you need to be quick running the actions), and canceling while it was uploading. And of course uploading all the way to the end. All without reloading to see if the state was properly reset.

Tell me what you think!