### PR TITLE
Remove the left margin from the bottom panels that align with timeline on active tab

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -16,6 +16,7 @@ export const PROCESSED_PROFILE_VERSION = 32;
 // components need to share these values.
 export const TIMELINE_MARGIN_RIGHT = 15;
 export const TIMELINE_MARGIN_LEFT = 150;
+export const ACTIVE_TAB_TIMELINE_MARGIN_LEFT = 0;
 
 export const TIMELINE_SETTINGS_HEIGHT = 26;
 

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -71,6 +71,7 @@ const TWO_PI = Math.PI * 2;
 const MARKER_DOT_RADIUS = 0.25;
 const TEXT_OFFSET_START = 3;
 const DOT_WIDTH = 10;
+const LABEL_PADDING = 5;
 
 class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
   _textMeasurement: null | TextMeasurement;
@@ -432,7 +433,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
         name,
         TIMELINE_MARGIN_LEFT
       );
-      ctx.fillText(fittedText, 5, y + TEXT_OFFSET_TOP);
+      ctx.fillText(fittedText, LABEL_PADDING, y + TEXT_OFFSET_TOP);
     }
 
     // Draw the bucket names.
@@ -455,7 +456,11 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
 
       // Draw the text.
       ctx.fillStyle = '#000000';
-      ctx.fillText(bucketName, 5 + TIMELINE_MARGIN_LEFT, y + TEXT_OFFSET_TOP);
+      ctx.fillText(
+        bucketName,
+        LABEL_PADDING + TIMELINE_MARGIN_LEFT,
+        y + TEXT_OFFSET_TOP
+      );
     }
   }
 

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -27,6 +27,7 @@ import type {
   Marker,
   MarkerTimingAndBuckets,
   MarkerIndex,
+  TimelineTrackOrganization,
 } from 'firefox-profiler/types';
 import { getStartEndRangeForMarker } from 'firefox-profiler/utils';
 
@@ -41,6 +42,31 @@ type MarkerDrawingInformation = {
   text: string,
 };
 
+// We can hover over multiple items with Marker chart when we are in the active
+// tab view. Usually on other charts, we only have one selected item at a time.
+// But in here, we can hover over both markers and marker labels.
+// Also, they can be hovered at the same time. That's why we keep both of their
+// state in a two value tuple.
+// So if we take a look at all the possible states, we can have:
+//    [Hovered Marker Index, Hovered label row]
+// 1. [123                 , null             ]
+// 2. [null                , 12               ] (for active tab only)
+// 3. [123                 , 12               ] (for active tab only)
+// 4. [null                , null             ] (not used, we use primitive null
+//                                              to make shared canvas happy)
+// First state is the most common case, which is the only one available for the
+// full view. We have second and third cases for active tab view where we can
+// also see the hovered labels. 4th case is not used. We use primitive `null`
+// instead when both of the states are null, because that's what our shared
+// canvas component require.
+type IndexIntoHoveredLabelRow = number;
+type HoveredMarkerChartItems = [
+  MarkerIndex | null,
+  IndexIntoHoveredLabelRow | null
+];
+const HOVERED_MARKER_INDEX = 0;
+const HOVERED_LABEL_INDEX = 1;
+
 type OwnProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -54,6 +80,7 @@ type OwnProps = {|
   +marginRight: CssPixels,
   +rightClickedMarkerIndex: MarkerIndex | null,
   +shouldDisplayTooltips: () => boolean,
+  +timelineTrackOrganization: TimelineTrackOrganization,
 |};
 
 type Props = {|
@@ -78,14 +105,15 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
 
   drawCanvas = (
     ctx: CanvasRenderingContext2D,
-    hoveredItem: MarkerIndex | null,
-    prevHoveredItem: MarkerIndex | null,
+    hoveredItems: HoveredMarkerChartItems | null,
+    prevHoveredItems: HoveredMarkerChartItems | null,
     isHoveredOnlyDifferent: boolean
   ) => {
     const {
       rowHeight,
       markerTimingAndBuckets,
       rightClickedMarkerIndex,
+      timelineTrackOrganization,
       viewport: {
         viewportTop,
         viewportBottom,
@@ -93,6 +121,15 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
         containerHeight,
       },
     } = this.props;
+    const hoveredMarker =
+      hoveredItems === null ? null : hoveredItems[HOVERED_MARKER_INDEX];
+    const hoveredLabel =
+      hoveredItems === null ? null : hoveredItems[HOVERED_LABEL_INDEX];
+    const prevHoveredMarker =
+      prevHoveredItems === null ? null : prevHoveredItems[HOVERED_MARKER_INDEX];
+    const prevHoveredLabel =
+      prevHoveredItems === null ? null : prevHoveredItems[HOVERED_LABEL_INDEX];
+
     // Convert CssPixels to Stack Depth
     const startRow = Math.floor(viewportTop / rowHeight);
     const endRow = Math.min(
@@ -106,31 +143,50 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       rightClickedMarkerIndex === null
         ? undefined
         : markerIndexToTimingRow.get(rightClickedMarkerIndex);
-    const newRow: number | void =
-      hoveredItem === null
+    let newRow: number | void =
+      hoveredMarker === null
         ? undefined
-        : markerIndexToTimingRow.get(hoveredItem);
+        : markerIndexToTimingRow.get(hoveredMarker);
+    if (
+      timelineTrackOrganization.type === 'active-tab' &&
+      newRow === undefined &&
+      hoveredLabel !== null
+    ) {
+      // If it's active tab view and we don't know the row yet, assign
+      // `hoveredLabel` if it's non-null.
+      newRow = hoveredLabel;
+    }
 
     if (isHoveredOnlyDifferent) {
       // Only re-draw the rows that have been updated if only the hovering information
       // is different.
-
-      const oldRow: number | void =
-        prevHoveredItem === null
+      let oldRow: number | void =
+        prevHoveredMarker === null
           ? undefined
-          : markerIndexToTimingRow.get(prevHoveredItem);
+          : markerIndexToTimingRow.get(prevHoveredMarker);
+      if (
+        timelineTrackOrganization.type === 'active-tab' &&
+        oldRow === undefined &&
+        prevHoveredLabel !== null
+      ) {
+        // If it's active tab view and we don't know the row yet, assign
+        // `prevHoveredLabel` if it's non-null.
+        oldRow = prevHoveredLabel;
+      }
 
       if (newRow !== undefined) {
         this.clearRow(ctx, newRow);
         this.highlightRow(ctx, newRow);
-        this.drawMarkers(ctx, hoveredItem, newRow, newRow + 1);
-        this.drawSeparatorsAndLabels(ctx, newRow, newRow + 1);
+        this.drawMarkers(ctx, hoveredMarker, newRow, newRow + 1);
+        if (hoveredLabel === null) {
+          this.drawSeparatorsAndLabels(ctx, newRow, newRow + 1);
+        }
       }
       if (oldRow !== undefined && oldRow !== newRow) {
         if (oldRow !== rightClickedRow) {
           this.clearRow(ctx, oldRow);
         }
-        this.drawMarkers(ctx, hoveredItem, oldRow, oldRow + 1);
+        this.drawMarkers(ctx, hoveredMarker, oldRow, oldRow + 1);
         this.drawSeparatorsAndLabels(ctx, oldRow, oldRow + 1);
       }
     } else {
@@ -141,7 +197,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       } else if (newRow !== undefined) {
         this.highlightRow(ctx, newRow);
       }
-      this.drawMarkers(ctx, hoveredItem, startRow, endRow);
+      this.drawMarkers(ctx, hoveredMarker, startRow, endRow);
       this.drawSeparatorsAndLabels(ctx, startRow, endRow);
     }
   };
@@ -400,12 +456,16 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       markerTimingAndBuckets,
       rowHeight,
       marginLeft,
+      timelineTrackOrganization,
       viewport: { viewportTop, containerWidth, containerHeight },
     } = this.props;
 
     // Draw separators
     ctx.fillStyle = GREY_20;
