### PR TITLE
Do not change the preview selection if the user is already selecting one

### DIFF
--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -98,21 +98,32 @@ class Screenshots extends PureComponent<Props, State> {
     });
   };
 
-  _handleClick = (event: SyntheticMouseEvent<HTMLDivElement>) => {
-    const { screenshots, updatePreviewSelection } = this.props;
+  // This selects a screenshot when clicking on the screenshot strip. Note that
+  // we use the mouseup event so that isMakingPreviewSelection is still
+  // accurate.
+  _selectScreenshotOnClick = (event: SyntheticMouseEvent<HTMLDivElement>) => {
+    const {
+      screenshots,
+      updatePreviewSelection,
+      isMakingPreviewSelection,
+    } = this.props;
+    if (isMakingPreviewSelection) {
+      // Avoid reseting the selection if the user is currently selecting one.
+      return;
+    }
+
     const { left } = event.currentTarget.getBoundingClientRect();
     const offsetX = event.pageX - left;
     const screenshotIndex = this.findScreenshotAtMouse(offsetX);
-    if (screenshotIndex === null) return null;
+    if (screenshotIndex === null) return;
     const { start, end } = screenshots[screenshotIndex];
-    if (end === null) return null;
+    if (end === null) return;
     updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart: start,
       selectionEnd: end,
     });
-    return null;
   };
 
   render() {
@@ -142,7 +153,7 @@ class Screenshots extends PureComponent<Props, State> {
         style={{ height: trackHeight }}
         onMouseLeave={this._handleMouseLeave}
         onMouseMove={this._handleMouseMove}
-        onClick={this._handleClick}
+        onMouseUp={this._selectScreenshotOnClick}
       >
         <ScreenshotStrip
           thread={thread}

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockDomRect } from 'firefox-profiler/test/fixtures/mocks/domrect.js';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import {
   getBoundingBox,
@@ -32,17 +33,7 @@ import { ensureExists } from '../../utils/flow';
 import type { Profile } from 'firefox-profiler/types';
 
 describe('Timeline multiple thread selection', function() {
-  const originalDOMRect = global.DOMRect;
-  beforeEach(() => {
-    global.DOMRect = class DOMRect {};
-  });
-  afterEach(() => {
-    if (originalDOMRect) {
-      global.DOMRect = originalDOMRect;
-    } else {
-      delete global.DOMRect;
-    }
-  });
+  autoMockDomRect();
 
   function setup() {
     const profile = getProfileWithNiceTracks();

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -27,10 +27,12 @@ import {
   getMouseEvent,
   addRootOverlayElement,
   removeRootOverlayElement,
+  fireFullClick,
 } from '../fixtures/utils';
 import { getScreenshotTrackProfile } from '../fixtures/profiles/processed-profile';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { getPreviewSelection } from '../../selectors/profile';
+import { autoMockDomRect } from 'firefox-profiler/test/fixtures/mocks/domrect.js';
 
 // Mock out the getBoundingBox to have a 400 pixel width.
 const TRACK_WIDTH = 400;
@@ -38,6 +40,8 @@ const LEFT = 100;
 const TOP = 7;
 
 describe('timeline/TrackScreenshots', function() {
+  autoMockDomRect();
+
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 
@@ -253,7 +257,7 @@ function setup(
   }
 
   function screenshotClick(pageX: number) {
-    fireEvent(screenshotTrack(), getMouseEvent('click', { pageX, pageY: 0 }));
+    fireFullClick(screenshotTrack(), { pageX, pageY: 0 });
   }
 
   function screenshotTrack() {

--- a/src/test/fixtures/mocks/domrect.js
+++ b/src/test/fixtures/mocks/domrect.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// This can be removed when JSDOM gets a DOMRect implementation.
+// See https://github.com/jsdom/jsdom/pull/2926
+
+const originalDOMRect = global.DOMRect;
+
+class DOMRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+
+  constructor(x: number, y: number, width: number, height: number) {
+    this.x = y;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+  }
+
+  get top() {
+    return this.y + Math.min(this.height, 0);
+  }
+
+  get bottom() {
+    return this.y + Math.max(this.height, 0);
+  }
+
+  get left() {
+    return this.x + Math.min(this.width, 0);
+  }
+
+  get right() {
+    return this.x + Math.max(this.width, 0);
+  }
+}
+
+export function autoMockDomRect() {
+  beforeEach(() => {
+    global.DOMRect = DOMRect;
+  });
+
+  afterEach(() => {
+    if (originalDOMRect) {
+      global.DOMRect = originalDOMRect;
+    } else {
+      delete global.DOMRect;
+    }
+  });
+}

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -293,8 +293,8 @@ export function fireFullClick(
   options?: FakeMouseEventInit
 ) {
   fireEvent(element, getMouseEvent('mousedown', options));
-  fireEvent(element, getMouseEvent('click', options));
   fireEvent(element, getMouseEvent('mouseup', options));
+  fireEvent(element, getMouseEvent('click', options));
 }
 
 /**


### PR DESCRIPTION
Fixes #3031

Deploy previews:
[main](https://main--perf-html.netlify.app/public/rvrdhrqr4pdbmq2s78grx94q4v6fdtfvvsmrv50/calltree/?globalTrackOrder=13-0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10-11&hiddenLocalTracksByPid=95575-3-4-5~95583-1&localTrackOrderByPid=95575-4-5-0-1-2-3-6-7-8-9~95576-1-0-2~95588-1-0-2~95577-1-2-0-3-4~95584-1-0-2-3~95578-1-0-2-3~95579-1-0-2-3~95586-1-0-2-3~95587-1-0-2-3~95585-1-0-2-3~95580-1-0-2-3~95581-1-2-0-3-4~95583-1-0-2-3~&thread=0&v=5)
[deploy preview](https://deploy-preview-3033--perf-html.netlify.app/public/rvrdhrqr4pdbmq2s78grx94q4v6fdtfvvsmrv50/calltree/?globalTrackOrder=13-0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10-11&hiddenLocalTracksByPid=95575-3-4-5~95583-1&localTrackOrderByPid=95575-4-5-0-1-2-3-6-7-8-9~95576-1-0-2~95588-1-0-2~95577-1-2-0-3-4~95584-1-0-2-3~95578-1-0-2-3~95579-1-0-2-3~95586-1-0-2-3~95587-1-0-2-3~95585-1-0-2-3~95580-1-0-2-3~95581-1-2-0-3-4~95583-1-0-2-3~&thread=0&v=5)

Also:
![image](https://user-images.githubusercontent.com/454175/98237379-1508fa80-1f65-11eb-9a73-260ae49e106c.png)
😍