### PR TITLE
Persist the view query string during profile load on from-addon

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -113,10 +113,12 @@ export function setHasZoomedViaMousewheel() {
  * This function is called when we start setting up the initial url state.
  * It takes the location and profile data, converts the location into url
  * state and then dispatches relevant actions to finalize the view.
+ * `profile` parameter can be null when the data source can't provide the profile
+ * and the url upgrader step is not needed (e.g. 'from-addon').
  */
 export function setupInitialUrlState(
   location: Location,
-  profile: Profile
+  profile: Profile | null
 ): ThunkAction<void> {
   return dispatch => {
     let urlState;

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -935,7 +935,7 @@ export function retrieveProfileFromAddon(): ThunkAction<Promise<void>> {
       await getProfileFromAddon(dispatch, geckoProfiler);
     } catch (error) {
       dispatch(fatalError(error));
-      throw error;
+      console.error(error);
     }
   };
 }
@@ -1426,7 +1426,7 @@ export function getProfilesFromRawUrl(
         // for the process. Moreover we don't want to wait for the end of
         // symbolication and rather want to show the UI as soon as we get
         // the profile data.
-        dispatch(retrieveProfileFromAddon()).catch(() => {});
+        dispatch(retrieveProfileFromAddon());
         break;
       case 'public':
         await dispatch(retrieveProfileFromStore(pathParts[1], true));

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1407,9 +1407,7 @@ export function retrieveProfilesToCompare(
 // the url and processing the UrlState.
 export function getProfilesFromRawUrl(
   location: Location
-): ThunkAction<
-  Promise<{| profile: Profile | null, shouldSetupInitialUrlState: boolean |}>
-> {
+): ThunkAction<Promise<Profile | null>> {
   return async (dispatch, getState) => {
     const pathParts = location.pathname.split('/').filter(d => d);
     let dataSource = ensureIsValidDataSource(pathParts[0]);
@@ -1420,17 +1418,15 @@ export function getProfilesFromRawUrl(
     }
     dispatch(setDataSource(dataSource));
 
-    let shouldSetupInitialUrlState = true;
     switch (dataSource) {
       case 'from-addon':
       case 'unpublished':
-        shouldSetupInitialUrlState = false;
         // We don't need to `await` the result because there's no url upgrading
         // when retrieving the profile from the addon and we don't need to wait
         // for the process. Moreover we don't want to wait for the end of
         // symbolication and rather want to show the UI as soon as we get
         // the profile data.
-        dispatch(retrieveProfileFromAddon());
+        dispatch(retrieveProfileFromAddon()).catch(() => {});
         break;
       case 'public':
         await dispatch(retrieveProfileFromStore(pathParts[1], true));
@@ -1464,9 +1460,6 @@ export function getProfilesFromRawUrl(
 
     // Profile may be null only for the `from-addon` dataSource since we do
     // not `await` for retrieveProfileFromAddon function.
-    return {
-      profile: getProfileOrNull(getState()),
-      shouldSetupInitialUrlState,
-    };
+    return getProfileOrNull(getState());
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -499,9 +499,18 @@ type Location = {
   hash: string,
 };
 
+/**
+ * Create url state from window.location.
+ *
+ * `profile` parameter is nullable and optional. It's nullable because data sources
+ * like from-addon can't upgrade a url for a freshly captured profile. So we need
+ * to skip upgrading for these sources. It's also optional for only testing purpose.
+ * That way we won't have to create a profile for every time we want to create a
+ * state from location. Do not use it except testing.
+ */
 export function stateFromLocation(
   location: Location,
-  profile?: Profile
+  profile?: Profile | null
 ): UrlState {
   const { pathname, query } = upgradeLocationToCurrentVersion(
     {
@@ -670,10 +679,13 @@ type ProcessedLocationBeforeUpgrade = {|
 
 export function upgradeLocationToCurrentVersion(
   processedLocation: ProcessedLocationBeforeUpgrade,
-  profile?: Profile
+  profile?: Profile | null
 ): ProcessedLocation {
   const urlVersion = +processedLocation.query.v || 0;
-  if (urlVersion === CURRENT_URL_VERSION) {
+  if (profile === null || urlVersion === CURRENT_URL_VERSION) {
+    // Do not upgrade when either profile data is null or url is on the latest
+    // version already. Profile can be null only when the source could not provide
+    // that for upgrader and therefore upgrading step is not needed (e.g. 'from-addon').
     return processedLocation;
   }
 

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -500,13 +500,13 @@ type Location = {
 };
 
 /**
- * Create url state from window.location.
+ * Parse the window.location string to create the UrlState.
  *
  * `profile` parameter is nullable and optional. It's nullable because data sources
  * like from-addon can't upgrade a url for a freshly captured profile. So we need
- * to skip upgrading for these sources. It's also optional for only testing purpose.
- * That way we won't have to create a profile for every time we want to create a
- * state from location. Do not use it except testing.
+ * to skip upgrading for these sources. It's also optional for both testing
+ * purposes and for places where we would like to do the upgrading without
+ * providing any profile.
  */
 export function stateFromLocation(
   location: Location,

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -55,7 +55,7 @@ class ProfileLoaderImpl extends PureComponent<Props> {
     switch (dataSource) {
       case 'from-addon':
       case 'unpublished':
-        retrieveProfileFromAddon().catch(e => console.error(e));
+        retrieveProfileFromAddon();
         break;
       case 'from-file':
         // retrieveProfileFromFile should already have been called

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -107,15 +107,8 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       // case of fatal errors in the process of retrieving and processing a
       // profile. To handle the latter case properly, we won't `pushState` if
       // we're in a FATAL_ERROR state.
-      const {
-        profile,
-        shouldSetupInitialUrlState,
-      } = await getProfilesFromRawUrl(window.location);
-      if (profile !== null && shouldSetupInitialUrlState) {
-        setupInitialUrlState(window.location, profile);
-      } else {
-        urlSetupDone();
-      }
+      const profile = await getProfilesFromRawUrl(window.location);
+      setupInitialUrlState(window.location, profile);
     } catch (error) {
       // Complete the URL setup, as values can come from the user, so we should
       // still proceed with loading the app.

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -15,6 +15,7 @@ import {
   getDataSource,
   getHash,
   getCurrentSearchString,
+  getTimelineTrackOrganization,
 } from '../../selectors/url-state';
 import { waitUntilState } from '../fixtures/utils';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
@@ -313,5 +314,17 @@ describe('UrlManager', function() {
     expect(getDataSource(getState())).toMatch('public');
     expect(getHash(getState())).toMatch('SOME_OTHER_HASH');
     expect(previousLocation).toEqual(window.location.href);
+  });
+
+  it('persists view query string for `from-addon` data source', async function() {
+    const { getState, waitUntilUrlSetupPhase, createUrlManager } = setup(
+      '/from-addon/?view=active-tab'
+    );
+    await createUrlManager();
+    await waitUntilUrlSetupPhase('done');
+
+    // It should successfully preserve the view query string and update the
+    // timeline track organization state.
+    expect(getTimelineTrackOrganization(getState()).type).toBe('active-tab');
   });
 });

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -279,19 +279,13 @@ describe('UrlManager', function() {
     createUrlManager();
     await waitUntilUrlSetupPhase('done');
 
-    // FIXME: for from-addon the history gets rewritten several times at load
-    // time: once without anything in the state, and once once the state is
-    // ready. The reason is that we don't wait for the result of the "view
-    // profile" action before setting url setup to "done". There are some
-    // reasons to this but we'll likely want to change it and fix the "reason"
-    // differently.
-    expect(window.history.length).toBe(2);
+    expect(window.history.length).toBe(1);
 
     // Now the user publishes.
     dispatch(profilePublished('SOME_HASH', null));
     expect(getDataSource(getState())).toMatch('public');
     expect(getHash(getState())).toMatch('SOME_HASH');
-    expect(window.history.length).toBe(3);
+    expect(window.history.length).toBe(2);
 
     // Then wants to go back in history. This shouldn't work!
     let previousLocation = window.location.href;
@@ -302,7 +296,7 @@ describe('UrlManager', function() {
 
     // We went back, the entry number 2 has been replaced, but there are still 3
     // entries in the history.
-    expect(window.history.length).toBe(3);
+    expect(window.history.length).toBe(2);
 
     // Now let's publish again
     dispatch(profilePublished('SOME_OTHER_HASH', null));
@@ -311,7 +305,7 @@ describe('UrlManager', function() {
 
     // It's still 3 because the 3rd entry has been removed and replaced by this
     // new state (remember we were at entry number 2).
-    expect(window.history.length).toBe(3);
+    expect(window.history.length).toBe(2);
 
     // The user wants to go back, but this won't work!
     previousLocation = window.location.href;


### PR DESCRIPTION
After [Bug 1667061](https://bugzilla.mozilla.org/show_bug.cgi?id=1667061), we will be sending the view information depending on the selected preset. But with only the patches on the backend, it wasn't working properly. Because we are not properly persisting the view information on from-addon profile load. We had to also include that inside the SET_DATA_SOURCE action so we don't lose it.

I added a test for this change. But if you want to test it manually, it's a bit tricky because we are not sendin this query string from Firefox at the moment. For macOS, you can use this custom Firefox build I made for my testing (warning, I did a debug build and it's very slow :( )
[NightlyDebug.zip](https://github.com/firefox-devtools/profiler/files/5562731/NightlyDebug.zip)

STR: 
1. Enable profiler popup
2. Change the base-url to https://deploy-preview-3065--perf-html.netlify.app/ on about:config.
3. Select Web developer preset.
4. Capture a profile

Result: It should show active tab view properly with `?view=active-tab`.