-    ctx.fillRect(marginLeft - 1, 0, 1, containerHeight);
+    if (timelineTrackOrganization.type !== 'active-tab') {
+      // Don't draw the separator on the right side if we are in the active tab.
+      ctx.fillRect(marginLeft - 1, 0, 1, containerHeight);
+    }
     for (let rowIndex = startRow; rowIndex < endRow; rowIndex++) {
       // `- 1` at the end, because the top separator is not drawn in the canvas,
       // it's drawn using CSS' border property. And canvas positioning is 0-based.
@@ -429,10 +489,22 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       }
 
       const y = rowIndex * rowHeight - viewportTop;
+      // Even though it's on active tab view, have a hard cap on the text length.
       const fittedText = textMeasurement.getFittedText(
         name,
         TIMELINE_MARGIN_LEFT
       );
+
+      if (timelineTrackOrganization.type === 'active-tab') {
+        // Draw the text backgound for active tab.
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+        const textWidth = textMeasurement.getTextWidth(fittedText);
+        ctx.fillRect(0, y, textWidth + LABEL_PADDING * 2, rowHeight);
+
+        // Set the fill style back for text.
+        ctx.fillStyle = '#000000';
+      }
+
       ctx.fillText(fittedText, LABEL_PADDING, y + TEXT_OFFSET_TOP);
     }
 
@@ -456,15 +528,11 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
 
       // Draw the text.
       ctx.fillStyle = '#000000';
-      ctx.fillText(
-        bucketName,
-        LABEL_PADDING + TIMELINE_MARGIN_LEFT,
-        y + TEXT_OFFSET_TOP
-      );
+      ctx.fillText(bucketName, LABEL_PADDING + marginLeft, y + TEXT_OFFSET_TOP);
     }
   }
 
