### PR TITLE
Add a keyboard shortcut panel that is revealed by the shortcut "?"

### DIFF
--- a/src/components/app/KeyboardShortcut.css
+++ b/src/components/app/KeyboardShortcut.css
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.appKeyboardShortcuts {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: none;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 20px;
+  animation: appKeyboardShortcutsFadeIn 0.2s;
+  background: #000a;
+}
+
+.appKeyboardShortcuts.open {
+  display: flex;
+  align-items: center;
+}
+
+.appKeyboardShortcutsBox {
+  overflow: hidden;
+  max-width: 800px;
+
+  /* appKeyboardShortcuts margin top + bottom = 40px */
+  max-height: calc(100% - 40px);
+  margin: 0 auto;
+  animation: arrowPanelAppear 0.2s cubic-bezier(0.07, 0.95, 0, 1);
+  background: #fff;
+  border-radius: 5px;
+  filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.4))
+    drop-shadow(0 4px 5px rgba(0, 0, 0, 0.4));
+}
+
+.appKeyboardShortcutsScroll {
+  overflow-y: scroll;
+}
+
+.appKeyboardShortcutsRow {
+  display: flex;
+  max-width: 400px;
+  margin: 7px 0px;
+}
+
+.appKeyboardShortcutsLabel {
+  flex: 1;
+  font-size: 13px;
+  padding-inline-end: 25px;
+}
+
+.appKeyboardShortcutsShortcut {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 5px;
+  background: rgba(222, 222, 227, 0.79);
+  border-radius: 3px;
+  box-shadow: 1px 1px rgba(0, 0, 0, 0.27);
+  color: #000;
+  margin-inline-start: 6px;
+}
+
+.appKeyboardShortcutsContent {
+  display: grid;
+  margin: 40px;
+  grid-gap: 80px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.appKeyboardShortcutsContent h2 {
+  margin: 40px 0 10px;
+}
+
+.appKeyboardShortcutsContent h2:first-child {
+  margin-top: 0;
+}
+
+.appKeyboardShortcutsHeader {
+  display: flex;
+  border-bottom: 1px solid var(--grey-30);
+  background: var(--grey-20);
+  font-size: 13px;
+}
+
+.appKeyboardShortcutsHeaderTitle {
+  flex: 1;
+  margin: 10px;
+}
+
+.appKeyboardShortcutsHeaderClose {
+  padding: 6px 6px 6px 30px;
+  border: 0;
+
+  /* Allow for the photon focus ring to fit in the space by using a 4px margin. */
+  margin: 4px;
+  background: url(../../../res/img/svg/searchfield-cancel.svg) 10px center
+    no-repeat;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: inherit;
+}
+
+.appKeyboardShortcutsHeaderClose:hover {
+  background-color: var(--grey-30);
+}
+
+.appKeyboardShortcutsNoInteract {
+  pointer-events: none;
+}
+
+@keyframes appKeyboardShortcutsFadeIn {
+  from {
+    background: #0000;
+  }
+  to {
+    background: #000a;
+  }
+}

--- a/src/components/app/KeyboardShortcut.js
+++ b/src/components/app/KeyboardShortcut.js
@@ -1,0 +1,270 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { coerce } from '../../utils/flow';
+import classNames from 'classnames';
+
+import './KeyboardShortcut.css';
+
+type Props = {|
+  +wrapperClassName: string,
+  +children: React.Node,
+|};
+
+type State = {|
+  +isOpen: boolean,
+  +focusAfterClosed: HTMLElement | null,
+|};
+
+/**
+ * Display a list of shortcuts that overlays the screen.
+ */
+export class KeyboardShortcut extends React.PureComponent<Props, State> {
+  state = {
+    isOpen: false,
+    // This is a false positive due to how it's used, see the line:
+    //  `focusAfterClosed.focus()`
+    // eslint-disable-next-line react/no-unused-state
+    focusAfterClosed: null,
+  };
+
+  _focusArea = React.createRef<HTMLDivElement>();
+
+  componentDidMount() {
+    window.addEventListener('keydown', this._handleKeyPress);
+  }
+
+  _focus() {
+    requestAnimationFrame(() => {
+      // Only manipulate the DOM outside of the React setState update cycle, otherwise
+      // this triggers a React warning, plus we'll want the DOM to have been updated.
+      // However, this DOM update isn't future proof if React changes to a more
+      // asynchronous rendering method.
+      //
+      // "unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering."
+      const div = this._focusArea.current;
+      if (div) {
+        div.focus();
+      }
+    });
+  }
+
+  _open = (state: State): $Shape<State> => {
+    if (state.isOpen) {
+      // Do nothing.
+      return {};
+    }
+    const focusAfterClosed = document.activeElement;
+    this._trapFocus();
+    this._focus();
+    return { isOpen: true, focusAfterClosed };
+  };
+
+  _close = (state: State): $Shape<State> => {
+    const { focusAfterClosed, isOpen } = state;
+
+    if (!isOpen) {
+      // Do nothing.
+      return {};
+    }
+    this._untrapFocus();
+    if (focusAfterClosed) {
+      requestAnimationFrame(() => {
+        // Restore focus, but not during a React setState call, otherwise this triggers
+        // a React warning:
+        // "unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering."
+        focusAfterClosed.focus();
+      });
+    }
+
+    return { isOpen: false, focusAfterClosed: null };
+  };
+
+  _handleCloseClick = () => {
+    this.setState(this._close);
+  };
+
+  _handleKeyPress = (event: KeyboardEvent) => {
+    const target = coerce<EventTarget, HTMLElement>(event.target);
+    switch (event.key) {
+      case '?': {
+        if (
+          target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT'
+        ) {
+          // Ignore this from input-like things.
+          return;
+        }
+        // Toggle the state.
+        this.setState(state =>
+          state.isOpen ? this._close(state) : this._open(state)
+        );
+        break;
+      }
+      case 'Escape': {
+        // Unconditionally run close on escape, which is a noop if it's not open.
+        this.setState(this._close);
+        break;
+      }
+      default:
+      // Do nothing.
+    }
+  };
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this._handleKeyPress);
+    this._untrapFocus();
+  }
+
+  _trapFocus() {
+    document.addEventListener('focus', this._trapFocusHandler, true);
+  }
+
+  _untrapFocus() {
+    document.removeEventListener('focus', this._trapFocusHandler, true);
+  }
+
+  // This is inspired by:
+  // https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html
+  _trapFocusHandler = (event: FocusEvent) => {
+    const div = this._focusArea.current;
+    if (!div) {
+      return;
+    }
+    if (!div.contains(coerce<EventTarget, Node>(event.target))) {
+      // TODO - This does not handle shift-tabbing going to the last focusable
+      // element in the list.
+      div.focus();
+    }
+  };
+
+  renderShortcuts() {
+    if (!this.state.isOpen) {
+      return null;
+    }
+
+    return (
+      <>
+        <div className="appKeyboardShortcutsHeader">
+          <div
+            className="appKeyboardShortcutsHeaderTitle"
+            /* aria-labelledby id */
+            id="AppKeyboardShortcutsHeaderTitle"
+          >
+            Keyboard shortcuts
+          </div>
+          <button
+            type="button"
+            className="appKeyboardShortcutsHeaderClose"
+            onClick={this._handleCloseClick}
+          >
+            Close
+          </button>
+        </div>
+        <div className="appKeyboardShortcutsContent">
+          <div className="appKeyboardShortcutsColumn">
+            <h2>Call Tree</h2>
+            <Shortcut label="Close call node" shortcut="ArrowLeft" />
+            <Shortcut label="Open call node" shortcut="ArrowRight" />
+            <Shortcut label="Open all child call nodes" shortcut="*" />
+            <Shortcut
+              label="Copy call node label"
+              shortcut="ctrl,c"
+              macShortcut="cmd,c"
+            />
+
+            <h2>Flame Graph</h2>
+            <Shortcut label="Move view up" shortcut="w" />
+            <Shortcut label="Move view down" shortcut="s" />
+            <Shortcut label="Move selection up" shortcut="ArrowUp" />
+            <Shortcut label="Move selection down" shortcut="ArrowDown" />
+            <Shortcut label="Move selection left" shortcut="ArrowLeft" />
+            <Shortcut label="Move selection right" shortcut="ArrowRight" />
+
+            <h2>Marker Table</h2>
+            <Shortcut
+              label="Copy marker label"
+              shortcut="ctrl,c"
+              macShortcut="cmd,c"
+            />
+          </div>
+          <div className="appKeyboardShortcutsColumn">
+            <h2>Timeline</h2>
+            <Shortcut
+              label="Select multiple threads"
+              shortcut="ctrl,click"
+              macShortcut="cmd,click"
+            />
+
+            <h2>Call Tree Transforms</h2>
+            <Shortcut label="Merge function" shortcut="m" />
+            <Shortcut label="Merge node only" shortcut="M" />
+            <Shortcut label="Focus on function" shortcut="f" />
+            <Shortcut label="Focus on subtree only" shortcut="F" />
+            <Shortcut label="Collapse function" shortcut="c" />
+            <Shortcut label="Collapse library" shortcut="C" />
+            <Shortcut label="Drop samples with this function" shortcut="d" />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  render() {
+    const { wrapperClassName, children } = this.props;
+    const { isOpen } = this.state;
+    return (
+      <>
+        <div
+          className={classNames(wrapperClassName, {
+            appKeyboardShortcutsNoInteract: isOpen,
+          })}
+        >
+          {children}
+        </div>
+        <div
+          className={classNames({ appKeyboardShortcuts: true, open: isOpen })}
+        >
+          <div
+            className="appKeyboardShortcutsBox"
+            ref={this._focusArea}
+            tabIndex="0"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="AppKeyboardShortcutsHeaderTitle"
+          >
+            {this.renderShortcuts()}
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+type ShortcutProps = $ReadOnly<{|
+  label: string,
+  shortcut: string,
+  macShortcut?: string,
+|}>;
+
+function Shortcut(props: ShortcutProps) {
+  let shortcut = props.shortcut;
+  if (props.macShortcut && window.navigator.platform.includes('Mac')) {
+    shortcut = props.macShortcut;
+  }
+  return (
+    <div className="appKeyboardShortcutsRow">
+      <div className="appKeyboardShortcutsLabel">{props.label}</div>
+      {shortcut.split(',').map((shortcut, index) => (
+        <kbd key={index} className="appKeyboardShortcutsShortcut">
+          {shortcut}
+        </kbd>
+      ))}
+    </div>
+  );
+}

--- a/src/components/app/KeyboardShortcut.js
+++ b/src/components/app/KeyboardShortcut.js
@@ -17,6 +17,8 @@ type Props = {|
 
 type State = {|
   +isOpen: boolean,
+  // The modal steals the focus of the screen. This is the element that was focused
+  // before showing the modal. The focus will be restored once the modal is dismissed.
   +focusAfterClosed: HTMLElement | null,
 |};
 
@@ -26,10 +28,9 @@ type State = {|
 export class KeyboardShortcut extends React.PureComponent<Props, State> {
   state = {
     isOpen: false,
-    // This is a false positive due to how it's used, see the line:
+    // The eslint error is a false positive due to how it's used, see the line:
     //  `focusAfterClosed.focus()`
-    // eslint-disable-next-line react/no-unused-state
-    focusAfterClosed: null,
+    focusAfterClosed: null, // eslint-disable-line react/no-unused-state
   };
 
   _focusArea = React.createRef<HTMLDivElement>();
@@ -143,7 +144,7 @@ export class KeyboardShortcut extends React.PureComponent<Props, State> {
     }
   };
 
-  renderShortcuts() {
+  maybeRenderShortcuts() {
     if (!this.state.isOpen) {
       return null;
     }
@@ -227,6 +228,9 @@ export class KeyboardShortcut extends React.PureComponent<Props, State> {
         >
           {children}
         </div>
+        {/* Always render this div so that we can target the _focusArea ref outside
+            of the React life-cycle. The keyboard shortcuts will only render if the
+            modal is actual open. */}
         <div
           className={classNames({ appKeyboardShortcuts: true, open: isOpen })}
         >
@@ -238,7 +242,7 @@ export class KeyboardShortcut extends React.PureComponent<Props, State> {
             aria-modal="true"
             aria-labelledby="AppKeyboardShortcutsHeaderTitle"
           >
-            {this.renderShortcuts()}
+            {this.maybeRenderShortcuts()}
           </div>
         </div>
       </>

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -79,8 +79,11 @@
 }
 
 .profileViewerSplitter {
-  /* Reset the position: absolute that is set by the splitter-layout class */
-  position: unset;
+  /* Create a stacking context, so that the KeyboardShortcut can overlay the profile
+     viewer. In addition, the built-in class uses position: absolute, which is not
+     appropriate here. */
+  position: relative;
+  z-index: 0;
 }
 
 .profileViewerSplitter > .layout-pane:not(.layout-pane-primary) {

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -14,6 +14,7 @@ import { WindowTitle } from '../shared/WindowTitle';
 import { SymbolicationStatusOverlay } from './SymbolicationStatusOverlay';
 import { ProfileName } from './ProfileName';
 import { BeforeUnloadManager } from './BeforeUnloadManager';
+import { KeyboardShortcut } from './KeyboardShortcut';
 
 import { returnToZipFileList } from '../../actions/zipped-profiles';
 import Timeline from '../timeline';
@@ -69,8 +70,8 @@ class ProfileViewerImpl extends PureComponent<Props> {
     } = this.props;
 
     return (
-      <div
-        className={classNames({
+      <KeyboardShortcut
+        wrapperClassName={classNames({
           profileViewerWrapper: true,
           profileViewerWrapperBackground: hasSanitizedProfile,
         })}
@@ -140,7 +141,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
           <BeforeUnloadManager />
           <DebugWarning />
         </div>
-      </div>
+      </KeyboardShortcut>
     );
   }
 }

--- a/src/test/components/KeyboardShortcut.test.js
+++ b/src/test/components/KeyboardShortcut.test.js
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import createStore from 'firefox-profiler/app-logic/create-store';
+import { KeyboardShortcut } from 'firefox-profiler/components/app/KeyboardShortcut';
+import { fireFullKeyPress } from 'firefox-profiler/test/fixtures/utils';
+import { coerce } from 'firefox-profiler/utils/flow';
+import mockRaf from '../fixtures/mocks/request-animation-frame';
+
+describe('app/KeyboardShortcut', function() {
+  function setup() {
+    const store = createStore();
+    const renderResults = render(
+      <Provider store={store}>
+        <KeyboardShortcut wrapperClassName="exampleClassName">
+          <div>Content</div>
+          <button type="button">Click me</button>
+        </KeyboardShortcut>
+      </Provider>
+    );
+
+    return { ...renderResults, ...store };
+  }
+
+  it('can open and close when hitting ? and Escape respectively', () => {
+    const { getByText, queryByText } = setup();
+
+    expect(queryByText('Keyboard shortcuts')).toBeFalsy();
+
+    // Show the dialog.
+    fireFullKeyPress(coerce<Window, HTMLElement>(window), { key: '?' });
+    expect(getByText('Keyboard shortcuts')).toBeTruthy();
+
+    // Hide the dialog.
+    fireFullKeyPress(coerce<Window, HTMLElement>(window), { key: 'Escape' });
+    expect(queryByText('Keyboard shortcuts')).toBeFalsy();
+  });
+
+  it('matches the snapshot when closed', () => {
+    const { container } = setup();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches the snapshot when open', () => {
+    const { container } = setup();
+    fireFullKeyPress(coerce<Window, HTMLElement>(window), { key: '?' });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('reverts to the previous active element', () => {
+    const flushRafCalls = mockRaf();
+    const { getByRole } = setup();
+
+    const clickMe = getByRole('button', { text: 'Click me' });
+    clickMe.focus();
+
+    expect(document.activeElement).toBe(clickMe);
+
+    fireFullKeyPress(coerce<Window, HTMLElement>(window), { key: '?' });
+    flushRafCalls(); // The focus is changed after react render.
+
+    expect(document.activeElement).toBe(getByRole('dialog'));
+
+    fireFullKeyPress(coerce<Window, HTMLElement>(window), { key: 'Escape' });
+    flushRafCalls(); // The focus is changed after react render.
+
+    expect(document.activeElement).toBe(clickMe);
+  });
+});

--- a/src/test/components/__snapshots__/KeyboardShortcut.test.js.snap
+++ b/src/test/components/__snapshots__/KeyboardShortcut.test.js.snap
@@ -1,0 +1,382 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app/KeyboardShortcut matches the snapshot when closed 1`] = `
+<div>
+  <div
+    class="exampleClassName"
+  >
+    <div>
+      Content
+    </div>
+    <button
+      type="button"
+    >
+      Click me
+    </button>
+  </div>
+  <div
+    class="appKeyboardShortcuts"
+  >
+    <div
+      aria-labelledby="AppKeyboardShortcutsHeaderTitle"
+      aria-modal="true"
+      class="appKeyboardShortcutsBox"
+      role="dialog"
+      tabindex="0"
+    />
+  </div>
+</div>
+`;
+
+exports[`app/KeyboardShortcut matches the snapshot when open 1`] = `
+<div>
+  <div
+    class="exampleClassName appKeyboardShortcutsNoInteract"
+  >
+    <div>
+      Content
+    </div>
+    <button
+      type="button"
+    >
+      Click me
+    </button>
+  </div>
+  <div
+    class="appKeyboardShortcuts open"
+  >
+    <div
+      aria-labelledby="AppKeyboardShortcutsHeaderTitle"
+      aria-modal="true"
+      class="appKeyboardShortcutsBox"
+      role="dialog"
+      tabindex="0"
+    >
+      <div
+        class="appKeyboardShortcutsHeader"
+      >
+        <div
+          class="appKeyboardShortcutsHeaderTitle"
+          id="AppKeyboardShortcutsHeaderTitle"
+        >
+          Keyboard shortcuts
+        </div>
+        <button
+          class="appKeyboardShortcutsHeaderClose"
+          type="button"
+        >
+          Close
+        </button>
+      </div>
+      <div
+        class="appKeyboardShortcutsContent"
+      >
+        <div
+          class="appKeyboardShortcutsColumn"
+        >
+          <h2>
+            Call Tree
+          </h2>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Close call node
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ArrowLeft
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Open call node
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ArrowRight
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Open all child call nodes
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              *
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Copy call node label
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ctrl
+            </kbd>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              c
+            </kbd>
+          </div>
+          <h2>
+            Flame Graph
+          </h2>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Move view up
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              w
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Move view down
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              s
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Move selection up
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ArrowUp
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Move selection down
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ArrowDown
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Move selection left
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ArrowLeft
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Move selection right
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ArrowRight
+            </kbd>
+          </div>
+          <h2>
+            Marker Table
+          </h2>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Copy marker label
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ctrl
+            </kbd>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              c
+            </kbd>
+          </div>
+        </div>
+        <div
+          class="appKeyboardShortcutsColumn"
+        >
+          <h2>
+            Timeline
+          </h2>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Select multiple threads
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              ctrl
+            </kbd>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              click
+            </kbd>
+          </div>
+          <h2>
+            Call Tree Transforms
+          </h2>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Merge function
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              m
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Merge node only
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              M
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Focus on function
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              f
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Focus on subtree only
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              F
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Collapse function
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              c
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Collapse library
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              C
+            </kbd>
+          </div>
+          <div
+            class="appKeyboardShortcutsRow"
+          >
+            <div
+              class="appKeyboardShortcutsLabel"
+            >
+              Drop samples with this function
+            </div>
+            <kbd
+              class="appKeyboardShortcutsShortcut"
+            >
+              d
+            </kbd>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
<img width="889" alt="image" src="https://user-images.githubusercontent.com/1588648/97491873-c3db8400-1930-11eb-8f94-adde4d501e02.png">

This patch shows a panel detailing shortcuts when hitting the "?" shortcut. It removes the modal on Escape or with clicking the close button. I took care to handle keyboard focus in this patch. I didn't see any way of testing this interaction in depth using our existing testing tools, but I did some basic tests.