### PR TITLE
Make Appveyor faster

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,7 @@ test_script:
   # Output useful info for debugging.
   - yarn versions
   # run tests
-  - yarn license-check
-  - yarn test-alex
-  - yarn lint
-  - yarn flow:ci
-  - yarn test
+  - yarn test-all:ci
   - yarn build-prod:quiet
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ platform: x64 # flow needs 64b platforms
 # Install scripts. (runs after repo cloning)
 install:
   # 1. Select the right node
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
+  - ps: Install-Product node $env:nodejs_version $env:platform
   # 2. Setup the project
   - yarn install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start-photon": "node res/photon/server",
     "test": "cross-env LC_ALL=C NODE_ENV=test jest",
     "test-all": "run-p --max-parallel 4 flow license-check lint test test-alex test-lockfile",
+    "test-all:ci": "run-p --max-parallel 4 flow:ci license-check lint test test-alex test-lockfile",
     "test-build-coverage": "jest --coverage --coverageReporters=html",
     "test-serve-coverage": "ws -d coverage/ -p 4343",
     "test-coverage": "run-s test-build-coverage test-serve-coverage",


### PR DESCRIPTION
Even though it's not required, I'm always waiting for Appveyor results. I just can't help myself... I don't want to wait too much for it :( So, let's see if I can make it faster.


Now we are using the faster Install-Product for installing node 12 and parallelizing the tests. That gives us ~2 min build time boost.