### PR TITLE
issue #2964 Changed formatNumber to formatTimestamp function and updated snapshot test

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -7,7 +7,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import {
-  formatNumber,
   formatMilliseconds,
   formatTimestamp,
 } from '../../utils/format-numbers';
@@ -314,7 +313,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
           <div className="tooltipDetailsBackTrace">
             {data.type === 'Styles' || marker.name === 'Reflow' ? (
               <h2 className="tooltipBackTraceTitle">
-                First invalidated {formatNumber(causeAge)}ms before the flush,
+                First invalidated {formatTimestamp(causeAge)} before the flush,
                 at:
               </h2>
             ) : null}

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3060,7 +3060,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
       >
         First invalidated 
         500μs
-         before the flush, at:
+         befor the flush, at:
       </h2>
       <ul
         class="backtrace"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3059,8 +3059,8 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
         class="tooltipBackTraceTitle"
       >
         First invalidated 
-        0.50
-        ms before the flush, at:
+        500μs
+         before the flush, at:
       </h2>
       <ul
         class="backtrace"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3060,7 +3060,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
       >
         First invalidated 
         500μs
-         befor the flush, at:
+         before the flush, at:
       </h2>
       <ul
         class="backtrace"


### PR DESCRIPTION
Changed formatNumber to formatTimestamp function in Marker.js for issue #2964 in order to print the proper time unit, also updated the snapshots tests to reflect the changes made. Kindly review @canova @km-js 