### PR TITLE
Re-work the focus to use a denser focus by default

### DIFF
--- a/res/css/focus.css
+++ b/res/css/focus.css
@@ -8,20 +8,34 @@ button::-moz-focus-inner {
   border: 0;
 }
 
+:root {
+  --photon-focus-shadow: 0 0 0 1px var(--blue-50) inset,
+    0 0 0 1px var(--blue-50), 0 0 0 4px var(--blue-50-a30);
+}
+
+/**
+ * Use the photon styling for certain input elements. This styling is larger and can
+ * break out of our denser UI, but still works nicely for a few different elements.
+ */
 input[type='radio']:focus,
 input[type='checkbox']:focus,
+input[type='range']:focus {
+  box-shadow: var(--photon-focus-shadow);
+  outline: 0;
+}
+
+/**
+ * Use a simple inset 2px border for other inputs. This matches up nicer for our dense
+ * UI. The photon styling tends to be clipped by hidden overflows otherwise. The box
+ * shadow inset will also not affect layout.
+ */
 input[type='button']:focus,
 input[type='submit']:focus,
 input[type='reset']:focus,
 input[type='image']:focus,
-input[type='range']:focus,
-button:focus {
-  box-shadow: 0 0 0 1px var(--blue-50) inset, 0 0 0 1px var(--blue-50),
-    0 0 0 4px var(--blue-50-a30);
-  outline: 0;
-}
-
+button:focus,
 a:focus {
-  box-shadow: 0 0 0 2px var(--blue-50), 0 0 0 6px var(--blue-50-a30);
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px var(--blue-50) inset;
   outline: 0;
 }

