### PR TITLE
Add call tree transform shortcuts

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -475,7 +475,6 @@ body,
 .react-contextmenu.react-contextmenu--visible {
   display: block;
   max-height: 90vh;
-  padding-right: 9px;
   overflow-y: auto;
 }
 

--- a/res/css/style.css
+++ b/res/css/style.css
@@ -495,9 +495,9 @@ body,
 .react-contextmenu-item.react-contextmenu-item--active,
 .react-contextmenu-item:hover,
 .react-contextmenu-item--selected {
-  border-color: highlight;
-  background-color: highlight;
-  color: highlighttext;
+  border-color: var(--blue-60);
+  background-color: var(--blue-60);
+  color: #fff;
   text-decoration: none;
 }
 

--- a/res/img/svg/merge-icon.svg
+++ b/res/img/svg/merge-icon.svg
@@ -3,10 +3,10 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-    <circle fill="context-fill" fill-opacity="context-fill-opacity" cx="3" cy="3" r="2"></circle>
-    <circle fill="context-fill" fill-opacity="context-fill-opacity" cx="13" cy="13" r="2"></circle>
-    <path d="M12.5,12.5 L9.5,9.5" stroke="context-fill" stroke-opacity="context-fill-opacity" stroke-linecap="square"></path>
+    <circle fill="#000000" cx="3" cy="3" r="2"></circle>
+    <circle fill="#000000" cx="13" cy="13" r="2"></circle>
+    <path d="M12.5,12.5 L9.5,9.5" stroke="#000000" stroke-linecap="square"></path>
     <circle stroke="#0A0A0A" cx="8" cy="8" r="1.5"></circle>
-    <path d="M6.5,6.5 L3.5,3.5" stroke="context-fill" stroke-opacity="context-fill-opacity" stroke-linecap="square"></path>
+    <path d="M6.5,6.5 L3.5,3.5" stroke="#000000" stroke-linecap="square"></path>
   </g>
 </svg>

--- a/res/img/svg/merge-icon.svg
+++ b/res/img/svg/merge-icon.svg
@@ -3,10 +3,10 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-    <circle fill="#000000" cx="3" cy="3" r="2"></circle>
-    <circle fill="#000000" cx="13" cy="13" r="2"></circle>
-    <path d="M12.5,12.5 L9.5,9.5" stroke="#000000" stroke-linecap="square"></path>
+    <circle fill="context-fill" fill-opacity="context-fill-opacity" cx="3" cy="3" r="2"></circle>
+    <circle fill="context-fill" fill-opacity="context-fill-opacity" cx="13" cy="13" r="2"></circle>
+    <path d="M12.5,12.5 L9.5,9.5" stroke="context-fill" stroke-opacity="context-fill-opacity" stroke-linecap="square"></path>
     <circle stroke="#0A0A0A" cx="8" cy="8" r="1.5"></circle>
-    <path d="M6.5,6.5 L3.5,3.5" stroke="#000000" stroke-linecap="square"></path>
+    <path d="M6.5,6.5 L3.5,3.5" stroke="context-fill" stroke-opacity="context-fill-opacity" stroke-linecap="square"></path>
   </g>
 </svg>

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -30,6 +30,7 @@ import {
   getLocalTrackOrder,
   getSelectedTab,
   getHiddenLocalTracks,
+  getInvertCallstack,
 } from 'firefox-profiler/selectors/url-state';
 import {
   getCallNodePathFromIndex,
@@ -64,6 +65,7 @@ import type {
   ThreadsKey,
   Milliseconds,
 } from 'firefox-profiler/types';
+import { funcHasRecursiveCall } from '../profile-logic/transforms';
 
 /**
  * This file contains actions that pertain to changing the view on the profile, including
@@ -1369,5 +1371,109 @@ export function changeMouseTimePosition(
   return {
     type: 'CHANGE_MOUSE_TIME_POSITION',
     mouseTimePosition,
+  };
+}
+
+export function handleCallNodeTransformShortcut(
+  event: SyntheticKeyboardEvent<>,
+  threadsKey: ThreadsKey,
+  callNodeIndex: IndexIntoCallNodeTable
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+    const threadSelectors = getThreadSelectorsFromThreadsKey(threadsKey);
+    const unfilteredThread = threadSelectors.getThread(getState());
+    const { callNodeTable } = threadSelectors.getCallNodeInfo(getState());
+    const implementation = getImplementationFilter(getState());
+    const inverted = getInvertCallstack(getState());
+    const callNodePath = getCallNodePathFromIndex(callNodeIndex, callNodeTable);
+    const funcIndex = callNodeTable.func[callNodeIndex];
+
+    switch (event.key) {
+      case 'F':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'focus-subtree',
+            callNodePath: callNodePath,
+            implementation,
+            inverted,
+          })
+        );
+        break;
+      case 'f':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'focus-function',
+            funcIndex,
+          })
+        );
+        break;
+      case 'M':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'merge-call-node',
+            callNodePath: callNodePath,
+            implementation,
+          })
+        );
+        break;
+      case 'm':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'merge-function',
+            funcIndex,
+          })
+        );
+        break;
+      case 'd':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'drop-function',
+            funcIndex,
+          })
+        );
+        break;
+      case 'C': {
+        const { funcTable } = unfilteredThread;
+        const resourceIndex = funcTable.resource[funcIndex];
+        // A new collapsed func will be inserted into the table at the end. Deduce
+        // the index here.
+        const collapsedFuncIndex = funcTable.length;
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'collapse-resource',
+            resourceIndex,
+            collapsedFuncIndex,
+            implementation,
+          })
+        );
+        break;
+      }
+      case 'r': {
+        if (funcHasRecursiveCall(unfilteredThread, implementation, funcIndex)) {
+          dispatch(
+            addTransformToStack(threadsKey, {
+              type: 'collapse-direct-recursion',
+              funcIndex,
+              implementation,
+            })
+          );
+        }
+        break;
+      }
+      case 'c': {
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'collapse-function-subtree',
+            funcIndex,
+          })
+        );
+        break;
+      }
+      default:
+      // This did not match a call tree transform.
+    }
   };
 }

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -28,6 +28,7 @@ import {
   changeRightClickedCallNode,
   changeExpandedCallNodes,
   addTransformToStack,
+  handleCallNodeTransformShortcut,
 } from 'firefox-profiler/actions/profile-view';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 
@@ -67,6 +68,7 @@ type DispatchProps = {|
   +changeRightClickedCallNode: typeof changeRightClickedCallNode,
   +changeExpandedCallNodes: typeof changeExpandedCallNodes,
   +addTransformToStack: typeof addTransformToStack,
+  +handleCallNodeTransformShortcut: typeof handleCallNodeTransformShortcut,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -228,6 +230,16 @@ class CallTreeImpl extends PureComponent<Props> {
     );
   };
 
+  _onKeyDown = (
+    event: SyntheticKeyboardEvent<>,
+    callNodeIndex: IndexIntoCallNodeTable | null
+  ) => {
+    if (callNodeIndex !== null) {
+      const { handleCallNodeTransformShortcut, threadsKey } = this.props;
+      handleCallNodeTransformShortcut(event, threadsKey, callNodeIndex);
+    }
+  };
+
   procureInterestingInitialSelection() {
     // Expand the heaviest callstack up to a certain depth and select the frame
     // at that depth.
@@ -293,6 +305,7 @@ class CallTreeImpl extends PureComponent<Props> {
         maxNodeDepth={callNodeMaxDepth}
         rowHeight={16}
         indentWidth={10}
+        onKeyDown={this._onKeyDown}
       />
     );
   }
@@ -326,6 +339,7 @@ export const CallTree = explicitConnect<{||}, StateProps, DispatchProps>({
     changeRightClickedCallNode,
     changeExpandedCallNodes,
     addTransformToStack,
+    handleCallNodeTransformShortcut,
   },
   component: CallTreeImpl,
 });

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -26,6 +26,7 @@ import { getCallNodePathFromIndex } from 'firefox-profiler/profile-logic/profile
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
+  handleCallNodeTransformShortcut,
 } from 'firefox-profiler/actions/profile-view';
 
 import type {
@@ -88,6 +89,7 @@ type StateProps = {|
 type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
   +changeRightClickedCallNode: typeof changeRightClickedCallNode,
+  +handleCallNodeTransformShortcut: typeof handleCallNodeTransformShortcut,
 |};
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
@@ -189,6 +191,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
       callNodeInfo: { callNodeTable },
       selectedCallNodeIndex,
       changeSelectedCallNode,
+      handleCallNodeTransformShortcut,
     } = this.props;
 
     if (selectedCallNodeIndex === null) {
@@ -246,7 +249,11 @@ class FlameGraphImpl extends React.PureComponent<Props> {
         break;
       }
       default:
-        // Other keys are ignored
+        handleCallNodeTransformShortcut(
+          event,
+          threadsKey,
+          selectedCallNodeIndex
+        );
         break;
     }
   };
@@ -381,6 +388,7 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
   mapDispatchToProps: {
     changeSelectedCallNode,
     changeRightClickedCallNode,
+    handleCallNodeTransformShortcut,
   },
   options: { forwardRef: true },
   component: FlameGraphImpl,

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -76,7 +76,7 @@ class NetworkChartImpl extends React.PureComponent<Props> {
     // Not implemented.
   };
 
-  _onKeyDown = (_event: KeyboardEvent) => {
+  _onKeyDown = (_event: SyntheticKeyboardEvent<>) => {
     // Not implemented.
   };
 

--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -7,7 +7,8 @@
   margin-inline-end: 8px;
   pointer-events: auto;
 }
-.react-contextmenu-item--selected > .callNodeContextMenuIcon {
+.react-contextmenu-item:hover .callNodeContextMenuIcon,
+.react-contextmenu-item:active .callNodeContextMenuIcon {
   filter: invert(1);
 }
 
@@ -31,6 +32,7 @@
 .callNodeContextMenuLabel {
   color: #555;
   font-weight: bold;
+  margin-inline: 2px;
 }
 
 .react-contextmenu-item--selected > .callNodeContextMenuLabel {

--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -7,6 +7,8 @@
   margin-inline-end: 8px;
   pointer-events: auto;
 }
+
+.react-contextmenu-item--selected > .callNodeContextMenuIcon,
 .react-contextmenu-item:hover .callNodeContextMenuIcon,
 .react-contextmenu-item:active .callNodeContextMenuIcon {
   filter: invert(1);
@@ -35,10 +37,7 @@
   margin-inline: 2px;
 }
 
-.react-contextmenu-item--selected > .callNodeContextMenuLabel {
-  color: #fff;
-}
-
+.react-contextmenu-item--selected > .callNodeContextMenuLabel,
 .react-contextmenu-item:hover .callNodeContextMenuLabel,
 .react-contextmenu-item:active .callNodeContextMenuLabel {
   color: #fff;
@@ -49,7 +48,7 @@
 }
 
 .callNodeContextMenuWithKey > div {
-  /* Verticially align the text with the icon */
+  /* Vertically align the text with the icon */
   display: flex;
   flex: 1;
 }

--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -38,3 +38,33 @@
 .react-contextmenu-item--selected > .callNodeContextMenuLabel {
   color: #fff;
 }
+
+.react-contextmenu-item:hover .callNodeContextMenuLabel,
+.react-contextmenu-item:active .callNodeContextMenuLabel {
+  color: #fff;
+}
+
+.callNodeContextMenuWithKey {
+  display: flex;
+}
+
+.callNodeContextMenuWithKey > div {
+  /* Verticially align the text with the icon */
+  display: flex;
+  flex: 1;
+}
+
+.callNodeContextMenuWithKey > kbd {
+  display: inline-block;
+  padding: 0 5px;
+
+  /* This color is based off of photon grey, but adjusted to have a nice visual look
+     when hovering. */
+  background: #dedee3c9;
+  border-radius: 3px;
+  box-shadow: 1px 1px #0004;
+
+  /* Override the hover color. */
+  color: #000;
+  margin-inline-start: 12px;
+}

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import React, { PureComponent, Fragment } from 'react';
+import * as React from 'react';
 import { MenuItem } from 'react-contextmenu';
 import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
@@ -64,7 +64,7 @@ type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 import './CallNodeContextMenu.css';
 
-class CallNodeContextMenuImpl extends PureComponent<Props> {
+class CallNodeContextMenuImpl extends React.PureComponent<Props> {
   _hidingTimeout: TimeoutID | null = null;
 
   // Using setTimeout here is a bit complex, but is necessary to make the menu
@@ -446,7 +446,7 @@ class CallNodeContextMenuImpl extends PureComponent<Props> {
     const showExpandAll = selectedTab === 'calltree';
 
     return (
-      <Fragment>
+      <>
         <TransformMenuItem
           shortcut="m"
           icon="Merge"
@@ -569,12 +569,12 @@ class CallNodeContextMenuImpl extends PureComponent<Props> {
         <div className="react-contextmenu-separator" />
 
         {showExpandAll ? (
-          <Fragment>
+          <>
             <MenuItem onClick={this._handleClick} data={{ type: 'expand-all' }}>
               Expand all
             </MenuItem>
             <div className="react-contextmenu-separator" />
-          </Fragment>
+          </>
         ) : null}
         <MenuItem onClick={this._handleClick} data={{ type: 'searchfox' }}>
           Look up the function name on Searchfox
@@ -593,7 +593,7 @@ class CallNodeContextMenuImpl extends PureComponent<Props> {
         <MenuItem onClick={this._handleClick} data={{ type: 'copy-stack' }}>
           Copy stack
         </MenuItem>
-      </Fragment>
+      </>
     );
   }
 
@@ -662,8 +662,8 @@ export const CallNodeContextMenu = explicitConnect<
 });
 
 function TransformMenuItem(props: {|
-  +children: *,
-  +onClick: *,
+  +children: React.Node,
+  +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
   +transform: string,
   +shortcut: string,
   +icon: string,

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -341,6 +341,7 @@ type TreeViewProps<DisplayData> = {|
   +onEnterKey?: NodeIndex => mixed,
   +rowHeight: CssPixels,
   +indentWidth: CssPixels,
+  +onKeyDown?: (SyntheticKeyboardEvent<>, null | NodeIndex) => void,
 |};
 
 export class TreeView<DisplayData: Object> extends React.PureComponent<
@@ -561,7 +562,11 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     }
   };
 
-  _onKeyDown = (event: KeyboardEvent) => {
+  _onKeyDown = (event: SyntheticKeyboardEvent<>) => {
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(event, this.props.selectedNodeId);
+    }
+
     const hasModifier = event.ctrlKey || event.altKey;
     const isNavigationKey =
       event.key.startsWith('Arrow') ||

--- a/src/components/shared/VirtualList.js
+++ b/src/components/shared/VirtualList.js
@@ -234,7 +234,7 @@ type VirtualListProps<Item> = {|
   +items: $ReadOnlyArray<Item>,
   +focusable: boolean,
   +specialItems: $ReadOnlyArray<Item | void>,
-  +onKeyDown: KeyboardEvent => void,
+  +onKeyDown: (SyntheticKeyboardEvent<>) => void,
   +onCopy: Event => void,
   // Set `disableOverscan` to `true` when you expect a lot of updates in a short
   // time: this will render only the visible part, which makes each update faster.

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -28,9 +28,9 @@ describe('calltree/CallNodeContextMenu', function() {
       funcNamesDictPerThread: [{ A, B }],
     } = getProfileFromTextSamples(`
       A               A               A
-      B[lib:library]  B[lib:library]  B[lib:library]
-      B[lib:library]  B[lib:library]  B[lib:library]
-      B[lib:library]  B[lib:library]  B[lib:library]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
       C               C               H
       D               F               I
       E               E
@@ -77,13 +77,16 @@ describe('calltree/CallNodeContextMenu', function() {
   describe('clicking on call tree transforms', function() {
     // Iterate through each transform slug, and click things in it.
     const fixtures = [
-      { matcher: /Merge node/, type: 'merge-call-node' },
       { matcher: /Merge function/, type: 'merge-function' },
-      { matcher: /Focus.*subtree/, type: 'focus-subtree' },
-      { matcher: /Focus.*function/, type: 'focus-function' },
-      { matcher: /Collapse.*subtree/, type: 'collapse-function-subtree' },
-      { matcher: /Collapse functions/, type: 'collapse-resource' },
-      { matcher: /Collapse.*recursion/, type: 'collapse-direct-recursion' },
+      { matcher: /Merge node only/, type: 'merge-call-node' },
+      { matcher: /Focus on subtree only/, type: 'focus-subtree' },
+      { matcher: /Focus on function/, type: 'focus-function' },
+      { matcher: /Collapse function/, type: 'collapse-function-subtree' },
+      { matcher: /XUL/, type: 'collapse-resource' },
+      {
+        matcher: /Collapse direct recursion/,
+        type: 'collapse-direct-recursion',
+      },
       { matcher: /Drop samples/, type: 'drop-function' },
     ];
 
@@ -110,7 +113,7 @@ describe('calltree/CallNodeContextMenu', function() {
       // This test only asserts that a bunch of call nodes were actually expanded.
       expect(
         selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
-      ).toHaveLength(11);
+      ).toHaveLength(7);
     });
 
     it('can look up functions on SearchFox', function() {

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -27,13 +27,13 @@ describe('calltree/CallNodeContextMenu', function() {
       profile,
       funcNamesDictPerThread: [{ A, B }],
     } = getProfileFromTextSamples(`
-      A               A               A
+      A           A           A
       B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
       B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
       B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
-      C               C               H
-      D               F               I
-      E               E
+      C           C           H
+      D           F           I
+      E           E
     `);
     const store = storeWithProfile(profile);
 
@@ -113,7 +113,7 @@ describe('calltree/CallNodeContextMenu', function() {
       // This test only asserts that a bunch of call nodes were actually expanded.
       expect(
         selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
-      ).toHaveLength(7);
+      ).toHaveLength(11);
     });
 
     it('can look up functions on SearchFox', function() {

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -9,11 +9,11 @@ import { Provider } from 'react-redux';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
 import { changeSelectedCallNode } from '../../actions/profile-view';
-import FlameGraph from '../../components/flame-graph';
+import { FlameGraph } from '../../components/flame-graph';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 import { fireFullKeyPress } from '../fixtures/utils';
-import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
+import { ProfileCallTreeView } from '../../components/calltree/ProfileCallTreeView';
 import type { TransformType } from 'firefox-profiler/types';
 
 type TestSetup = {|
@@ -70,7 +70,7 @@ function testTransformKeyboardShortcuts(setup: () => TestSetup) {
     expect(getTransformType()).toEqual('collapse-function-subtree');
   });
 
-  it('ignores shorcuts with modifiers', () => {
+  it('ignores shortcuts with modifiers', () => {
     const { pressKey, getTransformType } = setup();
     pressKey({ key: 'c', ctrlKey: true });
     pressKey({ key: 'c', metaKey: true });

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { storeWithProfile } from '../fixtures/stores';
+import { changeSelectedCallNode } from '../../actions/profile-view';
+import FlameGraph from '../../components/flame-graph';
+import { selectedThreadSelectors } from 'firefox-profiler/selectors';
+import { ensureExists } from '../../utils/flow';
+import { fireFullKeyPress } from '../fixtures/utils';
+import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
+import type { TransformType } from 'firefox-profiler/types';
+
+type TestSetup = {|
+  getTransformType: () => null | TransformType,
+  pressKey: (options: *) => void,
+|};
+
+function testTransformKeyboardShortcuts(setup: () => TestSetup) {
+  it('handles merge function', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'm' });
+    expect(getTransformType()).toEqual('merge-function');
+  });
+
+  it('handles focus subtree', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'F' });
+    expect(getTransformType()).toEqual('focus-subtree');
+  });
+
+  it('handles focus-function', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'f' });
+    expect(getTransformType()).toEqual('focus-function');
+  });
+
+  it('handles merge call node', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'M' });
+    expect(getTransformType()).toEqual('merge-call-node');
+  });
+
+  it('handles drop function', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'd' });
+    expect(getTransformType()).toEqual('drop-function');
+  });
+
+  it('handles collapse resource', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'C' });
+    expect(getTransformType()).toEqual('collapse-resource');
+  });
+
+  it('handles collapse direct recursion', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'r' });
+    expect(getTransformType()).toEqual('collapse-direct-recursion');
+  });
+
+  it('handles collapse function subtree', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'c' });
+    expect(getTransformType()).toEqual('collapse-function-subtree');
+  });
+
+  it('ignores shorcuts with modifiers', () => {
+    const { pressKey, getTransformType } = setup();
+    pressKey({ key: 'c', ctrlKey: true });
+    pressKey({ key: 'c', metaKey: true });
+    expect(getTransformType()).toEqual(null);
+  });
+}
+
+describe('flame graph transform shortcuts', () => {
+  testTransformKeyboardShortcuts(() => {
+    const {
+      profile,
+      funcNamesDictPerThread: [{ A, B }],
+    } = getProfileFromTextSamples(`
+      A               A               A
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      C               C               H
+      D               F               I
+      E               E
+    `);
+    const store = storeWithProfile(profile);
+    const { getState, dispatch } = store;
+
+    dispatch(changeSelectedCallNode(0, [A, B]));
+
+    const { container } = render(
+      <Provider store={store}>
+        <FlameGraph />
+      </Provider>
+    );
+
+    return {
+      getTransformType: () => {
+        const stack = selectedThreadSelectors.getTransformStack(getState());
+        switch (stack.length) {
+          case 0:
+            return null;
+          case 1:
+            return stack[0].type;
+          default:
+            throw new Error('This test assumes there is only one transform.');
+        }
+      },
+      // take either a key as a string, or a full event if we need more
+      // information like modifier keys.
+      pressKey: (options: *) => {
+        const div = ensureExists(
+          container.querySelector('.flameGraphContent'),
+          `Couldn't find the content div with selector .flameGraphContent`
+        );
+        fireFullKeyPress(div, options);
+      },
+    };
+  });
+});
+
+describe('CallTree transform shortcuts', () => {
+  testTransformKeyboardShortcuts(() => {
+    const {
+      profile,
+      funcNamesDictPerThread: [{ A, B }],
+    } = getProfileFromTextSamples(`
+      A               A               A
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      B[lib:XUL]  B[lib:XUL]  B[lib:XUL]
+      C               C               H
+      D               F               I
+      E               E
+    `);
+    const store = storeWithProfile(profile);
+    const { getState, dispatch } = store;
+
+    dispatch(changeSelectedCallNode(0, [A, B]));
+
+    const { container } = render(
+      <Provider store={store}>
+        <ProfileCallTreeView />
+      </Provider>
+    );
+
+    return {
+      getTransformType: () => {
+        const stack = selectedThreadSelectors.getTransformStack(getState());
+        switch (stack.length) {
+          case 0:
+            return null;
+          case 1:
+            return stack[0].type;
+          default:
+            throw new Error('This test assumes there is only one transform.');
+        }
+      },
+      // take either a key as a string, or a full event if we need more
+      // information like modifier keys.
+      pressKey: (options: *) => {
+        const treeViewBody = ensureExists(
+          container.querySelector('div.treeViewBody'),
+          `Couldn't find the tree view body with selector div.treeViewBody`
+        );
+        fireFullKeyPress(treeViewBody, options);
+      },
+    };
+  });
+});

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -13,71 +13,22 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     role="menuitem"
     tabindex="-1"
   >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconMerge"
-    />
-    Merge node into calling function
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconMerge"
-    />
-    Merge function into caller across the entire tree
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconFocus"
-    />
-    Focus on subtree
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconFocus"
-    />
-    Focus on function
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconCollapse"
-    />
-    Collapse function’s subtree across the entire tree
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconCollapse"
-    />
-    Collapse functions in
-     
-    <span
-      class="callNodeContextMenuLabel"
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Merging a function removes it from the profile, and assigns its time to the function that called it. This happens anywhere the function was called in the tree."
     >
-      library
-    </span>
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconMerge"
+        />
+        Merge function
+      </div>
+      <kbd>
+        m
+      </kbd>
+    </div>
   </div>
   <div
     aria-disabled="false"
@@ -85,10 +36,22 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     role="menuitem"
     tabindex="-1"
   >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconCollapse"
-    />
-    Collapse direct recursion
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Merging a node removes it from the profile, and assigns its time to the function's node that called it. It only removes the function from that specific part of the tree. Any other places the function was called will remain in the profile."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconMerge"
+        />
+        Merge node only
+      </div>
+      <kbd>
+        M
+      </kbd>
+    </div>
   </div>
   <div
     aria-disabled="false"
@@ -96,10 +59,142 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     role="menuitem"
     tabindex="-1"
   >
-    <span
-      class="callNodeContextMenuIcon callNodeContextMenuIconDrop"
-    />
-    Drop samples with this function
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Focusing on a function will remove any sample that does not include that function. In addition, it re-roots the call tree so that the function is the only root of the tree. This can combine multiple function call sites across a profile into one call node."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconFocus"
+        />
+        Focus on function
+      </div>
+      <kbd>
+        f
+      </kbd>
+    </div>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Focusing on a subtree will remove any sample that does not include that specific part of the call tree. It pulls out a branch of the call tree, however it only does it for that single call node. All other calls of the function are ignored."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconFocus"
+        />
+        Focus on subtree only
+      </div>
+      <kbd>
+        F
+      </kbd>
+    </div>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Collapsing a function will remove everything it called, and assign all of the time to the function. This can help simplify a profile that calls into code that does not need to be analyzed."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconCollapse"
+        />
+        Collapse function
+      </div>
+      <kbd>
+        c
+      </kbd>
+    </div>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Collapsing a resource will flatten out of all the calls into that resource into a single collapsed call node."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconCollapse"
+        />
+        Collapse
+        <span
+          class="callNodeContextMenuLabel"
+        >
+          XUL
+        </span>
+      </div>
+      <kbd>
+        C
+      </kbd>
+    </div>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Collapsing direct recursion removes calls that repeatedly recurse into the same function."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconCollapse"
+        />
+        Collapse direct recursion
+      </div>
+      <kbd>
+        r
+      </kbd>
+    </div>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <div
+      class="callNodeContextMenuWithKey"
+      title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not for the analysis."
+    >
+      <div
+        class="callNodeContextMenuWithKeyText"
+      >
+        <span
+          class="callNodeContextMenuIcon callNodeContextMenuIconDrop"
+        />
+        Drop samples with this function
+      </div>
+      <kbd>
+        d
+      </kbd>
+    </div>
   </div>
   <div
     class="react-contextmenu-separator"

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -325,3 +325,14 @@ export function fireFullContextMenu(
   fireEvent(element, getMouseEvent('mouseup', options));
   fireEvent(element, getMouseEvent('contextmenu', options));
 }
