### PR TITLE
Some more various CSS cleanups and simplifications around Menubutton

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.css
+++ b/src/components/app/MenuButtons/MetaInfo.css
@@ -2,20 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.menuButtonsMetaInfoButton {
-  /* Let this box shrink down to the size of the three dots and a bit of text. */
-  min-width: 75px;
-
-  /* Shrink down twice as fast as the range selection labels. */
-  flex-shrink: 2;
-}
-
-.menuButtonsMetaInfoButtonButton {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .metaInfoPanel {
   width: 350px;
   font-size: 12px;

--- a/src/components/app/MenuButtons/Permalink.css
+++ b/src/components/app/MenuButtons/Permalink.css
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.menuButtonsPermalinkPanel .arrowPanelContent {
+  /* Override the default padding for ArrowPanel */
+  padding: 4px;
+}
+
+.menuButtonsPermalinkTextField {
+  width: 16em;
+  height: 19px;
+}

--- a/src/components/app/MenuButtons/Permalink.js
+++ b/src/components/app/MenuButtons/Permalink.js
@@ -8,6 +8,8 @@ import * as React from 'react';
 import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
 import * as UrlUtils from 'firefox-profiler/utils/shorten-url';
 
+import './Permalink.css';
+
 type Props = {|
   +isNewlyPublished: boolean,
   // This is for injecting a URL shortener for tests. Normally we would use a Jest mock

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -7,17 +7,6 @@
   color: #fff;
 }
 
-.menuButtonsUploadingButtonLabel {
-  position: relative;
-  padding: 0 10px;
-  color: hsla(0, 0%, 100%, 0.7);
-  cursor: default;
-  line-height: 24px;
-  text-align: center;
-  -webkit-user-select: none;
-  user-select: none;
-}
-
 .menuButtonsShareButtonOriginal {
   background-color: var(--green-70);
   color: white;
@@ -70,11 +59,6 @@
 .menuButtonsPublishDataChoicesLabel {
   display: flex;
   margin: 4px 0;
-}
-
-.menuButtonsPublishDataLabel {
-  display: block;
-  line-height: 2.3;
 }
 
 .menuButtonsPublishButtons {

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -2,36 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.menuButtons {
+.menuButtonsButton {
   display: flex;
   height: 100%;
-  flex-flow: row nowrap;
-}
-
-.menuButtonsLink {
-  position: relative;
-  height: 24px;
-  padding: 0 20px;
-  border-left: 1px solid var(--grey-30);
-  color: var(--grey-90);
-  cursor: default;
-  line-height: 24px;
-  text-decoration: none;
-}
-
-.menuButtonsLink:hover {
-  background-color: rgba(0, 0, 0, 0.1);
-}
-.open-in-new {
-  padding: 10px;
-  background-image: url(../../../../res/img/svg/open-in-new.svg);
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 11px;
-}
-
-.menuButtonsButton {
-  height: 100%;
+  align-items: center;
   padding: 0 20px;
   border: 0;
   border-left: 1px solid var(--grey-30);
@@ -45,10 +19,24 @@
 }
 
 .menuButtonsButton:hover {
-  background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .buttonWithPanel.open > .menuButtonsButton,
 .menuButtonsButton:hover:active {
-  background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2));
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.menuButtonsLink {
+  position: relative; /* This allows positioning the ::before element. */
+  cursor: default;
+  text-decoration: none;
+}
+
+.open-in-new {
+  padding: 10px;
+  background-image: url(firefox-profiler-res/img/svg/open-in-new.svg);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 11px;
 }

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -176,22 +176,19 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
   render() {
     return (
       <>
-        {/* Place the info button outside of the menu buttons to allow it to shrink. */}
         {this._renderMetaInfoButton()}
-        <div className="menuButtons">
-          {this._renderRevertProfile()}
-          {this._renderPublishPanel()}
-          {this._renderPermalink()}
-          <a
-            href="/docs/"
-            target="_blank"
-            className="menuButtonsLink"
-            title="Open the documentation in a new window"
-          >
-            Docs
-            <i className="open-in-new" />
-          </a>
-        </div>
+        {this._renderRevertProfile()}
+        {this._renderPublishPanel()}
+        {this._renderPermalink()}
+        <a
+          href="/docs/"
+          target="_blank"
+          className="menuButtonsButton menuButtonsLink"
+          title="Open the documentation in a new window"
+        >
+          Docs
+          <i className="open-in-new" />
+        </a>
       </>
     );
   }

--- a/src/components/shared/ButtonWithPanel/ArrowPanel.css
+++ b/src/components/shared/ButtonWithPanel/ArrowPanel.css
@@ -99,13 +99,3 @@
   --internal-approx-distance-from-top: 60px;
   --internal-approx-distance-to-bottom: 100px;
 }
-
-.menuButtonsPermalinkPanel .arrowPanelContent {
-  /* Override the default padding for ArrowPanel */
-  padding: 4px;
-}
-
-.menuButtonsPermalinkTextField {
-  width: 16em;
-  height: 19px;
-}

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -608,30 +608,26 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the closed state 1`]
     />
   </div>
   <div
-    class="menuButtons"
+    class="buttonWithPanel menuButtonsShareButton menuButtonsShareButtonOriginal"
   >
-    <div
-      class="buttonWithPanel menuButtonsShareButton menuButtonsShareButtonOriginal"
-    >
-      <input
-        aria-expanded="false"
-        class="buttonWithPanelButton menuButtonsButton"
-        type="button"
-        value="Publish…"
-      />
-    </div>
-    <a
-      class="menuButtonsLink"
-      href="/docs/"
-      target="_blank"
-      title="Open the documentation in a new window"
-    >
-      Docs
-      <i
-        class="open-in-new"
-      />
-    </a>
+    <input
+      aria-expanded="false"
+      class="buttonWithPanelButton menuButtonsButton"
+      type="button"
+      value="Publish…"
+    />
   </div>
+  <a
+    class="menuButtonsButton menuButtonsLink"
+    href="/docs/"
+    target="_blank"
+    title="Open the documentation in a new window"
+  >
+    Docs
+    <i
+      class="open-in-new"
+    />
+  </a>
 </div>
 `;
 


### PR DESCRIPTION
This PR has a few fairly independant commits that are gathered in this PR because they're on the same topic: CSS 

This is a cleanup PR that has otherwise no visual changes:
* moves some CSS specific to the permalink to the dedicated file Permalink.css.
* removes the container of the right-most buttons; I think it was there because previously we wanted to prevent them from shrinking as much as the "profile info" button. You can test this by shrinking the window's width and look at the behavior of the buttons. There's some subtle change when the width is really small.
* removes some CSS that was unused as far as I could see.

I added github comments that should make it easy to look at the changes all together, but looking at commits separately might be easier.

Also here are links to previews:
* [main](https://main--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&thread=0&v=5)
* [deploy preview](https://deploy-preview-3004--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&thread=0&v=5)