### PR TITLE
Make the resources header and resource item headers cursor pointer on active tab

### DIFF
--- a/src/components/timeline/ActiveTabTimeline.css
+++ b/src/components/timeline/ActiveTabTimeline.css
@@ -26,7 +26,7 @@
   position: relative;
   height: var(--resources-header-height);
   padding-left: 20px;
-  cursor: default;
+  cursor: pointer;
   font-size: 12px;
   line-height: var(--resources-header-height);
 }
@@ -101,8 +101,8 @@
   overflow: hidden;
   max-width: calc(100% - 55px);
   padding: 0 5px 0 30px;
+  cursor: pointer;
   line-height: var(--resources-header-height);
-  pointer-events: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
Fixes #2598.

[Previously](https://main--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?resources&thread=19&v=5&view=active-tab)
[Deploy preview](https://deploy-preview-2800--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/calltree/?resources&thread=19&v=5&view=active-tab)