-  hitTest = (x: CssPixels, y: CssPixels): MarkerIndex | null => {
+  hitTest = (x: CssPixels, y: CssPixels): HoveredMarkerChartItems | null => {
     const {
       rangeStart,
       rangeEnd,
@@ -472,11 +540,14 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       rowHeight,
       marginLeft,
       marginRight,
+      timelineTrackOrganization,
       viewport: { viewportLeft, viewportRight, viewportTop, containerWidth },
     } = this.props;
     if (x < marginLeft - MARKER_DOT_RADIUS) {
       return null;
     }
+    let markerIndex = null;
+    let rowIndexOfLabel = null;
     const markerContainerWidth = containerWidth - marginLeft - marginRight;
 
     const rangeLength: Milliseconds = rangeEnd - rangeStart;
@@ -501,13 +572,49 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       // Ensure that really small markers are hoverable with a minDuration.
       const end = Math.max(start + minDuration, markerTiming.end[i]);
       if (start < time && end > time) {
-        return markerTiming.index[i];
+        markerIndex = markerTiming.index[i];
       }
     }
-    return null;
+
+    if (timelineTrackOrganization.type === 'active-tab') {
+      // We can also hover over a marker label on active tab view. That's why we
+      // also need to hit test for the labels. On active tab view, markers and
+      // labels can overlap with each other. Because of that, we need to hide
+      // the texts if we are hovering them to make the markers more visible.
+      const prevMarkerTiming = markerTimingAndBuckets[rowIndex - 1];
+      if (
+        // Only the first row of a marker type has label, so we are checking
+        // if we changed the marker type.
+        prevMarkerTiming.name !== markerTiming.name &&
+        // We don't have the canvas context in this function, but if we are doing
+        // the hit testing, that means we already rendered the chart and therefore
+        // we initialized `this._textMeasurement`. But we are checking it just in case.
+        this._textMeasurement
+      ) {
+        const textWidth = this._textMeasurement.getTextWidth(markerTiming.name);
+        if (x < textWidth + LABEL_PADDING * 2) {
+          rowIndexOfLabel = rowIndex;
+        }
+      }
+    }
+
+    if (markerIndex === null && rowIndexOfLabel === null) {
+      // If both of them are null, return a null instead of `[null, null]`.
+      // That's because shared canvas component only understands that.
+      return null;
+    }
+
+    // Yes, we are returning a new array all the time when we do the hit testing.
+    // I can hear you say "How does equality check work for old and new hovered
+    // items then?". Well, on the shared canvas component we have a function
+    // called `hoveredItemsAreEqual` that shallowly checks for equality of
+    // objects and arrays. So it's safe to return a new array all the time.
+    return [markerIndex, rowIndexOfLabel];
   };
 
-  onDoubleClickMarker = (markerIndex: MarkerIndex | null) => {
+  onDoubleClickMarker = (hoveredItems: HoveredMarkerChartItems | null) => {
+    const markerIndex =
+      hoveredItems === null ? null : hoveredItems[HOVERED_MARKER_INDEX];
     if (markerIndex === null) {
       return;
     }
@@ -532,7 +639,9 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
     });
   };
 
-  onRightClickMarker = (markerIndex: MarkerIndex | null) => {
+  onRightClickMarker = (hoveredItems: HoveredMarkerChartItems | null) => {
+    const markerIndex =
+      hoveredItems === null ? null : hoveredItems[HOVERED_MARKER_INDEX];
     const { changeRightClickedMarker, threadsKey } = this.props;
     changeRightClickedMarker(threadsKey, markerIndex);
   };
@@ -553,8 +662,10 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
     ctx.fillRect(x + c, bottom - c, width - 2 * c, c);
   }
 
