### PR TITLE
Make ctxId query string optional for active tab view

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -525,7 +525,7 @@ export function finalizeOriginProfileView(
 export function finalizeActiveTabProfileView(
   profile: Profile,
   selectedThreadIndex: ThreadIndex,
-  browsingContextID: BrowsingContextID
+  browsingContextID: BrowsingContextID | null
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const relevantPages = getRelevantPagesForActiveTab(getState());

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -138,7 +138,7 @@ type FullProfileSpecificBaseQuery = {|
 // Base query that only applies to active tab profile view.
 type ActiveTabProfileSpecificBaseQuery = {|
   resources: null | void,
-  ctxId: BrowsingContextID,
+  ctxId: BrowsingContextID | void,
 |};
 
 // Base query that only applies to origins profile view.
@@ -330,7 +330,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
         .isResourcesPanelOpen
         ? null
         : undefined;
-      baseQuery.ctxId = ctxId;
+      baseQuery.ctxId = ctxId || undefined;
       break;
     }
     case 'origins':
@@ -936,11 +936,7 @@ function validateTimelineTrackOrganization(
     case 'full':
       return { type: 'full' };
     case 'active-tab':
-      if (browsingContextID) {
-        return { type: 'active-tab', browsingContextID };
-      }
-      return { type: 'full' };
-
+      return { type: 'active-tab', browsingContextID };
     case 'origins':
       return { type: 'origins' };
     default:

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -720,8 +720,8 @@ export const getRelevantInnerWindowIDsForActiveTab: Selector<
 
 /**
  * A simple wrapper for getRelevantInnerWindowIDsForActiveTab.
- * It returns an empty Set if showTabOnly is null, and returns the real Set if
- * showTabOnly is assigned already. We should usually use this instead of the
+ * It returns an empty Set if ctxId is null, and returns the real Set if
+ * ctxId is assigned already. We should usually use this instead of the
  * wrapped function. But the wrapped function is helpful to calculate the hidden
  * tracks by active tab view during the first page load(inside viewProfile function).
  */

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -193,7 +193,7 @@ describe('timeline/TrackContextMenu', function() {
       // TODO - We should wait until we have some real tracks without a thread index.
     });
 
-    it('network track will be displayed when a number is not set for showTabOnly', () => {
+    it('network track will be displayed when a number is not set for ctxId', () => {
       const { container } = setupGlobalTrack(getNetworkTrackProfile(), 0);
       // We can't use getHumanReadableTracks here because that function doesn't
       // use the functions used by context menu directly and gives us wrong results.

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -176,7 +176,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
 </nav>
 `;
 
-exports[`timeline/TrackContextMenu selected global track network track will be displayed when a number is not set for showTabOnly 1`] = `
+exports[`timeline/TrackContextMenu selected global track network track will be displayed when a number is not set for ctxId 1`] = `
 <nav
   class="react-contextmenu timeline-context-menu"
   role="menu"

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -323,7 +323,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function() {
   const browsingContextID = 123123;
   const innerWindowID = 2;
 
-  function setup(showTabOnly, markers: ?Array<any>) {
+  function setup(ctxId, markers: ?Array<any>) {
     const profile = getProfileWithMarkers(
       markers || [
         [
@@ -379,7 +379,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function() {
     };
     const { getState, dispatch } = storeWithProfile(profile);
 
-    if (showTabOnly) {
+    if (ctxId) {
       dispatch(
         changeTimelineTrackOrganization({
           type: 'active-tab',

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -441,7 +441,7 @@ describe('actions/receive-profile', function() {
   describe('changeTimelineTrackOrganization', function() {
     const browsingContextID = 123;
     const innerWindowID = 111111;
-    function setup(initializeShowTabOnly: boolean = false) {
+    function setup(initializeCtxId: boolean = false) {
       const store = blankStore();
       const profile = getEmptyProfile();
 
@@ -465,7 +465,7 @@ describe('actions/receive-profile', function() {
       ];
 
       store.dispatch(viewProfile(profile));
-      if (initializeShowTabOnly) {
+      if (initializeCtxId) {
         store.dispatch(
           changeTimelineTrackOrganization({
             type: 'active-tab',

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -45,6 +45,7 @@ import {
   getActiveTabGlobalTracks,
   getActiveTabResourceTracks,
 } from '../selectors/profile';
+import { getView } from '../selectors/app';
 
 function _getStoreWithURL(
   settings: {
@@ -476,6 +477,18 @@ describe('ctxId', function() {
     expect(newUrl.search).toEqual(
       `?ctxId=123&thread=0&v=${CURRENT_URL_VERSION}&view=active-tab`
     );
+  });
+
+  it('if not present in the URL, still manages to load the active tab view', function() {
+    const { getState } = _getStoreWithURL({
+      search: '?view=active-tab',
+    });
+
+    expect(getView(getState()).phase).toEqual('DATA_LOADED');
+    expect(urlStateReducers.getTimelineTrackOrganization(getState())).toEqual({
+      type: 'active-tab',
+      browsingContextID: null,
+    });
   });
 });
 

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -398,8 +398,8 @@ describe('profileName', function() {
   });
 });
 
-describe('showTabOnly', function() {
-  it('serializes the showTabOnly in the URL', function() {
+describe('ctxId', function() {
+  it('serializes the ctxId in the URL', function() {
     const { getState, dispatch } = _getStoreWithURL();
     const browsingContextID = 123;
 
@@ -421,7 +421,7 @@ describe('showTabOnly', function() {
     });
   });
 
-  it('returns the full view when showTabOnly is not specified', function() {
+  it('returns the full view when ctxId is not specified', function() {
     const { getState } = _getStoreWithURL();
     expect(urlStateReducers.getTimelineTrackOrganization(getState())).toEqual({
       type: 'full',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -291,7 +291,7 @@ type ReceiveProfileAction =
       +type: 'VIEW_ACTIVE_TAB_PROFILE',
       +selectedThreadIndex: ThreadIndex,
       +activeTabTimeline: ActiveTabTimeline,
-      +browsingContextID: BrowsingContextID,
+      +browsingContextID: BrowsingContextID | null,
     |}
   | {|
       +type: 'DATA_RELOAD',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -280,7 +280,6 @@ type ReceiveProfileAction =
       +localTracksByPid: Map<Pid, LocalTrack[]>,
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
-      +showTabOnly?: BrowsingContextID | null,
     |}
   | {|
       +type: 'VIEW_ORIGINS_PROFILE',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -250,7 +250,7 @@ export type ProfileSpecificUrlState = {|
  */
 export type TimelineTrackOrganization =
   | {| +type: 'full' |}
-  | {| +type: 'active-tab', +browsingContextID: BrowsingContextID |}
+  | {| +type: 'active-tab', +browsingContextID: BrowsingContextID | null |}
   | {| +type: 'origins' |};
 
 export type UrlState = {|


### PR DESCRIPTION
Previously we had to have a `ctxId` to be able to switch to the active tab view, which makes it hard to switch directly by changing the url. Since the `browsingContextID` is present inside the profile data, we don't need to keep it on the URL. But we can still change to other tabs by changing the url if we want.
This will make the url handling better for directly opening the active tab if "web-developer" preset is selected. We won't have to know the `browsingContextID` beforehand, which is unnecessary.

I think it would be better to review commit by commit. 

[Current deploy, which falls back to full view](https://profiler.firefox.com/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?thread=8&v=5&view=active-tab)
[Deploy preview, shows the active tab properly](https://deploy-preview-2759--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?thread=8&v=5&view=active-tab)