### PR TITLE
Support the value gtk3 for the toolkit property too

### DIFF
--- a/src/app-logic/published-profiles-store.js
+++ b/src/app-logic/published-profiles-store.js
@@ -35,7 +35,9 @@ export type ProfileData = {|
     +toolkit?: string,
     +misc?: string,
     +oscpu?: string,
-    +toolkit?: 'gtk' | 'windows' | 'cocoa' | 'android' | string,
+    // Older versions of Firefox for Linux had the 2 flavors gtk2/gtk3, and so
+    // we could find the value "gtk3".
+    +toolkit?: 'gtk' | 'gtk3' | 'windows' | 'cocoa' | 'android' | string,
     +updateChannel?:
       | 'default' // Local builds
       | 'nightly'

--- a/src/profile-logic/profile-metainfo.js
+++ b/src/profile-logic/profile-metainfo.js
@@ -77,6 +77,7 @@ export function formatPlatform(meta: {
         : 'Windows';
     }
     case 'gtk':
+    case 'gtk3':
       // Typically `oscpu` contains 'Linux x86_64'.
       // We slice instead of always returning Linux for other Unixes. But we
       // haven't really tried them.

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -683,7 +683,9 @@ export type ProfileMeta = {|
     | 'X11'
     | string,
   // The widget toolkit used for GUI rendering.
-  toolkit?: 'gtk' | 'windows' | 'cocoa' | 'android' | string,
+  // Older versions of Firefox for Linux had the 2 flavors gtk2/gtk3, and so
+  // we could find the value "gtk3".
+  toolkit?: 'gtk' | 'gtk3' | 'windows' | 'cocoa' | 'android' | string,
 
   // The appBuildID, sourceURL, physicalCPUs and logicalCPUs properties landed
   // in Firefox 62, and are optional because older processed profile


### PR DESCRIPTION
This is a small fix for an issue I found when working with these values. Some older profiles have this value for the "toolkit" property.