### PR TITLE
Remove the empty object type

### DIFF
--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -195,7 +195,7 @@ function DocsButton() {
   );
 }
 
-function InstructionTransition(props: {}) {
+function InstructionTransition(props: { children: React.Node }) {
   return (
     <CSSTransition
       {...props}

--- a/src/components/shared/ContextMenuTrigger.js
+++ b/src/components/shared/ContextMenuTrigger.js
@@ -5,8 +5,9 @@
 
 import React, { PureComponent } from 'react';
 import { ContextMenuTrigger as ReactContextMenuTrigger } from 'react-contextmenu';
+import type { MixedObject } from 'firefox-profiler/types';
 
-export class ContextMenuTrigger extends PureComponent<{}> {
+export class ContextMenuTrigger extends PureComponent<MixedObject> {
   render() {
     return <ReactContextMenuTrigger holdToDisplay={-1} {...this.props} />;
   }

--- a/src/test/fixtures/mocks/response.js
+++ b/src/test/fixtures/mocks/response.js
@@ -5,6 +5,7 @@
 // @flow
 //
 import { STATUS_CODES } from 'http';
+import type { MixedObject } from 'firefox-profiler/types';
 
 // This is a partial implementation of the Fetch API's Response object,
 // implementing just what we need for these tests.
@@ -19,7 +20,7 @@ export class Response {
     options: {|
       status: number,
       statusText?: string,
-      headers?: {},
+      headers?: MixedObject,
     |}
   ) {
     this.status = options.status || 200;

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -34,7 +34,7 @@ declare class Window {
   geckoProfilerAddonInstalled?: () => void;
   isGeckoProfilerAddonInstalled?: boolean;
   InstallTrigger?: {
-    install: MixedObject => {},
+    install: MixedObject => void,
   };
 
   // For debugging purposes, allow tooltips to persist. This aids in inspecting

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -34,7 +34,7 @@ declare class Window {
   geckoProfilerAddonInstalled?: () => void;
   isGeckoProfilerAddonInstalled?: boolean;
   InstallTrigger?: {
-    install: MixedObject => void,
+    install: MixedObject => boolean,
   };
 
   // For debugging purposes, allow tooltips to persist. This aids in inspecting


### PR DESCRIPTION
I couldn't find a lint rule for this one, but it removes the `{}` type, of which there is no equivalent in TypeScript. There were only a few instances of this in our code. Please only consider the last commit. This is a requirement for #2931.