### PR TITLE
Issue 4

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Working on hiding all tracks components */
 
 // @flow
 import { oneLine } from 'common-tags';


### PR DESCRIPTION
#969 Navigate and zoom the flame graph just by a (double) clicking