### PR TITLE
Add full click behavior to tests: mousedown -> mouseup -> click

### DIFF
--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -10,12 +10,12 @@ import Timeline from '../../components/timeline';
 import ActiveTabGlobalTrack from '../../components/timeline/ActiveTabGlobalTrack';
 import ActiveTabResourcesPanel from '../../components/timeline/ActiveTabResourcesPanel';
 import ActiveTabResourceTrack from '../../components/timeline/ActiveTabResourceTrack';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
-import { getBoundingBox } from '../fixtures/utils';
+import { getBoundingBox, fireFullClick } from '../fixtures/utils';
 import { addActiveTabInformationToProfile } from '../fixtures/profiles/processed-profile';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import {
@@ -150,7 +150,7 @@ describe('ActiveTabTimeline', function() {
     it('can select a thread by clicking the row', () => {
       const { getState, getGlobalTrackRow, threadIndex } = setup();
       expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-      fireEvent.click(getGlobalTrackRow());
+      fireFullClick(getGlobalTrackRow());
       expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
     });
 
@@ -217,7 +217,7 @@ describe('ActiveTabTimeline', function() {
 
     it('matches the snapshot of a resources panel when opened', () => {
       const { container, getResourcesPanelHeader } = setup();
-      fireEvent.click(getResourcesPanelHeader());
+      fireFullClick(getResourcesPanelHeader());
       expect(container.firstChild).toMatchSnapshot();
     });
 
@@ -231,7 +231,7 @@ describe('ActiveTabTimeline', function() {
       const resourcesPanelHeader = getResourcesPanelHeader();
       expect(getResourceFrameTrack()).toBeFalsy();
 
-      fireEvent.click(resourcesPanelHeader);
+      fireFullClick(resourcesPanelHeader);
       expect(getResourceFrameTrack()).toBeTruthy();
     });
 
@@ -247,14 +247,14 @@ describe('ActiveTabTimeline', function() {
       expect(getSelectedThreadIndex(getState())).toBe(mainThreadIndex);
 
       // 1. Open the panel.
-      fireEvent.click(getResourcesPanelHeader());
+      fireFullClick(getResourcesPanelHeader());
       // 2. Select the reource track.
-      fireEvent.mouseUp(ensureExists(getResourceFrameTrack()));
+      fireFullClick(ensureExists(getResourceFrameTrack()));
       // Selected thread should be the resource now.
       expect(getSelectedThreadIndex(getState())).toBe(resourceThreadIndex);
 
       // 3. Close the panel.
-      fireEvent.click(getResourcesPanelHeader());
+      fireFullClick(getResourcesPanelHeader());
       // Now the main thread should be selected again.
       expect(getSelectedThreadIndex(getState())).toBe(mainThreadIndex);
     });
@@ -339,14 +339,14 @@ describe('ActiveTabTimeline', function() {
       it('can select a thread by clicking the label', () => {
         const { getState, getResourceFrameTrackLabel, threadIndex } = setup();
         expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-        fireEvent.mouseUp(getResourceFrameTrackLabel());
+        fireFullClick(getResourceFrameTrackLabel());
         expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
       });
 
       it('can select a thread by clicking the row', () => {
         const { getState, getResourceTrackRow, threadIndex } = setup();
         expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-        fireEvent.mouseUp(getResourceTrackRow());
+        fireFullClick(getResourceTrackRow());
         expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
       });
     });

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -8,6 +8,7 @@ import { render, fireEvent } from '@testing-library/react';
 import ButtonWithPanel from '../../components/shared/ButtonWithPanel';
 import ArrowPanel from '../../components/shared/ArrowPanel';
 import { ensureExists } from '../../utils/flow';
+import { fireFullClick } from '../fixtures/utils';
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -91,7 +92,7 @@ describe('shared/ButtonWithPanel', () => {
   it('opens the panel when the button is clicked and closes the panel when the escape key is pressed', () => {
     const { getByText, container } = setup();
 
-    fireEvent.click(getByText('My Button'));
+    fireFullClick(getByText('My Button'));
     jest.runAllTimers();
     expect(container.firstChild).toMatchSnapshot();
 
@@ -107,7 +108,7 @@ describe('shared/ButtonWithPanel', () => {
   it('opens the panel when the button is clicked and closes the panel by clicking outside the panel', () => {
     const { getByText, container } = setup();
 
-    fireEvent.click(getByText('My Button'));
+    fireFullClick(getByText('My Button'));
     jest.runAllTimers();
     expect(container.firstChild).toMatchSnapshot();
 
@@ -115,7 +116,7 @@ describe('shared/ButtonWithPanel', () => {
     const newDiv = ensureExists(document.body).appendChild(
       document.createElement('div')
     );
-    fireEvent.click(newDiv);
+    fireFullClick(newDiv);
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -123,12 +124,12 @@ describe('shared/ButtonWithPanel', () => {
   it('opens the panel when the button is clicked and closes the panel by clicking the button again', () => {
     const { getByText, container } = setup();
 
-    fireEvent.click(getByText('My Button'));
+    fireFullClick(getByText('My Button'));
     jest.runAllTimers();
 
     ensureExists(container.querySelector('.arrowPanel.open'));
 
-    fireEvent.click(getByText('My Button'));
+    fireFullClick(getByText('My Button'));
     jest.runAllTimers();
 
     expect(container.querySelector('.arrowPanel.open')).toBe(null);
@@ -137,17 +138,17 @@ describe('shared/ButtonWithPanel', () => {
   it('opens the panel when the button is clicked and does not close the panel by clicking inside the panel', () => {
     const { getByText, container } = setup();
 
-    fireEvent.click(getByText('My Button'));
+    fireFullClick(getByText('My Button'));
     jest.runAllTimers();
     ensureExists(container.querySelector('.arrowPanel.open'));
 
     // Clicking on the panel doesn't hide the popup.
-    fireEvent.click(getByText('Panel content'));
+    fireFullClick(getByText('Panel content'));
     jest.runAllTimers();
     ensureExists(container.querySelector('.arrowPanel.open'));
 
     // But clicking on the arrow area does.
-    fireEvent.click(ensureExists(container.querySelector('.arrowPanelArrow')));
+    fireFullClick(ensureExists(container.querySelector('.arrowPanelArrow')));
     jest.runAllTimers();
     expect(container.querySelector('.arrowPanel.open')).toBe(null);
   });

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import CallNodeContextMenu from '../../components/shared/CallNodeContextMenu';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import {
   changeRightClickedCallNode,
   changeExpandedCallNodes,
@@ -17,6 +17,7 @@ import { Provider } from 'react-redux';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 import copy from 'copy-to-clipboard';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('calltree/CallNodeContextMenu', function() {
   // Provide a store with a useful profile to assert context menu operations off of.
@@ -89,7 +90,7 @@ describe('calltree/CallNodeContextMenu', function() {
     fixtures.forEach(({ matcher, type }) => {
       it(`adds a transform for "${type}"`, function() {
         const { getState, getByText } = setup();
-        fireEvent.click(getByText(matcher));
+        fireFullClick(getByText(matcher));
         expect(
           selectedThreadSelectors.getTransformStack(getState())[0].type
         ).toBe(type);
@@ -104,7 +105,7 @@ describe('calltree/CallNodeContextMenu', function() {
         selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
       ).toHaveLength(1);
 
-      fireEvent.click(getByText('Expand all'));
+      fireFullClick(getByText('Expand all'));
 
       // This test only asserts that a bunch of call nodes were actually expanded.
       expect(
@@ -115,7 +116,7 @@ describe('calltree/CallNodeContextMenu', function() {
     it('can look up functions on SearchFox', function() {
       const { getByText } = setup();
       jest.spyOn(window, 'open').mockImplementation(() => {});
-      fireEvent.click(getByText(/Searchfox/));
+      fireFullClick(getByText(/Searchfox/));
       expect(window.open).toBeCalledWith(
         'https://searchfox.org/mozilla-central/search?q=B',
         '_blank'
@@ -125,7 +126,7 @@ describe('calltree/CallNodeContextMenu', function() {
     it('can copy a function name', function() {
       const { getByText } = setup();
       // Copy is a mocked module, clear it both before and after.
-      fireEvent.click(getByText('Copy function name'));
+      fireFullClick(getByText('Copy function name'));
       expect(copy).toBeCalledWith('B');
     });
 
@@ -148,14 +149,14 @@ describe('calltree/CallNodeContextMenu', function() {
       const { getByText } = setup(store);
 
       // Copy is a mocked module, clear it both before and after.
-      fireEvent.click(getByText('Copy script URL'));
+      fireFullClick(getByText('Copy script URL'));
       expect(copy).toBeCalledWith('https://example.com/script.js');
     });
 
     it('can copy a stack', function() {
       const { getByText } = setup();
       // Copy is a mocked module, clear it both before and after.
-      fireEvent.click(getByText('Copy stack'));
+      fireFullClick(getByText('Copy stack'));
       expect(copy).toBeCalledWith(`B\nA\n`);
     });
   });

--- a/src/test/components/CallTreeSidebar.test.js
+++ b/src/test/components/CallTreeSidebar.test.js
@@ -23,6 +23,7 @@ import {
 
 import type { CallNodePath } from 'firefox-profiler/types';
 import { ensureExists } from '../../utils/flow';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('CallTreeSidebar', function() {
   function getProfileWithCategories() {
@@ -180,7 +181,7 @@ describe('CallTreeSidebar', function() {
     expect(queryByText('FakeSubCategoryC')).toBe(null);
 
     const layoutCategory = getByText('Layout');
-    layoutCategory.click();
+    fireFullClick(layoutCategory);
 
     getByText('FakeSubCategoryC');
 

--- a/src/test/components/CompareHome.test.js
+++ b/src/test/components/CompareHome.test.js
@@ -11,6 +11,7 @@ import CompareHome from '../../components/app/CompareHome';
 import { getProfilesToCompare } from '../../selectors/url-state';
 
 import { blankStore } from '../fixtures/stores';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('app/CompareHome', () => {
   afterEach(cleanup);
@@ -41,7 +42,7 @@ describe('app/CompareHome', () => {
       target: { value: 'http://www.url12.com' },
     });
     const retrieveButton = getByText(/Retrieve/);
-    fireEvent.click(retrieveButton);
+    fireFullClick(retrieveButton);
 
     expect(getProfilesToCompare(getState())).toEqual([
       'http://www.url11.com',

--- a/src/test/components/ErrorBoundary.test.js
+++ b/src/test/components/ErrorBoundary.test.js
@@ -8,6 +8,7 @@ import { render } from '@testing-library/react';
 
 import { ErrorBoundary } from '../../components/app/ErrorBoundary';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('app/ErrorBoundary', function() {
   const childComponentText = 'This is a child component';
@@ -56,7 +57,7 @@ describe('app/ErrorBoundary', function() {
     ).toBe(true);
 
     // Click the button to expand the details.
-    getByText('View full error details').click();
+    fireFullClick(getByText('View full error details'));
 
     // The technical error now exists.
     expect(

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -20,6 +20,8 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
   getMouseEvent,
+  fireFullClick,
+  fireFullContextMenu,
 } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import {
@@ -64,7 +66,7 @@ describe('FlameGraph', function() {
     const { getByText, dispatch, getState } = setupFlameGraph();
     dispatch(changeInvertCallstack(true));
     expect(getInvertCallstack(getState())).toBe(true);
-    fireEvent.click(getByText(/Switch to the normal call stack/));
+    fireFullClick(getByText(/Switch to the normal call stack/));
     expect(getInvertCallstack(getState())).toBe(false);
   });
 
@@ -234,30 +236,22 @@ function setupFlameGraph() {
     return positioningOptions;
   }
 
+  const canvas = ensureExists(
+    container.querySelector('canvas'),
+    'The container should contain a canvas element.'
+  );
+
   function fireMouseEvent(eventName, options) {
-    fireEvent(
-      ensureExists(
-        container.querySelector('canvas'),
-        'The container should contain a canvas element.'
-      ),
-      getMouseEvent(eventName, options)
-    );
+    fireEvent(canvas, getMouseEvent(eventName, options));
   }
 
   // Note to a future developer: the x/y values can be derived from the
   // array returned by flushDrawLog().
   function rightClick(x: CssPixels, y: CssPixels) {
     const positioningOptions = getPositioningOptions(x, y);
-    const clickOptions = {
-      ...positioningOptions,
-      button: 2,
-      buttons: 2,
-    };
 
     fireMouseEvent('mousemove', positioningOptions);
-    fireMouseEvent('mousedown', clickOptions);
-    fireMouseEvent('mouseup', clickOptions);
-    fireMouseEvent('contextmenu', clickOptions);
+    fireFullContextMenu(canvas, positioningOptions);
     flushRafCalls();
   }
 
@@ -290,7 +284,7 @@ function setupFlameGraph() {
     );
 
   function clickMenuItem(strOrRegexp) {
-    fireEvent.click(getByText(strOrRegexp));
+    fireFullClick(getByText(strOrRegexp));
   }
 
   return {

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import {
   changeSelectedThread,
@@ -20,10 +20,11 @@ import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
-import { getBoundingBox } from '../fixtures/utils';
-
-const LEFT_CLICK = 0;
-const RIGHT_CLICK = 2;
+import {
+  getBoundingBox,
+  fireFullClick,
+  fireFullContextMenu,
+} from '../fixtures/utils';
 
 describe('timeline/GlobalTrack', function() {
   /**
@@ -147,7 +148,7 @@ describe('timeline/GlobalTrack', function() {
       threadIndex,
     } = setup();
     expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-    fireEvent.mouseDown(getGlobalTrackLabel(), { button: LEFT_CLICK });
+    fireFullClick(getGlobalTrackLabel());
     expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
     expect(getGlobalTrackRow().classList.contains('selected')).toBe(true);
   });
@@ -160,7 +161,7 @@ describe('timeline/GlobalTrack', function() {
       trackReference,
     } = setup();
 
-    fireEvent.mouseDown(getGlobalTrackLabel(), { button: RIGHT_CLICK });
+    fireFullContextMenu(getGlobalTrackLabel());
     expect(getRightClickedTrack(getState())).toEqual(trackReference);
     expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
   });
@@ -168,7 +169,7 @@ describe('timeline/GlobalTrack', function() {
   it('can select a thread by clicking the row', () => {
     const { getState, getGlobalTrackRow, threadIndex } = setup();
     expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-    fireEvent.click(getGlobalTrackRow());
+    fireFullClick(getGlobalTrackRow());
     expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
   });
 

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -9,6 +9,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import createStore from '../../app-logic/create-store';
 import { mockWebChannel } from '../fixtures/mocks/web-channel';
+import { fireFullClick } from '../fixtures/utils';
 
 // Provide a mechanism to overwrite the navigator.userAgent, which can't be set.
 const FIREFOX =
@@ -118,7 +119,7 @@ describe('app/Home', function() {
     });
     await findByTestId('home-enable-popup-instructions');
 
-    getByText('Enable Profiler Menu Button').click();
+    fireFullClick(getByText('Enable Profiler Menu Button'));
 
     // Respond back from the browser that the menu button was enabled.
     triggerResponse({

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -9,7 +9,7 @@ import {
   TIMELINE_MARGIN_RIGHT,
 } from '../../app-logic/constants';
 import JsTracer from '../../components/js-tracer';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
@@ -18,6 +18,7 @@ import {
   getBoundingBox,
   addRootOverlayElement,
   removeRootOverlayElement,
+  fireFullClick,
 } from '../fixtures/utils';
 import { getProfileWithJsTracerEvents } from '../fixtures/profiles/processed-profile';
 import { getShowJsTracerSummary } from '../../selectors/url-state';
@@ -142,7 +143,7 @@ describe('StackChart', function() {
       events: simpleTracerEvents,
     });
     expect(getShowJsTracerSummary(getState())).toEqual(false);
-    fireEvent.click(getChangeJsTracerSummaryCheckbox());
+    fireFullClick(getChangeJsTracerSummaryCheckbox());
     expect(getShowJsTracerSummary(getState())).toEqual(true);
   });
 
@@ -151,7 +152,7 @@ describe('StackChart', function() {
       skipLoadingScreen: true,
       events: simpleTracerEvents,
     });
-    fireEvent.click(getChangeJsTracerSummaryCheckbox());
+    fireFullClick(getChangeJsTracerSummaryCheckbox());
     expect(ctx.__flushDrawLog()).toMatchSnapshot();
   });
 });

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -13,7 +13,7 @@ import type {
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import {
   changeSelectedThread,
@@ -37,14 +37,16 @@ import {
   getStoreWithMemoryTrack,
 } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
-import { getBoundingBox } from '../fixtures/utils';
+import {
+  getBoundingBox,
+  fireFullClick,
+  fireFullContextMenu,
+} from '../fixtures/utils';
 
 // In getProfileWithNiceTracks, the two pids are 111 and 222 for the
 // "GeckoMain process" and "GeckoMain tab" respectively. Use 222 since it has
 // local tracks.
 const PID = 222;
-const LEFT_CLICK = 0;
-const RIGHT_CLICK = 2;
 
 describe('timeline/LocalTrack', function() {
   describe('with a thread track', function() {
@@ -79,7 +81,7 @@ describe('timeline/LocalTrack', function() {
         getLocalTrackRow,
       } = setupThreadTrack();
       expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-      fireEvent.mouseDown(getLocalTrackLabel(), { button: LEFT_CLICK });
+      fireFullClick(getLocalTrackLabel());
       expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
       expect(getLocalTrackRow().classList.contains('selected')).toBe(true);
     });
@@ -92,7 +94,7 @@ describe('timeline/LocalTrack', function() {
         trackReference,
       } = setupThreadTrack();
 
-      fireEvent.mouseDown(getLocalTrackLabel(), { button: RIGHT_CLICK });
+      fireFullContextMenu(getLocalTrackLabel());
       expect(getRightClickedTrack(getState())).toEqual(trackReference);
       expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
     });
@@ -100,7 +102,7 @@ describe('timeline/LocalTrack', function() {
     it('can select a thread by clicking the row', () => {
       const { getState, getLocalTrackRow, threadIndex } = setupThreadTrack();
       expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-      fireEvent.click(getLocalTrackRow());
+      fireFullClick(getLocalTrackRow());
       expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
     });
 

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -32,6 +32,8 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
   findFillTextPositionFromDrawLog,
+  fireFullClick,
+  fireFullContextMenu,
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
@@ -338,18 +340,14 @@ describe('MarkerChart', function() {
 
       function rightClick(where: { x: CssPixels, y: CssPixels }) {
         const positioningOptions = getPositioningOptions(where);
-        const clickOptions = {
-          ...positioningOptions,
-          button: 2,
-          buttons: 2,
-        };
-
+        const canvas = ensureExists(
+          container.querySelector('canvas'),
+          `Couldn't find the canvas element`
+        );
         // Because different components listen to different events, we trigger
         // all the right events, to be as close as possible to the real stuff.
         fireMouseEvent('mousemove', positioningOptions);
-        fireMouseEvent('mousedown', clickOptions);
-        fireMouseEvent('mouseup', clickOptions);
-        fireMouseEvent('contextmenu', clickOptions);
+        fireFullContextMenu(canvas, positioningOptions);
         flushRafCalls();
       }
 
@@ -360,7 +358,7 @@ describe('MarkerChart', function() {
       }
 
       function clickOnMenuItem(stringOrRegexp) {
-        fireEvent.click(getByText(stringOrRegexp));
+        fireFullClick(getByText(stringOrRegexp));
       }
 
       function findFillTextPosition(

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -18,6 +18,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { processProfile } from '../../profile-logic/process-profile';
+import { fireFullClick } from '../fixtures/utils';
 import type { Profile, SymbolicationStatus } from 'firefox-profiler/types';
 
 // We mock profile-store but we want the real error, so that we can simulate it.
@@ -141,7 +142,7 @@ describe('app/MenuButtons', function() {
       queryByText('Include preference values');
     const getPanel = () => getByTestId('MenuButtonsPublish-container');
     const clickAndRunTimers = where => {
-      fireEvent.click(where);
+      fireFullClick(where);
       jest.runAllTimers();
     };
 
@@ -322,7 +323,7 @@ describe('<MenuButtonsMetaInfo>', function() {
 
     const { container, getByText } = setup(profile);
     const metaInfoButton = getByText('Firefox 48 – macOS 10.11');
-    fireEvent.click(metaInfoButton);
+    fireFullClick(metaInfoButton);
     jest.runAllTimers();
 
     expect(container.firstChild).toMatchSnapshot();
@@ -342,7 +343,7 @@ describe('<MenuButtonsMetaInfo>', function() {
     const { getByText, container } = setup(profile);
 
     const metaInfoButton = getByText('Firefox 48 – macOS 10.11');
-    fireEvent.click(metaInfoButton);
+    fireFullClick(metaInfoButton);
     jest.runAllTimers();
 
     expect(container.firstChild).toMatchSnapshot();
@@ -362,7 +363,7 @@ describe('<MenuButtonsMetaInfo>', function() {
 
       // Open up the arrow panel for the test.
       const { getByText } = setupResult;
-      fireEvent.click(getByText('Firefox'));
+      fireFullClick(getByText('Firefox'));
       jest.runAllTimers();
 
       return setupResult;
@@ -375,7 +376,7 @@ describe('<MenuButtonsMetaInfo>', function() {
       });
 
       expect(getByText('Profile is symbolicated')).toBeTruthy();
-      getByText('Re-symbolicate profile').click();
+      fireFullClick(getByText('Re-symbolicate profile'));
       expect(resymbolicateProfile).toHaveBeenCalled();
     });
 
@@ -386,7 +387,7 @@ describe('<MenuButtonsMetaInfo>', function() {
       });
 
       expect(getByText('Profile is not symbolicated')).toBeTruthy();
-      getByText('Symbolicate profile').click();
+      fireFullClick(getByText('Symbolicate profile'));
       expect(resymbolicateProfile).toHaveBeenCalled();
     });
 

--- a/src/test/components/MenuButtonsPermalinks.test.js
+++ b/src/test/components/MenuButtonsPermalinks.test.js
@@ -5,11 +5,12 @@
 // @flow
 import * as React from 'react';
 import MenuButtons from '../../components/app/MenuButtons';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
 import { stateFromLocation } from '../../app-logic/url-handling';
 import { ensureExists } from '../../utils/flow';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('<Permalink>', function() {
   function setup(search = '', injectedUrlShortener) {
@@ -43,7 +44,7 @@ describe('<Permalink>', function() {
     const getPermalinkButton = () => getByText('Permalink');
     const queryInput = () => queryByTestId('MenuButtonsPermalink-input');
     const clickAndRunTimers = where => {
-      fireEvent.click(where);
+      fireFullClick(where);
       jest.runAllTimers();
     };
 

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -36,6 +36,8 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
   getMouseEvent,
+  fireFullClick,
+  fireFullContextMenu,
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
@@ -116,17 +118,6 @@ function setupWithProfile(profile) {
       `Couldn't find the context menu.`
     );
 
-  function rightClick(where) {
-    const clickOptions = {
-      button: 2,
-      buttons: 2,
-    };
-
-    fireEvent.mouseDown(where, clickOptions);
-    fireEvent.mouseUp(where, clickOptions);
-    fireEvent.contextMenu(where, clickOptions);
-  }
-
   return {
     ...renderResult,
     ...store,
@@ -139,7 +130,6 @@ function setupWithProfile(profile) {
     getPhaseElementStyles,
     rowItem,
     getContextMenu,
-    rightClick,
   };
 }
 
@@ -176,12 +166,12 @@ describe('NetworkChart', function() {
         endTime: 70,
       }),
     ];
-    const { getByText, getContextMenu, rightClick } = setupWithPayload(markers);
-    rightClick(getByText('/1'));
+    const { getByText, getContextMenu } = setupWithPayload(markers);
+    fireFullContextMenu(getByText('/1'));
 
     expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
 
-    fireEvent.click(getByText('Copy URL'));
+    fireFullClick(getByText('Copy URL'));
     expect(copy).toHaveBeenLastCalledWith('https://mozilla.org/1');
     expect(getContextMenu()).not.toHaveClass('react-contextmenu--visible');
 
@@ -676,12 +666,11 @@ describe('Network Chart/tooltip behavior', () => {
     const {
       rowItem,
       queryByTestId,
-      rightClick,
       getByText,
       getContextMenu,
     } = setupWithPayload(getNetworkMarkers());
 
-    rightClick(getByText('mozilla.org'));
+    fireFullContextMenu(getByText('mozilla.org'));
 
     expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
 

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -17,7 +17,12 @@ import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
-import { getBoundingBox, createSelectChanger } from '../fixtures/utils';
+import {
+  getBoundingBox,
+  createSelectChanger,
+  fireFullClick,
+  fireFullContextMenu,
+} from '../fixtures/utils';
 import {
   getProfileFromTextSamples,
   getProfileWithJsAllocations,
@@ -86,27 +91,11 @@ describe('calltree/ProfileCallTreeView', function() {
         `Couldn't find the context menu.`
       );
 
-    // Because different components listen to different events, we trigger all
-    // the right events as part of click and rightClick actions.
-    const click = (element: HTMLElement) => {
-      fireEvent.mouseDown(element);
-      fireEvent.mouseUp(element);
-      fireEvent.click(element);
-    };
-
-    const rightClick = (element: HTMLElement) => {
-      fireEvent.mouseDown(element, { button: 2, buttons: 2 });
-      fireEvent.mouseUp(element, { button: 2, buttons: 2 });
-      fireEvent.contextMenu(element);
-    };
-
     return {
       ...store,
       ...renderResult,
       getRowElement,
       getContextMenu,
-      click,
-      rightClick,
     };
   }
 
@@ -177,12 +166,12 @@ describe('calltree/ProfileCallTreeView', function() {
   });
 
   it('selects a node when left clicking', () => {
-    const { getByText, getRowElement, click } = setup();
+    const { getByText, getRowElement } = setup();
 
-    click(getByText('A'));
+    fireFullClick(getByText('A'));
     expect(getRowElement('A')).toHaveClass('isSelected');
 
-    click(getByText('B'));
+    fireFullClick(getByText('B'));
     expect(getRowElement('A')).not.toHaveClass('isSelected');
     expect(getRowElement('B')).toHaveClass('isSelected');
   });
@@ -191,17 +180,17 @@ describe('calltree/ProfileCallTreeView', function() {
     // Fake timers are needed when dealing with the context menu.
     jest.useFakeTimers();
 
-    const { getContextMenu, getByText, getRowElement, rightClick } = setup();
+    const { getContextMenu, getByText, getRowElement } = setup();
 
     function checkMenuIsDisplayedForNode(str) {
       expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
 
       // Note that selecting a menu item will close the menu.
-      fireEvent.click(getByText('Copy function name'));
+      fireFullClick(getByText('Copy function name'));
       expect(copy).toHaveBeenLastCalledWith(str);
     }
 
-    rightClick(getByText('A'));
+    fireFullContextMenu(getByText('A'));
     expect(getRowElement('A')).toHaveClass('isRightClicked');
     checkMenuIsDisplayedForNode('A');
 
@@ -209,8 +198,8 @@ describe('calltree/ProfileCallTreeView', function() {
     jest.runAllTimers();
 
     // Now try it again by right clicking 2 nodes in sequence.
-    rightClick(getByText('A'));
-    rightClick(getByText('C'));
+    fireFullContextMenu(getByText('A'));
+    fireFullContextMenu(getByText('C'));
     expect(getRowElement('C')).toHaveClass('isRightClicked');
     checkMenuIsDisplayedForNode('C');
 
@@ -219,8 +208,8 @@ describe('calltree/ProfileCallTreeView', function() {
 
     // And now let's do it again, but this time waiting for timers before
     // clicking, because the timer can impact the menu being displayed.
-    rightClick(getByText('A'));
-    rightClick(getByText('C'));
+    fireFullContextMenu(getByText('A'));
+    fireFullContextMenu(getByText('C'));
     jest.runAllTimers();
     expect(getRowElement('C')).toHaveClass('isRightClicked');
     checkMenuIsDisplayedForNode('C');
@@ -230,11 +219,11 @@ describe('calltree/ProfileCallTreeView', function() {
     // Fake timers are needed when dealing with the context menu.
     jest.useFakeTimers();
 
-    const { getContextMenu, getByText, click, rightClick, container } = setup();
-    rightClick(getByText('A'));
+    const { getContextMenu, getByText, container } = setup();
+    fireFullContextMenu(getByText('A'));
     expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
 
-    click(getByText('C'));
+    fireFullClick(getByText('C'));
     expect(getContextMenu()).not.toHaveClass('react-contextmenu--visible');
 
     jest.runAllTimers();
@@ -245,13 +234,13 @@ describe('calltree/ProfileCallTreeView', function() {
     // Fake timers are needed when dealing with the context menu.
     jest.useFakeTimers();
 
-    const { getByText, getRowElement, click, rightClick } = setup();
+    const { getByText, getRowElement } = setup();
 
-    click(getByText('A'));
+    fireFullClick(getByText('A'));
     expect(getRowElement('A')).toHaveClass('isSelected');
     expect(getRowElement('A')).not.toHaveClass('isRightClicked');
 
-    rightClick(getByText('A'));
+    fireFullContextMenu(getByText('A'));
     // Both classes will be set, but our CSS styles `rightClicked` only when
     // `selected` is not present either.
     expect(getRowElement('A')).toHaveClass('isSelected');
@@ -262,15 +251,15 @@ describe('calltree/ProfileCallTreeView', function() {
     // Fake timers are needed when dealing with the context menu.
     jest.useFakeTimers();
 
-    const { getByText, getRowElement, click, rightClick } = setup();
+    const { getByText, getRowElement } = setup();
 
-    rightClick(getByText('A'));
+    fireFullContextMenu(getByText('A'));
     expect(getRowElement('A')).not.toHaveClass('isSelected');
     expect(getRowElement('A')).toHaveClass('isRightClicked');
 
     // When the node is highlighted from a right click, left clicking it will
     // chnage its highlight style.
-    click(getByText('A'));
+    fireFullClick(getByText('A'));
     expect(getRowElement('A')).toHaveClass('isSelected');
     expect(getRowElement('A')).toHaveClass('isRightClicked');
 

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import serviceWorkerRuntime from 'offline-plugin/runtime';
 
 import ServiceWorkerManager from '../../components/app/ServiceWorkerManager';
@@ -22,6 +22,7 @@ import { ensureExists } from '../../utils/flow';
 
 import { blankStore } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { fireFullClick } from '../fixtures/utils';
 
 // Mock the offline plugin library.
 jest.mock('offline-plugin/runtime', () => ({
@@ -128,7 +129,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(container.firstChild).toMatchSnapshot();
 
       // Let's hide the notice.
-      fireEvent.click(getCloseButton());
+      fireFullClick(getCloseButton());
       expect(container.firstChild).toBe(null);
 
       // But getting a new update should display the notice again.
@@ -140,7 +141,7 @@ describe('app/ServiceWorkerManager', () => {
 
       // But let's do it now.
       const reloadButton = getReloadButton();
-      fireEvent.click(reloadButton);
+      fireFullClick(reloadButton);
 
       expect(serviceWorkerRuntime.applyUpdate).toHaveBeenCalled();
       expect(reloadButton.textContent).toBe('Installing…');

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -434,11 +434,7 @@ function setup(profile: Profile, funcNames: string[] = []): * {
     const positioningOptions = getPositioningOptions(where);
 
     fireMouseEvent('mousemove', positioningOptions);
-    fireFullClick(stackChartCanvas, {
-      ...positioningOptions,
-      button: 0,
-      buttons: 0,
-    });
+    fireFullClick(stackChartCanvas, positioningOptions);
     flushRafCalls();
   }
 

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -39,6 +39,8 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
   findFillTextPositionFromDrawLog,
+  fireFullClick,
+  fireFullContextMenu,
 } from '../fixtures/utils';
 import {
   getProfileFromTextSamples,
@@ -219,7 +221,7 @@ describe('MarkerChart', function() {
     expect(UrlStateSelectors.getShowUserTimings(getState())).toBe(false);
     expect(getCheckedState(checkbox)).toBe(false);
 
-    checkbox.click();
+    fireFullClick(checkbox);
 
     expect(UrlStateSelectors.getShowUserTimings(getState())).toBe(true);
     expect(getCheckedState(checkbox)).toBe(true);
@@ -284,7 +286,7 @@ function getUserTiming(name: string, startTime: number, duration: number) {
 function showUserTimings({ ctx, getByLabelText, flushRafCalls }) {
   ctx.__flushDrawLog();
   const checkbox = getByLabelText('Show user timing');
-  checkbox.click();
+  fireFullClick(checkbox);
   flushRafCalls();
 }
 
@@ -430,31 +432,21 @@ function setup(profile: Profile, funcNames: string[] = []): * {
   // Use findFillTextPosition to determin the position.
   function leftClick(where: Position) {
     const positioningOptions = getPositioningOptions(where);
-    const clickOptions = {
+
+    fireMouseEvent('mousemove', positioningOptions);
+    fireFullClick(stackChartCanvas, {
       ...positioningOptions,
       button: 0,
       buttons: 0,
-    };
-
-    fireMouseEvent('mousemove', positioningOptions);
-    fireMouseEvent('mousedown', clickOptions);
-    fireMouseEvent('mouseup', clickOptions);
-    fireMouseEvent('click', clickOptions);
+    });
     flushRafCalls();
   }
 
   function rightClick(where: Position) {
     const positioningOptions = getPositioningOptions(where);
-    const clickOptions = {
-      ...positioningOptions,
-      button: 2,
-      buttons: 2,
-    };
 
     fireMouseEvent('mousemove', positioningOptions);
-    fireMouseEvent('mousedown', clickOptions);
-    fireMouseEvent('mouseup', clickOptions);
-    fireMouseEvent('contextmenu', clickOptions);
+    fireFullContextMenu(stackChartCanvas, positioningOptions);
     flushRafCalls();
   }
 
@@ -470,7 +462,7 @@ function setup(profile: Profile, funcNames: string[] = []): * {
     );
 
   function clickMenuItem(strOrRegexp) {
-    fireEvent.click(getByText(strOrRegexp));
+    fireFullClick(getByText(strOrRegexp));
   }
 
   function findFillTextPosition(fillText: string): Position {

--- a/src/test/components/StackSettings.test.js
+++ b/src/test/components/StackSettings.test.js
@@ -11,6 +11,7 @@ import {
   getImplementationFilter,
   getCurrentSearchString,
 } from '../../selectors/url-state';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('StackSettings', function() {
   function setup() {
@@ -46,7 +47,7 @@ describe('StackSettings', function() {
     expect(getImplementationFilter(getState())).toEqual('combined');
     const radioButton = getByLabelText(/JavaScript/);
 
-    radioButton.click();
+    fireFullClick(radioButton);
 
     expect(getCheckedState(radioButton)).toBe(true);
     expect(getImplementationFilter(getState())).toEqual('js');
@@ -57,7 +58,7 @@ describe('StackSettings', function() {
     expect(getImplementationFilter(getState())).toEqual('combined');
     const radioButton = getByLabelText(/Native/);
 
-    radioButton.click();
+    fireFullClick(radioButton);
 
     expect(getCheckedState(radioButton)).toBe(true);
     expect(getImplementationFilter(getState())).toEqual('cpp');
@@ -65,11 +66,11 @@ describe('StackSettings', function() {
 
   it('can change the implementation filter to All stacks', function() {
     const { getByLabelText, getState } = setup();
-    getByLabelText(/Native/).click();
+    fireFullClick(getByLabelText(/Native/));
     expect(getImplementationFilter(getState())).toEqual('cpp');
     const radioButton = getByLabelText(/All stacks/);
 
-    radioButton.click();
+    fireFullClick(radioButton);
 
     expect(getCheckedState(radioButton)).toBe(true);
     expect(getImplementationFilter(getState())).toEqual('combined');

--- a/src/test/components/TabBar.test.js
+++ b/src/test/components/TabBar.test.js
@@ -5,8 +5,9 @@
 // @flow
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import TabBar from '../../components/app/TabBar';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('app/TabBar', () => {
   it('renders the TabBar and handles clicks properly', () => {
@@ -27,8 +28,7 @@ describe('app/TabBar', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    const leftClick = { button: 0 };
-    fireEvent.click(getByText('Call Tree'), leftClick);
+    fireFullClick(getByText('Call Tree'));
     expect(handleTabSelection).toHaveBeenCalledWith('calltree');
   });
 });

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -12,7 +12,7 @@ import type {
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
@@ -20,7 +20,7 @@ import TrackThread from '../../components/timeline/TrackThread';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
-import { getBoundingBox, getMouseEvent } from '../fixtures/utils';
+import { getBoundingBox, fireFullClick } from '../fixtures/utils';
 
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
@@ -89,13 +89,10 @@ describe('ThreadActivityGraph', function() {
       index: IndexIntoSamplesTable,
       graphHeightPercentage: number
     ) {
-      fireEvent(
-        activityGraphCanvas,
-        getMouseEvent('mouseup', {
-          pageX: getSamplesPixelPosition(index),
-          pageY: GRAPH_HEIGHT * graphHeightPercentage,
-        })
-      );
+      fireFullClick(activityGraphCanvas, {
+        pageX: getSamplesPixelPosition(index),
+        pageY: GRAPH_HEIGHT * graphHeightPercentage,
+      });
     }
 
     // This function gets the selected call node path as a list of function names.

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -5,13 +5,17 @@
 // @flow
 import * as React from 'react';
 import Timeline from '../../components/timeline';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
-import { getBoundingBox } from '../fixtures/utils';
+import {
+  getBoundingBox,
+  fireFullClick,
+  fireFullContextMenu,
+} from '../fixtures/utils';
 import ReactDOM from 'react-dom';
 import { getTimelineTrackOrganization } from '../../selectors/url-state';
 import { getRightClickedTrack } from '../../selectors/profile';
@@ -157,13 +161,13 @@ describe('Timeline', function() {
         type: 'full',
       });
 
-      fireEvent.click(getByText('Show active tab only'));
+      fireFullClick(getByText('Show active tab only'));
       expect(getTimelineTrackOrganization(store.getState())).toEqual({
         type: 'active-tab',
         browsingContextID: 123,
       });
 
-      fireEvent.click(getByText('Show active tab only'));
+      fireFullClick(getByText('Show active tab only'));
       expect(getTimelineTrackOrganization(store.getState())).toEqual({
         type: 'full',
       });
@@ -187,15 +191,13 @@ describe('Timeline', function() {
 
       expect(getRightClickedTrack(store.getState())).toEqual(null);
 
-      fireEvent.mouseDown(getByRole('button', { name: 'Process 0' }), {
-        button: 2,
-      });
+      fireFullContextMenu(getByRole('button', { name: 'Process 0' }));
       expect(getRightClickedTrack(store.getState())).toEqual({
         trackIndex: 0,
         type: 'global',
       });
 
-      fireEvent.click(getByText('/ tracks visible'));
+      fireFullClick(getByText('/ tracks visible'));
       expect(getRightClickedTrack(store.getState())).toEqual(null);
     });
   });

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -24,6 +24,8 @@ import {
   getMouseEvent,
   addRootOverlayElement,
   removeRootOverlayElement,
+  fireFullClick,
+  fireFullContextMenu,
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { ensureExists } from '../../utils/flow';
@@ -81,7 +83,7 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   }
 
   function clickOnMenuItem(stringOrRegexp) {
-    fireEvent.click(renderResult.getByText(stringOrRegexp));
+    fireFullClick(renderResult.getByText(stringOrRegexp));
   }
 
   function fireMouseEvent(eventName, options) {
@@ -119,18 +121,15 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   // array returned by ctx.__flushDrawLog().
   function rightClick(where: { x: CssPixels, y: CssPixels }) {
     const positioningOptions = getPositioningOptions(where);
-    const clickOptions = {
-      ...positioningOptions,
-      button: 2,
-      buttons: 2,
-    };
+    const canvas = ensureExists(
+      renderResult.container.querySelector('canvas'),
+      `Couldn't find the canvas element`
+    );
 
     // Because different components listen to different events, we trigger
     // all the right events, to be as close as possible to the real stuff.
     fireMouseEvent('mousemove', positioningOptions);
-    fireMouseEvent('mousedown', clickOptions);
-    fireMouseEvent('mouseup', clickOptions);
-    fireMouseEvent('contextmenu', clickOptions);
+    fireFullContextMenu(canvas, positioningOptions);
 
     flushRafTwice();
   }

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ensureExists } from '../../utils/flow';
 
 import {
@@ -29,6 +29,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 
 import { storeWithProfile } from '../fixtures/stores';
+import { fireFullClick } from '../fixtures/utils';
 
 describe('timeline/TrackContextMenu', function() {
   /**
@@ -118,7 +119,7 @@ describe('timeline/TrackContextMenu', function() {
 
     it('can isolate the process', function() {
       const { isolateProcessItem, getState } = setupGlobalTrack();
-      fireEvent.click(isolateProcessItem());
+      fireFullClick(isolateProcessItem());
       expect(getHumanReadableTracks(getState())).toEqual([
         'hide [thread GeckoMain process]',
         'show [thread GeckoMain tab] SELECTED',
@@ -129,7 +130,7 @@ describe('timeline/TrackContextMenu', function() {
 
     it("can isolate the process's main thread", function() {
       const { isolateProcessMainThreadItem, getState } = setupGlobalTrack();
-      fireEvent.click(isolateProcessMainThreadItem());
+      fireFullClick(isolateProcessMainThreadItem());
       expect(getHumanReadableTracks(getState())).toEqual([
         'hide [thread GeckoMain process]',
         'show [thread GeckoMain tab] SELECTED',
@@ -156,7 +157,7 @@ describe('timeline/TrackContextMenu', function() {
       ]);
 
       expect(isolateProcessMainThreadItem).toThrow();
-      fireEvent.click(isolateProcessItem());
+      fireFullClick(isolateProcessItem());
       expect(getHumanReadableTracks(getState())).toEqual([
         'hide [thread GeckoMain process]',
         'show [process]',
@@ -169,7 +170,7 @@ describe('timeline/TrackContextMenu', function() {
       const { isolateScreenshotTrack, getState } = setupGlobalTrack(
         getScreenshotTrackProfile()
       );
-      fireEvent.click(isolateScreenshotTrack());
+      fireFullClick(isolateScreenshotTrack());
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [screenshots]',
         'hide [screenshots]',
@@ -181,9 +182,9 @@ describe('timeline/TrackContextMenu', function() {
     it('can toggle a global track by clicking it', function() {
       const { trackItem, trackIndex, getState } = setupGlobalTrack();
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(false);
-      fireEvent.click(trackItem());
+      fireFullClick(trackItem());
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(true);
-      fireEvent.click(trackItem());
+      fireFullClick(trackItem());
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(false);
     });
 
@@ -257,7 +258,7 @@ describe('timeline/TrackContextMenu', function() {
 
     it('can isolate the local track', function() {
       const { isolateLocalTrackItem, getState } = setupLocalTrack();
-      fireEvent.click(isolateLocalTrackItem());
+      fireFullClick(isolateLocalTrackItem());
       expect(getHumanReadableTracks(getState())).toEqual([
         'hide [thread GeckoMain process]',
         'show [thread GeckoMain tab]',
@@ -269,9 +270,9 @@ describe('timeline/TrackContextMenu', function() {
     it('can toggle a local track by clicking it', function() {
       const { trackItem, pid, trackIndex, getState } = setupLocalTrack();
       expect(getHiddenLocalTracks(getState(), pid).has(trackIndex)).toBe(false);
-      fireEvent.click(trackItem());
+      fireFullClick(trackItem());
       expect(getHiddenLocalTracks(getState(), pid).has(trackIndex)).toBe(true);
-      fireEvent.click(trackItem());
+      fireFullClick(trackItem());
       expect(getHiddenLocalTracks(getState(), pid).has(trackIndex)).toBe(false);
     });
 
@@ -316,7 +317,7 @@ describe('timeline/TrackContextMenu', function() {
     it('will unhide the global track when unhiding one of its local tracks', function() {
       const { getState, globalTrackItem, localTrackItem } = setupTracks();
       // Hide the global track.
-      fireEvent.click(globalTrackItem());
+      fireFullClick(globalTrackItem());
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain process] SELECTED',
         // The "GeckoMain tab" process is now hidden.
@@ -328,7 +329,7 @@ describe('timeline/TrackContextMenu', function() {
       ]);
 
       // Unhide "DOM Worker" local track.
-      fireEvent.click(localTrackItem());
+      fireFullClick(localTrackItem());
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain process] SELECTED',
         // The "GeckoMain tab" process is visible again.

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -8,7 +8,7 @@ import type { Profile, FileIoPayload } from 'firefox-profiler/types';
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { oneLine } from 'common-tags';
 
 import {
@@ -26,9 +26,9 @@ import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getBoundingBox,
-  getMouseEvent,
   addRootOverlayElement,
   removeRootOverlayElement,
+  fireFullClick,
 } from '../fixtures/utils';
 
 import {
@@ -184,28 +184,16 @@ describe('timeline/TrackThread', function() {
           thread.stringTable.getString(thread.funcTable.name[funcIndex])
         );
 
-    fireEvent(
-      stackGraphCanvas(),
-      getMouseEvent('mouseup', getFillRectCenterByIndex(log, 0))
-    );
+    fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 0));
     expect(getCallNodePath()).toEqual(['a', 'b', 'c']);
 
-    fireEvent(
-      stackGraphCanvas(),
-      getMouseEvent('mouseup', getFillRectCenterByIndex(log, 1))
-    );
+    fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 1));
     expect(getCallNodePath()).toEqual(['d', 'e', 'f']);
 
-    fireEvent(
-      stackGraphCanvas(),
-      getMouseEvent('mouseup', getFillRectCenterByIndex(log, 2))
-    );
+    fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 2));
     expect(getCallNodePath()).toEqual(['g', 'h', 'i']);
 
-    fireEvent(
-      stackGraphCanvas(),
-      getMouseEvent('mouseup', getFillRectCenterByIndex(log, 3))
-    );
+    fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 3));
     expect(getCallNodePath()).toEqual(['j', 'k', 'l']);
   });
 
@@ -239,32 +227,20 @@ describe('timeline/TrackThread', function() {
     {
       const log = changeInvertCallstackAndGetDrawLog(true);
 
-      fireEvent(
-        stackGraphCanvas(),
-        getMouseEvent('mouseup', getFillRectCenterByIndex(log, 0))
-      );
+      fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 0));
       expect(getCallNodePath()).toEqual(['c']);
 
-      fireEvent(
-        stackGraphCanvas(),
-        getMouseEvent('mouseup', getFillRectCenterByIndex(log, 2))
-      );
+      fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 2));
       expect(getCallNodePath()).toEqual(['i']);
     }
     {
       // Switch back to "uninverted" mode
       const log = changeInvertCallstackAndGetDrawLog(false);
 
-      fireEvent(
-        stackGraphCanvas(),
-        getMouseEvent('mouseup', getFillRectCenterByIndex(log, 0))
-      );
+      fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 0));
       expect(getCallNodePath()).toEqual(['a', 'b', 'c']);
 
-      fireEvent(
-        stackGraphCanvas(),
-        getMouseEvent('mouseup', getFillRectCenterByIndex(log, 2))
-      );
+      fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 2));
       expect(getCallNodePath()).toEqual(['g', 'h', 'i']);
     }
   });
@@ -280,8 +256,7 @@ describe('timeline/TrackThread', function() {
     const log = ctx.__flushDrawLog();
 
     function clickAndGetMarkerName(event) {
-      fireEvent(markerCanvas(), getMouseEvent('mousedown', event));
-      fireEvent(markerCanvas(), getMouseEvent('mouseup', event));
+      fireFullClick(markerCanvas(), event);
       return getPreviewSelection(getState());
     }
 

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -6,14 +6,18 @@
 import * as React from 'react';
 import ZipFileViewer from '../../components/app/ZipFileViewer';
 import { Provider } from 'react-redux';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import * as UrlStateSelectors from '../../selectors/url-state';
 import * as ZippedProfileSelectors from '../../selectors/zipped-profiles';
 
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
-import { getBoundingBox, waitUntilState } from '../fixtures/utils';
+import {
+  getBoundingBox,
+  waitUntilState,
+  fireFullClick,
+} from '../fixtures/utils';
 
 describe('calltree/ZipFileTree', function() {
   async function setup() {
@@ -106,7 +110,7 @@ describe('calltree/ZipFileTree', function() {
         waitUntilDoneProcessingZip,
         profileViewer,
       } = await setupClickingTest();
-      fireEvent.click(profile1OpenLink);
+      fireFullClick(profile1OpenLink);
       expect(UrlStateSelectors.getPathInZipFileFromUrl(getState())).toBe(
         'foo/bar/profile1.json'
       );
@@ -135,7 +139,7 @@ describe('calltree/ZipFileTree', function() {
         waitUntilDoneProcessingZip,
       } = await setupClickingTest();
 
-      fireEvent.click(profile1OpenLink);
+      fireFullClick(profile1OpenLink);
       await waitUntilDoneProcessingZip();
       expect(profileViewer()).toBeTruthy();
     });

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -284,33 +284,38 @@ export function findFillTextPositionFromDrawLog(
 }
 
 /**
- * JSDom only sends one event at a time, but a lot of component logic assumes that
- * events come in a natural cascade. This utility ensures that cascasde gets fired
- * correctly. This also includes the fix to make properties like pageX work.
+ * React Testing Library only sends one event at a time, but a lot of component logic
+ * assumes that events come in a natural cascade. This utility ensures that cascasde
+ * gets fired correctly. This also includes the fix to make properties like pageX work.
  */
 export function fireFullClick(
   element: HTMLElement,
   options?: FakeMouseEventInit
 ) {
   fireEvent(element, getMouseEvent('mousedown', options));
-  fireEvent(element, getMouseEvent('mouseup', options));
   fireEvent(element, getMouseEvent('click', options));
+  fireEvent(element, getMouseEvent('mouseup', options));
 }
 
+/**
+ * This utility will fire a full context menu event as a user would. The options
+ * paramter is optional. It will always add the `button` and `buttons` value to
+ * ensure that it is correct, unless the ctrlKey is specified, as that is a valid
+ * option in macOS to open a context menu.
+ */
 export function fireFullContextMenu(
   element: HTMLElement,
-  options?: FakeMouseEventInit
+  options: FakeMouseEventInit = {}
 ) {
   const isMacContextMenu =
-    options &&
-    options.ctrlKey &&
-    !options.metaKey &&
-    !options.shiftKey &&
-    !options.altKey;
+    options.ctrlKey && !options.metaKey && !options.shiftKey && !options.altKey;
 
   if (!isMacContextMenu) {
+    // Ensure that the `options` properties "button" and "buttons" have the correct
+    // values of 2, so that tests don't have to specify this. The only time this value
+    // would not be 2 is on a Mac context menu event.
     options = {
-      ...(options || {}),
+      ...options,
       button: 2,
       buttons: 2,
     };

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -282,3 +282,41 @@ export function findFillTextPositionFromDrawLog(
 
   return positions[0];
 }
+
+/**
+ * JSDom only sends one event at a time, but a lot of component logic assumes that
+ * events come in a natural cascade. This utility ensures that cascasde gets fired
+ * correctly. This also includes the fix to make properties like pageX work.
+ */
+export function fireFullClick(
+  element: HTMLElement,
+  options?: FakeMouseEventInit
+) {
+  fireEvent(element, getMouseEvent('mousedown', options));
+  fireEvent(element, getMouseEvent('mouseup', options));
+  fireEvent(element, getMouseEvent('click', options));
+}
+
+export function fireFullContextMenu(
+  element: HTMLElement,
+  options?: FakeMouseEventInit
+) {
+  const isMacContextMenu =
+    options &&
+    options.ctrlKey &&
+    !options.metaKey &&
+    !options.shiftKey &&
+    !options.altKey;
+
+  if (!isMacContextMenu) {
+    options = {
+      ...(options || {}),
+      button: 2,
+      buttons: 2,
+    };
+  }
+
+  fireEvent(element, getMouseEvent('mousedown', options));
+  fireEvent(element, getMouseEvent('mouseup', options));
+  fireEvent(element, getMouseEvent('contextmenu', options));
+}


### PR DESCRIPTION
Most of our tests would just fire the part of the click event they were interested in. However, the real behavior in the browser is a bit more complicated with a sequence of events: mousedown -> mouseup -> click. This patch updates the tests to always use the "full" behavior. This should be more maintainable for when different events listen to different events. That way a "click" in tests is closer to actual user behavior.

This is a breakout from #2706.