### PR TITLE
Fix two visual metrics tracks related issues

### DIFF
--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -144,7 +144,6 @@ class GlobalTrackComponent extends PureComponent<Props> {
           <TrackVisualProgress
             progressGraphData={progressGraphData}
             graphDotTooltipText=" visual completeness at this time"
-            windowId={globalTrack.id}
           />
         );
       }
@@ -156,7 +155,6 @@ class GlobalTrackComponent extends PureComponent<Props> {
           <TrackVisualProgress
             progressGraphData={progressGraphData}
             graphDotTooltipText=" perceptual visual completeness at this time"
-            windowId={globalTrack.id}
           />
         );
       }
@@ -168,7 +166,6 @@ class GlobalTrackComponent extends PureComponent<Props> {
           <TrackVisualProgress
             progressGraphData={progressGraphData}
             graphDotTooltipText=" contentful visual completeness at this time"
-            windowId={globalTrack.id}
           />
         );
       }

--- a/src/components/timeline/TrackVisualProgress.js
+++ b/src/components/timeline/TrackVisualProgress.js
@@ -23,7 +23,6 @@ import './TrackVisualProgress.css';
 type OwnProps = {|
   +progressGraphData: ProgressGraphData[],
   +graphDotTooltipText: string,
-  +windowId: string,
 |};
 
 type StateProps = {|

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -377,9 +377,9 @@ export function computeGlobalTracks(profile: Profile): GlobalTrack[] {
       for (const id of ids) {
         globalTracks.push({ type: 'screenshots', id, threadIndex });
         if (profile.meta && profile.meta.visualMetrics) {
-          globalTracks.push({ type: 'visual-progress', id });
-          globalTracks.push({ type: 'perceptual-visual-progress', id });
-          globalTracks.push({ type: 'contentful-visual-progress', id });
+          globalTracks.push({ type: 'visual-progress' });
+          globalTracks.push({ type: 'perceptual-visual-progress' });
+          globalTracks.push({ type: 'contentful-visual-progress' });
         }
       }
     }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -376,13 +376,15 @@ export function computeGlobalTracks(profile: Profile): GlobalTrack[] {
       }
       for (const id of ids) {
         globalTracks.push({ type: 'screenshots', id, threadIndex });
-        if (profile.meta && profile.meta.visualMetrics) {
-          globalTracks.push({ type: 'visual-progress' });
-          globalTracks.push({ type: 'perceptual-visual-progress' });
-          globalTracks.push({ type: 'contentful-visual-progress' });
-        }
       }
     }
+  }
+
+  // Add the visual progress tracks if we have visualMetrics data.
+  if (profile.meta && profile.meta.visualMetrics) {
+    globalTracks.push({ type: 'visual-progress' });
+    globalTracks.push({ type: 'perceptual-visual-progress' });
+    globalTracks.push({ type: 'contentful-visual-progress' });
   }
 
   // When adding a new track type, this sort ensures that the newer tracks are added

--- a/src/test/components/TrackVisualProgress.test.js
+++ b/src/test/components/TrackVisualProgress.test.js
@@ -72,7 +72,6 @@ describe('TrackVisualProgress', function() {
         <TrackVisualProgress
           progressGraphData={VisualProgress}
           graphDotTooltipText=" visual completeness at this time"
-          windowId="0"
         />
       </Provider>
     );

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -205,9 +205,9 @@ export type StackType = 'js' | 'native' | 'unsymbolicated';
 export type GlobalTrack =
   | {| +type: 'process', +pid: Pid, +mainThreadIndex: ThreadIndex | null |}
   | {| +type: 'screenshots', +id: string, +threadIndex: ThreadIndex |}
-  | {| +type: 'visual-progress', +id: string |}
-  | {| +type: 'perceptual-visual-progress', +id: string |}
-  | {| +type: 'contentful-visual-progress', +id: string |};
+  | {| +type: 'visual-progress' |}
+  | {| +type: 'perceptual-visual-progress' |}
+  | {| +type: 'contentful-visual-progress' |};
 
 export type LocalTrack =
   | {| +type: 'thread', +threadIndex: ThreadIndex |}


### PR DESCRIPTION
We had two issues related to visual metrics tracks and this PR fixes them:
- If there was no screenshot, we were not seeing the visual metrics tracks even though we had visual metrics data.
- And if we had 2 windows and therefore 2 screenshots tracks, we were seeing 2 times more visual metrics tracks with the same data, which was consuming the space unnecessarily (and were keeping `windowId` without using that anywhere)
