### PR TITLE
Fix marker table component default export

### DIFF
--- a/src/components/marker-table/MarkerTableEmptyReasons.js
+++ b/src/components/marker-table/MarkerTableEmptyReasons.js
@@ -18,7 +18,7 @@ type StateProps = {|
 |};
 
 type Props = ConnectedProps<{||}, StateProps, {||}>;
-class MarkerTableEmptyReasons extends PureComponent<Props> {
+class MarkerTableEmptyReasonsImpl extends PureComponent<Props> {
   render() {
     const { isMarkerTableEmptyInFullRange, threadName } = this.props;
 
@@ -36,12 +36,12 @@ class MarkerTableEmptyReasons extends PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, {||}>({
+export const MarkerTableEmptyReasons = explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: (state: State) => ({
     threadName: selectedThreadSelectors.getFriendlyThreadName(state),
     isMarkerTableEmptyInFullRange: selectedThreadSelectors.getAreMarkerPanelsEmptyInFullRange(
       state
     ),
   }),
-  component: MarkerTableEmptyReasons,
+  component: MarkerTableEmptyReasonsImpl,
 });

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -9,7 +9,7 @@ import memoize from 'memoize-immutable';
 
 import explicitConnect from '../../utils/connect';
 import TreeView from '../shared/TreeView';
-import MarkerTableEmptyReasons from './MarkerTableEmptyReasons';
+import { MarkerTableEmptyReasons } from './MarkerTableEmptyReasons';
 import {
   getZeroAt,
   getScrollToSelectionGeneration,


### PR DESCRIPTION
This PR fixes the component in `src/components/marker-table` to only use named export.
Partly fixes issue [#2819](https://github.com/firefox-devtools/profiler/issues/2819)