### PR TITLE
More improvements to ArrowPanels

### DIFF
--- a/src/components/app/MenuButtons/Permalink.js
+++ b/src/components/app/MenuButtons/Permalink.js
@@ -74,7 +74,7 @@ export class MenuButtonsPermalink extends React.PureComponent<Props, State> {
         buttonClassName="menuButtonsButton"
         ref={this._takePermalinkButtonRef}
         label="Permalink"
-        defaultOpen={this.props.isNewlyPublished}
+        initialOpen={this.props.isNewlyPublished}
         panel={
           <ArrowPanel
             className="menuButtonsPermalinkPanel"

--- a/src/components/shared/ArrowPanel.js
+++ b/src/components/shared/ArrowPanel.js
@@ -12,8 +12,11 @@ require('./ArrowPanel.css');
 type Props = {|
   +onOpen?: () => mixed,
   +onClose?: () => mixed,
-  +onOkButtonClick?: () => mixed,
-  +onCancelButtonClick?: () => mixed,
+  // If these callbacks return promises, they will be waited for before the
+  // panel is closed. To make this explicit we added Promise<mixed> even if that
+  // isn't necessary to pass Flow checks.
+  +onOkButtonClick?: () => mixed | Promise<mixed>,
+  +onCancelButtonClick?: () => mixed | Promise<mixed>,
   +className: string,
   +children: React.Node,
   +title?: string,
@@ -85,18 +88,18 @@ class ArrowPanel extends React.PureComponent<Props, State> {
     }
   };
 
-  _onOkButtonClick = () => {
-    this.close();
+  _onOkButtonClick = async () => {
     if (this.props.onOkButtonClick) {
-      this.props.onOkButtonClick();
+      await this.props.onOkButtonClick();
     }
+    this.close();
   };
 
-  _onCancelButtonClick = () => {
-    this.close();
+  _onCancelButtonClick = async () => {
     if (this.props.onCancelButtonClick) {
-      this.props.onCancelButtonClick();
+      await this.props.onCancelButtonClick();
     }
+    this.close();
   };
 
   render() {

--- a/src/components/shared/ArrowPanel.js
+++ b/src/components/shared/ArrowPanel.js
@@ -10,22 +10,22 @@ import classNames from 'classnames';
 require('./ArrowPanel.css');
 
 type Props = {|
-  onOpen?: () => mixed,
-  onClose?: () => mixed,
-  onOkButtonClick?: () => mixed,
-  onCancelButtonClick?: () => mixed,
-  className: string,
-  children: React.Node,
-  title?: string,
-  okButtonText?: string,
-  okButtonType?: 'default' | 'primary' | 'destructive',
-  cancelButtonText?: string,
+  +onOpen?: () => mixed,
+  +onClose?: () => mixed,
+  +onOkButtonClick?: () => mixed,
+  +onCancelButtonClick?: () => mixed,
+  +className: string,
+  +children: React.Node,
+  +title?: string,
+  +okButtonText?: string,
+  +okButtonType?: 'default' | 'primary' | 'destructive',
+  +cancelButtonText?: string,
 |};
 
 type State = {|
-  open: boolean,
-  isClosing: boolean,
-  openGeneration: number,
+  +open: boolean,
+  +isClosing: boolean,
+  +openGeneration: number,
 |};
 
 class ArrowPanel extends React.PureComponent<Props, State> {

--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -29,7 +29,6 @@ type Props = {|
   +panel: React.Element<
     Class<Panel & React.Component<$Subtype<PanelProps>, any>>
   >,
-  +open?: boolean,
   // This prop tells the panel to be open by default, but the open/close state is fully
   // managed by the ButtonWithPanel component.
   +defaultOpen?: boolean,
@@ -46,7 +45,7 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = { open: !!props.open };
+    this.state = { open: !!props.defaultOpen };
   }
 
   componentDidMount() {
@@ -54,7 +53,7 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
     window.addEventListener('click', this._onWindowClick);
     // the panel can be closed by pressing the Esc key
     window.addEventListener('keydown', this._onKeyDown);
-    if (this.props.open || this.props.defaultOpen) {
+    if (this.state.open) {
       this.openPanel();
     }
   }
@@ -62,12 +61,6 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
   componentWillUnmount() {
     window.removeEventListener('keydown', this._onKeyDown);
     window.removeEventListener('click', this._onWindowClick);
-  }
-
-  UNSAFE_componentWillReceiveProps(props: Props) {
-    if (props.open !== this.props.open) {
-      this.setState({ open: !!props.open });
-    }
   }
 
   _onPanelOpen = () => {

--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -31,7 +31,7 @@ type Props = {|
   >,
   // This prop tells the panel to be open by default, but the open/close state is fully
   // managed by the ButtonWithPanel component.
-  +defaultOpen?: boolean,
+  +initialOpen?: boolean,
   // The class name of the button input element.
   +buttonClassName?: string,
 |};
@@ -45,7 +45,7 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = { open: !!props.defaultOpen };
+    this.state = { open: !!props.initialOpen };
   }
 
   componentDidMount() {

--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -10,8 +10,8 @@ import classNames from 'classnames';
 import './ButtonWithPanel.css';
 
 type PanelProps = {
-  onOpen?: () => mixed,
-  onClose?: () => mixed,
+  +onOpen?: () => mixed,
+  +onClose?: () => mixed,
 };
 
 interface Panel {

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -41,7 +41,7 @@ describe('shared/ButtonWithPanel', () => {
       <ButtonWithPanel
         className="button"
         label="My Button"
-        defaultOpen={true}
+        initialOpen={true}
         panel={
           <ArrowPanel className="panel">
             <div>Panel content</div>
@@ -58,7 +58,7 @@ describe('shared/ButtonWithPanel', () => {
         <ButtonWithPanel
           className="button"
           label="My Button"
-          defaultOpen={true}
+          initialOpen={true}
           panel={
             <ArrowPanel
               className="panel"
@@ -79,7 +79,7 @@ describe('shared/ButtonWithPanel', () => {
         <ButtonWithPanel
           className="button"
           label="My Button"
-          defaultOpen={true}
+          initialOpen={true}
           panel={
             <ArrowPanel
               className="panel"
@@ -121,7 +121,7 @@ describe('shared/ButtonWithPanel', () => {
         <ButtonWithPanel
           className="button"
           label="My Button"
-          defaultOpen={true}
+          initialOpen={true}
           panel={
             <ArrowPanel className="panel">
               <div data-testid="panel-content">Panel content</div>

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -41,7 +41,7 @@ describe('shared/ButtonWithPanel', () => {
       <ButtonWithPanel
         className="button"
         label="My Button"
-        open={true}
+        defaultOpen={true}
         panel={
           <ArrowPanel className="panel">
             <div>Panel content</div>
@@ -58,7 +58,7 @@ describe('shared/ButtonWithPanel', () => {
         <ButtonWithPanel
           className="button"
           label="My Button"
-          open={true}
+          defaultOpen={true}
           panel={
             <ArrowPanel
               className="panel"
@@ -79,7 +79,7 @@ describe('shared/ButtonWithPanel', () => {
         <ButtonWithPanel
           className="button"
           label="My Button"
-          open={true}
+          defaultOpen={true}
           panel={
             <ArrowPanel
               className="panel"
@@ -121,7 +121,7 @@ describe('shared/ButtonWithPanel', () => {
         <ButtonWithPanel
           className="button"
           label="My Button"
-          open={true}
+          defaultOpen={true}
           panel={
             <ArrowPanel className="panel">
               <div data-testid="panel-content">Panel content</div>

--- a/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
+++ b/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
@@ -173,7 +173,7 @@ exports[`shared/ButtonWithPanel renders the ButtonWithPanel with a closed panel 
 </div>
 `;
 
-exports[`shared/ButtonWithPanel various panel contents renders panels with default buttons and titles 1`] = `
+exports[`shared/ButtonWithPanel with ok and cancel buttons renders panels with default buttons and titles 1`] = `
 <div
   class="buttonWithPanel button open"
 >
@@ -222,7 +222,7 @@ exports[`shared/ButtonWithPanel various panel contents renders panels with defau
 </div>
 `;
 
-exports[`shared/ButtonWithPanel various panel contents renders panels with specified buttons 1`] = `
+exports[`shared/ButtonWithPanel with ok and cancel buttons renders panels with specified buttons 1`] = `
 <div
   class="buttonWithPanel button open"
 >
@@ -235,11 +235,16 @@ exports[`shared/ButtonWithPanel various panel contents renders panels with speci
     class="arrowPanelAnchor"
   >
     <div
-      class="arrowPanel open hasButtons panel"
+      class="arrowPanel open hasTitle hasButtons panel"
     >
       <div
         class="arrowPanelArrow"
       />
+      <h1
+        class="arrowPanelTitle"
+      >
+        Wonderful content
+      </h1>
       <div
         class="arrowPanelContent"
       >


### PR DESCRIPTION
Each commit are fairly independent.

Again, this shouln't change anything with existing profiles.

Some explanations about the changes and the rationale:
1. Remove the unused 'open' property => this was used in tests only. I replaced it with `defaultOpen`. The alternative was to use only the property `open` and make it a controlled component, getting rid of the internal state and imperative functions, but that would be much more work. So instead I decided to make it a fully uncontrolled component. Previously this was in-between and not really consistent. If necessary, to reset the state we can use a key, like explained in react docs.
2. Rename `defaultOpen` to `initialOpen` => just felt more correct.
3. read-only props and state => no comment :-)
4. Make the closing of panels wait for callbacks => this is necessary so that I can keep the panel open while the delete operation is progressing, so that I can add diagnostic and show errors if they happen.
    The alternative of having buttons handled in the content instead of ArrowPanel (like you suggested in the previous patch) still has the problem that we need a way to close the panel that's not awkward. I feel like this is much more work. Note: in the publish panel we could get away with it because we switch the ButtonWithPanel to a simple Button which makes the panel just vanish, but I can't do that here.

(waiting before asking a review because I want to make sure this solves all my problems)