### PR TITLE
Migrate components in app folder to use named exports #2819

### DIFF
--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -7,10 +7,10 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
-import ProfileViewer from './ProfileViewer';
-import ZipFileViewer from './ZipFileViewer';
-import Home from './Home';
-import CompareHome from './CompareHome';
+import { ProfileViewer } from './ProfileViewer';
+import { ZipFileViewer } from './ZipFileViewer';
+import { Home } from './Home';
+import { CompareHome } from './CompareHome';
 import { ProfileRootMessage } from './ProfileRootMessage';
 import { getView } from '../../selectors/app';
 import { getHasZipFile } from '../../selectors/zipped-profiles';

--- a/src/components/app/BeforeUnloadManager.js
+++ b/src/components/app/BeforeUnloadManager.js
@@ -16,7 +16,7 @@ type StateProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 
-class BeforeUnloadManager extends React.PureComponent<Props> {
+class BeforeUnloadManagerImpl extends React.PureComponent<Props> {
   manageBeforeUnloadListener() {
     const { isUploading } = this.props;
     if (isUploading) {
@@ -51,9 +51,9 @@ class BeforeUnloadManager extends React.PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, {||}>({
+export const BeforeUnloadManager = explicitConnect<{||}, StateProps, {||}>({
   mapStateToProps: state => ({
     isUploading: getUploadPhase(state) === 'uploading',
   }),
-  component: BeforeUnloadManager,
+  component: BeforeUnloadManagerImpl,
 });

--- a/src/components/app/CompareHome.js
+++ b/src/components/app/CompareHome.js
@@ -24,7 +24,7 @@ type State = {|
   profile2: string,
 |};
 
-class CompareHome extends PureComponent<Props, State> {
+class CompareHomeImpl extends PureComponent<Props, State> {
   state = { profile1: '', profile2: '' };
 
   handleInputChange = (event: SyntheticInputEvent<>) => {
@@ -91,7 +91,7 @@ class CompareHome extends PureComponent<Props, State> {
   }
 }
 
-export default explicitConnect<{||}, {||}, DispatchProps>({
+export const CompareHome = explicitConnect<{||}, {||}, DispatchProps>({
   mapDispatchToProps: { changeProfilesToCompare },
-  component: CompareHome,
+  component: CompareHomeImpl,
 });

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 
 import explicitConnect from '../../utils/connect';
-import TabBar from './TabBar';
+import { TabBar } from './TabBar';
 import { ErrorBoundary } from './ErrorBoundary';
 import ProfileCallTreeView from '../calltree/ProfileCallTreeView';
 import MarkerTable from '../marker-table';
@@ -45,7 +45,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
-class ProfileViewer extends PureComponent<Props> {
+class ProfileViewerImpl extends PureComponent<Props> {
   _onSelectTab = (selectedTab: string) => {
     const { changeSelectedTab } = this.props;
     const tabSlug = toValidTabSlug(selectedTab);
@@ -111,7 +111,7 @@ class ProfileViewer extends PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export const Details = explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     visibleTabs: selectedThreadSelectors.getUsefulTabs(state),
     selectedTab: getSelectedTab(state),
@@ -121,5 +121,5 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     changeSelectedTab,
     changeSidebarOpenState,
   },
-  component: ProfileViewer,
+  component: ProfileViewerImpl,
 });

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import SplitterLayout from 'react-splitter-layout';
 
-import Details from './Details';
+import { Details } from './Details';
 import { selectSidebar } from '../sidebar';
 
 import { invalidatePanelLayout } from '../../actions/app';
@@ -30,7 +30,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
-function DetailsContainer({
+function DetailsContainerImpl({
   selectedTab,
   isSidebarOpen,
   invalidatePanelLayout,
@@ -50,7 +50,11 @@ function DetailsContainer({
   );
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export const DetailsContainer = explicitConnect<
+  {||},
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: state => ({
     selectedTab: getSelectedTab(state),
     isSidebarOpen: getIsSidebarOpen(state),
@@ -58,5 +62,5 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapDispatchToProps: {
     invalidatePanelLayout,
   },
-  component: DetailsContainer,
+  component: DetailsContainerImpl,
 });

--- a/src/components/app/FooterLinks.js
+++ b/src/components/app/FooterLinks.js
@@ -8,7 +8,7 @@ require('./FooterLinks.css');
 
 type State = {| hide: boolean |};
 
-class FooterLinks extends PureComponent<{||}, State> {
+export class FooterLinks extends PureComponent<{||}, State> {
   _onClick = () => {
     this.setState({ hide: true });
   };
@@ -60,5 +60,3 @@ class FooterLinks extends PureComponent<{||}, State> {
     );
   }
 }
-
-export default FooterLinks;

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -243,7 +243,7 @@ type PopupAddonInstallPhase =
   // Other browsers:
   | 'other-browser';
 
-class Home extends React.PureComponent<HomeProps, HomeState> {
+class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
   constructor(props: HomeProps) {
     super(props);
     // Start by suggesting that we install the add-on.
@@ -542,7 +542,7 @@ function _isFirefox(): boolean {
   return Boolean(navigator.userAgent.match(/Firefox\/\d+\.\d+/));
 }
 
-export default explicitConnect<OwnHomeProps, {||}, DispatchHomeProps>({
+export const Home = explicitConnect<OwnHomeProps, {||}, DispatchHomeProps>({
   mapDispatchToProps: { retrieveProfileFromFile, triggerLoadingFromUrl },
-  component: Home,
+  component: HomeImpl,
 });

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -69,7 +69,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
-class MenuButtons extends React.PureComponent<Props> {
+class MenuButtonsImpl extends React.PureComponent<Props> {
   componentDidMount() {
     // Clear out the newly published notice from the URL.
     this.props.dismissNewlyPublished();
@@ -180,21 +180,23 @@ class MenuButtons extends React.PureComponent<Props> {
   }
 }
 
-export default explicitConnect<OwnProps, StateProps, DispatchProps>({
-  mapStateToProps: state => ({
-    profile: getProfile(state),
-    rootRange: getProfileRootRange(state),
-    dataSource: getDataSource(state),
-    isNewlyPublished: getIsNewlyPublished(state),
-    uploadPhase: getUploadPhase(state),
-    hasPrePublishedState: getHasPrePublishedState(state),
-    symbolicationStatus: getSymbolicationStatus(state),
-    abortFunction: getAbortFunction(state),
-  }),
-  mapDispatchToProps: {
-    dismissNewlyPublished,
-    revertToPrePublishedState,
-    resymbolicateProfile,
-  },
-  component: MenuButtons,
-});
+export const MenuButtons = explicitConnect<OwnProps, StateProps, DispatchProps>(
+  {
+    mapStateToProps: state => ({
+      profile: getProfile(state),
+      rootRange: getProfileRootRange(state),
+      dataSource: getDataSource(state),
+      isNewlyPublished: getIsNewlyPublished(state),
+      uploadPhase: getUploadPhase(state),
+      hasPrePublishedState: getHasPrePublishedState(state),
+      symbolicationStatus: getSymbolicationStatus(state),
+      abortFunction: getAbortFunction(state),
+    }),
+    mapDispatchToProps: {
+      dismissNewlyPublished,
+      revertToPrePublishedState,
+      resymbolicateProfile,
+    },
+    component: MenuButtonsImpl,
+  }
+);

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -34,7 +34,7 @@ type DispatchProps = {|
 |};
 type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
 
-class ProfileFilterNavigatorBar extends React.PureComponent<Props> {
+class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
   _getItemsWithFirstElement = memoize(
     (firstItem, items) => [firstItem, ...items],
     {
@@ -85,7 +85,11 @@ class ProfileFilterNavigatorBar extends React.PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export const ProfileFilterNavigator = explicitConnect<
+  {||},
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: state => {
     const items = getCommittedRangeLabels(state);
     const previewSelection = getPreviewSelection(state);
@@ -110,5 +114,5 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
   mapDispatchToProps: {
     onPop: popCommittedRanges,
   },
-  component: ProfileFilterNavigatorBar,
+  component: ProfileFilterNavigatorBarImpl,
 });

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -7,13 +7,13 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
-import DetailsContainer from './DetailsContainer';
-import ProfileFilterNavigator from './ProfileFilterNavigator';
-import MenuButtons from './MenuButtons';
+import { DetailsContainer } from './DetailsContainer';
+import { ProfileFilterNavigator } from './ProfileFilterNavigator';
+import { MenuButtons } from './MenuButtons';
 import WindowTitle from '../shared/WindowTitle';
-import SymbolicationStatusOverlay from './SymbolicationStatusOverlay';
+import { SymbolicationStatusOverlay } from './SymbolicationStatusOverlay';
 import { ProfileName } from './ProfileName';
-import BeforeUnloadManager from './BeforeUnloadManager';
+import { BeforeUnloadManager } from './BeforeUnloadManager';
 
 import { returnToZipFileList } from '../../actions/zipped-profiles';
 import Timeline from '../timeline';
@@ -53,7 +53,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
-class ProfileViewer extends PureComponent<Props> {
+class ProfileViewerImpl extends PureComponent<Props> {
   render() {
     const {
       hasZipFile,
@@ -143,7 +143,7 @@ class ProfileViewer extends PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export const ProfileViewer = explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     hasZipFile: getHasZipFile(state),
     timelineHeight: getTimelineHeight(state),
@@ -157,5 +157,5 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     returnToZipFileList,
     invalidatePanelLayout,
   },
-  component: ProfileViewer,
+  component: ProfileViewerImpl,
 });

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -5,8 +5,8 @@
 
 import React, { PureComponent } from 'react';
 import { Provider } from 'react-redux';
-import UrlManager from './UrlManager';
-import FooterLinks from './FooterLinks';
+import { UrlManager } from './UrlManager';
+import { FooterLinks } from './FooterLinks';
 import { ErrorBoundary } from './ErrorBoundary';
 import { AppViewRouter } from './AppViewRouter';
 import { ProfileLoader } from './ProfileLoader';
@@ -20,7 +20,7 @@ type RootProps = {
 
 import { DragAndDrop } from './DragAndDrop';
 
-export default class Root extends PureComponent<RootProps> {
+export class Root extends PureComponent<RootProps> {
   render() {
     const { store } = this.props;
     return (

--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -38,7 +38,7 @@ type StateProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 
-class SymbolicationStatusOverlay extends PureComponent<Props> {
+class SymbolicationStatusOverlayImpl extends PureComponent<Props> {
   render() {
     const { symbolicationStatus, waitingForLibs } = this.props;
     if (symbolicationStatus === 'SYMBOLICATING') {
@@ -66,10 +66,14 @@ class SymbolicationStatusOverlay extends PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, {||}>({
+export const SymbolicationStatusOverlay = explicitConnect<
+  {||},
+  StateProps,
+  {||}
+>({
   mapStateToProps: state => ({
     symbolicationStatus: getSymbolicationStatus(state),
     waitingForLibs: getProfileViewOptions(state).waitingForLibs,
   }),
-  component: SymbolicationStatusOverlay,
+  component: SymbolicationStatusOverlayImpl,
 });

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -19,7 +19,7 @@ type Props = {|
   +extraElements?: React.Node,
 |};
 
-class TabBar extends React.PureComponent<Props> {
+export class TabBar extends React.PureComponent<Props> {
   _onClickListener = (e: SyntheticMouseEvent<HTMLElement>) => {
     this.props.onSelectTab(e.currentTarget.dataset.name);
   };
@@ -81,5 +81,3 @@ class TabBar extends React.PureComponent<Props> {
     );
   }
 }
-
-export default TabBar;

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -82,7 +82,7 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
  *       view with the `UrlState` information.
  *    4. Display the profile view.
  */
-class UrlManager extends React.PureComponent<Props> {
+class UrlManagerImpl extends React.PureComponent<Props> {
   async _processInitialUrls() {
     const {
       startFetchingProfiles,
@@ -237,7 +237,7 @@ class UrlManager extends React.PureComponent<Props> {
   }
 }
 
-export default explicitConnect<OwnProps, StateProps, DispatchProps>({
+export const UrlManager = explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: state => ({
     urlState: state.urlState,
     urlSetupPhase: getUrlSetupPhase(state),
@@ -251,5 +251,5 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     setupInitialUrlState,
     getProfilesFromRawUrl,
   },
-  component: UrlManager,
+  component: UrlManagerImpl,
 });

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -25,7 +25,7 @@ import {
 } from '../../selectors/zipped-profiles';
 import { getPathInZipFileFromUrl } from '../../selectors/url-state';
 import TreeView from '../shared/TreeView';
-import ProfileViewer from './ProfileViewer';
+import { ProfileViewer } from './ProfileViewer';
 
 import type { ConnectedProps } from '../../utils/connect';
 import type { ZipFileState } from 'firefox-profiler/types';
@@ -122,7 +122,7 @@ const ZipFileRow = explicitConnect<
  * to a particular one. However, it is a general purpose zip file
  * viewer to load profiles, so it can be used on arbitrary profiles.
  */
-class ZipFileViewer extends React.PureComponent<Props> {
+class ZipFileViewerImpl extends React.PureComponent<Props> {
   _fixedColumns = [];
   _mainColumn = { propName: 'name', title: '', component: ZipFileRow };
   _treeView: ?TreeView<ZipDisplayData>;
@@ -338,7 +338,7 @@ class ZipFileViewer extends React.PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export const ZipFileViewer = explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: state => {
     const zipFileTree = getZipFileTree(state);
     if (zipFileTree === null) {
@@ -370,5 +370,5 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     returnToZipFileList,
     showErrorForNoFileInZip,
   },
-  component: ZipFileViewer,
+  component: ZipFileViewerImpl,
 });

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ import 'react-splitter-layout/lib/index.css';
 // Now import the JS after the CSS.
 import React from 'react';
 import { render } from 'react-dom';
-import Root from './components/app/Root';
+import { Root } from './components/app/Root';
 import createStore from './app-logic/create-store';
 import {
   addDataToWindowObject,

--- a/src/test/components/BeforeUnloadManager.test.js
+++ b/src/test/components/BeforeUnloadManager.test.js
@@ -5,7 +5,7 @@
 // @flow
 import * as React from 'react';
 import { render, fireEvent, cleanup } from '@testing-library/react';
-import BeforeUnloadManager from '../../components/app/BeforeUnloadManager';
+import { BeforeUnloadManager } from '../../components/app/BeforeUnloadManager';
 import { blankStore } from '../fixtures/stores';
 import { Provider } from 'react-redux';
 import { uploadStarted } from 'firefox-profiler/actions/publish';

--- a/src/test/components/CompareHome.test.js
+++ b/src/test/components/CompareHome.test.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render, fireEvent, cleanup } from '@testing-library/react';
 
-import CompareHome from '../../components/app/CompareHome';
+import { CompareHome } from '../../components/app/CompareHome';
 import { getProfilesToCompare } from '../../selectors/url-state';
 
 import { blankStore } from '../fixtures/stores';

--- a/src/test/components/Details.test.js
+++ b/src/test/components/Details.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
-import Details from '../../components/app/Details';
+import { Details } from '../../components/app/Details';
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';

--- a/src/test/components/DetailsContainer.test.js
+++ b/src/test/components/DetailsContainer.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
-import DetailsContainer from '../../components/app/DetailsContainer';
+import { DetailsContainer } from '../../components/app/DetailsContainer';
 import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
@@ -15,7 +15,9 @@ import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profil
 import { tabSlugs } from '../../app-logic/tabs-handling';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
-jest.mock('../../components/app/Details', () => 'details-viewer');
+jest.mock('../../components/app/Details', () => ({
+  Details: 'details-viewer',
+}));
 
 describe('app/DetailsContainer', function() {
   function setup() {

--- a/src/test/components/FilterNavigatorBar.test.js
+++ b/src/test/components/FilterNavigatorBar.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
-import ProfileFilterNavigator from '../../components/app/ProfileFilterNavigator';
+import { ProfileFilterNavigator } from '../../components/app/ProfileFilterNavigator';
 import * as ProfileView from '../../actions/profile-view';
 import * as ReceiveProfile from '../../actions/receive-profile';
 import { storeWithProfile } from '../fixtures/stores';

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 import * as React from 'react';
-import Home from '../../components/app/Home';
+import { Home } from '../../components/app/Home';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import createStore from '../../app-logic/create-store';

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 import * as React from 'react';
-import MenuButtons from '../../components/app/MenuButtons';
+import { MenuButtons } from '../../components/app/MenuButtons';
 import { MenuButtonsMetaInfo } from '../../components/app/MenuButtons/MetaInfo';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';

--- a/src/test/components/MenuButtonsPermalinks.test.js
+++ b/src/test/components/MenuButtonsPermalinks.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 import * as React from 'react';
-import MenuButtons from '../../components/app/MenuButtons';
+import { MenuButtons } from '../../components/app/MenuButtons';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';

--- a/src/test/components/ProfileViewer.test.js
+++ b/src/test/components/ProfileViewer.test.js
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import ProfileViewer from '../../components/app/ProfileViewer';
+import { ProfileViewer } from '../../components/app/ProfileViewer';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';

--- a/src/test/components/Root-history.test.js
+++ b/src/test/components/Root-history.test.js
@@ -7,7 +7,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 
-import Root from '../../components/app/Root';
+import { Root } from '../../components/app/Root';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileUrlForHash } from '../../actions/receive-profile';
 import { blankStore } from '../fixtures/stores';

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -19,11 +19,17 @@ jest.mock('../../actions/receive-profile', () => ({
 // We mock <ProfileViewer> because it's complex and we should really test it
 // elsewhere. Using a custom name makes it possible to test that  _this_
 // component is used.
-jest.mock('../../components/app/ProfileViewer', () => 'profile-viewer');
+jest.mock('../../components/app/ProfileViewer', () => ({
+  ProfileViewer: 'profile-viewer',
+}));
 // We mock <Home> as well because it brings too much noise in snapshots and it's
 // overly tested in another test file.
-jest.mock('../../components/app/Home', () => 'home');
-jest.mock('../../components/app/CompareHome', () => 'compare-home');
+jest.mock('../../components/app/Home', () => ({
+  Home: 'home',
+}));
+jest.mock('../../components/app/CompareHome', () => ({
+  CompareHome: 'compare-home',
+}));
 // ListOfPublishedProfiles depends on IDB and renders asynchronously, so we'll
 // just test we want to render it, but otherwise test it more fully in a
 // separate test file.

--- a/src/test/components/TabBar.test.js
+++ b/src/test/components/TabBar.test.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import TabBar from '../../components/app/TabBar';
+import { TabBar } from '../../components/app/TabBar';
 import { fireFullClick } from '../fixtures/utils';
 
 describe('app/TabBar', () => {

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -9,7 +9,7 @@ import { render } from '@testing-library/react';
 
 import { makeProfileSerializable } from '../../profile-logic/process-profile';
 import { getView, getUrlSetupPhase } from '../../selectors/app';
-import UrlManager from '../../components/app/UrlManager';
+import { UrlManager } from '../../components/app/UrlManager';
 import { blankStore } from '../fixtures/stores';
 import {
   getDataSource,

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 import * as React from 'react';
-import ZipFileViewer from '../../components/app/ZipFileViewer';
+import { ZipFileViewer } from '../../components/app/ZipFileViewer';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 


### PR DESCRIPTION
### Goal
Components in src/components/app should be migrated to use named exports