### PR TITLE
Always display the link to the uploaded recordings page from the home…

### DIFF
--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -358,13 +358,21 @@ export class ListOfPublishedProfiles extends PureComponent<Props, State> {
             />
           ))}
         </ul>
-        {profilesRestCount > 0 ? (
+        {withActionButtons ? null : (
           <p>
             <InnerNavigationLink dataSource="uploaded-recordings">
-              See and manage all your recordings ({profilesRestCount} more)
+              {profilesRestCount > 0 ? (
+                <>
+                  See and manage all your recordings ({profilesRestCount} more)
+                </>
+              ) : profileDataList.length > 1 ? (
+                <>Manage these recordings</>
+              ) : (
+                <>Manage this recording</>
+              )}
             </InnerNavigationLink>
           </p>
-        ) : null}
+        )}
       </>
     );
   }

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -143,7 +143,8 @@ describe('ListOfPublishedProfiles', () => {
     const { getByText, getByTitle, container } = renderResult;
 
     function getAllRecordingsLink() {
-      return getByText(/all your recordings/);
+      // This regexp should match all possible flavor of this link.
+      return getByText(/manage.*recording/i);
     }
 
     function getDeleteButtonForProfile(
@@ -216,19 +217,48 @@ describe('ListOfPublishedProfiles', () => {
     await findByText(/macOS/);
     expect(container.querySelectorAll('li')).toHaveLength(3);
     getAllRecordingsLink(); // This shouldn't throw.
-    expect(container.firstChild).toMatchSnapshot();
+    // Note: we're testing on `container` instead of `container.firstChild`
+    // because this component renders a fragment with several HTML elements.
+    expect(container).toMatchSnapshot();
   });
 
-  it('does not display the link to all recordings when there is 3 profiles or less', async () => {
+  it('still displays the link to all recordings when there is 3 profiles or less', async () => {
     await storeProfileInformations(listOfProfileInformations.slice(0, 3));
-    const { findByText, getAllRecordingsLink } = setup({ limit: 3 });
+    const { container, findByText, getAllRecordingsLink } = setup({ limit: 3 });
     await findByText(/Layout profile/);
+    getAllRecordingsLink(); // This shouldn't throw.
+    // Note: we're testing on `container` instead of `container.firstChild`
+    // because this component renders a fragment with several HTML elements.
+    expect(container).toMatchSnapshot();
+  });
+
+  it('still displays the link to all recordings when there is only 1 profile', async () => {
+    await storeProfileInformations(listOfProfileInformations.slice(0, 1));
+    const { container, findByText, getAllRecordingsLink } = setup({ limit: 3 });
+    await findByText(/Fennec/);
+    getAllRecordingsLink(); // This shouldn't throw.
+    // Note: we're testing on `container` instead of `container.firstChild`
+    // because this component renders a fragment with several HTML elements.
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders a generic message when there is no profiles', async () => {
+    const { container, findByText, getAllRecordingsLink } = setup({ limit: 3 });
+    await findByText(/no profile/i);
     expect(() => getAllRecordingsLink()).toThrow('Unable to find an element');
+    // Note: we're testing on `container` instead of `container.firstChild`
+    // because this component renders a fragment with several HTML elements.
+    expect(container).toMatchSnapshot();
   });
 
   it('renders action buttons when appropriate', async () => {
     await storeProfileInformations(listOfProfileInformations);
-    const { findByText, getAllByText, getDeleteButtonForProfile } = setup({
+    const {
+      container,
+      findByText,
+      getAllByText,
+      getDeleteButtonForProfile,
+    } = setup({
       withActionButtons: true,
     });
 
@@ -247,6 +277,10 @@ describe('ListOfPublishedProfiles', () => {
         expect(button.disabled).toBe(true); // eslint-disable-line jest/no-conditional-expect
       }
     }
+
+    // Note: we're testing on `container` instead of `container.firstChild`
+    // because this component renders a fragment with several HTML elements.
+    expect(container).toMatchSnapshot();
   });
 
   describe('profile deletion', () => {

--- a/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
+++ b/src/test/components/__snapshots__/ListOfPublishedProfiles.test.js.snap
@@ -1,143 +1,154 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ListOfPublishedProfiles limits the number of rendered profiles with the limit prop 1`] = `
-<ul
-  class="publishedProfilesList"
->
-  <li
-    class="publishedProfilesListItem"
+<div>
+  <ul
+    class="publishedProfilesList"
   >
-    <a
-      class="publishedProfilesLink"
-      href="http://localhost//public/MACOSX/marker-chart/"
-      title="Click here to load profile MacOS X profile"
+    <li
+      class="publishedProfilesListItem"
     >
-      <div
-        class="publishedProfilesDate"
-      >
-        Jul 5, 2020
-      </div>
-      <div
-        class="publishedProfilesInfo"
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//public/MACOSX/marker-chart/"
+        title="Click here to load profile MacOS X profile"
       >
         <div
-          class="publishedProfilesName"
+          class="publishedProfilesDate"
         >
-          <strong>
-            MacOS X profile
-          </strong>
-           (
-          38.0s
-          )
+          Jul 5, 2020
         </div>
         <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Firefox"
+            class="publishedProfilesName"
           >
-            Firefox 62
+            <strong>
+              MacOS X profile
+            </strong>
+             (
+            38.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit="macOS 10.12"
+            class="profileMetaInfoSummary"
           >
-            macOS 10.12
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 62
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="macOS 10.12"
+            >
+              macOS 10.12
+            </div>
           </div>
         </div>
-      </div>
-    </a>
-  </li>
-  <li
-    class="publishedProfilesListItem"
-  >
-    <a
-      class="publishedProfilesLink"
-      href="http://localhost//"
-      title="Click here to load profile #012345"
+      </a>
+    </li>
+    <li
+      class="publishedProfilesListItem"
     >
-      <div
-        class="publishedProfilesDate"
-      >
-        2:00 PM
-      </div>
-      <div
-        class="publishedProfilesInfo"
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//"
+        title="Click here to load profile #012345"
       >
         <div
-          class="publishedProfilesName"
+          class="publishedProfilesDate"
         >
-          <strong>
-            Profile #012345
-          </strong>
-           (
-          2.0s
-          )
+          2:00 PM
         </div>
         <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Fennec"
+            class="publishedProfilesName"
           >
-            Fennec
+            <strong>
+              Profile #012345
+            </strong>
+             (
+            2.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit=""
-          />
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Fennec"
+            >
+              Fennec
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit=""
+            />
+          </div>
         </div>
-      </div>
-    </a>
-  </li>
-  <li
-    class="publishedProfilesListItem"
-  >
-    <a
-      class="publishedProfilesLink"
-      href="http://localhost//public/WINDOWS/marker-chart/"
-      title="Click here to load profile Another good profile"
+      </a>
+    </li>
+    <li
+      class="publishedProfilesListItem"
     >
-      <div
-        class="publishedProfilesDate"
-      >
-        1:00 PM
-      </div>
-      <div
-        class="publishedProfilesInfo"
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//public/WINDOWS/marker-chart/"
+        title="Click here to load profile Another good profile"
       >
         <div
-          class="publishedProfilesName"
+          class="publishedProfilesDate"
         >
-          <strong>
-            Another good profile
-          </strong>
-           (
-          38.0s
-          )
+          1:00 PM
         </div>
         <div
-          class="profileMetaInfoSummary"
+          class="publishedProfilesInfo"
         >
           <div
-            class="profileMetaInfoSummaryProductAndVersion"
-            data-product="Firefox"
+            class="publishedProfilesName"
           >
-            Firefox 77
+            <strong>
+              Another good profile
+            </strong>
+             (
+            38.0s
+            )
           </div>
           <div
-            class="profileMetaInfoSummaryPlatform"
-            data-toolkit="Windows 10"
+            class="profileMetaInfoSummary"
           >
-            Windows 10
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 77
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Windows 10"
+            >
+              Windows 10
+            </div>
           </div>
         </div>
-      </div>
+      </a>
+    </li>
+  </ul>
+  <p>
+    <a
+      href="/uploaded-recordings/"
+    >
+      See and manage all your recordings (
+      2
+       more)
     </a>
-  </li>
-</ul>
+  </p>
+</div>
 `;
 
 exports[`ListOfPublishedProfiles profile deletion can delete profiles 1`] = `
@@ -173,5 +184,517 @@ exports[`ListOfPublishedProfiles profile deletion can delete profiles 1`] = `
       />
     </div>
   </div>
+</div>
+`;
+
+exports[`ListOfPublishedProfiles renders a generic message when there is no profiles 1`] = `
+<div>
+  <p
+    class="photon-body-30"
+  >
+    No profile has been published yet!
+  </p>
+</div>
+`;
+
+exports[`ListOfPublishedProfiles renders action buttons when appropriate 1`] = `
+<div>
+  <ul
+    class="publishedProfilesList"
+  >
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//public/MACOSX/marker-chart/"
+        title="Click here to load profile MacOS X profile"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          Jul 5, 2020
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              MacOS X profile
+            </strong>
+             (
+            38.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 62
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="macOS 10.12"
+            >
+              macOS 10.12
+            </div>
+          </div>
+        </div>
+      </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//"
+        title="Click here to load profile #012345"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          2:00 PM
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Profile #012345
+            </strong>
+             (
+            2.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Fennec"
+            >
+              Fennec
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit=""
+            />
+          </div>
+        </div>
+      </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <div
+          class="buttonWithPanel"
+        >
+          <input
+            class="buttonWithPanelButton publishedProfilesDeleteButton photon-button photon-button-default"
+            title="Click here to delete the profile #012345"
+            type="button"
+            value="Delete"
+          />
+        </div>
+      </div>
+    </li>
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//public/WINDOWS/marker-chart/"
+        title="Click here to load profile Another good profile"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          1:00 PM
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Another good profile
+            </strong>
+             (
+            38.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 77
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Windows 10"
+            >
+              Windows 10
+            </div>
+          </div>
+        </div>
+      </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//"
+        title="Click here to load profile Layout profile"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          Jul 3, 8:00 AM
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Layout profile
+            </strong>
+             (
+            0.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 68
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Linux"
+            >
+              Linux
+            </div>
+          </div>
+        </div>
+      </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//public/123abc456/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&search=bla&thread=11&v=5"
+        title="Click here to load profile #123abc"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          May 20, 2018
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Profile #123abc
+            </strong>
+             (
+            0.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox Preview"
+            >
+              Firefox Preview 80
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Android 7"
+            >
+              Android 7
+            </div>
+          </div>
+        </div>
+      </a>
+      <div
+        class="publishedProfilesActionButtons"
+      >
+        <button
+          class="publishedProfilesDeleteButton photon-button photon-button-default"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`ListOfPublishedProfiles still displays the link to all recordings when there is 3 profiles or less 1`] = `
+<div>
+  <ul
+    class="publishedProfilesList"
+  >
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//"
+        title="Click here to load profile #012345"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          2:00 PM
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Profile #012345
+            </strong>
+             (
+            2.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Fennec"
+            >
+              Fennec
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit=""
+            />
+          </div>
+        </div>
+      </a>
+    </li>
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//"
+        title="Click here to load profile Layout profile"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          Jul 3, 8:00 AM
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Layout profile
+            </strong>
+             (
+            0.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox"
+            >
+              Firefox 68
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Linux"
+            >
+              Linux
+            </div>
+          </div>
+        </div>
+      </a>
+    </li>
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//public/123abc456/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&search=bla&thread=11&v=5"
+        title="Click here to load profile #123abc"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          May 20, 2018
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Profile #123abc
+            </strong>
+             (
+            0.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Firefox Preview"
+            >
+              Firefox Preview 80
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit="Android 7"
+            >
+              Android 7
+            </div>
+          </div>
+        </div>
+      </a>
+    </li>
+  </ul>
+  <p>
+    <a
+      href="/uploaded-recordings/"
+    >
+      Manage these recordings
+    </a>
+  </p>
+</div>
+`;
+
+exports[`ListOfPublishedProfiles still displays the link to all recordings when there is only 1 profile 1`] = `
+<div>
+  <ul
+    class="publishedProfilesList"
+  >
+    <li
+      class="publishedProfilesListItem"
+    >
+      <a
+        class="publishedProfilesLink"
+        href="http://localhost//"
+        title="Click here to load profile #012345"
+      >
+        <div
+          class="publishedProfilesDate"
+        >
+          2:00 PM
+        </div>
+        <div
+          class="publishedProfilesInfo"
+        >
+          <div
+            class="publishedProfilesName"
+          >
+            <strong>
+              Profile #012345
+            </strong>
+             (
+            2.0s
+            )
+          </div>
+          <div
+            class="profileMetaInfoSummary"
+          >
+            <div
+              class="profileMetaInfoSummaryProductAndVersion"
+              data-product="Fennec"
+            >
+              Fennec
+            </div>
+            <div
+              class="profileMetaInfoSummaryPlatform"
+              data-toolkit=""
+            />
+          </div>
+        </div>
+      </a>
+    </li>
+  </ul>
+  <p>
+    <a
+      href="/uploaded-recordings/"
+    >
+      Manage this recording
+    </a>
+  </p>
 </div>
 `;


### PR DESCRIPTION
… page

This is a small follow-up to the patch that added "delete" buttons to the list of uploaded recordings. 
The problem was that previously we didn't show the link in the home page when we could display all recordings (if there are 3 of less). But we also don't show the delete button in the home page! So if the user has only 3 profiles or less there's no link to go and be able to delete them.

So this patch fixes this :-)

[deploy preview home](https://deploy-preview-2816--perf-html.netlify.app/)
[deploy preview with a profile](https://deploy-preview-2816--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&profileName=&thread=0&v=3)  to republish and have some entries in the list.