### PR TITLE
Display merged threads in the active tab view

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -35,7 +35,7 @@ import { selectedThreadSelectors } from '../selectors/per-thread';
 
 import type {
   Profile,
-  ThreadIndex,
+  ThreadsKey,
   CssPixels,
   Action,
   ThunkAction,
@@ -168,18 +168,18 @@ export function updateUrlState(newUrlState: UrlState | null): Action {
 }
 
 export function reportTrackThreadHeight(
-  threadIndex: ThreadIndex,
+  threadsKey: ThreadsKey,
   height: CssPixels
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const trackThreadHeights = getTrackThreadHeights(getState());
-    const previousHeight = trackThreadHeights[threadIndex];
+    const previousHeight = trackThreadHeights[threadsKey];
     if (previousHeight !== height) {
       // Guard against unnecessary dispatches. This could happen frequently.
       dispatch({
         type: 'UPDATE_TRACK_THREAD_HEIGHT',
         height,
-        threadIndex,
+        threadsKey,
       });
     }
   };

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -72,10 +72,10 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
     const { globalTrack } = this.props;
     switch (globalTrack.type) {
       case 'tab': {
-        const { mainThreadIndex } = globalTrack;
+        const { threadsKey } = globalTrack;
         return (
           <TimelineTrackThread
-            threadsKey={mainThreadIndex}
+            threadsKey={threadsKey}
             showMemoryMarkers={false}
             trackType="expanded"
             trackName="Active Tab"

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -75,7 +75,7 @@ class ActiveTabGlobalTrackComponent extends PureComponent<Props> {
         const { mainThreadIndex } = globalTrack;
         return (
           <TimelineTrackThread
-            threadIndex={mainThreadIndex}
+            threadsKey={mainThreadIndex}
             showMemoryMarkers={false}
             trackType="expanded"
             trackName="Active Tab"

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -90,7 +90,7 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
       case 'thread':
         return (
           <TrackThread
-            threadIndex={resourceTrack.threadIndex}
+            threadsKey={resourceTrack.threadIndex}
             trackType={isOpen ? 'expanded' : 'condensed'}
             trackName={resourceTrack.name}
           />

--- a/src/components/timeline/ActiveTabResourcesPanel.js
+++ b/src/components/timeline/ActiveTabResourcesPanel.js
@@ -9,14 +9,17 @@ import classNames from 'classnames';
 import explicitConnect from '../../utils/connect';
 import { withSize } from '../shared/WithSize';
 import { getIsActiveTabResourcesPanelOpen } from '../../selectors/url-state';
+import { getActiveTabResourcesThreadsKey } from '../../selectors/profile';
 import { toggleResourcesPanel } from '../../actions/app';
 import { ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT } from '../../app-logic/constants';
 import ActiveTabTimelineResourceTrack from './ActiveTabResourceTrack';
+import TrackThread from './TrackThread';
 
 import type { SizeProps } from '../shared/WithSize';
 import type {
   ActiveTabResourceTrack,
   InitialSelectedTrackReference,
+  ThreadsKey,
 } from 'firefox-profiler/types';
 import type { ConnectedProps } from '../../utils/connect';
 
@@ -30,6 +33,7 @@ type OwnProps = {|
 
 type StateProps = {|
   isActiveTabResourcesPanelOpen: boolean,
+  resourcesThreadsKey: ThreadsKey,
 |};
 
 type DispatchProps = {|
@@ -48,6 +52,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
       toggleResourcesPanel,
       isActiveTabResourcesPanelOpen,
       setInitialSelected,
+      resourcesThreadsKey,
     } = this.props;
     return (
       <div
@@ -63,6 +68,11 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
           })}
         >
           Resources ({resourceTracks.length})
+          <TrackThread
+            threadsKey={resourcesThreadsKey}
+            trackType="condensed"
+            trackName="Merged resource tracks"
+          />
         </div>
         {isActiveTabResourcesPanelOpen ? (
           <ol className="timelineResourceTracks">
@@ -84,6 +94,7 @@ class ActiveTabResourcesPanel extends React.PureComponent<Props> {
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     isActiveTabResourcesPanelOpen: getIsActiveTabResourcesPanelOpen(state),
+    resourcesThreadsKey: getActiveTabResourcesThreadsKey(state),
   }),
   mapDispatchToProps: { toggleResourcesPanel },
   component: withSize<Props>(ActiveTabResourcesPanel),

--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -58,6 +58,14 @@
   transition: height 0.2s;
 }
 
+.timelineResourcesHeader .timelineMarkers {
+  /*
+   * TODO: Currently we don't show any markers for merged resource track but we
+   * should add jank markers.
+   */
+  height: 0;
+}
+
 /* Set the marker height of the closed resources to 3px */
 .timelineTrackResourceRow:not(.opened) .timelineMarkers {
   height: 3px;
@@ -79,6 +87,10 @@
  */
 .timelineTrackResourceRow .timelineMarkersGeckoMain {
   height: 9px;
+}
+
+.timelineResourcesHeader .threadActivityGraph {
+  height: 20px;
 }
 
 .timelineTrackResourceRow:not(.opened) .threadActivityGraph {
@@ -126,4 +138,12 @@
 
 .timelineTrackResourceLabel span {
   font-weight: bold;
+}
+
+.timelineResourcesHeader .timelineTrackThread.condensed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--resources-header-height);
 }

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -127,7 +127,7 @@ class GlobalTrackComponent extends PureComponent<Props> {
         }
         return (
           <TimelineTrackThread
-            threadIndex={mainThreadIndex}
+            threadsKey={mainThreadIndex}
             showMemoryMarkers={!processesWithMemoryTrack.has(globalTrack.pid)}
             trackType="expanded"
             trackName={trackName}

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -94,7 +94,7 @@ class LocalTrackComponent extends PureComponent<Props> {
       case 'thread':
         return (
           <TrackThread
-            threadIndex={localTrack.threadIndex}
+            threadsKey={localTrack.threadIndex}
             trackType="expanded"
             trackName={trackName}
           />

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -5,6 +5,7 @@
 // @flow
 import * as React from 'react';
 import classNames from 'classnames';
+import memoize from 'memoize-immutable';
 
 import { markerStyles, overlayFills } from '../../profile-logic/marker-styles';
 import { withSize } from '../shared/WithSize';
@@ -516,6 +517,14 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
 export const TimelineMarkers = withSize<Props>(TimelineMarkersImplementation);
 
 /**
+ * Memoize the isSelected result of the markers since this is user multiple times.
+ */
+const _getTimelineMarkersIsSelected = memoize(
+  (selectedThreads, threadsKey) => hasThreadKeys(selectedThreads, threadsKey),
+  { limit: 1 }
+);
+
+/**
  * Create a special connected component for Jank instances.
  */
 export const TimelineMarkersJank = explicitConnect<
@@ -532,7 +541,7 @@ export const TimelineMarkersJank = explicitConnect<
       getMarker: selectors.getMarkerGetter(state),
       // These don't use marker schema as they are derived.
       markerIndexes: selectors.getJankMarkerIndexesForHeader(state),
-      isSelected: hasThreadKeys(selectedThreads, threadsKey),
+      isSelected: _getTimelineMarkersIsSelected(selectedThreads, threadsKey),
       isModifyingSelection: getPreviewSelection(state).isModifying,
       testId: 'TimelineMarkersJank',
       rightClickedMarker: selectors.getRightClickedMarker(state),
@@ -562,7 +571,7 @@ export const TimelineMarkersOverview = explicitConnect<
           : null,
       getMarker: selectors.getMarkerGetter(state),
       markerIndexes: selectors.getTimelineOverviewMarkerIndexes(state),
-      isSelected: hasThreadKeys(selectedThreads, threadsKey),
+      isSelected: _getTimelineMarkersIsSelected(selectedThreads, threadsKey),
       isModifyingSelection: getPreviewSelection(state).isModifying,
       testId: 'TimelineMarkersOverview',
       rightClickedMarker: selectors.getRightClickedMarker(state),
@@ -588,7 +597,7 @@ export const TimelineMarkersFileIo = explicitConnect<
     return {
       getMarker: selectors.getMarkerGetter(state),
       markerIndexes: selectors.getTimelineFileIoMarkerIndexes(state),
-      isSelected: hasThreadKeys(selectedThreads, threadsKey),
+      isSelected: _getTimelineMarkersIsSelected(selectedThreads, threadsKey),
       isModifyingSelection: getPreviewSelection(state).isModifying,
       testId: 'TimelineMarkersFileIo',
       rightClickedMarker: selectors.getRightClickedMarker(state),
@@ -614,7 +623,7 @@ export const TimelineMarkersMemory = explicitConnect<
     return {
       getMarker: selectors.getMarkerGetter(state),
       markerIndexes: selectors.getTimelineMemoryMarkerIndexes(state),
-      isSelected: hasThreadKeys(selectedThreads, threadsKey),
+      isSelected: _getTimelineMarkersIsSelected(selectedThreads, threadsKey),
       isModifyingSelection: getPreviewSelection(state).isModifying,
       additionalClassName: 'timelineMarkersMemory',
       testId: 'TimelineMarkersMemory',
@@ -641,7 +650,7 @@ export const TimelineMarkersIPC = explicitConnect<
     return {
       getMarker: selectors.getMarkerGetter(state),
       markerIndexes: selectors.getTimelineIPCMarkerIndexes(state),
-      isSelected: hasThreadKeys(selectedThreads, threadsKey),
+      isSelected: _getTimelineMarkersIsSelected(selectedThreads, threadsKey),
       isModifyingSelection: getPreviewSelection(state).isModifying,
       additionalClassName: 'timelineMarkersIPC',
       testId: 'TimelineMarkersIPC',

--- a/src/components/timeline/TrackIPC.js
+++ b/src/components/timeline/TrackIPC.js
@@ -60,7 +60,7 @@ export class TrackIPCImpl extends React.PureComponent<Props, State> {
         <TimelineMarkersIPC
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
-          threadIndex={threadIndex}
+          threadsKey={threadIndex}
           onSelect={this._onMarkerSelect}
         />
       </div>

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -72,7 +72,7 @@ export class TrackMemoryImpl extends React.PureComponent<Props, State> {
         <TimelineMarkersMemory
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
-          threadIndex={threadIndex}
+          threadsKey={threadIndex}
           onSelect={this._onMarkerSelect}
         />
         <TrackMemoryGraph

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -6,6 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
+import memoize from 'memoize-immutable';
 import explicitConnect from '../../utils/connect';
 import { withSize, type SizeProps } from '../shared/WithSize';
 import ThreadStackGraph from '../shared/thread/StackGraph';
@@ -320,13 +321,21 @@ class TimelineTrackThread extends PureComponent<Props> {
   }
 }
 
+/**
+ * Memoize the hasThreadKeys to not compute it all the time.
+ */
+const _getTimelineIsSelected = memoize(
+  (selectedThreads, threadsKey) => hasThreadKeys(selectedThreads, threadsKey),
+  { limit: 1 }
+);
+
 export default explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: (state: State, ownProps: OwnProps) => {
     const { threadsKey } = ownProps;
     const selectors = getThreadSelectorsFromThreadsKey(threadsKey);
     const selectedThreadIndexes = getSelectedThreadIndexes(state);
     const committedRange = getCommittedRange(state);
-    const selectedCallNodeIndex = hasThreadKeys(
+    const selectedCallNodeIndex = _getTimelineIsSelected(
       selectedThreadIndexes,
       threadsKey
     )

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -202,6 +202,7 @@ class TimelineTrackThread extends PureComponent<Props> {
         filteredThread.name === 'Compositor' ||
         filteredThread.name === 'Renderer' ||
         filteredThread.name === 'Java Main Thread' ||
+        filteredThread.name === 'Merged thread' ||
         filteredThread.name.startsWith('MediaDecoderStateMachine')) &&
       processType !== 'plugin';
 

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -5,6 +5,7 @@
 
 import { getThreadSelectors } from '../selectors/per-thread';
 import { isMainThread } from './tracks';
+import { getThreadsKey } from './profile-data';
 import { ensureExists } from '../utils/flow';
 
 import type {
@@ -123,12 +124,14 @@ export function computeActiveTabTracks(
     }
   }
 
+  const mainTrackIndexesSet = new Set(mainTrackIndexes);
   const mainTrack: ActiveTabMainTrack = {
     type: 'tab',
     // FIXME: We should revert back to full view if we failed to find a track
     // index for the main track.
     mainThreadIndex: mainTrackIndexes[0] || 0,
-    threadIndexes: new Set(mainTrackIndexes),
+    threadIndexes: mainTrackIndexesSet,
+    threadsKey: getThreadsKey(mainTrackIndexesSet),
   };
   return { mainTrack, screenshots, resources };
 }

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -133,7 +133,11 @@ export function computeActiveTabTracks(
     threadIndexes: mainTrackIndexesSet,
     threadsKey: getThreadsKey(mainTrackIndexesSet),
   };
-  return { mainTrack, screenshots, resources };
+  const resourcesThreadsKey = getThreadsKey(
+    new Set(resources.map(resource => resource.threadIndex))
+  );
+
+  return { mainTrack, screenshots, resources, resourcesThreadsKey };
 }
 
 /**

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -128,7 +128,7 @@ export function computeActiveTabTracks(
     // FIXME: We should revert back to full view if we failed to find a track
     // index for the main track.
     mainThreadIndex: mainTrackIndexes[0] || 0,
-    threadIndexes: mainTrackIndexes,
+    threadIndexes: new Set(mainTrackIndexes),
   };
   return { mainTrack, screenshots, resources };
 }

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -885,6 +885,7 @@ function getComparisonThread(
  * Merge threads inside a profile.
  * The threads should belong to the same profile because unlike mergeProfilesForDiffing,
  * this does not merge the profile level information like metadata, categories etc.
+ * TODO: Overlapping threads will not look great due to #2783.
  */
 export function mergeThreads(threads: Thread[]): Thread {
   const newStringTable = new UniqueStringArray();

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2675,5 +2675,11 @@ export function getOrCreateURIResource(
  * See the ThreadsKey type for an explanation.
  */
 export function getThreadsKey(threadIndexes: Set<ThreadIndex>): ThreadsKey {
+  if (threadIndexes.size === 1) {
+    // Return the ThreadIndex directly if there is only one thread.
+    // We know this value exists because of the size check, even if Flow doesn't.
+    return (threadIndexes.values().next().value: any);
+  }
+
   return [...threadIndexes].sort((a, b) => b - a).join(',');
 }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2692,5 +2692,10 @@ export function hasThreadKeys(
   threadsKey: ThreadsKey
 ): boolean {
   const threadIndexes = ('' + threadsKey).split(',').map(n => +n);
-  return threadIndexes.every(threadIndex => threadIndexesSet.has(threadIndex));
+  for (const threadIndex of threadIndexes) {
+    if (!threadIndexesSet.has(threadIndex)) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2683,3 +2683,14 @@ export function getThreadsKey(threadIndexes: Set<ThreadIndex>): ThreadsKey {
 
   return [...threadIndexes].sort((a, b) => b - a).join(',');
 }
+
+/**
+ * Checks if threadIndexesSet contains all the threads in the threadsKey.
+ */
+export function hasThreadKeys(
+  threadIndexesSet: Set<ThreadIndex>,
+  threadsKey: ThreadsKey
+): boolean {
+  const threadIndexes = ('' + threadsKey).split(',').map(n => +n);
+  return threadIndexes.every(threadIndex => threadIndexesSet.has(threadIndex));
+}

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -13,8 +13,9 @@ import type {
   IsSidebarOpenPerPanelState,
   Reducer,
   UrlSetupPhase,
-  ThreadIndex,
+  ThreadsKey,
   ExperimentalFlags,
+  CssPixels,
 } from 'firefox-profiler/types';
 
 const view: Reducer<AppViewState> = (
@@ -163,14 +164,14 @@ const lastVisibleThreadTabSlug: Reducer<TabSlug> = (
   }
 };
 
-const trackThreadHeights: Reducer<Array<ThreadIndex | void>> = (
-  state = [],
+const trackThreadHeights: Reducer<{ [key: ThreadsKey]: CssPixels }> = (
+  state = {},
   action
 ) => {
   switch (action.type) {
     case 'UPDATE_TRACK_THREAD_HEIGHT': {
-      const newState = state.slice();
-      newState[action.threadIndex] = action.height;
+      const newState = { ...state };
+      newState[action.threadsKey] = action.height;
       return newState;
     }
     default:

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -263,7 +263,12 @@ const viewOptionsPerThread: Reducer<ThreadViewOptionsPerThreads> = (
     case 'CHANGE_INVERT_CALLSTACK': {
       const { callTree, callNodeTable, selectedThreadIndexes } = action;
       return objectMap(state, (viewOptions, threadsKey) => {
-        if (threadsKey === ProfileData.getThreadsKey(selectedThreadIndexes)) {
+        if (
+          // `Object.entries` converts number threadsKeys into strings, so
+          // converting right hand side to string as well.
+          threadsKey ===
+          ProfileData.getThreadsKey(selectedThreadIndexes).toString()
+        ) {
           // Only attempt this on the current thread, as we need the transformed thread
           // There is no guarantee that this has been calculated on all the other threads,
           // and we shouldn't attempt to expect it, as that could be quite a perf cost.

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -144,17 +144,13 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
         // Add the height of the main track.
         // The thread tracks have enough complexity that it warrants measuring
         // them rather than statically using a value like the other tracks.
-        const { mainThreadIndex } = activeTabTimeline.mainTrack;
-        if (mainThreadIndex === null) {
-          height += TRACK_PROCESS_BLANK_HEIGHT + border;
-        } else {
-          const trackThreadHeight = trackThreadHeights[mainThreadIndex];
-          if (trackThreadHeight === undefined) {
-            // The height isn't computed yet, return.
-            return null;
-          }
-          height += trackThreadHeight + border;
+        const { threadsKey } = activeTabTimeline.mainTrack;
+        const trackThreadHeight = trackThreadHeights[threadsKey];
+        if (trackThreadHeight === undefined) {
+          // The height isn't computed yet, return.
+          return null;
         }
+        height += trackThreadHeight + border;
 
         // Add the height of screenshot tracks.
         for (let i = 0; i < activeTabTimeline.screenshots.length; i++) {

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -41,7 +41,7 @@ import type {
   UrlSetupPhase,
   Selector,
   CssPixels,
-  ThreadIndex,
+  ThreadsKey,
   ExperimentalFlags,
 } from 'firefox-profiler/types';
 
@@ -61,9 +61,9 @@ export const getPanelLayoutGeneration: Selector<number> = state =>
   getApp(state).panelLayoutGeneration;
 export const getLastVisibleThreadTabSlug: Selector<TabSlug> = state =>
   getApp(state).lastVisibleThreadTabSlug;
-export const getTrackThreadHeights: Selector<
-  Array<ThreadIndex | void>
-> = state => getApp(state).trackThreadHeights;
+export const getTrackThreadHeights: Selector<{
+  [key: ThreadsKey]: CssPixels,
+}> = state => getApp(state).trackThreadHeights;
 export const getIsNewlyPublished: Selector<boolean> = state =>
   getApp(state).isNewlyPublished;
 export const getExperimental: Selector<ExperimentalFlags> = state =>

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -48,8 +48,13 @@ export type ThreadSelectors = {|
  */
 const _threadSelectorsCache: { [number]: ThreadSelectors } = {};
 const _mergedThreadSelectorsMemoized = memoize(
-  (threadIndexes: Set<ThreadIndex>, threadsKey: ThreadsKey) =>
-    _buildThreadSelectors(threadIndexes, threadsKey),
+  (threadsKey: ThreadsKey) => {
+    // We don't pass this set inside this memoization function since we create
+    // an intermediate Set whenever we need to access the cache. Memoize should
+    // only use threadsKey as the key.
+    const threadIndexes = new Set(('' + threadsKey).split(',').map(n => +n));
+    return _buildThreadSelectors(threadIndexes, threadsKey);
+  },
   { limit: 5 }
 );
 
@@ -121,7 +126,7 @@ export const getThreadSelectorsFromThreadsKey = (
     return getSingleThreadSelectors((threadIndexes.values().next().value: any));
   }
 
-  return _mergedThreadSelectorsMemoized(threadIndexes, threadsKey);
+  return _mergedThreadSelectorsMemoized(threadsKey);
 };
 
 function _buildThreadSelectors(

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -66,6 +66,7 @@ import type {
   OriginsViewState,
   ActiveTabTimeline,
   ActiveTabMainTrack,
+  ThreadsKey,
   $ReturnType,
   MarkerSchema,
   MarkerSchemaByName,
@@ -482,6 +483,9 @@ export const getActiveTabGlobalTracks: Selector<
 export const getActiveTabResourceTracks: Selector<
   ActiveTabResourceTrack[]
 > = state => getActiveTabTimeline(state).resources;
+
+export const getActiveTabResourcesThreadsKey: Selector<ThreadsKey> = state =>
+  getActiveTabTimeline(state).resourcesThreadsKey;
 
 /**
  * This returns all TrackReferences for global tracks.

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -67,7 +67,7 @@ describe('ThreadActivityGraph', function() {
     const renderResult = render(
       <Provider store={store}>
         <TrackThread
-          threadIndex={0}
+          threadsKey={0}
           trackType="expanded"
           trackName="Test Track"
         />

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -65,7 +65,7 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
         <TimelineMarkersOverview
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
-          threadIndex={0}
+          threadsKey={0}
           onSelect={() => {}}
         />
         <MarkerContextMenu />

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -113,7 +113,7 @@ describe('timeline/TrackThread', function() {
     const renderResult = render(
       <Provider store={store}>
         <TrackThread
-          threadIndex={threadIndex}
+          threadsKey={threadIndex}
           trackType="expanded"
           trackName="Test Track"
         />

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -142,6 +142,46 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
     Resources (
     1
     )
+    <div
+      class="timelineTrackThread condensed"
+    >
+      <div
+        class="threadActivityGraph"
+      >
+        <canvas
+          class="threadActivityGraphCanvas threadActivityGraphCanvas"
+          height="300"
+          width="200"
+        >
+          <h2>
+            Activity Graph for 
+            Merged resource tracks
+          </h2>
+          <p>
+            This graph shows a visual chart of thread activity.
+          </p>
+        </canvas>
+      </div>
+      <div
+        class="timelineTrackThreadMarkers"
+      >
+        <div
+          class="timelineMarkers"
+          data-testid="TimelineMarkersJank"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="timelineEmptyThreadIndicator"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -157,6 +197,46 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
     Resources (
     1
     )
+    <div
+      class="timelineTrackThread condensed"
+    >
+      <div
+        class="threadActivityGraph"
+      >
+        <canvas
+          class="threadActivityGraphCanvas threadActivityGraphCanvas"
+          height="300"
+          width="200"
+        >
+          <h2>
+            Activity Graph for 
+            Merged resource tracks
+          </h2>
+          <p>
+            This graph shows a visual chart of thread activity.
+          </p>
+        </canvas>
+      </div>
+      <div
+        class="timelineTrackThreadMarkers"
+      >
+        <div
+          class="timelineMarkers"
+          data-testid="TimelineMarkersJank"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <canvas
+              class="timelineMarkersCanvas"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="timelineEmptyThreadIndicator"
+      />
+    </div>
   </div>
   <ol
     class="timelineResourceTracks"

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -11,7 +11,7 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
       class="timelineTrackTrack"
     >
       <div
-        class="timelineTrackThread"
+        class="timelineTrackThread expanded"
       >
         <div
           class="threadActivityGraph"
@@ -87,7 +87,7 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
       class="timelineTrackTrack"
     >
       <div
-        class="timelineTrackThread"
+        class="timelineTrackThread condensed"
       >
         <div
           class="threadActivityGraph"
@@ -180,7 +180,7 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
           class="timelineTrackTrack"
         >
           <div
-            class="timelineTrackThread"
+            class="timelineTrackThread condensed"
           >
             <div
               class="threadActivityGraph"
@@ -272,7 +272,7 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                 class="timelineTrackTrack"
               >
                 <div
-                  class="timelineTrackThread"
+                  class="timelineTrackThread expanded"
                 >
                   <div
                     class="threadActivityGraph"

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -29,7 +29,7 @@ process: \\"tab\\" (222)"
       class="timelineTrackTrack"
     >
       <div
-        class="timelineTrackThread"
+        class="timelineTrackThread expanded"
       >
         <div
           class="timelineMarkers timelineMarkersMemory"
@@ -115,7 +115,7 @@ process: \\"tab\\" (222)"
           class="timelineTrackTrack"
         >
           <div
-            class="timelineTrackThread"
+            class="timelineTrackThread expanded"
           >
             <div
               class="timelineMarkers selected"
@@ -175,7 +175,7 @@ process: \\"tab\\" (222)"
           class="timelineTrackTrack"
         >
           <div
-            class="timelineTrackThread"
+            class="timelineTrackThread expanded"
           >
             <div
               class="timelineMarkers"
@@ -268,7 +268,7 @@ process: \\"default\\" (5555)"
           class="timelineTrackTrack"
         >
           <div
-            class="timelineTrackThread"
+            class="timelineTrackThread expanded"
           >
             <div
               class="timelineMarkers"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -139,7 +139,7 @@ process: \\"tab\\" (222)"
       class="timelineTrackTrack"
     >
       <div
-        class="timelineTrackThread"
+        class="timelineTrackThread expanded"
       >
         <div
           class="timelineMarkers"

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -2526,7 +2526,7 @@ Array [
 
 exports[`ThreadActivityGraph matches the component snapshot 1`] = `
 <div
-  class="timelineTrackThread"
+  class="timelineTrackThread expanded"
 >
   <div
     class="timelineMarkers selected"

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -64,7 +64,7 @@ Array [
 
 exports[`timeline/TrackThread matches the snapshot for the component 1`] = `
 <div
-  class="timelineTrackThread"
+  class="timelineTrackThread expanded"
 >
   <div
     class="timelineMarkers selected"

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -230,7 +230,7 @@ export function getHumanReadableActiveTabTracks(state: State): string[] {
     switch (globalTrack.type) {
       case 'tab': {
         // Only print the main track if we actually managed to find it.
-        if (globalTrack.threadIndexes.length > 0) {
+        if (globalTrack.threadIndexes.size > 0) {
           const selected = selectedThreadIndexes.has(
             globalTrack.mainThreadIndex
           )

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -453,7 +453,7 @@ describe('ctxId', function() {
       {
         type: 'tab',
         mainThreadIndex: 0,
-        threadIndexes: [0],
+        threadIndexes: new Set([0]),
       },
     ]);
     // TODO: Resource track type will be changed soon.

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -454,6 +454,7 @@ describe('ctxId', function() {
         type: 'tab',
         mainThreadIndex: 0,
         threadIndexes: new Set([0]),
+        threadsKey: 0,
       },
     ]);
     // TODO: Resource track type will be changed soon.

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -139,7 +139,7 @@ type ProfileAction =
   | {|
       +type: 'UPDATE_TRACK_THREAD_HEIGHT',
       +height: CssPixels,
-      +threadIndex: ThreadIndex,
+      +threadsKey: ThreadsKey,
     |}
   | {|
       +type: 'CHANGE_RIGHT_CLICKED_CALL_NODE',

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -280,6 +280,7 @@ export type ActiveTabMainTrack = {|
   type: 'tab',
   mainThreadIndex: ThreadIndex,
   threadIndexes: Set<ThreadIndex>,
+  threadsKey: ThreadsKey,
 |};
 
 export type ActiveTabScreenshotTrack = {|

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -279,7 +279,7 @@ export type OriginsTimeline = Array<
 export type ActiveTabMainTrack = {|
   type: 'tab',
   mainThreadIndex: ThreadIndex,
-  threadIndexes: Array<ThreadIndex>,
+  threadIndexes: Set<ThreadIndex>,
 |};
 
 export type ActiveTabScreenshotTrack = {|

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -312,6 +312,7 @@ export type ActiveTabTimeline = {
   mainTrack: ActiveTabMainTrack,
   screenshots: Array<ActiveTabScreenshotTrack>,
   resources: Array<ActiveTabResourceTrack>,
+  resourcesThreadsKey: ThreadsKey,
 };
 
 export type ActiveTabGlobalTrack =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -16,7 +16,7 @@ import type {
   CheckedSharingOptions,
 } from './actions';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { StartEndRange } from './units';
+import type { StartEndRange, CssPixels } from './units';
 import type { Profile, ThreadIndex, Pid, BrowsingContextID } from './profile';
 
 import type {
@@ -171,7 +171,9 @@ export type AppState = {|
   +isSidebarOpenPerPanel: IsSidebarOpenPerPanelState,
   +panelLayoutGeneration: number,
   +lastVisibleThreadTabSlug: TabSlug,
-  +trackThreadHeights: Array<ThreadIndex | void>,
+  +trackThreadHeights: {
+    [key: ThreadsKey]: CssPixels,
+  },
   +isNewlyPublished: boolean,
   +isDragAndDropDragging: boolean,
   +isDragAndDropOverlayRegistered: boolean,


### PR DESCRIPTION
With this PR, we are finally starting to see the merged threads in two places:
1. Main track, if there are more than one processes involved in the tab.
2. Resources panel header, for merged resources tracks.

This PR is rebased on top of #2706 so we can use the same stuff. We need to land that PR first to be able to land this one.

[Deploy preview](https://deploy-preview-2752--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?resources&thread=19&v=5&view=active-tab)