### PR TITLE
Add keyboard shortcuts to CallTree (draft)

### DIFF
--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -336,6 +336,7 @@ type TreeViewProps<DisplayData> = {|
   +contextMenu?: React.Element<any>,
   +contextMenuId?: string,
   +maxNodeDepth: number,
+  +onTransformKeyPress: KeyboardEvent => mixed,
   +onSelectionChange: NodeIndex => mixed,
   +onRightClickSelection?: NodeIndex => mixed,
   +onEnterKey?: NodeIndex => mixed,
@@ -521,6 +522,10 @@ class TreeView<DisplayData: Object> extends React.PureComponent<
     this._toggle(nodeId, newExpanded, true);
   }
 
+  _transform(event: KeyboardEvent) {
+    this.props.onTransformKeyPress(event);
+  }
+
   _select(nodeId: NodeIndex) {
     this.props.onSelectionChange(nodeId);
   }
@@ -562,7 +567,6 @@ class TreeView<DisplayData: Object> extends React.PureComponent<
   };
 
   _onKeyDown = (event: KeyboardEvent) => {
-    const hasModifier = event.ctrlKey || event.altKey;
     const isNavigationKey =
       event.key.startsWith('Arrow') ||
       event.key.startsWith('Page') ||
@@ -571,10 +575,6 @@ class TreeView<DisplayData: Object> extends React.PureComponent<
     const isAsteriskKey = event.key === '*';
     const isEnterKey = event.key === 'Enter';
 
-    if (hasModifier || (!isNavigationKey && !isAsteriskKey && !isEnterKey)) {
-      // No key events that we care about were found, so don't try and handle them.
-      return;
-    }
     event.stopPropagation();
     event.preventDefault();
 
@@ -587,6 +587,11 @@ class TreeView<DisplayData: Object> extends React.PureComponent<
     if (selected === null || selectedRowIndex === -1) {
       // the first condition is redundant, but it makes flow happy
       this._select(visibleRows[0]);
+      return;
+    }
+
+    if (!isNavigationKey && !isAsteriskKey && !isEnterKey) {
+      this._transform(event);
       return;
     }
 


### PR DESCRIPTION
Draft to implement #2519 

Working keyboard shortcuts for call tree. See CallTree.js for the shortcuts as labels haven't been added to the context menu yet. For example ctrl + alt + z to apply focus-subtree transform.

TODO:

- Refactor some functions such as  CallNodeContextMenu.getNameForSelectedResource to use in CallTree. They're needed to check whether the transform being applied to the current selected node is valid
- Define and agree upon the shortcuts for each transform (arbitrary ones used in this draft)
- Add shortcuts to stack chart and flame graph.. Ideally call tree, stack chart and flame graph would share the same keyDown handler but currently that is not the case. Maybe refactoring needed here
- Add labels to the context menu to suggest the shortcuts