### PR TITLE
Toggle resource track only clicking the label

### DIFF
--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -58,22 +58,26 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
     };
   }
 
-  _onMouseUp = (event: MouseEvent) => {
+  _onMouseUp = fromWhere => (event: MouseEvent) => {
     const { isSelected } = this.props;
     const { isOpen } = this.state;
 
     if (event.button === 0) {
       // Don't allow clicks on the threads list to steal focus from the tree view.
       event.preventDefault();
-      if (isSelected || !isOpen) {
-        // We have two different states for selected tracks and open tracks because
-        // non selected tracks also can stay opened. We can only close the track if
-        // the track is already selected.
-        this.setState(prevState => {
-          return { isOpen: !prevState.isOpen };
-        });
+      if (fromWhere === 'timelineTrackResourceLabel') {
+        if (isSelected || !isOpen) {
+          // We have two different states for selected tracks and open tracks because
+          // non selected tracks also can stay opened. We can only close the track if
+          // the track is already selected.
+          this.setState(prevState => {
+            return { isOpen: !prevState.isOpen };
+          });
+        }
+        this.props.selectActiveTabTrack(this._getTrackReference());
+      } else {
+        this.props.selectActiveTabTrack(this._getTrackReference());
       }
-      this.props.selectActiveTabTrack(this._getTrackReference());
     }
   };
 
@@ -171,9 +175,12 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
             selected: isSelected,
             opened: isOpen,
           })}
-          onMouseUp={this._onMouseUp}
+          onMouseUp={this._onMouseUp('timelineTrackRow')}
         >
-          <div className="timelineTrackResourceLabel">
+          <div
+            className="timelineTrackResourceLabel"
+            onMouseUp={this._onMouseUp('timelineTrackResourceLabel')}
+          >
             <span>{trackLabel}</span> {resourceTrack.name}
           </div>
           <div className="timelineTrackTrack">{this.renderTrack()}</div>

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -58,14 +58,17 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
     };
   }
 
-  _onMouseUp = fromWhere => (event: MouseEvent) => {
+  _onMouseUp = (
+    clickedArea: 'timelineTrackResourceLabel' | 'timelineTrackRow'
+  ) => (event: MouseEvent) => {
     const { isSelected } = this.props;
     const { isOpen } = this.state;
 
     if (event.button === 0) {
       // Don't allow clicks on the threads list to steal focus from the tree view.
       event.preventDefault();
-      if (fromWhere === 'timelineTrackResourceLabel') {
+      //Only toggle the resource track when the resource label is clicked
+      if (clickedArea === 'timelineTrackResourceLabel') {
         if (isSelected || !isOpen) {
           // We have two different states for selected tracks and open tracks because
           // non selected tracks also can stay opened. We can only close the track if
@@ -74,10 +77,8 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
             return { isOpen: !prevState.isOpen };
           });
         }
-        this.props.selectActiveTabTrack(this._getTrackReference());
-      } else {
-        this.props.selectActiveTabTrack(this._getTrackReference());
       }
+      this.props.selectActiveTabTrack(this._getTrackReference());
     }
   };
 

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -305,6 +305,8 @@ describe('ActiveTabTimeline', function() {
           container.querySelector('.timelineTrackResourceRow'),
           `Couldn't find the track resource row with selector .timelineTrackResourceRow`
         );
+      const isResourceTrackOpen = () =>
+        getResourceTrackRow().classList.contains('opened');
 
       return {
         ...renderResult,
@@ -317,6 +319,7 @@ describe('ActiveTabTimeline', function() {
         getResourceFrameTrackLabel,
         getResourceTrackRow,
         resourcePage,
+        isResourceTrackOpen,
       };
     }
 
@@ -354,23 +357,28 @@ describe('ActiveTabTimeline', function() {
         const {
           getState,
           getResourceFrameTrackLabel,
-          getResourceTrackRow,
           threadIndex,
+          isResourceTrackOpen,
         } = setup();
         expect(getFirstSelectedThreadIndex(getState())).not.toBe(threadIndex);
-        expect(getResourceTrackRow().classList.contains('opened')).toBe(false);
+        expect(isResourceTrackOpen()).toBe(false);
         fireFullClick(getResourceFrameTrackLabel());
         expect(getFirstSelectedThreadIndex(getState())).toBe(threadIndex);
-        expect(getResourceTrackRow().classList.contains('opened')).toBe(true);
+        expect(isResourceTrackOpen()).toBe(true);
       });
 
       it('does not toggle a selected track by clicking other part of the track except label', () => {
-        const { getState, getResourceTrackRow, threadIndex } = setup();
+        const {
+          getState,
+          getResourceTrackRow,
+          threadIndex,
+          isResourceTrackOpen,
+        } = setup();
         expect(getFirstSelectedThreadIndex(getState())).not.toBe(threadIndex);
-        expect(getResourceTrackRow().classList.contains('opened')).toBe(false);
+        expect(isResourceTrackOpen()).toBe(false);
         fireFullClick(getResourceTrackRow());
         expect(getFirstSelectedThreadIndex(getState())).toBe(threadIndex);
-        expect(getResourceTrackRow().classList.contains('opened')).toBe(false);
+        expect(isResourceTrackOpen()).toBe(false);
       });
     });
   });

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -349,6 +349,27 @@ describe('ActiveTabTimeline', function() {
         fireFullClick(getResourceTrackRow());
         expect(getFirstSelectedThreadIndex(getState())).toBe(threadIndex);
       });
+
+      it('can toggle a selected track by clicking the label', () => {
+        const {
+          getState,
+          getResourceFrameTrackLabel,
+          getResourceTrackRow,
+          threadIndex,
+        } = setup();
+        expect(getFirstSelectedThreadIndex(getState())).not.toBe(threadIndex);
+        expect(getResourceTrackRow().classList.contains('opened')).toBe(false);
+        fireFullClick(getResourceFrameTrackLabel());
+        expect(getFirstSelectedThreadIndex(getState())).toBe(threadIndex);
+        expect(getResourceTrackRow().classList.contains('opened')).toBe(true);
+      });
+
+      it('does not toggle a selected track by clicking other part of the track except label', () => {
+        const { getState, getResourceTrackRow, threadIndex } = setup();
+        expect(getFirstSelectedThreadIndex(getState())).not.toBe(threadIndex);
+        fireFullClick(getResourceTrackRow());
+        expect(getFirstSelectedThreadIndex(getState())).toBe(threadIndex);
+      });
     });
   });
 });

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -367,8 +367,10 @@ describe('ActiveTabTimeline', function() {
       it('does not toggle a selected track by clicking other part of the track except label', () => {
         const { getState, getResourceTrackRow, threadIndex } = setup();
         expect(getFirstSelectedThreadIndex(getState())).not.toBe(threadIndex);
+        expect(getResourceTrackRow().classList.contains('opened')).toBe(false);
         fireFullClick(getResourceTrackRow());
         expect(getFirstSelectedThreadIndex(getState())).toBe(threadIndex);
+        expect(getResourceTrackRow().classList.contains('opened')).toBe(false);
       });
     });
   });


### PR DESCRIPTION
Fixes issue #2812. The code works like this:

![Screen Capture_select-area_20200930160442](https://user-images.githubusercontent.com/37832457/94673520-a9fe4f80-0338-11eb-8fe3-1b5efac40837.gif)