-  getHoveredMarkerInfo = (markerIndex: MarkerIndex): React.Node => {
-    if (!this.props.shouldDisplayTooltips()) {
+  getHoveredMarkerInfo = ([
+    markerIndex: MarkerIndex | null,
+  ]: HoveredMarkerChartItems): React.Node => {
+    if (!this.props.shouldDisplayTooltips() || markerIndex === null) {
       return null;
     }
 

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -123,12 +123,14 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
         this.clearRow(ctx, newRow);
         this.highlightRow(ctx, newRow);
         this.drawMarkers(ctx, hoveredItem, newRow, newRow + 1);
+        this.drawSeparatorsAndLabels(ctx, newRow, newRow + 1);
       }
       if (oldRow !== undefined && oldRow !== newRow) {
         if (oldRow !== rightClickedRow) {
           this.clearRow(ctx, oldRow);
         }
         this.drawMarkers(ctx, hoveredItem, oldRow, oldRow + 1);
+        this.drawSeparatorsAndLabels(ctx, oldRow, oldRow + 1);
       }
     } else {
       ctx.fillStyle = '#ffffff';
@@ -375,7 +377,6 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       containerWidth,
       rowHeight - 1 // Subtract 1 for borders.
     );
-    this.drawSeparatorsAndLabels(ctx, rowIndex, rowIndex + 1); // To redraw the Separators and Labels after clearing them
   }
 
   /**

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -495,7 +495,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
 
       if (timelineTrackOrganization.type === 'active-tab') {
         // Draw the text backgound for active tab.
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+        ctx.fillStyle = '#ffffffbf'; // white with 75% opacity
         const textWidth = textMeasurement.getTextWidth(fittedText);
         ctx.fillRect(0, y, textWidth + LABEL_PADDING * 2, rowHeight);
 

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -119,14 +119,19 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
         containerHeight,
       },
     } = this.props;
-    const hoveredMarker =
-      hoveredItems === null ? null : hoveredItems.markerIndex;
-    const hoveredLabel =
-      hoveredItems === null ? null : hoveredItems.rowIndexOfLabel;
-    const prevHoveredMarker =
-      prevHoveredItems === null ? null : prevHoveredItems.markerIndex;
-    const prevHoveredLabel =
-      prevHoveredItems === null ? null : prevHoveredItems.rowIndexOfLabel;
+    let hoveredMarker = null;
+    let hoveredLabel = null;
+    let prevHoveredMarker = null;
+    let prevHoveredLabel = null;
+
+    if (hoveredItems) {
+      hoveredMarker = hoveredItems.markerIndex;
+      hoveredLabel = hoveredItems.rowIndexOfLabel;
+    }
+    if (prevHoveredItems) {
+      prevHoveredMarker = prevHoveredItems.markerIndex;
+      prevHoveredLabel = prevHoveredItems.rowIndexOfLabel;
+    }
 
     // Convert CssPixels to Stack Depth
     const startRow = Math.floor(viewportTop / rowHeight);
@@ -151,7 +156,9 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       hoveredLabel !== null
     ) {
       // If it's active tab view and we don't know the row yet, assign
-      // `hoveredLabel` if it's non-null.
+      // `hoveredLabel` if it's non-null. This is needed because we can hover
+      // the label and not the marker. That way we are making sure that we
+      // select the correct row.
       newRow = hoveredLabel;
     }
 
@@ -168,7 +175,9 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
         prevHoveredLabel !== null
       ) {
         // If it's active tab view and we don't know the row yet, assign
-        // `prevHoveredLabel` if it's non-null.
+        // `prevHoveredLabel` if it's non-null. This is needed because we can
+        // hover the label and not the marker. That way we are making sure that
+        // previous hovered row is correct.
         oldRow = prevHoveredLabel;
       }
 

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -60,12 +60,10 @@ type MarkerDrawingInformation = {
 // instead when both of the states are null, because that's what our shared
 // canvas component require.
 type IndexIntoHoveredLabelRow = number;
-type HoveredMarkerChartItems = [
-  MarkerIndex | null,
-  IndexIntoHoveredLabelRow | null
-];
-const HOVERED_MARKER_INDEX = 0;
-const HOVERED_LABEL_INDEX = 1;
+type HoveredMarkerChartItems = {|
+  markerIndex: MarkerIndex | null,
+  rowIndexOfLabel: IndexIntoHoveredLabelRow | null,
+|};
 
 type OwnProps = {|
   +rangeStart: Milliseconds,
@@ -122,13 +120,13 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
       },
     } = this.props;
     const hoveredMarker =
-      hoveredItems === null ? null : hoveredItems[HOVERED_MARKER_INDEX];
+      hoveredItems === null ? null : hoveredItems.markerIndex;
     const hoveredLabel =
-      hoveredItems === null ? null : hoveredItems[HOVERED_LABEL_INDEX];
+      hoveredItems === null ? null : hoveredItems.rowIndexOfLabel;
     const prevHoveredMarker =
-      prevHoveredItems === null ? null : prevHoveredItems[HOVERED_MARKER_INDEX];
+      prevHoveredItems === null ? null : prevHoveredItems.markerIndex;
     const prevHoveredLabel =
-      prevHoveredItems === null ? null : prevHoveredItems[HOVERED_LABEL_INDEX];
+      prevHoveredItems === null ? null : prevHoveredItems.rowIndexOfLabel;
 
     // Convert CssPixels to Stack Depth
     const startRow = Math.floor(viewportTop / rowHeight);
@@ -609,12 +607,11 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
     // items then?". Well, on the shared canvas component we have a function
     // called `hoveredItemsAreEqual` that shallowly checks for equality of
     // objects and arrays. So it's safe to return a new array all the time.
-    return [markerIndex, rowIndexOfLabel];
+    return { markerIndex, rowIndexOfLabel };
   };
 
   onDoubleClickMarker = (hoveredItems: HoveredMarkerChartItems | null) => {
-    const markerIndex =
-      hoveredItems === null ? null : hoveredItems[HOVERED_MARKER_INDEX];
+    const markerIndex = hoveredItems === null ? null : hoveredItems.markerIndex;
     if (markerIndex === null) {
       return;
     }
@@ -640,8 +637,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
   };
 
   onRightClickMarker = (hoveredItems: HoveredMarkerChartItems | null) => {
-    const markerIndex =
-      hoveredItems === null ? null : hoveredItems[HOVERED_MARKER_INDEX];
+    const markerIndex = hoveredItems === null ? null : hoveredItems.markerIndex;
     const { changeRightClickedMarker, threadsKey } = this.props;
     changeRightClickedMarker(threadsKey, markerIndex);
   };
@@ -662,9 +658,9 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props, State> {
     ctx.fillRect(x + c, bottom - c, width - 2 * c, c);
   }
 
-  getHoveredMarkerInfo = ([
-    markerIndex: MarkerIndex | null,
-  ]: HoveredMarkerChartItems): React.Node => {
+  getHoveredMarkerInfo = ({
+    markerIndex,
+  }: HoveredMarkerChartItems): React.Node => {
     if (!this.props.shouldDisplayTooltips() || markerIndex === null) {
       return null;
     }

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -4,10 +4,7 @@
 
 // @flow
 import * as React from 'react';
-import {
-  TIMELINE_MARGIN_LEFT,
-  TIMELINE_MARGIN_RIGHT,
-} from '../../app-logic/constants';
+import { TIMELINE_MARGIN_RIGHT } from '../../app-logic/constants';
 import explicitConnect from '../../utils/connect';
 import { MarkerChartCanvas } from './Canvas';
 import { MarkerChartEmptyReasons } from './MarkerChartEmptyReasons';
@@ -18,7 +15,11 @@ import {
   getPreviewSelection,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedThreadsKey } from '../../selectors/url-state';
+import {
+  getSelectedThreadsKey,
+  getTimelineTrackOrganization,
+} from '../../selectors/url-state';
+import { getTimelineMarginLeft } from '../../selectors/app';
 import {
   updatePreviewSelection,
   changeRightClickedMarker,
@@ -33,6 +34,8 @@ import type {
   StartEndRange,
   PreviewSelection,
   ThreadsKey,
+  CssPixels,
+  TimelineTrackOrganization,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -54,6 +57,8 @@ type StateProps = {|
   +threadsKey: ThreadsKey,
   +previewSelection: PreviewSelection,
   +rightClickedMarkerIndex: MarkerIndex | null,
+  +timelineMarginLeft: CssPixels,
+  +timelineTrackOrganization: TimelineTrackOrganization,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -103,6 +108,8 @@ class MarkerChartImpl extends React.PureComponent<Props> {
       updatePreviewSelection,
       changeRightClickedMarker,
       rightClickedMarkerIndex,
+      timelineMarginLeft,
+      timelineTrackOrganization,
     } = this.props;
 
     // The viewport needs to know about the height of what it's drawing, calculate
@@ -134,7 +141,7 @@ class MarkerChartImpl extends React.PureComponent<Props> {
                 maxViewportHeight,
                 viewportNeedsUpdate,
                 maximumZoom: this.getMaximumZoom(),
-                marginLeft: TIMELINE_MARGIN_LEFT,
+                marginLeft: timelineMarginLeft,
                 marginRight: TIMELINE_MARGIN_RIGHT,
                 containerRef: this._takeViewportRef,
               }}
@@ -148,10 +155,11 @@ class MarkerChartImpl extends React.PureComponent<Props> {
                 rangeEnd: timeRange.end,
                 rowHeight: ROW_HEIGHT,
                 threadsKey,
-                marginLeft: TIMELINE_MARGIN_LEFT,
+                marginLeft: timelineMarginLeft,
                 marginRight: TIMELINE_MARGIN_RIGHT,
                 rightClickedMarkerIndex,
                 shouldDisplayTooltips: this._shouldDisplayTooltips,
+                timelineTrackOrganization,
               }}
             />
           </ContextMenuTrigger>
@@ -184,6 +192,8 @@ export const MarkerChart = explicitConnect<{||}, StateProps, DispatchProps>({
       rightClickedMarkerIndex: selectedThreadSelectors.getRightClickedMarkerIndex(
         state
       ),
+      timelineMarginLeft: getTimelineMarginLeft(state),
+      timelineTrackOrganization: getTimelineTrackOrganization(state),
     };
   },
   mapDispatchToProps: { updatePreviewSelection, changeRightClickedMarker },

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -6,10 +6,7 @@
 import { GREY_30 } from 'photon-colors';
 import * as React from 'react';
 import memoize from 'memoize-immutable';
-import {
-  TIMELINE_MARGIN_LEFT,
-  TIMELINE_MARGIN_RIGHT,
-} from '../../app-logic/constants';
+import { TIMELINE_MARGIN_RIGHT } from '../../app-logic/constants';
 import {
   withChartViewport,
   type WithChartViewport,
@@ -67,6 +64,7 @@ type OwnProps = {|
   +onRightClick: (IndexIntoCallNodeTable | null) => void,
   +shouldDisplayTooltips: () => boolean,
   +scrollToSelectionGeneration: number,
+  +marginLeft: CssPixels,
 |};
 
 type Props = $ReadOnly<{|
@@ -157,6 +155,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       categories,
       callNodeInfo: { callNodeTable },
       getMarker,
+      marginLeft,
       viewport: {
         containerWidth,
         containerHeight,
@@ -190,7 +189,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
     const endDepth = Math.ceil(viewportBottom / stackFrameHeight);
 
     const innerContainerWidth =
-      containerWidth - TIMELINE_MARGIN_LEFT - TIMELINE_MARGIN_RIGHT;
+      containerWidth - marginLeft - TIMELINE_MARGIN_RIGHT;
     const innerDevicePixelsWidth = innerContainerWidth * devicePixelRatio;
 
     const pixelAtViewportPosition = (
@@ -198,7 +197,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
     ): DevicePixels =>
       devicePixelRatio *
       // The right hand side of this formula is all in CSS pixels.
-      (TIMELINE_MARGIN_LEFT +
+      (marginLeft +
         ((viewportPosition - viewportLeft) * innerContainerWidth) /
           viewportLength);
 
@@ -231,9 +230,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
 
       // Decide which samples to actually draw
       const timeAtStart: Milliseconds =
-        rangeStart +
-        rangeLength * viewportLeft -
-        timePerPixel * TIMELINE_MARGIN_LEFT;
+        rangeStart + rangeLength * viewportLeft - timePerPixel * marginLeft;
       const timeAtEnd: Milliseconds = rangeStart + rangeLength * viewportRight;
 
       let lastDrawnPixelX = 0;
@@ -525,17 +522,18 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       rangeStart,
       rangeEnd,
       combinedTimingRows,
+      marginLeft,
       viewport: { viewportLeft, viewportRight, viewportTop, containerWidth },
     } = this.props;
 
     const innerDevicePixelsWidth =
-      containerWidth - TIMELINE_MARGIN_LEFT - TIMELINE_MARGIN_RIGHT;
+      containerWidth - marginLeft - TIMELINE_MARGIN_RIGHT;
     const rangeLength: Milliseconds = rangeEnd - rangeStart;
     const viewportLength: UnitIntervalOfProfileRange =
       viewportRight - viewportLeft;
     const unitIntervalTime: UnitIntervalOfProfileRange =
       viewportLeft +
-      viewportLength * ((x - TIMELINE_MARGIN_LEFT) / innerDevicePixelsWidth);
+      viewportLength * ((x - marginLeft) / innerDevicePixelsWidth);
     const time: Milliseconds = rangeStart + unitIntervalTime * rangeLength;
     const depth = Math.floor((y + viewportTop) / ROW_CSS_PIXELS_HEIGHT);
     const stackTiming = combinedTimingRows[depth];

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -5,7 +5,6 @@
 // @flow
 import * as React from 'react';
 import {
-  TIMELINE_MARGIN_LEFT,
   TIMELINE_MARGIN_RIGHT,
   JS_TRACER_MAXIMUM_CHART_ZOOM,
 } from '../../app-logic/constants';
@@ -24,6 +23,7 @@ import {
   getShowUserTimings,
   getSelectedThreadsKey,
 } from '../../selectors/url-state';
+import { getTimelineMarginLeft } from '../../selectors/app';
 import { StackChartEmptyReasons } from './StackChartEmptyReasons';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 import StackSettings from '../shared/StackSettings';
@@ -51,6 +51,7 @@ import type {
   PreviewSelection,
   WeightType,
   ThreadsKey,
+  CssPixels,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -76,6 +77,7 @@ type StateProps = {|
   +scrollToSelectionGeneration: number,
   +getMarker: MarkerIndex => Marker,
   +userTimings: MarkerIndex[],
+  +timelineMarginLeft: CssPixels,
 |};
 
 type DispatchProps = {|
@@ -155,6 +157,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       getMarker,
       userTimings,
       weightType,
+      timelineMarginLeft,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -184,7 +187,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   timeRange,
                   maxViewportHeight,
                   viewportNeedsUpdate,
-                  marginLeft: TIMELINE_MARGIN_LEFT,
+                  marginLeft: timelineMarginLeft,
                   marginRight: TIMELINE_MARGIN_RIGHT,
                   maximumZoom: this.getMaximumZoom(),
                   containerRef: this._takeViewportRef,
@@ -210,6 +213,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   onRightClick: this._onRightClickedCallNodeChange,
                   shouldDisplayTooltips: this._shouldDisplayTooltips,
                   scrollToSelectionGeneration,
+                  marginLeft: timelineMarginLeft,
                 }}
               />
             </div>
@@ -249,6 +253,7 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       pages: getPageList(state),
       getMarker: selectedThreadSelectors.getMarkerGetter(state),
       userTimings: selectedThreadSelectors.getUserTimingMarkerIndexes(state),
+      timelineMarginLeft: getTimelineMarginLeft(state),
     };
   },
   mapDispatchToProps: {

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -32,6 +32,8 @@ import {
   TRACK_VISUAL_PROGRESS_HEIGHT,
   ACTIVE_TAB_TIMELINE_RESOURCES_HEADER_HEIGHT,
   TRACK_EVENT_DELAY_HEIGHT,
+  TIMELINE_MARGIN_LEFT,
+  ACTIVE_TAB_TIMELINE_MARGIN_LEFT,
 } from '../app-logic/constants';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -309,5 +311,26 @@ export const getIsNewProfileLoadAllowed: Selector<boolean> = createSelector(
       (appPhase === 'INITIALIZING' && dataSource !== 'none') ||
       zipPhase === 'PROCESS_PROFILE_FROM_ZIP_FILE';
     return !isLoading;
+  }
+);
+
+/**
+ * Height of screenshot track is different depending on the view.
+ */
+export const getTimelineMarginLeft: Selector<number> = createSelector(
+  getTimelineTrackOrganization,
+  timelineTrackOrganization => {
+    switch (timelineTrackOrganization.type) {
+      case 'active-tab':
+        return ACTIVE_TAB_TIMELINE_MARGIN_LEFT;
+      case 'full':
+      case 'origins':
+        return TIMELINE_MARGIN_LEFT;
+      default:
+        throw assertExhaustiveCheck(
+          timelineTrackOrganization,
+          `Unhandled TimelineTrackOrganization`
+        );
+    }
   }
 );

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -24,6 +24,8 @@ import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getProfileWithMarkers,
+  addActiveTabInformationToProfile,
+  addMarkersToThreadWithCorrespondingSamples,
   type TestDefinedMarkers,
 } from '../fixtures/profiles/processed-profile';
 import {
@@ -36,6 +38,7 @@ import {
   fireFullContextMenu,
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
 
 import type {
   UserTimingMarkerPayload,
@@ -499,6 +502,177 @@ describe('MarkerChart', function() {
       dispatch(changeSelectedTab('marker-chart'));
       dispatch(changeMarkersSearchString('MATCH_NOTHING'));
       expect(container.querySelector('.EmptyReasons')).toMatchSnapshot();
+    });
+  });
+
+  describe('with active tab', () => {
+    function setupForActiveTab() {
+      // Setup the profile data for active tab.
+      const {
+        profile,
+        firstTabBrowsingContextID,
+        parentInnerWindowIDsWithChildren,
+      } = addActiveTabInformationToProfile(getProfileWithMarkers([...MARKERS]));
+      profile.meta.configuration = {
+        threads: [],
+        features: [],
+        capacity: 1000000,
+        activeBrowsingContextID: firstTabBrowsingContextID,
+      };
+      addMarkersToThreadWithCorrespondingSamples(profile.threads[0], [
+        [
+          'Marker Navigation',
+          3,
+          null,
+          {
+            type: 'tracing',
+            category: 'Navigation',
+            interval: 'start',
+            innerWindowID: parentInnerWindowIDsWithChildren,
+          },
+        ],
+        [
+          'Marker DomEvent',
+          4,
+          10,
+          {
+            type: 'DOMEvent',
+            latency: 7,
+            eventType: 'click',
+            innerWindowID: parentInnerWindowIDsWithChildren,
+          },
+        ],
+      ]);
+
+      const setupResult = setupWithProfile(profile);
+      // Switch to active tab view.
+      setupResult.dispatch(
+        changeTimelineTrackOrganization({
+          type: 'active-tab',
+          browsingContextID: firstTabBrowsingContextID,
+        })
+      );
+
+      return {
+        ...setupResult,
+      };
+    }
+
+    it('renders the marker chart and matches the snapshot', () => {
+      window.devicePixelRatio = 2;
+      const {
+        dispatch,
+        flushRafCalls,
+        flushDrawLog,
+        container,
+      } = setupForActiveTab();
+
+      dispatch(changeSelectedTab('marker-chart'));
+      flushRafCalls();
+
+      const drawCalls = flushDrawLog();
+      expect(container.firstChild).toMatchSnapshot();
+      expect(drawCalls).toMatchSnapshot();
+
+      delete window.devicePixelRatio;
+    });
+
+    it('renders the hovered marker properly', () => {
+      window.devicePixelRatio = 1;
+
+      const {
+        dispatch,
+        flushRafCalls,
+        flushDrawLog,
+        fireMouseEvent,
+      } = setupForActiveTab();
+
+      dispatch(changeSelectedTab('marker-chart'));
+      flushRafCalls();
+      // No tooltip displayed yet
+      expect(document.querySelector('.tooltip')).toBeFalsy();
+
+      {
+        const drawLog = flushDrawLog();
+
+        // Find the DomEvent with the eventType 'click'.
+        const { x, y } = findFillTextPositionFromDrawLog(drawLog, 'click');
+
+        // Move the mouse on top of an item.
+        fireMouseEvent('mousemove', {
+          offsetX: x,
+          offsetY: y,
+          pageX: x,
+          pageY: y,
+        });
+      }
+
+      flushRafCalls();
+
+      const drawLog = flushDrawLog();
+      if (drawLog.length === 0) {
+        throw new Error('The mouse move produced no draw commands.');
+      }
+      expect(drawLog).toMatchSnapshot();
+
+      // The tooltip should be displayed
+      expect(
+        ensureExists(
+          document.querySelector('.tooltip'),
+          'A tooltip component must exist for this test.'
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('does not render the hovered label', () => {
+      window.devicePixelRatio = 1;
+
+      const {
+        dispatch,
+        flushRafCalls,
+        flushDrawLog,
+        fireMouseEvent,
+      } = setupForActiveTab();
+
+      dispatch(changeSelectedTab('marker-chart'));
+      flushRafCalls();
+
+      const getLabelFromDrawLog = (drawLog, markerLabel) =>
+        drawLog.filter(
+          ([operation, text]) =>
+            operation === 'fillText' && text === markerLabel
+        );
+
+      {
+        // First make sure that the marker label is present.
+        const drawLog = flushDrawLog();
+        expect(getLabelFromDrawLog(drawLog, 'Marker DomEvent')).toHaveLength(1);
+
+        // Find the DomEvent label.
+        const { x, y } = findFillTextPositionFromDrawLog(
+          drawLog,
+          'Marker DomEvent'
+        );
+
+        // Move the mouse on top of the label.
+        fireMouseEvent('mousemove', {
+          offsetX: x,
+          offsetY: y,
+          pageX: x,
+          pageY: y,
+        });
+      }
+
+      flushRafCalls();
+
+      const drawLog = flushDrawLog();
+      if (drawLog.length === 0) {
+        throw new Error('The mouse move produced no draw commands.');
+      }
+
+      // Now, since we hovered over the label, it should not be rendered.
+      expect(getLabelFromDrawLog(drawLog, 'Marker DomEvent')).toHaveLength(0);
+      expect(drawLog).toMatchSnapshot();
     });
   });
 });

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -784,3 +784,523 @@ Array [
   ],
 ]
 `;
+
+exports[`MarkerChart with active tab does not render the hovered label 1`] = `
+Array [
+  Array [
+    "set fillStyle",
+    "#fff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    365,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "rgba(40, 122, 169, 0.2)",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    365,
+    15,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    89,
+    17,
+    129.25,
+    1,
+  ],
+  Array [
+    "fillRect",
+    88,
+    18,
+    131.25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    89,
+    29,
+    129.25,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "click",
+    91,
+    27,
+  ],
+]
+`;
+
+exports[`MarkerChart with active tab renders the hovered marker properly 1`] = `
+Array [
+  Array [
+    "set fillStyle",
+    "#fff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    365,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "rgba(40, 122, 169, 0.2)",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    365,
+    15,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "Highlight",
+  ],
+  Array [
+    "fillRect",
+    89,
+    17,
+    129.25,
+    1,
+  ],
+  Array [
+    "fillRect",
+    88,
+    18,
+    131.25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    89,
+    29,
+    129.25,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "HighlightText",
+  ],
+  Array [
+    "fillText",
+    "click",
+    91,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf0",
+  ],
+  Array [
+    "fillRect",
+    0,
+    31,
+    365,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffffbf",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    85,
+    16,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Marker DomEvent",
+    5,
+    27,
+  ],
+]
+`;
+
+exports[`MarkerChart with active tab renders the hovered marker properly 2`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 102px; top: 38px;"
+>
+  <div
+    class="tooltipMarker"
+    style="--tooltip-detail-max-width: 600px;"
+  >
+    <div
+      class="tooltipHeader"
+    >
+      <div
+        class="tooltipOneLine"
+      >
+        <div
+          class="tooltipTiming"
+        >
+          6ms
+        </div>
+        <div
+          class="tooltipTitle"
+        >
+          click — DOMEvent
+        </div>
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Latency
+        :
+      </div>
+      7ms
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
+      <div
+        class="tooltipLabel"
+      >
+        URL
+        :
+      </div>
+      Page #1
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerChart with active tab renders the marker chart and matches the snapshot 1`] = `
+<div
+  aria-labelledby="marker-chart-tab-button"
+  class="markerChart"
+  id="marker-chart-tab"
+  role="tabpanel"
+>
+  <div
+    class="markerSettings"
+  >
+    <div
+      class="markerSettingsSpacer"
+    />
+    <div
+      class="panelSearchField markerSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter Markers: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display markers that match a certain name"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <div
+    class="react-contextmenu-wrapper treeViewContextMenu"
+  >
+    <div
+      class="chartViewport"
+      tabindex="0"
+    >
+      <div>
+        <canvas
+          class="chartCanvas markerChartCanvas"
+          height="600"
+          style="width: 365px; height: 300px;"
+          width="730"
+        />
+      </div>
+      <div
+        class="chartViewportScroll hidden"
+      >
+        Zoom Chart:
+        <kbd
+          class="chartViewportScrollKbd"
+        >
+          Ctrl + Scroll
+        </kbd>
+        or
+        <kbd
+          class="chartViewportScrollKbd"
+        >
+          Shift + Scroll
+        </kbd>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerChart with active tab renders the marker chart and matches the snapshot 2`] = `
+Array [
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    2,
+    2,
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "fillRect",
+    88.5,
+    17,
+    129.25,
+    1,
+  ],
+  Array [
+    "fillRect",
+    87.5,
+    18,
+    131.25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    88.5,
+    29,
+    129.25,
+    1,
+  ],
+  Array [
+    "measureText",
+    "click",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "click",
+    90.5,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "arc",
+    70.5,
+    39.5,
+    3.75,
+    0,
+    6.283185307179586,
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf0",
+  ],
+  Array [
+    "fillRect",
+    0,
+    15,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    31,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    47,
+    365,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "measureText",
+    "Marker DomEvent",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffffbf",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    85,
+    16,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Marker DomEvent",
+    5,
+    27,
+  ],
+  Array [
+    "measureText",
+    "Marker Navigation",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffffbf",
+  ],
+  Array [
+    "fillRect",
+    0,
+    32,
+    95,
+    16,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Marker Navigation",
+    5,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf0",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    16,
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "fillRect",
+    0,
+    -1,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    365,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Idle",
+    5,
+    11,
+  ],
+]
+`;

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -49,34 +49,6 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf0",
-  ],
-  Array [
-    "fillRect",
-    149,
-    0,
-    1,
-    300,
-  ],
-  Array [
-    "fillRect",
-    0,
-    143,
-    365,
-    1,
-  ],
-  Array [
-    "set fillStyle",
-    "#000000",
-  ],
-  Array [
-    "fillText",
-    "UserTiming",
-    5,
-    139,
-  ],
-  Array [
-    "set fillStyle",
     "rgba(40, 122, 169, 0.2)",
   ],
   Array [
@@ -123,6 +95,34 @@ Array [
     "fillText",
     "Marker B",
     178,
+    139,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf0",
+  ],
+  Array [
+    "fillRect",
+    149,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    0,
+    143,
+    365,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "UserTiming",
+    5,
     139,
   ],
 ]


