### PR TITLE
Migrate relative paths to absolute: src/components/app part 2 #2871

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -40,7 +40,7 @@ import type {
   CallNodeDisplayData,
   WeightType,
 } from 'firefox-profiler/types';
-import type { CallTree } from '../../profile-logic/call-tree';
+import type { CallTree as CallTreeType } from '../../profile-logic/call-tree';
 
 import type { Column } from '../shared/TreeView';
 import type { ConnectedProps } from '../../utils/connect';
@@ -49,7 +49,7 @@ type StateProps = {|
   +threadsKey: ThreadsKey,
   +scrollToSelectionGeneration: number,
   +focusCallTreeGeneration: number,
-  +tree: CallTree,
+  +tree: CallTreeType,
   +callNodeInfo: CallNodeInfo,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
@@ -71,7 +71,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
-class CallTreeComponent extends PureComponent<Props> {
+class CallTreeImpl extends PureComponent<Props> {
   _mainColumn: Column = { propName: 'name', title: '' };
   _appendageColumn: Column = { propName: 'lib', title: '' };
   _treeView: TreeView<CallNodeDisplayData> | null = null;
@@ -298,7 +298,7 @@ class CallTreeComponent extends PureComponent<Props> {
   }
 }
 
-export default explicitConnect<{||}, StateProps, DispatchProps>({
+export const CallTree = explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: (state: State) => ({
     threadsKey: getSelectedThreadsKey(state),
     scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
@@ -327,5 +327,5 @@ export default explicitConnect<{||}, StateProps, DispatchProps>({
     changeExpandedCallNodes,
     addTransformToStack,
   },
-  component: CallTreeComponent,
+  component: CallTreeImpl,
 });

--- a/src/components/calltree/ProfileCallTreeView.js
+++ b/src/components/calltree/ProfileCallTreeView.js
@@ -5,7 +5,7 @@
 // @flow
 
 import React from 'react';
-import CallTree from './CallTree';
+import { CallTree } from './CallTree';
 import StackSettings from '../shared/StackSettings';
 import TransformNavigator from '../shared/TransformNavigator';
 


### PR DESCRIPTION
@canova i have fixed the missed default export we had on my previous PR [HERE](https://github.com/firefox-devtools/profiler/pull/2853)
Addresses issue #2819 