### PR TITLE
Extract a reusable app header component

### DIFF
--- a/res/css/photon/index.css
+++ b/res/css/photon/index.css
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@import './typography.css';
 @import './button.css';
 @import './checkbox.css';
 @import './input.css';

--- a/res/css/photon/typography.css
+++ b/res/css/photon/typography.css
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Specification at https://design.firefox.com/photon/visuals/typography.html */
+
+/* The idea is to use the same numbers for the same context (eg title 20 with
+ * body 20 and caption 20), and of course use the hierarchy of titles when
+ * needed.
+ *
+ * When using these styles one has to take care to colors and margins as well.
+ * Margins are well described in
+ * https://design.firefox.com/photon/visuals/grid.html.
+ *
+ * In the future we may want to make this more generic by applying these styles
+ * by default to h1, h2, h3, etc.
+ */
+
+.photon-display-20 {
+  font-size: 36px;
+  font-weight: 200;
+}
+
+.photon-title-40 {
+  font-size: 28px;
+  font-weight: 300;
+}
+
+.photon-title-30 {
+  font-size: 22px;
+  font-weight: 300;
+}
+
+.photon-title-20 {
+  font-size: 17px;
+  font-weight: 500;
+}
+
+.photon-title-10 {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.photon-body-30 {
+  font-size: 17px;
+  font-weight: 400;
+}
+
+.photon-body-20,
+.photon-caption-30 {
+  font-size: 15px;
+  font-weight: 400;
+}
+
+.photon-body-10,
+.photon-caption-20 {
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.photon-caption-10 {
+  font-size: 11px;
+  font-weight: 400;
+}

--- a/res/photon/index.html
+++ b/res/photon/index.html
@@ -5,50 +5,50 @@
     <title>Photon Styling Examples</title>
   </head>
   <body>
-    <h1>Photon Styling Examples</h1>
+    <h1 class='photon-title-40'>Photon Styling Examples</h1>
     <p>This page has examples for the profiler’s implementation of the <a href="https://design.firefox.com/photon/">Photon design spec</a>.</p>
 
-    <h2>Photon Buttons</h2>
+    <h2 class='photon-title-30'>Photon Buttons</h2>
     <div class="row">
-      <h3>Photon Button</h3>
+      <h3 class='photon-title-20'>Photon Button</h3>
       <pre>&lt;button type="button" class="photon-button"&gt;Photon Button&lt;/button&gt;</pre>
       <button type="button" class="photon-button">Photon Button</button>
     </div>
 
     <div class="row">
-      <h3>Photon Button Default</h3>
+      <h3 class='photon-title-20'>Photon Button Default</h3>
       <pre>&lt;button type="button" class="photon-button photon-button-default"&gt;Default&lt;/button&gt;</pre>
       <button type="button" class="photon-button photon-button-default">Default</button>
     </div>
 
     <div class="row">
-      <h3>Photon Button Primary</h3>
+      <h3 class='photon-title-20'>Photon Button Primary</h3>
       <pre>&lt;button type="button" class="photon-button photon-button-primary"&gt;Primary&lt;/button&gt;</pre>
       <button type="button" class="photon-button photon-button-primary">Primary</button>
     </div>
 
     <div class="row">
-      <h3>Photon Button Micro</h3>
+      <h3 class='photon-title-20'>Photon Button Micro</h3>
       <pre>&lt;button type="button" class="photon-button photon-button-micro"&gt;Photon Micro Button&lt;/button&gt;</pre>
       <button type="button" class="photon-button photon-button-micro">Photon Micro Button</button>
     </div>
 
     <div class="row">
-      <h3>Photon Button Ghost</h3>
+      <h3 class='photon-title-20'>Photon Button Ghost</h3>
       <pre>&lt;button type="button" class="photon-button photon-button-ghost photon-button-test-image"&gt;&lt;/button&gt;</pre>
       <button type="button" class="photon-button photon-button-ghost photon-button-test-image"></button>
     </div>
 
-    <h2>Photon inputs</h2>
+    <h2 class='photon-title-30'>Photon inputs</h2>
 
     <div class="row">
-      <h3>Photon Input</h3>
+      <h3 class='photon-title-20'>Photon Input</h3>
       <pre>&lt;input type="text" class="photon-input" value="Example text" /&gt;</pre>
       <input type="text" class="photon-input" value="Example text" />
     </div>
 
     <div class="row">
-      <h3>Photon Checkbox</h3>
+      <h3 class='photon-title-20'>Photon Checkbox</h3>
       <pre>
 &lt;label class="photon-label photon-label-default"&gt;
   &lt;input type="checkbox" class="photon-checkbox photon-checkbox-default" /&gt;
@@ -62,7 +62,7 @@
     </div>
 
     <div class="row">
-      <h3>Photon Checkbox Micro (Unofficial)</h3>
+      <h3 class='photon-title-20'>Photon Checkbox Micro (Unofficial)</h3>
       <pre>
 &lt;label class="photon-label photon-label-micro"&gt;
   &lt;input type="checkbox" class="photon-checkbox-micro" /&gt;
@@ -76,7 +76,7 @@
     </div>
 
     <div class="row">
-      <h3>Photon Radio</h3>
+      <h3 class='photon-title-20'>Photon Radio</h3>
       <pre>
 &lt;label class="photon-label photon-label-default"&gt;
   &lt;input type="radio" name="radio-example" class="photon-radio photon-radio-default" /&gt;
@@ -106,7 +106,7 @@
     </div>
 
     <div class="row">
-      <h3>Photon Radio Micro (Unofficial)</h3>
+      <h3 class='photon-title-20'>Photon Radio Micro (Unofficial)</h3>
       <pre>
 &lt;label class="photon-label photon-label-micro"&gt;
   &lt;input type="radio" name="radio-example" class="photon-radio photon-radio-micro" /&gt;
@@ -135,11 +135,11 @@
       </label>
     </div>
 
-    <h2>Photon Message Bars</h2>
+    <h2 class='photon-title-30'>Photon Message Bars</h2>
     <p>These components work well both when taking all the available space or
     when they're smaller (sized in a flex component for example).</p>
 
-    <h3>Photon Message Bar Generic</h3>
+    <h3 class='photon-title-20'>Photon Message Bar Generic</h3>
       <div class="row">
         <pre>
 &lt;div class="photon-message-bar"&gt;
@@ -223,7 +223,7 @@
       </div>
     </div>
   </div>
-      <h3>Photon Message Bar Error</h3>
+      <h3 class='photon-title-20'>Photon Message Bar Error</h3>
       <div class="row">
         <pre>
 &lt;div class="photon-message-bar photon-message-bar-error"&gt;
@@ -308,7 +308,7 @@
     </div>
   </div>
 
-  <h3>Photon Message Bar Warning</h3>
+  <h3 class='photon-title-20'>Photon Message Bar Warning</h3>
   <div class="row">
     <pre>
 &lt;div class="photon-message-bar photon-message-bar-warning"&gt;
@@ -390,5 +390,33 @@
         </button>
       </div>
     </div>
+
+    <h2 class="photon-title-30">Typography</h2>
+    Please look only at the font sizes and weights. We don't change colors or
+    paddings with these classes..
+    <pre>
+&lt;div class="photon-display-20"&gt;Something just happened.&lt;/div&gt;
+&lt;h4 class="photon-title-30"&gt;Title 30 followed with body 30&lt;/h4&gt;
+&lt;div class="photon-body-30"&gt;This is a large body of text.&lt;/div&gt;
+&lt;div class="photon-caption-30"&gt;This is a caption. Normally its color is also paler.&lt;/div&gt;
+&lt;h4 class="photon-title-20"&gt;Title 20 followed with body 20&lt;/h4&gt;
+&lt;div class="photon-body-20"&gt;This is a large body of text.&lt;/div&gt;
+&lt;div class="photon-caption-20"&gt;This is a caption. Normally its color is also paler.&lt;/div&gt;
+&lt;h4 class="photon-title-10"&gt;Title 10 followed with body 10&lt;/h4&gt;
+&lt;div class="photon-body-10"&gt;This is a large body of text.&lt;/div&gt;
+&lt;div class="photon-caption-10"&gt;This is a caption. Normally its color is also paler.&lt;/div&gt;
+    </pre>
+    <div class="photon-display-20">
+      Something just happened.
+    </div>
+    <h4 class="photon-title-30">Title 30 followed with body 30</h4>
+    <div class="photon-body-30">This is a large body of text.</div>
+    <div class="photon-caption-30">This is a caption. Normally its color is also paler.</div>
+    <h4 class="photon-title-20">Title 20 followed with body 20</h4>
+    <div class="photon-body-20">This is a large body of text.</div>
+    <div class="photon-caption-20">This is a caption. Normally its color is also paler.</div>
+    <h4 class="photon-title-10">Title 10 followed with body 10</h4>
+    <div class="photon-body-10">This is a large body of text.</div>
+    <div class="photon-caption-10">This is a caption. Normally its color is also paler.</div>
   </body>
 </html>

--- a/src/components/app/AppHeader.css
+++ b/src/components/app/AppHeader.css
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.appHeader {
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid #ddd;
+
+  /* Negative margin is here to compensate for the children's margins */
+  margin: 0 -0.2em 0.5em;
+  font-size: 1.5em;
+}
+
+.appHeaderLink {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* Note that :focus styles are defined in focus.css */
+.appHeaderLink:hover {
+  text-decoration: underline;
+}
+
+.appHeaderSlogan {
+  margin: 0 0.2em;
+}
+
+.appHeaderSubtext {
+  font-weight: normal;
+}
+
+.appHeaderGithubIcon {
+  margin: 0 0.2em;
+}
+
+.appHeaderGithubIcon svg {
+  vertical-align: middle;
+}

--- a/src/components/app/AppHeader.js
+++ b/src/components/app/AppHeader.js
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+/*
+ * This file implements a header to be used on top of our content pages. It
+ * renders a title as well as links to our github and our home page.
+ */
+
+import * as React from 'react';
+
+import { setDataSource } from 'firefox-profiler/actions/profile-view';
+import explicitConnect, {
+  type ConnectedProps,
+} from 'firefox-profiler/utils/connect';
+
+import './AppHeader.css';
+
+type DispatchProps = {|
+  +setDataSource: typeof setDataSource,
+|};
+type Props = ConnectedProps<{||}, {||}, DispatchProps>;
+
+class AppHeaderImpl extends React.PureComponent<Props> {
+  onClick = (e: SyntheticMouseEvent<>) => {
+    const { setDataSource } = this.props;
+    if (e.ctrlKey || e.metaKey) {
+      // The user clearly wanted to open this link in a new tab.
+      return;
+    }
+
+    e.preventDefault();
+
+    setDataSource('none');
+  };
+
+  render() {
+    return (
+      <header>
+        <h1 className="appHeader">
+          <span className="appHeaderSlogan">
+            <a className="appHeaderLink" href="/" onClick={this.onClick}>
+              Firefox Profiler
+            </a>
+            <span className="appHeaderSubtext">
+              {' '}
+              &mdash; Web app for Firefox performance analysis
+            </span>
+          </span>
+          <a
+            className="appHeaderGithubIcon"
+            href="https://github.com/firefox-devtools/profiler"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Go to our git repository (this opens in a new window)"
+          >
+            <svg
+              width="22"
+              height="22"
+              className="octicon octicon-mark-github"
+              viewBox="0 0 16 16"
+              version="1.1"
+              aria-label="github"
+            >
+              <path
+                fillRule="evenodd"
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+              />
+            </svg>
+          </a>
+        </h1>
+      </header>
+    );
+  }
+}
+
+export const AppHeader = explicitConnect<{||}, {||}, DispatchProps>({
+  mapDispatchToProps: { setDataSource },
+  component: AppHeaderImpl,
+});

--- a/src/components/app/CompareHome.css
+++ b/src/components/app/CompareHome.css
@@ -11,6 +11,7 @@
   background: #fff;
   border-radius: 3px;
   box-shadow: 0 5px 25px #0b1f50;
+  font-size: 130%;
 }
 
 .compareHomeForm {

--- a/src/components/app/CompareHome.js
+++ b/src/components/app/CompareHome.js
@@ -6,6 +6,7 @@
 
 import React, { PureComponent } from 'react';
 
+import { AppHeader } from './AppHeader';
 import { changeProfilesToCompare } from '../../actions/app';
 import explicitConnect from '../../utils/connect';
 import type { ConnectedProps } from '../../utils/connect';
@@ -43,10 +44,11 @@ class CompareHome extends PureComponent<Props, State> {
 
     return (
       <main className="compareHome">
-        <h1 className="compareHomeTitle">
+        <AppHeader />
+        <h2 className="photon-title-20">
           Enter the profile URLs that you’d like to compare
-        </h1>
-        <p>
+        </h2>
+        <p className="photon-body-20">
           The tool will extract the data from the selected track and range for
           each profile, and put them both on the same view to make them easy to
           compare.

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -45,32 +45,6 @@
   box-shadow: 0.1em 0.1em 0 #bbb;
 }
 
-.homeTitle {
-  display: flex;
-  justify-content: space-between;
-  padding-bottom: 0.5em;
-  border-bottom: 1px solid #ddd;
-
-  /* Negative margin is here to compensate for the children's margins */
-  margin: 0 -0.2em 0.5em;
-}
-
-.homeTitleSlogan {
-  margin: 0 0.2em;
-}
-
-.homeTitleSubtext {
-  font-weight: normal;
-}
-
-.homeTitleGithubIcon {
-  margin: 0 0.2em;
-}
-
-.homeTitleGithubIcon svg {
-  vertical-align: middle;
-}
-
 .homeSectionItems {
   margin: 1em 0;
 }

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -5,6 +5,9 @@
 // @flow
 
 import * as React from 'react';
+
+import { AppHeader } from './AppHeader';
+
 import explicitConnect from '../../utils/connect';
 import classNames from 'classnames';
 import AddonScreenshot from '../../../res/img/jpg/gecko-profiler-screenshot-2019-02-05.jpg';
@@ -503,51 +506,20 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
 
     return (
       <div className="home">
-        <section className="homeSection">
-          <header>
-            <h1 className="homeTitle">
-              <span className="homeTitleSlogan">
-                <span className="homeTitleText">Firefox Profiler</span>
-                <span className="homeTitleSubtext">
-                  {' '}
-                  &mdash; Web app for Firefox performance analysis
-                </span>
-              </span>
-              <a
-                className="homeTitleGithubIcon"
-                href="https://github.com/firefox-devtools/profiler"
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Go to our git repository (this opens in a new window)"
-              >
-                <svg
-                  width="22"
-                  height="22"
-                  className="octicon octicon-mark-github"
-                  viewBox="0 0 16 16"
-                  version="1.1"
-                  aria-label="github"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-                  />
-                </svg>
-              </a>
-            </h1>
-            {specialMessage ? (
-              <div className="homeSpecialMessage">{specialMessage}</div>
-            ) : null}
-            <p>
-              Capture a performance profile. Analyze it. Share it. Make the web
-              faster.
-            </p>
-          </header>
+        <main className="homeSection">
+          <AppHeader />
+          {specialMessage ? (
+            <div className="homeSpecialMessage">{specialMessage}</div>
+          ) : null}
+          <p>
+            Capture a performance profile. Analyze it. Share it. Make the web
+            faster.
+          </p>
           <TransitionGroup className="homeInstructionsTransitionGroup">
             {this._renderInstructions()}
           </TransitionGroup>
           <DragAndDropOverlay />
-        </section>
+        </main>
       </div>
     );
   }

--- a/src/test/components/__snapshots__/CompareHome.test.js.snap
+++ b/src/test/components/__snapshots__/CompareHome.test.js.snap
@@ -4,12 +4,57 @@ exports[`app/CompareHome matches the snapshot 1`] = `
 <main
   class="compareHome"
 >
-  <h1
-    class="compareHomeTitle"
+  <header>
+    <h1
+      class="appHeader"
+    >
+      <span
+        class="appHeaderSlogan"
+      >
+        <a
+          class="appHeaderLink"
+          href="/"
+        >
+          Firefox Profiler
+        </a>
+        <span
+          class="appHeaderSubtext"
+        >
+           
+          — Web app for Firefox performance analysis
+        </span>
+      </span>
+      <a
+        class="appHeaderGithubIcon"
+        href="https://github.com/firefox-devtools/profiler"
+        rel="noopener noreferrer"
+        target="_blank"
+        title="Go to our git repository (this opens in a new window)"
+      >
+        <svg
+          aria-label="github"
+          class="octicon octicon-mark-github"
+          height="22"
+          version="1.1"
+          viewBox="0 0 16 16"
+          width="22"
+        >
+          <path
+            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </a>
+    </h1>
+  </header>
+  <h2
+    class="photon-title-20"
   >
     Enter the profile URLs that you’d like to compare
-  </h1>
-  <p>
+  </h2>
+  <p
+    class="photon-body-20"
+  >
     The tool will extract the data from the selected track and range for each profile, and put them both on the same view to make them easy to compare.
   </p>
   <form

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -79,30 +79,31 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
 <div
   class="home"
 >
-  <section
+  <main
     class="homeSection"
   >
     <header>
       <h1
-        class="homeTitle"
+        class="appHeader"
       >
         <span
-          class="homeTitleSlogan"
+          class="appHeaderSlogan"
         >
-          <span
-            class="homeTitleText"
+          <a
+            class="appHeaderLink"
+            href="/"
           >
             Firefox Profiler
-          </span>
+          </a>
           <span
-            class="homeTitleSubtext"
+            class="appHeaderSubtext"
           >
              
             — Web app for Firefox performance analysis
           </span>
         </span>
         <a
-          class="homeTitleGithubIcon"
+          class="appHeaderGithubIcon"
           href="https://github.com/firefox-devtools/profiler"
           rel="noopener noreferrer"
           target="_blank"
@@ -123,15 +124,15 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
           </svg>
         </a>
       </h1>
-      <div
-        class="homeSpecialMessage"
-      >
-        This is a special message
-      </div>
-      <p>
-        Capture a performance profile. Analyze it. Share it. Make the web faster.
-      </p>
     </header>
+    <div
+      class="homeSpecialMessage"
+    >
+      This is a special message
+    </div>
+    <p>
+      Capture a performance profile. Analyze it. Share it. Make the web faster.
+    </p>
     <div
       class="homeInstructionsTransitionGroup"
     >
@@ -216,7 +217,7 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
         Drop a saved profile here
       </div>
     </div>
-  </section>
+  </main>
 </div>
 `;
 
@@ -224,30 +225,31 @@ exports[`app/Home renders the install screen for the extension 1`] = `
 <div
   class="home"
 >
-  <section
+  <main
     class="homeSection"
   >
     <header>
       <h1
-        class="homeTitle"
+        class="appHeader"
       >
         <span
-          class="homeTitleSlogan"
+          class="appHeaderSlogan"
         >
-          <span
-            class="homeTitleText"
+          <a
+            class="appHeaderLink"
+            href="/"
           >
             Firefox Profiler
-          </span>
+          </a>
           <span
-            class="homeTitleSubtext"
+            class="appHeaderSubtext"
           >
              
             — Web app for Firefox performance analysis
           </span>
         </span>
         <a
-          class="homeTitleGithubIcon"
+          class="appHeaderGithubIcon"
           href="https://github.com/firefox-devtools/profiler"
           rel="noopener noreferrer"
           target="_blank"
@@ -268,15 +270,15 @@ exports[`app/Home renders the install screen for the extension 1`] = `
           </svg>
         </a>
       </h1>
-      <div
-        class="homeSpecialMessage"
-      >
-        This is a special message
-      </div>
-      <p>
-        Capture a performance profile. Analyze it. Share it. Make the web faster.
-      </p>
     </header>
+    <div
+      class="homeSpecialMessage"
+    >
+      This is a special message
+    </div>
+    <p>
+      Capture a performance profile. Analyze it. Share it. Make the web faster.
+    </p>
     <div
       class="homeInstructionsTransitionGroup"
     >
@@ -362,7 +364,7 @@ exports[`app/Home renders the install screen for the extension 1`] = `
         Drop a saved profile here
       </div>
     </div>
-  </section>
+  </main>
 </div>
 `;
 
@@ -370,30 +372,31 @@ exports[`app/Home renders the usage instructions for pages with the extension in
 <div
   class="home"
 >
-  <section
+  <main
     class="homeSection"
   >
     <header>
       <h1
-        class="homeTitle"
+        class="appHeader"
       >
         <span
-          class="homeTitleSlogan"
+          class="appHeaderSlogan"
         >
-          <span
-            class="homeTitleText"
+          <a
+            class="appHeaderLink"
+            href="/"
           >
             Firefox Profiler
-          </span>
+          </a>
           <span
-            class="homeTitleSubtext"
+            class="appHeaderSubtext"
           >
              
             — Web app for Firefox performance analysis
           </span>
         </span>
         <a
-          class="homeTitleGithubIcon"
+          class="appHeaderGithubIcon"
           href="https://github.com/firefox-devtools/profiler"
           rel="noopener noreferrer"
           target="_blank"
@@ -414,15 +417,15 @@ exports[`app/Home renders the usage instructions for pages with the extension in
           </svg>
         </a>
       </h1>
-      <div
-        class="homeSpecialMessage"
-      >
-        This is a special message
-      </div>
-      <p>
-        Capture a performance profile. Analyze it. Share it. Make the web faster.
-      </p>
     </header>
+    <div
+      class="homeSpecialMessage"
+    >
+      This is a special message
+    </div>
+    <p>
+      Capture a performance profile. Analyze it. Share it. Make the web faster.
+    </p>
     <div
       class="homeInstructionsTransitionGroup"
     >
@@ -529,7 +532,7 @@ exports[`app/Home renders the usage instructions for pages with the extension in
         Drop a saved profile here
       </div>
     </div>
-  </section>
+  </main>
 </div>
 `;
 


### PR DESCRIPTION
I want to reuse this header in the new "my profiles" page. 

After extracting it I also added it in the Compare home page, and found there was a problem when I naturally tried to use the back/forward buttons, so I tried to fix this too.

Also I introduced some typography styles from photon, probably we should try to use them more broadly. But I think this is more work because we need to look at how it's used throughout the app. Commits should be fairly independent.

Home page (shouldn't have a significant change):
[Before](https://profiler.firefox.com/) / [Deploy preview](https://deploy-preview-2696--perf-html.netlify.app/)

Compare:
[Before](https://profiler.firefox.com/compare/) / [Deploy preview](https://deploy-preview-2696--perf-html.netlify.app/compare/)

The coverage is improved by the tests in the other PR.