### PR TITLE
Add a shellcheck job to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ executors:
   node:
     docker:
       - image: cimg/node:12.18
+  base:
+    docker:
+      - image: cimg/base:stable
+
+orbs:
+  shellcheck: circleci/shellcheck@2.0.0
 
 commands:
   checkout-and-dependencies:
@@ -68,6 +74,17 @@ jobs:
       - checkout-and-dependencies
       - run: yarn test-lockfile
 
+  # This is implemented as a separate job instead of using the orb's predefined
+  # job so that we can have a more descriptive name when reported to github.
+  # See also https://github.com/CircleCI-Public/shellcheck-orb/issues/29
+  shellcheck:
+    executor: base
+    steps:
+      - checkout
+      - shellcheck/install
+      - shellcheck/check:
+          dir: ./bin
+
 workflows:
   version: 2
   main:
@@ -79,3 +96,4 @@ workflows:
       - licence-check
       - alex
       - yarn_lock
+      - shellcheck


### PR DESCRIPTION
I double-checked that adding a mistake to the shell script will fail the build.

I considered adding it as a dependency to our project (there's a npm package to download it, although I'm a bit reluctant to use it) but decided this isn't worth it.