### PR TITLE
Support using the back and forward buttons when moving between content pages

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1431,7 +1431,8 @@ export function getProfilesFromRawUrl(
       case 'none':
       case 'from-file':
       case 'local':
-        throw new Error(`There is no profile to download`);
+        // There is no profile to download for these datasources.
+        break;
       default:
         throw assertExhaustiveCheck(
           dataSource,

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -92,7 +92,6 @@ describe('UrlManager', function() {
 
   it('sets up the URL', async function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(getUrlSetupPhase(getState())).toBe('initial-load');
     createUrlManager();
@@ -102,16 +101,13 @@ describe('UrlManager', function() {
     await waitUntilUrlSetupPhase('done');
     expect(getUrlSetupPhase(getState())).toBe('done');
     expect(getDataSource(getState())).toMatch('none');
-    expect(console.error).toHaveBeenCalled();
   });
 
   it('has no data source by default', async function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup();
-    jest.spyOn(console, 'error').mockImplementation(() => {});
     createUrlManager();
     await waitUntilUrlSetupPhase('done');
     expect(getDataSource(getState())).toMatch('none');
-    expect(console.error).toHaveBeenCalled();
   });
 
   it('sets the data source to from-addon', async function() {
@@ -129,13 +125,11 @@ describe('UrlManager', function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup(
       '/from-file/'
     );
-    jest.spyOn(console, 'error').mockImplementation(() => {});
     expect(getDataSource(getState())).toMatch('none');
     createUrlManager();
 
     await waitUntilUrlSetupPhase('done');
     expect(getDataSource(getState())).toMatch('none');
-    expect(console.error).toHaveBeenCalled();
   });
 
   it(`sets the data source to public and doesn't change the URL when there's a fetch error`, async function() {

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -22,7 +22,10 @@ import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profil
 import { CURRENT_URL_VERSION } from '../../app-logic/url-handling';
 import { autoMockFullNavigation } from '../fixtures/mocks/window-navigation';
 import { profilePublished } from 'firefox-profiler/actions/publish';
-import { changeCallTreeSearchString } from 'firefox-profiler/actions/profile-view';
+import {
+  changeCallTreeSearchString,
+  setDataSource,
+} from 'firefox-profiler/actions/profile-view';
 
 jest.mock('../../profile-logic/symbol-store');
 
@@ -228,6 +231,47 @@ describe('UrlManager', function() {
     // Look again at this search.
     window.history.forward();
     expect(getCurrentSearchString(getState())).toBe('B');
+  });
+
+  it('allows navigating back and forward when moving between content pages', async () => {
+    // The test will start at the home.
+    const urlPath = '/ ';
+    const {
+      getState,
+      createUrlManager,
+      waitUntilUrlSetupPhase,
+      dispatch,
+    } = setup(urlPath);
+    createUrlManager();
+
+    await waitUntilUrlSetupPhase('done');
+    expect(getDataSource(getState())).toBe('none');
+    expect(window.history.length).toBe(1);
+
+    // Now the user clicks on the "all recordings" link. This will change the
+    // datasource, we're simulating that.
+    dispatch(setDataSource('uploaded-recordings'));
+    expect(getDataSource(getState())).toBe('uploaded-recordings');
+    expect(window.history.length).toBe(2);
+
+    // The user goes back to the home by pressing the browser's back button.
+    window.history.back();
+    expect(getDataSource(getState())).toBe('none');
+
+    // Now the user goes to the compare form clicking a link on the homepage,
+    // we're simulating that by changing the data source.
+    dispatch(setDataSource('compare'));
+    expect(getDataSource(getState())).toBe('compare');
+    // Click on the header
+    dispatch(setDataSource('none'));
+    expect(window.history.length).toBe(3);
+
+    // The user goes back to the compare form using the browser's back button.
+    window.history.back();
+    expect(getDataSource(getState())).toBe('compare');
+    // The user goes back to the home using the browser's back button.
+    window.history.back();
+    expect(getDataSource(getState())).toBe('none');
   });
 
   it('prevents navigating back after publishing', async () => {

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1821,17 +1821,21 @@ describe('actions/receive-profile', function() {
       return expect(waitUntilSymbolication()).resolves.toBe(undefined);
     });
 
-    it('does not retrieve profile from other data sources', async function() {
-      ['/none/', '/from-file/', 'local'].forEach(async sourcePath => {
-        await expect(
-          setup({
+    ['none', 'from-file', 'local', 'uploaded-recordings', 'compare'].forEach(
+      dataSource => {
+        it(`does not retrieve a profile for the datasource ${dataSource}`, async function() {
+          const sourcePath = `/${dataSource}/`;
+          const { getState } = await setup({
             pathname: sourcePath,
             search: '',
             hash: '',
-          })
-        ).rejects.toThrow();
-      });
-    });
+          });
+          expect(ProfileViewSelectors.getProfileOrNull(getState())).toEqual(
+            null
+          );
+        });
+      }
+    );
   });
 });
 


### PR DESCRIPTION
This PR includes the commits from #2743 so please look at the 3 last commits only.
* The first commit fixes the problem
* The second commit is a test, I double checked that this erroring without the fix.
* The last commit is a small fix to stop erroring to the console when we're in the datasources that don't use a profile.

Here is a STR that this PR fixes:
1. Go to [the uploaded recordings view](https://profiler.firefox.com/uploaded-recordings/)
2. Click on the "Firefox Profiler" title, this is a link that moves back to the home.
3. Press the browser's "back" button

=> we should go back to the uploaded recordings view.

This is made a lot more visible once #2729 lands, because links to move between these pages will be present in the home page directly. That's why I wanted to fix this in the context of this project.

Here is [the uploaded recordings view in the deploy preview](https://deploy-preview-2748--perf-html.netlify.app/uploaded-recordings/), to check that this is now working as expected.

Fixes #2739