### PR TITLE
Add unload warning during profile upload phase

### DIFF
--- a/src/components/app/BeforeUnloadManager.js
+++ b/src/components/app/BeforeUnloadManager.js
@@ -1,0 +1,56 @@
+/* this source code form is subject to the terms of the mozilla public
+ * license, v. 2.0. if a copy of the mpl was not distributed with this
+ * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import explicitConnect from '../../utils/connect';
+
+import type { ConnectedProps } from '../../utils/connect';
+import { getUploadPhase } from '../../selectors/publish';
+
+type StateProps = {|
+  +isUploading: boolean,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, {||}>;
+
+class BeforeUnloadManager extends React.PureComponent<Props> {
+  manageBeforeUnloadListener() {
+    const { isUploading } = this.props;
+    if (isUploading) {
+      window.addEventListener('beforeunload', this.handleUnload);
+    } else {
+      window.removeEventListener('beforeunload', this.handleUnload);
+    }
+  }
+
+  handleUnload = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = 'Are you sure you want to close while uploading?';
+  };
+
+  componentDidMount() {
+    this.manageBeforeUnloadListener();
+  }
+
+  componentDidUpdate() {
+    this.manageBeforeUnloadListener();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.handleUnload);
+  }
+
+  render() {
+    return false;
+  }
+}
+
+export default explicitConnect<{||}, StateProps, {||}>({
+  mapStateToProps: state => ({
+    isUploading: getUploadPhase(state) === 'uploading',
+  }),
+  component: BeforeUnloadManager,
+});

--- a/src/components/app/BeforeUnloadManager.js
+++ b/src/components/app/BeforeUnloadManager.js
@@ -27,6 +27,9 @@ class BeforeUnloadManager extends React.PureComponent<Props> {
   }
 
   handleUnload = (event: BeforeUnloadEvent) => {
+    // To be cross-browser and future-proof, we need to use these techniques.
+    // Especially at the time this code is written, Chrome doesn't support using
+    // preventDefault to trigger the unload alert.
     event.preventDefault();
     event.returnValue = 'Are you sure you want to close while uploading?';
   };

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -13,6 +13,7 @@ import MenuButtons from './MenuButtons';
 import WindowTitle from '../shared/WindowTitle';
 import SymbolicationStatusOverlay from './SymbolicationStatusOverlay';
 import { ProfileName } from './ProfileName';
+import BeforeUnloadManager from './BeforeUnloadManager';
 
 import { returnToZipFileList } from '../../actions/zipped-profiles';
 import Timeline from '../timeline';
@@ -135,6 +136,7 @@ class ProfileViewer extends PureComponent<Props> {
           </SplitterLayout>
           <WindowTitle />
           <SymbolicationStatusOverlay />
+          <BeforeUnloadManager />
         </div>
       </div>
     );

--- a/src/test/components/BeforeUnloadManager.test.js
+++ b/src/test/components/BeforeUnloadManager.test.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import BeforeUnloadManager from '../../components/app/BeforeUnloadManager';
+import { blankStore } from '../fixtures/stores';
+import { Provider } from 'react-redux';
+import { uploadStarted } from 'firefox-profiler/actions/publish';
+import { getUploadPhase } from '../../selectors/publish';
+
+describe('app/BeforeUnloadManager', () => {
+  function setup() {
+    const store = blankStore();
+    const { dispatch, getState } = store;
+
+    const createBeforeUnloadManager = () =>
+      render(
+        <Provider store={store}>
+          <BeforeUnloadManager />
+        </Provider>
+      );
+    return { dispatch, getState, createBeforeUnloadManager };
+  }
+
+  afterEach(cleanup);
+
+  it('Prevents default beforeunload behaviour', () => {
+    const { dispatch, getState, createBeforeUnloadManager } = setup();
+    createBeforeUnloadManager();
+
+    // simulate profile upload phase
+    dispatch(uploadStarted());
+    expect(getUploadPhase(getState())).toBe('uploading');
+
+    const event = new Event('beforeunload');
+
+    /* Because of the current jsdom implementation, we need to mock
+       preventDefault(). To prevent a Flow error when assigning jest.fn()
+       to event.preventDefault (not writeable), we add the following line.
+    */
+    // $FlowExpectError
+    event.preventDefault = jest.fn();
+
+    const returnValue = fireEvent((window: any), event);
+    expect(returnValue).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/src/test/components/BeforeUnloadManager.test.js
+++ b/src/test/components/BeforeUnloadManager.test.js
@@ -44,8 +44,8 @@ describe('app/BeforeUnloadManager', () => {
     // $FlowExpectError
     event.preventDefault = jest.fn();
 
-    const returnValue = fireEvent((window: any), event);
-    expect(returnValue).toBe(true);
+    fireEvent((window: any), event);
+    expect((event: any).returnValue).toBeTruthy();
     expect(event.preventDefault).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Hello,

I am submitting a broken PR for #573  to get some feedback. I've added a `beforeunload` event listener on the ProfileViewer component during the profile upload phase to warn users before exiting. I'm under the impression that the goal was to add a react component that would replace the default browser warning. I'm unsure as to how to replace this prompt with a react component. I read the [beforeunload](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) documentation and it mentioned something about customized messages being deprecated. Would it still be possible to replace the default warning then?
