### PR TITLE
Extract the delete and profile info panels to their own components

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -4,7 +4,6 @@
 
 // @flow
 import * as React from 'react';
-import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
 import { MetaOverheadStatistics } from './MetaOverheadStatistics';
 import {
   formatBytes,
@@ -31,7 +30,7 @@ type Props = {|
 /**
  * This component formats the profile's meta information into a dropdown panel.
  */
-export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
+export class MetaInfoPanel extends React.PureComponent<Props> {
   /**
    * This method provides information about the symbolication status, and a button
    * to re-trigger symbolication.
@@ -114,143 +113,135 @@ export class MenuButtonsMetaInfo extends React.PureComponent<Props> {
     }
 
     return (
-      <ButtonWithPanel
-        className="menuButtonsMetaInfoButton"
-        buttonClassName="menuButtonsButton menuButtonsMetaInfoButtonButton"
-        label="Profile Info"
-        panelClassName="metaInfoPanel"
-        panelContent={
+      <>
+        <h2 className="metaInfoSubTitle">Profile Information</h2>
+        <div className="metaInfoSection">
+          {meta.startTime ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Recording started:</span>
+              {_formatDate(meta.startTime)}
+            </div>
+          ) : null}
+          {meta.interval ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Interval:</span>
+              {formatTimestamp(meta.interval, 4, 1)}
+            </div>
+          ) : null}
+          {meta.preprocessedProfileVersion ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Profile Version:</span>
+              {meta.preprocessedProfileVersion}
+            </div>
+          ) : null}
+          {configuration ? (
+            <>
+              <div className="metaInfoRow">
+                <span className="metaInfoLabel">Buffer Capacity:</span>
+                {formatBytes(configuration.capacity)}
+              </div>
+              <div className="metaInfoRow">
+                <span className="metaInfoLabel">Buffer Duration:</span>
+                {configuration.duration
+                  ? `${configuration.duration} seconds`
+                  : 'Unlimited'}
+              </div>
+              <div className="metaInfoSection">
+                {_renderRowOfList('Features', configuration.features)}
+                {_renderRowOfList('Threads Filter', configuration.threads)}
+              </div>
+            </>
+          ) : null}
+          {this.renderSymbolication()}
+        </div>
+        <h2 className="metaInfoSubTitle">Application</h2>
+        <div className="metaInfoSection">
+          {meta.product ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Name and version:</span>
+              {formatProductAndVersion(meta)}
+            </div>
+          ) : null}
+          {meta.updateChannel ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Update Channel:</span>
+              {meta.updateChannel}
+            </div>
+          ) : null}
+          {meta.appBuildID ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Build ID:</span>
+              {meta.sourceURL ? (
+                <a
+                  href={meta.sourceURL}
+                  title={meta.sourceURL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {meta.appBuildID}
+                </a>
+              ) : (
+                meta.appBuildID
+              )}
+            </div>
+          ) : null}
+          {meta.debug !== undefined ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">Build Type:</span>
+              {meta.debug ? 'Debug' : 'Opt'}
+            </div>
+          ) : null}
+          {meta.extensions
+            ? _renderRowOfList('Extensions', meta.extensions.name)
+            : null}
+        </div>
+        <h2 className="metaInfoSubTitle">Platform</h2>
+        <div className="metaInfoSection">
+          {platformInformation ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">OS:</span>
+              {platformInformation}
+            </div>
+          ) : null}
+          {meta.abi ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">ABI:</span>
+              {meta.abi}
+            </div>
+          ) : null}
+          {cpuCount}
+        </div>
+        {meta.visualMetrics ? (
           <>
-            <h2 className="metaInfoSubTitle">Profile Information</h2>
+            <h2 className="metaInfoSubTitle">Visual Metrics</h2>
             <div className="metaInfoSection">
-              {meta.startTime ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Recording started:</span>
-                  {_formatDate(meta.startTime)}
-                </div>
-              ) : null}
-              {meta.interval ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Interval:</span>
-                  {formatTimestamp(meta.interval, 4, 1)}
-                </div>
-              ) : null}
-              {meta.preprocessedProfileVersion ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Profile Version:</span>
-                  {meta.preprocessedProfileVersion}
-                </div>
-              ) : null}
-              {configuration ? (
-                <>
-                  <div className="metaInfoRow">
-                    <span className="metaInfoLabel">Buffer Capacity:</span>
-                    {formatBytes(configuration.capacity)}
-                  </div>
-                  <div className="metaInfoRow">
-                    <span className="metaInfoLabel">Buffer Duration:</span>
-                    {configuration.duration
-                      ? `${configuration.duration} seconds`
-                      : 'Unlimited'}
-                  </div>
-                  <div className="metaInfoSection">
-                    {_renderRowOfList('Features', configuration.features)}
-                    {_renderRowOfList('Threads Filter', configuration.threads)}
-                  </div>
-                </>
-              ) : null}
-              {this.renderSymbolication()}
+              <div className="metaInfoRow">
+                <span className="visualMetricsLabel">Speed Index:</span>
+                {meta.visualMetrics.SpeedIndex}
+              </div>
+              <div className="metaInfoRow">
+                <span className="visualMetricsLabel">
+                  Perceptual Speed Index:
+                </span>
+                {meta.visualMetrics.PerceptualSpeedIndex}
+              </div>
+              <div className="metaInfoRow">
+                <span className="visualMetricsLabel">
+                  Contentful Speed Index:
+                </span>
+                {meta.visualMetrics.ContentfulSpeedIndex}
+              </div>
             </div>
-            <h2 className="metaInfoSubTitle">Application</h2>
-            <div className="metaInfoSection">
-              {meta.product ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Name and version:</span>
-                  {formatProductAndVersion(meta)}
-                </div>
-              ) : null}
-              {meta.updateChannel ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Update Channel:</span>
-                  {meta.updateChannel}
-                </div>
-              ) : null}
-              {meta.appBuildID ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Build ID:</span>
-                  {meta.sourceURL ? (
-                    <a
-                      href={meta.sourceURL}
-                      title={meta.sourceURL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {meta.appBuildID}
-                    </a>
-                  ) : (
-                    meta.appBuildID
-                  )}
-                </div>
-              ) : null}
-              {meta.debug !== undefined ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">Build Type:</span>
-                  {meta.debug ? 'Debug' : 'Opt'}
-                </div>
-              ) : null}
-              {meta.extensions
-                ? _renderRowOfList('Extensions', meta.extensions.name)
-                : null}
-            </div>
-            <h2 className="metaInfoSubTitle">Platform</h2>
-            <div className="metaInfoSection">
-              {platformInformation ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">OS:</span>
-                  {platformInformation}
-                </div>
-              ) : null}
-              {meta.abi ? (
-                <div className="metaInfoRow">
-                  <span className="metaInfoLabel">ABI:</span>
-                  {meta.abi}
-                </div>
-              ) : null}
-              {cpuCount}
-            </div>
-            {meta.visualMetrics ? (
-              <>
-                <h2 className="metaInfoSubTitle">Visual Metrics</h2>
-                <div className="metaInfoSection">
-                  <div className="metaInfoRow">
-                    <span className="visualMetricsLabel">Speed Index:</span>
-                    {meta.visualMetrics.SpeedIndex}
-                  </div>
-                  <div className="metaInfoRow">
-                    <span className="visualMetricsLabel">
-                      Perceptual Speed Index:
-                    </span>
-                    {meta.visualMetrics.PerceptualSpeedIndex}
-                  </div>
-                  <div className="metaInfoRow">
-                    <span className="visualMetricsLabel">
-                      Contentful Speed Index:
-                    </span>
-                    {meta.visualMetrics.ContentfulSpeedIndex}
-                  </div>
-                </div>
-              </>
-            ) : null}
-            {/*
+          </>
+        ) : null}
+        {/*
               Older profiles(before FF 70) don't have any overhead info.
               Don't show anything if that's the case.
             */}
-            {profilerOverhead ? (
-              <MetaOverheadStatistics profilerOverhead={profilerOverhead} />
-            ) : null}
-          </>
-        }
-      />
+        {profilerOverhead ? (
+          <MetaOverheadStatistics profilerOverhead={profilerOverhead} />
+        ) : null}
+      </>
     );
   }
 }

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -18,10 +18,13 @@ import {
 } from 'firefox-profiler/selectors/profile';
 import { getDataSource } from 'firefox-profiler/selectors/url-state';
 import { getIsNewlyPublished } from 'firefox-profiler/selectors/app';
