### PR TITLE
Issue #1818 - When searching in the stack chart, the matched nodes should be highlighted

### DIFF
--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -65,6 +65,7 @@ type OwnProps = {|
   +shouldDisplayTooltips: () => boolean,
   +scrollToSelectionGeneration: number,
   +marginLeft: CssPixels,
+  +searchStringsRegExp: RegExp | null,
 |};
 
 type Props = $ReadOnly<{|
@@ -164,6 +165,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
         viewportTop,
         viewportBottom,
       },
+      searchStringsRegExp,
     } = this.props;
     const fastFillStyle = new FastFillStyle(ctx);
 
@@ -335,6 +337,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
               ? colorStyles.selectedFillStyle
               : colorStyles.unselectedFillStyle
           );
+
           ctx.fillRect(
             intX,
             intY,
@@ -345,6 +348,17 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
             intW + BORDER_OPACITY,
             intH
           );
+
+          if (searchStringsRegExp && searchStringsRegExp.test(text)) {
+            ctx.save();
+
+            ctx.fillStyle = 'rgba(0, 0, 255, 0.7)';
+
+            ctx.fillRect(intX, intY, intW + BORDER_OPACITY, intH);
+
+            ctx.restore();
+          }
+
           lastDrawnPixelX =
             intX +
             intW +

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -22,6 +22,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 import {
   getShowUserTimings,
   getSelectedThreadsKey,
+  getSearchStringsAsRegExp,
 } from '../../selectors/url-state';
 import { getTimelineMarginLeft } from '../../selectors/app';
 import { StackChartEmptyReasons } from './StackChartEmptyReasons';
@@ -78,6 +79,7 @@ type StateProps = {|
   +getMarker: MarkerIndex => Marker,
   +userTimings: MarkerIndex[],
   +timelineMarginLeft: CssPixels,
+  +searchStringsRegExp: RegExp | null,
 |};
 
 type DispatchProps = {|
@@ -158,6 +160,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       userTimings,
       weightType,
       timelineMarginLeft,
+      searchStringsRegExp,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -214,6 +217,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   shouldDisplayTooltips: this._shouldDisplayTooltips,
                   scrollToSelectionGeneration,
                   marginLeft: timelineMarginLeft,
+                  searchStringsRegExp,
                 }}
               />
             </div>
@@ -254,6 +258,7 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       getMarker: selectedThreadSelectors.getMarkerGetter(state),
       userTimings: selectedThreadSelectors.getUserTimingMarkerIndexes(state),
       timelineMarginLeft: getTimelineMarginLeft(state),
+      searchStringsRegExp: getSearchStringsAsRegExp(state),
     };
   },
   mapDispatchToProps: {


### PR DESCRIPTION
The initial proposal was to use a border to highlight the matched nodes in the stack chart. But as it turned out the nodes are too tiny and I couldn't find suitable border size. So I just draw another semitransparent rectangle at the top of the matched node. I don't think this is a production-ready solution (I didn't check performance, the appearance of the highlighting can and should be improved), but now we may discuss it and I will improve it.

Ref #1818