### PR TITLE
Rework the undeployment process

### DIFF
--- a/bin/revert-last-deployment.sh
+++ b/bin/revert-last-deployment.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# This script will undeploy the last deployed version.
+
+# Exit with an error if any command exits with an error.
+set -e
+
+# This function outputs the command as well as executes it.
+echo_and_exec_cmd() {
+  echo "[exec] $*"
+  "$@"
+}
+
+# This tries to find the upstream remote name
+UPSTREAM=$(git remote -v | grep -E 'devtools-html/perf\.html|firefox-devtools/profiler' | head -1 | awk '{ print $1 }')
+if [ -z "$UPSTREAM" ] ; then
+  echo 1>&2 "Error: couldn't find the upstream remote. Is it well configured?"
+  echo 1>&2 "We're looking for either devtools-html/perf.html or firefox-devtools/profiler."
+  exit 1
+fi
+
+# This looks at your working directory, to error early if it's dirty.
+git_status=$(LC_ALL=C git status --porcelain --ignore-submodules -unormal 2>&1)
+if [ -n "$git_status" ] ; then
+  echo 1>&2 "Error: your working directory contains uncommitted changes."
+  echo 1>&2 "Please commit all your changes before running this script."
+  exit 1
+fi
+
+# Now to the real stuff.
+echo "This script will reset the production branch on the remote '$UPSTREAM' to the previous version."
+echo -n "Are you sure?"
+read -r enter
+
+echo ">>> Fetching upstream $UPSTREAM"
+echo_and_exec_cmd git fetch "$UPSTREAM"
+
+echo ">>> Resetting to the previous commit"
+echo_and_exec_cmd git checkout "$UPSTREAM/production"
+echo_and_exec_cmd git reset --hard HEAD^
+
+echo ">>> Running tests"
+echo_and_exec_cmd yarn
+echo_and_exec_cmd yarn test-all
+
+echo ">>> Force-pushing to $UPSTREAM's production branch. Note you'll need to disable
+branch protection for this to succeed."
+echo -n "Are you ready?"
+read -r enter
+echo_and_exec_cmd git push -f --no-verify "$UPSTREAM" HEAD:production
+
+echo ">>> Going back to your previous banch"
+echo_and_exec_cmd git checkout -
+
+echo ">>> Done!"

--- a/bin/revert-last-deployment.sh
+++ b/bin/revert-last-deployment.sh
@@ -28,7 +28,7 @@ fi
 
 # Now to the real stuff.
 echo "This script will reset the production branch on the remote '$UPSTREAM' to the previous version."
-echo -n "Are you sure?"
+printf "Are you sure?"
 read -r enter
 
 echo ">>> Fetching upstream $UPSTREAM"
@@ -44,9 +44,13 @@ echo_and_exec_cmd yarn test-all
 
 echo ">>> Force-pushing to $UPSTREAM's production branch. Note you'll need to disable
 branch protection for this to succeed."
-echo -n "Are you ready?"
+echo "Go to https://github.com/firefox-devtools/profiler/settings/branches and enable force pushing."
+printf "Hit enter when you are ready."
 read -r enter
 echo_and_exec_cmd git push -f --no-verify "$UPSTREAM" HEAD:production
+
+echo "Please re-enable now the force push protection on https://github.com/firefox-devtools/profiler/settings/branches"
+printf "Hit enter when you are ready."
 
 echo ">>> Going back to your previous banch"
 echo_and_exec_cmd git checkout -

--- a/bin/revert-last-deployment.sh
+++ b/bin/revert-last-deployment.sh
@@ -51,6 +51,8 @@ echo_and_exec_cmd git push -f --no-verify "$UPSTREAM" HEAD:production
 
 echo "Please re-enable now the force push protection on https://github.com/firefox-devtools/profiler/settings/branches"
 printf "Hit enter when you are ready."
+# shellcheck disable=SC2034
+read -r enter
 
 echo ">>> Going back to your previous banch"
 echo_and_exec_cmd git checkout -

--- a/docs-developer/deploying.md
+++ b/docs-developer/deploying.md
@@ -28,11 +28,14 @@ if you have access.
 
 ## How to revert to a previous version
 
-In case the deployed version is bad we can revert to a previous version using
-Netlify's dashboard.
+The easiest way is to reset the production branch to a previous version, and
+force push it. You'll need to enable force-pushing for the branch production,
+using the [Branch Settings on GitHub](https://github.com/firefox-devtools/profiler/settings/branches).
 
-[Search for the previous production build](https://app.netlify.com/sites/perf-html/deploys?filter=production)
-and deploy it from its detail page.
+You can use the following script:
+```
+sh bin/revert-last-deployment.sh
+```
 
 When you're ready with a fix landed on `main`, you can push a new version to the
 `production` branch as described in the first part.


### PR DESCRIPTION
Because there are quite some git commands here, I decided that writing a script was a good idea. I ran it through shellcheck to catch errors (and I actually caught POSIX compatibility errors), but it would still be a good idea if you can run it through your shell.
(note: shellcheck still reports some errors but that should do no harm in our case)

You can run it freely because the push will fail, because the branch is protected.
If you want to run it completely, you can replace `$UPSTREAM` in the last command by your own remote, commit to a new commit (so that your working directory isn't dirty), and run the script again. This should go to the end and upload to the `production` branch of your fork, then go back to the previous branch.