### PR TITLE
Fix sidebar category twisty positioning on scroll

### DIFF
--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -12,7 +12,7 @@
 }
 
 .sidebar-contents-wrapper {
-  /* Allow absolute positioning that is independent of the scrolling. */
+  /* Allow absolute positioning that is dependent of the scrolling. */
   position: relative;
   line-height: 1.5;
 }

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -12,6 +12,8 @@
 }
 
 .sidebar-contents-wrapper {
+  /* Allow absolute positioning that is independent of the scrolling. */
+  position: relative;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
STR: Load a profile with the categories sidebar, then scroll the view. The arrows stay absolutely positioned and ignore the scroll:

Broken example:
<img width="276" alt="image" src="https://user-images.githubusercontent.com/1588648/88061882-b773ae00-cb2d-11ea-89f8-e1b62bb8a3aa.png">
