### PR TITLE
Change the active tab profile view state to better handle the tracks

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -10,7 +10,7 @@ import {
   getSelectedThreadIndex,
 } from '../selectors/url-state';
 import { getTrackThreadHeights } from '../selectors/app';
-import { getActiveTabGlobalTracks } from '../selectors/profile';
+import { getActiveTabMainTrack } from '../selectors/profile';
 import { sendAnalytics } from '../utils/analytics';
 import { stateFromLocation } from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';
@@ -213,15 +213,7 @@ export function toggleResourcesPanel(): ThunkAction<void> {
     if (isResourcesPanelOpen) {
       // If it was open when we dispatched that action, it means we are closing this panel.
       // We would like to also select the main track when we close this panel.
-      const globalTracks = getActiveTabGlobalTracks(getState());
-      const mainTrack = globalTracks.find(track => track.type === 'tab');
-
-      if (mainTrack === undefined) {
-        throw new Error(
-          'Failed to find the main track index in active tab view'
-        );
-      }
-
+      const mainTrack = getActiveTabMainTrack(getState());
       selectedThreadIndex = mainTrack.threadIndex;
     }
 

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -214,7 +214,7 @@ export function toggleResourcesPanel(): ThunkAction<void> {
       // If it was open when we dispatched that action, it means we are closing this panel.
       // We would like to also select the main track when we close this panel.
       const mainTrack = getActiveTabMainTrack(getState());
-      selectedThreadIndex = mainTrack.threadIndex;
+      selectedThreadIndex = mainTrack.mainThreadIndex;
     }
 
     // Toggle the resources panel eventually.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -405,7 +405,7 @@ export function selectActiveTabTrack(
         // Go through each type, and determine the selected slug and thread index.
         switch (globalTrack.type) {
           case 'tab': {
-            selectedThreadIndex = globalTrack.threadIndex;
+            selectedThreadIndex = globalTrack.mainThreadIndex;
             // Ensure a relevant thread-based tab is used.
             if (selectedTab === 'network-chart') {
               selectedTab = getLastVisibleThreadTabSlug(getState());

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -526,7 +526,7 @@ export function finalizeActiveTabProfileView(
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const relevantPages = getRelevantPagesForActiveTab(getState());
-    const { globalTracks, resourceTracks } = computeActiveTabTracks(
+    const activeTabTimeline = computeActiveTabTracks(
       profile,
       relevantPages,
       getState()
@@ -536,8 +536,7 @@ export function finalizeActiveTabProfileView(
 
     dispatch({
       type: 'VIEW_ACTIVE_TAB_PROFILE',
-      globalTracks,
-      resourceTracks,
+      activeTabTimeline,
       selectedThreadIndex,
       browsingContextID,
     });

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -72,10 +72,10 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
     const { globalTrack } = this.props;
     switch (globalTrack.type) {
       case 'tab': {
-        const { threadIndex } = globalTrack;
+        const { mainThreadIndex } = globalTrack;
         return (
           <TimelineTrackThread
-            threadIndex={threadIndex}
+            threadIndex={mainThreadIndex}
             showMemoryMarkers={false}
             trackType="expanded"
           />
@@ -165,8 +165,8 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     switch (globalTrack.type) {
       case 'tab': {
         // Look up the thread information for the process if it exists.
-        if (globalTrack.threadIndex !== null) {
-          const threadIndex = globalTrack.threadIndex;
+        if (globalTrack.mainThreadIndex !== null) {
+          const threadIndex = globalTrack.mainThreadIndex;
           isSelected =
             threadIndex === getSelectedThreadIndex(state) &&
             selectedTab !== 'network-chart';

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -125,6 +125,8 @@ export function computeActiveTabTracks(
 
   const mainTrack: ActiveTabMainTrack = {
     type: 'tab',
+    // FIXME: We should revert back to full view if we failed to find a track
+    // index for the main track.
     mainThreadIndex: mainTrackIndexes[0] || 0,
     threadIndexes: mainTrackIndexes,
   };

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -14,15 +14,10 @@ import type {
   InnerWindowID,
   Page,
   Thread,
-  ActiveTabGlobalTrack,
-  ActiveTabResourceTrack,
   ScreenshotPayload,
+  ActiveTabTimeline,
+  ActiveTabMainTrack,
 } from 'firefox-profiler/types';
-
-const ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER = {
-  screenshots: 0,
-  tab: 1,
-};
 
 /**
  * Checks whether the tab filtered thread is empty or not.
@@ -63,13 +58,11 @@ export function computeActiveTabTracks(
   profile: Profile,
   relevantPages: Page[],
   state: State
-): {|
-  globalTracks: ActiveTabGlobalTrack[],
-  resourceTracks: ActiveTabResourceTrack[],
-|} {
+): ActiveTabTimeline {
   // Global tracks that are certainly global tracks.
-  const globalTracks: ActiveTabGlobalTrack[] = [];
-  const resourceTracks = [];
+  const mainTrack: ActiveTabMainTrack = { type: 'tab', threadIndex: 0 };
+  const resources = [];
+  const screenshots = [];
   const topmostInnerWindowIDs = getTopmostInnerWindowIDs(relevantPages);
   const innerWindowIDToPageMap = _getInnerWindowIDToPageMap(relevantPages);
 
@@ -87,13 +80,11 @@ export function computeActiveTabTracks(
 
       if (isTopmostThread(thread, topmostInnerWindowIDs)) {
         // This is a topmost thread, add it to global tracks.
-        globalTracks.push({
-          type: 'tab',
-          threadIndex: threadIndex,
-        });
+        // FIXME: there can be multiple topmost threads. Will resolve that in the following commit.
+        mainTrack.threadIndex = threadIndex;
       } else {
         if (!isTabFilteredThreadEmpty(threadIndex, state)) {
-          resourceTracks.push({
+          resources.push({
             type: 'sub-frame',
             threadIndex,
             name: _getActiveTabResourceName(thread, innerWindowIDToPageMap),
@@ -105,7 +96,7 @@ export function computeActiveTabTracks(
       // track. Find out if that thread contains the active tab data, and add it
       // as a resource track if it does.
       if (!isTabFilteredThreadEmpty(threadIndex, state)) {
-        resourceTracks.push({
+        resources.push({
           type: 'thread',
           threadIndex,
           name: _getActiveTabResourceName(thread, innerWindowIDToPageMap),
@@ -128,21 +119,12 @@ export function computeActiveTabTracks(
         }
       }
       for (const id of windowIDs) {
-        globalTracks.push({ type: 'screenshots', id, threadIndex });
+        screenshots.push({ type: 'screenshots', id, threadIndex });
       }
     }
   }
 
-  // When adding a new track type, this sort ensures that the newer tracks are added
-  // at the end so that the global track indexes are stable and backwards compatible.
-  globalTracks.sort(
-    // In place sort!
-    (a, b) =>
-      ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER[a.type] -
-      ACTIVE_TAB_GLOBAL_TRACK_INDEX_ORDER[b.type]
-  );
-
-  return { globalTracks, resourceTracks };
+  return { mainTrack, screenshots, resources };
 }
 
 /**

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -60,7 +60,7 @@ export function computeActiveTabTracks(
   state: State
 ): ActiveTabTimeline {
   // Global tracks that are certainly global tracks.
-  const mainTrack: ActiveTabMainTrack = { type: 'tab', threadIndex: 0 };
+  const mainTrackIndexes = [];
   const resources = [];
   const screenshots = [];
   const topmostInnerWindowIDs = getTopmostInnerWindowIDs(relevantPages);
@@ -80,8 +80,7 @@ export function computeActiveTabTracks(
 
       if (isTopmostThread(thread, topmostInnerWindowIDs)) {
         // This is a topmost thread, add it to global tracks.
-        // FIXME: there can be multiple topmost threads. Will resolve that in the following commit.
-        mainTrack.threadIndex = threadIndex;
+        mainTrackIndexes.push(threadIndex);
       } else {
         if (!isTabFilteredThreadEmpty(threadIndex, state)) {
           resources.push({
@@ -124,6 +123,11 @@ export function computeActiveTabTracks(
     }
   }
 
+  const mainTrack: ActiveTabMainTrack = {
+    type: 'tab',
+    mainThreadIndex: mainTrackIndexes[0] || 0,
+    threadIndexes: mainTrackIndexes,
+  };
   return { mainTrack, screenshots, resources };
 }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -13,9 +13,7 @@ import type {
   Pid,
   LocalTrack,
   GlobalTrack,
-  ActiveTabGlobalTrack,
   OriginsTimeline,
-  ActiveTabResourceTrack,
   StartEndRange,
   PreviewSelection,
   RequestedLib,
@@ -26,6 +24,7 @@ import type {
   ThreadViewOptions,
   RightClickedCallNode,
   RightClickedMarker,
+  ActiveTabTimeline,
 } from 'firefox-profiler/types';
 
 const profile: Reducer<Profile | null> = (state = null, action) => {
@@ -99,29 +98,13 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
  * function update would force it to be recomputed on every symbolication update
  * pass. It is valid for the lifetime of the profile.
  */
-const activeTabGlobalTracks: Reducer<ActiveTabGlobalTrack[]> = (
-  state = [],
+const activeTabTimeline: Reducer<ActiveTabTimeline | null> = (
+  state = null,
   action
 ) => {
   switch (action.type) {
     case 'VIEW_ACTIVE_TAB_PROFILE':
-      return action.globalTracks;
-    default:
-      return state;
-  }
-};
-
-/**
- * This can be derived like the globalTracks information, but is stored in the state
- * for the same reason.
- */
-const activeTabResourceTracks: Reducer<ActiveTabResourceTrack[]> = (
-  state = [],
-  action
-) => {
-  switch (action.type) {
-    case 'VIEW_ACTIVE_TAB_PROFILE':
-      return action.resourceTracks;
+      return action.activeTabTimeline;
     default:
       return state;
   }
@@ -613,8 +596,7 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
       localTracksByPid,
     }),
     activeTab: combineReducers({
-      globalTracks: activeTabGlobalTracks,
-      resourceTracks: activeTabResourceTracks,
+      activeTabTimeline,
     }),
     origins: combineReducers({
       originsTimeline,

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -138,11 +138,11 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
         // Add the height of the main track.
         // The thread tracks have enough complexity that it warrants measuring
         // them rather than statically using a value like the other tracks.
-        const { threadIndex } = activeTabTimeline.mainTrack;
-        if (threadIndex === null) {
+        const { mainThreadIndex } = activeTabTimeline.mainTrack;
+        if (mainThreadIndex === null) {
           height += TRACK_PROCESS_BLANK_HEIGHT + border;
         } else {
-          const trackThreadHeight = trackThreadHeights[threadIndex];
+          const trackThreadHeight = trackThreadHeights[mainThreadIndex];
           if (trackThreadHeight === undefined) {
             // The height isn't computed yet, return.
             return null;

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -59,6 +59,8 @@ import type {
   FullProfileViewState,
   ActiveTabProfileViewState,
   OriginsViewState,
+  ActiveTabTimeline,
+  ActiveTabMainTrack,
   $ReturnType,
 } from 'firefox-profiler/types';
 
@@ -427,16 +429,25 @@ export const getLocalTrackName = (
 /**
  * Returns global tracks for the active tab view.
  */
+export const getActiveTabTimeline: Selector<ActiveTabTimeline> = state =>
+  getActiveTabProfileView(state).activeTabTimeline;
+
+export const getActiveTabMainTrack: Selector<ActiveTabMainTrack> = state =>
+  getActiveTabTimeline(state).mainTrack;
+
 export const getActiveTabGlobalTracks: Selector<
   ActiveTabGlobalTrack[]
-> = state => getActiveTabProfileView(state).globalTracks;
+> = state => [
+  ...getActiveTabTimeline(state).screenshots,
+  getActiveTabTimeline(state).mainTrack,
+];
 
 /**
  * Returns resource tracks for the active tab view.
  */
 export const getActiveTabResourceTracks: Selector<
   ActiveTabResourceTrack[]
-> = state => getActiveTabProfileView(state).resourceTracks;
+> = state => getActiveTabTimeline(state).resources;
 
 /**
  * This returns all TrackReferences for global tracks.

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -93,7 +93,7 @@ describe('ActiveTabTimeline', function() {
       if (track.type !== 'tab') {
         throw new Error('Expected a tab track.');
       }
-      const threadIndex = track.threadIndex;
+      const threadIndex = track.mainThreadIndex;
 
       if (threadIndex !== null) {
         // The assertions are simpler if the GeckoMain tab thread is not already selected.

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -217,10 +217,15 @@ export function getHumanReadableActiveTabTracks(state: State): string[] {
   for (const globalTrack of globalTracks) {
     switch (globalTrack.type) {
       case 'tab': {
-        const selected =
-          globalTrack.threadIndex === selectedThreadIndex ? ' SELECTED' : '';
-        text.push(`main track [tab]${selected}`);
-        // TODO: Add resource tracks
+        // Only print the main track if we actually managed to find it.
+        if (globalTrack.threadIndexes.length > 0) {
+          const selected =
+            globalTrack.mainThreadIndex === selectedThreadIndex
+              ? ' SELECTED'
+              : '';
+          text.push(`main track [tab]${selected}`);
+          // TODO: Add resource tracks
+        }
         break;
       }
       case 'screenshots': {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -444,7 +444,8 @@ describe('showTabOnly', function() {
     expect(globalTracks).toEqual([
       {
         type: 'tab',
-        threadIndex: 0,
+        mainThreadIndex: 0,
+        threadIndexes: [0],
       },
     ]);
     // TODO: Resource track type will be changed soon.

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -19,9 +19,8 @@ import type {
   LocalTrack,
   TrackIndex,
   MarkerIndex,
-  ActiveTabGlobalTrack,
   OriginsTimeline,
-  ActiveTabResourceTrack,
+  ActiveTabTimeline,
 } from './profile-derived';
 import type { FuncToFuncMap } from '../profile-logic/symbolication';
 import type { TemporaryError } from '../utils/errors';
@@ -284,8 +283,7 @@ type ReceiveProfileAction =
   | {|
       +type: 'VIEW_ACTIVE_TAB_PROFILE',
       +selectedThreadIndex: ThreadIndex,
-      +globalTracks: ActiveTabGlobalTrack[],
-      +resourceTracks: ActiveTabResourceTrack[],
+      +activeTabTimeline: ActiveTabTimeline,
       +browsingContextID: BrowsingContextID,
     |}
   | {|

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -254,6 +254,13 @@ export type OriginsTimeline = Array<
 /**
  * Active tab view tracks
  */
+
+/**
+ * Main track for active tab view.
+ * Currently it holds mainThreadIndex to make things easier because most of the
+ * places require a single thread index instead of thread indexes array.
+ * This will go away soon.
+ */
 export type ActiveTabMainTrack = {|
   type: 'tab',
   mainThreadIndex: ThreadIndex,
@@ -278,6 +285,13 @@ export type ActiveTabResourceTrack =
       +name: string,
     |};
 
+/**
+ * Timeline for active tab view.
+ * It holds main track for the current tab, screenshots and resource tracks.
+ * Main track is being computed during profile load and rest is being added to resources.
+ * This timeline type is different compared to full view. This makes making main
+ * track acess a lot easier.
+ */
 export type ActiveTabTimeline = {
   mainTrack: ActiveTabMainTrack,
   screenshots: Array<ActiveTabScreenshotTrack>,

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -254,9 +254,16 @@ export type OriginsTimeline = Array<
 /**
  * Active tab view tracks
  */
-export type ActiveTabGlobalTrack =
-  | {| +type: 'tab', +threadIndex: ThreadIndex |}
-  | {| +type: 'screenshots', +id: string, +threadIndex: ThreadIndex |};
+export type ActiveTabMainTrack = {|
+  type: 'tab',
+  threadIndex: ThreadIndex,
+|};
+
+export type ActiveTabScreenshotTrack = {|
+  +type: 'screenshots',
+  +id: string,
+  +threadIndex: ThreadIndex,
+|};
 
 export type ActiveTabResourceTrack =
   | {|
@@ -269,6 +276,16 @@ export type ActiveTabResourceTrack =
       +threadIndex: ThreadIndex,
       +name: string,
     |};
+
+export type ActiveTabTimeline = {
+  mainTrack: ActiveTabMainTrack,
+  screenshots: Array<ActiveTabScreenshotTrack>,
+  resources: Array<ActiveTabResourceTrack>,
+};
+
+export type ActiveTabGlobalTrack =
+  | ActiveTabMainTrack
+  | ActiveTabScreenshotTrack;
 
 export type ActiveTabTrack = ActiveTabGlobalTrack | ActiveTabResourceTrack;
 

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -256,7 +256,8 @@ export type OriginsTimeline = Array<
  */
 export type ActiveTabMainTrack = {|
   type: 'tab',
-  threadIndex: ThreadIndex,
+  mainThreadIndex: ThreadIndex,
+  threadIndexes: Array<ThreadIndex>,
 |};
 
 export type ActiveTabScreenshotTrack = {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -25,9 +25,8 @@ import type {
   LocalTrack,
   TrackIndex,
   MarkerIndex,
-  ActiveTabGlobalTrack,
+  ActiveTabTimeline,
   OriginsTimeline,
-  ActiveTabResourceTrack,
 } from './profile-derived';
 import type { Attempt } from '../utils/errors';
 import type { TransformStacksPerThread } from './transforms';
@@ -74,8 +73,7 @@ export type OriginsViewState = {|
  * They should not be used from the full view.
  */
 export type ActiveTabProfileViewState = {|
-  globalTracks: ActiveTabGlobalTrack[],
-  resourceTracks: ActiveTabResourceTrack[],
+  activeTabTimeline: ActiveTabTimeline,
 |};
 
 /**


### PR DESCRIPTION
I wanted to change the profile view state of active tab to. It looks more like the origins profile view state now. But still has a method to get the whole "global tracks" (combines main track with screenshots) because lots of the code depends on this currently.
First commit changes that structure, and second commit adds the other mainTrack threads to the mainTrack.threadIndexes list, because main track can include multiple threads and we should eventually merge it.