### PR TITLE
Be more precise on marker schema for Text markers

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -368,11 +368,12 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
   }
 
   _renderTitle(): string {
-    const { marker, markerLabelMakerByName } = this.props;
+    const { marker, markerSchemaByName, markerLabelMakerByName } = this.props;
     const { data } = marker;
     if (data) {
       // Add the details for the markers based on their Marker schema.
-      const applyLabel = markerLabelMakerByName[getMarkerSchemaName(marker)];
+      const applyLabel =
+        markerLabelMakerByName[getMarkerSchemaName(markerSchemaByName, marker)];
       if (applyLabel) {
         return applyLabel(data);
       }

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -37,6 +37,7 @@ import type {
   IndexedArray,
   DerivedMarkerInfo,
   MarkerSchema,
+  MarkerSchemaByName,
   MarkerDisplayLocation,
 } from 'firefox-profiler/types';
 
@@ -1368,6 +1369,7 @@ export function filterMarkerByDisplayLocation(
   getMarker: MarkerIndex => Marker,
   markerIndexes: MarkerIndex[],
   markerSchema: MarkerSchema[],
+  markerSchemaByName: MarkerSchemaByName,
   displayLocation: MarkerDisplayLocation,
   // This argument allows a filtering function to customize the result, without having
   // to loop through all of the markers again. Return a boolean if making a decision,
@@ -1385,6 +1387,6 @@ export function filterMarkerByDisplayLocation(
       return additionalResult;
     }
 
-    return markerTypes.has(getMarkerSchemaName(marker));
+    return markerTypes.has(getMarkerSchemaName(markerSchemaByName, marker));
   });
 }

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -214,7 +214,10 @@ export const markerSchema: MarkerSchema[] = [
  * but for practical purposes, there are a few other options, see the
  * implementation of this function for details.
  */
-export function getMarkerSchemaName(marker: Marker): string {
+export function getMarkerSchemaName(
+  markerSchemaByName: MarkerSchemaByName,
+  marker: Marker
+): string {
   const { data, name } = marker;
   // Fall back to using the name if no payload exists.
 
@@ -227,8 +230,9 @@ export function getMarkerSchemaName(marker: Marker): string {
     }
     if (type === 'Text') {
       // Text markers are a cheap and easy way to create markers with
-      // a category,
-      return name;
+      // a category. Check for schema if it exists, if not, fallback to
+      // a Text type marker.
+      return markerSchemaByName[name] === undefined ? 'Text' : name;
     }
     return data.type;
   }
@@ -244,7 +248,9 @@ export function getMarkerSchema(
   markerSchemaByName: MarkerSchemaByName,
   marker: Marker
 ): MarkerSchema | null {
-  return markerSchemaByName[getMarkerSchemaName(marker)] || null;
+  return (
+    markerSchemaByName[getMarkerSchemaName(markerSchemaByName, marker)] || null
+  );
 }
 
 export function formatFromMarkerSchema(

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -232,6 +232,7 @@ export function getMarkerSelectorsPerThread(
     getMarkerGetter,
     getCommittedRangeAndTabFilteredMarkerIndexes,
     ProfileSelectors.getMarkerSchema,
+    ProfileSelectors.getMarkerSchemaByName,
     () => 'timeline-overview',
     MarkerData.filterMarkerByDisplayLocation
   );
@@ -400,6 +401,7 @@ export function getMarkerSelectorsPerThread(
     getMarkerGetter,
     getCommittedRangeAndTabFilteredMarkerIndexes,
     ProfileSelectors.getMarkerSchema,
+    ProfileSelectors.getMarkerSchemaByName,
     () => 'timeline-fileio',
     // Custom filtering in addition to the schema logic:
     () => MarkerData.isOnThreadFileIoMarker,
@@ -415,6 +417,7 @@ export function getMarkerSelectorsPerThread(
     getMarkerGetter,
     getCommittedRangeAndTabFilteredMarkerIndexes,
     ProfileSelectors.getMarkerSchema,
+    ProfileSelectors.getMarkerSchemaByName,
     () => 'timeline-memory',
     MarkerData.filterMarkerByDisplayLocation
   );
@@ -426,6 +429,7 @@ export function getMarkerSelectorsPerThread(
     getMarkerGetter,
     getCommittedRangeAndTabFilteredMarkerIndexes,
     ProfileSelectors.getMarkerSchema,
+    ProfileSelectors.getMarkerSchemaByName,
     () => 'timeline-ipc',
     MarkerData.filterMarkerByDisplayLocation
   );

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3199,6 +3199,13 @@ exports[`TooltipMarker renders tooltips for various markers: TTFI-21.4 1`] = `
     <div
       class="tooltipLabel"
     >
+      Details
+      :
+    </div>
+    TTFI after 100.01ms (longTask was 100.001ms)
+    <div
+      class="tooltipLabel"
+    >
       Thread
       :
     </div>


### PR DESCRIPTION
This uses schema for Text markers only if another schema doesn't exist.

Before:
<img width="697" alt="image" src="https://user-images.githubusercontent.com/1588648/93259046-d9239700-f764-11ea-8d4d-be3ba393293d.png">

After:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/1588648/93258950-b42f2400-f764-11ea-9396-2fc652ec14e2.png">
