### PR TITLE
Remove the Object type, and switch to MixedObject

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,6 +91,17 @@ module.exports = {
     // We use the version from the flowtype plugin so that flow assertions don't
     // output an error.
     'flowtype/no-unused-expressions': 'error',
+    // The Object type and Function type aren't particularly useful, and usually hide
+    // type errors. It also blocks a migration to TypeScript. Disable this rule if
+    // using the Object or Function as generic type bounds.
+    'flowtype/no-weak-types': [
+      'error',
+      {
+        any: false,
+        Object: true,
+        Function: true,
+      },
+    ],
     'no-useless-call': 'error',
     'no-useless-computed-key': 'error',
     'no-useless-concat': 'error',

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -964,7 +964,7 @@ type FetchProfileArgs = {
   url: string,
   onTemporaryError: TemporaryError => void,
   // Allow tests to capture the reported error, but normally use console.error.
-  reportError?: Function,
+  reportError?: (...data: Array<any>) => void,
 };
 
 type ProfileOrZip = {
@@ -1056,7 +1056,7 @@ function _deduceContentType(
 async function _extractProfileOrZipFromResponse(
   url: string,
   response: Response,
-  reportError: Function
+  reportError: (...data: Array<any>) => void
 ): Promise<ProfileOrZip> {
   const contentType = _deduceContentType(
     url,
@@ -1089,7 +1089,7 @@ async function _extractProfileOrZipFromResponse(
  */
 async function _extractZipFromResponse(
   response: Response,
-  reportError: Function
+  reportError: (...data: Array<any>) => void
 ): Promise<JSZip> {
   const buffer = await response.arrayBuffer();
   try {
@@ -1112,7 +1112,7 @@ async function _extractZipFromResponse(
  */
 async function _extractJsonFromResponse(
   response: Response,
-  reportError: Function,
+  reportError: (...data: Array<any>) => void,
   fileType: 'application/json' | null
 ): Promise<any> {
   try {

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -6,7 +6,7 @@
 import { oneLine } from 'common-tags';
 import queryString from 'query-string';
 import {
-  processProfile,
+  processGeckoProfile,
   unserializeProfileOfArbitraryFormat,
 } from 'firefox-profiler/profile-logic/process-profile';
 import { SymbolStore } from 'firefox-profiler/profile-logic/symbol-store';
@@ -811,7 +811,7 @@ async function getProfileFromAddon(
   // XXX update state to show that we're connected to the profiler addon
   const rawGeckoProfile = await geckoProfiler.getProfile();
   const unpackedProfile = await _unpackGeckoProfileFromAddon(rawGeckoProfile);
-  const profile = processProfile(unpackedProfile);
+  const profile = processGeckoProfile(unpackedProfile);
   await dispatch(loadProfile(profile, { geckoProfiler }));
 
   return profile;

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -655,7 +655,7 @@ type ProcessedLocation = {|
 
 type ProcessedLocationBeforeUpgrade = {|
   ...ProcessedLocation,
-  query: Object,
+  query: any,
 |};
 
 export function upgradeLocationToCurrentVersion(

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -84,7 +84,7 @@ type NetworkPhaseProps = {|
   +previousName: string,
   +value: number | string,
   +duration: Milliseconds,
-  +style: Object,
+  +style: MixedObject,
 |};
 
 function NetworkPhase({

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -28,6 +28,7 @@ import type {
   Marker,
   MarkerIndex,
   NetworkPayload,
+  MixedObject,
 } from 'firefox-profiler/types';
 
 // This regexp is used to split a pathname into a directory path and a filename.

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -1,8 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 // @flow
+
+// This file uses extensive use of Object generic trait bounds, which is a false
+// positive for this rule.
+/* eslint-disable flowtype/no-weak-types */
 
 import * as React from 'react';
 import classNames from 'classnames';
@@ -187,6 +190,7 @@ type TreeViewRowScrolledColumnsProps<DisplayData: Object> = {|
   +indentWidth: CssPixels,
 |};
 
+// This is a false-positive, as it's used as a generic trait bounds.
 class TreeViewRowScrolledColumns<
   DisplayData: Object
 > extends React.PureComponent<TreeViewRowScrolledColumnsProps<DisplayData>> {
@@ -559,7 +563,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     const { tree, selectedNodeId, mainColumn } = this.props;
     if (selectedNodeId) {
       const displayData = tree.getDisplayData(selectedNodeId);
-      const clipboardData: DataTransfer = (event: Object).clipboardData;
+      const clipboardData: DataTransfer = (event: any).clipboardData;
       clipboardData.setData('text/plain', displayData[mainColumn.propName]);
     }
   };

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -177,6 +177,8 @@ const PINCH_ZOOM_FACTOR = 3;
  * by separating out the type definition.
  */
 export type WithChartViewport<
+  // False positive generic trait bounds.
+  // eslint-disable-next-line flowtype/no-weak-types
   ChartOwnProps: Object,
   // The chart component's props are given the viewport object, as well as the original
   // ChartOwnProps.

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -34,6 +34,8 @@ import type {
   CssPixels,
   DevicePixels,
   UnitIntervalOfProfileRange,
+  MarkerIndex,
+  Marker,
 } from 'firefox-profiler/types';
 
 import type {
@@ -56,7 +58,7 @@ type OwnProps = {|
   +updatePreviewSelection: WrapFunctionInDispatch<
     typeof updatePreviewSelection
   >,
-  +getMarker: Function,
+  +getMarker: MarkerIndex => Marker,
   +categories: CategoryList,
   +callNodeInfo: CallNodeInfo,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -47,6 +47,7 @@ import type {
   GlobalTrack,
   LocalTrack,
   InitialSelectedTrackReference,
+  MixedObject,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -54,7 +55,7 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 type OwnProps = {|
   +trackReference: GlobalTrackReference,
   +trackIndex: TrackIndex,
-  +style?: Object /* This is used by Reorderable */,
+  +style?: MixedObject /* This is used by Reorderable */,
   +setInitialSelected: (el: InitialSelectedTrackReference) => void,
 |};
 

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -34,6 +34,7 @@ import type {
   Pid,
   TrackIndex,
   LocalTrack,
+  MixedObject,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -42,7 +43,7 @@ type OwnProps = {|
   +pid: Pid,
   +localTrack: LocalTrack,
   +trackIndex: TrackIndex,
-  +style?: Object /* This is used by Reorderable */,
+  +style?: MixedObject /* This is used by Reorderable */,
   +setIsInitialSelectedPane: (value: boolean) => void,
 |};
 

--- a/src/components/timeline/TrackEventDelayGraph.js
+++ b/src/components/timeline/TrackEventDelayGraph.js
@@ -181,7 +181,7 @@ type StateProps = {|
   +thread: Thread,
   +filteredThread: Thread,
   +unfilteredSamplesRange: StartEndRange | null,
-  +eventDelays: Object,
+  +eventDelays: EventDelayInfo,
 |};
 
 type DispatchProps = {||};

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -18,13 +18,32 @@ import { GECKO_PROFILE_VERSION } from '../app-logic/constants';
 // Treat those as version zero.
 const UNANNOTATED_VERSION = 0;
 
+function getProfileMeta(profile: mixed): MixedObject {
+  let meta = null;
+
+  if (
+    profile &&
+    typeof profile === 'object' &&
+    profile.meta &&
+    typeof profile.meta === 'object'
+  ) {
+    meta = profile.meta;
+  }
+
+  if (!meta) {
+    throw new Error('Could not find the meta property on a profile.');
+  }
+
+  return meta;
+}
+
 /**
  * Upgrades the supplied profile to the current version, by mutating |profile|.
  * Throws an exception if the profile is too new.
  * @param {object} profile The profile in the "Gecko profile" format.
  */
-export function upgradeGeckoProfileToCurrentVersion(profile: Object) {
-  const profileVersion = profile.meta.version || UNANNOTATED_VERSION;
+export function upgradeGeckoProfileToCurrentVersion(json: mixed) {
+  const profileVersion = getProfileMeta(json).version || UNANNOTATED_VERSION;
   if (profileVersion === GECKO_PROFILE_VERSION) {
     return;
   }
@@ -44,11 +63,11 @@ export function upgradeGeckoProfileToCurrentVersion(profile: Object) {
     destVersion++
   ) {
     if (destVersion in _upgraders) {
-      _upgraders[destVersion](profile);
+      _upgraders[destVersion](json);
     }
   }
 
-  profile.meta.version = GECKO_PROFILE_VERSION;
+  getProfileMeta(json).version = GECKO_PROFILE_VERSION;
 }
 
 function _archFromAbi(abi) {

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -19,22 +19,16 @@ import { GECKO_PROFILE_VERSION } from '../app-logic/constants';
 const UNANNOTATED_VERSION = 0;
 
 function getProfileMeta(profile: mixed): MixedObject {
-  let meta = null;
-
   if (
     profile &&
     typeof profile === 'object' &&
     profile.meta &&
     typeof profile.meta === 'object'
   ) {
-    meta = profile.meta;
+    return profile.meta;
   }
 
-  if (!meta) {
-    throw new Error('Could not find the meta property on a profile.');
-  }
-
-  return meta;
+  throw new Error('Could not find the meta property on a profile.');
 }
 
 /**

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -9,6 +9,7 @@ import type {
   IndexIntoFuncTable,
   IndexIntoStackTable,
   IndexIntoResourceTable,
+  MixedObject,
 } from 'firefox-profiler/types';
 
 import {
@@ -257,7 +258,11 @@ function findEvent<T: TracingEventUnion>(
   return events ? events.find(f) : undefined;
 }
 
-function findEvents<T: Object>(
+function findEvents<
+  // False positive, generic type bounds:
+  // eslint-disable-next-line flowtype/no-weak-types
+  T: Object
+>(
   eventsByName: Map<string, TracingEventUnion[]>,
   name: string,
   f: T => boolean
@@ -848,7 +853,7 @@ function extractMarkers(
         );
         const { thread } = threadInfo;
         const { markers, stringTable } = thread;
-        let argData: Object | null = null;
+        let argData: MixedObject | null = null;
         if (event.args && typeof event.args === 'object') {
           argData = (event.args: any).data || null;
         }

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -16,7 +16,7 @@ import {
   getEmptyProfile,
   getEmptyThread,
 } from '../../profile-logic/data-structures';
-import { ensureExists } from '../../utils/flow';
+import { ensureExists, coerce } from '../../utils/flow';
 import {
   INSTANT,
   INTERVAL,
@@ -161,33 +161,6 @@ type ScreenshotEvent = TracingEvent<{|
   args: { snapshot: string },
 |}>;
 
-export function isChromeProfile(profile: mixed): boolean {
-  if (!profile || typeof profile !== 'object') {
-    return false;
-  }
-
-  if (Array.isArray(profile)) {
-    // Chrome profiles come as a list of events.
-    const event = profile[0];
-    // Lightly check that some properties exist that are in the TracingEvent.
-    return (
-      typeof event === 'object' &&
-      event !== null &&
-      'ph' in event &&
-      'cat' in event &&
-      'args' in event
-    );
-  }
-
-  // A node.js profile is a single CpuProfileData, as opposed to a list of events.
-  return (
-    'samples' in profile &&
-    'timeDeltas' in profile &&
-    'startTime' in profile &&
-    'endTime' in profile
-  );
-}
-
 function wrapCpuProfileInEvent(cpuProfile: CpuProfileData): CpuProfileEvent {
   return {
     name: 'CpuProfile',
@@ -203,18 +176,49 @@ function wrapCpuProfileInEvent(cpuProfile: CpuProfileData): CpuProfileEvent {
   };
 }
 
-export function convertChromeProfile(
-  profile: CpuProfileData | TracingEventUnion[]
-): Promise<Profile> {
-  if (!Array.isArray(profile)) {
-    // Assume that this is CpuProfileData from a node profile. Wrap it
-    // in a list of TracingEvents so that the logic below can be re-used.
-    profile = [wrapCpuProfileInEvent(profile)];
+export function attemptToConvertChromeProfile(
+  json: mixed
+): Promise<Profile> | null {
+  if (!json) {
+    return null;
+  }
+
+  let events: TracingEventUnion[] | void;
+
+  if (Array.isArray(json)) {
+    // Chrome profiles come as a list of events.
+    const event: mixed = json[0];
+    // Lightly check that some properties exist that are in the TracingEvent.
+    if (
+      event &&
+      typeof event === 'object' &&
+      'ph' in event &&
+      'cat' in event &&
+      'args' in event
+    ) {
+      events = coerce<mixed[], TracingEventUnion[]>(json);
+    }
+  } else if (
+    // A node.js profile is a single CpuProfileData, as opposed to a list of events.
+    typeof json === 'object' &&
+    'samples' in json &&
+    'timeDeltas' in json &&
+    'startTime' in json &&
+    'endTime' in json
+  ) {
+    events = [];
+    events.push(
+      wrapCpuProfileInEvent(coerce<MixedObject, CpuProfileData>(json))
+    );
+  }
+
+  if (!events) {
+    return null;
   }
 
   const eventsByName: Map<string, TracingEventUnion[]> = new Map();
 
-  for (const tracingEvent of profile) {
+  for (const tracingEvent of events) {
     if (
       typeof tracingEvent !== 'object' ||
       tracingEvent === null ||

--- a/src/profile-logic/import/linux-perf.js
+++ b/src/profile-logic/import/linux-perf.js
@@ -4,6 +4,8 @@
 
 // @flow
 
+import type { MixedObject } from 'firefox-profiler/types';
+
 /**
  * The "perf script" format is the plain text format that is output by an
  * invocation of `perf script`, where `perf` is the Linux perf command line tool.
@@ -21,7 +23,7 @@ export function isPerfScriptFormat(profile: string): boolean {
 
 // Don't try and type this more specifically. It will be run through the Gecko upgrader
 // process.
-type GeckoProfileVersion4 = Object;
+type GeckoProfileVersion4 = MixedObject;
 
 /**
  * Convert the output from `perf script` into the gecko profile format (version 4).

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -96,7 +96,7 @@ type RegExpResult = null | string[];
  * And turn it into a data table of the form
  *  `{ length: number, field1: array, field2: array }`
  */
-function _toStructOfArrays(geckoTable: Object): Object {
+function _toStructOfArrays(geckoTable: any): any {
   const result = { length: geckoTable.data.length };
   for (const fieldName in geckoTable.schema) {
     const fieldIndex = geckoTable.schema[fieldName];
@@ -571,7 +571,7 @@ function _processStackTable(
  * synchronous stack. Otherwise, if it happened before, it was an async stack, and is
  * most likely some event that happened in the past that triggered the marker.
  */
-function _convertStackToCause(data: Object): Object {
+function _convertStackToCause(data: any): any {
   if ('stack' in data && data.stack && data.stack.samples.data.length > 0) {
     const { stack, ...newData } = data;
     const stackIndex = stack.samples.data[0][stack.samples.schema.stack];
@@ -764,8 +764,7 @@ function _processMarkerPayload(
   // If there is a "stack" field, convert it to a "cause" field. This is
   // pre-emptively done for every single marker payload.
   //
-  // Warning: This function converts the payload into an Object type, which is
-  // about as bad as an any.
+  // Warning: This function converts the payload into an any type
   const payload = _convertStackToCause(geckoPayload);
 
   switch (payload.type) {

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1236,7 +1236,7 @@ function processMarkerSchema(geckoProfile: GeckoProfile): MarkerSchema[] {
  * Throws an exception if it encounters an incompatible profile.
  * For a description of the processed format, look at docs-developer/gecko-profile-format.md
  */
-export function processProfile(
+export function processGeckoProfile(
   rawProfile: GeckoProfile | { profile: GeckoProfile }
 ): Profile {
   // We may have been given a DevTools profile, in that case extract the Gecko Profile.
@@ -1474,7 +1474,7 @@ export async function unserializeProfileOfArbitraryFormat(
       return convertChromeProfile(profile);
     }
     // Else: Treat it as a Gecko profile and just attempt to process it.
-    return processProfile(profile);
+    return processGeckoProfile(profile);
   } catch (e) {
     throw new Error(`Unserializing the profile failed: ${e}`);
   }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -16,7 +16,7 @@ import {
   getEmptyUnbalancedNativeAllocationsTable,
 } from './data-structures';
 import { immutableUpdate, ensureExists, coerce } from '../utils/flow';
-import { attemptToUpgradeProcessedProfileToCurrentVersion } from './processed-profile-versioning';
+import { attemptToUpgradeProcessedProfileThroughMutation } from './processed-profile-versioning';
 import { upgradeGeckoProfileToCurrentVersion } from './gecko-profile-versioning';
 import {
   isPerfScriptFormat,
@@ -1488,7 +1488,7 @@ export async function unserializeProfileOfArbitraryFormat(
       json = arbitraryFormat;
     }
 
-    const processedProfile = attemptToUpgradeProcessedProfileToCurrentVersion(
+    const processedProfile = attemptToUpgradeProcessedProfileThroughMutation(
       json
     );
     if (processedProfile) {

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -120,7 +120,7 @@ function _mutateProfileToEnsureCauseBacktraces(profile) {
 /**
  * Guess the marker categories for a profile.
  */
-function _guessMarkerCategories(profile: Object) {
+function _guessMarkerCategories(profile: any) {
   // [key, categoryName]
   const keyToCategoryName = [
     ['DOMEvent', 'DOM'],

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -26,11 +26,11 @@ const UNANNOTATED_VERSION = 0;
 
 /**
  * Upgrades the supplied profile to the current version, by mutating |profile|.
- * Throws an exception if the profile is too new.
- * @param {object} profile The "serialized" form of a processed profile,
- *                         i.e. stringArray instead of stringTable.
+ * Throws an exception if the profile is too new. If the profile does not appear
+ * to be a processed profile, then return null. The profile provided is the
+ * "serialized" form of a processed profile, i.e. stringArray instead of stringTable.
  */
-export function attemptToUpgradeProcessedProfileToCurrentVersion(
+export function attemptToUpgradeProcessedProfileThroughMutation(
   profile: mixed
 ): SerializableProfile | null {
   if (!profile || typeof profile !== 'object') {
@@ -55,7 +55,8 @@ export function attemptToUpgradeProcessedProfileToCurrentVersion(
       typeof firstThread !== 'object' ||
       !firstThread.stringArray
     ) {
-      // There is no stringArray, which means this is most likely a Gecko Profile.
+      // Could not find a thread that contains a stringArray, which means this is
+      // most likely a Gecko Profile.
       return null;
     }
   }

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -335,7 +335,7 @@ export function getThreadSelectorsPerThread(
         : JsTracer.getJsTracerLeafTiming(jsTracerTable, stringTable)
   );
 
-  const getProcessedEventDelays: Selector<EventDelayInfo | null> = createSelector(
+  const getProcessedEventDelaysOrNull: Selector<EventDelayInfo | null> = createSelector(
     getSamplesTable,
     ProfileSelectors.getProfileInterval,
     (samplesTable, interval) =>
@@ -343,6 +343,12 @@ export function getThreadSelectorsPerThread(
         ? null
         : ProfileData.processEventDelays(samplesTable, interval)
   );
+
+  const getProcessedEventDelays: Selector<EventDelayInfo> = state =>
+    ensureExists(
+      getProcessedEventDelaysOrNull(state),
+      'Could not get the processed event delays'
+    );
 
   return {
     getThread,

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -17,7 +17,7 @@ import {
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
-import { processProfile } from '../../profile-logic/process-profile';
+import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { fireFullClick } from '../fixtures/utils';
 import type { Profile, SymbolicationStatus } from 'firefox-profiler/types';
 
@@ -307,7 +307,7 @@ describe('<MetaInfoPanel>', function() {
 
   it('matches the snapshot', () => {
     // Using gecko profile because it has metadata and profilerOverhead data in it.
-    const profile = processProfile(createGeckoProfile());
+    const profile = processGeckoProfile(createGeckoProfile());
     profile.meta.configuration = {
       features: ['js', 'threads'],
       threads: ['GeckoMain', 'DOM Worker'],
@@ -323,7 +323,7 @@ describe('<MetaInfoPanel>', function() {
 
   it('with no statistics object should not make the app crash', () => {
     // Using gecko profile because it has metadata and profilerOverhead data in it.
-    const profile = processProfile(createGeckoProfile());
+    const profile = processGeckoProfile(createGeckoProfile());
     // We are removing statistics objects from all overhead objects to test
     // the robustness of our handling code.
     if (profile.profilerOverhead) {

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -12,7 +12,7 @@ import copy from 'copy-to-clipboard';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ProfileCallTreeView } from '../../components/calltree/ProfileCallTreeView';
 import { CallNodeContextMenu } from '../../components/shared/CallNodeContextMenu';
-import { processProfile } from '../../profile-logic/process-profile';
+import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { ensureExists } from '../../utils/flow';
 
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -476,7 +476,7 @@ describe('ProfileCallTreeView/end-to-end', () => {
     jest.useFakeTimers();
 
     const geckoProfile = createGeckoProfile();
-    const processedProfile = processProfile(geckoProfile);
+    const processedProfile = processGeckoProfile(geckoProfile);
     const store = storeWithProfile(processedProfile);
     render(
       <Provider store={store}>

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -24,7 +24,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
-import type { Milliseconds } from 'firefox-profiler/types';
+import type { Milliseconds, MixedObject } from 'firefox-profiler/types';
 
 // The following define the magic values used for the mocked bounding box of the
 // the rendered component.
@@ -616,7 +616,7 @@ function getBoundingBoxForViewport(override: $Shape<BoundingBoxOverride> = {}) {
   return rect;
 }
 
-function setup(profileOverrides: Object = {}) {
+function setup(profileOverrides: MixedObject = {}) {
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
 
@@ -646,7 +646,7 @@ function setup(profileOverrides: Object = {}) {
     }),
     mapDispatchToProps: {},
     // eslint-disable-next-line react/display-name
-    component: (props: Object) => (
+    component: (props: any) => (
       <ChartWithViewport
         viewportProps={{
           previewSelection: props.previewSelection,

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -24,7 +24,12 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
-import type { Milliseconds, MixedObject } from 'firefox-profiler/types';
+import type {
+  Milliseconds,
+  MixedObject,
+  PreviewSelection,
+  StartEndRange,
+} from 'firefox-profiler/types';
 
 // The following define the magic values used for the mocked bounding box of the
 // the rendered component.
@@ -634,6 +639,14 @@ function setup(profileOverrides: MixedObject = {}) {
   // valid stateless component. $FlowExpectError
   const ChartWithViewport = withChartViewport(DummyChart);
 
+  type Props = {
+    previewSelection: PreviewSelection,
+    timeRange: StartEndRange,
+    maxViewportHeight?: number,
+    startsAtBottom: boolean,
+    ...
+  };
+
   // The viewport component started out as an unconnected component, but then it
   // started subscribing to the store an dispatching its own actions. This migration
   // wasn't completely done, so it still has a few pieces of state passed in through
@@ -646,7 +659,7 @@ function setup(profileOverrides: MixedObject = {}) {
     }),
     mapDispatchToProps: {},
     // eslint-disable-next-line react/display-name
-    component: (props: any) => (
+    component: (props: Props) => (
       <ChartWithViewport
         viewportProps={{
           previewSelection: props.previewSelection,

--- a/src/test/fixtures/stores.js
+++ b/src/test/fixtures/stores.js
@@ -6,7 +6,7 @@
 import createStore from '../../app-logic/create-store';
 import { viewProfile } from '../../actions/receive-profile';
 import { createGeckoProfileWithJsTimings } from './profiles/gecko-profile';
-import { processProfile } from '../../profile-logic/process-profile';
+import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { getProfileFromTextSamples } from './profiles/processed-profile';
 
 import type { Store, Profile } from 'firefox-profiler/types';
@@ -17,7 +17,7 @@ export function blankStore() {
 
 export function storeWithProfile(profile?: Profile): Store {
   if (!profile) {
-    profile = processProfile(createGeckoProfileWithJsTimings());
+    profile = processGeckoProfile(createGeckoProfileWithJsTimings());
     profile.meta.symbolicated = true;
   }
   const store = createStore();

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -66,7 +66,7 @@ class FakeMouseEvent extends MouseEvent {
 
   constructor(type: string, values: FakeMouseEventInit) {
     const { pageX, pageY, offsetX, offsetY, x, y, ...mouseValues } = values;
-    super(type, (mouseValues: Object));
+    super(type, (mouseValues: any));
 
     Object.assign(this, {
       offsetX: offsetX || 0,

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -12,7 +12,7 @@ import * as WorkerFactory from '../utils/worker-factory';
 afterEach(function() {
   // This `__shutdownWorkers` function only exists in the mocked test environment,
   // do not use flow typing on it.
-  const { __shutdownWorkers } = (WorkerFactory: Object);
+  const { __shutdownWorkers } = (WorkerFactory: any);
   __shutdownWorkers();
 });
 

--- a/src/test/store/__snapshots__/receive-profile.test.js.snap
+++ b/src/test/store/__snapshots__/receive-profile.test.js.snap
@@ -108,4 +108,4 @@ exports[`actions/receive-profile retrieveProfileFromFile will be an error to vie
 
 exports[`actions/receive-profile retrieveProfileFromFile will give an error when unable to decompress a zipped profile 1`] = `[Error: Can't find end of central directory : is this a zip file ? If it is, see https://stuk.github.io/jszip/documentation/howto/read_zip.html]`;
 
-exports[`actions/receive-profile retrieveProfileFromFile will give an error when unable to parse json 1`] = `[Error: Unserializing the profile failed: TypeError: Cannot read property 'version' of undefined]`;
+exports[`actions/receive-profile retrieveProfileFromFile will give an error when unable to parse json 1`] = `[Error: Unserializing the profile failed: Error: This does not appear to be a valid Gecko Profile, there is no meta field.]`;

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -25,11 +25,11 @@ describe('actions/icons', function() {
   beforeEach(() => {
     const mock = createImageMock();
     imageInstances = mock.instances;
-    (window: Object).Image = mock.Image;
+    (window: any).Image = mock.Image;
   });
 
   afterEach(() => {
-    delete (window: Object).Image;
+    delete (window: any).Image;
     imageInstances = [];
   });
 
@@ -93,7 +93,7 @@ describe('actions/icons', function() {
         expect(instance.src).toEqual(validIcons[i]);
         expect(instance.referrerPolicy).toEqual('no-referrer');
       });
-      imageInstances.forEach(instance => (instance: Object).onload());
+      imageInstances.forEach(instance => (instance: any).onload());
       await Promise.all(promises);
 
       const state = getState();
@@ -122,7 +122,7 @@ describe('actions/icons', function() {
         iconsActions.iconStartLoading(invalidIcon)
       );
       expect(imageInstances.length).toBe(1);
-      (imageInstances[0]: Object).onerror();
+      (imageInstances[0]: any).onerror();
 
       await actionPromise;
 

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -40,7 +40,7 @@ import JSZip from 'jszip';
 import {
   makeProfileSerializable,
   serializeProfile,
-  processProfile,
+  processGeckoProfile,
 } from '../../profile-logic/process-profile';
 import {
   getProfileFromTextSamples,
@@ -1589,7 +1589,7 @@ describe('actions/receive-profile', function() {
     it('keeps the initial rootRange as default', async function() {
       //Time sample has been set for 100000ms (100s)
       const { profile } = getProfileFromTextSamples(`
-        100000 
+        100000
         A
       `); //
       const { rootRange } = await setup(
@@ -1896,7 +1896,7 @@ describe('actions/receive-profile', function() {
       // Differently, `from-addon` calls the finalizeProfileView internally,
       // we don't need to call it again.
       await waitUntilPhase('DATA_LOADED');
-      const processedProfile = processProfile(geckoProfile);
+      const processedProfile = processGeckoProfile(geckoProfile);
       expect(ProfileViewSelectors.getProfile(getState())).toEqual(
         processedProfile
       );

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1266,8 +1266,8 @@ describe('actions/receive-profile', function() {
       expect(view.phase).toBe('FATAL_ERROR');
 
       expect(
-        // Coerce into the object to access the error property.
-        (view: Object).error
+        // Coerce into an any to access the error property.
+        (view: any).error
       ).toMatchSnapshot();
     });
 
@@ -1372,8 +1372,8 @@ describe('actions/receive-profile', function() {
       });
       expect(view.phase).toBe('FATAL_ERROR');
       expect(
-        // Coerce into the object to access the error property.
-        (view: Object).error
+        // Coerce into an any to access the error property.
+        (view: any).error
       ).toMatchSnapshot();
     });
   });
@@ -1744,7 +1744,10 @@ describe('actions/receive-profile', function() {
       };
     }
 
-    async function setup(location: Object, requiredProfile: number = 1) {
+    async function setup(
+      location: $Shape<Location>,
+      requiredProfile: number = 1
+    ) {
       const profile = _getSimpleProfile();
       const geckoProfile = createGeckoProfile();
 

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -13,7 +13,7 @@ import {
   INTERVAL_START,
   INTERVAL_END,
 } from 'firefox-profiler/app-logic/constants';
-import { processProfile } from '../../profile-logic/process-profile';
+import { processGeckoProfile } from '../../profile-logic/process-profile';
 import {
   filterRawMarkerTableToRange,
   filterRawMarkerTableToRangeWithMarkersToDelete,
@@ -42,7 +42,7 @@ import type {
 
 describe('Derive markers from Gecko phase markers', function() {
   function setupWithTestDefinedMarkers(markers) {
-    const profile = processProfile(createGeckoProfileWithMarkers(markers));
+    const profile = processGeckoProfile(createGeckoProfileWithMarkers(markers));
     profile.meta.symbolicated = true; // Avoid symbolication.
     const { getState } = storeWithProfile(profile);
     const mainGetMarker = selectedThreadSelectors.getMarkerGetter(getState());
@@ -316,7 +316,7 @@ describe('deriveMarkersFromRawMarkerTable', function() {
     // mock is called in one of the tests.
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const profile = processProfile(createGeckoProfile());
+    const profile = processGeckoProfile(createGeckoProfile());
     profile.meta.symbolicated = true; // avoid to kick off the symbolication process
     const thread = profile.threads[0]; // This is the parent process main thread
     const contentThread = profile.threads[2]; // This is the content process main thread

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -5,7 +5,7 @@
 
 import {
   extractFuncsAndResourcesFromFrameLocations,
-  processProfile,
+  processGeckoProfile,
   serializeProfile,
   unserializeProfileOfArbitraryFormat,
 } from '../../profile-logic/process-profile';
@@ -204,7 +204,7 @@ describe('gecko counters processing', function() {
 
   it('can extract the counter information correctly', function() {
     const { parentGeckoProfile, parentPid, childPid } = setup();
-    const processedProfile = processProfile(parentGeckoProfile);
+    const processedProfile = processGeckoProfile(parentGeckoProfile);
     const counters = ensureExists(
       processedProfile.counters,
       'Expected to find counters on the processed profile'
@@ -228,7 +228,7 @@ describe('gecko counters processing', function() {
 
   it('offsets the counter timing for child processes', function() {
     const { parentGeckoProfile, parentCounter, childCounter } = setup();
-    const processedProfile = processProfile(parentGeckoProfile);
+    const processedProfile = processGeckoProfile(parentGeckoProfile);
     const processedCounters = ensureExists(processedProfile.counters);
 
     const originalTime = [0, 1, 2, 3, 4, 5, 6];
@@ -291,7 +291,7 @@ describe('gecko profilerOverhead processing', function() {
 
   it('can extract the overhead information correctly', function() {
     const { parentGeckoProfile, parentPid, childPid } = setup();
-    const processedProfile = processProfile(parentGeckoProfile);
+    const processedProfile = processGeckoProfile(parentGeckoProfile);
     const overhead = ensureExists(
       processedProfile.profilerOverhead,
       'Expected to find profilerOverhead on the processed profile'
@@ -315,7 +315,7 @@ describe('gecko profilerOverhead processing', function() {
 
   it('offsets the overhead timing for child processes', function() {
     const { parentGeckoProfile, parentOverhead, childOverhead } = setup();
-    const processedProfile = processProfile(parentGeckoProfile);
+    const processedProfile = processGeckoProfile(parentGeckoProfile);
     const processedOverheads = ensureExists(processedProfile.profilerOverhead);
 
     const originalTime = [0, 1000, 2000, 3000, 4000, 5000, 6000];
@@ -339,13 +339,13 @@ describe('gecko profilerOverhead processing', function() {
 
 describe('serializeProfile', function() {
   it('should produce a parsable profile string', async function() {
-    const profile = processProfile(createGeckoProfile());
+    const profile = processGeckoProfile(createGeckoProfile());
     const serialized = serializeProfile(profile);
     expect(JSON.parse.bind(null, serialized)).not.toThrow();
   });
 
   it('should produce the same profile in a roundtrip', async function() {
-    const profile = processProfile(createGeckoProfile());
+    const profile = processGeckoProfile(createGeckoProfile());
     const serialized = serializeProfile(profile);
     const roundtrip = await unserializeProfileOfArbitraryFormat(serialized);
     // FIXME: Uncomment this line after resolving `undefined` serialization issue
@@ -409,7 +409,7 @@ describe('js allocation processing', function() {
     expect(markersAndAllocationsLength).toEqual(originalMarkersLength + 3);
 
     // Process the profile and get out the new thread.
-    const processedProfile = processProfile(geckoProfile);
+    const processedProfile = processGeckoProfile(geckoProfile);
     const processedThread = processedProfile.threads[0];
 
     // Check for the existence of the allocations.
@@ -479,7 +479,7 @@ describe('native allocation processing', function() {
     expect(markersAndAllocationsLength).toEqual(originalMarkersLength + 3);
 
     // Process the profile and get out the new thread.
-    const processedProfile = processProfile(geckoProfile);
+    const processedProfile = processGeckoProfile(geckoProfile);
     const processedThread = processedProfile.threads[0];
 
     // Check for the existence of the allocations.

--- a/src/test/unit/profile-conversion.test.js
+++ b/src/test/unit/profile-conversion.test.js
@@ -62,7 +62,7 @@ describe('converting Google Chrome profile', function() {
     // behavior.
     jest
       .spyOn(Image.prototype, 'addEventListener')
-      .mockImplementation((name: string, callback: Function) => {
+      .mockImplementation((name: string, callback) => {
         if (name === 'load') {
           callback();
         }
@@ -85,7 +85,7 @@ describe('converting Google Chrome profile', function() {
     // rely on the Image loading behavior.
     jest
       .spyOn(Image.prototype, 'addEventListener')
-      .mockImplementation((name: string, callback: Function) => {
+      .mockImplementation((name: string, callback) => {
         if (name === 'load') {
           callback();
         }

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -7,7 +7,10 @@ import {
   symbolicateProfile,
   applySymbolicationStep,
 } from '../../profile-logic/symbolication';
-import { processGeckoProfile } from '../../profile-logic/process-profile';
+import {
+  processGeckoProfile,
+  processGeckoOrDevToolsProfile,
+} from '../../profile-logic/process-profile';
 import {
   getCallNodeInfo,
   filterThreadByImplementation,
@@ -337,7 +340,7 @@ describe('process-profile', function() {
   describe('DevTools profiles', function() {
     it('should process correctly', function() {
       // Mock out a DevTools profile.
-      const profile = processGeckoProfile({
+      const profile = processGeckoOrDevToolsProfile({
         label: null,
         duration: null,
         markers: null,

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -7,7 +7,7 @@ import {
   symbolicateProfile,
   applySymbolicationStep,
 } from '../../profile-logic/symbolication';
-import { processProfile } from '../../profile-logic/process-profile';
+import { processGeckoProfile } from '../../profile-logic/process-profile';
 import {
   getCallNodeInfo,
   filterThreadByImplementation,
@@ -117,9 +117,8 @@ describe('data-table-utils', function() {
 });
 
 describe('process-profile', function() {
-  describe('processProfile', function() {
-    const profile = processProfile(createGeckoProfile());
-
+  describe('processGeckoProfile', function() {
+    const profile = processGeckoProfile(createGeckoProfile());
     it('should have three threads', function() {
       expect(profile.threads.length).toEqual(3);
     });
@@ -279,7 +278,7 @@ describe('process-profile', function() {
 
   describe('JS tracer', function() {
     it('does not have JS tracer information by default', function() {
-      const profile = processProfile(createGeckoProfile());
+      const profile = processGeckoProfile(createGeckoProfile());
       expect(profile.threads[0].jsTracer).toBe(undefined);
     });
 
@@ -310,7 +309,7 @@ describe('process-profile', function() {
       const timestampOffsetMicro = timestampOffsetMs * 1000;
 
       // Process the profile, and grab the threads we are interested in.
-      const processedProfile = processProfile(geckoProfile);
+      const processedProfile = processGeckoProfile(geckoProfile);
       const childProcessThread = ensureExists(
         processedProfile.threads.find(thread => thread.jsTracer),
         'Could not find the thread with the JS tracer information'
@@ -338,7 +337,7 @@ describe('process-profile', function() {
   describe('DevTools profiles', function() {
     it('should process correctly', function() {
       // Mock out a DevTools profile.
-      const profile = processProfile({
+      const profile = processGeckoProfile({
         label: null,
         duration: null,
         markers: null,
@@ -380,7 +379,7 @@ describe('process-profile', function() {
         ],
       };
 
-      const profile = processProfile(geckoProfile);
+      const profile = processGeckoProfile(geckoProfile);
       expect(profile.meta.extensions).toEqual({
         baseURL: [
           'moz-extension://bf3bb73c-919c-4fef-95c4-070a19fdaf85/',
@@ -396,7 +395,7 @@ describe('process-profile', function() {
       const geckoProfile = createGeckoProfile();
       delete geckoProfile.meta.extensions;
 
-      const profile = processProfile(geckoProfile);
+      const profile = processGeckoProfile(geckoProfile);
       expect(profile.meta.extensions).toEqual({
         baseURL: [],
         id: [],
@@ -409,7 +408,7 @@ describe('process-profile', function() {
 
 describe('profile-data', function() {
   describe('createCallNodeTableAndFixupSamples', function() {
-    const profile = processProfile(createGeckoProfile());
+    const profile = processGeckoProfile(createGeckoProfile());
     const defaultCategory = profile.meta.categories.findIndex(
       c => c.name === 'Other'
     );
@@ -599,7 +598,7 @@ describe('symbolication', function() {
     let symbolicatedProfile = null;
 
     beforeAll(function() {
-      unsymbolicatedProfile = processProfile(createGeckoProfile());
+      unsymbolicatedProfile = processGeckoProfile(createGeckoProfile());
       const symbolTable = new Map();
       symbolTable.set(0, 'first symbol');
       symbolTable.set(0xf00, 'second symbol');
@@ -661,7 +660,7 @@ describe('symbolication', function() {
 });
 
 describe('filter-by-implementation', function() {
-  const profile = processProfile(createGeckoProfileWithJsTimings());
+  const profile = processGeckoProfile(createGeckoProfileWithJsTimings());
   const defaultCategory = profile.meta.categories.findIndex(
     c => c.name === 'Other'
   );

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -122,6 +122,7 @@ describe('data-table-utils', function() {
 describe('process-profile', function() {
   describe('processGeckoProfile', function() {
     const profile = processGeckoProfile(createGeckoProfile());
+
     it('should have three threads', function() {
       expect(profile.threads.length).toEqual(3);
     });

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { processProfile } from '../../profile-logic/process-profile';
+import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { sanitizePII } from '../../profile-logic/sanitize';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
@@ -25,7 +25,7 @@ import { getTimeRangeForThread } from '../../profile-logic/profile-data';
 describe('sanitizePII', function() {
   function setup(
     piiConfig,
-    originalProfile = processProfile(createGeckoProfile())
+    originalProfile = processGeckoProfile(createGeckoProfile())
   ): * {
     const PIIToRemove: RemoveProfileInformation = {
       shouldRemoveThreads: new Set(),

--- a/src/test/unit/web-channel.test.js
+++ b/src/test/unit/web-channel.test.js
@@ -51,7 +51,7 @@ describe('event handlers for Firefox WebChannel events', function() {
 
     // The triggerResponse doesn't allow unknown message types, so coerce it
     // into a Function to test the error path.
-    (triggerResponse: Function)({
+    (triggerResponse: any)({
       errno: 2,
       error: 'No Such Channel',
     });
@@ -73,7 +73,7 @@ describe('event handlers for Firefox WebChannel events', function() {
 
     // The triggerResponse doesn't allow unknown message types, so coerce it
     // into a Function to test the error path.
-    (triggerResponse: Function)('Invalid message');
+    (triggerResponse: any)('Invalid message');
 
     await expect(response).rejects.toEqual(
       new Error('A malformed WebChannel event was received.')

--- a/src/test/unit/window-console.test.js
+++ b/src/test/unit/window-console.test.js
@@ -30,10 +30,10 @@ describe('console-accessible values on the window object', function() {
 
   it('logs a friendly message', function() {
     const log = console.log;
-    (console: Object).log = jest.fn();
+    (console: any).log = jest.fn();
     logFriendlyPreamble();
     expect(console.log.mock.calls.length).toEqual(2);
     expect(console.log.mock.calls).toMatchSnapshot();
-    (console: Object).log = log;
+    (console: any).log = log;
   });
 });

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -17,6 +17,7 @@ import type {
 } from './profile';
 import type { MarkerPayload_Gecko, MarkerSchema } from './markers';
 import type { Milliseconds, Nanoseconds } from './units';
+import type { MixedObject } from './utils';
 
 export type IndexIntoGeckoFrameTable = number;
 export type IndexIntoGeckoStackTable = number;
@@ -154,7 +155,7 @@ export type GeckoFrameTable = {|
       // for JS frames, an index into the string table, usually "Baseline" or "Ion"
       null | IndexIntoStringTable,
       // JSON info about JIT optimizations.
-      null | Object,
+      null | MixedObject,
       // The line of code
       null | number,
       // The column of code
@@ -171,7 +172,7 @@ export type GeckoFrameStruct = {|
   location: IndexIntoStringTable[],
   relevantForJS: Array<boolean>,
   implementation: Array<null | IndexIntoStringTable>,
-  optimizations: Array<null | Object>,
+  optimizations: Array<null | MixedObject>,
   line: Array<null | number>,
   column: Array<null | number>,
   category: Array<null | number>,
@@ -340,7 +341,7 @@ export type GeckoProfileWithMeta<Meta> = {|
   pages?: PageList,
   threads: GeckoThread[],
   pausedRanges: PausedRange[],
-  tasktracer?: Object,
+  tasktracer?: MixedObject,
   processes: GeckoSubprocessProfile[],
   jsTracerDictionary?: string[],
 |};

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -6,11 +6,12 @@
 import type { IDBFactory, IDBKeyRange } from '../indexeddb';
 import type { SymbolTableAsTuple } from '../../profile-logic/symbol-store-db';
 import type { GoogleAnalytics } from '../../utils/analytics';
+import type { MixedObject } from '../utils';
 
 // Because this type isn't an existing Global type, but still it's useful to
 // have it available, we define it with a $ as prfix.
 declare type $GeckoProfiler = {
-  getProfile: () => Object,
+  getProfile: () => MixedObject,
   getSymbolTable: (
     debugName: string,
     breakpadId: string
@@ -33,7 +34,7 @@ declare class Window {
   geckoProfilerAddonInstalled?: () => void;
   isGeckoProfilerAddonInstalled?: boolean;
   InstallTrigger?: {
-    install: Object => {},
+    install: MixedObject => {},
   };
 
   // For debugging purposes, allow tooltips to persist. This aids in inspecting

--- a/src/types/libdef/npm-custom/jest_v26.x.x.js
+++ b/src/types/libdef/npm-custom/jest_v26.x.x.js
@@ -1,3 +1,4 @@
+/* eslint-disable flowtype/no-weak-types */
 // @flow
 // This comes from https://github.com/flow-typed/flow-typed/blob/51c898e2447e35c4fbe31ff40168cc463ef53aec/definitions/npm/jest_v26.x.x/flow_v0.104.x-/jest_v26.x.x.js
 // This was copied "manually" because our flow version is older than this, but

--- a/src/types/libdef/npm-custom/memoize-immutable_v3.x.x.js
+++ b/src/types/libdef/npm-custom/memoize-immutable_v3.x.x.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+/* eslint-disable flowtype/no-weak-types */
+
 declare module 'memoize-immutable' {
   declare interface CacheInstance<K, V> {
     has(K): boolean;

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -148,7 +148,12 @@ export type IPCSharedData = {|
  * This utility type removes the "cause" property from a payload, and replaces it with
  * a stack. This effectively converts it from a processed payload to a Gecko payload.
  */
-export type $ReplaceCauseWithStack<T: Object> = {|
+
+export type $ReplaceCauseWithStack<
+  // False positive, generic type bounds are alright:
+  // eslint-disable-next-line flowtype/no-weak-types
+  T: Object
+> = {|
   ...$Diff<
     T,
     // Remove the cause property.
@@ -495,14 +500,14 @@ export type TextMarkerPayload = {|
 export type ChromeCompleteTraceEventPayload = {|
   type: 'CompleteTraceEvent',
   category: string,
-  data: Object | null,
+  data: MixedObject | null,
 |};
 
 // ph: 'I' in the Trace Event Format
 export type ChromeInstantTraceEventPayload = {|
   type: 'InstantTraceEvent',
   category: string,
-  data: Object | null,
+  data: MixedObject | null,
 |};
 
 // ph: 'B' | 'E' in the Trace Event Format
@@ -510,7 +515,7 @@ export type ChromeDurationTraceEventPayload = {|
   type: 'tracing',
   category: 'FromChrome',
   interval: 'start' | 'end',
-  data: Object | null,
+  data: MixedObject | null,
   cause?: CauseBacktrace,
 |};
 

--- a/src/types/utils.js
+++ b/src/types/utils.js
@@ -32,6 +32,4 @@ export type ObjectMap<T> = {
   __proto__: null,
 };
 
-export type AnyObject = { [key: string]: any };
 export type MixedObject = { [key: string]: mixed };
-export type EmptyObject = { [key: string]: empty };

--- a/src/types/utils.js
+++ b/src/types/utils.js
@@ -31,3 +31,7 @@ export type ObjectMap<T> = {
   // No prototype was created:
   __proto__: null,
 };
+
+export type AnyObject = { [key: string]: any };
+export type MixedObject = { [key: string]: mixed };
+export type EmptyObject = { [key: string]: empty };

--- a/src/utils/__mocks__/worker-factory.js
+++ b/src/utils/__mocks__/worker-factory.js
@@ -38,7 +38,7 @@ class NodeWorker {
     this._instance.postMessage(payload, transfer);
   }
 
-  onMessage = (message: Object) => {
+  onMessage = (message: any) => {
     if (this.onmessage) {
       this.onmessage(new MessageEvent('message', { data: message }));
     }

--- a/src/utils/__mocks__/worker-factory.js
+++ b/src/utils/__mocks__/worker-factory.js
@@ -38,7 +38,7 @@ class NodeWorker {
     this._instance.postMessage(payload, transfer);
   }
 
-  onMessage = (message: any) => {
+  onMessage = (message: mixed) => {
     if (this.onmessage) {
       this.onmessage(new MessageEvent('message', { data: message }));
     }

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+// Ignore for this file, which uses extensive use of generic type bounds, which
+// triggers a false positive with this rule.
+/* eslint-disable flowtype/no-weak-types */
+
 import * as React from 'react';
 import { connect } from 'react-redux';
 import type {

--- a/src/utils/css-geometry-tools.js
+++ b/src/utils/css-geometry-tools.js
@@ -109,5 +109,5 @@ export function extractDomRectValue(
   rect: DOMRect,
   key: 'top' | 'left' | 'right' | 'bottom'
 ): number {
-  return (rect: Object)[key];
+  return (rect: any)[key];
 }

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -31,7 +31,7 @@ export function assertExhaustiveCheck(
  * type information of the object. Flow will occasionally throw errors when
  * inferring what is going on with Object.assign.
  */
-export function immutableUpdate<T: Object>(object: T, ...rest: Object[]): T {
+export function immutableUpdate<T>(object: T, ...rest: any[]): T {
   return Object.assign({}, object, ...rest);
 }
 
@@ -123,7 +123,7 @@ export function coerceMatchingShape<T>(item: $Shape<T>): T {
 export function objectValues<Value, Obj: {| [string]: Value |}>(
   object: Obj
 ): Value[] {
-  return (Object.values: Function)(object);
+  return (Object.values: any)(object);
 }
 
 /**
@@ -133,7 +133,7 @@ export function objectValues<Value, Obj: {| [string]: Value |}>(
 export function objectEntries<Key, Value>(object: {
   [Key]: Value,
 }): Array<[Key, Value]> {
-  return (Object.entries: Function)(object);
+  return (Object.entries: any)(object);
 }
 
 /**
@@ -151,6 +151,8 @@ export function objectMap<Return, Key, Value>(
   return result;
 }
 
+// Generic bounds with an Object is a false positive.
+// eslint-disable-next-line flowtype/no-weak-types
 export function getObjectValuesAsUnion<T: Object>(obj: T): Array<$Values<T>> {
   return Object.values(obj);
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -34,7 +34,13 @@ export class FastFillStyle {
 /**
  * Perform a simple shallow object equality check.
  */
-export function objectShallowEquals(a: Object, b: Object): boolean {
+export function objectShallowEquals<
+  // False positive, Objects are fine as generic trait bounds.
+  // eslint-disable-next-line flowtype/no-weak-types
+  A: Object,
+  // eslint-disable-next-line flowtype/no-weak-types
+  B: Object
+>(a: A, b: B): boolean {
   let aLength = 0;
   let bLength = 0;
   for (const key in a) {

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 import { stripIndent } from 'common-tags';
-import type { GetState, Dispatch } from 'firefox-profiler/types';
+import type { GetState, Dispatch, MixedObject } from 'firefox-profiler/types';
 import { selectorsForConsole } from 'firefox-profiler/selectors';
 import actions from '../actions';
 
@@ -20,7 +20,7 @@ const defineProperty = Object.defineProperty;
 export function addDataToWindowObject(
   getState: GetState,
   dispatch: Dispatch,
-  target: Object = window
+  target: MixedObject = window
 ) {
   defineProperty(target, 'profile', {
     enumerable: true,


### PR DESCRIPTION
This is one of the requirements for the TypeScript migration: #2931.
It also adds better type safety by removing an ineffective type.

I added a lint rule to ensure we don't regress this change. I also broke out the riskier changes into their own commits to call them out. The commit with most of the changes should be only type changes, not behavior changes. This change warrants a bit of manual testing on profile loading. On my end, I loaded up a battery of different profiles that I have saved locally, especially around the profile importing.