### PR TITLE
Fix switching back to full view if selected thread index is not present for active tab

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -185,8 +185,11 @@ export function finalizeProfileView(
         break;
       case 'active-tab':
         if (selectedThreadIndex === null) {
-          // Switch back over to the full view.
-          timelineTrackOrganization = { type: 'full' };
+          // Switch back over to the full view if selectedThreadIndex is not present.
+          // We check this here because if selectedThreadIndex is null, that means
+          // it's a new profile from Firefox directly and has no profile information
+          // encoded in the URL. But we only allow conversions from full view currently.
+          dispatch(finalizeFullProfileView(profile, selectedThreadIndex));
         } else {
           // The url state says this is an active tab view. We should compute and
           // initialize the state relevant to that state.

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -189,7 +189,7 @@ export function finalizeProfileView(
           // We check this here because if selectedThreadIndex is null, that means
           // it's a new profile from Firefox directly and has no profile information
           // encoded in the URL. But we only allow conversions from full view currently.
-          dispatch(finalizeFullProfileView(profile, selectedThreadIndex));
+          dispatch(finalizeFullProfileView(profile, null));
         } else {
           // The url state says this is an active tab view. We should compute and
           // initialize the state relevant to that state.


### PR DESCRIPTION
This fixes the issue of switching to full view. It doesn't have a test because I think it's not necessary especially because we are going to remove this part soon (we want to be able to open the active tab view directly if preset is web dev.)