### PR TITLE
Move ServiceWorkerManager up in the component hierarchy

### DIFF
--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import React, { Fragment, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
 import ProfileViewer from './ProfileViewer';
@@ -15,7 +15,6 @@ import { ProfileRootMessage } from './ProfileRootMessage';
 import { getView } from '../../selectors/app';
 import { getHasZipFile } from '../../selectors/zipped-profiles';
 import { getDataSource, getProfilesToCompare } from '../../selectors/url-state';
-import ServiceWorkerManager from './ServiceWorkerManager';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 import { ListOfPublishedProfiles } from './ListOfPublishedProfiles';
 import { assertExhaustiveCheck } from '../../utils/flow';
@@ -43,7 +42,7 @@ type AppViewRouterStateProps = {|
 type AppViewRouterProps = ConnectedProps<{||}, AppViewRouterStateProps, {||}>;
 
 class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
-  renderCurrentRoute() {
+  render() {
     const { view, dataSource, profilesToCompare, hasZipFile } = this.props;
     const phase = view.phase;
 
@@ -110,15 +109,6 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
           <Home specialMessage="The URL you came in on was not recognized." />
         );
     }
-  }
-
-  render() {
-    return (
-      <Fragment>
-        <ServiceWorkerManager />
-        {this.renderCurrentRoute()}
-      </Fragment>
-    );
   }
 }
 

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -10,6 +10,7 @@ import FooterLinks from './FooterLinks';
 import { ErrorBoundary } from './ErrorBoundary';
 import { AppViewRouter } from './AppViewRouter';
 import { ProfileLoader } from './ProfileLoader';
+import ServiceWorkerManager from './ServiceWorkerManager';
 
 import type { Store } from 'firefox-profiler/types';
 
@@ -27,6 +28,7 @@ export default class Root extends PureComponent<RootProps> {
         <Provider store={store}>
           <DragAndDrop>
             <UrlManager>
+              <ServiceWorkerManager />
               <ProfileLoader />
               <AppViewRouter />
               <FooterLinks />


### PR DESCRIPTION
This should make no difference because we were using a Fragment, but this simplifies AppViewRouter a bit.

I checked that a service worker was still added with the various datasources.