### PR TITLE
Timeline keypress fix

### DIFF
--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -110,7 +110,9 @@ class GlobalTrackComponent extends PureComponent<Props> {
    * get in the way of the mouse up behavior. The keypress then needs to check that it's
    * a validation "activation" key, such as Enter of Spacebar.
    */
-  _selectCurrentTrack = (event: MouseEvent | KeyboardEvent) => {
+  _selectCurrentTrack = (
+    event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>
+  ) => {
     if (
       event.button === 2 ||
       (window.navigator.platform === 'MacIntel' && event.ctrlKey)
@@ -297,7 +299,7 @@ class GlobalTrackComponent extends PureComponent<Props> {
             <button
               type="button"
               className="timelineTrackNameButton"
-              onKeyPress={this._selectCurrentTrack}
+              onKeyUp={this._selectCurrentTrack}
             >
               {trackName}
               {

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -92,12 +92,41 @@ class GlobalTrackComponent extends PureComponent<Props> {
     }
   };
 
-  _selectCurrentTrack = (event: MouseEvent) => {
+  /**
+   * Special care must be taken when selecting a track. This handler is registered in two
+   * places.
+   *
+   *  1. mouse up of the entire track's wrapping div.
+   *  2. keypress of the focusable button
+   *
+   * This is done to allow for two behaviors that conflict with each other. It's important
+   * when making a preview selection to not select a track on the mouse up. In order to
+   * prevent this, the mouse up handler in the preview selection component prevents further
+   * propagation.
+   *
+   * However, for accessibility reasons, we want to be able to select tracks using the
+   * keyboard. In order to still allow for this behavior, we also listen for the keypress
+   * handler on the button. We do this rather than with the onClick event, as this would
+   * get in the way of the mouse up behavior. The keypress then needs to check that it's
+   * a validation "activation" key, such as Enter of Spacebar.
+   */
+  _selectCurrentTrack = (event: MouseEvent | KeyboardEvent) => {
     if (
       event.button === 2 ||
       (window.navigator.platform === 'MacIntel' && event.ctrlKey)
     ) {
       // This is a right click, do nothing.
+      return;
+    }
+
+    if (
+      // Is this a keypress?
+      typeof event.key === 'string' &&
+      // Only allow Spacebar and Enter, which signals the button is being pressed.
+      event.key !== ' ' &&
+      event.key !== 'Enter'
+    ) {
+      // Ignore this keypress.
       return;
     }
 
@@ -265,7 +294,11 @@ class GlobalTrackComponent extends PureComponent<Props> {
               onMouseDown: this._onLabelMouseDown,
             }}
           >
-            <button type="button" className="timelineTrackNameButton">
+            <button
+              type="button"
+              className="timelineTrackNameButton"
+              onKeyPress={this._selectCurrentTrack}
+            >
               {trackName}
               {
                 // Only show the PID if:

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -68,7 +68,25 @@ class LocalTrackComponent extends PureComponent<Props> {
     }
   };
 
-  _selectCurrentTrack = (event: MouseEvent) => {
+  /**
+   * Special care must be taken when selecting a track. This handler is registered in two
+   * places.
+   *
+   *  1. mouse up of the entire track's wrapping div.
+   *  2. keypress of the focusable button
+   *
+   * This is done to allow for two behaviors that conflict with each other. It's important
+   * when making a preview selection to not select a track on the mouse up. In order to
+   * prevent this, the mouse up handler in the preview selection component prevents further
+   * propagation.
+   *
+   * However, for accessibility reasons, we want to be able to select tracks using the
+   * keyboard. In order to still allow for this behavior, we also listen for the keypress
+   * handler on the button. We do this rather than with the onClick event, as this would
+   * get in the way of the mouse up behavior. The keypress then needs to check that it's
+   * a validation "activation" key, such as Enter of Spacebar.
+   */
+  _selectCurrentTrack = (event: MouseEvent | KeyboardEvent) => {
     if (
       event.button === 2 ||
       // Macs can right click with the ctrl key.
@@ -77,6 +95,18 @@ class LocalTrackComponent extends PureComponent<Props> {
       // This is a right click, do nothing.
       return;
     }
+
+    if (
+      // Is this a keypress?
+      typeof event.key === 'string' &&
+      // Only allow Spacebar and Enter, which signals the button is being pressed.
+      event.key !== ' ' &&
+      event.key !== 'Enter'
+    ) {
+      // Ignore this keypress.
+      return;
+    }
+
     this.props.selectTrack(
       this._getTrackReference(),
       getTrackSelectionModifier(event)
@@ -148,7 +178,11 @@ class LocalTrackComponent extends PureComponent<Props> {
               onMouseDown: this._onLabelMouseDown,
             }}
           >
-            <button type="button" className="timelineTrackNameButton">
+            <button
+              type="button"
+              className="timelineTrackNameButton"
+              onKeyPress={this._selectCurrentTrack}
+            >
               {trackName}
             </button>
           </ContextMenuTrigger>

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -86,7 +86,9 @@ class LocalTrackComponent extends PureComponent<Props> {
    * get in the way of the mouse up behavior. The keypress then needs to check that it's
    * a validation "activation" key, such as Enter of Spacebar.
    */
-  _selectCurrentTrack = (event: MouseEvent | KeyboardEvent) => {
+  _selectCurrentTrack = (
+    event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>
+  ) => {
     if (
       event.button === 2 ||
       // Macs can right click with the ctrl key.
@@ -181,7 +183,7 @@ class LocalTrackComponent extends PureComponent<Props> {
             <button
               type="button"
               className="timelineTrackNameButton"
-              onKeyPress={this._selectCurrentTrack}
+              onKeyUp={this._selectCurrentTrack}
             >
               {trackName}
             </button>

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -14,6 +14,7 @@ import mockRaf from '../fixtures/mocks/request-animation-frame';
 import {
   getBoundingBox,
   fireFullClick,
+  fireFullKeyPress,
   fireFullContextMenu,
 } from '../fixtures/utils';
 import ReactDOM from 'react-dom';
@@ -237,6 +238,61 @@ describe('Timeline multiple thread selection', function() {
       'show [thread GeckoMain process]',
       'show [thread GeckoMain tab] SELECTED',
       '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style]',
+    ]);
+  });
+
+  it('will select a thread through enter and spacebar keypresses', function() {
+    const { getState, getByRole } = setup();
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    fireFullKeyPress(getByRole('button', { name: 'DOM Worker' }), {
+      key: 'Enter',
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style]',
+    ]);
+
+    fireFullKeyPress(getByRole('button', { name: 'GeckoMain PID: 111' }), {
+      key: ' ',
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+  });
+
+  it('will not select a track through a random keypress', function() {
+    const { getState, getByRole } = setup();
+
+    const domWorker = getByRole('button', { name: 'DOM Worker' });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    fireFullKeyPress(domWorker, { key: 'a' });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
       '  - show [thread Style]',
     ]);
   });

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -242,7 +242,65 @@ describe('Timeline multiple thread selection', function() {
     ]);
   });
 
-  it('will select a thread through enter and spacebar keypresses', function() {
+  it('will select a thread through enter and spacebar keypresses for global tracks', function() {
+    const { getState, getByRole } = setup();
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    fireFullKeyPress(getByRole('button', { name: 'GeckoMain PID: 111' }), {
+      key: ' ',
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    fireFullKeyPress(
+      getByRole('button', { name: 'Content Process PID: 222' }),
+      {
+        key: 'Enter',
+      }
+    );
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+  });
+
+  it('will not select a track through a random keypress for a global track', function() {
+    const { getState, getByRole } = setup();
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    fireFullKeyPress(getByRole('button', { name: 'GeckoMain PID: 111' }), {
+      key: 'a',
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+  });
+
+  it('will select a thread through enter and spacebar keypresses for local tracks', function() {
     const { getState, getByRole } = setup();
 
     expect(getHumanReadableTracks(getState())).toEqual([
@@ -263,19 +321,19 @@ describe('Timeline multiple thread selection', function() {
       '  - show [thread Style]',
     ]);
 
-    fireFullKeyPress(getByRole('button', { name: 'GeckoMain PID: 111' }), {
+    fireFullKeyPress(getByRole('button', { name: 'Style' }), {
       key: ' ',
     });
 
     expect(getHumanReadableTracks(getState())).toEqual([
-      'show [thread GeckoMain process] SELECTED',
+      'show [thread GeckoMain process]',
       'show [thread GeckoMain tab]',
       '  - show [thread DOM Worker]',
-      '  - show [thread Style]',
+      '  - show [thread Style] SELECTED',
     ]);
   });
 
-  it('will not select a track through a random keypress', function() {
+  it('will not select a track through a random keypress for local tracks', function() {
     const { getState, getByRole } = setup();
 
     const domWorker = getByRole('button', { name: 'DOM Worker' });

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -341,8 +341,61 @@ export function fireFullContextMenu(
  * And addition Julien's review comments here:
  * https://github.com/firefox-devtools/profiler/pull/2842/commits/6be20eb6eafca56644b1d55010cc1824a1d03695#r501061693
  */
-export function fireFullKeyPress(element: HTMLElement, options?: *) {
-  fireEvent.keyDown(element, options);
-  fireEvent.keyPress(element, options);
-  fireEvent.keyUp(element, options);
+export function fireFullKeyPress(
+  element: HTMLElement,
+  options: { key: string, ... }
+) {
+  // Note the key is lowercase here.
+  const codes: { [key: string]: number } = {
+    enter: 13,
+    escape: 27,
+    ' ': 32,
+    '?': 191,
+    a: 65,
+    b: 66,
+    c: 67,
+    d: 68,
+    e: 69,
+    f: 70,
+    g: 71,
+    h: 72,
+    i: 73,
+    j: 74,
+    k: 75,
+    l: 76,
+    m: 77,
+    n: 78,
+    o: 79,
+    p: 80,
+    q: 81,
+    r: 82,
+    s: 83,
+    t: 84,
+    u: 85,
+    v: 86,
+    w: 87,
+    x: 88,
+    y: 89,
+    z: 90,
+  };
+
+  // It's important that the codes are correctly configured here, or else the keypress
+  // event won't fire.
+  // https://github.com/testing-library/react-testing-library/issues/269#issuecomment-455854112
+  const optionsConfigured = {
+    code: codes[options.key.toLowerCase()],
+    charCode: codes[options.key.toLowerCase()],
+    ...options,
+  };
+
+  if (!optionsConfigured.code) {
+    throw new Error(
+      `An unhandled keypress key was encountered: "${options.key}", look it up here:` +
+        ` https://keycode.info/ and then add to this function.`
+    );
+  }
+
+  fireEvent.keyDown(element, optionsConfigured);
+  fireEvent.keyPress(element, optionsConfigured);
+  fireEvent.keyUp(element, optionsConfigured);
 }

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -345,7 +345,8 @@ export function fireFullKeyPress(
   element: HTMLElement,
   options: { key: string, ... }
 ) {
-  // Note the key is lowercase here.
+  // Since this is test code, only use QWERTY layout keyboards.
+  // Note the key is always converted to lowercase here.
   const codes: { [key: string]: number } = {
     enter: 13,
     escape: 27,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -94,7 +94,11 @@ export function getStartEndRangeForMarker(
  * See issue #2710 about adding "shift" behavior.
  */
 export function getTrackSelectionModifier(
-  event: MouseEvent | KeyboardEvent | SyntheticMouseEvent<>
+  event:
+    | MouseEvent
+    | KeyboardEvent
+    | SyntheticMouseEvent<>
+    | SyntheticKeyboardEvent<>
 ): 'ctrl' | 'none' {
   if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey) {
     return 'ctrl';


### PR DESCRIPTION
Resolves #3018

This should fix the events that are fired. I couldn't figure out how to get it to work with the original bubbling behavior. I added a big comment over `_selectCurrentTrack` that explains the solution a bit. I also had to augment the `fireFullKeyPress` to work correctly. I linked to the problem.