### PR TITLE
No existential types in Flow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,6 +102,7 @@ module.exports = {
         Function: true,
       },
     ],
+    'flowtype/no-existential-type': 'error',
     'no-useless-call': 'error',
     'no-useless-computed-key': 'error',
     'no-useless-concat': 'error',

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1213,7 +1213,7 @@ export function waitingForProfileFromFile(): Action {
   };
 }
 
-function _fileReader(input: File): * {
+function _fileReader(input: File) {
   const reader = new FileReader();
   const promise = new Promise((resolve, reject) => {
     // Flow's definition for FileReader doesn't handle the polymorphic nature of

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -74,8 +74,11 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class CallTreeImpl extends PureComponent<Props> {
-  _mainColumn: Column = { propName: 'name', title: '' };
-  _appendageColumn: Column = { propName: 'lib', title: '' };
+  _mainColumn: Column<CallNodeDisplayData> = { propName: 'name', title: '' };
+  _appendageColumn: Column<CallNodeDisplayData> = {
+    propName: 'lib',
+    title: '',
+  };
   _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = treeView => (this._treeView = treeView);
 
@@ -84,7 +87,7 @@ class CallTreeImpl extends PureComponent<Props> {
    * appropriate labels for the call tree based on this weight.
    */
   _weightTypeToColumns = memoize(
-    (weightType: WeightType): Column[] => {
+    (weightType: WeightType): Column<CallNodeDisplayData>[] => {
       switch (weightType) {
         case 'tracing-ms':
           return [

--- a/src/components/shared/Draggable.js
+++ b/src/components/shared/Draggable.js
@@ -12,7 +12,7 @@ export type OnMove = (
   dx: number,
   dy: number,
   isModifying: boolean
-) => *;
+) => void;
 
 type Props = {
   value: { +selectionStart: Milliseconds, +selectionEnd: Milliseconds },
@@ -36,8 +36,8 @@ type State = {
 export class Draggable extends React.PureComponent<Props, State> {
   _container: HTMLDivElement | null = null;
   _handlers: {
-    mouseMoveHandler: MouseEvent => *,
-    mouseUpHandler: MouseEvent => *,
+    mouseMoveHandler: MouseEvent => void,
+    mouseUpHandler: MouseEvent => void,
   } | null = null;
   state = {
     dragging: false,
@@ -88,8 +88,8 @@ export class Draggable extends React.PureComponent<Props, State> {
   };
 
   _installMoveAndUpHandlers(
-    mouseMoveHandler: MouseEvent => *,
-    mouseUpHandler: MouseEvent => *
+    mouseMoveHandler: MouseEvent => void,
+    mouseUpHandler: MouseEvent => void
   ) {
     this._handlers = { mouseMoveHandler, mouseUpHandler };
     window.addEventListener('mousemove', mouseMoveHandler, true);

--- a/src/components/shared/FilterNavigatorBar.js
+++ b/src/components/shared/FilterNavigatorBar.js
@@ -18,7 +18,7 @@ type Props = {|
       }
     | string
   >,
-  +onPop: number => *,
+  +onPop: number => mixed,
   +selectedItem: number,
   +uncommittedItem?: string,
 |};

--- a/src/components/shared/VirtualList.js
+++ b/src/components/shared/VirtualList.js
@@ -235,7 +235,7 @@ type VirtualListProps<Item> = {|
   +focusable: boolean,
   +specialItems: $ReadOnlyArray<Item | void>,
   +onKeyDown: (SyntheticKeyboardEvent<>) => void,
-  +onCopy: Event => void,
+  +onCopy: ClipboardEvent => void,
   // Set `disableOverscan` to `true` when you expect a lot of updates in a short
   // time: this will render only the visible part, which makes each update faster.
   +disableOverscan: boolean,
@@ -299,7 +299,7 @@ export class VirtualList<Item> extends React.PureComponent<
     this.forceUpdate();
   };
 
-  _onCopy = (event: Event) => {
+  _onCopy = (event: ClipboardEvent) => {
     if (document.activeElement === this._container.current) {
       this.props.onCopy(event);
     }

--- a/src/components/shared/WithSize.js
+++ b/src/components/shared/WithSize.js
@@ -40,6 +40,9 @@ export function withSize<
   // they are injected by this higher order component.
   $ReadOnly<$Diff<Props, SizeProps>>
 > {
+  // An existential type in a generic is a bit tricky to remove. Perhaps this can
+  // use a hook instead.
+  // eslint-disable-next-line flowtype/no-existential-type
   return class WithSizeWrapper extends React.PureComponent<*, State> {
     _isSizeInfoDirty: boolean = false;
     state = { width: 0, height: 0 };

--- a/src/components/shared/WithSize.js
+++ b/src/components/shared/WithSize.js
@@ -42,6 +42,7 @@ export function withSize<
 > {
   // An existential type in a generic is a bit tricky to remove. Perhaps this can
   // use a hook instead.
+  // See: https://github.com/firefox-devtools/profiler/issues/3062
   // eslint-disable-next-line flowtype/no-existential-type
   return class WithSizeWrapper extends React.PureComponent<*, State> {
     _isSizeInfoDirty: boolean = false;

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -1,8 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 // @flow
+
+// This is using the existential types in the generics, which would be harder to
+// remove. It might be possible to switch this took use hooks.
+/* eslint-disable flowtype/no-existential-type */
+
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from 'firefox-profiler/utils/connect';

--- a/src/components/tooltip/GCMarker.js
+++ b/src/components/tooltip/GCMarker.js
@@ -342,7 +342,7 @@ export function getGCSliceDetails(
 
 type PhaseTimeTuple = {| name: string, time: Microseconds |};
 
-function _markerDetailPhase(p: PhaseTimeTuple): * {
+function _markerDetailPhase(p: PhaseTimeTuple) {
   return (
     <TooltipDetail key={'GC Phase - ' + p.name} label={'Phase ' + p.name}>
       {formatMilliseconds(p.time / 1000)}

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -262,7 +262,7 @@ export function shallowCloneRawMarkerTable(
   };
 }
 
-export function getResourceTypes(): * {
+export function getResourceTypes() {
   return {
     unknown: 0,
     library: 1,

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -406,7 +406,7 @@ export function correlateIPCMarkers(threads: Thread[]): IPCMarkerCorrelations {
 export function deriveMarkersFromRawMarkerTable(
   rawMarkers: RawMarkerTable,
   stringTable: UniqueStringArray,
-  threadId: number,
+  threadId: number | void,
   threadRange: StartEndRange,
   ipcCorrelations: IPCMarkerCorrelations
 ): DerivedMarkerInfo {
@@ -575,7 +575,11 @@ export function deriveMarkersFromRawMarkerTable(
         }
 
         case 'IPC': {
-          const sharedData = ipcCorrelations.get(threadId, rawMarkerIndex);
+          const sharedData = ipcCorrelations.get(
+            // Older profiles don't have a tid, but they also don't have the IPC markers.
+            threadId || 0,
+            rawMarkerIndex
+          );
           if (!sharedData) {
             // Since shared data is generated for every IPC message, this should
             // never happen unless something has gone catastrophically wrong.

--- a/src/profile-logic/profile-store.js
+++ b/src/profile-logic/profile-store.js
@@ -19,7 +19,7 @@ export class UploadAbortedError extends Error {
   name = 'UploadAbortedError';
 }
 
-export function uploadBinaryProfileData(): * {
+export function uploadBinaryProfileData() {
   const xhr = new XMLHttpRequest();
   let isAborted = false;
 

--- a/src/profile-logic/symbol-store-db.js
+++ b/src/profile-logic/symbol-store-db.js
@@ -262,7 +262,9 @@ export default class SymbolStoreDB {
     beforeDate: Date,
     callback: () => void
   ): void {
-    const lastUsedDateIndex: IDBIndex<*, Date, *> = store.index('lastUsedDate');
+    const lastUsedDateIndex: IDBIndex<any, Date, any> = store.index(
+      'lastUsedDate'
+    );
     // Get a cursor that walks all records whose lastUsedDate is less than beforeDate.
     const range = window.IDBKeyRange.upperBound(beforeDate, true);
     const cursorReq = lastUsedDateIndex.openCursor(
@@ -288,7 +290,9 @@ export default class SymbolStoreDB {
   ): void {
     // Get a cursor that walks the records from oldest to newest
     // lastUsedDate.
-    const lastUsedDateIndex: IDBIndex<*, Date, *> = store.index('lastUsedDate');
+    const lastUsedDateIndex: IDBIndex<any, Date, any> = store.index(
+      'lastUsedDate'
+    );
     const cursorReq = lastUsedDateIndex.openCursor();
     let deletedCount = 0;
     cursorReq.onsuccess = () => {

--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -50,7 +50,7 @@ type NeededThreadSelectors = {
  */
 export function getComposedSelectorsPerThread(
   threadSelectors: NeededThreadSelectors
-): * {
+) {
   /**
    * Visible tabs are computed based on the current state of the profile. Some
    * effort is made to not show a tab when there is no data available for it or

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -14,6 +14,7 @@ import { getRightClickedMarkerInfo } from '../right-clicked-marker';
 import { getLabelGetter } from '../../profile-logic/marker-schema';
 import { assertExhaustiveCheck } from '../../utils/flow';
 
+import type { ThreadSelectorsPerThread } from './thread';
 import type {
   RawMarkerTable,
   ThreadIndex,
@@ -42,7 +43,7 @@ export type MarkerSelectorsPerThread = $ReturnType<
  * Create the selectors for a thread that have to do with either markers.
  */
 export function getMarkerSelectorsPerThread(
-  threadSelectors: *,
+  threadSelectors: ThreadSelectorsPerThread,
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
 ) {

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -51,7 +51,7 @@ export function getStackAndSampleSelectorsPerThread(
   threadSelectors: ThreadSelectorsPerThread,
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
-): * {
+) {
   /**
    * The buffers of the samples can be cleared out. This function lets us know the
    * absolute range of samples that we have collected.

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -50,7 +50,7 @@ export type ThreadSelectorsPerThread = $ReturnType<
 export function getThreadSelectorsPerThread(
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
-): * {
+) {
   const getMergedThread: Selector<Thread> = createSelector(
     ProfileSelectors.getProfile,
     profile =>

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -80,8 +80,9 @@ export const getOriginsProfileView: Selector<OriginsViewState> = state =>
 /**
  * Profile View Options
  */
-export const getProfileViewOptions: Selector<*> = state =>
-  getProfileView(state).viewOptions;
+export const getProfileViewOptions: Selector<
+  $PropertyType<ProfileViewState, 'viewOptions'>
+> = state => getProfileView(state).viewOptions;
 export const getProfileRootRange: Selector<StartEndRange> = state =>
   getProfileViewOptions(state).rootRange;
 export const getSymbolicationStatus: Selector<SymbolicationStatus> = state =>
@@ -240,7 +241,7 @@ export const getCounterSelectors = (index: CounterIndex): CounterSelectors => {
  * signature of each selector is defined in the function body, and inferred in the return
  * type of the function.
  */
-function _createCounterSelectors(counterIndex: CounterIndex): * {
+function _createCounterSelectors(counterIndex: CounterIndex) {
   const getCounter: Selector<Counter> = state =>
     ensureExists(
       getProfile(state).counters,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -26,6 +26,9 @@ import type {
   StartEndRange,
   TrackIndex,
   ThreadsKey,
+  ProfileSpecificUrlState,
+  FullProfileSpecificUrlState,
+  ActiveTabSpecificProfileUrlState,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -38,11 +41,11 @@ import { formatMetaInfoString } from '../profile-logic/profile-metainfo';
  */
 export const getUrlState: Selector<UrlState> = (state): UrlState =>
   state.urlState;
-export const getProfileSpecificState: Selector<*> = state =>
+export const getProfileSpecificState: Selector<ProfileSpecificUrlState> = state =>
   getUrlState(state).profileSpecific;
-export const getFullProfileSpecificState: Selector<*> = state =>
+export const getFullProfileSpecificState: Selector<FullProfileSpecificUrlState> = state =>
   getProfileSpecificState(state).full;
-export const getActiveTabProfileSpecificState: Selector<*> = state =>
+export const getActiveTabProfileSpecificState: Selector<ActiveTabSpecificProfileUrlState> = state =>
   getProfileSpecificState(state).activeTab;
 
 export const getDataSource: Selector<DataSource> = state =>

--- a/src/selectors/zipped-profiles.js
+++ b/src/selectors/zipped-profiles.js
@@ -87,7 +87,7 @@ export const getZipFileTreeOrNull: Selector<ZipFiles.ZipFileTree | null> = creat
  * Avoid a null check, by throwing an error if trying to use zip a file when it doesn't
  * exist.
  */
-export const getZipFileTree: Selector<*> = state =>
+export const getZipFileTree: Selector<ZipFiles.ZipFileTree> = state =>
   ensureExists(
     getZipFileTreeOrNull(state),
     'Attempted to view a profile from a zip, when there is no zip file loaded.'

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -31,7 +31,7 @@ let userAgent;
 });
 
 describe('app/Home', function() {
-  function setup(userAgentToConfigure: string): * {
+  function setup(userAgentToConfigure: string) {
     userAgent = userAgentToConfigure;
     const renderResults = render(
       <Provider store={createStore()}>

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -20,7 +20,10 @@ import {
   removeRootOverlayElement,
   fireFullClick,
 } from '../fixtures/utils';
-import { getProfileWithJsTracerEvents } from '../fixtures/profiles/processed-profile';
+import {
+  getProfileWithJsTracerEvents,
+  type TestDefinedJsTracerEvent,
+} from '../fixtures/profiles/processed-profile';
 import { getShowJsTracerSummary } from '../../selectors/url-state';
 jest.useFakeTimers();
 
@@ -38,7 +41,7 @@ describe('StackChart', function() {
     events,
   }: {
     skipLoadingScreen: boolean,
-    events: Array<*>,
+    events: TestDefinedJsTracerEvent[],
   }) {
     const flushRafCalls = mockRaf();
     const ctx = mockCanvasContext();

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -764,7 +764,7 @@ describe('MarkerChart', function() {
 /**
  * This is a quick helper to create UserTiming markers.
  */
-function getUserTiming(name: string, startTime: number, endTime: number): * {
+function getUserTiming(name: string, startTime: number, endTime: number) {
   return [
     'UserTiming',
     startTime,

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -361,7 +361,7 @@ function setupSamples(
 /**
  * Setup the stack chart component with a profile.
  */
-function setup(profile: Profile, funcNames: string[] = []): * {
+function setup(profile: Profile, funcNames: string[] = []) {
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
 

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -25,7 +25,7 @@ describe('TooltipCallNode', function() {
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;
 
-    function renderTooltip(): * {
+    function renderTooltip() {
       // This component is not currently connected.
       return render(
         <Provider store={store}>

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -16,9 +16,11 @@ import { fireFullKeyPress } from '../fixtures/utils';
 import { ProfileCallTreeView } from '../../components/calltree/ProfileCallTreeView';
 import type { TransformType } from 'firefox-profiler/types';
 
+type KeyPressOptions = { key: string, ... };
+
 type TestSetup = {|
   getTransformType: () => null | TransformType,
-  pressKey: (options: *) => void,
+  pressKey: (options: KeyPressOptions) => void,
 |};
 
 function testTransformKeyboardShortcuts(setup: () => TestSetup) {
@@ -117,7 +119,7 @@ describe('flame graph transform shortcuts', () => {
       },
       // take either a key as a string, or a full event if we need more
       // information like modifier keys.
-      pressKey: (options: *) => {
+      pressKey: (options: KeyPressOptions) => {
         const div = ensureExists(
           container.querySelector('.flameGraphContent'),
           `Couldn't find the content div with selector .flameGraphContent`
@@ -167,7 +169,7 @@ describe('CallTree transform shortcuts', () => {
       },
       // take either a key as a string, or a full event if we need more
       // information like modifier keys.
-      pressKey: (options: *) => {
+      pressKey: (options: KeyPressOptions) => {
         const treeViewBody = ensureExists(
           container.querySelector('div.treeViewBody'),
           `Couldn't find the tree view body with selector div.treeViewBody`

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -20,6 +20,7 @@ import type {
   IndexIntoCategoryList,
   MarkerPayload_Gecko,
   IPCMarkerPayload_Gecko,
+  GeckoMarkerTuple,
 } from 'firefox-profiler/types';
 
 import {
@@ -82,7 +83,7 @@ export function createGeckoMarkerStack({
 
 export function createGeckoSubprocessProfile(
   parentProfile: GeckoProfile,
-  extraMarkers: * = []
+  extraMarkers: GeckoMarkerTuple[] = []
 ): GeckoSubprocessProfile {
   const contentProcessMeta: GeckoProfileShortMeta = {
     version: parentProfile.meta.version,
@@ -380,7 +381,7 @@ function _createIPCMarker({
   side,
   direction,
   phase,
-}) {
+}): GeckoMarkerTuple {
   return [
     18, // IPC: see string table in _createGeckoThread
     time,
@@ -411,7 +412,7 @@ function _createIPCMarkerSet({
   recvEndTime,
   endTime,
   messageSeqno,
-}) {
+}): GeckoMarkerTuple[] {
   return [
     _createIPCMarker({
       time: startTime,

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1251,7 +1251,7 @@ export function getThreadWithEventDelay(
  *         - E (total: 3, self: 3)
  */
 
-export function getProfileWithJsAllocations(): * {
+export function getProfileWithJsAllocations() {
   // First create a normal sample-based profile.
   const {
     profile,
@@ -1327,7 +1327,7 @@ export function getProfileWithJsAllocations(): * {
  *       - D (total: -11, self: —)
  *         - E (total: -11, self: -11)
  */
-export function getProfileWithUnbalancedNativeAllocations(): * {
+export function getProfileWithUnbalancedNativeAllocations() {
   // First create a normal sample-based profile.
   const {
     profile,
@@ -1391,7 +1391,7 @@ export function getProfileWithUnbalancedNativeAllocations(): * {
  *       - Gjs (total: 13, self: 13)
  */
 
-export function getProfileWithBalancedNativeAllocations(): * {
+export function getProfileWithBalancedNativeAllocations() {
   // First create a normal sample-based profile.
   const {
     profile,
@@ -1467,7 +1467,7 @@ export function getProfileWithBalancedNativeAllocations(): * {
 export function addActiveTabInformationToProfile(
   profile: Profile,
   activeBrowsingContextID?: BrowsingContextID
-): * {
+) {
   const firstTabBrowsingContextID = 1;
   const secondTabBrowsingContextID = 4;
   const parentInnerWindowIDsWithChildren = 11111111111;

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -172,7 +172,7 @@ export function getProfileWithNiceTracks(): Profile {
   return profile;
 }
 
-export function getStoreWithMemoryTrack(pid: number = 222): * {
+export function getStoreWithMemoryTrack(pid: number = 222) {
   const { profile } = getProfileFromTextSamples(
     // Create a trivial profile with 10 samples, all of the function "A".
     Array(10)

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -250,7 +250,7 @@ export function removeRootOverlayElement() {
  * Usage:
  * changeSelect({ from: 'Timing Data', to: 'Deallocations' });
  */
-export function createSelectChanger(renderResult: RenderResult<*>) {
+export function createSelectChanger(renderResult: RenderResult<>) {
   return function changeSelect({ from, to }: {| from: string, to: string |}) {
     // Look up the <option> with the text label.
     const option = renderResult.getByText(to);

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -21,7 +21,7 @@ import {
 import type { Profile } from 'firefox-profiler/types';
 
 describe('jsTracerFixed', function() {
-  function fixTiming(events: *) {
+  function fixTiming(events) {
     const profile = getProfileWithJsTracerEvents(events);
     const jsTracer = ensureExists(profile.threads[0].jsTracer);
     const jsTracerFixed = getJsTracerFixed(jsTracer);

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -21,7 +21,7 @@ import {
 import type { Profile } from 'firefox-profiler/types';
 
 describe('jsTracerFixed', function() {
-  function fixTiming(events) {
+  function fixTiming(events: TestDefinedJsTracerEvent[]) {
     const profile = getProfileWithJsTracerEvents(events);
     const jsTracer = ensureExists(profile.threads[0].jsTracer);
     const jsTracerFixed = getJsTracerFixed(jsTracer);

--- a/src/test/store/origins.test.js
+++ b/src/test/store/origins.test.js
@@ -69,7 +69,7 @@ function getProfileWithOrigins(...originThreads: TestDefinedOriginThread[]) {
 }
 
 describe('origins timeline', function() {
-  function setup(...originThreads: TestDefinedOriginThread[]): * {
+  function setup(...originThreads: TestDefinedOriginThread[]) {
     const store = createStore();
     const profile = getProfileWithOrigins(...originThreads);
     const { dispatch } = store;

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -55,6 +55,7 @@ import type {
   TrackReference,
   Milliseconds,
   BrowsingContextID,
+  Thread,
 } from 'firefox-profiler/types';
 
 describe('call node paths on implementation filter change', function() {
@@ -2952,7 +2953,7 @@ describe('getTimingsForSidebar', () => {
 // Verify that getFriendlyThreadName gives the expected names for threads with or without processName.
 describe('getFriendlyThreadName', function() {
   // Setup a profile with threads based on the given overrides.
-  function setup(threadOverrides: Array<*>) {
+  function setup(threadOverrides: Array<$Shape<Thread>>) {
     const profile = getEmptyProfile();
     for (const threadOverride of threadOverrides) {
       profile.threads.push(getEmptyThread(threadOverride));
@@ -3347,10 +3348,7 @@ describe('pages and active tab selectors', function() {
 });
 
 describe('traced timing', function() {
-  function setup(
-    { inverted }: {| inverted: boolean |},
-    textSamples: string
-  ): * {
+  function setup({ inverted }: {| inverted: boolean |}, textSamples: string) {
     const { profile, funcNamesDictPerThread } = getProfileFromTextSamples(
       textSamples
     );

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1419,7 +1419,7 @@ describe('actions/receive-profile', function() {
         urlSearch1: 'thread=0',
         urlSearch2: 'thread=0',
       }
-    ): * {
+    ) {
       const fakeUrl1 = `https://fakeurl.com/public/fakehash1/?${urlSearch1}&v=3`;
       const fakeUrl2 = `https://fakeurl.com/public/fakehash2/?${urlSearch2}&v=3`;
 
@@ -1429,7 +1429,7 @@ describe('actions/receive-profile', function() {
     async function setupWithShortUrl(
       profiles: SetupProfileParams,
       { urlSearch1, urlSearch2 }: SetupUrlSearchParams
-    ): * {
+    ) {
       const longUrl1 = `https://fakeurl.com/public/fakehash1/?${urlSearch1}&v=3`;
       const longUrl2 = `https://fakeurl.com/public/fakehash2/?${urlSearch2}&v=3`;
       const shortUrl1 = 'https://perfht.ml/FAKEBITLYHASH1';
@@ -1471,7 +1471,7 @@ describe('actions/receive-profile', function() {
       { profile1, profile2 }: SetupProfileParams,
       { url1, url2 }: SetupUrlParams,
       { skipMarkers }: SetupOptionsParams = {}
-    ): * {
+    ) {
       if (skipMarkers !== true) {
         profile1.threads.forEach(thread =>
           addMarkersToThreadWithCorrespondingSamples(thread, [

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -26,7 +26,7 @@ describe('sanitizePII', function() {
   function setup(
     piiConfig,
     originalProfile = processGeckoProfile(createGeckoProfile())
-  ): * {
+  ) {
     const PIIToRemove: RemoveProfileInformation = {
       shouldRemoveThreads: new Set(),
       shouldRemoveThreadsWithScreenshots: new Set(),

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -38,6 +38,15 @@ export type IndexIntoGeckoStackTable = number;
 // };
 export type MarkerPhase = 0 | 1 | 2 | 3;
 
+export type GeckoMarkerTuple = [
+  IndexIntoStringTable,
+  Milliseconds | null,
+  Milliseconds | null,
+  MarkerPhase,
+  IndexIntoCategoryList,
+  MarkerPayload_Gecko
+];
+
 export type GeckoMarkers = {
   schema: {
     name: 0,
@@ -47,16 +56,7 @@ export type GeckoMarkers = {
     category: 4,
     data: 5,
   },
-  data: Array<
-    [
-      IndexIntoStringTable,
-      Milliseconds | null,
-      Milliseconds | null,
-      MarkerPhase,
-      IndexIntoCategoryList,
-      MarkerPayload_Gecko
-    ]
-  >,
+  data: Array<GeckoMarkerTuple>,
 };
 
 /**

--- a/src/types/libdef/npm-custom/@testing-library/react_v10.x.x.js
+++ b/src/types/libdef/npm-custom/@testing-library/react_v10.x.x.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable flowtype/no-existential-type */
 
 // This file is copied from:
 // I couldn't figure out how to get the CLI to accept the proper arguments.

--- a/src/types/libdef/npm-custom/jest_v26.x.x.js
+++ b/src/types/libdef/npm-custom/jest_v26.x.x.js
@@ -1,3 +1,4 @@
+/* eslint-disable flowtype/no-existential-type */
 /* eslint-disable flowtype/no-weak-types */
 // @flow
 // This comes from https://github.com/flow-typed/flow-typed/blob/51c898e2447e35c4fbe31ff40168cc463ef53aec/definitions/npm/jest_v26.x.x/flow_v0.104.x-/jest_v26.x.x.js

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -7,6 +7,10 @@
 // triggers a false positive with this rule.
 /* eslint-disable flowtype/no-weak-types */
 
+// At this time, it's not worth migrating away from this existential type. It's
+// probably possible to move to using the built-in react-redux types.
+/* eslint-disable flowtype/no-existential-type */
+
 import * as React from 'react';
 import { connect } from 'react-redux';
 import type {


### PR DESCRIPTION
This PR is cleaning up our Flow types by mostly removing the undocumented and [deprecated existential type](https://flow.org/en/docs/linting/rule-reference/#toc-deprecated-type). It mostly causes problems, and is often used in a lazy fashion, rather than strictly typing things. It is also one of the per-requisites for #2931. I added an eslint rule to make sure we don't regress this change. Take care to review on a commit-by-commit basis, as this includes work from other PRs. I'm spreading the review load a bit, so @canova this is the first of these reviews I'm sending your way.