### PR TITLE
Fix stacking context for overlays and permalink

### DIFF
--- a/res/index.html
+++ b/res/index.html
@@ -9,7 +9,7 @@
 <title>Firefox Profiler</title>
 <script src='/before-load.js'></script>
 </head>
-<body style='background-color: #363959; /* ink-70 */'>
+<body style='background-color: #363959; /* ink-70 */ transform-style: preserve-3d;'>
 <div id="root"></div>
 <div id="root-overlay"></div>
 </body>

--- a/src/components/shared/ButtonWithPanel/ArrowPanel.css
+++ b/src/components/shared/ButtonWithPanel/ArrowPanel.css
@@ -4,9 +4,10 @@
 
 .arrowPanelAnchor {
   position: absolute;
-  z-index: 10;
+  z-index: 5;
   top: 75%;
   left: 50%;
+  transform: translateZ(3rem);
 }
 
 .arrowPanel {

--- a/src/components/timeline/TrackScreenshots.css
+++ b/src/components/timeline/TrackScreenshots.css
@@ -33,6 +33,7 @@
   position: absolute;
   z-index: 4; /* Ensure this is higher than any other timeline element. */
   pointer-events: none;
+  transform: translateZ(2rem);
 }
 
 .timelineTrackScreenshotHoverImg {

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -1,5 +1,6 @@
 .tooltip {
   position: fixed;
+  z-index: 6;
   display: inline-block;
   overflow: hidden;
 
@@ -17,6 +18,7 @@
   pointer-events: none;
   text-align: left;
   text-overflow: ellipsis;
+  transform: translateZ(4rem);
   transition: opacity 250ms;
 }
 


### PR DESCRIPTION
This pull request fixes the stacking order for tooltips, screenshots and permalink so that tooltips above appear permalinks, but screenshots do not.
Fixes #1274 