### PR TITLE
Make ButtonWithPanel encapsulate focus operations

### DIFF
--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -99,8 +99,6 @@ class PublishedProfile extends React.PureComponent<
     status: 'idle',
   };
   _componentDeleteButtonRef = React.createRef();
-  _domDeleteButtonRef = React.createRef();
-  _actionButtonsRef = React.createRef();
 
   onConfirmDeletion = async () => {
     const { profileToken, jwtToken } = this.props.profileData;
@@ -142,25 +140,6 @@ class PublishedProfile extends React.PureComponent<
     // let's move directly to the deleted state:
     if (this.state.status === 'just-deleted') {
       this.setState({ status: 'deleted' });
-    }
-
-    // Let's focus the delete button after dismissing the dialog, but _only_ if
-    // the focus was part of the dialog before.
-    // Note: we might need to get a more precise ref to the right
-    // buttonWithPanel wrapper when we'll have more buttons.
-    const deleteButton = this._domDeleteButtonRef.current;
-    const actionButtons = this._actionButtonsRef.current;
-    try {
-      if (
-        deleteButton &&
-        actionButtons &&
-        actionButtons.matches(':focus-within')
-      ) {
-        deleteButton.focus();
-      }
-    } catch (e) {
-      // This browser doesn't support :focus-within (especially JSDOM), let's
-      // degrade gracefully by not refocusing the delete button.
     }
   };
 
@@ -232,14 +211,10 @@ class PublishedProfile extends React.PureComponent<
           </div>
         </a>
         {withActionButtons ? (
-          <div
-            className="publishedProfilesActionButtons"
-            ref={this._actionButtonsRef}
-          >
+          <div className="publishedProfilesActionButtons">
             {profileData.jwtToken ? (
               <ButtonWithPanel
                 ref={this._componentDeleteButtonRef}
-                buttonRef={this._domDeleteButtonRef}
                 buttonClassName="publishedProfilesDeleteButton photon-button photon-button-default"
                 label="Delete"
                 title={`Click here to delete the profile ${smallProfileName}`}

--- a/src/components/shared/ButtonWithPanel/index.js
+++ b/src/components/shared/ButtonWithPanel/index.js
@@ -43,7 +43,6 @@ type Props = {|
   +buttonClassName?: string,
   +onPanelOpen?: () => mixed,
   +onPanelClose?: () => mixed,
-  +buttonRef?: {| -current: null | HTMLInputElement |},
   +title?: string,
 |};
 
@@ -53,6 +52,8 @@ type State = {|
 
 export class ButtonWithPanel extends React.PureComponent<Props, State> {
   _panel: ArrowPanel | null = null;
+  _buttonRef = React.createRef<HTMLInputElement>();
+  _wrapperRef = React.createRef<HTMLElement>();
 
   constructor(props: Props) {
     super(props);
@@ -83,6 +84,16 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
 
   _onPanelClose = () => {
     this.setState({ open: false });
+
+    // Let's focus the delete button after dismissing the dialog, but _only_ if
+    // the focus was part of the dialog before.
+    // Note this branch isn't tested because jsdom doesn't support the
+    // :focus-within selector.
+    /* istanbul ignore if */
+    if (this.isFocusWithin()) {
+      this.focus();
+    }
+
     if (this.props.onPanelClose) {
       this.props.onPanelClose();
     }
@@ -122,6 +133,27 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
     }
   };
 
+  // This function isn't called in tests because isFocusWithin never returns
+  // true in jsdom. So let's ignore ir from the code coverage report.
+  /* istanbul ignore next */
+  focus() {
+    if (this._buttonRef.current) {
+      this._buttonRef.current.focus();
+    }
+  }
+
+  isFocusWithin(): boolean {
+    try {
+      if (this._wrapperRef.current) {
+        return this._wrapperRef.current.matches(':focus-within');
+      }
+    } catch {
+      // This browser doesn't support :focus-within (especially JSDOM), let's
+      // degrade gracefully.
+    }
+    return false;
+  }
+
   render() {
     const {
       className,
@@ -129,12 +161,14 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
       panelContent,
       panelClassName,
       buttonClassName,
-      buttonRef,
       title,
     } = this.props;
     const { open } = this.state;
     return (
-      <div className={classNames('buttonWithPanel', className, { open })}>
+      <div
+        className={classNames('buttonWithPanel', className, { open })}
+        ref={this._wrapperRef}
+      >
         <input
           type="button"
           className={classNames('buttonWithPanelButton', buttonClassName)}
@@ -142,7 +176,7 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
           aria-expanded={String(open)}
           title={open ? null : title}
           onClick={this._onButtonClick}
-          ref={buttonRef}
+          ref={this._buttonRef}
         />
         <ArrowPanel
           className={panelClassName}


### PR DESCRIPTION
This is an evolution of the previous commit https://github.com/firefox-devtools/profiler/pull/2805/commits/dcbbb8bf651009e1509e2ad885aaed9305817f31 in #2805 that you already reviewed. As we discussed I've moved all the focus handling code inside `ButtonWithPanel`, so now it also works in all menu buttons.

Sadly it's not possible to test this because of how I made it work: by using the CSS selector `:focus-within`. Indeed it's not implemented in jsdom. Then I tested this manually, both in the menu buttons and in the uploaded recordings list.