### PR TITLE
Add delete button to the uploaded recordings panel

### DIFF
--- a/res/css/photon/confirm-dialog.css
+++ b/res/css/photon/confirm-dialog.css
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* This implements a confirm dialog using Photon components. 
+ * While not formally part of photon.
+ *
+ * This is how we can use it:
+ *
+ *  <div className="confirmDialog">
+ *    <h3 className="confirmDialogTitle">
+ *      Wonderful title
+ *    </h3>
+ *    <div className="confirmDialogContent">
+ *      Wonderful content
+ *    </div>
+ *    <div className="confirmDialogButtons">
+ *      <input
+ *        type="button"
+ *        className="photon-button photon-button-default"
+ *        value="Cancel"
+ *        onClick={doSomethingOnCancel}
+ *      />
+ *      <input
+ *        type="button"
+ *        className="photon-button photon-button-destructive"
+ *        value="Confirm"
+ *        onClick={doSomethingOnConfirm}
+ *      />
+ *    </div>
+ *  </div>
+ *
+ */
+
+.confirmDialogTitle {
+  margin: 0;
+  font-size: 1.2em;
+}
+
+.confirmDialogContent {
+  margin: 16px 0;
+}
+
+.confirmDialogButtons {
+  display: flex;
+  gap: 8px;
+}

--- a/res/css/photon/index.css
+++ b/res/css/photon/index.css
@@ -9,3 +9,4 @@
 @import './label.css';
 @import './message-bar.css';
 @import './radio-button.css';
+@import './confirm-dialog.css';

--- a/res/img/svg/check-dark.svg
+++ b/res/img/svg/check-dark.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="rgba(12, 12, 13, .8)" d="M6 14a1 1 0 0 1-.707-.293l-3-3a1 1 0 0 1 1.414-1.414l2.157 2.157 6.316-9.023a1 1 0 0 1 1.639 1.146l-7 10a1 1 0 0 1-.732.427A.863.863 0 0 1 6 14z"></path></svg>

--- a/res/img/svg/error-red.svg
+++ b/res/img/svg/error-red.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="#d70022">
+  <path fill-rule="evenodd" d="M12 6A6 6 0 1 1 0 6a6 6 0 0 1 12 0zM5.75 8a.75.75 0 0 0-.75.75v.5c0 .41.34.75.75.75h.5c.41 0 .75-.34.75-.75v-.5A.75.75 0 0 0 6.25 8h-.5zM5 6c0 .54.46 1 1 1s1-.46 1-1V3.15c0-.54-.46-1-1-1s-1 .46-1 1V6z"/>
+</svg>

--- a/res/photon/index.html
+++ b/res/photon/index.html
@@ -427,7 +427,8 @@
     <h2 class="photon-title-30">Typography</h2>
     Please look only at the font sizes and weights. We don't change colors or
     paddings with these classes..
-    <pre>
+    <div class='row'>
+      <pre>
 &lt;div class="photon-display-20"&gt;Something just happened.&lt;/div&gt;
 &lt;h4 class="photon-title-30"&gt;Title 30 followed with body 30&lt;/h4&gt;
 &lt;div class="photon-body-30"&gt;This is a large body of text.&lt;/div&gt;
@@ -438,18 +439,74 @@
 &lt;h4 class="photon-title-10"&gt;Title 10 followed with body 10&lt;/h4&gt;
 &lt;div class="photon-body-10"&gt;This is a large body of text.&lt;/div&gt;
 &lt;div class="photon-caption-10"&gt;This is a caption. Normally its color is also paler.&lt;/div&gt;
-    </pre>
-    <div class="photon-display-20">
-      Something just happened.
+      </pre>
     </div>
-    <h4 class="photon-title-30">Title 30 followed with body 30</h4>
-    <div class="photon-body-30">This is a large body of text.</div>
-    <div class="photon-caption-30">This is a caption. Normally its color is also paler.</div>
-    <h4 class="photon-title-20">Title 20 followed with body 20</h4>
-    <div class="photon-body-20">This is a large body of text.</div>
-    <div class="photon-caption-20">This is a caption. Normally its color is also paler.</div>
-    <h4 class="photon-title-10">Title 10 followed with body 10</h4>
-    <div class="photon-body-10">This is a large body of text.</div>
-    <div class="photon-caption-10">This is a caption. Normally its color is also paler.</div>
+    <div class='row'>
+      <div class="photon-display-20">
+        Something just happened.
+      </div>
+      <h4 class="photon-title-30">Title 30 followed with body 30</h4>
+      <div class="photon-body-30">This is a large body of text.</div>
+      <div class="photon-caption-30">This is a caption. Normally its color is also paler.</div>
+      <h4 class="photon-title-20">Title 20 followed with body 20</h4>
+      <div class="photon-body-20">This is a large body of text.</div>
+      <div class="photon-caption-20">This is a caption. Normally its color is also paler.</div>
+      <h4 class="photon-title-10">Title 10 followed with body 10</h4>
+      <div class="photon-body-10">This is a large body of text.</div>
+      <div class="photon-caption-10">This is a caption. Normally its color is also paler.</div>
+    </div>
+
+    <h2 class='photon-title-30'>Bigger components</h2>
+    <h3 class='photon-title-20'>Confirm dialog</h3>
+    <p>This is used to display a confirmation dialog. This will be usually used
+    inside another container.</p>
+    <div class='row'>
+      <pre>
+&lt;div className="confirmDialog"&gt;
+  &lt;h3 className="confirmDialogTitle"&gt;
+    Wonderful title
+  &lt;/h3&gt;
+  &lt;div className="confirmDialogContent"&gt;
+    Wonderful content
+  &lt;/div&gt;
+  &lt;div className="confirmDialogButtons"&gt;
+    &lt;input
+      type="button"
+      className="photon-button photon-button-default"
+      value="Cancel"
+      onClick={doSomethingOnCancel}
+    /&gt;
+    &lt;input
+      type="button"
+      className="photon-button photon-button-destructive"
+      value="Confirm"
+      onClick={doSomethingOnConfirm}
+    /&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+      </pre>
+    </div>
+    <div class='row'>
+      <div class="confirmDialog">
+        <h3 class="confirmDialogTitle">
+          Wonderful title
+        </h3>
+        <div class="confirmDialogContent">
+          Wonderful content
+        </div>
+        <div class="confirmDialogButtons">
+          <input
+            type="button"
+            class="photon-button photon-button-default"
+            value="Cancel"
+            />
+          <input
+            type="button"
+            class="photon-button photon-button-destructive"
+            value="Confirm"
+            />
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -527,7 +527,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               <h2 className="homeRecentUploadedRecordingsTitle protocol-display-xxs">
                 Recent uploaded recordings
               </h2>
-              <ListOfPublishedProfiles limit={3} />
+              <ListOfPublishedProfiles limit={3} withActionButtons={false} />
             </section>
             {/* End of grid container */}
           </section>

--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -8,32 +8,33 @@
   list-style: none;
 }
 
-.publishedProfilesDate {
-  position: absolute;
-}
-
-.publishedProfilesName {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.publishedProfilesName,
-.publishedProfilesList .profileMetaInfoSummary {
-  padding-left: 10em;
-}
-
 .publishedProfilesListItem {
   padding: 0;
 }
 
 .publishedProfilesLink {
-  display: block;
-  padding: 5px;
+  display: flex;
+  padding: 4px 8px; /* 4px as vertical padding so that it's 8 when added up, and 8px for the left and right padddings */
   color: inherit;
   text-decoration: none;
 }
 
 .publishedProfilesLink:hover {
   background: var(--grey-90-a05);
+}
+
+.publishedProfilesDate {
+  width: 10em; /* The default flex properties make that it can shrink, so this is really the initial size. */
+  padding-right: 4px;
+  white-space: nowrap;
+}
+
+.publishedProfilesInfo {
+  min-width: 0;
+}
+
+.publishedProfilesName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -100,3 +100,14 @@
     16px;
   white-space: nowrap;
 }