--- a/res/css/focus.css
+++ b/res/css/focus.css
@@ -19,7 +19,8 @@ button::-moz-focus-inner {
  */
 input[type='radio']:focus,
 input[type='checkbox']:focus,
-input[type='range']:focus {
+input[type='range']:focus,
+button.photon-button-primary:focus {
   box-shadow: var(--photon-focus-shadow);
   outline: 0;
 }

--- a/res/css/focus.css
+++ b/res/css/focus.css
@@ -20,6 +20,8 @@ button::-moz-focus-inner {
 input[type='radio']:focus,
 input[type='checkbox']:focus,
 input[type='range']:focus,
+input[type='button'].photon-button-primary:focus,
+input[type='submit'].photon-button-primary:focus,
 button.photon-button-primary:focus {
   box-shadow: var(--photon-focus-shadow);
   outline: 0;

--- a/src/components/app/AppHeader.css
+++ b/src/components/app/AppHeader.css
@@ -32,9 +32,7 @@
 }
 
 .appHeaderGithubIcon {
-  margin: 0 0.2em;
-}
-
-.appHeaderGithubIcon svg {
-  vertical-align: middle;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.2em;
 }

--- a/src/components/app/CompareHome.js
+++ b/src/components/app/CompareHome.js
@@ -81,7 +81,7 @@ class CompareHomeImpl extends PureComponent<Props, State> {
             value={profile2}
           />
           <input
-            className="compareHomeSubmitButton"
+            className="compareHomeSubmitButton photon-button photon-button-primary"
             type="submit"
             value="Retrieve profiles"
           />

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -88,21 +88,27 @@
   transition: background-color 300ms;
 }
 
+/* Overcome the selector specificity of the default focus styling by including the tag. */
+a.homeSectionButton:focus,
+button.homeSectionButton:focus {
+  border-radius: 0;
+  box-shadow: var(--photon-focus-shadow);
+  outline: 0;
+}
+
 .homeSectionLoadProfile {
   position: relative;
 }
 
 .homeSectionActionButtons {
-  display: flex;
+  display: grid;
+  grid-gap: 10px;
+  grid-template-columns: 1fr 1fr;
 }
 
 .homeSectionActionButtons .homeSectionButton {
   flex: 1;
   margin: 5px 0;
-}
-
-.homeSectionActionButtons button {
-  border-left: none;
 }
 
 .homeSectionLoadFromUrl {

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -101,9 +101,8 @@ button.homeSectionButton:focus {
 }
 
 .homeSectionActionButtons {
-  display: grid;
-  grid-gap: 10px;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  gap: 10px;
 }
 
 .homeSectionActionButtons .homeSectionButton {

--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -38,11 +38,9 @@
   display: flex;
   justify-content: space-between;
 
-  /* The padding compensates for the negative margin. The negative margin is
-   * there so that the left border (implemented as a box-shadow below) go
-   * outside the line. */
-  padding: 2px 0;
-  margin: -2px 0;
+  /* Ensure that the left "focus-within" border (implemented as a box-shadow below) goes
+   * outside button's focus border. */
+  padding: 1px 0;
 }
 
 .publishedProfilesLink {
@@ -61,7 +59,7 @@
 /**
  * Overcome the selector specificity of the focus by including the "a"
  */
-a.publishedProfilesLink:focus {
+.publishedProfilesLink:focus {
   border-radius: 0;
   box-shadow: var(--photon-focus-shadow);
 }

--- a/src/components/app/ListOfPublishedProfiles.css
+++ b/src/components/app/ListOfPublishedProfiles.css
@@ -58,6 +58,14 @@
   background: var(--grey-90-a05);
 }
 
+/**
+ * Overcome the selector specificity of the focus by including the "a"
+ */
+a.publishedProfilesLink:focus {
+  border-radius: 0;
+  box-shadow: var(--photon-focus-shadow);
+}
+
 .publishedProfilesListItem_ConfirmDialogIsOpen,
 .publishedProfilesListItem:focus-within {
   box-shadow: -3px 0 0 var(--blue-60); /* This is a border that doesn't move the content. */

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -56,8 +56,8 @@
  * both of them, so one element won't be able to have both a right and a left
  * borders with this technique.
  * We're using ::after for borders because ::before is used for icons. */
-.menuButtonsButton-hasRightBorder::after,
-.menuButtonsButton-hasLeftBorder::after {
+.menuButtonsButton-hasRightBorder::before,
+.menuButtonsButton-hasLeftBorder::before {
   position: absolute;
   top: 4px;
   width: 1px;
@@ -66,12 +66,22 @@
   content: '';
 }
 
-.menuButtonsButton-hasLeftBorder::after {
-  left: 0;
+/* Accomodate spacing for the border so that it doesn't occlude the button. */
+.menuButtonsButton-hasLeftBorder {
+  margin-left: 1px;
 }
 
-.menuButtonsButton-hasRightBorder::after {
-  right: 0;
+/* Accomodate spacing for the border so that it doesn't occlude the button. */
+.menuButtonsButton-hasRightBorder {
+  margin-right: 1px;
+}
+
+.menuButtonsButton-hasLeftBorder::before {
+  left: -1px;
+}
+
+.menuButtonsButton-hasRightBorder::before {
+  right: -1px;
 }
 
 /* This icon is defined as a separate element, so that it can possibly be reused

--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -6,7 +6,7 @@
 .tabBarTabButton {
   width: 100%;
   height: 100%;
-  padding: 0;
+  padding: 6px 4px;
   border: none;
   margin: 0;
   background: none;
@@ -37,7 +37,7 @@
   position: relative;
   overflow: hidden;
   width: 8em;
-  padding: 6px 4px;
+  padding: 0;
   border: solid transparent;
   border-width: 0 1px 0 1px;
   background-clip: padding-box;
@@ -71,21 +71,28 @@
   background-color: var(--blue-50);
 }
 
-.tabBarTabWrapper:not(.beingReordered) > .tabBarTab:not(.selected):hover {
+.tabBarTab:not(.selected):hover {
   border-color: var(--grey-20);
   background-color: var(--grey-20);
 }
 
-.tabBarTabWrapper:not(.beingReordered)
-  > .tabBarTab:not(.selected):hover::before {
+.tabBarTabWrapper > .tabBarTab:not(.selected):hover::before {
   background-color: var(--grey-40);
 }
 
 .tabBarTab.selected {
   /* Cut off the bottom of the border for the tab line. */
   top: 1px;
-  padding-top: 5px;
   border-color: var(--grey-30);
   background: #fff;
   color: var(--blue-60);
+}
+
+.tabBarTab.selected .tabBarTabButton {
+  /* The tab is shifted down 1px, bring the button's height back up 1px so that the
+     focus is not cut off. */
+  height: calc(100% - 1px);
+
+  /* Prevent the text being shifted down when the tabBarTab is re-positioned. */
+  padding-top: 4px;
 }

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -24,7 +24,6 @@
   min-width: 0;
   height: 24px;
   flex-flow: row nowrap;
-  padding: 0 6px 0 8px;
   border: solid transparent;
   border-width: 0 8px 0 6px;
   border-right-color: transparent !important;
@@ -37,16 +36,16 @@
 .filterNavigatorBarRootItem {
   max-width: 100%;
   flex-shrink: 0;
-  margin-left: -8px;
+  margin-left: -6px;
 }
 
+/* This rule must reset all of the browser's built-in <button> stylings. */
 .filterNavigatorBarItemContent {
   display: flex;
   overflow: hidden;
-
-  /* These lines are mostly to override the default browser styles for `<button>`.
-   * The 8px are used by the box-shadow when the button receives focus */
-  padding: 0;
+  height: 100%;
+  align-items: center;
+  padding: 0 5px;
   border: none;
   margin: auto;
   background: none;

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -47,11 +47,9 @@
 
 .timelineTrackNameButton {
   overflow: hidden;
-
-  /* The 8px are used by the box-shadow when the button receives focus */
-  width: calc(100% - 8px);
-  height: calc(100% - 8px);
-  padding: 0 0 0 10px;
+  width: 100%;
+  height: 100%;
+  padding: 0 0 0 14px;
   border: none;
   margin: auto;
   background: none;

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -7,6 +7,9 @@
  * into one file, as it is mostly shared style.
  */
 .timelineTrack {
+  /* Position this element relative, so that the .timelineTrackRow.selected::after rule
+   * can position relative to the track. */
+  position: relative;
   padding: 0;
   border-top: 1px solid var(--grey-30);
   margin: 0;

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -21,6 +21,20 @@
   overflow-y: auto;
 }
 
+.timelineOverflowEdgeIndicatorScrollbox:focus {
+  outline: 0;
+}
+
+.timelineOverflowEdgeIndicatorScrollbox:focus
+  .timelineTrackRow.selected::after {
+  position: absolute;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--blue-60);
+  content: '';
+}
+
 .timelineThreadList {
   width: calc(100vw - var(--vertical-scrollbar-reserved-width));
   padding: 0;
@@ -62,7 +76,11 @@
   padding: 0;
 }
 
-.timelineSettingsHiddenTracks {
+/**
+ * Increase the selector specificity by 1 to overcome built-in photon focus styles.
+ * This button's rule is also duplicated in focus.css.
+ */
+button.timelineSettingsHiddenTracks {
   /* Make sure and override all rules that have to do with button defaults. */
   position: relative;
   height: 17px;
@@ -78,6 +96,11 @@
 
 .timelineSettingsHiddenTracks:hover {
   background-color: var(--blue-70);
+}
+
+button.timelineSettingsHiddenTracks:focus {
+  border-radius: 12px;
+  box-shadow: var(--photon-focus-shadow);
 }
 
 .timelineSettingsHiddenTracks:active {

--- a/src/test/components/__snapshots__/CompareHome.test.js.snap
+++ b/src/test/components/__snapshots__/CompareHome.test.js.snap
@@ -91,7 +91,7 @@ exports[`app/CompareHome matches the snapshot 1`] = `
       value=""
     />
     <input
-      class="compareHomeSubmitButton"
+      class="compareHomeSubmitButton photon-button photon-button-primary"
       type="submit"
       value="Retrieve profiles"
     />


### PR DESCRIPTION
Our current focus is a bit problematic, in that it defaults to a big focus photon ring. The photon design system didn't really take into account our much denser DevTools UI.

I kept some of the photon styling where it makes sense. I broke the work into a few different commits, to help with the review process. I would recommend manually testing this by tabbing through everything in the UI and see how it looks. I did adjust a few pieces of padding/margin here and there to ensure that certain things had a nice focus ring around it. Most everything should look exactly the same with no focus, unless I point out otherwise.

Home: [Before](https://profiler.firefox.com/) [After](https://deploy-preview-3035--perf-html.netlify.app)
Compare: [Before](https://profiler.firefox.com/compare) [After](https://deploy-preview-3035--perf-html.netlify.app/compare)
Recordings: [Before](https://profiler.firefox.com/uploaded-recordings) [After](https://deploy-preview-3035--perf-html.netlify.app/uploaded-recordings)
Profile view: [Before](https://profiler.firefox.com/public/34223146e56cb03d587c06a03df67c4f4a2ac1e0/calltree/?globalTrackOrder=1-2-3-4-0-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=17852-1-0~17857-0~&range=3002m7640~3889m4314&thread=6&v=5) [After](https://deploy-preview-3035--perf-html.netlify.app/public/34223146e56cb03d587c06a03df67c4f4a2ac1e0/calltree/?globalTrackOrder=1-2-3-4-0-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=17852-1-0~17857-0~&range=3002m7640~3889m4314&thread=6&v=5)

