### PR TITLE
Extract the delete button into its own component

### DIFF
--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -99,23 +99,3 @@
 .publishedProfilesDeleteButton {
   margin-left: 8px;
 }
-
-.publishedProfilesDeleteSuccess {
-  /* Note: 20px is: 16px (icon width) + 4px (distance from the text) */
-  padding-left: 20px;
-  margin: 0;
-  background: url(../../../res/img/svg/check-dark.svg) no-repeat left / 16px
-    16px;
-  white-space: nowrap;
-}
-
-.publishedProfilesDeleteError {
-  /* Note: 24px is: 16px (icon width) + 4px (icon padding) + 4px (distance from the text) */
-  padding-left: 24px;
-
-  /* The icon is 4px below the top */
-  background: url(../../../res/img/svg/error-red.svg) no-repeat 0 4px / 16px
-    16px;
-  color: var(--red-60);
-  word-break: break-word;
-}

--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -10,15 +10,13 @@ import classNames from 'classnames';
 
 import { InnerNavigationLink } from 'firefox-profiler/components/shared/InnerNavigationLink';
 import { ProfileMetaInfoSummary } from 'firefox-profiler/components/shared/ProfileMetaInfoSummary';
-import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
+import { ProfileDeleteButton } from './ProfileDeleteButton';
 
 import {
   listAllProfileData,
-  deleteProfileData,
   type ProfileData,
 } from 'firefox-profiler/app-logic/published-profiles-store';
 import { formatSeconds } from 'firefox-profiler/utils/format-numbers';
-import { deleteProfileOnServer } from 'firefox-profiler/profile-logic/profile-store';
 
 import type { Milliseconds, StartEndRange } from 'firefox-profiler/types/units';
 