+
+.publishedProfilesDeleteError {
+  /* Note: 24px is: 16px (icon width) + 4px (icon padding) + 4px (distance from the text) */
+  padding-left: 24px;
+
+  /* The icon is 4px below the top */
+  background: url(../../../res/img/svg/error-red.svg) no-repeat 0 4px / 16px
+    16px;
+  color: var(--red-60);
+  word-break: break-word;
+}

--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -2,6 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/*
+ * This implements the layout of the list of recorded profiles. This is used in
+ * 2 locations: in the full uploaded recordings page, or as a small widget in
+ * the home page.
+ *
+ * This is a list, where each list item's layout is:
+ *
+ * /-----------------------------------------------------------------------------------------------------\
+ * | li.publishedProfilesListItem - This is one line in the list.                                        |
+ * | /-------------------------------------------------------------\ /---------------------------------\ |
+ * | | a.publishedProfilesLink                                     | | .publishedProfilesActionButtons | |
+ * | | /------------------------\ /------------------------------\ | |                                 | |
+ * | | | .publishedProfilesDate | | .publishedProfilesInfo       | | | (This element is optional.)     | |
+ * | | |                        | | /--------------------------\ | | |                                 | |
+ * | | |                        | | | .publishedProfilesName   | | | |  /---------------\              | |
+ * | | |                        | | \--------------------------/ | | |  | delete button |              | |
+ * | | |                        | | /--------------------------\ | | |  \---------------/              | |
+ * | | |                        | | | profile metainfo summary | | | |                                 | |
+ * | | |                        | | \--------------------------/ | | | Eventually we'll have more      | |
+ * | | \------------------------/ \------------------------------/ | | buttons here.                   | |
+ * | \-------------------------------------------------------------/ \---------------------------------/ |
+ * \-----------------------------------------------------------------------------------------------------/
+ *
+ * We use nested Flex boxes to achieve this layout.
+ */
+
 .publishedProfilesList {
   padding: 0;
   margin: 0;
@@ -9,18 +35,24 @@
 }
 
 .publishedProfilesListItem {
+  display: flex;
+  justify-content: space-between;
   padding: 0;
 }
 
 .publishedProfilesLink {
   display: flex;
+  min-width: 0;
+  flex: auto;
   padding: 4px 8px; /* 4px as vertical padding so that it's 8 when added up, and 8px for the left and right padddings */
   color: inherit;
   text-decoration: none;
 }
 
