### PR TITLE
Extend background width

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -109,6 +109,8 @@ body,
 }
 
 .treeViewBodyInner1 {
+  /* This allows the right column to expand more than its content, so that the
+   * background always extends to the right edge. */
   flex-grow: 1;
 }
 

--- a/res/css/style.css
+++ b/res/css/style.css
@@ -98,6 +98,7 @@ body,
   top: 0;
   left: 0;
   display: flex;
+  min-width: 100%;
   flex-flow: row nowrap;
 }
 
@@ -105,6 +106,10 @@ body,
   position: sticky;
   z-index: 2;
   left: 0;
+}
+
+.treeViewBodyInner1 {
+  flex-grow: 1;
 }
 
 .treeViewBodyInner {

--- a/src/components/shared/VirtualList.js
+++ b/src/components/shared/VirtualList.js
@@ -196,7 +196,7 @@ class VirtualListInner<Item> extends React.PureComponent<
         // Add padding to list height to account for overlay scrollbars.
         style={{
           height: `${(items.length + 1) * itemHeight}px`,
-          width: columnIndex === 1 ? containerWidth : undefined,
+          minWidth: columnIndex === 1 ? containerWidth : undefined,
         }}
       >
         <div

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -161,7 +161,7 @@ describe('calltree/ProfileCallTreeView', function() {
     const treeBody = ensureExists(
       container.querySelector('.treeViewBodyInner1')
     );
-    const treeBodyWidth = parseInt(treeBody.style.width);
+    const treeBodyWidth = parseInt(treeBody.style.minWidth);
     expect(treeBodyWidth).toBeGreaterThan(3000);
   });
 

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -291,7 +291,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -413,7 +413,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -951,7 +951,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 64px; width: 3000px;"
+            style="height: 64px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -1489,7 +1489,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -2139,7 +2139,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -2789,7 +2789,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -3863,7 +3863,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -4481,7 +4481,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -5099,7 +5099,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -5686,7 +5686,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 112px; width: 3000px;"
+            style="height: 112px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -6259,7 +6259,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 112px; width: 3000px;"
+            style="height: 112px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -6770,7 +6770,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 80px; width: 3000px;"
+            style="height: 80px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -7224,7 +7224,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 80px; width: 3000px;"
+            style="height: 80px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -7740,7 +7740,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 112px; width: 3000px;"
+            style="height: 112px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"

--- a/src/test/components/__snapshots__/ZipFileTree.test.js.snap
+++ b/src/test/components/__snapshots__/ZipFileTree.test.js.snap
@@ -73,7 +73,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
             </div>
             <div
               class="treeViewBodyInner treeViewBodyInner1"
-              style="height: 210px; width: 3000px;"
+              style="height: 210px; min-width: 3000px;"
             >
               <div
                 class="treeViewBodyInner treeViewBodyInner1TopSpacer"


### PR DESCRIPTION
Fixes  #2474 

Hi, @julienw. I got tangled with some git related mistakes (😅), so I started afresh.

Please see the closed PR #2593 which relates to issue #2474 where the `innerBody` does not extend to the full width of the container. I noted your advice and removed `width: 100%` and also included a `flex-grow` property to `.treeViewBodyInner1`.

PS: Thank you for your patience with me :)

On smaller screen:
![Screenshot from 2020-07-11 00-15-33](https://user-images.githubusercontent.com/60417145/87216230-bfe90f00-c30b-11ea-95e6-75ad031df91f.png)

On larger screen:
![Screenshot from 2020-07-11 00-15-55](https://user-images.githubusercontent.com/60417145/87216231-c11a3c00-c30b-11ea-8dde-05c9a955fa23.png)
