### PR TITLE
Issue 2922 require to import v1

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -79,7 +79,7 @@ type HoveredStackTiming = {|
   +flameGraphTimingIndex: IndexIntoFlameGraphTiming,
 |};
 
-require('./Canvas.css');
+import './Canvas.css';
 
 const ROW_HEIGHT = 16;
 const TEXT_OFFSET_START = 3;

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -50,7 +50,7 @@ import type { CallTree } from 'firefox-profiler/profile-logic/call-tree';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
-require('./FlameGraph.css');
+import './FlameGraph.css' ;
 
 const STACK_FRAME_HEIGHT = 16;
 

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -50,7 +50,7 @@ import type { CallTree } from 'firefox-profiler/profile-logic/call-tree';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
-import './FlameGraph.css' ;
+import './FlameGraph.css';
 
 const STACK_FRAME_HEIGHT = 16;
 

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -14,7 +14,7 @@ import { FlameGraph } from './FlameGraph';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
-require('./MaybeFlameGraph.css');
+import './MaybeFlameGraph.css';
 
 type StateProps = {|
   +maxStackDepth: number,


### PR DESCRIPTION
Converted CSS "requests" to "imports" on the three needed files in /flame-graph directory.

Canvas.js, FlameGraph.js, MaybeFlameGraph.js. Previous PR had a small but thankfully to yarn unforgivable error on FlameGraph.js. I believe that's fixed now, re-ran tests several times.

Fixes part of #2922