-import { MenuButtonsMetaInfo } from 'firefox-profiler/components/app/MenuButtons/MetaInfo';
+
+/* Note: the order of import is important, from most general to most specific,
+ * so that the CSS rules are in the correct order. */
+import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
+import { MetaInfoPanel } from 'firefox-profiler/components/app/MenuButtons/MetaInfo';
 import { MenuButtonsPublish } from 'firefox-profiler/components/app/MenuButtons/Publish';
 import { MenuButtonsPermalink } from 'firefox-profiler/components/app/MenuButtons/Permalink';
-import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
 import { revertToPrePublishedState } from 'firefox-profiler/actions/publish';
 import { dismissNewlyPublished } from 'firefox-profiler/actions/app';
 import {
@@ -73,6 +76,25 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
   componentDidMount() {
     // Clear out the newly published notice from the URL.
     this.props.dismissNewlyPublished();
+  }
+
+  _renderMetaInfoButton() {
+    const { profile, symbolicationStatus, resymbolicateProfile } = this.props;
+    return (
+      <ButtonWithPanel
+        className="menuButtonsMetaInfoButton"
+        buttonClassName="menuButtonsButton menuButtonsMetaInfoButtonButton"
+        label="Profile Info"
+        panelClassName="metaInfoPanel"
+        panelContent={
+          <MetaInfoPanel
+            profile={profile}
+            symbolicationStatus={symbolicationStatus}
+            resymbolicateProfile={resymbolicateProfile}
+          />
+        }
+      />
+    );
   }
 
   _renderPublishPanel() {
@@ -152,15 +174,10 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
   }
 
   render() {
-    const { profile, symbolicationStatus, resymbolicateProfile } = this.props;
     return (
       <>
         {/* Place the info button outside of the menu buttons to allow it to shrink. */}
-        <MenuButtonsMetaInfo
-          profile={profile}
-          symbolicationStatus={symbolicationStatus}
-          resymbolicateProfile={resymbolicateProfile}
-        />
+        {this._renderMetaInfoButton()}
         <div className="menuButtons">
           {this._renderRevertProfile()}
           {this._renderPublishPanel()}

--- a/src/components/app/ProfileDeleteButton.js
+++ b/src/components/app/ProfileDeleteButton.js
@@ -20,9 +20,9 @@ type ButtonProps = {|
   +jwtToken: string,
   +profileToken: string,
   +buttonClassName?: string,
-  +onOpenConfirmDialog?: () => mixed,
-  +onCloseConfirmDialog?: () => mixed,
-  +onCloseSuccessMessage?: () => mixed,
+  +onOpenConfirmDialog: () => mixed,
+  +onCloseConfirmDialog: () => mixed,
+  +onCloseSuccessMessage: () => mixed,
 |};
 
 export class ProfileDeleteButton extends PureComponent<ButtonProps> {
@@ -32,13 +32,11 @@ export class ProfileDeleteButton extends PureComponent<ButtonProps> {
   onCloseConfirmDialog = () => {
     // In case we deleted the profile, and the user dismisses the success panel,
     // let's move directly to the deleted state:
-    if (this._hasBeenDeleted && this.props.onCloseSuccessMessage) {
+    if (this._hasBeenDeleted) {
       this.props.onCloseSuccessMessage();
     }
 
-    if (this.props.onCloseConfirmDialog) {
-      this.props.onCloseConfirmDialog();
-    }
+    this.props.onCloseConfirmDialog();
   };
 
   onProfileDeleted = () => {

--- a/src/components/app/ProfileDeleteButton.js
+++ b/src/components/app/ProfileDeleteButton.js
@@ -14,11 +14,21 @@ import { deleteProfileOnServer } from 'firefox-profiler/profile-logic/profile-st
 
 import './ProfileDeleteButton.css';
 
+/*
+ * You can use this component directly if you want to provide a button to delete
+ * a specific profile on the server.
+ * If you're interested by the panel displayed when clicking on this button,
+ * you'll want to use ProfileDeletePanel defined below.
+ */
 type ButtonProps = {|
+  /* This string will be used in a title */
   +profileName: string,
+  /* This string will be used in longer sentence in a tooltip */
   +smallProfileName: string,
-  +jwtToken: string,
+  /* This identifies the profile we want to delete. This is also commonly known as the "hash" of the profile. */
   +profileToken: string,
+  /* This token is used to authenticate the deletion HTTP request to the server. */
+  +jwtToken: string,
   +buttonClassName?: string,
   +onOpenConfirmDialog: () => mixed,
   +onCloseConfirmDialog: () => mixed,
@@ -85,9 +95,15 @@ export class ProfileDeleteButton extends PureComponent<ButtonProps> {
   }
 }
 
+/*
+ * This Panel implements a confirmation dialog to delete a profile, as well as
+ * calling the deletion process when the user confirms.
+ */
 type PanelProps = {|
   +profileName: string,
+  /* This identifies the profile we want to delete. This is also commonly known as the "hash" of the profile. */
   +profileToken: string,
+  /* This token is used to authenticate the deletion HTTP request to the server. */
   +jwtToken: string,
   +onProfileDeleted: () => mixed,
   +onProfileDeleteCanceled: () => mixed,

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -6,7 +6,11 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, getByText as globalGetByText } from '@testing-library/react';
+import {
+  render,
+  getByText as globalGetByText,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 
 import { ListOfPublishedProfiles } from 'firefox-profiler/components/app/ListOfPublishedProfiles';
 import {
@@ -367,7 +371,7 @@ describe('ListOfPublishedProfiles', () => {
 
       // Clicking elsewhere should make the successful message disappear.
       fireFullClick((window: any));
-      expect(queryByText(/successfully/i)).toBe(null);
+      waitForElementToBeRemoved(queryByText(/successfully/i));
     });
 
     it('can cancel the deletion', async () => {

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -5,7 +5,7 @@
 // @flow
 import * as React from 'react';
 import { MenuButtons } from '../../components/app/MenuButtons';
-import { MenuButtonsMetaInfo } from '../../components/app/MenuButtons/MetaInfo';
+import { MetaInfoPanel } from '../../components/app/MenuButtons/MetaInfo';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
@@ -283,35 +283,29 @@ describe('app/MenuButtons', function() {
   });
 });
 
-describe('<MenuButtonsMetaInfo>', function() {
+describe('<MetaInfoPanel>', function() {
   function setup(profile: Profile, symbolicationStatus = 'DONE') {
-    jest.useFakeTimers();
     jest.spyOn(Date.prototype, 'toLocaleString').mockImplementation(function() {
       // eslint-disable-next-line babel/no-invalid-this
       return 'toLocaleString ' + this.toUTCString();
     });
-    const store = storeWithProfile(profile);
     const resymbolicateProfile = jest.fn();
 
     const renderResults = render(
-      <Provider store={store}>
-        <MenuButtonsMetaInfo
-          profile={profile}
-          resymbolicateProfile={resymbolicateProfile}
-          symbolicationStatus={symbolicationStatus}
-        />
-      </Provider>
+      <MetaInfoPanel
+        profile={profile}
+        resymbolicateProfile={resymbolicateProfile}
+        symbolicationStatus={symbolicationStatus}
+      />
     );
 
     return {
-      store,
       resymbolicateProfile,
-      renderResults,
       ...renderResults,
     };
   }
 
-  it('matches the snapshot', async () => {
+  it('matches the snapshot', () => {
     // Using gecko profile because it has metadata and profilerOverhead data in it.
     const profile = processProfile(createGeckoProfile());
     profile.meta.configuration = {
@@ -321,15 +315,13 @@ describe('<MenuButtonsMetaInfo>', function() {
       duration: 20,
     };
 
-    const { container, getByText } = setup(profile);
-    const metaInfoButton = getByText('Profile Info');
-    fireFullClick(metaInfoButton);
-    jest.runAllTimers();
-
-    expect(container.firstChild).toMatchSnapshot();
+    const { container } = setup(profile);
+    // This component renders a fragment, so we look at the full container so
+    // that we get all children.
+    expect(container).toMatchSnapshot();
   });
 
-  it('with no statistics object should not make the app crash', async () => {
+  it('with no statistics object should not make the app crash', () => {
     // Using gecko profile because it has metadata and profilerOverhead data in it.
     const profile = processProfile(createGeckoProfile());
     // We are removing statistics objects from all overhead objects to test
@@ -340,13 +332,10 @@ describe('<MenuButtonsMetaInfo>', function() {
       }
     }
 
-    const { getByText, container } = setup(profile);
-
-    const metaInfoButton = getByText('Profile Info');
-    fireFullClick(metaInfoButton);
-    jest.runAllTimers();
-
-    expect(container.firstChild).toMatchSnapshot();
+    const { container } = setup(profile);
+    // This component renders a fragment, so we look at the full container so
+    // that we get all children.
+    expect(container).toMatchSnapshot();
   });
 
   describe('symbolication', function() {
@@ -359,14 +348,7 @@ describe('<MenuButtonsMetaInfo>', function() {
       const { profile } = getProfileFromTextSamples('A');
       profile.meta.symbolicated = config.symbolicated;
 
-      const setupResult = setup(profile, config.symbolicationStatus);
-
-      // Open up the arrow panel for the test.
-      const { getByText } = setupResult;
-      fireEvent.click(getByText('Profile Info'));
-      jest.runAllTimers();
-
-      return setupResult;
+      return setup(profile, config.symbolicationStatus);
     }
 
     it('handles successfully symbolicated profiles', () => {

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,617 +1,571 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MenuButtonsMetaInfo> matches the snapshot 1`] = `
-<div
-  class="buttonWithPanel menuButtonsMetaInfoButton open"
->
-  <input
-    aria-expanded="true"
-    class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton"
-    type="button"
-    value="Profile Info"
-  />
+exports[`<MetaInfoPanel> matches the snapshot 1`] = `
+<div>
+  <h2
+    class="metaInfoSubTitle"
+  >
+    Profile Information
+  </h2>
   <div
-    class="arrowPanelAnchor"
+    class="metaInfoSection"
   >
     <div
-      class="arrowPanel open metaInfoPanel"
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Recording started:
+      </span>
+      toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Interval:
+      </span>
+      1ms
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Profile Version:
+      </span>
+      32
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Buffer Capacity:
+      </span>
+      16.0KB
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Buffer Duration:
+      </span>
+      20 seconds
+    </div>
+    <div
+      class="metaInfoSection"
     >
       <div
-        class="arrowPanelArrow"
-      />
-      <div
-        class="arrowPanelContent"
+        class="metaInfoRow"
       >
-        <h2
-          class="metaInfoSubTitle"
+        <span
+          class="metaInfoLabel"
         >
-          Profile Information
-        </h2>
-        <div
-          class="metaInfoSection"
+          Features
+          :
+        </span>
+        <ul
+          class="metaInfoList"
         >
-          <div
-            class="metaInfoRow"
+          <li
+            class="metaInfoListItem"
           >
-            <span
-              class="metaInfoLabel"
-            >
-              Recording started:
-            </span>
-            toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-          </div>
-          <div
-            class="metaInfoRow"
+            js
+          </li>
+          <li
+            class="metaInfoListItem"
           >
-            <span
-              class="metaInfoLabel"
-            >
-              Interval:
-            </span>
-            1ms
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Profile Version:
-            </span>
-            32
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Buffer Capacity:
-            </span>
-            16.0KB
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Buffer Duration:
-            </span>
-            20 seconds
-          </div>
-          <div
-            class="metaInfoSection"
-          >
-            <div
-              class="metaInfoRow"
-            >
-              <span
-                class="metaInfoLabel"
-              >
-                Features
-                :
-              </span>
-              <ul
-                class="metaInfoList"
-              >
-                <li
-                  class="metaInfoListItem"
-                >
-                  js
-                </li>
-                <li
-                  class="metaInfoListItem"
-                >
-                  threads
-                </li>
-              </ul>
-            </div>
-            <div
-              class="metaInfoRow"
-            >
-              <span
-                class="metaInfoLabel"
-              >
-                Threads Filter
-                :
-              </span>
-              <ul
-                class="metaInfoList"
-              >
-                <li
-                  class="metaInfoListItem"
-                >
-                  GeckoMain
-                </li>
-                <li
-                  class="metaInfoListItem"
-                >
-                  DOM Worker
-                </li>
-              </ul>
-            </div>
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Symbols:
-            </span>
-            Profile is not symbolicated
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            />
-            <button
-              class="photon-button photon-button-micro"
-              type="button"
-            >
-              Symbolicate profile
-            </button>
-          </div>
-        </div>
-        <h2
-          class="metaInfoSubTitle"
+            threads
+          </li>
+        </ul>
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
         >
-          Application
-        </h2>
-        <div
-          class="metaInfoSection"
+          Threads Filter
+          :
+        </span>
+        <ul
+          class="metaInfoList"
         >
-          <div
-            class="metaInfoRow"
+          <li
+            class="metaInfoListItem"
           >
-            <span
-              class="metaInfoLabel"
-            >
-              Name and version:
-            </span>
-            Firefox 48
-          </div>
-          <div
-            class="metaInfoRow"
+            GeckoMain
+          </li>
+          <li
+            class="metaInfoListItem"
           >
-            <span
-              class="metaInfoLabel"
-            >
-              Update Channel:
-            </span>
-            nightly
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Build ID:
-            </span>
-            20181126165837
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Build Type:
-            </span>
-            Debug
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Extensions
-              :
-            </span>
-            <ul
-              class="metaInfoList"
-            >
-              <li
-                class="metaInfoListItem"
-              >
-                Form Autofill
-              </li>
-              <li
-                class="metaInfoListItem"
-              >
-                Firefox Screenshots
-              </li>
-              <li
-                class="metaInfoListItem"
-              >
-                Gecko Profiler
-              </li>
-            </ul>
-          </div>
-        </div>
-        <h2
-          class="metaInfoSubTitle"
-        >
-          Platform
-        </h2>
-        <div
-          class="metaInfoSection"
-        >
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              OS:
-            </span>
-            macOS 10.11
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              ABI:
-            </span>
-            x86_64-gcc3
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              CPU:
-            </span>
-            4 physical cores
-            , 
-            8 logical cores
-          </div>
-        </div>
-        <details>
-          <summary
-            class="arrowPanelSubTitle"
-          >
-            Profiler Overhead
-          </summary>
-          <div
-            class="arrowPanelSection"
-          >
-            <div
-              class="metaInfoGrid"
-            >
-              <div />
-              <div>
-                Mean
-              </div>
-              <div>
-                Max
-              </div>
-              <div>
-                Min
-              </div>
-              <div>
-                Overhead
-              </div>
-              <div>
-                227μs
-              </div>
-              <div>
-                410μs
-              </div>
-              <div>
-                38μs
-              </div>
-              <div>
-                Cleaning
-              </div>
-              <div>
-                54μs
-              </div>
-              <div>
-                100μs
-              </div>
-              <div>
-                7.0μs
-              </div>
-              <div>
-                Counter
-              </div>
-              <div>
-                59μs
-              </div>
-              <div>
-                105μs
-              </div>
-              <div>
-                12μs
-              </div>
-              <div>
-                Interval
-              </div>
-              <div>
-                857μs
-              </div>
-              <div>
-                1,000μs
-              </div>
-              <div>
-                0.000μs
-              </div>
-              <div>
-                Lockings
-              </div>
-              <div>
-                49μs
-              </div>
-              <div>
-                95μs
-              </div>
-              <div>
-                2.0μs
-              </div>
-            </div>
-            <div
-              class="metaInfoRow"
-            >
-              <span
-                class="metaInfoWideLabel"
-              >
-                Overhead Durations:
-              </span>
-              <span
-                class="metaInfoValueRight"
-              >
-                1,586μs
-              </span>
-            </div>
-            <div
-              class="metaInfoRow"
-            >
-              <span
-                class="metaInfoWideLabel"
-              >
-                Overhead Percentage:
-              </span>
-              <span
-                class="metaInfoValueRight"
-              >
-                26,433%
-              </span>
-            </div>
-            <div
-              class="metaInfoRow"
-            >
-              <span
-                class="metaInfoWideLabel"
-              >
-                Profiled Duration:
-              </span>
-              <span
-                class="metaInfoValueRight"
-              >
-                6.0μs
-              </span>
-            </div>
-          </div>
-        </details>
+            DOM Worker
+          </li>
+        </ul>
       </div>
     </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Symbols:
+      </span>
+      Profile is not symbolicated
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      />
+      <button
+        class="photon-button photon-button-micro"
+        type="button"
+      >
+        Symbolicate profile
+      </button>
+    </div>
   </div>
+  <h2
+    class="metaInfoSubTitle"
+  >
+    Application
+  </h2>
+  <div
+    class="metaInfoSection"
+  >
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Name and version:
+      </span>
+      Firefox 48
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Update Channel:
+      </span>
+      nightly
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Build ID:
+      </span>
+      20181126165837
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Build Type:
+      </span>
+      Debug
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Extensions
+        :
+      </span>
+      <ul
+        class="metaInfoList"
+      >
+        <li
+          class="metaInfoListItem"
+        >
+          Form Autofill
+        </li>
+        <li
+          class="metaInfoListItem"
+        >
+          Firefox Screenshots
+        </li>
+        <li
+          class="metaInfoListItem"
+        >
+          Gecko Profiler
+        </li>
+      </ul>
+    </div>
+  </div>
+  <h2
+    class="metaInfoSubTitle"
+  >
+    Platform
+  </h2>
+  <div
+    class="metaInfoSection"
+  >
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        OS:
+      </span>
+      macOS 10.11
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        ABI:
+      </span>
+      x86_64-gcc3
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        CPU:
+      </span>
+      4 physical cores
+      , 
+      8 logical cores
+    </div>
+  </div>
+  <details>
+    <summary
+      class="arrowPanelSubTitle"
+    >
+      Profiler Overhead
+    </summary>
+    <div
+      class="arrowPanelSection"
+    >
+      <div
+        class="metaInfoGrid"
+      >
+        <div />
+        <div>
+          Mean
+        </div>
+        <div>
+          Max
+        </div>
+        <div>
+          Min
+        </div>
+        <div>
+          Overhead
+        </div>
+        <div>
+          227μs
+        </div>
+        <div>
+          410μs
+        </div>
+        <div>
+          38μs
+        </div>
+        <div>
+          Cleaning
+        </div>
+        <div>
+          54μs
+        </div>
+        <div>
+          100μs
+        </div>
+        <div>
+          7.0μs
+        </div>
+        <div>
+          Counter
+        </div>
+        <div>
+          59μs
+        </div>
+        <div>
+          105μs
+        </div>
+        <div>
+          12μs
+        </div>
+        <div>
+          Interval
+        </div>
+        <div>
+          857μs
+        </div>
+        <div>
+          1,000μs
+        </div>
+        <div>
+          0.000μs
+        </div>
+        <div>
+          Lockings
+        </div>
+        <div>
+          49μs
+        </div>
+        <div>
+          95μs
+        </div>
+        <div>
+          2.0μs
+        </div>
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoWideLabel"
+        >
+          Overhead Durations:
+        </span>
+        <span
+          class="metaInfoValueRight"
+        >
+          1,586μs
+        </span>
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoWideLabel"
+        >
+          Overhead Percentage:
+        </span>
+        <span
+          class="metaInfoValueRight"
+        >
+          26,433%
+        </span>
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoWideLabel"
+        >
+          Profiled Duration:
+        </span>
+        <span
+          class="metaInfoValueRight"
+        >
+          6.0μs
+        </span>
+      </div>
+    </div>
+  </details>
 </div>
 `;
 
-exports[`<MenuButtonsMetaInfo> with no statistics object should not make the app crash 1`] = `
-<div
-  class="buttonWithPanel menuButtonsMetaInfoButton open"
->
-  <input
-    aria-expanded="true"
-    class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton"
-    type="button"
-    value="Profile Info"
-  />
+exports[`<MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
+<div>
+  <h2
+    class="metaInfoSubTitle"
+  >
+    Profile Information
+  </h2>
   <div
-    class="arrowPanelAnchor"
+    class="metaInfoSection"
   >
     <div
-      class="arrowPanel open metaInfoPanel"
+      class="metaInfoRow"
     >
-      <div
-        class="arrowPanelArrow"
-      />
-      <div
-        class="arrowPanelContent"
+      <span
+        class="metaInfoLabel"
       >
-        <h2
-          class="metaInfoSubTitle"
+        Recording started:
+      </span>
+      toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Interval:
+      </span>
+      1ms
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Profile Version:
+      </span>
+      32
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Symbols:
+      </span>
+      Profile is not symbolicated
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      />
+      <button
+        class="photon-button photon-button-micro"
+        type="button"
+      >
+        Symbolicate profile
+      </button>
+    </div>
+  </div>
+  <h2
+    class="metaInfoSubTitle"
+  >
+    Application
+  </h2>
+  <div
+    class="metaInfoSection"
+  >
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Name and version:
+      </span>
+      Firefox 48
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Update Channel:
+      </span>
+      nightly
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Build ID:
+      </span>
+      20181126165837
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Build Type:
+      </span>
+      Debug
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        Extensions
+        :
+      </span>
+      <ul
+        class="metaInfoList"
+      >
+        <li
+          class="metaInfoListItem"
         >
-          Profile Information
-        </h2>
-        <div
-          class="metaInfoSection"
+          Form Autofill
+        </li>
+        <li
+          class="metaInfoListItem"
         >
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Recording started:
-            </span>
-            toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Interval:
-            </span>
-            1ms
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Profile Version:
-            </span>
-            32
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Symbols:
-            </span>
-            Profile is not symbolicated
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            />
-            <button
-              class="photon-button photon-button-micro"
-              type="button"
-            >
-              Symbolicate profile
-            </button>
-          </div>
-        </div>
-        <h2
-          class="metaInfoSubTitle"
+          Firefox Screenshots
+        </li>
+        <li
+          class="metaInfoListItem"
         >
-          Application
-        </h2>
-        <div
-          class="metaInfoSection"
-        >
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Name and version:
-            </span>
-            Firefox 48
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Update Channel:
-            </span>
-            nightly
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Build ID:
-            </span>
-            20181126165837
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Build Type:
-            </span>
-            Debug
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              Extensions
-              :
-            </span>
-            <ul
-              class="metaInfoList"
-            >
-              <li
-                class="metaInfoListItem"
-              >
-                Form Autofill
-              </li>
-              <li
-                class="metaInfoListItem"
-              >
-                Firefox Screenshots
-              </li>
-              <li
-                class="metaInfoListItem"
-              >
-                Gecko Profiler
-              </li>
-            </ul>
-          </div>
-        </div>
-        <h2
-          class="metaInfoSubTitle"
-        >
-          Platform
-        </h2>
-        <div
-          class="metaInfoSection"
-        >
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              OS:
-            </span>
-            macOS 10.11
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              ABI:
-            </span>
-            x86_64-gcc3
-          </div>
-          <div
-            class="metaInfoRow"
-          >
-            <span
-              class="metaInfoLabel"
-            >
-              CPU:
-            </span>
-            4 physical cores
-            , 
-            8 logical cores
-          </div>
-        </div>
-      </div>
+          Gecko Profiler
+        </li>
+      </ul>
+    </div>
+  </div>
+  <h2
+    class="metaInfoSubTitle"
+  >
+    Platform
+  </h2>
+  <div
+    class="metaInfoSection"
+  >
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        OS:
+      </span>
+      macOS 10.11
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        ABI:
+      </span>
+      x86_64-gcc3
+    </div>
+    <div
+      class="metaInfoRow"
+    >
+      <span
+        class="metaInfoLabel"
+      >
+        CPU:
+      </span>
+      4 physical cores
+      , 
+      8 logical cores
     </div>
   </div>
 </div>


### PR DESCRIPTION
In the current code, both for ProfileDeleteButton and MetaInfoButton, we have both the panel and its controlling button in one component. This makes it not flexible and difficult to reuse differently.

However, with the new design, we'll have a workflow that looks like this:
1. the user clicks "Profile Info"
2. in the displayed panel, only for profiles uploaded by this user, we'll have a top part with some information about the uploaded profile, and a button to delete it.
3. When the user presses this button the panel will be replaced by the delete confirmation.

In a more future design, the "re-upload" button could be here too, and clicking it would replace the panel with the publish panel. The publish panel is already a separate component.

So that's why this PR uncouples both the "Delete confirmation" panel and the "Meta info" panel from their respective buttons.

The 2 commits are independent but I grouped them in one PR because that's fairly related. They should be easier to review by hiding the whitespace changes.

This is just a refactor, there should be no visual change with this PR.

Deploy previews for the metainfo panel:
* [main](https://main--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&thread=0&v=5)
* [deploy preview](https://deploy-preview-3003--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&thread=0&v=5)

Deploy previews for the uploaded recordings page (to check the delete confirmation):
* [main](https://main--perf-html.netlify.app/uploaded-recordings/)
* [deploy preview](https://deploy-preview-3004--perf-html.netlify.app/uploaded-recordings/)

Obviously you'll have to reupload a profile first so that it shows up in this view.