### PR DESCRIPTION
Since we removed the left track label area from the timeline on active tab, we also had to align the panels with the timeline. This PR removes that margin from the panels if the the view is active tab.
For marker chart, things were a bit trickier, because we had some labels on the left side. With this PR, we are making the marker labels hover over the markers. But also we are making the labels hidden if we hover over them to make sure it's not concealing the markers below.

Now it's possible to hover both markers and labels in the marker chart. To make this possible, I changed the `hoveredItem` to keep a tuple of marker and label instead.

Also PR looks pretty big right now but actually it's not that bad. I added some snapshots for marker chart drawing in the active tab. That made the PR look pretty big. It would be good to review this commit by commit.

[Deploy preview](https://deploy-preview-2834--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/marker-chart/?ctxId=12&range=821m22356&thread=19&v=5&view=active-tab)
[Also this is the deploy preview with full view, to make sure we are not breaking the marker chart](https://deploy-preview-2834--perf-html.netlify.app/public/014dcadd045f9bc8d43359dbef1905a7a995d25f/marker-chart/?globalTrackOrder=14-0-1-2-3-4-5-6-7-8-9-10-11-12-13&hiddenGlobalTracks=2-3-4-5-6-7-8-9-10-11-12&hiddenLocalTracksByPid=60384-2-3-4-5&localTrackOrderByPid=60384-6-7-0-1-2-3-4-5~60773-0-1~60796-0-1~60795-0-1~60752-0-1~60750-0-1~60749-0-1~60727-0-1~60726-0-1~60397-0~60705-0-1~60398-0~60399-0~60684-0-1~&thread=0&v=5)