### PR TITLE
Marker tooltip improvements

### DIFF
--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -554,7 +554,11 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
 
     const marker = this.props.getMarker(markerIndex);
     return (
-      <TooltipMarker marker={marker} threadIndex={this.props.threadIndex} />
+      <TooltipMarker
+        marker={marker}
+        threadIndex={this.props.threadIndex}
+        restrictHeightWidth={true}
+      />
     );
   };
 

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -497,6 +497,7 @@ class NetworkChartRow extends React.PureComponent<NetworkChartRowProps, State> {
               className="tooltipNetwork"
               marker={marker}
               threadIndex={this.props.threadIndex}
+              restrictHeightWidth={true}
             />
           </Tooltip>
         ) : null}

--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -15,7 +15,7 @@
   /* Box */
   padding: 0;
   margin: 0;
-  list-style-position: inside;
+  list-style: none;
 
   /* Other */
   text-overflow: ellipsis;

--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -1,49 +1,23 @@
 .backtrace {
-  --gradient-height: calc(var(--max-height) - 5em);
-
-  /* Box */
-  max-width: 35em;
+  max-width: var(--tooltip-detail-max-width);
   padding: 0;
-  margin: 5px;
-
-  /* Other */
-  font-size: 0.9em;
-  line-height: 1.5;
+  margin: 0;
 }
 
 .tooltip .backtrace {
   overflow: hidden;
-  max-height: var(--max-height);
-
-  /* The gradient is defined towards the bottom so that we hide the end of the
-   * backtrace only when the element is tall enough, which is when the backtrace
-   * is long. */
-
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    white,
-    white var(--gradient-height),
-    transparent
-  );
-  mask-image: linear-gradient(
-    to bottom,
-    white,
-    white var(--gradient-height),
-    transparent
-  );
 }
 
 .backtraceStackFrame {
   /* Position */
-  display: block;
   overflow: hidden;
 
   /* Box */
   padding: 0;
   margin: 0;
+  list-style-position: inside;
 
   /* Other */
-  list-style: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -21,13 +21,15 @@ require('./Backtrace.css');
 
 type Props = {|
   +thread: Thread,
-  +maxHeight: string | number,
+  // Tooltips will want to only show a certain number of stacks, while the sidebars
+  // can show all of the stacks.
+  +maxStacks: number,
   +stackIndex: IndexIntoStackTable,
   +implementationFilter: ImplementationFilter,
 |};
 
 function Backtrace(props: Props) {
-  const { stackIndex, thread, implementationFilter, maxHeight } = props;
+  const { stackIndex, thread, implementationFilter, maxStacks } = props;
   const callNodePath = filterCallNodePathByImplementation(
     thread,
     implementationFilter,
@@ -40,14 +42,18 @@ function Backtrace(props: Props) {
 
   if (funcNamesAndOrigins.length) {
     return (
-      <ol className="backtrace" style={{ '--max-height': maxHeight }}>
-        {funcNamesAndOrigins.map(({ funcName, origin }, i) => (
-          <li key={i} className="backtraceStackFrame">
-            {funcName}
-            <em className="backtraceStackFrameOrigin">{origin}</em>
-          </li>
-        ))}
-      </ol>
+      <ul className="backtrace">
+        {funcNamesAndOrigins
+          // Truncate the stacks
+          .slice(0, maxStacks)
+          .map(({ funcName, origin }, i) => (
+            <li key={i} className="backtraceStackFrame">
+              {funcName}
+              <em className="backtraceStackFrameOrigin">{origin}</em>
+            </li>
+          ))}
+        {funcNamesAndOrigins.length > maxStacks ? '…' : null}
+      </ul>
     );
   }
   return (

--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -49,7 +49,7 @@ export default class SampleTooltipContents extends React.PureComponent<Props> {
           <div className="tooltipLabel">Stack:</div>
         </div>
         <Backtrace
-          maxHeight="9.2em"
+          maxStacks={20}
           stackIndex={stackIndex}
           thread={fullThread}
           implementationFilter="combined"

--- a/src/components/sidebar/MarkerSidebar.js
+++ b/src/components/sidebar/MarkerSidebar.js
@@ -36,7 +36,11 @@ class MarkerSidebar extends React.PureComponent<Props> {
     return (
       <aside className="sidebar sidebar-marker-table">
         <div className="sidebar-contents-wrapper">
-          <TooltipMarker marker={marker} threadIndex={selectedThreadIndex} />
+          <TooltipMarker
+            marker={marker}
+            threadIndex={selectedThreadIndex}
+            restrictHeightWidth={false}
+          />
         </div>
       </aside>
     );

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -432,6 +432,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
         <TooltipMarker
           marker={getMarker(markerIndex)}
           threadIndex={threadIndex}
+          restrictHeightWidth={true}
         />
       );
     }

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -496,7 +496,11 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
         </ContextMenuTrigger>
         {shouldShowTooltip && hoveredItem ? (
           <Tooltip mouseX={mouseX} mouseY={mouseY}>
-            <TooltipMarker marker={hoveredItem} threadIndex={threadIndex} />
+            <TooltipMarker
+              marker={hoveredItem}
+              threadIndex={threadIndex}
+              restrictHeightWidth={true}
+            />
           </Tooltip>
         ) : null}
       </div>

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -394,9 +394,9 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
           </div>
         </div>
         <TooltipDetails>
+          {this._renderMarkerDetails()}
           {this._renderThreadDetails()}
           {this._maybeRenderPageUrl()}
-          {this._renderMarkerDetails()}
         </TooltipDetails>
         {this._maybeRenderBacktrace()}
         {this._maybeRenderNetworkPhases()}

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -30,6 +30,7 @@ import {
   TooltipDetails,
   TooltipDetail,
   type TooltipDetailComponent,
+  TooltipDetailSeparator,
 } from './TooltipDetails';
 import Backtrace from '../shared/Backtrace';
 
@@ -109,7 +110,14 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
     if (page) {
       try {
         const { host } = new URL(page.url);
-        const [protocol, ...rest] = page.url.split(host);
+        const hostIndex = page.url.indexOf(host);
+        if (hostIndex === -1) {
+          throw new Error(
+            'Unable to find the host in the URL. This is a programming error.'
+          );
+        }
+        const protocol = page.url.slice(0, hostIndex);
+        const rest = page.url.slice(hostIndex + host.length);
         return (
           <TooltipDetail label="URL">
             <div className="tooltipDetailsUrl">
@@ -325,7 +333,8 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
     if (data && 'cause' in data && data.cause) {
       const { cause } = data;
       const causeAge = start - cause.time;
-      return (
+      return [
+        <TooltipDetailSeparator key="backtrace-separator" />,
         <TooltipDetail label="Stack" key="backtrace">
           <div className="tooltipDetailsBackTrace">
             {data.type === 'Styles' || marker.name === 'Reflow' ? (
@@ -341,8 +350,8 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
               implementationFilter={implementationFilter}
             />
           </div>
-        </TooltipDetail>
-      );
+        </TooltipDetail>,
+      ];
     }
     return null;
   }

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -104,7 +104,22 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
     const page = pages.find(page => page.innerWindowID === innerWindowID);
 
     if (page) {
-      return <TooltipDetail label="URL">{page.url}</TooltipDetail>;
+      try {
+        const { host } = new URL(page.url);
+        const [protocol, ...rest] = page.url.split(host);
+        return (
+          <TooltipDetail label="URL">
+            <div className="tooltipDetailsUrl">
+              <span className="tooltipDetailsDim">{protocol}</span>
+              {host}
+              <span className="tooltipDetailsDim">{rest}</span>
+            </div>
+          </TooltipDetail>
+        );
+      } catch (error) {
+        // Could not parse the URL. Just display the entire thing
+        return <TooltipDetail label="URL">{page.url}</TooltipDetail>;
+      }
     }
     return null;
   };

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -36,7 +36,6 @@ import Backtrace from '../shared/Backtrace';
 import { bailoutTypeInformation } from '../../profile-logic/marker-info';
 import {
   formatFromMarkerSchema,
-  getMarkerLabelMaker,
   getMarkerSchema,
   getMarkerSchemaName,
 } from '../../profile-logic/marker-schema';

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -65,6 +65,18 @@
   grid-template-columns: min-content auto;
 }
 
+.tooltipDetailsUrl {
+  /* URLs can be really long, and it's disruptive when widths change rapidly
+   * this components. Define an arbitrary max-width in px to restrict this change.
+   * Set the variable to 100% to allow the full-width, e.g. in the sidebar. */
+  max-width: var(--tooltip-detail-max-width);
+  overflow-wrap: anywhere;
+}
+
+.tooltipDetailsDim {
+  color: var(--grey-50);
+}
+
 .tooltipLabel {
   color: var(--grey-50);
   text-align: right;

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -101,3 +101,23 @@
   color: var(--grey-50);
   white-space: nowrap;
 }
+
+/**
+ * Overwrite styles for the sidebar.
+ */
+.sidebar .tooltipDetails {
+  /* Force the details to the max-width, even if they have long pieces of text. */
+  overflow: hidden;
+  grid-gap: 2px 0;
+
+  /* Don't let the width overflow for long pieces of text */
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto auto;
+}
+
+.sidebar .tooltipLabel {
+  margin-top: 8px;
+  color: var(--grey-60);
+  font-weight: bold;
+  text-align: left;
+}

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -4,11 +4,10 @@
   overflow: hidden;
 
   /**
-   * The margin size is defined in Tooltip.js, as 8px.
-   * The border is 1px.
-   * Take both of these sizes into account: 8px + 8px + 1px + 1px = 18px
+   * The VISUAL_MARGIN = 8 for the Tooltip is defined in src/components/tooltip/Tooltip.js.
+   * Both added together equals: 8px + 8px = 16px
    */
-  max-width: calc(100% - 18px);
+  max-width: calc(100% - 16px);
   box-sizing: border-box;
   padding: 8px;
   border: 1px solid #ccc;
@@ -73,12 +72,18 @@
   grid-template-columns: min-content auto;
 }
 
+.tooltipDetailSeparator {
+  border-top: 1px solid var(--grey-40);
+  margin: 4px 0;
+  grid-column: 1 / 3;
+}
+
 .tooltipDetailsUrl {
   /* URLs can be really long, and it's disruptive when widths change rapidly
    * this components. Define an arbitrary max-width in px to restrict this change.
    * Set the variable to 100% to allow the full-width, e.g. in the sidebar. */
   max-width: var(--tooltip-detail-max-width);
-  overflow-wrap: anywhere;
+  word-break: break-all;
 }
 
 .tooltipDetailsDim {
@@ -120,7 +125,6 @@
 
   /* Don't let the width overflow for long pieces of text */
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto auto;
 }
 
 .sidebar .tooltipLabel {
@@ -128,4 +132,8 @@
   color: var(--grey-60);
   font-weight: bold;
   text-align: left;
+}
+
+.sidebar .tooltipDetailSeparator {
+  display: none;
 }

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -2,12 +2,19 @@
   position: fixed;
   display: inline-block;
   overflow: hidden;
-  max-width: 100%;
+
+  /**
+   * The margin size is defined in Tooltip.js, as 8px.
+   * The border is 1px.
+   * Take both of these sizes into account: 8px + 8px + 1px + 1px = 18px
+   */
+  max-width: calc(100% - 18px);
   box-sizing: border-box;
-  padding: 5px;
+  padding: 8px;
   border: 1px solid #ccc;
   background-color: var(--grey-10);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  line-height: 1.4;
   pointer-events: none;
   text-align: left;
   text-overflow: ellipsis;
@@ -54,8 +61,9 @@
 }
 
 .tooltipHeader {
-  padding-bottom: 5px;
+  padding-bottom: 8px;
   border-bottom: 1px solid var(--grey-40);
+  font-size: 12px;
 }
 
 .tooltipDetails {

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -11,6 +11,8 @@ import { ensureExists } from '../../utils/flow';
 require('./Tooltip.css');
 
 export const MOUSE_OFFSET = 11;
+// If changing this value, make sure and adjust the max-width in the .tooltip class.
+export const MARGIN: CssPixels = 8;
 
 type Props = {
   mouseX: CssPixels,
@@ -100,7 +102,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
           top = mouseY - interiorElement.offsetHeight - MOUSE_OFFSET;
         } else {
           // Otherwise we align the tooltip with the window's top edge.
-          top = 0;
+          top = MARGIN;
         }
       }
 
@@ -119,7 +121,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
           left = mouseX - interiorElement.offsetWidth - MOUSE_OFFSET;
         } else {
           // Otherwise, align the tooltip with the window's left edge.
-          left = 0;
+          left = MARGIN;
         }
       }
     }

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -12,7 +12,7 @@ require('./Tooltip.css');
 
 export const MOUSE_OFFSET = 11;
 // If changing this value, make sure and adjust the max-width in the .tooltip class.
-export const MARGIN: CssPixels = 8;
+export const VISUAL_MARGIN: CssPixels = 8;
 
 type Props = {
   mouseX: CssPixels,
@@ -102,7 +102,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
           top = mouseY - interiorElement.offsetHeight - MOUSE_OFFSET;
         } else {
           // Otherwise we align the tooltip with the window's top edge.
-          top = MARGIN;
+          top = VISUAL_MARGIN;
         }
       }
 
@@ -121,7 +121,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
           left = mouseX - interiorElement.offsetWidth - MOUSE_OFFSET;
         } else {
           // Otherwise, align the tooltip with the window's left edge.
-          left = MARGIN;
+          left = VISUAL_MARGIN;
         }
       }
     }