@@ -82,8 +80,7 @@ type PublishedProfileProps = {|
 
 type PublishedProfileState = {|
   +confirmDialogIsOpen: boolean,
-  +status: 'idle' | 'working' | 'just-deleted' | 'deleted',
-  +error: Error | null,
+  +hasBeenDeleted: boolean,
 |};
 
 /**
@@ -95,83 +92,26 @@ class PublishedProfile extends React.PureComponent<
 > {
   state = {
     confirmDialogIsOpen: false,
-    error: null,
-    status: 'idle',
-  };
-  _componentDeleteButtonRef = React.createRef();
-
-  onConfirmDeletion = async () => {
-    const { profileToken, jwtToken } = this.props.profileData;
-
-    this.setState({ status: 'working' });
-    try {
-      if (!jwtToken) {
-        throw new Error(
-          `We have no JWT token for this profile, so we can't delete it. This shouldn't happen.`
-        );
-      }
-      await deleteProfileOnServer({ profileToken, jwtToken });
-      await deleteProfileData(profileToken);
-      this.setState({ status: 'just-deleted' });
-    } catch (e) {
-      this.setState({
-        error: e,
-        status: 'idle',
-      });
-      // Also output the error to the console for easier debugging.
-      console.error(
-        'An error was triggered when we tried to delete a profile.',
-        e
-      );
-    }
-  };
-
-  onCancelDeletion = () => {
-    // Close the panel when the user clicks on the Cancel button.
-    if (this._componentDeleteButtonRef.current) {
-      this._componentDeleteButtonRef.current.closePanel();
-    }
-  };
-
-  onCloseConfirmDialog = () => {
-    this.setState({ confirmDialogIsOpen: false });
-
-    // In case we deleted the profile, and the user dismisses the success panel,
-    // let's move directly to the deleted state:
-    if (this.state.status === 'just-deleted') {
-      this.setState({ status: 'deleted' });
-    }
+    hasBeenDeleted: false,
   };
 
   onOpenConfirmDialog = () => {
     this.setState({ confirmDialogIsOpen: true });
   };
 
-  preventClick(e) {
-    e.preventDefault();
-  }
+  onCloseConfirmDialog = () => {
+    this.setState({ confirmDialogIsOpen: false });
+  };
 
-  _renderPossibleErrorMessage() {
-    const { error } = this.state;
-    if (!error) {
-      return null;
-    }
-
-    return (
-      <p className="publishedProfilesDeleteError">
-        An error happened while deleting this profile.{' '}
-        <a href="#" title={error.message} onClick={this.preventClick}>
-          Hover to know more.
-        </a>
-      </p>
-    );
-  }
+  onCloseSuccessMessage = () => {
+    this.setState({ hasBeenDeleted: true });
+  };
 
   render() {
     const { profileData, nowTimestamp, withActionButtons } = this.props;
-    const { confirmDialogIsOpen, status } = this.state;
+    const { confirmDialogIsOpen, hasBeenDeleted } = this.state;
 
-    if (status === 'deleted') {
+    if (hasBeenDeleted) {
       return null;
     }
 
@@ -213,48 +153,15 @@ class PublishedProfile extends React.PureComponent<
         {withActionButtons ? (
           <div className="publishedProfilesActionButtons">
             {profileData.jwtToken ? (
-              <ButtonWithPanel
-                ref={this._componentDeleteButtonRef}
-                buttonClassName="publishedProfilesDeleteButton photon-button photon-button-default"
-                label="Delete"
-                title={`Click here to delete the profile ${smallProfileName}`}
-                onPanelOpen={this.onOpenConfirmDialog}
-                onPanelClose={this.onCloseConfirmDialog}
-                panelContent={
-                  status === 'just-deleted' ? (
-                    <p className="publishedProfilesDeleteSuccess">
-                      Successfully deleted uploaded data.
-                    </p>
-                  ) : (
-                    <div className="confirmDialog">
-                      <h2 className="confirmDialogTitle">
-                        Delete {profileName}
-                      </h2>
-                      <div className="confirmDialogContent">
-                        Are you sure you want to delete uploaded data for this
-                        profile? Links that were previously shared will no
-                        longer work.
-                        {this._renderPossibleErrorMessage()}
-                      </div>
-                      <div className="confirmDialogButtons">
-                        <input
-                          type="button"
-                          className="photon-button photon-button-default"
-                          value="Cancel"
-                          disabled={status === 'working'}
-                          onClick={this.onCancelDeletion}
-                        />
-                        <input
-                          type="button"
-                          className="photon-button photon-button-destructive"
-                          value={status === 'working' ? 'Deleting…' : 'Delete'}
-                          disabled={status === 'working'}
-                          onClick={this.onConfirmDeletion}
-                        />
-                      </div>
-                    </div>
-                  )
-                }
+              <ProfileDeleteButton
+                buttonClassName="publishedProfilesDeleteButton"
+                profileName={profileName}
+                smallProfileName={smallProfileName}
+                jwtToken={profileData.jwtToken}
+                profileToken={profileData.profileToken}
+                onOpenConfirmDialog={this.onOpenConfirmDialog}
+                onCloseConfirmDialog={this.onCloseConfirmDialog}
+                onCloseSuccessMessage={this.onCloseSuccessMessage}
               />
             ) : (
               <button

--- a/src/components/app/ProfileDeleteButton.css
+++ b/src/components/app/ProfileDeleteButton.css
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.profileDeleteButtonSuccess {
+  /* Note: 20px is: 16px (icon width) + 4px (distance from the text) */
+  padding-left: 20px;
+  margin: 0;
+  background: url(../../../res/img/svg/check-dark.svg) no-repeat left / 16px
+    16px;
+  white-space: nowrap;
+}
+
+.profileDeleteButtonError {
+  /* Note: 24px is: 16px (icon width) + 4px (icon padding) + 4px (distance from the text) */
+  padding-left: 24px;
+
+  /* The icon is 4px below the top */
+  background: url(../../../res/img/svg/error-red.svg) no-repeat 0 4px / 16px
+    16px;
+  color: var(--red-60);
+  word-break: break-word;
+}

