### PR TITLE
Expose compare and uploaded recordings panels in home

### DIFF
--- a/res/css/protocol/index.css
+++ b/res/css/protocol/index.css
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@import './typography.css';

--- a/res/css/protocol/typography.css
+++ b/res/css/protocol/typography.css
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Specification at https://protocol.mozilla.org/fundamentals/typography.html
+ * This is the protocol styling guide, which is different than the photon design
+ * guide. We can use it for content pages (as opposed to the app).
+ *
+ * In the future we may want to make this more generic by applying these styles
+ * by default to h1, h2, h3, etc, in content pages.
+ */
+
+.protocol-display-xxl {
+  font-size: 64px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-display-xl {
+  font-size: 56px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-display-lg {
+  font-size: 48px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-display-md {
+  font-size: 40px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-display-sm {
+  font-size: 32px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-display-xs {
+  font-size: 24px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-display-xxs {
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 1.1;
+}
+
+.protocol-body-lg {
+  font-size: 18px;
+  line-height: 1.5;
+}
+
+.protocol-body-md {
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.protocol-body-sm {
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.protocol-body-xs {
+  font-size: 12px;
+  line-height: 1.5;
+}

--- a/src/components/app/AppHeader.js
+++ b/src/components/app/AppHeader.js
@@ -10,39 +10,19 @@
 
 import * as React from 'react';
 
-import { setDataSource } from 'firefox-profiler/actions/profile-view';
-import explicitConnect, {
-  type ConnectedProps,
-} from 'firefox-profiler/utils/connect';
+import { InnerNavigationLink } from 'firefox-profiler/components/shared/InnerNavigationLink';
 
 import './AppHeader.css';
 
-type DispatchProps = {|
-  +setDataSource: typeof setDataSource,
-|};
-type Props = ConnectedProps<{||}, {||}, DispatchProps>;
-
-class AppHeaderImpl extends React.PureComponent<Props> {
-  onClick = (e: SyntheticMouseEvent<>) => {
-    const { setDataSource } = this.props;
-    if (e.ctrlKey || e.metaKey) {
-      // The user clearly wanted to open this link in a new tab.
-      return;
-    }
-
-    e.preventDefault();
-
-    setDataSource('none');
-  };
-
+export class AppHeader extends React.PureComponent<{||}> {
   render() {
     return (
       <header>
         <h1 className="appHeader">
           <span className="appHeaderSlogan">
-            <a className="appHeaderLink" href="/" onClick={this.onClick}>
+            <InnerNavigationLink dataSource="none" className="appHeaderLink">
               Firefox Profiler
-            </a>
+            </InnerNavigationLink>
             <span className="appHeaderSubtext">
               {' '}
               &mdash; Web app for Firefox performance analysis
@@ -74,8 +54,3 @@ class AppHeaderImpl extends React.PureComponent<Props> {
     );
   }
 }
-
-export const AppHeader = explicitConnect<{||}, {||}, DispatchProps>({
-  mapDispatchToProps: { setDataSource },
-  component: AppHeaderImpl,
-});

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -27,7 +27,7 @@
   width: 75%;
   max-width: 1200px;
   box-sizing: border-box;
-  padding: 8em;
+  padding: 4em 8em;
   border: 1px solid #ccc;
   background-color: #fff;
   border-radius: 3px;

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -59,6 +59,12 @@
   place-self: center;
 }
 
+.homeAdditionalContentTitle {
+  margin-top: 0;
+  margin-bottom: 10px;
+  grid-column: 1 / -1; /* from start to end */
+}
+
 .homeSectionButton {
   display: block;
   width: 100%;
@@ -137,10 +143,11 @@
   filter: grayscale(1) brightness(3);
 }
 
-.homeInstructions {
+.homeInstructions,
+.homeAdditionalContent {
   display: grid;
   margin-top: 30px;
-  gap: 30px;
+  column-gap: 30px;
   grid-template-columns: 1fr 1fr;
 }
 
@@ -197,6 +204,8 @@ label.homeSectionButton:focus-within {
     max-width: 80%;
     padding: 3em;
   }
+
+  .homeAdditionalContent,
   .homeInstructions {
     grid: none;
   }

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -65,6 +65,11 @@
   grid-column: 1 / -1; /* from start to end */
 }
 
+.homeActions > p:first-child,
+.homeRecentUploadedRecordingsTitle {
+  margin-top: 0;
+}
+
 .homeSectionButton {
   display: block;
   width: 100%;

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -56,6 +56,7 @@
   border: 1px solid #d1d1d1;
   border-radius: 0.4em;
   box-shadow: 0 2px 4px #ddd;
+  place-self: center;
 }
 
 .homeSectionButton {
@@ -136,26 +137,11 @@
   filter: grayscale(1) brightness(3);
 }
 
-.homeSectionPerfScreenshot {
-  width: 1346px;
-  max-width: 90%;
-  height: auto;
-  margin-top: 15px;
-  margin-bottom: -40px;
-}
-
 .homeInstructions {
-  display: flex;
+  display: grid;
   margin-top: 30px;
-}
-
-.homeInstructionsLeft,
-.homeInstructionsRight {
-  width: 50%;
-}
-
-.homeInstructionsRight {
-  padding-left: 30px;
+  gap: 30px;
+  grid-template-columns: 1fr 1fr;
 }
 
 .homeInstructionsTransitionGroup {
@@ -212,17 +198,7 @@ label.homeSectionButton:focus-within {
     padding: 3em;
   }
   .homeInstructions {
-    display: block;
-  }
-  .homeInstructionsLeft,
-  .homeInstructionsRight {
-    width: 100%;
-  }
-  .homeInstructionsLeft {
-    text-align: center;
-  }
-  .homeInstructionsRight {
-    padding-left: 0;
+    grid: none;
   }
 }
 

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -7,6 +7,7 @@
 import * as React from 'react';
 
 import { AppHeader } from './AppHeader';
+import { InnerNavigationLink } from 'firefox-profiler/components/shared/InnerNavigationLink';
 
 import explicitConnect from '../../utils/connect';
 import classNames from 'classnames';
@@ -135,9 +136,7 @@ class ActionButtons extends React.PureComponent<
         </div>
         {this.state.isLoadFromUrlPressed ? (
           <LoadFromUrl {...this.props} />
-        ) : (
-          <p>You can also drag and drop a profile file here to load it.</p>
-        )}
+        ) : null}
       </div>
     );
   }
@@ -362,11 +361,6 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               profile in Firefox, then analyze it and share it with
               profiler.firefox.com.
             </p>
-            <ActionButtons
-              // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
-              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
-              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
-            />
           </div>
           {/* end of grid container */}
         </div>
@@ -404,11 +398,6 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               profile in Firefox, then analyze it and share it with
               profiler.firefox.com.
             </p>
-            <ActionButtons
-              // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
-              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
-              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
-            />
           </div>
           {/* end of grid container */}
         </div>
@@ -441,11 +430,6 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               profiler.firefox.com.
             </p>
             {this._renderShortcuts()}
-            <ActionButtons
-              // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
-              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
-              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
-            />
           </div>
           {/* end of grid container */}
         </div>
@@ -476,11 +460,6 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>.
               However, existing profiles can be viewed in any modern browser.
             </p>
-            <ActionButtons
-              // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
-              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
-              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
-            />
           </div>
           {/* end of grid container */}
         </div>
@@ -518,6 +497,32 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
           <TransitionGroup className="homeInstructionsTransitionGroup">
             {this._renderInstructions()}
           </TransitionGroup>
+          <section className="homeAdditionalContent">
+            {/* Grid container: homeAdditionalContent */}
+            <h2 className="homeAdditionalContentTitle photon-title-30">
+              {/* Title: full width */}
+              Load existing profiles
+            </h2>
+            <section className="homeActions">
+              {/* Actions: left column */}
+              <p>
+                You can <strong>drag and drop</strong> a profile file here to
+                load it, or:
+              </p>
+              <ActionButtons
+                // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
+                retrieveProfileFromFile={this.props.retrieveProfileFromFile}
+                triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
+              />
+              <p>
+                You can also compare recordings.{' '}
+                <InnerNavigationLink dataSource="compare">
+                  Open the comparing interface.
+                </InnerNavigationLink>
+              </p>
+            </section>
+            {/* End of grid container */}
+          </section>
           <DragAndDropOverlay />
         </main>
       </div>

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -500,7 +500,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
           </TransitionGroup>
           <section className="homeAdditionalContent">
             {/* Grid container: homeAdditionalContent */}
-            <h2 className="homeAdditionalContentTitle photon-title-30">
+            <h2 className="homeAdditionalContentTitle protocol-display-xs">
               {/* Title: full width */}
               Load existing profiles
             </h2>
@@ -524,7 +524,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
             </section>
             <section>
               {/* Recent recordings: right column */}
-              <h2 className="homeRecentUploadedRecordingsTitle photon-title-20">
+              <h2 className="homeRecentUploadedRecordingsTitle protocol-display-xxs">
                 Recent uploaded recordings
               </h2>
               <ListOfPublishedProfiles limit={3} />

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -339,16 +339,15 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
           className="homeInstructions"
           data-testid="home-enable-popup-instructions"
         >
-          <div className="homeInstructionsLeft">
-            <div style={{ textAlign: 'center' }}>
-              <img
-                className="homeSectionScreenshot"
-                src={PerfScreenshot}
-                alt="screenshot of profiler.firefox.com"
-              />
-            </div>
-          </div>
-          <div className="homeInstructionsRight">
+          {/* Grid container: homeInstructions */}
+          {/* Left column: img */}
+          <img
+            className="homeSectionScreenshot"
+            src={PerfScreenshot}
+            alt="screenshot of profiler.firefox.com"
+          />
+          {/* Right column: instructions */}
+          <div>
             <button
               type="button"
               className="homeSectionButton"
@@ -369,6 +368,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
             />
           </div>
+          {/* end of grid container */}
         </div>
       </InstructionTransition>
     );
@@ -381,16 +381,15 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
           className="homeInstructions"
           data-testid="home-install-addon-instructions"
         >
-          <div className="homeInstructionsLeft">
-            <div style={{ textAlign: 'center' }}>
-              <img
-                className="homeSectionScreenshot"
-                src={PerfScreenshot}
-                alt="screenshot of profiler.firefox.com"
-              />
-            </div>
-          </div>
-          <div className="homeInstructionsRight">
+          {/* Grid container: homeInstructions */}
+          {/* Left column: img */}
+          <img
+            className="homeSectionScreenshot"
+            src={PerfScreenshot}
+            alt="screenshot of profiler.firefox.com"
+          />
+          {/* Right column: instructions */}
+          <div>
             <InstallButton
               name="Gecko Profiler"
               className="homeSectionButton"
@@ -411,6 +410,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
             />
           </div>
+          {/* end of grid container */}
         </div>
       </InstructionTransition>
     );
@@ -423,16 +423,15 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
           className="homeInstructions"
           data-testid="home-record-instructions"
         >
-          <div className="homeInstructionsLeft">
-            <p>
-              <img
-                className="homeSectionScreenshot"
-                src={screenshotSrc}
-                alt="Screenshot of the profiler settings from the Firefox menu."
-              />
-            </p>
-          </div>
-          <div className="homeInstructionsRight">
+          {/* Grid container: homeInstructions */}
+          {/* Left column: img */}
+          <img
+            className="homeSectionScreenshot"
+            src={screenshotSrc}
+            alt="Screenshot of the profiler settings from the Firefox menu."
+          />
+          {/* Right column: instructions */}
+          <div>
             <DocsButton />
             <p>
               To start profiling, click on the profiling button, or use the
@@ -448,6 +447,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
             />
           </div>
+          {/* end of grid container */}
         </div>
       </InstructionTransition>
     );
@@ -460,16 +460,15 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
           className="homeInstructions"
           data-testid="home-other-browser-instructions"
         >
-          <div className="homeInstructionsLeft">
-            <div style={{ textAlign: 'center' }}>
-              <img
-                className="homeSectionScreenshot"
-                src={PerfScreenshot}
-                alt="screenshot of profiler.firefox.com"
-              />
-            </div>
-          </div>
-          <div className="homeInstructionsRight">
+          {/* Grid container: homeInstructions */}
+          {/* Left column: img */}
+          <img
+            className="homeSectionScreenshot"
+            src={PerfScreenshot}
+            alt="screenshot of profiler.firefox.com"
+          />
+          {/* Right column: instructions */}
+          <div>
             <DocsButton />
             <h2>How to view and record profiles</h2>
             <p>
@@ -483,6 +482,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
             />
           </div>
+          {/* end of grid container */}
         </div>
       </InstructionTransition>
     );

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -8,6 +8,7 @@ import * as React from 'react';
 
 import { AppHeader } from './AppHeader';
 import { InnerNavigationLink } from 'firefox-profiler/components/shared/InnerNavigationLink';
+import { ListOfPublishedProfiles } from './ListOfPublishedProfiles';
 
 import explicitConnect from '../../utils/connect';
 import classNames from 'classnames';
@@ -520,6 +521,13 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
                   Open the comparing interface.
                 </InnerNavigationLink>
               </p>
+            </section>
+            <section>
+              {/* Recent recordings: right column */}
+              <h2 className="homeRecentUploadedRecordingsTitle photon-title-20">
+                Recent uploaded recordings
+              </h2>
+              <ListOfPublishedProfiles limit={3} />
             </section>
             {/* End of grid container */}
           </section>

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -7,6 +7,7 @@
 import React, { PureComponent } from 'react';
 import memoize from 'memoize-immutable';
 
+import { InnerNavigationLink } from 'firefox-profiler/components/shared/InnerNavigationLink';
 import {
   listAllProfileData,
   type ProfileData,
@@ -102,11 +103,15 @@ function PublishedProfile({
   );
 }
 
+type Props = {|
+  limit?: number,
+|};
+
 type State = {|
   profileDataList: null | ProfileData[],
 |};
 
-export class ListOfPublishedProfiles extends PureComponent<{||}, State> {
+export class ListOfPublishedProfiles extends PureComponent<Props, State> {
   state = {
     profileDataList: null,
   };
@@ -123,6 +128,7 @@ export class ListOfPublishedProfiles extends PureComponent<{||}, State> {
   }
 
   render() {
+    const { limit } = this.props;
     const { profileDataList } = this.state;
 
     if (!profileDataList) {
@@ -135,18 +141,34 @@ export class ListOfPublishedProfiles extends PureComponent<{||}, State> {
       );
     }
 
+    const reducedProfileDataList = limit
+      ? profileDataList.slice(0, limit)
+      : profileDataList;
+
+    const profilesRestCount =
+      profileDataList.length - reducedProfileDataList.length;
+
     const nowTimestamp = Date.now();
 
     return (
-      <ul className="publishedProfilesList">
-        {profileDataList.map(profileData => (
-          <PublishedProfile
-            key={profileData.profileToken}
-            profileData={profileData}
-            nowTimestamp={nowTimestamp}
-          />
-        ))}
-      </ul>
+      <>
+        <ul className="publishedProfilesList">
+          {reducedProfileDataList.map(profileData => (
+            <PublishedProfile
+              key={profileData.profileToken}
+              profileData={profileData}
+              nowTimestamp={nowTimestamp}
+            />
+          ))}
+        </ul>
+        {profilesRestCount > 0 ? (
+          <p>
+            <InnerNavigationLink dataSource="uploaded-recordings">
+              See all your recordings ({profilesRestCount} more)
+            </InnerNavigationLink>
+          </p>
+        ) : null}
+      </>
     );
   }
 }

--- a/src/components/shared/InnerNavigationLink.js
+++ b/src/components/shared/InnerNavigationLink.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+
+import { setDataSource } from 'firefox-profiler/actions/profile-view';
+
+import explicitConnect, {
+  type ConnectedProps,
+} from 'firefox-profiler/utils/connect';
+
+import type { DataSource } from 'firefox-profiler/types';
+
+type OwnProps = {|
+  +className?: string,
+  +dataSource: DataSource,
+  +children: React.Node,
+|};
+
+type DispatchProps = {|
+  +setDataSource: typeof setDataSource,
+|};
+
+type Props = ConnectedProps<OwnProps, {||}, DispatchProps>;
+
+class InnerNavigationLinkImpl extends React.PureComponent<Props> {
+  onClick = (e: SyntheticMouseEvent<>) => {
+    const { setDataSource, dataSource } = this.props;
+    if (e.ctrlKey || e.metaKey) {
+      // The user clearly wanted to open this link in a new tab.
+      return;
+    }
+
+    e.preventDefault();
+
+    setDataSource(dataSource);
+  };
+
+  render() {
+    const { className, children, dataSource } = this.props;
+    const href = dataSource === 'none' ? '/' : `/${dataSource}/`;
+
+    return (
+      <a className={className} href={href} onClick={this.onClick}>
+        {children}
+      </a>
+    );
+  }
+}
+
+export const InnerNavigationLink = explicitConnect<
+  OwnProps,
+  {||},
+  DispatchProps
+>({
+  mapDispatchToProps: { setDataSource },
+  component: InnerNavigationLinkImpl,
+});

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@
 import '../res/css/focus.css';
 import 'photon-colors/photon-colors.css';
 import '../res/css/photon/index.css';
+import '../res/css/protocol/index.css';
 import '../res/css/style.css';
 import '../res/css/global.css';
 import '../res/css/categories.css';

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -11,6 +11,13 @@ import createStore from '../../app-logic/create-store';
 import { mockWebChannel } from '../fixtures/mocks/web-channel';
 import { fireFullClick } from '../fixtures/utils';
 
+// ListOfPublishedProfiles depends on IDB and renders asynchronously, so we'll
+// just test we want to render it, but otherwise test it more fully in a
+// separate test file.
+jest.mock('../../components/app/ListOfPublishedProfiles', () => ({
+  ListOfPublishedProfiles: 'list-of-published-profiles',
+}));
+
 // Provide a mechanism to overwrite the navigator.userAgent, which can't be set.
 const FIREFOX =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+
+import { ListOfPublishedProfiles } from 'firefox-profiler/components/app/ListOfPublishedProfiles';
+import { storeProfileData } from 'firefox-profiler/app-logic/published-profiles-store';
+import { blankStore } from '../fixtures/stores';
+import { mockDate } from '../fixtures/mocks/date';
+
+import 'fake-indexeddb/auto';
+import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
+
+function resetIndexedDb() {
+  // This is the recommended way to reset the IDB state between test runs, but
+  // neither flow nor eslint like that we assign to indexedDB directly, for
+  // different reasons.
+  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
+  indexedDB = new FDBFactory();
+}
+beforeEach(resetIndexedDb);
+afterEach(resetIndexedDb);
+
+const listOfProfileInformations = [
+  {
+    profileToken: '0123456789',
+    jwtToken: null,
+    publishedDate: new Date('4 Jul 2020 14:00'), // "today" earlier
+    name: '',
+    preset: null,
+    originHostname: null,
+    meta: {
+      product: 'Fennec',
+      // Not more meta information, to test that we can handle profiles that
+      // don't have this information.
+    },
+    urlPath: '/',
+    publishedRange: { start: 1000, end: 3000 },
+  },
+  {
+    profileToken: 'ABCDEFGHI',
+    jwtToken: null,
+    publishedDate: new Date('3 Jul 2020 08:00'), // yesterday
+    name: 'Layout profile',
+    preset: 'web',
+    originHostname: null,
+    meta: {
+      product: 'Firefox',
+      platform: 'X11',
+      toolkit: 'gtk',
+      oscpu: 'Linux x86_64',
+      misc: 'rv:68.0',
+    },
+    urlPath: '/',
+    publishedRange: { start: 1000, end: 1005 },
+  },
+  {
+    profileToken: '123abc456',
+    jwtToken: null,
+    publishedDate: new Date('20 May 2018'), // ancient date
+    name: '',
+    preset: null,
+    originHostname: 'https://www.cnn.com',
+    meta: {
+      product: 'Firefox Preview',
+      platform: 'Android 7.0',
+      toolkit: 'android',
+      misc: 'rv:80.0',
+      oscpu: 'Linux armv7l',
+    },
+    urlPath:
+      '/public/123abc456/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&search=bla&thread=11&v=5',
+    // This tests ranges that should show up as µs
+    publishedRange: { start: 40000, end: 40000.1 },
+  },
+  {
+    profileToken: 'WINDOWS',
+    jwtToken: null,
+    publishedDate: new Date('4 Jul 2020 13:00'),
+    name: 'Another good profile',
+    preset: null,
+    originHostname: 'https://profiler.firefox.com',
+    meta: {
+      product: 'Firefox',
+      platform: 'Windows',
+      toolkit: 'windows',
+      misc: 'rv:77.0',
+      oscpu: 'Windows NT 10.0; Win64; x64',
+    },
+    urlPath: '/public/WINDOWS/marker-chart/',
+    publishedRange: { start: 2000, end: 40000 },
+  },
+  {
+    profileToken: 'MACOSX',
+    jwtToken: null,
+    publishedDate: new Date('5 Jul 2020 11:00'), // This is the future!
+    name: 'MacOS X profile',
+    preset: null,
+    originHostname: 'https://mozilla.org',
+    meta: {
+      product: 'Firefox',
+      platform: 'Macintosh',
+      toolkit: 'cocoa',
+      misc: 'rv:62.0',
+      oscpu: 'Intel Mac OS X 10.12',
+    },
+    urlPath: '/public/MACOSX/marker-chart/',
+    publishedRange: { start: 2000, end: 40000 },
+  },
+];
+
+async function storeProfileInformations(listOfProfileInformations) {
+  for (const profileInfo of listOfProfileInformations) {
+    await storeProfileData(profileInfo);
+  }
+}
+
+describe('ListOfPublishedProfiles', () => {
+  function setup(props) {
+    // Because the rendering is dependent on the timezone, all dates in this
+    // test are using a timezone-dependent format so that the rendering is the
+    // same in all timezones.
+    mockDate('4 Jul 2020 15:00'); // Now is 4th of July, at 3pm local timezone.
+
+    const store = blankStore();
+    const renderResult = render(
+      <Provider store={store}>
+        <ListOfPublishedProfiles {...props} />
+      </Provider>
+    );
+
+    const { getByText } = renderResult;
+
+    function getAllRecordingsLink() {
+      return getByText(/See all your recordings/);
+    }
+
+    return {
+      ...renderResult,
+      getAllRecordingsLink,
+    };
+  }
+
+  it('limits the number of rendered profiles with the limit prop', async () => {
+    // 1. Add some profiles to the local indexeddb.
+    await storeProfileInformations(listOfProfileInformations);
+
+    // 2. Render the component and test.
+    const { container, findByText, getAllRecordingsLink } = setup({ limit: 3 });
+    await findByText(/macOS/);
+    expect(container.querySelectorAll('li')).toHaveLength(3);
+    getAllRecordingsLink(); // This shouldn't throw.
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('does not display the link to all recordings when there is 3 profiles or less', async () => {
+    await storeProfileInformations(listOfProfileInformations.slice(0, 3));
+    const { findByText, getAllRecordingsLink } = setup({ limit: 3 });
+    await findByText(/Layout profile/);
+    expect(() => getAllRecordingsLink()).toThrow('Unable to find an element');
+  });
+});

--- a/src/test/components/Root-history.test.js
+++ b/src/test/components/Root-history.test.js
@@ -19,6 +19,13 @@ import { makeProfileSerializable } from '../../profile-logic/process-profile';
 
 import type { SerializableProfile } from 'firefox-profiler/types';
 
+// ListOfPublishedProfiles depends on IDB and renders asynchronously, so we'll
+// just test we want to render it, but otherwise test it more fully in a
+// separate test file.
+jest.mock('../../components/app/ListOfPublishedProfiles', () => ({
+  ListOfPublishedProfiles: 'list-of-published-profiles',
+}));
+
 describe('Root with history', function() {
   // Cleanup the tests through a side-effect.
   let _cleanup;

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -34,33 +34,6 @@ exports[`app/Home renders a button to enable the popup when it is available 1`] 
     <p>
       Enable the profiler menu button to start recording a performance profile in Firefox, then analyze it and share it with profiler.firefox.com.
     </p>
-    <div
-      class="homeSectionLoadProfile"
-    >
-      <div
-        class="homeSectionActionButtons"
-      >
-        <label
-          class="homeSectionButton"
-        >
-          <input
-            class="homeSectionUploadFromFileInput"
-            type="file"
-          />
-          Load a profile from file
-        </label>
-        <button
-          aria-expanded="false"
-          class="homeSectionButton"
-          type="button"
-        >
-          Load a profile from a URL
-        </button>
-      </div>
-      <p>
-        You can also drag and drop a profile file here to load it.
-      </p>
-    </div>
   </div>
 </div>
 `;
@@ -158,36 +131,72 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
             </a>
             . However, existing profiles can be viewed in any modern browser.
           </p>
-          <div
-            class="homeSectionLoadProfile"
-          >
-            <div
-              class="homeSectionActionButtons"
-            >
-              <label
-                class="homeSectionButton"
-              >
-                <input
-                  class="homeSectionUploadFromFileInput"
-                  type="file"
-                />
-                Load a profile from file
-              </label>
-              <button
-                aria-expanded="false"
-                class="homeSectionButton"
-                type="button"
-              >
-                Load a profile from a URL
-              </button>
-            </div>
-            <p>
-              You can also drag and drop a profile file here to load it.
-            </p>
-          </div>
         </div>
       </div>
     </div>
+    <section
+      class="homeAdditionalContent"
+    >
+      <h2
+        class="homeAdditionalContentTitle photon-title-30"
+      >
+        Load existing profiles
+      </h2>
+      <section
+        class="homeActions"
+      >
+        <p>
+          You can 
+          <strong>
+            drag and drop
+          </strong>
+           a profile file here to load it, or:
+        </p>
+        <div
+          class="homeSectionLoadProfile"
+        >
+          <div
+            class="homeSectionActionButtons"
+          >
+            <label
+              class="homeSectionButton"
+            >
+              <input
+                class="homeSectionUploadFromFileInput"
+                type="file"
+              />
+              Load a profile from file
+            </label>
+            <button
+              aria-expanded="false"
+              class="homeSectionButton"
+              type="button"
+            >
+              Load a profile from a URL
+            </button>
+          </div>
+        </div>
+        <p>
+          You can also compare recordings.
+           
+          <a
+            href="/compare/"
+          >
+            Open the comparing interface.
+          </a>
+        </p>
+      </section>
+      <section>
+        <h2
+          class="homeRecentUploadedRecordingsTitle photon-title-20"
+        >
+          Recent uploaded recordings
+        </h2>
+        <list-of-published-profiles
+          limit="3"
+        />
+      </section>
+    </section>
     <div
       class="dragAndDropOverlayWrapper"
     >
@@ -295,36 +304,72 @@ exports[`app/Home renders the install screen for the extension 1`] = `
           <p>
             Install the Gecko Profiler Add-on to start recording a performance profile in Firefox, then analyze it and share it with profiler.firefox.com.
           </p>
-          <div
-            class="homeSectionLoadProfile"
-          >
-            <div
-              class="homeSectionActionButtons"
-            >
-              <label
-                class="homeSectionButton"
-              >
-                <input
-                  class="homeSectionUploadFromFileInput"
-                  type="file"
-                />
-                Load a profile from file
-              </label>
-              <button
-                aria-expanded="false"
-                class="homeSectionButton"
-                type="button"
-              >
-                Load a profile from a URL
-              </button>
-            </div>
-            <p>
-              You can also drag and drop a profile file here to load it.
-            </p>
-          </div>
         </div>
       </div>
     </div>
+    <section
+      class="homeAdditionalContent"
+    >
+      <h2
+        class="homeAdditionalContentTitle photon-title-30"
+      >
+        Load existing profiles
+      </h2>
+      <section
+        class="homeActions"
+      >
+        <p>
+          You can 
+          <strong>
+            drag and drop
+          </strong>
+           a profile file here to load it, or:
+        </p>
+        <div
+          class="homeSectionLoadProfile"
+        >
+          <div
+            class="homeSectionActionButtons"
+          >
+            <label
+              class="homeSectionButton"
+            >
+              <input
+                class="homeSectionUploadFromFileInput"
+                type="file"
+              />
+              Load a profile from file
+            </label>
+            <button
+              aria-expanded="false"
+              class="homeSectionButton"
+              type="button"
+            >
+              Load a profile from a URL
+            </button>
+          </div>
+        </div>
+        <p>
+          You can also compare recordings.
+           
+          <a
+            href="/compare/"
+          >
+            Open the comparing interface.
+          </a>
+        </p>
+      </section>
+      <section>
+        <h2
+          class="homeRecentUploadedRecordingsTitle photon-title-20"
+        >
+          Recent uploaded recordings
+        </h2>
+        <list-of-published-profiles
+          limit="3"
+        />
+      </section>
+    </section>
     <div
       class="dragAndDropOverlayWrapper"
     >
@@ -455,36 +500,72 @@ exports[`app/Home renders the usage instructions for pages with the extension in
                Capture and load profile
             </p>
           </div>
-          <div
-            class="homeSectionLoadProfile"
-          >
-            <div
-              class="homeSectionActionButtons"
-            >
-              <label
-                class="homeSectionButton"
-              >
-                <input
-                  class="homeSectionUploadFromFileInput"
-                  type="file"
-                />
-                Load a profile from file
-              </label>
-              <button
-                aria-expanded="false"
-                class="homeSectionButton"
-                type="button"
-              >
-                Load a profile from a URL
-              </button>
-            </div>
-            <p>
-              You can also drag and drop a profile file here to load it.
-            </p>
-          </div>
         </div>
       </div>
     </div>
+    <section
+      class="homeAdditionalContent"
+    >
+      <h2
+        class="homeAdditionalContentTitle photon-title-30"
+      >
+        Load existing profiles
+      </h2>
+      <section
+        class="homeActions"
+      >
+        <p>
+          You can 
+          <strong>
+            drag and drop
+          </strong>
+           a profile file here to load it, or:
+        </p>
+        <div
+          class="homeSectionLoadProfile"
+        >
+          <div
+            class="homeSectionActionButtons"
+          >
+            <label
+              class="homeSectionButton"
+            >
+              <input
+                class="homeSectionUploadFromFileInput"
+                type="file"
+              />
+              Load a profile from file
+            </label>
+            <button
+              aria-expanded="false"
+              class="homeSectionButton"
+              type="button"
+            >
+              Load a profile from a URL
+            </button>
+          </div>
+        </div>
+        <p>
+          You can also compare recordings.
+           
+          <a
+            href="/compare/"
+          >
+            Open the comparing interface.
+          </a>
+        </p>
+      </section>
+      <section>
+        <h2
+          class="homeRecentUploadedRecordingsTitle photon-title-20"
+        >
+          Recent uploaded recordings
+        </h2>
+        <list-of-published-profiles
+          limit="3"
+        />
+      </section>
+    </section>
     <div
       class="dragAndDropOverlayWrapper"
     >
@@ -553,33 +634,6 @@ exports[`app/Home renders the usage instructions for when the popup is enabled 1
           2
         </kbd>
          Capture and load profile
-      </p>
-    </div>
-    <div
-      class="homeSectionLoadProfile"
-    >
-      <div
-        class="homeSectionActionButtons"
-      >
-        <label
-          class="homeSectionButton"
-        >
-          <input
-            class="homeSectionUploadFromFileInput"
-            type="file"
-          />
-          Load a profile from file
-        </label>
-        <button
-          aria-expanded="false"
-          class="homeSectionButton"
-          type="button"
-        >
-          Load a profile from a URL
-        </button>
-      </div>
-      <p>
-        You can also drag and drop a profile file here to load it.
       </p>
     </div>
   </div>

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -138,7 +138,7 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
       class="homeAdditionalContent"
     >
       <h2
-        class="homeAdditionalContentTitle photon-title-30"
+        class="homeAdditionalContentTitle protocol-display-xs"
       >
         Load existing profiles
       </h2>
@@ -188,7 +188,7 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
       </section>
       <section>
         <h2
-          class="homeRecentUploadedRecordingsTitle photon-title-20"
+          class="homeRecentUploadedRecordingsTitle protocol-display-xxs"
         >
           Recent uploaded recordings
         </h2>
@@ -311,7 +311,7 @@ exports[`app/Home renders the install screen for the extension 1`] = `
       class="homeAdditionalContent"
     >
       <h2
-        class="homeAdditionalContentTitle photon-title-30"
+        class="homeAdditionalContentTitle protocol-display-xs"
       >
         Load existing profiles
       </h2>
@@ -361,7 +361,7 @@ exports[`app/Home renders the install screen for the extension 1`] = `
       </section>
       <section>
         <h2
-          class="homeRecentUploadedRecordingsTitle photon-title-20"
+          class="homeRecentUploadedRecordingsTitle protocol-display-xxs"
         >
           Recent uploaded recordings
         </h2>
@@ -507,7 +507,7 @@ exports[`app/Home renders the usage instructions for pages with the extension in
       class="homeAdditionalContent"
     >
       <h2
-        class="homeAdditionalContentTitle photon-title-30"
+        class="homeAdditionalContentTitle protocol-display-xs"
       >
         Load existing profiles
       </h2>
@@ -557,7 +557,7 @@ exports[`app/Home renders the usage instructions for pages with the extension in
       </section>
       <section>
         <h2
-          class="homeRecentUploadedRecordingsTitle photon-title-20"
+          class="homeRecentUploadedRecordingsTitle protocol-display-xxs"
         >
           Recent uploaded recordings
         </h2>

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -5,22 +5,12 @@ exports[`app/Home renders a button to enable the popup when it is available 1`] 
   class="homeInstructions"
   data-testid="home-enable-popup-instructions"
 >
-  <div
-    class="homeInstructionsLeft"
-  >
-    <div
-      style="text-align: center;"
-    >
-      <img
-        alt="screenshot of profiler.firefox.com"
-        class="homeSectionScreenshot"
-        src="test-file-stub"
-      />
-    </div>
-  </div>
-  <div
-    class="homeInstructionsRight"
-  >
+  <img
+    alt="screenshot of profiler.firefox.com"
+    class="homeSectionScreenshot"
+    src="test-file-stub"
+  />
+  <div>
     <button
       class="homeSectionButton"
       type="button"
@@ -140,22 +130,12 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
         class="homeInstructions"
         data-testid="home-other-browser-instructions"
       >
-        <div
-          class="homeInstructionsLeft"
-        >
-          <div
-            style="text-align: center;"
-          >
-            <img
-              alt="screenshot of profiler.firefox.com"
-              class="homeSectionScreenshot"
-              src="test-file-stub"
-            />
-          </div>
-        </div>
-        <div
-          class="homeInstructionsRight"
-        >
+        <img
+          alt="screenshot of profiler.firefox.com"
+          class="homeSectionScreenshot"
+          src="test-file-stub"
+        />
+        <div>
           <a
             class="homeSectionButton"
             href="/docs/"
@@ -286,22 +266,12 @@ exports[`app/Home renders the install screen for the extension 1`] = `
         class="homeInstructions"
         data-testid="home-install-addon-instructions"
       >
-        <div
-          class="homeInstructionsLeft"
-        >
-          <div
-            style="text-align: center;"
-          >
-            <img
-              alt="screenshot of profiler.firefox.com"
-              class="homeSectionScreenshot"
-              src="test-file-stub"
-            />
-          </div>
-        </div>
-        <div
-          class="homeInstructionsRight"
-        >
+        <img
+          alt="screenshot of profiler.firefox.com"
+          class="homeSectionScreenshot"
+          src="test-file-stub"
+        />
+        <div>
           <a
             class="homeSectionButton"
             href="https://raw.githubusercontent.com/firefox-devtools/Gecko-Profiler-Addon/master/gecko_profiler.xpi"
@@ -433,20 +403,12 @@ exports[`app/Home renders the usage instructions for pages with the extension in
         class="homeInstructions"
         data-testid="home-record-instructions"
       >
-        <div
-          class="homeInstructionsLeft"
-        >
-          <p>
-            <img
-              alt="Screenshot of the profiler settings from the Firefox menu."
-              class="homeSectionScreenshot"
-              src="test-file-stub"
-            />
-          </p>
-        </div>
-        <div
-          class="homeInstructionsRight"
-        >
+        <img
+          alt="Screenshot of the profiler settings from the Firefox menu."
+          class="homeSectionScreenshot"
+          src="test-file-stub"
+        />
+        <div>
           <a
             class="homeSectionButton"
             href="/docs/"
@@ -541,20 +503,12 @@ exports[`app/Home renders the usage instructions for when the popup is enabled 1
   class="homeInstructions homeTransition-enter homeTransition-enter-active"
   data-testid="home-record-instructions"
 >
-  <div
-    class="homeInstructionsLeft"
-  >
-    <p>
-      <img
-        alt="Screenshot of the profiler settings from the Firefox menu."
-        class="homeSectionScreenshot"
-        src="test-file-stub"
-      />
-    </p>
-  </div>
-  <div
-    class="homeInstructionsRight"
-  >
+  <img
+    alt="Screenshot of the profiler settings from the Firefox menu."
+    class="homeSectionScreenshot"
+    src="test-file-stub"
+  />
+  <div>
     <a
       class="homeSectionButton"
       href="/docs/"

--- a/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
+++ b/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListOfPublishedProfiles limits the number of rendered profiles with the limit prop 1`] = `
+<ul
+  class="publishedProfilesList"
+>
+  <li
+    class="publishedProfilesListItem"
+  >
+    <a
+      class="publishedProfilesLink"
+      href="http://localhost//public/MACOSX/marker-chart/"
+    >
+      <div
+        class="publishedProfilesDate"
+      >
+        Jul 5, 2020
+      </div>
+      <div
+        class="publishedProfilesName"
+      >
+        <strong>
+          MacOS X profile
+        </strong>
+         
+        (
+        38.0s
+        )
+      </div>
+      <div
+        class="profileMetaInfoSummary"
+      >
+        <div
+          class="profileMetaInfoSummaryProductAndVersion"
+          data-product="Firefox"
+        >
+          Firefox 62
+        </div>
+        <div
+          class="profileMetaInfoSummaryPlatform"
+          data-toolkit="macOS 10.12"
+        >
+          macOS 10.12
+        </div>
+      </div>
+    </a>
+  </li>
+  <li
+    class="publishedProfilesListItem"
+  >
+    <a
+      class="publishedProfilesLink"
+      href="http://localhost//"
+    >
+      <div
+        class="publishedProfilesDate"
+      >
+        2:00 PM
+      </div>
+      <div
+        class="publishedProfilesName"
+      >
+        <strong>
+          Profile #012345
+        </strong>
+         
+        (
+        2.0s
+        )
+      </div>
+      <div
+        class="profileMetaInfoSummary"
+      >
+        <div
+          class="profileMetaInfoSummaryProductAndVersion"
+          data-product="Fennec"
+        >
+          Fennec
+        </div>
+        <div
+          class="profileMetaInfoSummaryPlatform"
+          data-toolkit=""
+        />
+      </div>
+    </a>
+  </li>
+  <li
+    class="publishedProfilesListItem"
+  >
+    <a
+      class="publishedProfilesLink"
+      href="http://localhost//public/WINDOWS/marker-chart/"
+    >
+      <div
+        class="publishedProfilesDate"
+      >
+        1:00 PM
+      </div>
+      <div
+        class="publishedProfilesName"
+      >
+        <strong>
+          Another good profile
+        </strong>
+         
+        (
+        38.0s
+        )
+      </div>
+      <div
+        class="profileMetaInfoSummary"
+      >
+        <div
+          class="profileMetaInfoSummaryProductAndVersion"
+          data-product="Firefox"
+        >
+          Firefox 77
+        </div>
+        <div
+          class="profileMetaInfoSummaryPlatform"
+          data-toolkit="Windows 10"
+        >
+          Windows 10
+        </div>
+      </div>
+    </a>
+  </li>
+</ul>
+`;


### PR DESCRIPTION
**Edit:** This is now ready to land but I'd like that this lands together with #2748 because this makes that issue very apparent.

Here is the [deploy preview](https://deploy-preview-2729--perf-html.netlify.app/), but first you'll need to upload some profiles using this deploy-preview too. For example you can re-publish [this profile](https://deploy-preview-2729--perf-html.netlify.app/public/8787b63a23826e740ed2f5f11fd4a7cc98232ae6/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&search=bla&thread=11&v=5) several times to get several entries.

Here is a screenshot:
![Screen Shot 2020-08-25 at 11 27 31](https://user-images.githubusercontent.com/454175/91157716-fc0ede00-e6c5-11ea-9c1a-f4d15ebaa5d9.png)

I'm not super happy about the outcome. Especially the photon titles do not look so great in this context. Happy to make some changes about this !

Also ideally I would like the bottom part to go at the top when the button is detected as being added -- but only when it's detected at load time. By ignoring the addon case now I think this is doable but I thought this is more work and could fit in a separate PR.
