### PR TITLE
Allow active tab view to open urls directly without thread index

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -184,23 +184,14 @@ export function finalizeProfileView(
         dispatch(finalizeFullProfileView(profile, selectedThreadIndex));
         break;
       case 'active-tab':
-        if (selectedThreadIndex === null) {
-          // Switch back over to the full view if selectedThreadIndex is not present.
-          // We check this here because if selectedThreadIndex is null, that means
-          // it's a new profile from Firefox directly and has no profile information
-          // encoded in the URL. But we only allow conversions from full view currently.
-          dispatch(finalizeFullProfileView(profile, null));
-        } else {
-          // The url state says this is an active tab view. We should compute and
-          // initialize the state relevant to that state.
-          dispatch(
-            finalizeActiveTabProfileView(
-              profile,
-              selectedThreadIndex,
-              timelineTrackOrganization.browsingContextID
-            )
-          );
-        }
+        dispatch(
+          finalizeActiveTabProfileView(
+            profile,
+            selectedThreadIndex,
+            timelineTrackOrganization.browsingContextID
+          )
+        );
+
         break;
       case 'origins': {
         if (pages) {
@@ -524,7 +515,7 @@ export function finalizeOriginProfileView(
  */
 export function finalizeActiveTabProfileView(
   profile: Profile,
-  selectedThreadIndex: ThreadIndex,
+  selectedThreadIndex: ThreadIndex | null,
   browsingContextID: BrowsingContextID | null
 ): ThunkAction<void> {
   return (dispatch, getState) => {
@@ -535,7 +526,10 @@ export function finalizeActiveTabProfileView(
       getState()
     );
 
-    // TODO: check the selectedThreadIndex and select the proper one if it's out of bound.
+    if (selectedThreadIndex === null) {
+      // Select the main track if there is no selected thread.
+      selectedThreadIndex = activeTabTimeline.mainTrack.mainThreadIndex;
+    }
 
     dispatch({
       type: 'VIEW_ACTIVE_TAB_PROFILE',

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -184,13 +184,19 @@ export function finalizeProfileView(
         dispatch(finalizeFullProfileView(profile, selectedThreadIndex));
         break;
       case 'active-tab':
-        dispatch(
-          finalizeActiveTabProfileView(
-            profile,
-            selectedThreadIndex,
-            timelineTrackOrganization.browsingContextID
-          )
-        );
+        if (pages) {
+          dispatch(
+            finalizeActiveTabProfileView(
+              profile,
+              selectedThreadIndex,
+              timelineTrackOrganization.browsingContextID
+            )
+          );
+        } else {
+          // Don't fully trust the URL, this view doesn't support the active tab based
+          // view. Switch to fulll view.
+          dispatch(finalizeFullProfileView(profile, selectedThreadIndex));
+        }
 
         break;
       case 'origins': {

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -99,7 +99,7 @@ describe('ActiveTab', function() {
 });
 
 describe('finalizeProfileView', function() {
-  function setup(search: string, withPages: boolean = true) {
+  function setup({ search, noPages }: { search: string, noPages?: boolean }) {
     const { profile } = getProfileFromTextSamples('A');
     const newUrlState = stateFromLocation({
       pathname: '/public/FAKEHASH/calltree/',
@@ -107,7 +107,7 @@ describe('finalizeProfileView', function() {
       hash: '',
     });
 
-    if (!withPages) {
+    if (noPages) {
       delete profile.pages;
     }
 
@@ -124,7 +124,7 @@ describe('finalizeProfileView', function() {
   }
 
   it('loads the profile with only `view=active-tab` in active tab view', async function() {
-    const { getState } = setup('?view=active-tab&v=5');
+    const { getState } = setup({ search: '?view=active-tab&v=5' });
 
     // Check if we can successfully finalized the profile view for active tab.
     expect(getView(getState()).phase).toBe('DATA_LOADED');
@@ -135,7 +135,10 @@ describe('finalizeProfileView', function() {
   });
 
   it('switches back to full view if there is no `pages` array', async function() {
-    const { getState } = setup('?view=active-tab&v=5', false);
+    const { getState } = setup({
+      search: '?view=active-tab&v=5',
+      noPages: true,
+    });
 
     // Check if we can successfully finalized the profile view for full view.
     expect(getView(getState()).phase).toBe('DATA_LOADED');

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
+import {
+  changeTimelineTrackOrganization,
+  viewProfile,
+} from '../../actions/receive-profile';
 import {
   getHumanReadableActiveTabTracks,
   getProfileWithNiceTracks,
@@ -12,8 +15,12 @@ import {
   getScreenshotTrackProfile,
   addActiveTabInformationToProfile,
   addMarkersToThreadWithCorrespondingSamples,
+  getProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
-import { storeWithProfile } from '../fixtures/stores';
+import { storeWithProfile, blankStore } from '../fixtures/stores';
+import { getView } from '../../selectors/app';
+import { getTimelineTrackOrganization } from '../../selectors/url-state';
+import { stateFromLocation } from '../../app-logic/url-handling';
 
 describe('ActiveTab', function() {
   function setup(p = getProfileWithNiceTracks(), addInnerWindowID = true) {
@@ -87,6 +94,37 @@ describe('ActiveTab', function() {
       const { getState } = setup(profile, false);
 
       expect(getHumanReadableActiveTabTracks(getState()).length).toBe(0);
+    });
+  });
+});
+
+describe('finalizeProfileView', function() {
+  function setup(search: string) {
+    const { profile } = getProfileFromTextSamples('A');
+    const newUrlState = stateFromLocation({
+      pathname: '/public/FAKEHASH/calltree/',
+      search: '?' + search,
+      hash: '',
+    });
+
+    const store = blankStore();
+    store.dispatch({
+      type: 'UPDATE_URL_STATE',
+      newUrlState,
+    });
+
+    store.dispatch(viewProfile(profile));
+    return store;
+  }
+
+  it('loads the profile with only `view=active-tab` in active tab view', async function() {
+    const { getState } = setup('?view=active-tab&v=5');
+
+    // Check if we can successfully finalized the profile view for active tab.
+    expect(getView(getState()).phase).toBe('DATA_LOADED');
+    expect(getTimelineTrackOrganization(getState())).toEqual({
+      type: 'active-tab',
+      browsingContextID: null,
     });
   });
 });

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -99,7 +99,7 @@ describe('ActiveTab', function() {
 });
 
 describe('finalizeProfileView', function() {
-  function setup(search: string) {
+  function setup(search: string, withPages: boolean = true) {
     const { profile } = getProfileFromTextSamples('A');
     const newUrlState = stateFromLocation({
       pathname: '/public/FAKEHASH/calltree/',
@@ -107,12 +107,18 @@ describe('finalizeProfileView', function() {
       hash: '',
     });
 
+    if (!withPages) {
+      delete profile.pages;
+    }
+
+    // Create the store and dispatch the url state.
     const store = blankStore();
     store.dispatch({
       type: 'UPDATE_URL_STATE',
       newUrlState,
     });
 
+    // Lastly, load the profile to test finalizeProfileView.
     store.dispatch(viewProfile(profile));
     return store;
   }
@@ -125,6 +131,16 @@ describe('finalizeProfileView', function() {
     expect(getTimelineTrackOrganization(getState())).toEqual({
       type: 'active-tab',
       browsingContextID: null,
+    });
+  });
+
+  it('switches back to full view if there is no `pages` array', async function() {
+    const { getState } = setup('?view=active-tab&v=5', false);
+
+    // Check if we can successfully finalized the profile view for full view.
+    expect(getView(getState()).phase).toBe('DATA_LOADED');
+    expect(getTimelineTrackOrganization(getState())).toEqual({
+      type: 'full',
     });
   });
 });


### PR DESCRIPTION
First commit removes the need for `&thread=N` need from the url since we no longer need that.  Second commit adds the check for `pages` array instead. That was also the same for origins view and I wanted to change that for active tab for some time too. Now it should be better.

[Old behavior, which loads the full view because there is no thread in the url](https://profiler.firefox.com/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?v=5&view=active-tab)
[New behavior, which loads the active tab properly](https://deploy-preview-2786--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?v=5&view=active-tab)