### PR TITLE
Add an experimental app state and move event delay tracks in it

### DIFF
--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -14,6 +14,7 @@ import type {
   Reducer,
   UrlSetupPhase,
   ThreadIndex,
+  ExperimentalFlags,
 } from 'firefox-profiler/types';
 
 const view: Reducer<AppViewState> = (
@@ -233,7 +234,7 @@ const isDragAndDropOverlayRegistered: Reducer<boolean> = (
  * This way we can hide the event delay tracks by default and display if we
  * change the state.
  */
-const isEventDelayTracksEnabled: Reducer<boolean> = (state = false, action) => {
+const eventDelayTacks: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'ENABLE_EVENT_DELAY_TRACKS': {
       return true;
@@ -242,6 +243,17 @@ const isEventDelayTracksEnabled: Reducer<boolean> = (state = false, action) => {
       return state;
   }
 };
+
+/**
+ * Experimental features that are mostly disabled by default. You need to enable
+ * them from the DevTools console with `experimental.enable<feature-camel-case>()`,
+ * e.g. `experimental.enableEventDelayTracks()`.
+ * If you want to add a new experimental flag here, don't forget to add it to
+ * window.experimental object in window-console.js.
+ */
+const experimental: Reducer<ExperimentalFlags> = combineReducers({
+  eventDelayTacks,
+});
 
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,
@@ -254,7 +266,7 @@ const appStateReducer: Reducer<AppState> = combineReducers({
   isNewlyPublished,
   isDragAndDropDragging,
   isDragAndDropOverlayRegistered,
-  isEventDelayTracksEnabled,
+  experimental,
 });
 
 export default appStateReducer;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -234,7 +234,7 @@ const isDragAndDropOverlayRegistered: Reducer<boolean> = (
  * This way we can hide the event delay tracks by default and display if we
  * change the state.
  */
-const eventDelayTacks: Reducer<boolean> = (state = false, action) => {
+const eventDelayTracks: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'ENABLE_EVENT_DELAY_TRACKS': {
       return true;
@@ -252,7 +252,7 @@ const eventDelayTacks: Reducer<boolean> = (state = false, action) => {
  * window.experimental object in window-console.js.
  */
 const experimental: Reducer<ExperimentalFlags> = combineReducers({
-  eventDelayTacks,
+  eventDelayTracks,
 });
 
 const appStateReducer: Reducer<AppState> = combineReducers({

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -42,6 +42,7 @@ import type {
   Selector,
   CssPixels,
   ThreadIndex,
+  ExperimentalFlags,
 } from 'firefox-profiler/types';
 
 /**
@@ -65,8 +66,10 @@ export const getTrackThreadHeights: Selector<
 > = state => getApp(state).trackThreadHeights;
 export const getIsNewlyPublished: Selector<boolean> = state =>
   getApp(state).isNewlyPublished;
+export const getExperimental: Selector<ExperimentalFlags> = state =>
+  getApp(state).experimental;
 export const getIsEventDelayTracksEnabled: Selector<boolean> = state =>
-  getApp(state).isEventDelayTracksEnabled;
+  getExperimental(state).eventDelayTacks;
 
 export const getIsDragAndDropDragging: Selector<boolean> = state =>
   getApp(state).isDragAndDropDragging;

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -69,7 +69,7 @@ export const getIsNewlyPublished: Selector<boolean> = state =>
 export const getExperimental: Selector<ExperimentalFlags> = state =>
   getApp(state).experimental;
 export const getIsEventDelayTracksEnabled: Selector<boolean> = state =>
-  getExperimental(state).eventDelayTacks;
+  getExperimental(state).eventDelayTracks;
 
 export const getIsDragAndDropDragging: Selector<boolean> = state =>
   getApp(state).isDragAndDropDragging;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -158,7 +158,7 @@ export type UrlSetupPhase = 'initial-load' | 'loading-profile' | 'done';
  * e.g. `experimental.enableEventDelayTracks()`.
  */
 export type ExperimentalFlags = {|
-  +eventDelayTacks: boolean,
+  +eventDelayTracks: boolean,
 |};
 
 export type AppState = {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -152,6 +152,15 @@ export type IsSidebarOpenPerPanelState = { [TabSlug]: boolean };
 
 export type UrlSetupPhase = 'initial-load' | 'loading-profile' | 'done';
 
+/*
+ * Experimental features that are mostly disabled by default. You need to enable
+ * them from the DevTools console with `experimental.enable<feature-camel-case>()`,
+ * e.g. `experimental.enableEventDelayTracks()`.
+ */
+export type ExperimentalFlags = {|
+  +eventDelayTacks: boolean,
+|};
+
 export type AppState = {|
   +view: AppViewState,
   +urlSetupPhase: UrlSetupPhase,
@@ -163,7 +172,7 @@ export type AppState = {|
   +isNewlyPublished: boolean,
   +isDragAndDropDragging: boolean,
   +isDragAndDropOverlayRegistered: boolean,
-  +isEventDelayTracksEnabled: boolean,
+  +experimental: ExperimentalFlags,
 |};
 
 export type UploadPhase =


### PR DESCRIPTION
This is a small PR that creates an `experimental` state and moves the event delay tracks flag into it. It would be better to make this more generic, since we can add more experimental flag to the Firefox Profiler, like CPU usage.