### PR TITLE
Implement draft tooltip on select

### DIFF
--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -515,6 +515,17 @@ export class NetworkChartRow extends React.PureComponent<
             />
           </Tooltip>
         ) : null}
+        {shouldDisplayTooltips() && this.props.isSelected ? (
+          <div className="selectedTooltipContainer">
+            <TooltipMarker
+              className="selectedTooltip"
+              markerIndex={markerIndex}
+              marker={marker}
+              threadsKey={this.props.threadsKey}
+              restrictHeightWidth={true}
+            />
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -89,3 +89,24 @@
 .networkChartRowItem:hover .networkChartRowItemUriOptional {
   color: unset;
 }
+
+.selectedTooltip {
+  position: absolute;
+  z-index: 1;
+  top: -100px;
+  right: 5%;
+  width: 600px;
+  box-sizing: border-box;
+  padding: 8px;
+  border: 1px solid #ccc;
+  background-color: var(--grey-10);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  line-height: 1.4;
+  pointer-events: none;
+  text-align: left;
+  text-overflow: ellipsis;
+}
+
+.selectedTooltipContainer {
+  position: relative;
+}


### PR DESCRIPTION
Hi @julienw, 
Here's what I've done so far. It's behaving weirdly though, part of the new tooltip disappears momentarily when keying down the list for some reason. Thought might be z-index, but it wasn't. I positioned the tooltip a bit further right than you suggested for now, as I thought it'd be nice to have some more space to the left for hover tooltip, as both appear for now. I'll be happy to change this :) 
I also tried without making a new <div>, just using <TooltipMarker> without `top` property in CSS. When I did this, the tooltip followed the selected row, positioned just below each row without this issue of vanishing. I think it was quite nice, as it's closer in behaviour to the hover tooltip and not obscuring the bar. I also tried it with `fixed` position in the top right corner, which looked ok and eliminates the logic stuff but not really similar in behaviour to the hover tooltip :-/ 

Going forward, would we need a separate component for this new tooltip in order to implement the position logic? 
I'm assuming I'd need to implement some function using `pageY` state and checking the height of tooltip against the remaining height of the window, similar to Tooltip.js?

Finally, I've been looking into accessibility guidelines, which recommend having dismissible tooltips. Wonder if it's a good idea to make the tooltip dismissible with, for example, the `escape` key at some point? Just a thought. Probably not so important at this stage.

Thank you! :) 