### PR TITLE
CSS Loads - Change require to import: src/components/shared [#2922] 

### DIFF
--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -18,7 +18,7 @@ import type {
   ImplementationFilter,
 } from 'firefox-profiler/types';
 
-require('./Backtrace.css');
+import './Backtrace.css';
 
 type Props = {|
   +thread: Thread,

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -60,7 +60,7 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
-require('./CallNodeContextMenu.css');
+import './CallNodeContextMenu.css';
 
 class CallNodeContextMenu extends PureComponent<Props> {
   _hidingTimeout: TimeoutID | null = null;

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -38,7 +38,7 @@ type State<HoveredItem> = {
   pageY: CssPixels,
 };
 
-require('./Canvas.css');
+import './Canvas.css';
 
 /**
  * The maximum amount of movement in either direction between the

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -165,7 +165,7 @@ type State = {|
   isSizeSet: boolean,
 |};
 
-require('./Viewport.css');
+import './Viewport.css';
 
 // The overall zoom speed for shift and pinch zooming.
 const ZOOM_SPEED = 1.003;


### PR DESCRIPTION
As requested in this issue: https://github.com/firefox-devtools/profiler/issues/2922

This PR changes all uses of 'require' into 'import' for these files:

- [x] src/components/shared/: 
   - Backtrace.js: require('./Backtrace.css');
   - CallNodeContextMenu.js: require('./CallNodeContextMenu.css');
   - chart/Canvas.js: require('./Canvas.css');
   - chart/Viewport.js: require('./Viewport.css');