--- a/src/components/app/ProfileDeleteButton.js
+++ b/src/components/app/ProfileDeleteButton.js
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
+import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
+
+import { deleteProfileData } from 'firefox-profiler/app-logic/published-profiles-store';
+import { deleteProfileOnServer } from 'firefox-profiler/profile-logic/profile-store';
+
+import './ProfileDeleteButton.css';
+
+type Props = {|
+  +profileName: string,
+  +smallProfileName: string,
+  +jwtToken: string,
+  +profileToken: string,
+  +buttonClassName?: string,
+  +onOpenConfirmDialog?: () => mixed,
+  +onCloseConfirmDialog?: () => mixed,
+  +onCloseSuccessMessage?: () => mixed,
+|};
+
+type State = {|
+  +status: 'idle' | 'working' | 'just-deleted' | 'deleted',
+  +error: Error | null,
+|};
+
+export class ProfileDeleteButton extends PureComponent<Props, State> {
+  state = { error: null, status: 'idle' };
+  _componentDeleteButtonRef = React.createRef<ButtonWithPanel>();
+
+  onConfirmDeletion = async () => {
+    const { profileToken, jwtToken } = this.props;
+
+    this.setState({ status: 'working' });
+    try {
+      if (!jwtToken) {
+        throw new Error(
+          `We have no JWT token for this profile, so we can't delete it. This shouldn't happen.`
+        );
+      }
+      await deleteProfileOnServer({ profileToken, jwtToken });
+      await deleteProfileData(profileToken);
+      this.setState({ status: 'just-deleted' });
+    } catch (e) {
+      this.setState({
+        error: e,
+        status: 'idle',
+      });
+      // Also output the error to the console for easier debugging.
+      console.error(
+        'An error was triggered when we tried to delete a profile.',
+        e
+      );
+    }
+  };
+
+  onCancelDeletion = () => {
+    // Close the panel when the user clicks on the Cancel button.
+    if (this._componentDeleteButtonRef.current) {
+      this._componentDeleteButtonRef.current.closePanel();
+    }
+  };
+
+  _renderPossibleErrorMessage() {
+    const { error } = this.state;
+    if (!error) {
+      return null;
+    }
+
+    return (
+      <p className="profileDeleteButtonError">
+        An error happened while deleting this profile.{' '}
+        <a href="#" title={error.message} onClick={this.preventClick}>
+          Hover to know more.
+        </a>
+      </p>
+    );
+  }
+
+  onCloseConfirmDialog = () => {
+    // In case we deleted the profile, and the user dismisses the success panel,
+    // let's move directly to the deleted state:
+    if (this.state.status === 'just-deleted') {
+      this.setState({ status: 'deleted' });
+      if (this.props.onCloseSuccessMessage) {
+        this.props.onCloseSuccessMessage();
+      }
+    }
+
+    if (this.props.onCloseConfirmDialog) {
+      this.props.onCloseConfirmDialog();
+    }
+  };
+
+  preventClick(e: SyntheticMouseEvent<>) {
+    e.preventDefault();
+  }
+
+  render() {
+    const { profileName, smallProfileName, buttonClassName } = this.props;
+    const { status } = this.state;
+
+    return (
+      <ButtonWithPanel
+        ref={this._componentDeleteButtonRef}
+        buttonClassName={classNames(
+          buttonClassName,
+          'photon-button',
+          'photon-button-default'
+        )}
+        label="Delete"
+        title={`Click here to delete the profile ${smallProfileName}`}
+        onPanelOpen={this.props.onOpenConfirmDialog}
+        onPanelClose={this.onCloseConfirmDialog}
+        panelContent={
+          status === 'just-deleted' ? (
+            <p className="profileDeleteButtonSuccess">
+              Successfully deleted uploaded data.
+            </p>
+          ) : (
+            <div className="confirmDialog">
+              <h2 className="confirmDialogTitle">Delete {profileName}</h2>
+              <div className="confirmDialogContent">
+                Are you sure you want to delete uploaded data for this profile?
+                Links that were previously shared will no longer work.
+                {this._renderPossibleErrorMessage()}
+              </div>
+              <div className="confirmDialogButtons">
+                <input
+                  type="button"
+                  className="photon-button photon-button-default"
+                  value="Cancel"
+                  disabled={status === 'working'}
+                  onClick={this.onCancelDeletion}
+                />
+                <input
+                  type="button"
+                  className="photon-button photon-button-destructive"
+                  value={status === 'working' ? 'Deleting…' : 'Delete'}
+                  disabled={status === 'working'}
+                  onClick={this.onConfirmDeletion}
+                />
+              </div>
+            </div>
+          )
+        }
+      />
+    );
+  }
+}


### PR DESCRIPTION
This is a follow-up to #2802 with 2 more commits (in addition to the squashed versions of #2797 and #2802):

1. This removes all the dom refs from the list and instead make ButtonWithPanel own the focus operations.
2. This extracts all the deletion operations in its own separate component, so that I can reuse it more easily (hopefully) in the profile viewer.

There's no new test because the existing tests were quite high-level and they still pass without a change (yay for high-level tests).