### PR TITLE
Fix the scrollbar problem on active tab

### DIFF
--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -3,7 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .timelineSelection.activeTab {
-  --thread-label-column-width: 0;
+  /**
+   * We have to use `0px` instead of `0` because we are using this variable in
+   * `calc` functions and they expect a pixel unit instead of an integer.
+   */
+  /* stylelint-disable-next-line length-zero-no-unit */
+  --thread-label-column-width: 0px;
 }
 
 .timelineTrack:not(:first-child)


### PR DESCRIPTION
Scrollbar was not showing up properly on active tab due to this css
variable. That's because we are using this value inside the `calc`
function and it expects this value to be a pixel. For example, this
is the one use case of this variable:
`margin-left: calc(var(--thread-label-column-width) * -1);`
If we put an integer to this variable instead, calc result will be
integer and this margin property will fail to compute. So we *must* use a
pixel for this variable even though it's `0`.

Look at the timeline right scrollbar:
[Deploy preview](https://deploy-preview-2668--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?ctxId=12&resources&thread=7&v=5&view=active-tab)
[Current](https://profiler.firefox.com/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?ctxId=12&resources&thread=7&v=5&view=active-tab)