--- a/src/components/tooltip/TooltipDetails.js
+++ b/src/components/tooltip/TooltipDetails.js
@@ -44,7 +44,13 @@ export function TooltipDetail({ label, children }: DetailProps) {
   );
 }
 
-export type TooltipDetailComponent = React.Element<typeof TooltipDetail> | null;
+export function TooltipDetailSeparator() {
+  return <div className="tooltipDetailSeparator"></div>;
+}
+
+export type TooltipDetailComponent = React.Element<
+  typeof TooltipDetail | typeof TooltipDetailSeparator
+> | null;
 type Props = {|
   // This component accepts only TooltipDetail children.
   +children: React.ChildrenArray<TooltipDetailComponent>,

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -13,6 +13,7 @@ import {
   INTERVAL_START,
   INTERVAL_END,
 } from 'firefox-profiler/app-logic/constants';
+import { getMarkerSchemaName } from './marker-schema';
 
 import type {
   Thread,
@@ -36,6 +37,7 @@ import type {
   IndexedArray,
   DerivedMarkerInfo,
   MarkerSchema,
+  MarkerDisplayLocation,
 } from 'firefox-profiler/types';
 
 import type { UniqueStringArray } from '../utils/unique-string-array';

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -13,7 +13,6 @@ import {
   INTERVAL_START,
   INTERVAL_END,
 } from 'firefox-profiler/app-logic/constants';
-import { getMarkerSchemaName } from './marker-schema';
 
 import type {
   Thread,
@@ -37,7 +36,6 @@ import type {
   IndexedArray,
   DerivedMarkerInfo,
   MarkerSchema,
-  MarkerDisplayLocation,
 } from 'firefox-profiler/types';
 
 import type { UniqueStringArray } from '../utils/unique-string-array';

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -251,12 +251,14 @@ export function formatFromMarkerSchema(
   markerType: string,
   format: MarkerFormatType,
   value: any
-): string | null {
+): string {
   switch (format) {
     case 'url':
     case 'file-path':
     case 'string':
-      return value;
+      // Make sure a truthy string is returned here. Otherwise it can break
+      // grid layouts.
+      return String(value) || '(empty)';
     case 'duration':
     case 'time':
       return formatTimestamp(value);

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -12,13 +12,19 @@ import {
   formatMicroseconds,
   formatNanoseconds,
 } from '../utils/format-numbers';
-import type { MarkerFormatType } from 'firefox-profiler/types';
+import type {
+  MarkerFormatType,
+  MarkerSchema,
+  MarkerSchemaByName,
+  Marker,
+  MarkerLabelMaker,
+} from 'firefox-profiler/types';
 
 /**
  * TODO - These will eventually be stored in the profile, but for now
  * define them here.
  */
-export const markerSchema = [
+export const markerSchema: MarkerSchema[] = [
   {
     name: 'Bailout',
     display: ['marker-chart', 'marker-table'],
@@ -53,7 +59,7 @@ export const markerSchema = [
   },
   {
     name: 'CC',
-    label: 'Cycle Collect',
+    tooltipLabel: 'Cycle Collect',
     display: ['marker-chart', 'marker-table', 'timeline-memory'],
     data: [],
   },
@@ -132,8 +138,18 @@ export const markerSchema = [
   },
   {
     name: 'UserTiming',
+    tooltipLabel: '{name}',
     display: ['marker-chart', 'marker-table'],
-    data: [{ key: 'name', label: 'Name', format: 'string' }],
+    data: [
+      // name
+      { label: 'Marker', value: 'UserTiming' },
+      { key: 'entryType', label: 'Entry Type', format: 'string' },
+      {
+        label: 'Description',
+        value:
+          'UserTiming is created using the DOM APIs performance.mark() and performance.measure().',
+      },
+    ],
   },
   {
     name: 'Text',
@@ -149,12 +165,34 @@ export const markerSchema = [
     ],
   },
   {
-    name: 'tracing',
+    name: 'DOMEvent',
+    tooltipLabel: '{eventType}',
     display: ['marker-chart', 'marker-table'],
     data: [
-      // This is really the "type" of the marker.
-      { key: 'category', label: 'Category', format: 'string' },
+      { key: 'category', label: 'Marker', format: 'string' },
+      // eventType is only in the tooltipLabel
     ],
+  },
+  {
+    // TODO - Note that this marker is a "tracing" marker currently.
+    // See issue #2749
+    name: 'Paint',
+    display: ['marker-chart', 'marker-table'],
+    data: [{ key: 'category', label: 'Type', format: 'string' }],
+  },
+  {
+    // TODO - Note that this marker is a "tracing" marker currently.
+    // See issue #2749
+    name: 'Navigation',
+    display: ['marker-chart', 'marker-table'],
+    data: [{ key: 'category', label: 'Type', format: 'string' }],
+  },
+  {
+    // TODO - Note that this marker is a "tracing" marker currently.
+    // See issue #2749
+    name: 'Layout',
+    display: ['marker-chart', 'marker-table'],
+    data: [{ key: 'category', label: 'Type', format: 'string' }],
   },
   {
     name: 'IPC',
@@ -164,12 +202,51 @@ export const markerSchema = [
       { key: 'sync', label: 'Sync', format: 'string' },
     ],
   },
+  {
+    name: 'RefreshDriverTick',
+    display: ['marker-chart', 'marker-table'],
+    data: [{ key: 'name', label: 'Tick Reasons', format: 'string' }],
+  },
 ];
+
+/**
+ * For the most part, schema is matched up by the Payload's "type" field,
+ * but for practical purposes, there are a few other options, see the
+ * implementation of this function for details.
+ */
+export function getMarkerSchemaName(marker: Marker): string {
+  const { data, name } = marker;
+  // Fall back to using the name if no payload exists.
+
+  if (data) {
+    const { type } = data;
+    if (type === 'tracing' && data.category) {
+      // TODO - Tracing markers have a duplicate "category" field.
+      // See issue #2749
+      return data.category;
+    }
+    if (type === 'Text') {
+      // Text markers are a cheap and easy way to create markers with
+      // a category,
+      return marker.name;
+    }
+    return data.type;
+  }
+
+  return name;
+}
 
 /**
  * This function takes the intended marker schema for a marker field, and applies
  * the appropriate formatting function.
  */
+export function getMarkerSchema(
+  markerSchemaByName: MarkerSchemaByName,
+  marker: Marker
+): MarkerSchema | null {
+  return markerSchemaByName[getMarkerSchemaName(marker)] || null;
+}
+
 export function formatFromMarkerSchema(
   markerType: string,
   format: MarkerFormatType,
@@ -205,4 +282,43 @@ export function formatFromMarkerSchema(
       );
       return value;
   }
+}
+
+/**
+ * Marker schema can create a dynamic tooltip label. For instance a schema with
+ * a `tooltipLabel` field of "Event at {url}" would create a label based off of the
+ * "url" property in the payload.
+ */
+export function getMarkerLabelMaker(label: string): MarkerLabelMaker {
+  // Split the label on the "{key}" capture groups.
+  // Each (zero-indexed) even entry will be a string label.
+  // Each (zero-indexed) odd entry will be a key to the payload.
+  //
+  // e.g.
+  // "asdf {foo} jkl {bar}" -> ["asdf ", "foo", " jkl ", "bar"]
+  // "{foo} jkl {bar}"      -> ["", "foo", " jkl ", "bar"];
+  // "{foo}"                -> ["", "foo", ""];
+  const splits = label.split(/{(.+?)}/);
+  //                          {     } Split anytime text is in brackets.
+  //                           (   )  Capture the text inside the brackets.
+  //                            .+?   Match any character, non-greedily.
+
+  if (splits.length === 1) {
+    // Just return the label.
+    return () => label;
+  }
+
+  return data => {
+    let result: string = '';
+    for (let i = 0; i < splits.length; i++) {
+      const part = splits[i];
+      // Flip-flop between inserting a label, and looking up a value.
+      if (i % 2 === 0) {
+        result += part;
+      } else {
+        result += String(data[part]);
+      }
+    }
+    return result;
+  };
 }

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -228,7 +228,7 @@ export function getMarkerSchemaName(marker: Marker): string {
     if (type === 'Text') {
       // Text markers are a cheap and easy way to create markers with
       // a category,
-      return marker.name;
+      return name;
     }
     return data.type;
   }
@@ -293,17 +293,17 @@ export function formatFromMarkerSchema(
  */
 export function getMarkerLabelMaker(label: string): MarkerLabelMaker {
   // Split the label on the "{key}" capture groups.
-  // Each (zero-indexed) even entry will be a string label.
+  // Each (zero-indexed) even entry will be a raw string label.
   // Each (zero-indexed) odd entry will be a key to the payload.
   //
   // e.g.
   // "asdf {foo} jkl {bar}" -> ["asdf ", "foo", " jkl ", "bar"]
   // "{foo} jkl {bar}"      -> ["", "foo", " jkl ", "bar"];
   // "{foo}"                -> ["", "foo", ""];
-  const splits = label.split(/{(.+?)}/);
-  //                          {     } Split anytime text is in brackets.
-  //                           (   )  Capture the text inside the brackets.
-  //                            .+?   Match any character, non-greedily.
+  const splits = label.split(/{([^}]+)}/);
+  //                          {       } Split anytime text is in brackets.
+  //                           (     )  Capture the text inside the brackets.
+  //                            [^}]+   Match any character that is not a }.
 
   if (splits.length === 1) {
     // Just return the label.

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -184,7 +184,7 @@ export const getMarkerSchema: Selector<MarkerSchema[]> = () => markerSchema;
 export const getMarkerSchemaByName: Selector<MarkerSchemaByName> = createSelector(
   getMarkerSchema,
   schemaList => {
-    const result = {};
+    const result = Object.create(null);
     for (const schema of schemaList) {
       result[schema.name] = schema;
     }
@@ -195,7 +195,7 @@ export const getMarkerSchemaByName: Selector<MarkerSchemaByName> = createSelecto
 export const getMarkerLabelMakerByName: Selector<MarkerLabelMakerByName> = createSelector(
   getMarkerSchema,
   markerSchemaList => {
-    const results = {};
+    const results: MarkerLabelMakerByName = Object.create(null);
     for (const schema of markerSchemaList) {
       if (schema.tooltipLabel) {
         results[schema.name] = getMarkerLabelMaker(schema.tooltipLabel);

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -18,7 +18,10 @@ import {
   correlateIPCMarkers,
 } from '../profile-logic/marker-data';
 
-import { markerSchema } from '../profile-logic/marker-schema';
+import {
+  markerSchema,
+  getMarkerLabelMaker,
+} from '../profile-logic/marker-schema';
 
 import type {
   Profile,
@@ -67,6 +70,7 @@ import type {
   $ReturnType,
   MarkerSchema,
   MarkerSchemaByName,
+  MarkerLabelMakerByName,
 } from 'firefox-profiler/types';
 
 export const getProfileView: Selector<ProfileViewState> = state =>
@@ -185,6 +189,19 @@ export const getMarkerSchemaByName: Selector<MarkerSchemaByName> = createSelecto
       result[schema.name] = schema;
     }
     return result;
+  }
+);
+
+export const getMarkerLabelMakerByName: Selector<MarkerLabelMakerByName> = createSelector(
+  getMarkerSchema,
+  markerSchemaList => {
+    const results = {};
+    for (const schema of markerSchemaList) {
+      if (schema.tooltipLabel) {
+        results[schema.name] = getMarkerLabelMaker(schema.tooltipLabel);
+      }
+    }
+    return results;
   }
 );
 

--- a/src/test/components/Tooltip.test.js
+++ b/src/test/components/Tooltip.test.js
@@ -14,7 +14,10 @@ import {
 
 import { ensureExists } from '../../utils/flow';
 
-import Tooltip, { MOUSE_OFFSET } from '../../components/tooltip/Tooltip';
+import Tooltip, {
+  MOUSE_OFFSET,
+  MARGIN,
+} from '../../components/tooltip/Tooltip';
 
 describe('shared/Tooltip', () => {
   beforeEach(addRootOverlayElement);
@@ -75,8 +78,8 @@ describe('shared/Tooltip', () => {
         mouse: { x: 500, y: 300 },
       });
 
-      const expectedLeft = 0;
-      const expectedTop = 0;
+      const expectedLeft = MARGIN;
+      const expectedTop = MARGIN;
       expect(getTooltipStyle()).toEqual({
         left: `${expectedLeft}px`,
         top: `${expectedTop}px`,

--- a/src/test/components/Tooltip.test.js
+++ b/src/test/components/Tooltip.test.js
@@ -16,7 +16,7 @@ import { ensureExists } from '../../utils/flow';
 
 import Tooltip, {
   MOUSE_OFFSET,
-  MARGIN,
+  VISUAL_MARGIN,
 } from '../../components/tooltip/Tooltip';
 
 describe('shared/Tooltip', () => {
@@ -78,8 +78,8 @@ describe('shared/Tooltip', () => {
         mouse: { x: 500, y: 300 },
       });
 
-      const expectedLeft = MARGIN;
-      const expectedTop = MARGIN;
+      const expectedLeft = VISUAL_MARGIN;
+      const expectedTop = VISUAL_MARGIN;
       expect(getTooltipStyle()).toEqual({
         left: `${expectedLeft}px`,
         top: `${expectedTop}px`,

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -416,6 +416,7 @@ describe('TooltipMarker', function() {
             marker={marker}
             threadIndex={threadIndex}
             className="propClass"
+            restrictHeightWidth={true}
           />
         </Provider>
       );
@@ -449,7 +450,12 @@ describe('TooltipMarker', function() {
 
     return render(
       <Provider store={store}>
-        <TooltipMarker marker={marker} threadIndex={0} className="propClass" />
+        <TooltipMarker
+          marker={marker}
+          threadIndex={0}
+          className="propClass"
+          restrictHeightWidth={true}
+        />
       </Provider>
     );
   }
@@ -676,6 +682,7 @@ describe('TooltipMarker', function() {
           marker={marker}
           threadIndex={threadIndex}
           className="propClass"
+          restrictHeightWidth={true}
         />
       </Provider>
     );

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -136,6 +136,7 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
 >
   <div
     class="tooltipMarker"
+    style="--tooltip-detail-max-width: 600px;"
   >
     <div
       class="tooltipHeader"

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -161,13 +161,6 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
       <div
         class="tooltipLabel"
       >
-        Thread
-        :
-      </div>
-      Empty
-      <div
-        class="tooltipLabel"
-      >
         Marker
         :
       </div>
@@ -186,6 +179,13 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         :
       </div>
       UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -151,7 +151,7 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         <div
           class="tooltipTitle"
         >
-          UserTiming
+          Marker B
         </div>
       </div>
     </div>
@@ -168,10 +168,24 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
       <div
         class="tooltipLabel"
       >
-        Name
+        Marker
         :
       </div>
-      Marker B
+      UserTiming
+      <div
+        class="tooltipLabel"
+      >
+        Entry Type
+        :
+      </div>
+      measure
+      <div
+        class="tooltipLabel"
+      >
+        Description
+        :
+      </div>
+      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -51,6 +51,7 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
           Sync
           :
         </div>
+        false
         <div
           class="tooltipLabel"
         >

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -34,13 +34,6 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
         <div
           class="tooltipLabel"
         >
-          Thread
-          :
-        </div>
-        Empty
-        <div
-          class="tooltipLabel"
-        >
           Type
           :
         </div>
@@ -80,6 +73,13 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
           :
         </div>
         unknown
+        <div
+          class="tooltipLabel"
+        >
+          Thread
+          :
+        </div>
+        Empty
       </div>
     </div>
   </div>

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -9,6 +9,7 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
   >
     <div
       class="tooltipMarker"
+      style="--tooltip-detail-max-width: 100%;"
     >
       <div
         class="tooltipHeader"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -878,7 +878,7 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
         <div
           class="tooltipTitle"
         >
-          UserTiming
+          componentB
         </div>
       </div>
     </div>
@@ -895,10 +895,24 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
       <div
         class="tooltipLabel"
       >
-        Name
+        Marker
         :
       </div>
-      componentB
+      UserTiming
+      <div
+        class="tooltipLabel"
+      >
+        Entry Type
+        :
+      </div>
+      measure
+      <div
+        class="tooltipLabel"
+      >
+        Description
+        :
+      </div>
+      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -863,6 +863,7 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
 >
   <div
     class="tooltipMarker"
+    style="--tooltip-detail-max-width: 600px;"
   >
     <div
       class="tooltipHeader"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -888,13 +888,6 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
       <div
         class="tooltipLabel"
       >
-        Thread
-        :
-      </div>
-      Empty
-      <div
-        class="tooltipLabel"
-      >
         Marker
         :
       </div>
@@ -913,6 +906,13 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
         :
       </div>
       UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -62,6 +62,9 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
     </div>
     Renderer (TID: 123456)
     <div
+      class="tooltipDetailSeparator"
+    />
+    <div
       class="tooltipLabel"
     >
       Stack
@@ -1503,6 +1506,9 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
     </div>
     123
     <div
+      class="tooltipDetailSeparator"
+    />
+    <div
       class="tooltipLabel"
     >
       Stack
@@ -1735,6 +1741,9 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
       :
     </div>
     Main Thread
+    <div
+      class="tooltipDetailSeparator"
+    />
     <div
       class="tooltipLabel"
     >
@@ -2728,6 +2737,9 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
     </div>
     Main Thread
     <div
+      class="tooltipDetailSeparator"
+    />
+    <div
       class="tooltipLabel"
     >
       Stack
@@ -2974,6 +2986,9 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
       :
     </div>
     Main Thread
+    <div
+      class="tooltipDetailSeparator"
+    />
     <div
       class="tooltipLabel"
     >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1381,7 +1381,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
       <div
         class="tooltipTitle"
       >
-        DOMEvent
+        commandupdate
       </div>
     </div>
   </div>
@@ -1405,7 +1405,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
     <div
       class="tooltipLabel"
     >
-      Category
+      Marker
       :
     </div>
     DOMEvent
@@ -2541,7 +2541,7 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
     <div
       class="tooltipLabel"
     >
-      Category
+      Type
       :
     </div>
     Paint
@@ -2584,7 +2584,7 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.
     <div
       class="tooltipLabel"
     >
-      Category
+      Type
       :
     </div>
     Paint
@@ -2731,7 +2731,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
     <div
       class="tooltipLabel"
     >
-      Category
+      Type
       :
     </div>
     Paint
@@ -3246,13 +3246,6 @@ exports[`TooltipMarker renders tooltips for various markers: TTFI-21.4 1`] = `
       :
     </div>
     Main Thread
-    <div
-      class="tooltipLabel"
-    >
-      Details
-      :
-    </div>
-    TTFI after 100.01ms (longTask was 100.001ms)
   </div>
 </div>
 `;
@@ -3275,7 +3268,7 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
       <div
         class="tooltipTitle"
       >
-        UserTiming
+        foobar
       </div>
     </div>
   </div>
@@ -3292,10 +3285,24 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
     <div
       class="tooltipLabel"
     >
-      Name
+      Marker
       :
     </div>
-    foobar
+    UserTiming
+    <div
+      class="tooltipLabel"
+    >
+      Entry Type
+      :
+    </div>
+    mark
+    <div
+      class="tooltipLabel"
+    >
+      Description
+      :
+    </div>
+    UserTiming is created using the DOM APIs performance.mark() and performance.measure().
   </div>
 </div>
 `;

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -1401,7 +1401,21 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
       URL
       :
     </div>
-    https://developer.mozilla.org/en-US/
+    <div
+      class="tooltipDetailsUrl"
+    >
+      <span
+        class="tooltipDetailsDim"
+      >
+        https://
+      </span>
+      developer.mozilla.org
+      <span
+        class="tooltipDetailsDim"
+      >
+        /en-US/
+      </span>
+    </div>
     <div
       class="tooltipLabel"
     >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3,6 +3,7 @@
 exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -60,55 +61,60 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
       :
     </div>
     Renderer (TID: 123456)
-  </div>
-  <div
-    class="tooltipDetailsBackTrace"
-  >
-    <ol
-      class="backtrace"
-      style="--max-height: 30em;"
+    <div
+      class="tooltipLabel"
     >
-      <li
-        class="backtraceStackFrame"
+      Stack
+      :
+    </div>
+    <div
+      class="tooltipDetailsBackTrace"
+    >
+      <ul
+        class="backtrace"
       >
-        nsRefreshDriver::AddStyleFlushObserver
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::PostRestyleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        _main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-    </ol>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsRefreshDriver::AddStyleFlushObserver
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::PostRestyleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          XREMain::XRE_main
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          XRE_main
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          _main
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 `;
@@ -116,6 +122,7 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
 exports[`TooltipMarker renders properly network markers where content type is blank 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -287,6 +294,7 @@ exports[`TooltipMarker renders properly network markers where content type is bl
 exports[`TooltipMarker renders properly network markers where content type is missing 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -483,6 +491,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 1
 exports[`TooltipMarker renders properly network markers with a preconnect part 2`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -743,6 +752,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
 exports[`TooltipMarker renders properly network markers with a preconnect part containing only the domain lookup 2`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -929,6 +939,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
 exports[`TooltipMarker renders properly normal network markers 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1183,6 +1194,7 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
 exports[`TooltipMarker renders properly redirect network markers 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1289,6 +1301,7 @@ exports[`TooltipMarker renders properly redirect network markers 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1366,6 +1379,7 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1430,6 +1444,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
 exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profiled thread)-114.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1487,207 +1502,181 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
       :
     </div>
     123
-  </div>
-  <div
-    class="tooltipDetailsBackTrace"
-  >
-    <ol
-      class="backtrace"
-      style="--max-height: 30em;"
+    <div
+      class="tooltipLabel"
     >
-      <li
-        class="backtraceStackFrame"
+      Stack
+      :
+    </div>
+    <div
+      class="tooltipDetailsBackTrace"
+    >
+      <ul
+        class="backtrace"
       >
-        nsRefreshDriver::AddStyleFlushObserver
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::PostRestyleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsDocument::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::dom::Element::RemoveStates
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::UpdateAncestorState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::SetContentState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::NotifyMouseOut
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::GenerateMouseEnterExit
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::PreHandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEventInternal
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandlePositionedEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsViewManager::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsView::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsChildView::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        ChildViewMouseTracker::MouseMoved
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppShell::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppStartup::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_mainRun
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        _main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-    </ol>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsRefreshDriver::AddStyleFlushObserver
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::PostRestyleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsDocument::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::dom::Element::RemoveStates
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::UpdateAncestorState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::SetContentState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::NotifyMouseOut
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::GenerateMouseEnterExit
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::PreHandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEventInternal
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandlePositionedEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsViewManager::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsView::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsChildView::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          ChildViewMouseTracker::MouseMoved
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppShell::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppStartup::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        …
+      </ul>
+    </div>
   </div>
 </div>
 `;
@@ -1695,6 +1684,7 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
 exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1745,207 +1735,181 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
       :
     </div>
     Main Thread
-  </div>
-  <div
-    class="tooltipDetailsBackTrace"
-  >
-    <ol
-      class="backtrace"
-      style="--max-height: 30em;"
+    <div
+      class="tooltipLabel"
     >
-      <li
-        class="backtraceStackFrame"
+      Stack
+      :
+    </div>
+    <div
+      class="tooltipDetailsBackTrace"
+    >
+      <ul
+        class="backtrace"
       >
-        nsRefreshDriver::AddStyleFlushObserver
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::PostRestyleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsDocument::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::dom::Element::RemoveStates
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::UpdateAncestorState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::SetContentState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::NotifyMouseOut
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::GenerateMouseEnterExit
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::PreHandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEventInternal
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandlePositionedEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsViewManager::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsView::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsChildView::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        ChildViewMouseTracker::MouseMoved
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppShell::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppStartup::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_mainRun
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        _main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-    </ol>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsRefreshDriver::AddStyleFlushObserver
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::PostRestyleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsDocument::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::dom::Element::RemoveStates
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::UpdateAncestorState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::SetContentState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::NotifyMouseOut
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::GenerateMouseEnterExit
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::PreHandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEventInternal
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandlePositionedEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsViewManager::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsView::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsChildView::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          ChildViewMouseTracker::MouseMoved
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppShell::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppStartup::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        …
+      </ul>
+    </div>
   </div>
 </div>
 `;
@@ -1953,6 +1917,7 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2103,6 +2068,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
 exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2218,6 +2184,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
 exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2284,6 +2251,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = 
 exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2362,6 +2330,7 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2440,6 +2409,7 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2485,6 +2455,7 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
 exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2530,6 +2501,7 @@ exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2568,6 +2540,7 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
 exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2611,6 +2584,7 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.
 exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2656,6 +2630,7 @@ exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] =
 exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.9 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2715,6 +2690,7 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
 exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2751,207 +2727,181 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
       :
     </div>
     Main Thread
-  </div>
-  <div
-    class="tooltipDetailsBackTrace"
-  >
-    <ol
-      class="backtrace"
-      style="--max-height: 30em;"
+    <div
+      class="tooltipLabel"
     >
-      <li
-        class="backtraceStackFrame"
+      Stack
+      :
+    </div>
+    <div
+      class="tooltipDetailsBackTrace"
+    >
+      <ul
+        class="backtrace"
       >
-        nsRefreshDriver::AddStyleFlushObserver
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::PostRestyleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsDocument::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::dom::Element::RemoveStates
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::UpdateAncestorState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::SetContentState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::NotifyMouseOut
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::GenerateMouseEnterExit
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::PreHandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEventInternal
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandlePositionedEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsViewManager::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsView::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsChildView::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        ChildViewMouseTracker::MouseMoved
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppShell::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppStartup::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_mainRun
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        _main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-    </ol>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsRefreshDriver::AddStyleFlushObserver
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::PostRestyleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsDocument::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::dom::Element::RemoveStates
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::UpdateAncestorState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::SetContentState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::NotifyMouseOut
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::GenerateMouseEnterExit
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::PreHandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEventInternal
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandlePositionedEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsViewManager::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsView::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsChildView::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          ChildViewMouseTracker::MouseMoved
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppShell::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppStartup::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        …
+      </ul>
+    </div>
   </div>
 </div>
 `;
@@ -2959,6 +2909,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3023,214 +2974,188 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
       :
     </div>
     Main Thread
-  </div>
-  <div
-    class="tooltipDetailsBackTrace"
-  >
-    <h2
-      class="tooltipBackTraceTitle"
+    <div
+      class="tooltipLabel"
     >
-      First invalidated 
-      0.50
-      ms before the flush, at:
-    </h2>
-    <ol
-      class="backtrace"
-      style="--max-height: 30em;"
+      Stack
+      :
+    </div>
+    <div
+      class="tooltipDetailsBackTrace"
     >
-      <li
-        class="backtraceStackFrame"
+      <h2
+        class="tooltipBackTraceTitle"
       >
-        nsRefreshDriver::AddStyleFlushObserver
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
+        First invalidated 
+        0.50
+        ms before the flush, at:
+      </h2>
+      <ul
+        class="backtrace"
       >
-        mozilla::GeckoRestyleManager::PostRestyleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::GeckoRestyleManager::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsDocument::ContentStateChanged
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::dom::Element::RemoveStates
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::UpdateAncestorState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::SetContentState
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::NotifyMouseOut
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::GenerateMouseEnterExit
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::EventStateManager::PreHandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEventInternal
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandlePositionedEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        mozilla::PresShell::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsViewManager::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsView::HandleEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsChildView::DispatchEvent
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        ChildViewMouseTracker::MouseMoved
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppShell::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        nsAppStartup::Run
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_mainRun
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XREMain::XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        XRE_main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-      <li
-        class="backtraceStackFrame"
-      >
-        _main
-        <em
-          class="backtraceStackFrameOrigin"
-        />
-      </li>
-    </ol>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsRefreshDriver::AddStyleFlushObserver
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::PostRestyleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::GeckoRestyleManager::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsDocument::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::dom::Element::RemoveStates
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::UpdateAncestorState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::SetContentState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::NotifyMouseOut
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::GenerateMouseEnterExit
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::EventStateManager::PreHandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEventInternal
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandlePositionedEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          mozilla::PresShell::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsViewManager::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsView::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsChildView::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          ChildViewMouseTracker::MouseMoved
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppShell::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame"
+        >
+          nsAppStartup::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        …
+      </ul>
+    </div>
   </div>
 </div>
 `;
@@ -3238,6 +3163,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: TTFI-21.4 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3269,6 +3195,7 @@ exports[`TooltipMarker renders tooltips for various markers: TTFI-21.4 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`] = `
 <div
   class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -28,20 +28,6 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
     <div
       class="tooltipLabel"
     >
-      Recording Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
-      Occurring Thread
-      :
-    </div>
-    Renderer (TID: 123456)
-    <div
-      class="tooltipLabel"
-    >
       Operation
       :
     </div>
@@ -60,6 +46,20 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
       :
     </div>
     /foo/bar
+    <div
+      class="tooltipLabel"
+    >
+      Recording Thread
+      :
+    </div>
+    Empty
+    <div
+      class="tooltipLabel"
+    >
+      Occurring Thread
+      :
+    </div>
+    Renderer (TID: 123456)
   </div>
   <div
     class="tooltipDetailsBackTrace"
@@ -141,13 +141,6 @@ exports[`TooltipMarker renders properly network markers where content type is bl
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
       Status
       :
     </div>
@@ -184,6 +177,13 @@ exports[`TooltipMarker renders properly network markers where content type is bl
       :
     </div>
     45.9KB
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
   </div>
   <div
     class="tooltipNetworkPhases network-color-img"
@@ -312,13 +312,6 @@ exports[`TooltipMarker renders properly network markers where content type is mi
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
       Status
       :
     </div>
@@ -370,6 +363,13 @@ exports[`TooltipMarker renders properly network markers where content type is mi
       :
     </div>
     45.9KB
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
   </div>
   <div
     class="tooltipNetworkPhases network-color-img"
@@ -508,13 +508,6 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
       Status
       :
     </div>
@@ -566,6 +559,13 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
       :
     </div>
     45.9KB
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
   </div>
   <div
     class="tooltipNetworkPhases network-color-img"
@@ -768,13 +768,6 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
       Status
       :
     </div>
@@ -826,6 +819,13 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
       :
     </div>
     45.9KB
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
   </div>
   <div
     class="tooltipNetworkPhases network-color-img"
@@ -954,13 +954,6 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
       Status
       :
     </div>
@@ -1012,6 +1005,13 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
       :
     </div>
     45.9KB
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
   </div>
   <div
     class="tooltipNetworkPhases network-color-img"
@@ -1208,13 +1208,6 @@ exports[`TooltipMarker renders properly redirect network markers 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Empty
-    <div
-      class="tooltipLabel"
-    >
       Status
       :
     </div>
@@ -1262,6 +1255,13 @@ exports[`TooltipMarker renders properly redirect network markers 1`] = `
       :
     </div>
     0.000B
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
   </div>
   <div
     class="tooltipNetworkPhases network-color-other"
@@ -1309,13 +1309,6 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Type
       :
     </div>
@@ -1359,6 +1352,13 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
     >
       A shape guard based on TI information failed. (We saw an object whose shape does not match that / any of those observed by the baseline IC.)
     </div>
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -1391,6 +1391,13 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
     <div
       class="tooltipLabel"
     >
+      Marker
+      :
+    </div>
+    DOMEvent
+    <div
+      class="tooltipLabel"
+    >
       Thread
       :
     </div>
@@ -1416,13 +1423,6 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
         /en-US/
       </span>
     </div>
-    <div
-      class="tooltipLabel"
-    >
-      Marker
-      :
-    </div>
-    DOMEvent
   </div>
 </div>
 `;
@@ -1455,20 +1455,6 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
     <div
       class="tooltipLabel"
     >
-      Recording Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
-      Occurring Thread ID
-      :
-    </div>
-    123
-    <div
-      class="tooltipLabel"
-    >
       Operation
       :
     </div>
@@ -1487,6 +1473,20 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
       :
     </div>
     /foo/bar
+    <div
+      class="tooltipLabel"
+    >
+      Recording Thread
+      :
+    </div>
+    Main Thread
+    <div
+      class="tooltipLabel"
+    >
+      Occurring Thread ID
+      :
+    </div>
+    123
   </div>
   <div
     class="tooltipDetailsBackTrace"
@@ -1720,13 +1720,6 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Operation
       :
     </div>
@@ -1745,6 +1738,13 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
       :
     </div>
     /foo/bar
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
   <div
     class="tooltipDetailsBackTrace"
@@ -1973,13 +1973,6 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Non-incremental reason
       :
     </div>
@@ -2096,6 +2089,13 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
       :
     </div>
     14ms
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2120,13 +2120,6 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
   <div
     class="tooltipDetails"
   >
-    <div
-      class="tooltipLabel"
-    >
-      Thread
-      :
-    </div>
-    Main Thread
     <div
       class="tooltipLabel"
     >
@@ -2211,6 +2204,13 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
       :
     </div>
     1.5ms
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2235,13 +2235,6 @@ exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = 
   <div
     class="tooltipDetails"
   >
-    <div
-      class="tooltipLabel"
-    >
-      Thread
-      :
-    </div>
-    Main Thread
     <div
       class="tooltipLabel"
     >
@@ -2277,6 +2270,13 @@ exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = 
       :
     </div>
     1
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2309,13 +2309,6 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Type
       :
     </div>
@@ -2355,6 +2348,13 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
       :
     </div>
     unknown
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2387,13 +2387,6 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Type
       :
     </div>
@@ -2433,6 +2426,13 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
       :
     </div>
     unknown
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2460,13 +2460,6 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       URL
       :
     </div>
@@ -2478,6 +2471,13 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
       :
     </div>
     1,234
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2505,13 +2505,6 @@ exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Module
       :
     </div>
@@ -2523,6 +2516,13 @@ exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
       :
     </div>
     Random log message
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2550,17 +2550,17 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Type
       :
     </div>
     Paint
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2593,17 +2593,17 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Type
       :
     </div>
     Paint
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2631,13 +2631,6 @@ exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Sample start time
       :
     </div>
@@ -2649,6 +2642,13 @@ exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] =
       :
     </div>
     3,632,674,500μs
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2673,13 +2673,6 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
   <div
     class="tooltipDetails"
   >
-    <div
-      class="tooltipLabel"
-    >
-      Thread
-      :
-    </div>
-    Main Thread
     <div
       class="tooltipLabel"
     >
@@ -2708,6 +2701,13 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
       :
     </div>
     -1
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;
@@ -2740,17 +2740,17 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Type
       :
     </div>
     Paint
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
   <div
     class="tooltipDetailsBackTrace"
@@ -2984,13 +2984,6 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Elements traversed
       :
     </div>
@@ -3023,6 +3016,13 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
       :
     </div>
     20
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
   <div
     class="tooltipDetailsBackTrace"
@@ -3294,13 +3294,6 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
     <div
       class="tooltipLabel"
     >
-      Thread
-      :
-    </div>
-    Main Thread
-    <div
-      class="tooltipLabel"
-    >
       Marker
       :
     </div>
@@ -3319,6 +3312,13 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
       :
     </div>
     UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
   </div>
 </div>
 `;

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -2312,6 +2312,7 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
       Sync
       :
     </div>
+    false
     <div
       class="tooltipLabel"
     >
@@ -2389,6 +2390,7 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
       Sync
       :
     </div>
+    false
     <div
       class="tooltipLabel"
     >

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -67,27 +67,44 @@ export type MarkerDisplayLocation =
   // TODO - This is not supported yet.
   | 'stack-chart';
 
-export type MarkerSchema = {
+export type MarkerSchema = {|
   // The unique identifier for this marker.
   name: string, // e.g. "CC"
 
   // The label of how this marker should be displayed in the UI.
   // If none is provided, then the name is used.
-  label?: string, // e.g. "Cycle Collect"
+  tooltipLabel?: string, // e.g. "Cycle Collect"
 
   // The locations to display
   display: MarkerDisplayLocation[],
 
-  data: Array<{
-    key: string,
-    // If no label is provided, the key is displayed.
-    label?: string,
-    format: MarkerFormatType,
-    searchable?: boolean,
-  }>,
-};
+  data: Array<
+    | {|
+        key: string,
+        // If no label is provided, the key is displayed.
+        label?: string,
+        format: MarkerFormatType,
+        searchable?: boolean,
+      |}
+    | {|
+        // This type is a static bit of text that will be displayed
+        label: string,
+        value: string,
+      |}
+  >,
+|};
 
 export type MarkerSchemaByName = { [name: string]: MarkerSchema };
+
+// This type is a more dynamic version of the Payload type.
+type DynamicMarkerPayload = { [key: string]: any };
+// Marker schema can create a dynamic tooltip label. For instance a schema with
+// a `tooltipLabel` field of "Event at {url}" would create a label based off of the
+// "url" property in the payload.
+export type MarkerLabelMaker = DynamicMarkerPayload => string;
+export type MarkerLabelMakerByName = {
+  [name: string]: MarkerLabelMaker | void,
+};
 
 /**
  * Markers can include a stack. These are converted to a cause backtrace, which includes

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -6,6 +6,7 @@
 import type { Milliseconds, Microseconds, Seconds, Bytes } from './units';
 import type { GeckoMarkerStack } from './gecko-profile';
 import type { IndexIntoStackTable, IndexIntoStringTable } from './profile';
+import type { ObjectMap } from './utils';
 
 // Provide different formatting options for strings.
 export type MarkerFormatType =
@@ -94,7 +95,7 @@ export type MarkerSchema = {|
   >,
 |};
 
-export type MarkerSchemaByName = { [name: string]: MarkerSchema };
+export type MarkerSchemaByName = ObjectMap<MarkerSchema>;
 
 // This type is a more dynamic version of the Payload type.
 type DynamicMarkerPayload = { [key: string]: any };
@@ -102,9 +103,7 @@ type DynamicMarkerPayload = { [key: string]: any };
 // a `tooltipLabel` field of "Event at {url}" would create a label based off of the
 // "url" property in the payload.
 export type MarkerLabelMaker = DynamicMarkerPayload => string;
-export type MarkerLabelMakerByName = {
-  [name: string]: MarkerLabelMaker | void,
-};
+export type MarkerLabelMakerByName = ObjectMap<MarkerLabelMaker>;
 
 /**
  * Markers can include a stack. These are converted to a cause backtrace, which includes

--- a/src/types/utils.js
+++ b/src/types/utils.js
@@ -4,12 +4,6 @@
 
 // @flow
 
-/*
- * A not-void type
- * https://flow.org/try/#0C4TwDgpgBAcg9sAanAlgEygXigKClAHygDsBXAWwCMIAnPQqAZ2BpWIHN6jK44AbCAENiXEqT59RAQRo1BIADzCQAPlEB5SgCsIAY2ABuHDgBmpYvpRxiUMxYUAVAFywEydCoAUAN0F9SEC4OAJRBUADe9DQQwKQ0Nr7+EEYAvsZ2up4AjMFGGZ4ARMysHAW5puaZ4ba8LgDklII0dVAp5flkEu2VngDaWQA0UABMALrdFp7maBAmbBBoE5nlQA
- */
-export type NotVoidOrNull = number | string | boolean | Array<any> | Object;
-
 export type ExtractReturnType = <V>((...args: any[]) => V) => V;
 
 /**
@@ -25,3 +19,15 @@ export type IndexedArray<_IndexType, Value> = Array<Value>;
  * This is a utility type that extracts the return type of a function.
  */
 export type $ReturnType<Fn> = $Call<ExtractReturnType, Fn>;
+
+/**
+ * This type is equivalent to {[string]: T} for an object created without a prototype,
+ * e.g. Object.create(null).
+ *
+ * See: https://github.com/facebook/flow/issues/4967#issuecomment-402355640
+ */
+export type ObjectMap<T> = {
+  [string]: T,
+  // No prototype was created:
+  __proto__: null,
+};


### PR DESCRIPTION
Each commit can be read separately here. It is a collection of changes around how we deal with marker tooltips. It's also refining the marker schema in preparation for the timeline overview schema changes. I originally did that patch first, and then these. However, I felt that these were mostly unrelated, and were just about improving our existing tooltips.

The tooltips should overall have a bit more stability in their layout, and more space with padding. In addition, the marker table sidebar should be examined for changes.