-.publishedProfilesLink:hover {
-  background: var(--grey-90-a05);
+.publishedProfilesListItem_ConfirmDialogIsOpen .publishedProfilesLink,
+.publishedProfilesListItem:hover .publishedProfilesLink,
+.publishedProfilesListItem:focus-within .publishedProfilesLink {
+  background: var(--grey-90-a10);
 }
 
 .publishedProfilesDate {
@@ -36,5 +68,35 @@
 .publishedProfilesName {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.publishedProfilesActionButtons {
+  display: flex;
+  align-self: center;
+  padding-left: 8px;
+
+  /* We use opacity so that it's still reachable with the keyboard, both
+   * backwards and forwards. Also with this technique this always stays in the
+   * accessibility tree. */
+  opacity: 0;
+}
+
+.publishedProfilesListItem_ConfirmDialogIsOpen .publishedProfilesActionButtons,
+.publishedProfilesListItem:hover .publishedProfilesActionButtons,
+.publishedProfilesListItem:focus-within .publishedProfilesActionButtons {
+  opacity: 1;
+}
+
+.publishedProfilesDeleteButton {
+  margin-left: 8px;
+}
+
+.publishedProfilesDeleteSuccess {
+  /* Note: 20px is: 16px (icon width) + 4px (distance from the text) */
+  padding-left: 20px;
+  margin: 0;
+  background: url(../../../res/img/svg/check-dark.svg) no-repeat left / 16px
+    16px;
   white-space: nowrap;
 }

--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -37,7 +37,12 @@
 .publishedProfilesListItem {
   display: flex;
   justify-content: space-between;
-  padding: 0;
+
+  /* The padding compensates for the negative margin. The negative margin is
+   * there so that the left border (implemented as a box-shadow below) go
+   * outside the line. */
+  padding: 2px 0;
+  margin: -2px 0;
 }
 
 .publishedProfilesLink {
@@ -49,10 +54,13 @@
   text-decoration: none;
 }
 
-.publishedProfilesListItem_ConfirmDialogIsOpen .publishedProfilesLink,
-.publishedProfilesListItem:hover .publishedProfilesLink,
-.publishedProfilesListItem:focus-within .publishedProfilesLink {
-  background: var(--grey-90-a10);
+.publishedProfilesLink:hover {
+  background: var(--grey-90-a05);
+}
+
+.publishedProfilesListItem_ConfirmDialogIsOpen,
+.publishedProfilesListItem:focus-within {
+  box-shadow: -3px 0 0 var(--blue-60); /* This is a border that doesn't move the content. */
 }
 
 .publishedProfilesDate {

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -74,33 +74,35 @@ type PublishedProfileProps = {|
   +nowTimestamp: Milliseconds,
 |};
 
-function PublishedProfile({
-  profileData,
-  nowTimestamp,
-}: PublishedProfileProps) {
-  let { urlPath } = profileData;
-  if (!urlPath.startsWith('/')) {
-    urlPath = '/' + urlPath;
+class PublishedProfile extends React.PureComponent<PublishedProfileProps> {
+  render() {
+    const { profileData, nowTimestamp } = this.props;
+    let { urlPath } = profileData;
+    if (!urlPath.startsWith('/')) {
+      urlPath = '/' + urlPath;
+    }
+    const location = `${window.location.origin}/${urlPath}`;
+    return (
+      <li className="publishedProfilesListItem">
+        <a className="publishedProfilesLink" href={location}>
+          <div className="publishedProfilesDate">
+            {_formatDate(profileData.publishedDate, nowTimestamp)}
+          </div>
+          <div className="publishedProfilesInfo">
+            <div className="publishedProfilesName">
+              <strong>
+                {profileData.name
+                  ? profileData.name
+                  : `Profile #${profileData.profileToken.slice(0, 6)}`}
+              </strong>{' '}
+              ({_formatRange(profileData.publishedRange)})
+            </div>
+            <ProfileMetaInfoSummary meta={profileData.meta} />
+          </div>
+        </a>
+      </li>
+    );
   }
-  const location = `${window.location.origin}/${urlPath}`;
-  return (
-    <li className="publishedProfilesListItem">
-      <a className="publishedProfilesLink" href={location}>
-        <div className="publishedProfilesDate">
-          {_formatDate(profileData.publishedDate, nowTimestamp)}
-        </div>
-        <div className="publishedProfilesName">
-          <strong>
-            {profileData.name
-              ? profileData.name
-              : `Profile #${profileData.profileToken.slice(0, 6)}`}
-          </strong>{' '}
-          ({_formatRange(profileData.publishedRange)})
-        </div>
-        <ProfileMetaInfoSummary meta={profileData.meta} />
-      </a>
-    </li>
-  );
 }
 
 type Props = {|

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -6,14 +6,19 @@
 
 import React, { PureComponent } from 'react';
 import memoize from 'memoize-immutable';
+import classNames from 'classnames';
 
 import { InnerNavigationLink } from 'firefox-profiler/components/shared/InnerNavigationLink';
+import { ProfileMetaInfoSummary } from 'firefox-profiler/components/shared/ProfileMetaInfoSummary';
+import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
+
 import {
   listAllProfileData,
+  deleteProfileData,
   type ProfileData,
 } from 'firefox-profiler/app-logic/published-profiles-store';
 import { formatSeconds } from 'firefox-profiler/utils/format-numbers';
-import { ProfileMetaInfoSummary } from 'firefox-profiler/components/shared/ProfileMetaInfoSummary';
+import { deleteProfileOnServer } from 'firefox-profiler/profile-logic/profile-store';
 
 import type { Milliseconds, StartEndRange } from 'firefox-profiler/types/units';
 
@@ -74,32 +79,151 @@ type PublishedProfileProps = {|
   +nowTimestamp: Milliseconds,
 |};
 
-class PublishedProfile extends React.PureComponent<PublishedProfileProps> {
+type PublishedProfileState = {|
+  +confirmDialogIsOpen: boolean,
+  +status: 'idle' | 'working' | 'just-deleted' | 'deleted',
+|};
+
+class PublishedProfile extends React.PureComponent<
+  PublishedProfileProps,
+  PublishedProfileState
+> {
+  state = {
+    confirmDialogIsOpen: false,
+    status: 'idle',
+  };
+  _componentDeleteButtonRef = React.createRef();
+
+  onConfirmDeletion = async () => {
+    const { profileToken, jwtToken } = this.props.profileData;
+
+    this.setState({ status: 'working' });
+    if (!jwtToken) {
+      throw new Error(
+        `We have no JWT token for this profile, so we can't delete it. This shouldn't happen.`
+      );
+    }
+    await deleteProfileOnServer({ profileToken, jwtToken });
+    await deleteProfileData(profileToken);
+    this.setState({ status: 'just-deleted' });
+  };
+
+  onCancelDeletion = () => {
+    // Close the panel when the user clicks on the Cancel button.
+    if (this._componentDeleteButtonRef.current) {
+      this._componentDeleteButtonRef.current.closePanel();
+    }
+  };
+
+  onCloseConfirmDialog = () => {
+    this.setState({ confirmDialogIsOpen: false });
+
+    // In case we deleted the profile, and the user dismisses the success panel,
+    // let's move directly to the deleted state:
+    if (this.state.status === 'just-deleted') {
+      this.setState({ status: 'deleted' });
+    }
+  };
+
+  onOpenConfirmDialog = () => {
+    this.setState({ confirmDialogIsOpen: true });
+  };
+
   render() {
     const { profileData, nowTimestamp } = this.props;
+    const { confirmDialogIsOpen, status } = this.state;
+
+    if (status === 'deleted') {
+      return null;
+    }
+
     let { urlPath } = profileData;
     if (!urlPath.startsWith('/')) {
       urlPath = '/' + urlPath;
     }
     const location = `${window.location.origin}/${urlPath}`;
+    const slicedProfileToken = profileData.profileToken.slice(0, 6);
+    const profileName = profileData.name
+      ? profileData.name
+      : `Profile #${slicedProfileToken}`;
+    const smallProfileName = profileData.name
+      ? profileData.name
+      : '#' + slicedProfileToken;
+
     return (
-      <li className="publishedProfilesListItem">
-        <a className="publishedProfilesLink" href={location}>
+      <li
+        className={classNames('publishedProfilesListItem', {
+          publishedProfilesListItem_ConfirmDialogIsOpen: confirmDialogIsOpen,
+        })}
+      >
+        <a
+          className="publishedProfilesLink"
+          href={location}
+          title={`Click here to load profile ${smallProfileName}`}
+        >
           <div className="publishedProfilesDate">
             {_formatDate(profileData.publishedDate, nowTimestamp)}
           </div>
           <div className="publishedProfilesInfo">
             <div className="publishedProfilesName">
-              <strong>
-                {profileData.name
-                  ? profileData.name
-                  : `Profile #${profileData.profileToken.slice(0, 6)}`}
-              </strong>{' '}
-              ({_formatRange(profileData.publishedRange)})
+              <strong>{profileName}</strong> (
+              {_formatRange(profileData.publishedRange)})
             </div>
             <ProfileMetaInfoSummary meta={profileData.meta} />
           </div>
         </a>
+        <div className="publishedProfilesActionButtons">
+          {profileData.jwtToken ? (
+            <ButtonWithPanel
+              ref={this._componentDeleteButtonRef}
+              buttonClassName="publishedProfilesDeleteButton photon-button photon-button-default"
+              label="Delete"
+              title={`Click here to delete the profile ${smallProfileName}`}
+              onPanelOpen={this.onOpenConfirmDialog}
+              onPanelClose={this.onCloseConfirmDialog}
+              panelContent={
+                status === 'just-deleted' ? (
+                  <p className="publishedProfilesDeleteSuccess">
+                    Successfully deleted uploaded data.
+                  </p>
+                ) : (
+                  <div className="confirmDialog">
+                    <h2 className="confirmDialogTitle">Delete {profileName}</h2>
+                    <div className="confirmDialogContent">
+                      Are you sure you want to delete uploaded data for this
+                      profile? Links for shared copies will no longer work.
+                    </div>
+                    <div className="confirmDialogButtons">
+                      <input
+                        type="button"
+                        className="photon-button photon-button-default"
+                        value="Cancel"
+                        disabled={status === 'working'}
+                        onClick={this.onCancelDeletion}
+                      />
+                      <input
+                        type="button"
+                        className="photon-button photon-button-destructive"
+                        value={status === 'working' ? 'Deleting…' : 'Delete'}
+                        disabled={status === 'working'}
+                        onClick={this.onConfirmDeletion}
+                      />
+                    </div>
+                  </div>
+                )
+              }
+            />
+          ) : (
+            <button
+              className="publishedProfilesDeleteButton photon-button photon-button-default"
+              type="button"
+              title="This profile cannot be deleted because we lack the authorization information."
+              disabled
+            >
+              Delete
+            </button>
+          )}
+        </div>
       </li>
     );
   }
@@ -166,7 +290,7 @@ export class ListOfPublishedProfiles extends PureComponent<Props, State> {
         {profilesRestCount > 0 ? (
           <p>
             <InnerNavigationLink dataSource="uploaded-recordings">
-              See all your recordings ({profilesRestCount} more)
+              See and manage all your recordings ({profilesRestCount} more)
             </InnerNavigationLink>
           </p>
         ) : null}

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -94,6 +94,8 @@ class PublishedProfile extends React.PureComponent<
     status: 'idle',
   };
   _componentDeleteButtonRef = React.createRef();
+  _domDeleteButtonRef = React.createRef();
+  _actionButtonsRef = React.createRef();
 
   onConfirmDeletion = async () => {
     const { profileToken, jwtToken } = this.props.profileData;
@@ -123,6 +125,20 @@ class PublishedProfile extends React.PureComponent<
     // let's move directly to the deleted state:
     if (this.state.status === 'just-deleted') {
       this.setState({ status: 'deleted' });
+    }
+
+    // Let's focus the delete button after dismissing the dialog, but _only_ if
+    // the focus was part of the dialog before.
+    // Note: we might need to get a more precise ref to the right
+    // buttonWithPanel wrapper when we'll have more buttons.
+    const deleteButton = this._domDeleteButtonRef.current;
+    const actionButtons = this._actionButtonsRef.current;
+    if (
+      deleteButton &&
+      actionButtons &&
+      actionButtons.matches(':focus-within')
+    ) {
+      deleteButton.focus();
     }
   };
 
@@ -174,10 +190,14 @@ class PublishedProfile extends React.PureComponent<
           </div>
         </a>
         {withActionButtons ? (
-          <div className="publishedProfilesActionButtons">
+          <div
+            className="publishedProfilesActionButtons"
+            ref={this._actionButtonsRef}
+          >
             {profileData.jwtToken ? (
               <ButtonWithPanel
                 ref={this._componentDeleteButtonRef}
+                buttonRef={this._domDeleteButtonRef}
                 buttonClassName="publishedProfilesDeleteButton photon-button photon-button-default"
                 label="Delete"
                 title={`Click here to delete the profile ${smallProfileName}`}

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -117,6 +117,11 @@ class PublishedProfile extends React.PureComponent<
         error: e,
         status: 'idle',
       });
+      // Also output the error to the console for easier debugging.
+      console.error(
+        'An error was triggered when we tried to delete a profile.',
+        e
+      );
     }
   };
 
@@ -142,12 +147,17 @@ class PublishedProfile extends React.PureComponent<
     // buttonWithPanel wrapper when we'll have more buttons.
     const deleteButton = this._domDeleteButtonRef.current;
     const actionButtons = this._actionButtonsRef.current;
-    if (
-      deleteButton &&
-      actionButtons &&
-      actionButtons.matches(':focus-within')
-    ) {
-      deleteButton.focus();
+    try {
+      if (
+        deleteButton &&
+        actionButtons &&
+        actionButtons.matches(':focus-within')
+      ) {
+        deleteButton.focus();
+      }
+    } catch (e) {
+      // This browser doesn't support :focus-within (especially JSDOM), let's
+      // degrade gracefully by not refocusing the delete button.
     }
   };
 

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -257,7 +257,8 @@ class PublishedProfile extends React.PureComponent<
                       </h2>
                       <div className="confirmDialogContent">
                         Are you sure you want to delete uploaded data for this
-                        profile? Links for shared copies will no longer work.
+                        profile? Links that were previously shared will no
+                        longer work.
                         {this._renderPossibleErrorMessage()}
                       </div>
                       <div className="confirmDialogButtons">

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -77,6 +77,7 @@ function _formatRange(range: StartEndRange): string {
 type PublishedProfileProps = {|
   +profileData: ProfileData,
   +nowTimestamp: Milliseconds,
+  +withActionButtons: boolean,
 |};
 
 type PublishedProfileState = {|
@@ -130,7 +131,7 @@ class PublishedProfile extends React.PureComponent<
   };
 
   render() {
-    const { profileData, nowTimestamp } = this.props;
+    const { profileData, nowTimestamp, withActionButtons } = this.props;
     const { confirmDialogIsOpen, status } = this.state;
 
     if (status === 'deleted') {
@@ -172,64 +173,69 @@ class PublishedProfile extends React.PureComponent<
             <ProfileMetaInfoSummary meta={profileData.meta} />
           </div>
         </a>
-        <div className="publishedProfilesActionButtons">
-          {profileData.jwtToken ? (
-            <ButtonWithPanel
-              ref={this._componentDeleteButtonRef}
-              buttonClassName="publishedProfilesDeleteButton photon-button photon-button-default"
-              label="Delete"
-              title={`Click here to delete the profile ${smallProfileName}`}
-              onPanelOpen={this.onOpenConfirmDialog}
-              onPanelClose={this.onCloseConfirmDialog}
-              panelContent={
-                status === 'just-deleted' ? (
-                  <p className="publishedProfilesDeleteSuccess">
-                    Successfully deleted uploaded data.
-                  </p>
-                ) : (
-                  <div className="confirmDialog">
-                    <h2 className="confirmDialogTitle">Delete {profileName}</h2>
-                    <div className="confirmDialogContent">
-                      Are you sure you want to delete uploaded data for this
-                      profile? Links for shared copies will no longer work.
+        {withActionButtons ? (
+          <div className="publishedProfilesActionButtons">
+            {profileData.jwtToken ? (
+              <ButtonWithPanel
+                ref={this._componentDeleteButtonRef}
+                buttonClassName="publishedProfilesDeleteButton photon-button photon-button-default"
+                label="Delete"
+                title={`Click here to delete the profile ${smallProfileName}`}
+                onPanelOpen={this.onOpenConfirmDialog}
+                onPanelClose={this.onCloseConfirmDialog}
+                panelContent={
+                  status === 'just-deleted' ? (
+                    <p className="publishedProfilesDeleteSuccess">
+                      Successfully deleted uploaded data.
+                    </p>
+                  ) : (
+                    <div className="confirmDialog">
+                      <h2 className="confirmDialogTitle">
+                        Delete {profileName}
+                      </h2>
+                      <div className="confirmDialogContent">
+                        Are you sure you want to delete uploaded data for this
+                        profile? Links for shared copies will no longer work.
+                      </div>
+                      <div className="confirmDialogButtons">
+                        <input
+                          type="button"
+                          className="photon-button photon-button-default"
+                          value="Cancel"
+                          disabled={status === 'working'}
+                          onClick={this.onCancelDeletion}
+                        />
+                        <input
+                          type="button"
+                          className="photon-button photon-button-destructive"
+                          value={status === 'working' ? 'Deleting…' : 'Delete'}
+                          disabled={status === 'working'}
+                          onClick={this.onConfirmDeletion}
+                        />
+                      </div>
                     </div>
-                    <div className="confirmDialogButtons">
-                      <input
-                        type="button"
-                        className="photon-button photon-button-default"
-                        value="Cancel"
-                        disabled={status === 'working'}
-                        onClick={this.onCancelDeletion}
-                      />
-                      <input
-                        type="button"
-                        className="photon-button photon-button-destructive"
-                        value={status === 'working' ? 'Deleting…' : 'Delete'}
-                        disabled={status === 'working'}
-                        onClick={this.onConfirmDeletion}
-                      />
-                    </div>
-                  </div>
-                )
-              }
-            />
-          ) : (
-            <button
-              className="publishedProfilesDeleteButton photon-button photon-button-default"
-              type="button"
-              title="This profile cannot be deleted because we lack the authorization information."
-              disabled
-            >
-              Delete
-            </button>
-          )}
-        </div>
+                  )
+                }
+              />
+            ) : (
+              <button
+                className="publishedProfilesDeleteButton photon-button photon-button-default"
+                type="button"
+                title="This profile cannot be deleted because we lack the authorization information."
+                disabled
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        ) : null}
       </li>
     );
   }
 }
 
 type Props = {|
+  withActionButtons: boolean,
   limit?: number,
 |};
 
@@ -254,7 +260,7 @@ export class ListOfPublishedProfiles extends PureComponent<Props, State> {
   }
 
   render() {
-    const { limit } = this.props;
+    const { limit, withActionButtons } = this.props;
     const { profileDataList } = this.state;
 
     if (!profileDataList) {
@@ -284,6 +290,7 @@ export class ListOfPublishedProfiles extends PureComponent<Props, State> {
               key={profileData.profileToken}
               profileData={profileData}
               nowTimestamp={nowTimestamp}
+              withActionButtons={withActionButtons}
             />
           ))}
         </ul>

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -86,6 +86,9 @@ type PublishedProfileState = {|
   +error: Error | null,
 |};
 
+/**
+ * This implements one line in the list of published profiles.
+ */
 class PublishedProfile extends React.PureComponent<
   PublishedProfileProps,
   PublishedProfileState

--- a/src/components/app/UploadedRecordingsHome.css
+++ b/src/components/app/UploadedRecordingsHome.css
@@ -5,6 +5,7 @@
 .uploadedRecordingsHome {
   /* Box */
   width: 95%;
+  max-width: 900px;
   box-sizing: border-box;
   padding: 3em 1em;
   border: 1px solid #ccc;
@@ -22,18 +23,11 @@
  * for the first element.
  * We also add some more padding and change how the width is computed.
  *
- * 750px and 465px, seemed like the right values when testing on Linux. Fonts
+ * These values seemed like the right values when testing on Linux. Fonts
  * are usually larger on Linux for the profiler, so in other OSes we could
  * decide that the value is too large, but this is fine. */
-@media (min-width: 750px) {
-  .uploadedRecordingsHome {
-    width: 75%;
-    max-width: 1200px;
-    padding: 6em;
-  }
-}
 
-@media (min-width: 465px) {
+@media (min-width: 600px) {
   .uploadedRecordingsHome .profileMetaInfoSummaryProductAndVersion,
   .uploadedRecordingsHome .profileMetaInfoSummaryPlatform {
     flex: none;
@@ -41,5 +35,19 @@
 
   .uploadedRecordingsHome .profileMetaInfoSummaryProductAndVersion {
     min-width: 8.5em; /* This tries to align the second element, but we allow it to grow if necessary */
+  }
+}
+
+@media (min-width: 750px) {
+  .uploadedRecordingsHome {
+    width: 90%;
+    padding: 6%;
+  }
+}
+
+@media (min-width: 1000px) {
+  .uploadedRecordingsHome {
+    width: 75%;
+    padding: 6em;
   }
 }

--- a/src/components/app/UploadedRecordingsHome.js
+++ b/src/components/app/UploadedRecordingsHome.js
@@ -19,7 +19,7 @@ export class UploadedRecordingsHome extends PureComponent<{||}> {
       <main className="uploadedRecordingsHome">
         <AppHeader />
         <h2 className="photon-title-30">Uploaded Recordings</h2>
-        <ListOfPublishedProfiles />
+        <ListOfPublishedProfiles withActionButtons={true} />
       </main>
     );
   }

--- a/src/components/shared/ButtonWithPanel/index.js
+++ b/src/components/shared/ButtonWithPanel/index.js
@@ -139,7 +139,7 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
           type="button"
           className={classNames('buttonWithPanelButton', buttonClassName)}
           value={label}
-          title={title}
+          title={open ? null : title}
           onClick={this._onButtonClick}
           ref={buttonRef}
         />

--- a/src/components/shared/ButtonWithPanel/index.js
+++ b/src/components/shared/ButtonWithPanel/index.js
@@ -43,6 +43,7 @@ type Props = {|
   +buttonClassName?: string,
   +onPanelOpen?: () => mixed,
   +onPanelClose?: () => mixed,
+  +buttonRef?: {| -current: null | HTMLInputElement |},
   +title?: string,
 |};
 
@@ -128,6 +129,7 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
       panelContent,
       panelClassName,
       buttonClassName,
+      buttonRef,
       title,
     } = this.props;
     const { open } = this.state;
@@ -139,6 +141,7 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
           value={label}
           title={title}
           onClick={this._onButtonClick}
+          ref={buttonRef}
         />
         <ArrowPanel
           className={panelClassName}

--- a/src/components/shared/ButtonWithPanel/index.js
+++ b/src/components/shared/ButtonWithPanel/index.js
@@ -43,6 +43,7 @@ type Props = {|
   +buttonClassName?: string,
   +onPanelOpen?: () => mixed,
   +onPanelClose?: () => mixed,
+  +title?: string,
 |};
 
 type State = {|
@@ -127,6 +128,7 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
       panelContent,
       panelClassName,
       buttonClassName,
+      title,
     } = this.props;
     const { open } = this.state;
     return (
@@ -135,6 +137,7 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
           type="button"
           className={classNames('buttonWithPanelButton', buttonClassName)}
           value={label}
+          title={title}
           onClick={this._onButtonClick}
         />
         <ArrowPanel

--- a/src/components/shared/ProfileMetaInfoSummary.css
+++ b/src/components/shared/ProfileMetaInfoSummary.css
@@ -6,13 +6,14 @@
 
 .profileMetaInfoSummary {
   display: flex;
+  overflow: hidden;
+  min-width: 0;
   align-items: stretch;
 }
 
 .profileMetaInfoSummaryProductAndVersion,
 .profileMetaInfoSummaryPlatform {
   overflow: hidden;
-  flex: 1;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -21,6 +21,7 @@ describe('shared/ButtonWithPanel', () => {
         className="button"
         buttonClassName="buttonButton"
         label="My Button"
+        title="Click here to open the panel"
         panelClassName="panel"
         panelContent={<div>Panel content</div>}
       />
@@ -72,6 +73,15 @@ describe('shared/ButtonWithPanel', () => {
       );
       expect(queryByTestId('panel-content')).toBeTruthy();
     });
+  });
+
+  it('displays a title only when not open', () => {
+    const { getByText } = setup();
+    const button = getByText('My Button');
+    expect(button.title).toBe('Click here to open the panel');
+    fireFullClick(button);
+    jest.runAllTimers();
+    expect(button.title).toBe('');
   });
 
   it('opens the panel when the button is clicked and closes the panel when the escape key is pressed', () => {

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -130,7 +130,7 @@ describe('ListOfPublishedProfiles', () => {
     const store = blankStore();
     const renderResult = render(
       <Provider store={store}>
-        <ListOfPublishedProfiles {...props} />
+        <ListOfPublishedProfiles withActionButtons={false} {...props} />
       </Provider>
     );
 

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -6,12 +6,18 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
+import { render, getByText as globalGetByText } from '@testing-library/react';
 
 import { ListOfPublishedProfiles } from 'firefox-profiler/components/app/ListOfPublishedProfiles';
-import { storeProfileData } from 'firefox-profiler/app-logic/published-profiles-store';
-import { blankStore } from '../fixtures/stores';
-import { mockDate } from '../fixtures/mocks/date';
+import {
+  storeProfileData,
+  retrieveProfileData,
+} from 'firefox-profiler/app-logic/published-profiles-store';
+import { ensureExists } from 'firefox-profiler/utils/flow';
+import { blankStore } from 'firefox-profiler/test/fixtures/stores';
+import { mockDate } from 'firefox-profiler/test/fixtures/mocks/date';
+import { fireFullClick } from 'firefox-profiler/test/fixtures/utils';
+import { Response } from 'firefox-profiler/test/fixtures/mocks/response';
 
 import 'fake-indexeddb/auto';
 import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
@@ -29,7 +35,7 @@ afterEach(resetIndexedDb);
 const listOfProfileInformations = [
   {
     profileToken: '0123456789',
-    jwtToken: null,
+    jwtToken: 'FAKE_TOKEN',
     publishedDate: new Date('4 Jul 2020 14:00'), // "today" earlier
     name: '',
     preset: null,
@@ -134,15 +140,70 @@ describe('ListOfPublishedProfiles', () => {
       </Provider>
     );
 
-    const { getByText } = renderResult;
+    const { getByText, getByTitle, container } = renderResult;
 
     function getAllRecordingsLink() {
       return getByText(/all your recordings/);
     }
 
+    function getDeleteButtonForProfile(
+      profileName: string
+    ): HTMLInputElement | HTMLButtonElement {
+      const workingButton = getByTitle(new RegExp(`delete.*${profileName}`));
+      if (
+        !(workingButton instanceof HTMLInputElement) &&
+        !(workingButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error(
+          "Oops, the delete button should be a HTMLInputElement or HTMLButtonElement, but it isn't!"
+        );
+      }
+
+      return workingButton;
+    }
+
+    function getConfirmDeleteButton() {
+      const panelContent = ensureExists(
+        container.querySelector('.arrowPanelContent'),
+        "Expected that an ArrowPanel was rendered, but it's not there."
+      );
+      const confirmButton = globalGetByText(panelContent, 'Delete');
+      if (
+        !(confirmButton instanceof HTMLInputElement) &&
+        !(confirmButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error(
+          "Oops, the confirm button should be a HTMLInputElement or HTMLButtonElement, but it isn't!"
+        );
+      }
+
+      return confirmButton;
+    }
+
+    function getCancelDeleteButton() {
+      const panelContent = ensureExists(
+        container.querySelector('.arrowPanelContent'),
+        "Expected that an ArrowPanel was rendered, but it's not there."
+      );
+      const confirmButton = globalGetByText(panelContent, 'Cancel');
+      if (
+        !(confirmButton instanceof HTMLInputElement) &&
+        !(confirmButton instanceof HTMLButtonElement)
+      ) {
+        throw new Error(
+          "Oops, the confirm button should be a HTMLInputElement or HTMLButtonElement, but it isn't!"
+        );
+      }
+
+      return confirmButton;
+    }
+
     return {
       ...renderResult,
       getAllRecordingsLink,
+      getDeleteButtonForProfile,
+      getConfirmDeleteButton,
+      getCancelDeleteButton,
     };
   }
 
@@ -163,5 +224,189 @@ describe('ListOfPublishedProfiles', () => {
     const { findByText, getAllRecordingsLink } = setup({ limit: 3 });
     await findByText(/Layout profile/);
     expect(() => getAllRecordingsLink()).toThrow('Unable to find an element');
+  });
+
+  it('renders action buttons when appropriate', async () => {
+    await storeProfileInformations(listOfProfileInformations);
+    const { findByText, getAllByText, getDeleteButtonForProfile } = setup({
+      withActionButtons: true,
+    });
+
+    // Wait for the full rendering with a find* operation.
+    await findByText(/macOS/);
+
+    // Only this button isn't disabled, because it's the only one with the JWT information.
+    const workingButton = getDeleteButtonForProfile('#012345');
+    expect(workingButton.disabled).toBe(false);
+
+    // All others are disabled.
+    const allButtons = getAllByText('Delete');
+    for (const button of allButtons) {
+      if (button !== workingButton) {
+        // $FlowExpectError findAllByText returns HTMLElement, but we know these are buttons.
+        expect(button.disabled).toBe(true); // eslint-disable-line jest/no-conditional-expect
+      }
+    }
+  });
+
+  describe('profile deletion', () => {
+    beforeEach(() => {
+      window.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      delete window.fetch;
+    });
+
+    function mockFetchForDeleteProfile({
+      endpointUrl,
+      jwtToken,
+    }: {
+      endpointUrl: string,
+      jwtToken: string,
+    }) {
+      window.fetch.mockImplementation(async (urlString, options) => {
+        if (urlString !== endpointUrl) {
+          return new Response(null, { status: 404, statusText: 'Not found' });
+        }
+
+        const { method, headers } = options;
+
+        if (method !== 'DELETE') {
+          return new Response(null, {
+            status: 405,
+            statusText: 'Method not allowed',
+          });
+        }
+
+        if (
+          headers['Content-Type'] !== 'application/json' ||
+          headers.Accept !== 'application/vnd.firefox-profiler+json;version=1.0'
+        ) {
+          return new Response(null, {
+            status: 406,
+            statusText: 'Not acceptable',
+          });
+        }
+
+        if (headers.Authorization !== `Bearer ${jwtToken}`) {
+          return new Response(null, {
+            status: 401,
+            statusText: 'Forbidden',
+          });
+        }
+
+        return new Response('Profile successfully deleted.', { status: 200 });
+      });
+    }
+
+    it('can delete profiles', async () => {
+      const { profileToken, jwtToken } = listOfProfileInformations[0];
+      const endpointUrl = `https://api.profiler.firefox.com/profile/${profileToken}`;
+      mockFetchForDeleteProfile({ endpointUrl, jwtToken });
+
+      jest.useFakeTimers(); // ButtonWithPanel has some asynchronous behavior.
+      await storeProfileInformations(listOfProfileInformations);
+      const {
+        container,
+        getDeleteButtonForProfile,
+        findByText,
+        queryByText,
+        getConfirmDeleteButton,
+      } = setup({
+        withActionButtons: true,
+      });
+
+      // Wait for the full rendering with a find* operation.
+      await findByText(/macOS/);
+      const workingButton = getDeleteButtonForProfile('#012345');
+
+      // Click on the delete button
+      fireFullClick(workingButton);
+      jest.runAllTimers(); // Opening the panel involves a timeout.
+      expect(container.querySelector('.arrowPanelContent')).toMatchSnapshot();
+
+      // Click on the confirm button
+      fireFullClick(getConfirmDeleteButton());
+      await findByText(/successfully/i);
+      expect(await retrieveProfileData(profileToken)).toBe(undefined);
+
+      // Clicking elsewhere should make the successful message disappear.
+      fireFullClick((window: any));
+      expect(queryByText(/successfully/i)).toBe(null);
+    });
+
+    it('can cancel the deletion', async () => {
+      const { profileToken } = listOfProfileInformations[0];
+
+      jest.useFakeTimers(); // ButtonWithPanel has some asynchronous behavior.
+      await storeProfileInformations(listOfProfileInformations);
+      const {
+        getDeleteButtonForProfile,
+        findByText,
+        queryByText,
+        getCancelDeleteButton,
+      } = setup({
+        withActionButtons: true,
+      });
+
+      // Wait for the full rendering with a find* operation.
+      await findByText(/macOS/);
+      const workingButton = getDeleteButtonForProfile('#012345');
+
+      // Click on the delete button
+      fireFullClick(workingButton);
+      jest.runAllTimers(); // Opening the panel involves a timeout.
+
+      // Click on the cancel button
+      fireFullClick(getCancelDeleteButton());
+      jest.runAllTimers(); // Closing the panel involves a timeout too.
+      expect(queryByText(/are you sure/i)).toBe(null);
+      expect(await retrieveProfileData(profileToken)).toEqual(
+        listOfProfileInformations[0]
+      );
+    });
+
+    it('can handle errors', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { profileToken } = listOfProfileInformations[0];
+      const endpointUrl = `https://api.profiler.firefox.com/profile/${profileToken}`;
+      mockFetchForDeleteProfile({
+        endpointUrl,
+        jwtToken: 'THIS_TOKEN_IS_UNKNOWN',
+      });
+
+      jest.useFakeTimers(); // ButtonWithPanel has some asynchronous behavior.
+      await storeProfileInformations(listOfProfileInformations);
+      const {
+        getDeleteButtonForProfile,
+        findByText,
+        getByText,
+        getConfirmDeleteButton,
+      } = setup({
+        withActionButtons: true,
+      });
+
+      // Wait for the full rendering with a find* operation.
+      await findByText(/macOS/);
+      const workingButton = getDeleteButtonForProfile('#012345');
+
+      fireFullClick(workingButton);
+      jest.runAllTimers(); // Opening the panel involves a timeout.
+
+      fireFullClick(getConfirmDeleteButton());
+      await findByText(/An error happened/i);
+      const hoverLink = getByText(/Hover to know more/);
+      expect(hoverLink.title).toEqual(
+        'An error happened while deleting the profile with the token "0123456789": Forbidden (401)'
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(/when we tried to delete a profile/),
+        expect.any(Error)
+      );
+      expect(await retrieveProfileData(profileToken)).toEqual(
+        listOfProfileInformations[0]
+      );
+    });
   });
 });

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -137,7 +137,7 @@ describe('ListOfPublishedProfiles', () => {
     const { getByText } = renderResult;
 
     function getAllRecordingsLink() {
-      return getByText(/See all your recordings/);
+      return getByText(/all your recordings/);
     }
 
     return {

--- a/src/test/components/UploadedRecordingsHome.test.js
+++ b/src/test/components/UploadedRecordingsHome.test.js
@@ -51,7 +51,7 @@ describe('UploadedRecordingsHome', () => {
     // 1. Add some profiles to the local indexeddb.
     await storeProfileData({
       profileToken: '0123456789',
-      jwtToken: null,
+      jwtToken: 'FAKE_TOKEN',
       publishedDate: new Date('4 Jul 2020 14:00'), // "today" earlier
       name: '',
       preset: null,

--- a/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
+++ b/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
@@ -36,6 +36,7 @@ exports[`shared/ButtonWithPanel opens the panel when the button is clicked and c
 >
   <input
     class="buttonWithPanelButton buttonButton"
+    title="Click here to open the panel"
     type="button"
     value="My Button"
   />
@@ -96,6 +97,7 @@ exports[`shared/ButtonWithPanel opens the panel when the button is clicked and c
 >
   <input
     class="buttonWithPanelButton buttonButton"
+    title="Click here to open the panel"
     type="button"
     value="My Button"
   />
@@ -156,6 +158,7 @@ exports[`shared/ButtonWithPanel renders the ButtonWithPanel with a closed panel 
 >
   <input
     class="buttonWithPanelButton buttonButton"
+    title="Click here to open the panel"
     type="button"
     value="My Button"
   />

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -194,6 +194,7 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
         </h2>
         <list-of-published-profiles
           limit="3"
+          withactionbuttons="false"
         />
       </section>
     </section>
@@ -367,6 +368,7 @@ exports[`app/Home renders the install screen for the extension 1`] = `
         </h2>
         <list-of-published-profiles
           limit="3"
+          withactionbuttons="false"
         />
       </section>
     </section>
@@ -563,6 +565,7 @@ exports[`app/Home renders the usage instructions for pages with the extension in
         </h2>
         <list-of-published-profiles
           limit="3"
+          withactionbuttons="false"
         />
       </section>
     </section>

--- a/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
+++ b/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
@@ -139,3 +139,39 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
   </li>
 </ul>
 `;
+
+exports[`ListOfPublishedProfiles profile deletion can delete profiles 1`] = `
+<div
+  class="arrowPanelContent"
+>
+  <div
+    class="confirmDialog"
+  >
+    <h2
+      class="confirmDialogTitle"
+    >
+      Delete 
+      Profile #012345
+    </h2>
+    <div
+      class="confirmDialogContent"
+    >
+      Are you sure you want to delete uploaded data for this profile? Links for shared copies will no longer work.
+    </div>
+    <div
+      class="confirmDialogButtons"
+    >
+      <input
+        class="photon-button photon-button-default"
+        type="button"
+        value="Cancel"
+      />
+      <input
+        class="photon-button photon-button-destructive"
+        type="button"
+        value="Delete"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
+++ b/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
@@ -48,18 +48,6 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
         </div>
       </div>
     </a>
-    <div
-      class="publishedProfilesActionButtons"
-    >
-      <button
-        class="publishedProfilesDeleteButton photon-button photon-button-default"
-        disabled=""
-        title="This profile cannot be deleted because we lack the authorization information."
-        type="button"
-      >
-        Delete
-      </button>
-    </div>
   </li>
   <li
     class="publishedProfilesListItem"
@@ -103,18 +91,6 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
         </div>
       </div>
     </a>
-    <div
-      class="publishedProfilesActionButtons"
-    >
-      <button
-        class="publishedProfilesDeleteButton photon-button photon-button-default"
-        disabled=""
-        title="This profile cannot be deleted because we lack the authorization information."
-        type="button"
-      >
-        Delete
-      </button>
-    </div>
   </li>
   <li
     class="publishedProfilesListItem"
@@ -160,18 +136,6 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
         </div>
       </div>
     </a>
-    <div
-      class="publishedProfilesActionButtons"
-    >
-      <button
-        class="publishedProfilesDeleteButton photon-button photon-button-default"
-        disabled=""
-        title="This profile cannot be deleted because we lack the authorization information."
-        type="button"
-      >
-        Delete
-      </button>
-    </div>
   </li>
 </ul>
 `;

--- a/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
+++ b/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
@@ -10,6 +10,7 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
     <a
       class="publishedProfilesLink"
       href="http://localhost//public/MACOSX/marker-chart/"
+      title="Click here to load profile MacOS X profile"
     >
       <div
         class="publishedProfilesDate"
@@ -17,33 +18,48 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
         Jul 5, 2020
       </div>
       <div
-        class="publishedProfilesName"
-      >
-        <strong>
-          MacOS X profile
-        </strong>
-         
-        (
-        38.0s
-        )
-      </div>
-      <div
-        class="profileMetaInfoSummary"
+        class="publishedProfilesInfo"
       >
         <div
-          class="profileMetaInfoSummaryProductAndVersion"
-          data-product="Firefox"
+          class="publishedProfilesName"
         >
-          Firefox 62
+          <strong>
+            MacOS X profile
+          </strong>
+           (
+          38.0s
+          )
         </div>
         <div
-          class="profileMetaInfoSummaryPlatform"
-          data-toolkit="macOS 10.12"
+          class="profileMetaInfoSummary"
         >
-          macOS 10.12
+          <div
+            class="profileMetaInfoSummaryProductAndVersion"
+            data-product="Firefox"
+          >
+            Firefox 62
+          </div>
+          <div
+            class="profileMetaInfoSummaryPlatform"
+            data-toolkit="macOS 10.12"
+          >
+            macOS 10.12
+          </div>
         </div>
       </div>
     </a>
+    <div
+      class="publishedProfilesActionButtons"
+    >
+      <button
+        class="publishedProfilesDeleteButton photon-button photon-button-default"
+        disabled=""
+        title="This profile cannot be deleted because we lack the authorization information."
+        type="button"
+      >
+        Delete
+      </button>
+    </div>
   </li>
   <li
     class="publishedProfilesListItem"
@@ -51,6 +67,7 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
     <a
       class="publishedProfilesLink"
       href="http://localhost//"
+      title="Click here to load profile #012345"
     >
       <div
         class="publishedProfilesDate"
@@ -58,31 +75,46 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
         2:00 PM
       </div>
       <div
-        class="publishedProfilesName"
-      >
-        <strong>
-          Profile #012345
-        </strong>
-         
-        (
-        2.0s
-        )
-      </div>
-      <div
-        class="profileMetaInfoSummary"
+        class="publishedProfilesInfo"
       >
         <div
-          class="profileMetaInfoSummaryProductAndVersion"
-          data-product="Fennec"
+          class="publishedProfilesName"
         >
-          Fennec
+          <strong>
+            Profile #012345
+          </strong>
+           (
+          2.0s
+          )
         </div>
         <div
-          class="profileMetaInfoSummaryPlatform"
-          data-toolkit=""
-        />
+          class="profileMetaInfoSummary"
+        >
+          <div
+            class="profileMetaInfoSummaryProductAndVersion"
+            data-product="Fennec"
+          >
+            Fennec
+          </div>
+          <div
+            class="profileMetaInfoSummaryPlatform"
+            data-toolkit=""
+          />
+        </div>
       </div>
     </a>
+    <div
+      class="publishedProfilesActionButtons"
+    >
+      <button
+        class="publishedProfilesDeleteButton photon-button photon-button-default"
+        disabled=""
+        title="This profile cannot be deleted because we lack the authorization information."
+        type="button"
+      >
+        Delete
+      </button>
+    </div>
   </li>
   <li
     class="publishedProfilesListItem"
@@ -90,6 +122,7 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
     <a
       class="publishedProfilesLink"
       href="http://localhost//public/WINDOWS/marker-chart/"
+      title="Click here to load profile Another good profile"
     >
       <div
         class="publishedProfilesDate"
@@ -97,33 +130,48 @@ exports[`ListOfPublishedProfiles limits the number of rendered profiles with the
         1:00 PM
       </div>
       <div
-        class="publishedProfilesName"
-      >
-        <strong>
-          Another good profile
-        </strong>
-         
-        (
-        38.0s
-        )
-      </div>
-      <div
-        class="profileMetaInfoSummary"
+        class="publishedProfilesInfo"
       >
         <div
-          class="profileMetaInfoSummaryProductAndVersion"
-          data-product="Firefox"
+          class="publishedProfilesName"
         >
-          Firefox 77
+          <strong>
+            Another good profile
+          </strong>
+           (
+          38.0s
+          )
         </div>
         <div
-          class="profileMetaInfoSummaryPlatform"
-          data-toolkit="Windows 10"
+          class="profileMetaInfoSummary"
         >
-          Windows 10
+          <div
+            class="profileMetaInfoSummaryProductAndVersion"
+            data-product="Firefox"
+          >
+            Firefox 77
+          </div>
+          <div
+            class="profileMetaInfoSummaryPlatform"
+            data-toolkit="Windows 10"
+          >
+            Windows 10
+          </div>
         </div>
       </div>
     </a>
+    <div
+      class="publishedProfilesActionButtons"
+    >
+      <button
+        class="publishedProfilesDeleteButton photon-button photon-button-default"
+        disabled=""
+        title="This profile cannot be deleted because we lack the authorization information."
+        type="button"
+      >
+        Delete
+      </button>
+    </div>
   </li>
 </ul>
 `;

--- a/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
+++ b/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
@@ -156,7 +156,7 @@ exports[`ListOfPublishedProfiles profile deletion can delete profiles 1`] = `
     <div
       class="confirmDialogContent"
     >
-      Are you sure you want to delete uploaded data for this profile? Links for shared copies will no longer work.
+      Are you sure you want to delete uploaded data for this profile? Links that were previously shared will no longer work.
     </div>
     <div
       class="confirmDialogButtons"

--- a/src/test/components/__snapshots__/UploadedRecordingsHome.test.js.snap
+++ b/src/test/components/__snapshots__/UploadedRecordingsHome.test.js.snap
@@ -61,6 +61,7 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
       <a
         class="publishedProfilesLink"
         href="http://localhost//public/MACOSX/marker-chart/"
+        title="Click here to load profile MacOS X profile"
       >
         <div
           class="publishedProfilesDate"
@@ -68,33 +69,48 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
           Jul 5, 2020
         </div>
         <div
-          class="publishedProfilesName"
-        >
-          <strong>
-            MacOS X profile
-          </strong>
-           
-          (
-          38.0s
-          )
-        </div>
-        <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Firefox"
+            class="publishedProfilesName"
           >
-            Firefox 62
+            <strong>
+              MacOS X profile
+            </strong>
+             (
+            38.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit="macOS 10.12"
+            class="profileMetaInfoSummary"
           >
-            macOS 10.12
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 62
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="macOS 10.12"
+            >
+              macOS 10.12
+            </div>
           </div>
         </div>
       </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
     </li>
     <li
       class="publishedProfilesListItem"
@@ -102,6 +118,7 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
       <a
         class="publishedProfilesLink"
         href="http://localhost//"
+        title="Click here to load profile #012345"
       >
         <div
           class="publishedProfilesDate"
@@ -109,31 +126,46 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
           2:00 PM
         </div>
         <div
-          class="publishedProfilesName"
-        >
-          <strong>
-            Profile #012345
-          </strong>
-           
-          (
-          2.0s
-          )
-        </div>
-        <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Fennec"
+            class="publishedProfilesName"
           >
-            Fennec
+            <strong>
+              Profile #012345
+            </strong>
+             (
+            2.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit=""
-          />
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Fennec"
+            >
+              Fennec
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit=""
+            />
+          </div>
         </div>
       </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
     </li>
     <li
       class="publishedProfilesListItem"
@@ -141,6 +173,7 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
       <a
         class="publishedProfilesLink"
         href="http://localhost//public/WINDOWS/marker-chart/"
+        title="Click here to load profile Another good profile"
       >
         <div
           class="publishedProfilesDate"
@@ -148,33 +181,48 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
           1:00 PM
         </div>
         <div
-          class="publishedProfilesName"
-        >
-          <strong>
-            Another good profile
-          </strong>
-           
-          (
-          38.0s
-          )
-        </div>
-        <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Firefox"
+            class="publishedProfilesName"
           >
-            Firefox 77
+            <strong>
+              Another good profile
+            </strong>
+             (
+            38.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit="Windows 10"
+            class="profileMetaInfoSummary"
           >
-            Windows 10
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 77
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Windows 10"
+            >
+              Windows 10
+            </div>
           </div>
         </div>
       </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
     </li>
     <li
       class="publishedProfilesListItem"
@@ -182,6 +230,7 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
       <a
         class="publishedProfilesLink"
         href="http://localhost//"
+        title="Click here to load profile Layout profile"
       >
         <div
           class="publishedProfilesDate"
@@ -189,33 +238,48 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
           Jul 3, 8:00 AM
         </div>
         <div
-          class="publishedProfilesName"
-        >
-          <strong>
-            Layout profile
-          </strong>
-           
-          (
-          0.0s
-          )
-        </div>
-        <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Firefox"
+            class="publishedProfilesName"
           >
-            Firefox 68
+            <strong>
+              Layout profile
+            </strong>
+             (
+            0.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit="Linux"
+            class="profileMetaInfoSummary"
           >
-            Linux
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 68
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Linux"
+            >
+              Linux
+            </div>
           </div>
         </div>
       </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
     </li>
     <li
       class="publishedProfilesListItem"
@@ -223,6 +287,7 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
       <a
         class="publishedProfilesLink"
         href="http://localhost//public/123abc456/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&search=bla&thread=11&v=5"
+        title="Click here to load profile #123abc"
       >
         <div
           class="publishedProfilesDate"
@@ -230,33 +295,48 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
           May 20, 2018
         </div>
         <div
-          class="publishedProfilesName"
-        >
-          <strong>
-            Profile #123abc
-          </strong>
-           
-          (
-          0.0s
-          )
-        </div>
-        <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Firefox Preview"
+            class="publishedProfilesName"
           >
-            Firefox Preview 80
+            <strong>
+              Profile #123abc
+            </strong>
+             (
+            0.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit="Android 7"
+            class="profileMetaInfoSummary"
           >
-            Android 7
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox Preview"
+            >
+              Firefox Preview 80
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Android 7"
+            >
+              Android 7
+            </div>
           </div>
         </div>
       </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
     </li>
   </ul>
 </main>

--- a/src/test/components/__snapshots__/UploadedRecordingsHome.test.js.snap
+++ b/src/test/components/__snapshots__/UploadedRecordingsHome.test.js.snap
@@ -157,14 +157,16 @@ exports[`UploadedRecordingsHome matches a snapshot when rendering published prof
       <div
         class="publishedProfilesActionButtons"
       >
-        <button
-          class="publishedProfilesDeleteButton photon-button photon-button-default"
-          disabled=""
-          title="This profile cannot be deleted because we lack the authorization information."
-          type="button"
+        <div
+          class="buttonWithPanel"
         >
-          Delete
-        </button>
+          <input
+            class="buttonWithPanelButton publishedProfilesDeleteButton photon-button photon-button-default"
+            title="Click here to delete the profile #012345"
+            type="button"
+            value="Delete"
+          />
+        </div>
       </div>
     </li>
     <li


### PR DESCRIPTION
The first commit is a squashed #2797 so you don't need to look at it.

The second commit adds standard styles for a confirm dialog. The alternative is what I did initially and that you can look in https://github.com/julienw/perf.html/commit/0d2a8dc7ef63ad340121bde3aaf6aaa9d180fc2d and https://github.com/julienw/perf.html/commit/16c891b1a54d17e8cc45beaf6aa940773793346d. After trying both, now I think that the complexity that the old approach brought wasn't worth it, but I'd be happy to get your feedback.

The other commits should be quite straightforward, I tried to have small commits that help show how the various features are implemented separately.

There's a design/style choice that I can make explicit:
* the buttons (they include the confirm panel) are outside the links because otherwise the focus/click handling is very weird.
* the :hover effect is on the link and not the full LI, because otherwise it would be trigger on zones that have no action.
* also, I used the :hover effect when hovering the delete button too, so that it's clear for the user that this delete button relates to this profile information. I found it useful in bigger screens, where the delete button could be somewhat farther from the other text.

Here is the deploy preview, but first you'll need to upload some profiles using this deploy-preview too. For example you can re-publish this profile several times to get several entries.
Here is the [deploy preview](https://deploy-preview-2802--perf-html.netlify.app/uploaded-recordings/) but first you'll need to upload some profiles using this deploy-preview too. For example you can re-publish [this profile](https://deploy-preview-2802--perf-html.netlify.app/public/8787b63a23826e740ed2f5f11fd4a7cc98232ae6/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&search=bla&thread=11&v=5) several times to get several entries.

Known issue: I found this when I did a final check before the review. When deleting the last one, we don't get the message `No profile has been published yet!` until we reload the page, instead we have an empty list. This is because how I handle the deletion: the component representing a line returns `null` when it's deleted, instead of rerendering the full list. This is a bit of a hack, but maybe we can handle this in a follow-up so that we can move forward.