### PR TITLE
Limit the branches that appveyor runs on

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@ clone_depth: 5
 environment:
   nodejs_version: "12"
 platform: x64 # flow needs 64b platforms
+
+branches:
+  only:
+    - main
+    - production
+
 # Install scripts. (runs after repo cloning)
 install:
   # 1. Select the right node


### PR DESCRIPTION
I was looking at appveyor results for depfu PRs and realized that appveyor was building it twice: once as a new branch, once as a PR, for example in https://github.com/firefox-devtools/profiler/pull/3055:

![image](https://user-images.githubusercontent.com/454175/99248721-31c8ec00-2809-11eb-9827-1bbd22ad7593.png)

With this change this shouldn't be the case anymore.