### PR TITLE
Make sure that we disable the history replace state when we are done with it

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -72,8 +72,11 @@ function _maybeDisableHistoryReplaceState(): void {
  */
 export function withHistoryReplaceStateSync(fn: () => void): void {
   _enableHistoryReplaceState();
-  fn();
-  _maybeDisableHistoryReplaceState();
+  try {
+    fn();
+  } finally {
+    _maybeDisableHistoryReplaceState();
+  }
 }
 
 /**
@@ -83,8 +86,11 @@ export async function withHistoryReplaceStateAsync(
   fn: () => Promise<void>
 ): Promise<void> {
   _enableHistoryReplaceState();
-  await fn();
-  _maybeDisableHistoryReplaceState();
+  try {
+    await fn();
+  } finally {
+    _maybeDisableHistoryReplaceState();
+  }
 }
 
 /**


### PR DESCRIPTION
Without a try..finally block, if `fn` throws an error, we won't be able to disable the replace state and it will always stay that way. So with a finally block, even though it throws something, at least we will be able to recover the replace state. There are 2 Outreachy onboarding PRs that are also using these functions. We discovered this while looking at them.