### PR TITLE
Add an alias for the resources too

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,7 +15,7 @@
     ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
     ["module-resolver", {
       "alias": {
-        "firefox-profiler": "./src",
+        "firefox-profiler": "./src"
       }
     }]
   ]

--- a/.babelrc
+++ b/.babelrc
@@ -18,18 +18,5 @@
         "firefox-profiler": "./src",
       }
     }]
-  ],
-  env: {
-    test: {
-      presets: [
-        "@babel/preset-env",
-        "@babel/preset-react",
-        ["@babel/preset-flow", { all: true }]
-      ],
-      plugins: [
-        ["@babel/plugin-proposal-class-properties", { loose: true }],
-        ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
-      ],
-    }
-  }
+  ]
 }

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -49,7 +49,7 @@
   left: 10px;
   width: 44px;
   height: 44px;
-  background: url(../../../../res/img/svg/info.svg) center center no-repeat;
+  background: url(firefox-profiler-res/img/svg/info.svg) center center no-repeat;
 }
 
 .menuButtonsPublishTitle {
@@ -116,13 +116,15 @@
 .menuButtonsPublishButtonsSvgUpload {
   width: 20px;
   height: 20px;
-  background: url(../../../../res/img/svg/upload.svg) center center no-repeat;
+  background: url(firefox-profiler-res/img/svg/upload.svg) center center
+    no-repeat;
 }
 
 .menuButtonsPublishButtonsSvgDownload {
   width: 20px;
   height: 20px;
-  background: url(../../../../res/img/svg/download.svg) center center no-repeat;
+  background: url(firefox-profiler-res/img/svg/download.svg) center center
+    no-repeat;
 }
 
 .menuButtonsDownloadSize {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,11 +15,10 @@ const es6modulePaths = es6modules.map(module => {
 const config = {
   resolve: {
     alias: {
-      'redux-devtools/lib': path.join(__dirname, '..', '..', 'src'),
-      'redux-devtools': path.join(__dirname, '..', '..', 'src'),
-      react: path.join(__dirname, 'node_modules', 'react'),
+      // Note: the alias for firefox-profiler is defined at the Babel level, so
+      // that Jest can profit from it too.
+      'firefox-profiler-res': path.resolve(__dirname, 'res'),
     },
-    extensions: ['.js', '.wasm'],
   },
   devtool: 'source-map',
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,10 +99,6 @@ const config = {
     chunkFilename: '[id].[hash].bundle.js',
     publicPath: '/',
   },
-  optimization: {
-    // Workaround for https://github.com/webpack/webpack/issues/7760
-    usedExports: false,
-  },
 };
 
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
In this patch I add an alias for resources, especially for use for images in CSS files.

This also cleans things up a bit.

Because this touches some wasm configuraiton, I manually tested the symbolication in a custom Firefox build, both with dev and production deployments, and found that the wasm module is correctly loaded and working.