### PR TITLE
Preload the stored uploaded profile data into the state when we load a profile

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -40,6 +40,7 @@ import type {
   Action,
   ThunkAction,
   UrlState,
+  ProfileData,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 
@@ -292,4 +293,13 @@ export function enableEventDelayTracks(): ThunkAction<boolean> {
 
     return true;
   };
+}
+
+/**
+ * This caches the profile data in the local state for synchronous access.
+ */
+export function cacheStoredProfileData(
+  profileData: ProfileData | null
+): Action {
+  return { type: 'CACHE_STORED_PROFILE_DATA', profileData };
 }

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -255,9 +255,8 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
       // Because we want to store the published profile even when the upload
       // generation changed, we store the data here, before the state is fully
       // updated, and we'll have to predict the state inside this function.
-      // Note that this function is asynchronous, we don't await it on purpose.
       // We catch all errors in this function.
-      storeJustPublishedProfileData(
+      await storeJustPublishedProfileData(
         hash,
         hashOrToken === hash ? null : hashOrToken,
         sanitizedInformation,

--- a/src/app-logic/published-profiles-store.js
+++ b/src/app-logic/published-profiles-store.js
@@ -143,9 +143,15 @@ export async function listAllProfileData(): Promise<ProfileData[]> {
 
 export async function retrieveProfileData(
   profileToken: string
-): Promise<ProfileData | void> {
+): Promise<ProfileData | null> {
+  if (!profileToken) {
+    // If this is the empty string, let's skip the lookup.
+    return null;
+  }
+
   const db = await open();
-  return db.get(OBJECTSTORE_NAME, profileToken);
+  const result = await db.get(OBJECTSTORE_NAME, profileToken);
+  return result || null;
 }
 
 export async function deleteProfileData(profileToken: string): Promise<void> {

--- a/src/components/app/LoadStoredProfileDataManager.js
+++ b/src/components/app/LoadStoredProfileDataManager.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// This component is responsible for caching the stored profile data in the
+// redux state.  This will control whether we can delete this profile.
+
+// Implementation note:
+// This is done as a separate component than where the deletion button is
+// rendered, so that the button doesn't flick, because the access to the stored
+// profile data is asynchronous.
+// Also this isn't in a thunk action to make it independent from any other
+// change. It only depends on the current hash being changed.
+
+import { PureComponent } from 'react';
+
+import { getHash } from 'firefox-profiler/selectors/url-state';
+import { cacheStoredProfileData } from 'firefox-profiler/actions/app';
+
+import { retrieveProfileData } from 'firefox-profiler/app-logic/published-profiles-store';
+import explicitConnect from 'firefox-profiler/utils/connect';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type StateProps = {|
+  +hash: string,
+|};
+
+type DispatchProps = {|
+  +cacheStoredProfileData: typeof cacheStoredProfileData,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+class LoadStoredProfileDataManagerImpl extends PureComponent<Props> {
+  async updateCanBeDeletedState() {
+    // In tests we don't always have the indexeddb object. To avoid that we have
+    // to add it to a lot of tests, let's bail out in this case.
+    if (process.env.NODE_ENV === 'test' && window.indexedDB === undefined) {
+      return;
+    }
+
+    const { hash, cacheStoredProfileData } = this.props;
+    const profileData = await retrieveProfileData(hash);
+    cacheStoredProfileData(profileData || null);
+  }
+
+  componentDidMount() {
+    this.updateCanBeDeletedState();
+  }
+
+  componentDidUpdate() {
+    this.updateCanBeDeletedState();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export const LoadStoredProfileDataManager = explicitConnect<
+  {||},
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: state => ({
+    hash: getHash(state),
+  }),
+  mapDispatchToProps: { cacheStoredProfileData },
+  component: LoadStoredProfileDataManagerImpl,
+});

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -10,6 +10,7 @@ import explicitConnect from '../../utils/connect';
 import { DetailsContainer } from './DetailsContainer';
 import { ProfileFilterNavigator } from './ProfileFilterNavigator';
 import { MenuButtons } from './MenuButtons';
+import { LoadStoredProfileDataManager } from './LoadStoredProfileDataManager';
 import { WindowTitle } from '../shared/WindowTitle';
 import { SymbolicationStatusOverlay } from './SymbolicationStatusOverlay';
 import { ProfileName } from './ProfileName';
@@ -139,6 +140,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
           <SymbolicationStatusOverlay />
           <BeforeUnloadManager />
           <DebugWarning />
+          <LoadStoredProfileDataManager />
         </div>
       </div>
     );

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -16,6 +16,7 @@ import type {
   ThreadsKey,
   ExperimentalFlags,
   CssPixels,
+  ProfileData,
 } from 'firefox-profiler/types';
 
 const view: Reducer<AppViewState> = (
@@ -246,6 +247,22 @@ const eventDelayTracks: Reducer<boolean> = (state = false, action) => {
 };
 
 /**
+ * Holds the state for whether the user has the local data to delete the
+ * currently displayed profile.
+ */
+const cachedStoredProfileData: Reducer<ProfileData | null> = (
+  state = null,
+  action
+) => {
+  switch (action.type) {
+    case 'CACHE_STORED_PROFILE_DATA':
+      return action.profileData;
+    default:
+      return state;
+  }
+};
+
+/**
  * Experimental features that are mostly disabled by default. You need to enable
  * them from the DevTools console with `experimental.enable<feature-camel-case>()`,
  * e.g. `experimental.enableEventDelayTracks()`.
@@ -268,6 +285,7 @@ const appStateReducer: Reducer<AppState> = combineReducers({
   isDragAndDropDragging,
   isDragAndDropOverlayRegistered,
   experimental,
+  cachedStoredProfileData,
 });
 
 export default appStateReducer;

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -36,7 +36,6 @@ import {
   ACTIVE_TAB_TIMELINE_MARGIN_LEFT,
 } from '../app-logic/constants';
 
-import type { TabSlug } from '../app-logic/tabs-handling';
 import type {
   AppState,
   AppViewState,
@@ -45,7 +44,9 @@ import type {
   CssPixels,
   ThreadsKey,
   ExperimentalFlags,
+  ProfileData,
 } from 'firefox-profiler/types';
+import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 
 /**
  * Simple selectors into the app state.
@@ -77,6 +78,9 @@ export const getIsDragAndDropDragging: Selector<boolean> = state =>
   getApp(state).isDragAndDropDragging;
 export const getIsDragAndDropOverlayRegistered: Selector<boolean> = state =>
   getApp(state).isDragAndDropOverlayRegistered;
+
+export const getCachedStoredProfileData: Selector<ProfileData | null> = state =>
+  getApp(state).cachedStoredProfileData;
 
 /**
  * Height of screenshot track is different depending on the view.

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -363,7 +363,7 @@ describe('ListOfPublishedProfiles', () => {
       // Click on the confirm button
       fireFullClick(getConfirmDeleteButton());
       await findByText(/successfully/i);
-      expect(await retrieveProfileData(profileToken)).toBe(undefined);
+      expect(await retrieveProfileData(profileToken)).toBe(null);
 
       // Clicking elsewhere should make the successful message disappear.
       fireFullClick((window: any));

--- a/src/test/components/LoadStoredProfileDataManager.test.js
+++ b/src/test/components/LoadStoredProfileDataManager.test.js
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, waitFor } from '@testing-library/react';
+
+import { LoadStoredProfileDataManager } from 'firefox-profiler/components/app/LoadStoredProfileDataManager';
+import { getCachedStoredProfileData } from 'firefox-profiler/selectors/app';
+import { updateUrlState } from 'firefox-profiler/actions/app';
+
+import { storeProfileData } from 'firefox-profiler/app-logic/published-profiles-store';
+import { stateFromLocation } from 'firefox-profiler/app-logic/url-handling';
+
+import { blankStore } from '../fixtures/stores';
+
+import 'fake-indexeddb/auto';
+import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
+
+function resetIndexedDb() {
+  // This is the recommended way to reset the IDB state between test runs, but
+  // neither flow nor eslint like that we assign to indexedDB directly, for
+  // different reasons.
+  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
+  indexedDB = new FDBFactory();
+}
+beforeEach(resetIndexedDb);
+afterEach(resetIndexedDb);
+
+describe('app/LoadStoredProfileDataManager', () => {
+  function setup() {
+    const store = blankStore();
+    const renderResult = render(
+      <Provider store={store}>
+        <LoadStoredProfileDataManager />
+      </Provider>
+    );
+
+    function nextTick() {
+      return new Promise(resolve => setTimeout(resolve));
+    }
+
+    function navigateToHash(hash: string) {
+      const newUrlState = stateFromLocation({
+        pathname: `/public/${hash}/calltree`,
+        search: '',
+        hash: '',
+      });
+      store.dispatch(updateUrlState(newUrlState));
+    }
+
+    return {
+      ...renderResult,
+      ...store,
+      nextTick,
+      navigateToHash,
+    };
+  }
+
+  // eslint-disable-next-line jest/expect-expect
+  it('bails out if there is no indexedDB object', async () => {
+    window.indexedDB = undefined;
+    const { nextTick } = setup();
+
+    // All IndexedDB behavior is asynchronous, and errors themselves will be
+    // rejected promises that the test runner will catch. That's why we have to
+    // wait a bit to be sure that there's no error.
+    await nextTick();
+  });
+
+  it('populates the state if a known hash is loaded, resets it otherwise', async () => {
+    const profileData = {
+      profileToken: 'MACOSX',
+      jwtToken: null,
+      publishedDate: new Date('5 Jul 2020 11:00'), // This is the future!
+      name: 'MacOS X profile',
+      preset: null,
+      originHostname: 'https://mozilla.org',
+      meta: {
+        product: 'Firefox',
+        platform: 'Macintosh',
+        toolkit: 'cocoa',
+        misc: 'rv:62.0',
+        oscpu: 'Intel Mac OS X 10.12',
+      },
+      urlPath: '/public/MACOSX/marker-chart/',
+      publishedRange: { start: 2000, end: 40000 },
+    };
+
+    await storeProfileData(profileData);
+
+    const { navigateToHash, getState } = setup();
+    navigateToHash('MACOSX');
+    await waitFor(() =>
+      expect(getCachedStoredProfileData(getState())).toEqual(profileData)
+    );
+
+    // Then navigate to some unknown hash
+    navigateToHash('UNKNOWN_HASH');
+    await waitFor(() =>
+      expect(getCachedStoredProfileData(getState())).toBe(null)
+    );
+  });
+});

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -745,7 +745,7 @@ describe('attemptToPublish', function() {
       // This is the first request, it hasn't been added because the request was
       // aborted before the end.
       const firstRequestData = await retrieveProfileData(BARE_PROFILE_TOKEN);
-      expect(firstRequestData).toBe(undefined);
+      expect(firstRequestData).toBe(null);
 
       // And now, checking that we can retrieve this data when retrieving the
       // full list. The second profile comes first because it was answered

--- a/src/test/unit/published-profiles-store.test.js
+++ b/src/test/unit/published-profiles-store.test.js
@@ -87,7 +87,7 @@ describe('published-profiles-store', function() {
     await setup();
 
     await deleteProfileData('PROFILE-2');
-    expect(await retrieveProfileData('PROFILE-2')).toBe(undefined);
+    expect(await retrieveProfileData('PROFILE-2')).toBe(null);
     expect(await listAllProfileData()).toEqual([
       expect.objectContaining({ profileToken: 'PROFILE-3' }),
       expect.objectContaining({ profileToken: 'PROFILE-1' }),

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -28,7 +28,7 @@ import type { TemporaryError } from '../utils/errors';
 import type { Transform, TransformStacksPerThread } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState, UploadState, State } from './state';
+import type { UrlState, UploadState, State, ProfileData } from './state';
 import type { CssPixels, StartEndRange, Milliseconds } from './units';
 
 export type DataSource =
@@ -470,6 +470,11 @@ type DragAndDropAction =
       +type: 'UNREGISTER_DRAG_AND_DROP_OVERLAY',
     |};
 
+type CacheStoredProfileDataAction = {|
+  +type: 'CACHE_STORED_PROFILE_DATA',
+  +profileData: ProfileData | null,
+|};
+
 export type Action =
   | ProfileAction
   | ReceiveProfileAction
@@ -478,4 +483,5 @@ export type Action =
   | UrlStateAction
   | IconsAction
   | PublishAction
-  | DragAndDropAction;
+  | DragAndDropAction
+  | CacheStoredProfileDataAction;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -34,8 +34,12 @@ import type { TransformStacksPerThread } from './transforms';
 import type JSZip from 'jszip';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { PathSet } from '../utils/path.js';
+import type { ProfileData as ImportedProfileData } from 'firefox-profiler/app-logic/published-profiles-store';
 
 export type Reducer<T> = (T | void, Action) => T;
+
+// Reexport this type for easier access
+export type ProfileData = ImportedProfileData;
 
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {|
@@ -179,6 +183,7 @@ export type AppState = {|
   +isDragAndDropDragging: boolean,
   +isDragAndDropOverlayRegistered: boolean,
   +experimental: ExperimentalFlags,
+  +cachedStoredProfileData: ProfileData | null,
 |};
 
 export type UploadPhase =


### PR DESCRIPTION
Accessing indexeddb data is asynchronous, so when we want to use data coming from it in a component, this doesn't work well, because everything is synchronous in the React/Redux world.

In the "delete profile" case I want 2 things:
1. display when it was uploaded (the date)
2. know if we can delete it to be able to display the delete button

However I'll double-check to see if the asynchronous behavior is acceptable, that would make it possible to avoid this preloading.