### PR TITLE
Remove the unused threadIndex from _onMarkerSelect

### DIFF
--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -261,7 +261,7 @@ export type OwnProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +threadIndex: ThreadIndex,
-  +onSelect: (ThreadIndex, Milliseconds, Milliseconds) => mixed,
+  +onSelect: (Milliseconds, Milliseconds) => mixed,
 |};
 
 export type StateProps = {|
@@ -408,13 +408,13 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
           null /* extra null check because flow doesn't realize it's unnecessary */
       ) {
         e.stopPropagation();
-        const { onSelect, threadIndex, rangeStart, rangeEnd } = this.props;
+        const { onSelect, rangeStart, rangeEnd } = this.props;
         const { start, end } = getStartEndRangeForMarker(
           rangeStart,
           rangeEnd,
           mouseUpItem
         );
-        onSelect(threadIndex, start, end);
+        onSelect(start, end);
       }
       this.setState({
         hoveredItem: mouseUpItem,

--- a/src/components/timeline/TrackIPC.js
+++ b/src/components/timeline/TrackIPC.js
@@ -38,11 +38,7 @@ type State = {||};
  * A component for showing IPC messages for a particular thread.
  */
 export class TrackIPCImpl extends React.PureComponent<Props, State> {
-  _onMarkerSelect = (
-    threadIndex: ThreadIndex,
-    start: Milliseconds,
-    end: Milliseconds
-  ) => {
+  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
     const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
     updatePreviewSelection({
       hasSelection: true,

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -48,11 +48,7 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 type State = {||};
 
 export class TrackMemoryImpl extends React.PureComponent<Props, State> {
-  _onMarkerSelect = (
-    threadIndex: ThreadIndex,
-    start: Milliseconds,
-    end: Milliseconds
-  ) => {
+  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
     const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
     updatePreviewSelection({
       hasSelection: true,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -126,11 +126,7 @@ class TimelineTrackThread extends PureComponent<Props> {
     focusCallTree();
   };
 
-  _onMarkerSelect = (
-    threadIndex: ThreadIndex,
-    start: Milliseconds,
-    end: Milliseconds
-  ) => {
+  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
     const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
     updatePreviewSelection({
       hasSelection: true,


### PR DESCRIPTION
This is a small cleanup PR. I was changing this function for my thread merging work, then realized that we are not using this parameter at all. So just removed this instead. Created a separate PR so it would be easier to land and make the thread merging PR easier.