### PR TITLE
Add a test for the history API, and fix the back button for profiles loaded by URL

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -21,7 +21,10 @@ import {
   getThreads,
 } from '../selectors/profile';
 import { sendAnalytics } from '../utils/analytics';
-import { stateFromLocation } from '../app-logic/url-handling';
+import {
+  stateFromLocation,
+  withHistoryReplaceState,
+} from '../app-logic/url-handling';
 import { finalizeProfileView } from './receive-profile';
 import { fatalError } from './errors';
 import {
@@ -145,9 +148,13 @@ export function setupInitialUrlState(
     // other parts of the code.
     // The first dispatch here updates the url state, then changes state as the url
     // setup is done, and lastly finalizes the profile view since everything is set up now.
-    dispatch(updateUrlState(urlState));
-    dispatch(urlSetupDone());
-    dispatch(finalizeProfileView());
+    // All of this is done while the history is replaced, as this is part of the initial
+    // load process.
+    withHistoryReplaceState(() => {
+      dispatch(updateUrlState(urlState));
+      dispatch(urlSetupDone());
+      dispatch(finalizeProfileView());
+    });
   };
 }
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1139,7 +1139,7 @@ async function _extractJsonFromResponse(
   }
 }
 
-function getProfileUrlForHash(hash: string): string {
+export function getProfileUrlForHash(hash: string): string {
   // See https://cloud.google.com/storage/docs/access-public-data
   // The URL is https://storage.googleapis.com/<BUCKET>/<FILEPATH>.
   // https://<BUCKET>.storage.googleapis.com/<FILEPATH> seems to also work but

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -48,7 +48,21 @@ let _isReplaceState: boolean = false;
  * history API's behavior.
  */
 export function setHistoryReplaceState(value: boolean): void {
+  if (_isReplaceState === value) {
+    throw new Error(
+      `Trying to toggle the history replace state to: ${value.toString()} but it was already ${_isReplaceState.toString()}.`
+    );
+  }
   _isReplaceState = value;
+}
+
+/**
+ * This function only handles sync callbacks, but async could be handled if needed.
+ */
+export function withHistoryReplaceState(fn: () => void): void {
+  setHistoryReplaceState(true);
+  fn();
+  setHistoryReplaceState(false);
 }
 
 /**

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -92,6 +92,8 @@ class UrlManager extends React.PureComponent<Props> {
     // We have to wrap this because of the error introduced by upgrading to v0.96.0. See issue #1936.
     const getProfilesFromRawUrl: WrapFunctionInDispatch<GetProfilesFromRawUrl> = (this
       .props.getProfilesFromRawUrl: any);
+
+    // Notify the UI that we are starting to fetch profiles.
     startFetchingProfiles();
 
     try {
@@ -109,14 +111,15 @@ class UrlManager extends React.PureComponent<Props> {
         profile,
         shouldSetupInitialUrlState,
       } = await getProfilesFromRawUrl(window.location);
-
       if (profile !== null && shouldSetupInitialUrlState) {
         setupInitialUrlState(window.location, profile);
       } else {
         urlSetupDone();
       }
     } catch (error) {
-      // Silently complete the url setup.
+      // Complete the URL setup, as values can come from the user, so we should
+      // still proceed with loading the app.
+      console.error('There was an error in the initial URL setup.', error);
       urlSetupDone();
     }
   }

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -124,7 +124,7 @@ class UrlManager extends React.PureComponent<Props> {
     }
   }
 
-  _updateState() {
+  _updateState = () => {
     const { updateUrlState, show404, urlState: previousUrlState } = this.props;
     let newUrlState;
     if (window.history.state) {
@@ -161,11 +161,15 @@ class UrlManager extends React.PureComponent<Props> {
 
     // Update the Redux store.
     updateUrlState(newUrlState);
-  }
+  };
 
   componentDidMount() {
     this._processInitialUrls();
-    window.addEventListener('popstate', () => this._updateState());
+    window.addEventListener('popstate', this._updateState);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('popstate', () => this._updateState);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {

--- a/src/test/components/Root-history.test.js
+++ b/src/test/components/Root-history.test.js
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// We want to test these components in isolation and tightly control the actions
+// dispatched and avoid any side-effects.  That's why we mock this module and
+// return dummy thunk actions that return a Promise.
+// jest.mock('../../actions/receive-profile', () => ({
+//   // These mocks will get their implementation in the `setup` function.
+//   // Otherwise the implementation is wiped before the test starts.
+//   // See https://github.com/facebook/jest/issues/7573 for more info.
+//   retrieveProfileFromAddon: jest.fn(),
+//   retrieveProfileFromStore: jest.fn(),
+//   retrieveProfilesToCompare: jest.fn(),
+// }));
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import Root from '../../components/app/Root';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
+
+// Because this module is mocked but we want the real actions in the test, we
+// use `jest.requireActual` here.
+// These functions are mocks
+import { getProfileUrlForHash } from '../../actions/receive-profile';
+
+import { blankStore } from '../fixtures/stores';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { mockWindowLocation } from '../fixtures/mocks/window-location';
+import { mockWindowHistory } from '../fixtures/mocks/window-history';
+import { coerceMatchingShape } from '../../utils/flow';
+
+import type { SerializableProfile } from 'firefox-profiler/types';
+import { makeProfileSerializable } from '../../profile-logic/process-profile';
+
+describe('Root with history', function() {
+  // Cleanup the tests through a side-effect.
+  let _cleanup;
+  afterEach(() => {
+    if (!_cleanup) {
+      throw new Error('Expected the setup function to create a cleanup step.');
+    }
+    _cleanup();
+  });
+
+  type TestConfig = {|
+    profileHash?: string,
+  |};
+
+  function setup(config: TestConfig) {
+    const { profileHash } = config;
+
+    let resetWindowLocation;
+    const resetWindowHistory = mockWindowHistory();
+
+    // This test is driven primarily by the URL. Decide how to load things.
+    if (profileHash) {
+      // Load by URL, with a profile hash.
+      resetWindowLocation = mockWindowLocation(
+        `https://profiler.firefox.com/public/${profileHash}`
+      );
+
+      // Ensure this is a properly serialized profile.
+      const profile = makeProfileSerializable(
+        getProfileFromTextSamples('A  B  C  D  E').profile
+      );
+      mockFetchProfileAtUrl(getProfileUrlForHash('FAKEHASH'), profile);
+    } else {
+      throw new Error('TODO');
+    }
+
+    const ctx = mockCanvasContext();
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => ctx);
+
+    const store = blankStore();
+    const renderResult = render(<Root store={store} />);
+
+    _cleanup = () => {
+      // Cleanup the mocks.
+      resetWindowLocation();
+      resetWindowHistory();
+      delete window.fetch;
+      _cleanup = null;
+    };
+
+    const { findByRole } = renderResult;
+
+    async function waitForTab(details: *): Promise<HTMLElement> {
+      return findByRole('tab', details);
+    }
+
+    return {
+      ...renderResult,
+      ...store,
+      waitForTab,
+    };
+  }
+
+  it('can view a file from the profile store, use history with it', async function() {
+    const { getByText, queryByText, waitForTab } = setup({
+      profileHash: 'FAKEHASH',
+    });
+
+    expect(window.history.length).toBe(1);
+
+    expect(getByText('Downloading and processing the profile...')).toBeTruthy();
+    expect(queryByText('Call Tree')).toBeFalsy();
+
+    await Promise.all((window: any).fetch.mock.results.map(n => n.value));
+
+    // Wait until the call tree is visible.
+    await waitForTab({ name: 'Call Tree', selected: true });
+    await waitForTab({ name: 'Marker Chart', selected: false });
+
+    // History on load starts at 1.
+    expect(window.history.length).toBe(1);
+
+    // Going back doesn't do anything.
+    window.history.back();
+    expect(window.history.length).toBe(1);
+
+    // Trigger a history event by clicking a tab.
+    const markerChart = await waitForTab({
+      name: 'Marker Chart',
+      selected: false,
+    });
+    markerChart.click();
+
+    await waitForTab({ name: 'Call Tree', selected: false });
+    await waitForTab({ name: 'Marker Chart', selected: true });
+
+    expect(window.history.length).toBe(2);
+
+    // Now go back to the call tree.
+    window.history.back();
+
+    await waitForTab({ name: 'Call Tree', selected: true });
+    await waitForTab({ name: 'Marker Chart', selected: false });
+
+    // The history will still have the same length, as we haven't overwritten it.
+    expect(window.history.length).toBe(2);
+  });
+
+  it('resets the history length between tests', async function() {
+    setup({
+      profileHash: 'FAKEHASH',
+    });
+    expect(window.history.length).toBe(1);
+  });
+});
+
+function mockFetchProfileAtUrl(
+  url: string,
+  profile: SerializableProfile
+): void {
+  const responses = [];
+  const fetch = jest.fn().mockImplementation((fetchUrl: string) => {
+    if (fetchUrl === url) {
+      const response = coerceMatchingShape<Response>({
+        ok: true,
+        status: 200,
+        headers: coerceMatchingShape<Headers>({
+          get: () => 'application/json',
+        }),
+        json: () => Promise.resolve(profile),
+      });
+      responses.push(response);
+      return Promise.resolve(response);
+    }
+    return Promise.reject(
+      coerceMatchingShape<Response>({
+        ok: false,
+        status: 404,
+        statusText: 'Not found',
+      })
+    );
+  });
+
+  (window: any).fetch = fetch;
+}

--- a/src/test/components/Root-history.test.js
+++ b/src/test/components/Root-history.test.js
@@ -4,37 +4,20 @@
 
 // @flow
 
-// We want to test these components in isolation and tightly control the actions
-// dispatched and avoid any side-effects.  That's why we mock this module and
-// return dummy thunk actions that return a Promise.
-// jest.mock('../../actions/receive-profile', () => ({
-//   // These mocks will get their implementation in the `setup` function.
-//   // Otherwise the implementation is wiped before the test starts.
-//   // See https://github.com/facebook/jest/issues/7573 for more info.
-//   retrieveProfileFromAddon: jest.fn(),
-//   retrieveProfileFromStore: jest.fn(),
-//   retrieveProfilesToCompare: jest.fn(),
-// }));
-
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
 import Root from '../../components/app/Root';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
-
-// Because this module is mocked but we want the real actions in the test, we
-// use `jest.requireActual` here.
-// These functions are mocks
 import { getProfileUrlForHash } from '../../actions/receive-profile';
-
 import { blankStore } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { mockWindowLocation } from '../fixtures/mocks/window-location';
 import { mockWindowHistory } from '../fixtures/mocks/window-history';
 import { coerceMatchingShape } from '../../utils/flow';
+import { makeProfileSerializable } from '../../profile-logic/process-profile';
 
 import type { SerializableProfile } from 'firefox-profiler/types';
-import { makeProfileSerializable } from '../../profile-logic/process-profile';
 
 describe('Root with history', function() {
   // Cleanup the tests through a side-effect.
@@ -69,7 +52,10 @@ describe('Root with history', function() {
       );
       mockFetchProfileAtUrl(getProfileUrlForHash('FAKEHASH'), profile);
     } else {
-      throw new Error('TODO');
+      throw new Error(
+        'TODO - These tests need to add other views, which will not need the ' +
+          'profile hash. This is needed to complete #1789.'
+      );
     }
 
     const ctx = mockCanvasContext();

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
-import { serializeProfile } from '../../profile-logic/process-profile';
+import { makeProfileSerializable } from '../../profile-logic/process-profile';
 import { getView, getUrlSetupPhase } from '../../selectors/app';
 import UrlManager from '../../components/app/UrlManager';
 import { blankStore } from '../fixtures/stores';
@@ -31,7 +31,7 @@ describe('UrlManager', function() {
       },
       json: () =>
         Promise.resolve(
-          JSON.parse(serializeProfile(getProfileFromTextSamples('A').profile))
+          makeProfileSerializable(getProfileFromTextSamples('A').profile)
         ),
     }: any): Response);
     return fetch200Response;

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -82,6 +82,8 @@ describe('UrlManager', function() {
 
   it('sets up the URL', async function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
     expect(getUrlSetupPhase(getState())).toBe('initial-load');
     createUrlManager();
 
@@ -90,13 +92,16 @@ describe('UrlManager', function() {
     await waitUntilUrlSetupPhase('done');
     expect(getUrlSetupPhase(getState())).toBe('done');
     expect(getDataSource(getState())).toMatch('none');
+    expect(console.error).toHaveBeenCalled();
   });
 
   it('has no data source by default', async function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     createUrlManager();
     await waitUntilUrlSetupPhase('done');
     expect(getDataSource(getState())).toMatch('none');
+    expect(console.error).toHaveBeenCalled();
   });
 
   it('sets the data source to from-addon', async function() {
@@ -114,11 +119,13 @@ describe('UrlManager', function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup(
       '/from-file/'
     );
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     expect(getDataSource(getState())).toMatch('none');
     createUrlManager();
 
     await waitUntilUrlSetupPhase('done');
     expect(getDataSource(getState())).toMatch('none');
+    expect(console.error).toHaveBeenCalled();
   });
 
   it(`sets the data source to public and doesn't change the URL when there's a fetch error`, async function() {

--- a/src/test/fixtures/mocks/window-history.js
+++ b/src/test/fixtures/mocks/window-history.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { coerceMatchingShape } from '../../../utils/flow';
+
+/**
+ * jsdom leaves the history in place after every test, so the history will be dirty.
+ * Plus when we stop using a component it could still be subscribed to events, which
+ * does not really reflect real-world use cases. This mock creates a history API
+ * that can be thrown away after every use.
+ */
+export function mockWindowHistory() {
+  const originalHistory = Object.getOwnPropertyDescriptor(window, 'history');
+
+  let states = [null];
+  let index = 0;
+  const history = {
+    get length() {
+      return states.length;
+    },
+    scrollRestoration: 'auto',
+    state: null,
+    back() {
+      if (index <= 0) {
+        return;
+      }
+      index--;
+      history.state = states[index];
+      window.dispatchEvent(new Event('popstate'));
+    },
+    forward() {
+      if (index === states.length - 1) {
+        return;
+      }
+      index++;
+
+      history.state = states[index];
+      window.dispatchEvent(new Event('popstate'));
+    },
+    go() {
+      throw new Error('Not implemented.');
+    },
+    pushState(newState: any, _title: string, _url?: string) {
+      // The title and URL are ignored.
+      states = states.slice(0, index + 1);
+      states.push(newState);
+      index++;
+    },
+    replaceState(newState: any, _title: string, _url?: string) {
+      // The title and URL are ignored.
+      states[index] = newState;
+    },
+  };
+
+  Object.defineProperty(window, 'history', {
+    value: coerceMatchingShape<History>(history),
+    configurable: true,
+  });
+
+  // Return a function that resets the mock.
+  return () => {
+    // $FlowExpectError - Flow can't handle getOwnPropertyDescriptor being used on defineProperty.
+    Object.defineProperty(window, 'history', originalHistory);
+  };
+}

--- a/src/test/fixtures/mocks/window-history.js
+++ b/src/test/fixtures/mocks/window-history.js
@@ -7,9 +7,7 @@ import { coerceMatchingShape } from '../../../utils/flow';
 
 /**
  * jsdom leaves the history in place after every test, so the history will be dirty.
- * Plus when we stop using a component it could still be subscribed to events, which
- * does not really reflect real-world use cases. This mock creates a history API
- * that can be thrown away after every use.
+ * This mock creates a history API that can be thrown away after every use.
  */
 export function mockWindowHistory() {
   const originalHistory = Object.getOwnPropertyDescriptor(window, 'history');

--- a/src/test/fixtures/mocks/window-location.js
+++ b/src/test/fixtures/mocks/window-location.js
@@ -5,7 +5,8 @@
 // @flow
 
 /**
- * jsdom doesn't really know about this API.
+ * jsdom's implementation of this API doesn't allow for assigning to the location, which
+ * we need to be able to do for certain tests.
  */
 export function mockWindowLocation(location: string = 'http://localhost') {
   // This is the internal state.
@@ -16,23 +17,73 @@ export function mockWindowLocation(location: string = 'http://localhost') {
   }
 
   const nativeLocation = Object.getOwnPropertyDescriptor(window, 'location');
+  function accessError() {
+    throw new Error(
+      'Setting properties for the window.location object is not supported with this mock.'
+    );
+  }
 
   // It seems node v8 doesn't let us change the value unless we delete it before.
   delete window.location;
-  // $FlowExpectError because the value we pass isn't a proper Location object.
-  Object.defineProperty(window, 'location', {
-    get() {
+
+  const property = {
+    get(): $Shape<Location> {
       return {
         ancestorOrigins: [],
-        href: location,
-        origin: url.origin,
-        protocol: url.protocol,
-        host: url.host,
-        hostname: url.hostname,
-        port: url.port,
-        pathname: url.pathname,
-        search: url.search,
-        hash: url.hash,
+        get href() {
+          return location;
+        },
+        get origin() {
+          return url.origin;
+        },
+        get protocol() {
+          return url.protocol;
+        },
+        get host() {
+          return url.host;
+        },
+        get hostname() {
+          return url.hostname;
+        },
+        get port() {
+          return url.port;
+        },
+        get pathname() {
+          return url.pathname;
+        },
+        get search() {
+          return url.search;
+        },
+        get hash() {
+          return url.hash;
+        },
+        set href(v) {
+          accessError();
+        },
+        set origin(v) {
+          accessError();
+        },
+        set protocol(v) {
+          accessError();
+        },
+        set host(v) {
+          accessError();
+        },
+        set hostname(v) {
+          accessError();
+        },
+        set port(v) {
+          accessError();
+        },
+        set pathname(v) {
+          accessError();
+        },
+        set search(v) {
+          accessError();
+        },
+        set hash(v) {
+          accessError();
+        },
         assign: setLocation,
         reload: jest.fn(),
         replace: jest.fn(setLocation),
@@ -41,7 +92,10 @@ export function mockWindowLocation(location: string = 'http://localhost') {
     },
     configurable: true,
     set: setLocation,
-  });
+  };
+
+  // $FlowExpectError because the value we pass isn't a proper Location object.
+  Object.defineProperty(window, 'location', property);
 
   // Return a function that resets the mock.
   return () => {

--- a/src/test/fixtures/mocks/window-location.js
+++ b/src/test/fixtures/mocks/window-location.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+/**
+ * jsdom doesn't really know about this API.
+ */
+export function mockWindowLocation(location: string = 'http://localhost') {
+  // This is the internal state.
+  let url = new URL(location);
+  function setLocation(newUrl: string | { toString: () => string }): void {
+    location = newUrl.toString();
+    url = new URL(location);
+  }
+
+  const nativeLocation = Object.getOwnPropertyDescriptor(window, 'location');
+
+  // It seems node v8 doesn't let us change the value unless we delete it before.
+  delete window.location;
+  // $FlowExpectError because the value we pass isn't a proper Location object.
+  Object.defineProperty(window, 'location', {
+    get() {
+      return {
+        ancestorOrigins: [],
+        href: location,
+        origin: url.origin,
+        protocol: url.protocol,
+        host: url.host,
+        hostname: url.hostname,
+        port: url.port,
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+        assign: setLocation,
+        reload: jest.fn(),
+        replace: jest.fn(setLocation),
+        toString: () => location,
+      };
+    },
+    configurable: true,
+    set: setLocation,
+  });
+
+  // Return a function that resets the mock.
+  return () => {
+    // $FlowExpectError because nativeLocation doesn't match the type expected by Flow.
+    Object.defineProperty(window, 'location', nativeLocation);
+  };
+}

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -38,6 +38,7 @@ import fakeIndexedDB from 'fake-indexeddb';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import JSZip from 'jszip';
 import {
+  makeProfileSerializable,
   serializeProfile,
   processProfile,
 } from '../../profile-logic/process-profile';
@@ -677,8 +678,7 @@ describe('actions/receive-profile', function() {
       headers: {
         get: () => 'application/json',
       },
-      json: () =>
-        Promise.resolve(JSON.parse(serializeProfile(_getSimpleProfile()))),
+      json: () => Promise.resolve(makeProfileSerializable(_getSimpleProfile())),
     }: any): Response);
 
     beforeEach(function() {
@@ -727,9 +727,7 @@ describe('actions/receive-profile', function() {
         (({
           ...fetch200Response,
           json: () =>
-            Promise.resolve(
-              JSON.parse(serializeProfile(unsymbolicatedProfile))
-            ),
+            Promise.resolve(makeProfileSerializable(unsymbolicatedProfile)),
         }: any): Response)
       );
 
@@ -847,8 +845,7 @@ describe('actions/receive-profile', function() {
       headers: {
         get: () => 'application/json',
       },
-      json: () =>
-        Promise.resolve(JSON.parse(serializeProfile(_getSimpleProfile()))),
+      json: () => Promise.resolve(makeProfileSerializable(_getSimpleProfile())),
     }: any): Response);
 
     beforeEach(function() {

--- a/src/test/types/utils.js
+++ b/src/test/types/utils.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+// @flow
+/* eslint-disable no-unused-vars, flowtype/no-unused-expressions */
+
+import { coerce, coerceMatchingShape } from 'firefox-profiler/utils/flow';
+
+type CoerceA = {| startTime: number |};
+type CoerceB = {| startTime: number, endTime: number |};
+type CoerceC = number;
+
+const coerceA: CoerceA = { startTime: 0 };
+const coerceB: CoerceB = coerce<CoerceA, CoerceB>(coerceA);
+// $FlowExpectError - The coercion produces the correct value.
+const coerceC: CoerceC = coerce<CoerceA, CoerceB>(coerceA);
+// $FlowExpectError - The coercion must take the correct value.
+const coerceB2: CoerceB = coerce<CoerceA, CoerceB>(coerceB);
+
+const coerceMatchingShape1 = coerceMatchingShape<CoerceA>({ startTime: 0 });
+const coerceMatchingShape2 = coerceMatchingShape<CoerceB>({ startTime: 0 });
+// $FlowExpectError - The coercion must take the correct value.
+const coerceMatchingShape3 = coerceMatchingShape<CoerceB>({ time: 0 });

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -742,3 +742,17 @@ export type Profile = {|
   profilerOverhead?: ProfilerOverhead[],
   threads: Thread[],
 |};
+
+type SerializableThread = {|
+  ...$Diff<Thread, { stringTable: UniqueStringArray }>,
+  stringArray: string[],
+|};
+
+/**
+ * The UniqueStringArray is a class, and is not serializable to JSON. This profile
+ * variant is able to be based into JSON.stringify.
+ */
+export type SerializableProfile = {|
+  ...Profile,
+  threads: SerializableThread[],
+|};

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -102,6 +102,21 @@ export function convertToTransformType(type: string): TransformType | null {
 }
 
 /**
+ * This function coerces one type into another type.
+ * This is equivalent to: (((value: A): any): B)
+ */
+export function coerce<A, B>(item: A): B {
+  return (item: any);
+}
+
+/**
+ * It can be helpful to coerce one type that matches the shape of another.
+ */
+export function coerceMatchingShape<T>(item: $Shape<T>): T {
+  return (item: any);
+}
+
+/**
  * This is a type-friendly version of Object.values that assumes the object has
  * a Map-like structure.
  */


### PR DESCRIPTION
This helps with #1789, but does not resolve it. We need tests for every single profile source to ensure that loading is correct for the history and back button.

In these commits, the test is added first, and catches the current back button regression. The last commit fixes the issue. The first 3 commits were all transitory changes that I was making while working with the code.