### PR TITLE
[Deploy preview] Add experimental CPU tracks for each thread

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -350,6 +350,10 @@ export function selectTrack(
             selectedThreadIndex = localTrack.threadIndex;
             break;
           }
+          case 'cpu': {
+            selectedThreadIndex = localTrack.threadIndex;
+            break;
+          }
           default:
             throw assertExhaustiveCheck(
               localTrack,

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -29,6 +29,7 @@ import TrackNetwork from './TrackNetwork';
 import { TrackMemory } from './TrackMemory';
 import { TrackIPC } from './TrackIPC';
 import { getTrackSelectionModifier } from 'firefox-profiler/utils';
+import { TrackCPU } from './TrackCPU';
 import type {
   TrackReference,
   Pid,
@@ -140,6 +141,8 @@ class LocalTrackComponent extends PureComponent<Props> {
         return <TrackIPC threadIndex={localTrack.threadIndex} />;
       case 'event-delay':
         return <TrackEventDelay threadIndex={localTrack.threadIndex} />;
+      case 'cpu':
+        return <TrackCPU threadIndex={localTrack.threadIndex} />;
       default:
         console.error('Unhandled localTrack type', (localTrack: empty));
         return null;
@@ -214,7 +217,8 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
         isSelected =
           selectedThreadIndexes.has(threadIndex) &&
           selectedTab !== 'network-chart' &&
-          selectedTab !== 'event-delay';
+          selectedTab !== 'event-delay' &&
+          selectedTab !== 'cpu';
         titleText = selectors.getThreadProcessDetails(state);
         break;
       }
@@ -250,6 +254,17 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
           selectedTab !== 'event-delay';
         titleText =
           'Event Delay of ' + selectors.getThreadProcessDetails(state);
+        break;
+      }
+      case 'cpu': {
+        // Look up the thread information for the process if it exists.
+        const threadIndex = localTrack.threadIndex;
+        const selectedTab = getSelectedTab(state);
+        const selectors = getThreadSelectors(threadIndex);
+        isSelected =
+          threadIndex === selectedThreadIndexes.has(threadIndex) &&
+          selectedTab !== 'cpu';
+        titleText = 'CPU Usage of ' + selectors.getThreadProcessDetails(state);
         break;
       }
       default:

--- a/src/components/timeline/TrackCPU.css
+++ b/src/components/timeline/TrackCPU.css
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.timelineTrackMemoryGraph {
+  position: relative;
+  width: 100%;
+  height: var(--graph-height);
+}
+
+.timelineTrackMemoryCanvas {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.timelineTrackMemoryGraphDot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  margin-left: -3px;
+  background-color: var(--orange-60);
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.timelineTrackMemoryTooltipLine {
+  white-space: nowrap;
+}
+
+.timelineTrackMemoryTooltipNumber {
+  display: inline-block;
+  min-width: 60px;
+  color: var(--grey-60);
+  font-weight: bold;
+}
+
+.timelineMarkersMemory {
+  height: var(--markers-height, 15px);
+  opacity: 1;
+}

--- a/src/components/timeline/TrackCPU.js
+++ b/src/components/timeline/TrackCPU.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { TrackCPUGraph } from './TrackCPUGraph';
+import {
+  TRACK_EVENT_DELAY_HEIGHT,
+  TRACK_EVENT_DELAY_LINE_WIDTH,
+} from '../../app-logic/constants';
+
+import type { ThreadIndex } from 'firefox-profiler/types';
+
+import './TrackCPU.css';
+
+type Props = {|
+  +threadIndex: ThreadIndex,
+|};
+
+export class TrackCPU extends React.PureComponent<Props, {||}> {
+  render() {
+    const { threadIndex } = this.props;
+    const graphHeight = TRACK_EVENT_DELAY_HEIGHT;
+    return (
+      <div
+        className="timelineTrackMemory"
+        style={{
+          height: graphHeight,
+          '--graph-height': `${graphHeight}px`,
+          '--markers-height': `0px`,
+        }}
+      >
+        <TrackCPUGraph
+          threadIndex={threadIndex}
+          lineWidth={TRACK_EVENT_DELAY_LINE_WIDTH}
+          graphHeight={graphHeight}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/timeline/TrackCPUGraph.js
+++ b/src/components/timeline/TrackCPUGraph.js
@@ -1,0 +1,459 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { withSize } from '../shared/WithSize';
+import explicitConnect from '../../utils/connect';
+import { getCommittedRange, getProfileInterval } from '../../selectors/profile';
+import { getThreadSelectors } from '../../selectors/per-thread';
+import { getCPUSamples } from '../../profile-logic/profile-data';
+import { Tooltip } from '../tooltip/Tooltip';
+import EmptyThreadIndicator from './EmptyThreadIndicator';
+import { bisectionRight } from 'firefox-profiler/utils/bisect';
+
+import type {
+  Thread,
+  ThreadIndex,
+  Milliseconds,
+  CssPixels,
+  StartEndRange,
+  SamplesTable,
+  CPUSamples,
+} from 'firefox-profiler/types';
+
+import type { SizeProps } from '../shared/WithSize';
+import type { ConnectedProps } from '../../utils/connect';
+
+import './TrackCPU.css';
+
+/**
+ * When adding properties to these props, please consider the comment above the component.
+ */
+type CanvasProps = {|
+  +samples: SamplesTable,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +interval: Milliseconds,
+  +width: CssPixels,
+  +height: CssPixels,
+  +lineWidth: CssPixels,
+  +cpuSamples: CPUSamples,
+|};
+
+/**
+ * This component controls the rendering of the canvas. Every render call through
+ * React triggers a new canvas render. Because of this, it's important to only pass
+ * in the props that are needed for the canvas draw call.
+ */
+class TrackCPUCanvas extends React.PureComponent<CanvasProps> {
+  _canvas: null | HTMLCanvasElement = null;
+  _requestedAnimationFrame: boolean = false;
+
+  drawCanvas(canvas: HTMLCanvasElement): void {
+    const {
+      rangeStart,
+      rangeEnd,
+      samples,
+      height,
+      width,
+      lineWidth,
+      interval,
+      cpuSamples,
+    } = this.props;
+    if (width === 0) {
+      // This is attempting to draw before the canvas was laid out.
+      return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    const devicePixelRatio = window.devicePixelRatio;
+    const deviceWidth = width * devicePixelRatio;
+    const deviceHeight = height * devicePixelRatio;
+    const deviceLineWidth = lineWidth * devicePixelRatio;
+    const deviceLineHalfWidth = deviceLineWidth * 0.5;
+    const innerDeviceHeight = deviceHeight - deviceLineWidth;
+    const rangeLength = rangeEnd - rangeStart;
+    const millisecondWidth = deviceWidth / rangeLength;
+    const intervalWidth = interval * millisecondWidth;
+
+    // Resize and clear the canvas.
+    canvas.width = Math.round(deviceWidth);
+    canvas.height = Math.round(deviceHeight);
+    ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+
+    if (samples.length === 0) {
+      // There's no reason to draw the samples, there are none.
+      return;
+    }
+
+    const { threadCPUCycles, threadKernelTime, threadUserTime } = cpuSamples;
+
+    // Take the sample information, and convert it into chart coordinates. Use a slightly
+    // smaller space than the deviceHeight, so that the stroke will be fully visible
+    // both at the top and bottom of the chart.
+    if (
+      threadCPUCycles.samples.length === 0 ||
+      threadKernelTime.samples.length === 0 ||
+      threadUserTime.samples.length === 0
+    ) {
+      throw new Error('No sample found for CPU usage');
+    }
+
+    // const { min, range, samples: threadCPUCyclesSamples } = threadCPUCycles;
+    for (const cpuProp in cpuSamples) {
+      const cpuSampleItem = cpuSamples[cpuProp];
+      const { min, range, samples: samplesItem, strokeStyle } = cpuSampleItem;
+      // Draw the chart.
+      //
+      //                 ...--`
+      //  1 ...---```..--      `--. 2
+      //    |_____________________|
+      //  4                        3
+      //
+      // Start by drawing from 1 - 2. This will be the top of all the peaks of the
+      // memory graph.
+
+      ctx.lineWidth = deviceLineWidth;
+      ctx.strokeStyle = strokeStyle;
+      ctx.fillStyle = 'rgba(0,0,0,0)'; // transparent
+      ctx.beginPath();
+
+      // The x and y are used after the loop.
+      let x = 0;
+      let y = 0;
+      let firstX = 0;
+      for (let i = 0; i < samples.length; i++) {
+        // Create a path for the top of the chart. This is the line that will have
+        // a stroke applied to it.
+        x = (samples.time[i] - rangeStart) * millisecondWidth;
+        // Add on half the stroke's line width so that it won't be cut off the edge
+        // of the graph.
+        const unitGraphCount = (samplesItem[i] - min) / range;
+        y =
+          innerDeviceHeight -
+          innerDeviceHeight * unitGraphCount +
+          deviceLineHalfWidth;
+        if (i === 0) {
+          // This is the first iteration, only move the line, do not draw it. Also
+          // remember this first X, as the bottom of the graph will need to connect
+          // back up to it.
+          firstX = x;
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+      // The samples range ends at the time of the last sample, plus the interval.
+      // Draw this last bit.
+      ctx.lineTo(x + intervalWidth, y);
+
+      // Don't do the fill yet, just stroke the top line. This will draw a line from
+      // point 1 to 2 in the diagram above.
+      ctx.stroke();
+
+      // After doing the stroke, continue the path to complete the fill to the bottom
+      // of the canvas. This continues the path to point 3 and then 4.
+
+      // Create a line from 2 to 3.
+      ctx.lineTo(x + intervalWidth, deviceHeight);
+
+      // Create a line from 3 to 4.
+      ctx.lineTo(firstX, deviceHeight);
+
+      // The line from 4 to 1 will be implicitly filled in.
+      ctx.fill();
+    }
+  }
+
+  _scheduleDraw() {
+    if (!this._requestedAnimationFrame) {
+      this._requestedAnimationFrame = true;
+      window.requestAnimationFrame(() => {
+        this._requestedAnimationFrame = false;
+        const canvas = this._canvas;
+        if (canvas) {
+          this.drawCanvas(canvas);
+        }
+      });
+    }
+  }
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  render() {
+    this._scheduleDraw();
+
+    return (
+      <canvas className="timelineTrackMemoryCanvas" ref={this._takeCanvasRef} />
+    );
+  }
+}
+
+type OwnProps = {|
+  +threadIndex: ThreadIndex,
+  +lineWidth: CssPixels,
+  +graphHeight: CssPixels,
+|};
+
+type StateProps = {|
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +interval: Milliseconds,
+  +filteredThread: Thread,
+  +unfilteredSamplesRange: StartEndRange | null,
+  +cpuSamples: CPUSamples,
+|};
+
+type DispatchProps = {||};
+
+type Props = {|
+  ...SizeProps,
+  ...ConnectedProps<OwnProps, StateProps, DispatchProps>,
+|};
+
+type State = {|
+  hoveredSample: null | number,
+  mouseX: CssPixels,
+  mouseY: CssPixels,
+|};
+
+/**
+ * The memory track graph takes memory information from counters, and renders it as a
+ * graph in the timeline.
+ */
+class TrackCPUGraphImpl extends React.PureComponent<Props, State> {
+  state = {
+    hoveredSample: null,
+    mouseX: 0,
+    mouseY: 0,
+  };
+
+  _onMouseLeave = () => {
+    this.setState({ hoveredSample: null });
+  };
+
+  _onMouseMove = (event: SyntheticMouseEvent<HTMLDivElement>) => {
+    const { pageX: mouseX, pageY: mouseY } = event;
+    // Get the offset from here, and apply it to the time lookup.
+    const { left } = event.currentTarget.getBoundingClientRect();
+    const {
+      width,
+      rangeStart,
+      rangeEnd,
+      filteredThread,
+      interval,
+    } = this.props;
+    const rangeLength = rangeEnd - rangeStart;
+    const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
+    const { samples } = filteredThread;
+    if (samples.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No sample group found for CPU counter');
+    }
+    if (
+      timeAtMouse < samples.time[0] ||
+      timeAtMouse > samples.time[samples.length - 1] + interval
+    ) {
+      // We are outside the range of the samples, do not display hover information.
+      this.setState({ hoveredSample: null });
+    } else {
+      // When the mouse pointer hovers between two points, select the point that's closer.
+      let hoveredSample;
+      const bisectionCounter = bisectionRight(samples.time, timeAtMouse);
+      if (bisectionCounter > 0 && bisectionCounter < samples.time.length) {
+        const leftDistance = timeAtMouse - samples.time[bisectionCounter - 1];
+        const rightDistance = samples.time[bisectionCounter] - timeAtMouse;
+        if (leftDistance < rightDistance) {
+          // Left point is closer
+          hoveredSample = bisectionCounter - 1;
+        } else {
+          // Right point is closer
+          hoveredSample = bisectionCounter;
+        }
+      } else {
+        hoveredSample = bisectionCounter;
+      }
+      if (hoveredSample === samples.length) {
+        // When hovering the last sample, it's possible the mouse is past the time.
+        // In this case, hover over the last sample. This happens because of the
+        // ` + interval` line in the `if` condition above.
+        hoveredSample = samples.time.length - 1;
+      }
+      this.setState({
+        mouseX,
+        mouseY,
+        hoveredSample,
+      });
+    }
+  };
+
+  _renderTooltip(sampleIndex: number): React.Node {
+    if (this.props.filteredThread.samples.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No accumulated sample found for memory counter');
+    }
+    const { cpuSamples } = this.props;
+    const tooltip = [];
+
+    for (const cpuProp in cpuSamples) {
+      const cpuSampleItem = cpuSamples[cpuProp];
+      const { samples: samplesItem, strokeStyle } = cpuSampleItem;
+
+      const sample = samplesItem[sampleIndex];
+      tooltip.push(
+        <div
+          className="timelineTrackMemoryTooltip"
+          style={{ color: strokeStyle }}
+        >
+          <div className="timelineTrackMemoryTooltipLine">
+            <span className="timelineTrackMemoryTooltipNumber">{sample}</span>
+            {' ' + cpuProp}
+          </div>
+          {/* <div className="timelineTrackMemoryTooltipLine">
+            <span className="timelineTrackMemoryTooltipNumber">
+              {formatBytes(countRange)}
+            </span>
+            {' memory range in graph'}
+          </div> */}
+        </div>
+      );
+    }
+    return tooltip;
+  }
+
+  /**
+   * Create a div that is a dot on top of the graph representing the current
+   * height of the graph.
+   */
+  _renderCPUDots(counterIndex: number): React.Node {
+    const {
+      filteredThread,
+      rangeStart,
+      rangeEnd,
+      graphHeight,
+      width,
+      lineWidth,
+      cpuSamples,
+    } = this.props;
+    if (filteredThread.samples.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No sample group found for memory counter');
+    }
+    const dots = [];
+
+    for (const cpuProp in cpuSamples) {
+      const cpuSampleItem = cpuSamples[cpuProp];
+      const { min, range, samples: samplesItem, strokeStyle } = cpuSampleItem;
+
+      const { samples } = filteredThread;
+      const rangeLength = rangeEnd - rangeStart;
+      const left =
+        (width * (samples.time[counterIndex] - rangeStart)) / rangeLength;
+
+      const unitSampleCount = (samplesItem[counterIndex] - min) / range;
+      const innerTrackHeight = graphHeight - lineWidth / 2;
+      const top =
+        innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;
+
+      console.log(
+        'canova',
+        cpuProp,
+        stack,
+        top,
+        samplesItemCount,
+        samplesItem[counterIndex],
+        unitSampleCount,
+        innerTrackHeight
+      );
+
+      dots.push(
+        <div
+          style={{ left, top, 'background-color': strokeStyle }}
+          className="timelineTrackMemoryGraphDot"
+        />
+      );
+    }
+
+    return dots;
+  }
+
+  render() {
+    const { hoveredSample, mouseX, mouseY } = this.state;
+    const {
+      filteredThread,
+      interval,
+      rangeStart,
+      rangeEnd,
+      unfilteredSamplesRange,
+      graphHeight,
+      width,
+      lineWidth,
+      cpuSamples,
+    } = this.props;
+
+    return (
+      <div
+        className="timelineTrackMemoryGraph"
+        onMouseMove={this._onMouseMove}
+        onMouseLeave={this._onMouseLeave}
+      >
+        <TrackCPUCanvas
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          samples={filteredThread.samples}
+          height={graphHeight}
+          width={width}
+          lineWidth={lineWidth}
+          interval={interval}
+          cpuSamples={cpuSamples}
+        />
+        {hoveredSample === null ? null : (
+          <>
+            {this._renderCPUDots(hoveredSample)}
+            <Tooltip mouseX={mouseX} mouseY={mouseY}>
+              {this._renderTooltip(hoveredSample)}
+            </Tooltip>
+          </>
+        )}
+        <EmptyThreadIndicator
+          thread={filteredThread}
+          interval={interval}
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          unfilteredSamplesRange={unfilteredSamplesRange}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackCPUGraph = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { threadIndex } = ownProps;
+    const { start, end } = getCommittedRange(state);
+    const selectors = getThreadSelectors(threadIndex);
+    const filteredThread = selectors.getRangeFilteredThread(state);
+    console.log('thread index: ', threadIndex);
+    return {
+      rangeStart: start,
+      rangeEnd: end,
+      interval: getProfileInterval(state),
+      filteredThread: filteredThread,
+      unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),
+      cpuSamples: getCPUSamples(filteredThread.samples),
+    };
+  },
+  component: withSize<Props>(TrackCPUGraphImpl),
+});

--- a/src/components/timeline/TrackCPUGraph.js
+++ b/src/components/timeline/TrackCPUGraph.js
@@ -83,6 +83,7 @@ class TrackCPUCanvas extends React.PureComponent<CanvasProps> {
     canvas.width = Math.round(deviceWidth);
     canvas.height = Math.round(deviceHeight);
     ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+    ctx.lineJoin = 'round';
 
     if (samples.length === 0) {
       // There's no reason to draw the samples, there are none.
@@ -131,6 +132,7 @@ class TrackCPUCanvas extends React.PureComponent<CanvasProps> {
       ctx.lineWidth = deviceLineWidth;
       ctx.strokeStyle = strokeStyle;
       ctx.fillStyle = fillStyle;
+
       ctx.beginPath();
 
       // The x and y are used after the loop.

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -60,6 +60,17 @@ export function getEmptySamplesTableWithEventDelay(): SamplesTable {
     eventDelay: [],
     stack: [],
     time: [],
+    // New values related to cpu usage.
+    threadCPUCycles: [],
+    threadKernelTime: [],
+    threadUserTime: [],
+    processCPUCycles: [],
+    processKernelTime: [],
+    processUserTime: [],
+    systemIdleCPUCycles: [],
+    systemIdleTime: [],
+    systemKernelTime: [],
+    systemUserTime: [],
     length: 0,
   };
 }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -828,6 +828,17 @@ function _processSamples(geckoSamples: GeckoSampleStruct): SamplesTable {
     time: geckoSamples.time,
     weightType: 'samples',
     weight: null,
+    // CPU usage related stuff
+    threadCPUCycles: geckoSamples.threadCPUCycles,
+    threadKernelTime: geckoSamples.threadKernelTime,
+    threadUserTime: geckoSamples.threadUserTime,
+    processCPUCycles: geckoSamples.processCPUCycles,
+    processKernelTime: geckoSamples.processKernelTime,
+    processUserTime: geckoSamples.processUserTime,
+    systemIdleCPUCycles: geckoSamples.systemIdleCPUCycles,
+    systemIdleTime: geckoSamples.systemIdleTime,
+    systemKernelTime: geckoSamples.systemKernelTime,
+    systemUserTime: geckoSamples.systemUserTime,
     length: geckoSamples.length,
   };
 

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1724,7 +1724,33 @@ export function getCPUSamples(samplesTable: SamplesTable): CPUSamples {
   }
 
   // Min max and stuff
+  const userTime = cpuSamples.threadUserTime.samples;
+  const kernelTime = cpuSamples.threadKernelTime.samples;
+  const cpuCycles = cpuSamples.threadCPUCycles.samples;
+  cpuSamples.threadUserTime.samples = new Array(
+    cpuSamples.threadUserTime.samples.length
+  ).fill(0);
+  cpuSamples.threadKernelTime.samples = new Array(
+    cpuSamples.threadKernelTime.samples.length
+  ).fill(0);
+  cpuSamples.threadCPUCycles.samples = new Array(
+    cpuSamples.threadCPUCycles.samples.length
+  ).fill(0);
+
   for (let i = 0; i < samplesTable.length; i++) {
+    // Get the first derivative of the numbers.
+    if (i !== 0) {
+      const timeDiff = samplesTable.time[i] - samplesTable.time[i - 1];
+      cpuSamples.threadUserTime.samples[i] =
+        (userTime[i] - userTime[i - 1]) / timeDiff;
+
+      cpuSamples.threadKernelTime.samples[i] =
+        (kernelTime[i] - kernelTime[i - 1]) / timeDiff;
+
+      cpuSamples.threadCPUCycles.samples[i] =
+        (cpuCycles[i] - cpuCycles[i - 1]) / timeDiff;
+    }
+
     cpuSamples.threadCPUCycles.min = Math.min(
       cpuSamples.threadCPUCycles.samples[i],
       cpuSamples.threadCPUCycles.min

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -11,6 +11,8 @@ import {
   getEmptyUnbalancedNativeAllocationsTable,
   getEmptyBalancedNativeAllocationsTable,
 } from './data-structures';
+import { ORANGE_50, BLUE_50, MAGENTA_50 } from 'photon-colors';
+import { formatMilliseconds } from '../utils/format-numbers';
 
 import type {
   Profile,
@@ -50,6 +52,7 @@ import type {
   CallTreeSummaryStrategy,
   EventDelayInfo,
   ThreadsKey,
+  CPUSamples,
 } from 'firefox-profiler/types';
 
 import { bisectionRight, bisectionLeft } from 'firefox-profiler/utils/bisect';
@@ -1636,6 +1639,72 @@ export function processEventDelays(
     maxDelay,
     delayRange,
   };
+}
+
+/**
+ * TODO: write something
+ */
+export function getCPUSamples(samplesTable: SamplesTable): CPUSamples {
+  const cpuSamples = {
+    threadCPUCycles: {
+      min: 0,
+      max: 0,
+      range: 0,
+      samples: ensureExists(samplesTable.threadCPUCycles),
+      strokeStyle: ORANGE_50,
+      formatter: (val: number) => val,
+    },
+    threadKernelTime: {
+      min: 0,
+      max: 0,
+      range: 0,
+      samples: ensureExists(samplesTable.threadKernelTime),
+      strokeStyle: BLUE_50,
+      formatter: formatMilliseconds,
+    },
+    threadUserTime: {
+      min: 0,
+      max: 0,
+      range: 0,
+      samples: ensureExists(samplesTable.threadUserTime),
+      strokeStyle: MAGENTA_50,
+      formatter: formatMilliseconds,
+    },
+  };
+
+  for (let i = 0; i < samplesTable.length; i++) {
+    cpuSamples.threadCPUCycles.min = Math.min(
+      cpuSamples.threadCPUCycles.samples[i],
+      cpuSamples.threadCPUCycles.min
+    );
+    cpuSamples.threadCPUCycles.max = Math.max(
+      cpuSamples.threadCPUCycles.samples[i],
+      cpuSamples.threadCPUCycles.max
+    );
+    //////
+    cpuSamples.threadKernelTime.min = Math.min(
+      cpuSamples.threadKernelTime.samples[i],
+      cpuSamples.threadKernelTime.min
+    );
+    cpuSamples.threadKernelTime.max = Math.max(
+      cpuSamples.threadKernelTime.samples[i],
+      cpuSamples.threadKernelTime.max
+    );
+    //////
+    cpuSamples.threadUserTime.min = Math.min(
+      cpuSamples.threadUserTime.samples[i],
+      cpuSamples.threadUserTime.min
+    );
+    cpuSamples.threadUserTime.max = Math.max(
+      cpuSamples.threadUserTime.samples[i],
+      cpuSamples.threadUserTime.max
+    );
+  }
+
+  cpuSamples.threadCPUCycles.range =
+    cpuSamples.threadCPUCycles.max - cpuSamples.threadCPUCycles.min;
+
+  return cpuSamples;
 }
 
 // --------------- CallNodePath and CallNodeIndex manipulations ---------------

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1250,6 +1250,72 @@ export function filterThreadSamplesToRange(
     );
   }
 
+  const {
+    threadCPUCycles,
+    threadKernelTime,
+    threadUserTime,
+    processCPUCycles,
+    processKernelTime,
+    processUserTime,
+    systemIdleCPUCycles,
+    systemIdleTime,
+    systemKernelTime,
+    systemUserTime,
+  } = samples;
+  if (
+    threadCPUCycles &&
+    threadKernelTime &&
+    threadUserTime &&
+    processCPUCycles &&
+    processKernelTime &&
+    processUserTime &&
+    systemIdleCPUCycles &&
+    systemIdleTime &&
+    systemKernelTime &&
+    systemUserTime
+  ) {
+    newSamples.threadCPUCycles = threadCPUCycles.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.threadKernelTime = threadKernelTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.threadUserTime = threadUserTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.processCPUCycles = processCPUCycles.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.processKernelTime = processKernelTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.processUserTime = processUserTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.systemIdleCPUCycles = systemIdleCPUCycles.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.systemIdleTime = systemIdleTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.systemKernelTime = systemKernelTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+    newSamples.systemUserTime = systemUserTime.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+  }
+
   const newThread: Thread = {
     ...thread,
     samples: newSamples,

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -246,6 +246,12 @@ export function computeLocalTracksByPid(
       // This thread has IPC markers.
       tracks.push({ type: 'ipc', threadIndex });
     }
+
+    // TODO: Remove this code part of the code if you want to land this.
+    // This is for testing purpose.
+    if (thread.samples.threadCPUCycles) {
+      tracks.push({ type: 'cpu', threadIndex });
+    }
   }
 
   const { counters } = profile;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -245,6 +245,22 @@ const eventDelayTracks: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+/*
+ * This reducer hold the state for whether the event delay tracks are enabled.
+ * This way we can hide the event delay tracks by default and display if we
+ * change the state.
+ * TODO: change
+ * TODO: change the default value form true to false later since it should be disabled at first.
+ */
+const cpuTracks: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'ENABLE_CPU_TRACKS': {
+      return true;
+    }
+    default:
+      return state;
+  }
+};
 /**
  * Experimental features that are mostly disabled by default. You need to enable
  * them from the DevTools console with `experimental.enable<feature-camel-case>()`,
@@ -254,6 +270,7 @@ const eventDelayTracks: Reducer<boolean> = (state = false, action) => {
  */
 const experimental: Reducer<ExperimentalFlags> = combineReducers({
   eventDelayTracks,
+  cpuTracks,
 });
 
 const appStateReducer: Reducer<AppState> = combineReducers({

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -94,6 +94,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
+    case 'ENABLE_CPU_TRACKS':
       return action.localTracksByPid;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -382,6 +382,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
+    case 'ENABLE_CPU_TRACKS':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -72,7 +72,8 @@ export const getExperimental: Selector<ExperimentalFlags> = state =>
   getApp(state).experimental;
 export const getIsEventDelayTracksEnabled: Selector<boolean> = state =>
   getExperimental(state).eventDelayTracks;
-
+export const getIsCPUTracksEnabled: Selector<boolean> = state =>
+  getExperimental(state).cpuTracks;
 export const getIsDragAndDropDragging: Selector<boolean> = state =>
   getApp(state).isDragAndDropDragging;
 export const getIsDragAndDropOverlayRegistered: Selector<boolean> = state =>
@@ -274,6 +275,9 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                   break;
                 case 'ipc':
                   height += TRACK_IPC_HEIGHT + border;
+                  break;
+                case 'cpu':
+                  height += TRACK_MEMORY_HEIGHT + border;
                   break;
                 default:
                   throw assertExhaustiveCheck(localTrack);

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -263,6 +263,11 @@ type ProfileAction =
       +type: 'ENABLE_EVENT_DELAY_TRACKS',
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+    |}
+  | {|
+      +type: 'ENABLE_CPU_TRACKS',
+      +localTracksByPid: Map<Pid, LocalTrack[]>,
+      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
     |};
 
 type ReceiveProfileAction =

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -114,6 +114,17 @@ export type GeckoSampleStructWithResponsiveness = {|
   stack: Array<null | IndexIntoGeckoStackTable>,
   time: Milliseconds[],
   responsiveness: Array<?Milliseconds>,
+  // New values related to cpu usage.
+  threadCPUCycles?: Array<Milliseconds>,
+  threadKernelTime?: Array<Milliseconds>,
+  threadUserTime?: Array<Milliseconds>,
+  processCPUCycles?: Array<Milliseconds>,
+  processKernelTime?: Array<Milliseconds>,
+  processUserTime?: Array<Milliseconds>,
+  systemIdleCPUCycles?: Array<Milliseconds>,
+  systemIdleTime?: Array<Milliseconds>,
+  systemKernelTime?: Array<Milliseconds>,
+  systemUserTime?: Array<Milliseconds>,
   length: number,
 |};
 
@@ -122,6 +133,17 @@ export type GeckoSampleStructWithEventDelay = {|
   stack: Array<null | IndexIntoGeckoStackTable>,
   time: Milliseconds[],
   eventDelay: Array<?Milliseconds>,
+  // New values related to cpu usage.
+  threadCPUCycles?: Array<Milliseconds>,
+  threadKernelTime?: Array<Milliseconds>,
+  threadUserTime?: Array<Milliseconds>,
+  processCPUCycles?: Array<Milliseconds>,
+  processKernelTime?: Array<Milliseconds>,
+  processUserTime?: Array<Milliseconds>,
+  systemIdleCPUCycles?: Array<Milliseconds>,
+  systemIdleTime?: Array<Milliseconds>,
+  systemKernelTime?: Array<Milliseconds>,
+  systemUserTime?: Array<Milliseconds>,
   length: number,
 |};
 

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -200,6 +200,21 @@ export type AccumulatedCounterSamples = {|
   +accumulatedCounts: number[],
 |};
 
+type CPUSamplesSingle = {
+  +min: number,
+  +max: number,
+  +range: number,
+  +samples: number[],
+  +strokeStyle: string,
+  +formatter: (val: number) => number | string,
+};
+
+export type CPUSamples = {|
+  +threadCPUCycles: CPUSamplesSingle,
+  +threadKernelTime: CPUSamplesSingle,
+  +threadUserTime: CPUSamplesSingle,
+|};
+
 export type StackType = 'js' | 'native' | 'unsymbolicated';
 
 export type GlobalTrack =
@@ -214,7 +229,8 @@ export type LocalTrack =
   | {| +type: 'network', +threadIndex: ThreadIndex |}
   | {| +type: 'memory', +counterIndex: CounterIndex |}
   | {| +type: 'ipc', +threadIndex: ThreadIndex |}
-  | {| +type: 'event-delay', +threadIndex: ThreadIndex |};
+  | {| +type: 'event-delay', +threadIndex: ThreadIndex |}
+  | {| +type: 'cpu', +threadIndex: ThreadIndex |};
 
 export type Track = GlobalTrack | LocalTrack;
 export type TrackIndex = number;

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -165,6 +165,17 @@ export type SamplesTable = {|
   // See the WeightType type for more information.
   weight: null | number[],
   weightType: WeightType,
+  // New values related to cpu usage.
+  threadCPUCycles?: Array<Milliseconds>,
+  threadKernelTime?: Array<Milliseconds>,
+  threadUserTime?: Array<Milliseconds>,
+  processCPUCycles?: Array<Milliseconds>,
+  processKernelTime?: Array<Milliseconds>,
+  processUserTime?: Array<Milliseconds>,
+  systemIdleCPUCycles?: Array<Milliseconds>,
+  systemIdleTime?: Array<Milliseconds>,
+  systemKernelTime?: Array<Milliseconds>,
+  systemUserTime?: Array<Milliseconds>,
   length: number,
 |};
 

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -164,6 +164,7 @@ export type UrlSetupPhase = 'initial-load' | 'loading-profile' | 'done';
  */
 export type ExperimentalFlags = {|
   +eventDelayTracks: boolean,
+  +cpuTracks: boolean,
 |};
 
 export type AppState = {|

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -72,6 +72,16 @@ export function addDataToWindowObject(
         `);
       }
     },
+    enableCPUTracks() {
+      const areCPUTracksEnabled = dispatch(actions.enableCPUTracks());
+      if (areCPUTracksEnabled) {
+        console.log(stripIndent`
+          ✅ The CPU tracks are now enabled and should be displayed in the timeline.
+          👉 Note that this is an experimental feature that might still have bugs.
+          💡 As an experimental feature their presence isn't persisted as a URL parameter like the other things.
+        `);
+      }
+    },
   };
 
   target.getState = getState;


### PR DESCRIPTION
This PR adds some CPU tracks for each threads. This is not intended to be merged yet, it's mostly for testing the backend side.

[Deploy preview](https://deploy-preview-2724--perf-html.netlify.app/public/ftgmtm62zp2pcnjm7srs8ph533048qng2yyn1g0/calltree/?globalTrackOrder=0-1&hiddenLocalTracksByPid=2782004-2-3~2778912-0&localTrackOrderByPid=2782004-2-3-4-0-5-1-6~2778912-0-1~&thread=0&v=5)
cc @squelart 