### PR TITLE
The uploaded recordings list should update on window focus #2810

### DIFF
--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -185,20 +185,32 @@ type State = {|
 |};
 
 export class ListOfPublishedProfiles extends PureComponent<Props, State> {
+  _isMounted = false;
+
   state = {
     profileDataList: null,
   };
 
-  async _refreshList() {
+  _refreshList = async () => {
     const profileDataList = await listAllProfileData();
-    this.setState({
-      // We want to display the list with the most recent uploaded profile first.
-      profileDataList: profileDataList.reverse(),
-    });
-  }
+    if (this._isMounted) {
+      // It isn't ideal to use a setState here, but this is the only way.
+      this.setState({
+        // We want to display the list with the most recent uploaded profile first.
+        profileDataList: profileDataList.reverse(),
+      });
+    }
+  };
 
   async componentDidMount() {
+    this._isMounted = true;
     this._refreshList();
+    window.addEventListener('focus', this._refreshList);
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+    window.removeEventListener('focus', this._refreshList);
   }
 
   onProfileDelete = () => {

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -479,4 +479,60 @@ describe('ListOfPublishedProfiles', () => {
       );
     });
   });
+
+  describe('The uploaded recordings list should update on window focus', () => {
+    it('will update the stored profiles on window focus', async function() {
+      // Add 3 examples, all with the same name.
+      // mockDate('4 Jul 2020 15:00'); // Now is 4th of July, at 3pm local timezone.
+
+      const exampleProfileData = {
+        profileToken: 'MACOSX',
+        jwtToken: null,
+        publishedDate: new Date('4 Jul 2020 13:00'),
+        name: 'PROFILE',
+        preset: null,
+        originHostname: 'https://mozilla.org',
+        meta: {
+          product: 'Firefox',
+          platform: 'Macintosh',
+          toolkit: 'cocoa',
+          misc: 'rv:62.0',
+          oscpu: 'Intel Mac OS X 10.12',
+        },
+        urlPath: '/public/MACOSX/marker-chart/',
+        publishedRange: { start: 2000, end: 40000 },
+      };
+
+      await storeProfileData({
+        ...exampleProfileData,
+        profileToken: 'PROFILE-1',
+      });
+      await storeProfileData({
+        ...exampleProfileData,
+        profileToken: 'PROFILE-2',
+      });
+      await storeProfileData({
+        ...exampleProfileData,
+        profileToken: 'PROFILE-3',
+      });
+
+      const { findAllByText } = setup();
+      expect(await findAllByText(/PROFILE/)).toHaveLength(3);
+
+      // Add one more.
+      await storeProfileData({
+        ...exampleProfileData,
+        profileToken: 'PROFILE-4',
+      });
+
+      // Nothing is updated yet.
+      expect(await findAllByText(/PROFILE/)).toHaveLength(3);
+
+      // The new profile is now listed.
+      window.dispatchEvent(new Event('focus'));
+      setTimeout(async () => {
+        expect(await findAllByText(/PROFILE/)).toHaveLength(4);
+      }, 500);
+    });
+  });
 });

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -523,16 +523,19 @@ describe('ListOfPublishedProfiles', () => {
       await storeProfileData({
         ...exampleProfileData,
         profileToken: 'PROFILE-4',
+        name: 'NEW-PROFILE', // Adding with a new name so that we can look it up.
       });
 
-      // Nothing is updated yet.
+      // Nothing is updated yet: looking for the new profile name will throw.
+      await expect(() => findAllByText(/NEW-PROFILE/)).rejects.toThrow(
+        /Unable to find an element with the text/
+      );
       expect(await findAllByText(/PROFILE/)).toHaveLength(3);
 
       // The new profile is now listed.
       window.dispatchEvent(new Event('focus'));
-      setTimeout(async () => {
-        expect(await findAllByText(/PROFILE/)).toHaveLength(4);
-      }, 500);
+      await findAllByText(/NEW-PROFILE/);
+      expect(await findAllByText(/PROFILE/)).toHaveLength(4);
     });
   });
 });


### PR DESCRIPTION
This is a draft PR, some tests are failing on the function
`
     
    await findByText(/macOS/);

    await findByText(/Layout profile/);
`
Function findByText isn't working on my machine.

Code that has been created in ListOfPublishedProfiles.js seems to be working when testing manually.