### PR TITLE
Disable "length-zero-no-unit" stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,6 +11,7 @@
     "prettier/prettier": [
       true,
       { "parser": "css" }
-    ]
+    ],
+    "length-zero-no-unit": null
   }
 }

--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -7,7 +7,6 @@
    * We have to use `0px` instead of `0` because we are using this variable in
    * `calc` functions and they expect a pixel unit instead of an integer.
    */
-  /* stylelint-disable-next-line length-zero-no-unit */
   --thread-label-column-width: 0px;
 }
 


### PR DESCRIPTION
This rule doesn't align with our styling values and it sometimes makes
us write buggy code (because sometimes you need to specify the unit).
Also `yarn lint-fix-css` doesn't ignore the disabled lines somehow and
tries to fix them. So overall, it's better to just remove this rule all
together.