### PR TITLE
Add accessibility elements to our thread canvas graphs

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -29,6 +29,7 @@ import type {
 
 export type Props = {|
   +className: string,
+  +trackName: string,
   +fullThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
@@ -264,7 +265,7 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
 
   render() {
     this._renderCanvas();
-    const { fullThread, categories } = this.props;
+    const { fullThread, categories, trackName } = this.props;
     const { hoveredSample, mouseX, mouseY } = this.state;
     return (
       <div
@@ -280,7 +281,10 @@ class ThreadActivityGraph extends React.PureComponent<Props, State> {
           )}
           ref={this._takeCanvasRef}
           onMouseUp={this._onMouseUp}
-        />
+        >
+          <h2>Activity Graph for {trackName}</h2>
+          <p>This graph shows a visual chart of thread activity.</p>
+        </canvas>
         {hoveredSample === null ? null : (
           <Tooltip mouseX={mouseX} mouseY={mouseY}>
             <SampleTooltipContents

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -38,6 +38,7 @@ type Props = {|
   +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
   // Decide which way the stacks grow up from the floor, or down from the ceiling.
   +stacksGrowFromCeiling?: boolean,
+  +trackName: string,
 |};
 
 class StackGraph extends PureComponent<Props> {
@@ -236,8 +237,9 @@ class StackGraph extends PureComponent<Props> {
 
   render() {
     this._renderCanvas();
+    const { className, trackName } = this.props;
     return (
-      <div className={this.props.className}>
+      <div className={className}>
         <canvas
           className={classNames(
             `${this.props.className}Canvas`,
@@ -245,7 +247,10 @@ class StackGraph extends PureComponent<Props> {
           )}
           ref={this._takeCanvasRef}
           onMouseUp={this._onMouseUp}
-        />
+        >
+          <h2>Stack Graph for {trackName}</h2>
+          <p>This graph charts the stack height of each sample.</p>
+        </canvas>
       </div>
     );
   }

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -78,6 +78,7 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
             threadIndex={mainThreadIndex}
             showMemoryMarkers={false}
             trackType="expanded"
+            trackName="Active Tab"
           />
         );
       }

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -92,6 +92,7 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
           <TrackThread
             threadIndex={resourceTrack.threadIndex}
             trackType={isOpen ? 'expanded' : 'condensed'}
+            trackName={resourceTrack.name}
           />
         );
       default:

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -106,6 +106,7 @@ class GlobalTrackComponent extends PureComponent<Props> {
       globalTrack,
       processesWithMemoryTrack,
       progressGraphData,
+      trackName,
     } = this.props;
     switch (globalTrack.type) {
       case 'process': {
@@ -125,6 +126,7 @@ class GlobalTrackComponent extends PureComponent<Props> {
             threadIndex={mainThreadIndex}
             showMemoryMarkers={!processesWithMemoryTrack.has(globalTrack.pid)}
             trackType="expanded"
+            trackName={trackName}
           />
         );
       }

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -82,13 +82,14 @@ class LocalTrackComponent extends PureComponent<Props> {
   };
 
   renderTrack() {
-    const { localTrack } = this.props;
+    const { localTrack, trackName } = this.props;
     switch (localTrack.type) {
       case 'thread':
         return (
           <TrackThread
             threadIndex={localTrack.threadIndex}
             trackType="expanded"
+            trackName={trackName}
           />
         );
       case 'network':

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -234,6 +234,7 @@ class TimelineTrackThread extends PureComponent<Props> {
         ) : (
           <ThreadStackGraph
             className="threadStackGraph"
+            trackName={trackName}
             interval={interval}
             thread={filteredThread}
             tabFilteredThread={tabFilteredThread}

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -61,6 +61,7 @@ type OwnProps = {|
   +threadIndex: ThreadIndex,
   +trackType: 'expanded' | 'condensed',
   +showMemoryMarkers?: boolean,
+  +trackName: string,
 |};
 
 type StateProps = {|
@@ -166,6 +167,7 @@ class TimelineTrackThread extends PureComponent<Props> {
       treeOrderSampleComparator,
       trackType,
       timelineTrackOrganization,
+      trackName,
     } = this.props;
 
     const processType = filteredThread.processType;
@@ -219,6 +221,7 @@ class TimelineTrackThread extends PureComponent<Props> {
         {timelineType === 'category' && !filteredThread.isJsTracer ? (
           <ThreadActivityGraph
             className="threadActivityGraph"
+            trackName={trackName}
             interval={interval}
             fullThread={fullThread}
             rangeStart={rangeStart}

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -66,7 +66,11 @@ describe('ThreadActivityGraph', function() {
 
     const renderResult = render(
       <Provider store={store}>
-        <TrackThread threadIndex={0} trackType="expanded" />
+        <TrackThread
+          threadIndex={0}
+          trackType="expanded"
+          trackName="Test Track"
+        />
       </Provider>
     );
     const { container } = renderResult;

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -112,7 +112,11 @@ describe('timeline/TrackThread', function() {
 
     const renderResult = render(
       <Provider store={store}>
-        <TrackThread threadIndex={threadIndex} trackType="expanded" />
+        <TrackThread
+          threadIndex={threadIndex}
+          trackType="expanded"
+          trackName="Test Track"
+        />
       </Provider>
     );
     const { container } = renderResult;

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -20,7 +20,15 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
             class="threadActivityGraphCanvas threadActivityGraphCanvas"
             height="300"
             width="200"
-          />
+          >
+            <h2>
+              Activity Graph for 
+              Active Tab
+            </h2>
+            <p>
+              This graph shows a visual chart of thread activity.
+            </p>
+          </canvas>
         </div>
         <div
           class="timelineTrackThreadMarkers"
@@ -88,7 +96,15 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
             class="threadActivityGraphCanvas threadActivityGraphCanvas"
             height="300"
             width="200"
-          />
+          >
+            <h2>
+              Activity Graph for 
+              Page #3
+            </h2>
+            <p>
+              This graph shows a visual chart of thread activity.
+            </p>
+          </canvas>
         </div>
         <div
           class="timelineTrackThreadMarkers"
@@ -173,7 +189,15 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
                 class="threadActivityGraphCanvas threadActivityGraphCanvas"
                 height="300"
                 width="200"
-              />
+              >
+                <h2>
+                  Activity Graph for 
+                  Page #2
+                </h2>
+                <p>
+                  This graph shows a visual chart of thread activity.
+                </p>
+              </canvas>
             </div>
             <div
               class="timelineTrackThreadMarkers"
@@ -257,7 +281,15 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                       class="threadActivityGraphCanvas threadActivityGraphCanvas"
                       height="300"
                       width="200"
-                    />
+                    >
+                      <h2>
+                        Activity Graph for 
+                        Active Tab
+                      </h2>
+                      <p>
+                        This graph shows a visual chart of thread activity.
+                      </p>
+                    </canvas>
                   </div>
                   <div
                     class="timelineTrackThreadMarkers"

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -74,7 +74,15 @@ process: \\"tab\\" (222)"
             class="threadActivityGraphCanvas threadActivityGraphCanvas"
             height="400"
             width="400"
-          />
+          >
+            <h2>
+              Activity Graph for 
+              Content Process
+            </h2>
+            <p>
+              This graph shows a visual chart of thread activity.
+            </p>
+          </canvas>
         </div>
         <div
           class="timelineEmptyThreadIndicator"
@@ -128,7 +136,15 @@ process: \\"tab\\" (222)"
                 class="threadActivityGraphCanvas threadActivityGraphCanvas"
                 height="400"
                 width="400"
-              />
+              >
+                <h2>
+                  Activity Graph for 
+                  DOM Worker
+                </h2>
+                <p>
+                  This graph shows a visual chart of thread activity.
+                </p>
+              </canvas>
             </div>
             <div
               class="timelineEmptyThreadIndicator"
@@ -180,7 +196,15 @@ process: \\"tab\\" (222)"
                 class="threadActivityGraphCanvas threadActivityGraphCanvas"
                 height="400"
                 width="400"
-              />
+              >
+                <h2>
+                  Activity Graph for 
+                  Style
+                </h2>
+                <p>
+                  This graph shows a visual chart of thread activity.
+                </p>
+              </canvas>
             </div>
             <div
               class="timelineEmptyThreadIndicator"
@@ -265,7 +289,15 @@ process: \\"default\\" (5555)"
                 class="threadActivityGraphCanvas threadActivityGraphCanvas"
                 height="400"
                 width="400"
-              />
+              >
+                <h2>
+                  Activity Graph for 
+                  NoMain
+                </h2>
+                <p>
+                  This graph shows a visual chart of thread activity.
+                </p>
+              </canvas>
             </div>
             <div
               class="timelineEmptyThreadIndicator"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -160,7 +160,15 @@ process: \\"tab\\" (222)"
             class="threadActivityGraphCanvas threadActivityGraphCanvas"
             height="400"
             width="400"
-          />
+          >
+            <h2>
+              Activity Graph for 
+              DOM Worker
+            </h2>
+            <p>
+              This graph shows a visual chart of thread activity.
+            </p>
+          </canvas>
         </div>
         <div
           class="timelineEmptyThreadIndicator"

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -2547,7 +2547,15 @@ exports[`ThreadActivityGraph matches the component snapshot 1`] = `
       class="threadActivityGraphCanvas threadActivityGraphCanvas"
       height="10"
       width="80"
-    />
+    >
+      <h2>
+        Activity Graph for 
+        Test Track
+      </h2>
+      <p>
+        This graph shows a visual chart of thread activity.
+      </p>
+    </canvas>
   </div>
   <div
     class="timelineEmptyThreadIndicator"

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -87,7 +87,15 @@ exports[`timeline/TrackThread matches the snapshot for the component 1`] = `
       class="threadStackGraphCanvas threadStackGraphCanvas"
       height="50"
       width="400"
-    />
+    >
+      <h2>
+        Stack Graph for 
+        Test Track
+      </h2>
+      <p>
+        This graph charts the stack height of each sample.
+      </p>
+    </canvas>
   </div>
   <div
     class="timelineEmptyThreadIndicator"


### PR DESCRIPTION
I needed a way to select individual canvases in #2706 in tests, and adding accessibility elements seemed the easiest way. I opted for adding actual DOM element.

https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility 