### PR TITLE
Jank markers 2.0

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -218,7 +218,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
             const key = label + '-' + value;
             details.push(
               <TooltipDetail key={key} label={label}>
-                {value}
+                <div className="tooltipDetailsDescription">{value}</div>
               </TooltipDetail>
             );
           }

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -90,6 +90,11 @@
   color: var(--grey-50);
 }
 
+.tooltipDetailsDescription {
+  /* Stop long descriptions from making the tooltip disruptively long. */
+  max-width: var(--tooltip-detail-max-width);
+}
+
 .tooltipLabel {
   color: var(--grey-50);
   text-align: right;

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -68,14 +68,16 @@ export function deriveJankMarkers(
   thresholdInMs: number,
   otherCategoryIndex: IndexIntoCategoryList
 ): Marker[] {
-  const data = { type: 'Jank' };
   const addMarker = () =>
     jankInstances.push({
       start: lastTimestamp - lastResponsiveness,
       end: lastTimestamp,
-      name: `${lastResponsiveness.toFixed(2)}ms event processing delay`,
+      name: 'Jank',
       category: otherCategoryIndex,
-      data,
+      data: {
+        type: 'Jank',
+        delay: lastResponsiveness,
+      },
     });
 
   let lastResponsiveness: number = 0;

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -74,10 +74,7 @@ export function deriveJankMarkers(
       end: lastTimestamp,
       name: 'Jank',
       category: otherCategoryIndex,
-      data: {
-        type: 'Jank',
-        delay: lastResponsiveness,
-      },
+      data: { type: 'Jank' },
     });
 
   let lastResponsiveness: number = 0;

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -27,7 +27,7 @@ import type {
  * TODO - These will eventually be stored in the profile, but for now
  * define them here.
  */
-export const markerSchema: MarkerSchema[] = [
+export const markerSchemaGecko: MarkerSchema[] = [
   {
     name: 'Bailout',
     display: ['marker-chart', 'marker-table'],
@@ -229,6 +229,9 @@ export const markerSchema: MarkerSchema[] = [
     display: ['marker-table'],
     data: [],
   },
+];
+
+export const markerSchemaFrontEndOnly: MarkerSchema[] = [
   {
     name: 'Jank',
     display: ['marker-table', 'marker-chart'],

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -229,6 +229,23 @@ export const markerSchema: MarkerSchema[] = [
     display: ['marker-table'],
     data: [],
   },
+  {
+    name: 'Jank',
+    display: ['marker-table', 'marker-chart'],
+    tooltipLabel: 'Jank – event processing delay',
+    tableLabel: 'Event processing delay — {marker.data.delay}',
+    data: [
+      { key: 'delay', label: 'Delay', format: 'duration' },
+      {
+        label: 'Description',
+        value: oneLine`
+          Jank markers show when the main event loop of a thread has been busy. It is
+          a good indicator that there may be some kind of performance problem that
+          is worth investigating.
+        `,
+      },
+    ],
+  },
 ];
 
 /**

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -236,9 +236,8 @@ export const markerSchemaFrontEndOnly: MarkerSchema[] = [
     name: 'Jank',
     display: ['marker-table', 'marker-chart'],
     tooltipLabel: 'Jank – event processing delay',
-    tableLabel: 'Event processing delay — {marker.data.delay}',
+    tableLabel: 'Event processing delay',
     data: [
-      { key: 'delay', label: 'Delay', format: 'duration' },
       {
         label: 'Description',
         value: oneLine`

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -17,7 +17,10 @@ import {
   correlateIPCMarkers,
 } from '../profile-logic/marker-data';
 
-import { markerSchema } from '../profile-logic/marker-schema';
+import {
+  markerSchemaGecko,
+  markerSchemaFrontEndOnly,
+} from '../profile-logic/marker-schema';
 
 import type {
   Profile,
@@ -175,7 +178,12 @@ export const getContentfulSpeedIndexProgress: Selector<
 export const getProfilerConfiguration: Selector<?ProfilerConfiguration> = state =>
   getMeta(state).configuration;
 
-export const getMarkerSchema: Selector<MarkerSchema[]> = () => markerSchema;
+export const getMarkerSchema: Selector<MarkerSchema[]> = createSelector(
+  // TODO - This will be replaced with a function to get the schema. For now
+  // trivially pass in the Gecko schema.
+  () => markerSchemaGecko,
+  schema => [...schema, ...markerSchemaFrontEndOnly]
+);
 
 export const getMarkerSchemaByName: Selector<MarkerSchemaByName> = createSelector(
   getMarkerSchema,

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -13,6 +13,7 @@ import {
   getProfileFromTextSamples,
   getNetworkMarkers,
   getProfileWithMarkers,
+  getProfileWithEventDelays,
 } from '../fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { getFirstSelectedThreadIndex } from '../../selectors/url-state';
@@ -684,6 +685,38 @@ describe('TooltipMarker', function() {
           marker={marker}
           threadsKey={threadIndex}
           className="propClass"
+          restrictHeightWidth={true}
+        />
+      </Provider>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('shows a tooltip for Jank markers', function() {
+    const eventDelay = [
+      0,
+      20,
+      40,
+      60,
+      70,
+      // break point
+      0,
+      20,
+      40,
+    ];
+
+    const profile = getProfileWithEventDelays(eventDelay);
+    const store = storeWithProfile(profile);
+    const { getState } = store;
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+
+    const { container } = render(
+      <Provider store={store}>
+        <TooltipMarker
+          markerIndex={0}
+          marker={getMarker(0)}
+          threadsKey={0}
           restrictHeightWidth={true}
         />
       </Provider>

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -165,7 +165,11 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         Marker
         :
       </div>
-      UserTiming
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming
+      </div>
       <div
         class="tooltipLabel"
       >
@@ -179,7 +183,11 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         Description
         :
       </div>
-      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
       <div
         class="tooltipLabel"
       >

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -892,7 +892,11 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
         Marker
         :
       </div>
-      UserTiming
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming
+      </div>
       <div
         class="tooltipLabel"
       >
@@ -906,7 +910,11 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
         Description
         :
       </div>
-      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
       <div
         class="tooltipLabel"
       >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3316,13 +3316,6 @@ exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
     <div
       class="tooltipLabel"
     >
-      Delay
-      :
-    </div>
-    70ms
-    <div
-      class="tooltipLabel"
-    >
       Description
       :
     </div>

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3306,13 +3306,31 @@ exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
       <div
         class="tooltipTitle"
       >
-        70.00ms event processing delay
+        Jank – event processing delay
       </div>
     </div>
   </div>
   <div
     class="tooltipDetails"
   >
+    <div
+      class="tooltipLabel"
+    >
+      Delay
+      :
+    </div>
+    70ms
+    <div
+      class="tooltipLabel"
+    >
+      Description
+      :
+    </div>
+    <div
+      class="tooltipDetailsDescription"
+    >
+      Jank markers show when the main event loop of a thread has been busy. It is a good indicator that there may be some kind of performance problem that is worth investigating.
+    </div>
     <div
       class="tooltipLabel"
     >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3286,3 +3286,40 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
   </div>
 </div>
 `;
+
+exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
+<div
+  class="tooltipMarker"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        70ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        70.00ms event processing delay
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+</div>
+`;

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3253,7 +3253,11 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
       Marker
       :
     </div>
-    UserTiming
+    <div
+      class="tooltipDetailsDescription"
+    >
+      UserTiming
+    </div>
     <div
       class="tooltipLabel"
     >
@@ -3267,7 +3271,11 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
       Description
       :
     </div>
-    UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+    <div
+      class="tooltipDetailsDescription"
+    >
+      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+    </div>
     <div
       class="tooltipLabel"
     >

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -2701,10 +2701,11 @@ Array [
   Object {
     "category": 1,
     "data": Object {
+      "delay": 50,
       "type": "Jank",
     },
     "end": 55,
-    "name": "50.00ms event processing delay",
+    "name": "Jank",
     "start": 5,
   },
 ]

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -2701,7 +2701,6 @@ Array [
   Object {
     "category": 1,
     "data": Object {
-      "delay": 50,
       "type": "Jank",
     },
     "end": 55,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -673,7 +673,7 @@ export type MediaSampleMarkerPayload = {|
 /**
  * This type is generated on the Firefox Profiler side, and doesn't come from Gecko.
  */
-export type JankPayload = {| type: 'Jank' |};
+export type JankPayload = {| type: 'Jank', delay: Milliseconds |};
 
 /**
  * The union of all the different marker payloads that profiler.firefox.com knows about,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -673,7 +673,7 @@ export type MediaSampleMarkerPayload = {|
 /**
  * This type is generated on the Firefox Profiler side, and doesn't come from Gecko.
  */
-export type JankPayload = {| type: 'Jank', delay: Milliseconds |};
+export type JankPayload = {| type: 'Jank' |};
 
 /**
  * The union of all the different marker payloads that profiler.firefox.com knows about,


### PR DESCRIPTION
I [regressed the Jank markers](https://profiler.firefox.com/public/9m3g5mg7ajksfhsbyyevmzh04rp8xr42p9n4w8g/marker-chart/?globalTrackOrder=6-0-1-2-3-4-5&hiddenGlobalTracks=2-1-3-4-5&hiddenLocalTracksByPid=10328-2-3-4~10636-1&localTrackOrderByPid=10328-6-7-0-1-2-3-4-5~10724-1-0~11164-1-0~860-1-0~10636-3-0-1-2~10880-1-2-0~&markerSearch=processing&thread=0&v=5) a bit in my latest markers 2.0 patch. It's a bit odd because I thought I had handled this. Anyway, [here's a fix for it](https://deploy-preview-2845--perf-html.netlify.app/public/9m3g5mg7ajksfhsbyyevmzh04rp8xr42p9n4w8g/marker-chart/?globalTrackOrder=6-0-1-2-3-4-5&hiddenGlobalTracks=2-1-3-4-5&hiddenLocalTracksByPid=10328-2-3-4~10636-1&localTrackOrderByPid=10328-6-7-0-1-2-3-4-5~10724-1-0~11164-1-0~860-1-0~10636-3-0-1-2~10880-1-2-0~&markerSearch=jank&thread=0&v=5).

I also created a full schema definition for it.

<img width="802" alt="image" src="https://user-images.githubusercontent.com/1588648/95241107-efa49780-07d2-11eb-9a5b-9fe3953f39cf.png">

This is a schema that will not come in from Gecko, so I added a new capability to pull it in separately. PR #2785 will have to rebase through it, and hook up the appropriate selector.