+
+/**
+ * React Testing Library only sends one event at a time, but a lot of component logic
+ * assumes that events come in a natural cascade. This utility ensures that cascasde
+ * gets fired correctly.
+ */
+export function fireFullKeyPress(element: HTMLElement, options?: *) {
+  fireEvent.keyDown(element, options);
+  fireEvent.keyPress(element, options);
+  fireEvent.keyUp(element, options);
+}

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -329,7 +329,17 @@ export function fireFullContextMenu(
 /**
  * React Testing Library only sends one event at a time, but a lot of component logic
  * assumes that events come in a natural cascade. This utility ensures that cascasde
- * gets fired correctly.
+ * gets fired more correctly.
+ *
+ * Note, that this utility is not quite complete in it's implementation. There are
+ * more complex interactions with prevent defaulting, and passing in the correct
+ * keycode information.
+ *
+ * For a more complete implementation see:
+ * https://github.com/testing-library/user-event/blob/c187639cbc7d2651d3392db6967f614a75a32695/src/type.js#L283
+ *
+ * And addition Julien's review comments here:
+ * https://github.com/firefox-devtools/profiler/pull/2842/commits/6be20eb6eafca56644b1d55010cc1824a1d03695#r501061693
  */
 export function fireFullKeyPress(element: HTMLElement, options?: *) {
   fireEvent.keyDown(element, options);


### PR DESCRIPTION
Edit, this is now ready for review. It resolves #2519

---

This is a draft PR for adding call tree transform shortcuts. It should be mostly complete, except it needs tests.

<img width="330" alt="image" src="https://user-images.githubusercontent.com/1588648/95136691-34c1be80-072c-11eb-9e8a-8db487c972b2.png">

[Deploy preview](https://deploy-preview-2842--perf-html.netlify.app/public/8tzsbbb2mtvdebtad4r760re887mg5f3wn0md08/stack-chart/?globalTrackOrder=12-0-1-2-3-4-5-6-7-8-9-10-11&hiddenGlobalTracks=12-0-1-2-3-4-5-6-7-8-9-10&hiddenLocalTracksByPid=4453-0-1-2&localTrackOrderByPid=4404-2-3-0-1-4-5~15157-0-1~4426-0-1~15136-0-1~4452-0-1~4449-0-1~4448-0-1~14900-0-1~4450-0-1~4427-0-1~4892-0-1-2~4453-0-1-2~&profileName=cnn.com%20Sep%202020&range=1615m1803&thread=13&v=5)