### PR TITLE
Remove mainThreadIndex from active tab main track and use threadIndexes everywhere

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -235,7 +235,7 @@ export function toggleResourcesPanel(): ThunkAction<void> {
       // If it was open when we dispatched that action, it means we are closing this panel.
       // We would like to also select the main track when we close this panel.
       const mainTrack = getActiveTabMainTrack(getState());
-      selectedThreadIndexes = new Set([mainTrack.mainThreadIndex]);
+      selectedThreadIndexes = new Set([...mainTrack.threadIndexes]);
     }
 
     // Toggle the resources panel eventually.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -417,7 +417,7 @@ export function selectActiveTabTrack(
     const currentlySelectedTab = getSelectedTab(getState());
     const currentlySelectedThreadIndex = getSelectedThreadIndexes(getState());
     // These get assigned based on the track type.
-    let selectedThreadIndex = null;
+    let selectedThreadIndexes;
     let selectedTab = currentlySelectedTab;
 
     switch (trackReference.type) {
@@ -431,7 +431,7 @@ export function selectActiveTabTrack(
         // Go through each type, and determine the selected slug and thread index.
         switch (globalTrack.type) {
           case 'tab': {
-            selectedThreadIndex = globalTrack.mainThreadIndex;
+            selectedThreadIndexes = new Set([...globalTrack.threadIndexes]);
             // Ensure a relevant thread-based tab is used.
             if (selectedTab === 'network-chart') {
               selectedTab = getLastVisibleThreadTabSlug(getState());
@@ -460,7 +460,7 @@ export function selectActiveTabTrack(
         switch (resourceTrack.type) {
           case 'sub-frame':
           case 'thread': {
-            selectedThreadIndex = resourceTrack.threadIndex;
+            selectedThreadIndexes = new Set([resourceTrack.threadIndex]);
             // Ensure a relevant thread-based tab is used.
             if (selectedTab === 'network-chart') {
               selectedTab = getLastVisibleThreadTabSlug(getState());
@@ -482,7 +482,9 @@ export function selectActiveTabTrack(
         );
     }
 
-    const doesNextTrackHaveSelectedTab = getThreadSelectors(selectedThreadIndex)
+    const doesNextTrackHaveSelectedTab = getThreadSelectors(
+      selectedThreadIndexes
+    )
       .getUsefulTabs(getState())
       .includes(selectedTab);
 
@@ -494,14 +496,14 @@ export function selectActiveTabTrack(
 
     if (
       currentlySelectedTab === selectedTab &&
-      currentlySelectedThreadIndex === selectedThreadIndex
+      currentlySelectedThreadIndex === selectedThreadIndexes
     ) {
       return;
     }
 
     dispatch({
       type: 'SELECT_TRACK',
-      selectedThreadIndexes: new Set([selectedThreadIndex]),
+      selectedThreadIndexes,
       selectedTab,
     });
   };

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -539,7 +539,7 @@ export function finalizeActiveTabProfileView(
     if (selectedThreadIndexes === null) {
       // Select the main track if there is no selected thread.
       selectedThreadIndexes = new Set([
-        activeTabTimeline.mainTrack.mainThreadIndex,
+        ...activeTabTimeline.mainTrack.threadIndexes,
       ]);
     }
 

--- a/src/components/timeline/ActiveTabGlobalTrack.js
+++ b/src/components/timeline/ActiveTabGlobalTrack.js
@@ -21,6 +21,7 @@ import TimelineTrackThread from './TrackThread';
 import TimelineTrackScreenshots from './TrackScreenshots';
 import ActiveTabResourcesPanel from './ActiveTabResourcesPanel';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import { hasThreadKeys } from 'firefox-profiler/profile-logic/profile-data';
 
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type {
@@ -165,13 +166,11 @@ export default explicitConnect<OwnProps, StateProps, DispatchProps>({
     // Run different selectors based on the track type.
     switch (globalTrack.type) {
       case 'tab': {
-        // Look up the thread information for the process if it exists.
-        if (globalTrack.mainThreadIndex !== null) {
-          const threadIndex = globalTrack.mainThreadIndex;
-          isSelected =
-            getSelectedThreadIndexes(state).has(threadIndex) &&
-            selectedTab !== 'network-chart';
-        }
+        isSelected =
+          hasThreadKeys(
+            getSelectedThreadIndexes(state),
+            globalTrack.threadsKey
+          ) && selectedTab !== 'network-chart';
         resourceTracks = getActiveTabResourceTracks(state);
         break;
       }

--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -61,6 +61,8 @@ export function computeActiveTabTracks(
   state: State
 ): ActiveTabTimeline {
   // Global tracks that are certainly global tracks.
+  // FIXME: We should revert back to full view if we failed to find a track
+  // index for the main track.
   const mainTrackIndexes = [];
   const resources = [];
   const screenshots = [];
@@ -127,9 +129,6 @@ export function computeActiveTabTracks(
   const mainTrackIndexesSet = new Set(mainTrackIndexes);
   const mainTrack: ActiveTabMainTrack = {
     type: 'tab',
-    // FIXME: We should revert back to full view if we failed to find a track
-    // index for the main track.
-    mainThreadIndex: mainTrackIndexes[0] || 0,
     threadIndexes: mainTrackIndexesSet,
     threadsKey: getThreadsKey(mainTrackIndexesSet),
   };

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -34,7 +34,7 @@ import {
   correlateIPCMarkers,
 } from './marker-data';
 import { UniqueStringArray } from '../utils/unique-string-array';
-import { ensureExists } from '../utils/flow';
+import { ensureExists, getFirstItemFromSet } from '../utils/flow';
 
 import type {
   Profile,
@@ -125,7 +125,7 @@ export function mergeProfilesForDiffing(
     if (selectedThreadIndexes === null) {
       throw new Error(`No thread has been selected in profile ${i}`);
     }
-    const selectedThreadIndex = selectedThreadIndexes.values().next().value;
+    const selectedThreadIndex = getFirstItemFromSet(selectedThreadIndexes);
     if (selectedThreadIndexes.size !== 1 || selectedThreadIndex === undefined) {
       throw new Error(
         'Only one thread selection is currently supported for the comparison view.'

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -53,7 +53,11 @@ import type {
 } from 'firefox-profiler/types';
 
 import { bisectionRight, bisectionLeft } from 'firefox-profiler/utils/bisect';
-import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
+import {
+  assertExhaustiveCheck,
+  ensureExists,
+  getFirstItemFromSet,
+} from '../utils/flow';
 
 import { timeCode } from '../utils/time-code';
 import { hashPath } from '../utils/path';
@@ -2670,7 +2674,7 @@ export function getThreadsKey(threadIndexes: Set<ThreadIndex>): ThreadsKey {
   if (threadIndexes.size === 1) {
     // Return the ThreadIndex directly if there is only one thread.
     // We know this value exists because of the size check, even if Flow doesn't.
-    return (threadIndexes.values().next().value: any);
+    return ensureExists(getFirstItemFromSet(threadIndexes));
   }
 
   return [...threadIndexes].sort((a, b) => b - a).join(',');

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -23,7 +23,7 @@ import {
   type ComposedSelectorsPerThread,
 } from './composed';
 import * as ProfileSelectors from '../profile';
-import { ensureExists } from '../../utils/flow';
+import { ensureExists, getFirstItemFromSet } from '../../utils/flow';
 
 import type { ThreadIndex, Selector, ThreadsKey } from 'firefox-profiler/types';
 
@@ -123,7 +123,9 @@ export const getThreadSelectorsFromThreadsKey = (
   if (threadIndexes.size === 1) {
     // We should get the single thread and use its caching mechanism.
     // We know this value exists because of the size check, even if Flow doesn't.
-    return getSingleThreadSelectors((threadIndexes.values().next().value: any));
+    return getSingleThreadSelectors(
+      ensureExists(getFirstItemFromSet(threadIndexes))
+    );
   }
 
   return _mergedThreadSelectorsMemoized(threadsKey);

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -30,7 +30,7 @@ import type {
 } from 'firefox-profiler/types';
 
 import type { UniqueStringArray } from '../../utils/unique-string-array';
-import { ensureExists } from '../../utils/flow';
+import { ensureExists, getFirstItemFromSet } from '../../utils/flow';
 import { mergeThreads } from '../../profile-logic/merge-compare';
 import { defaultThreadViewOptions } from '../../reducers/profile-view';
 
@@ -65,7 +65,7 @@ export function getThreadSelectorsPerThread(
   const getThread: Selector<Thread> = state =>
     threadIndexes.size === 1
       ? ProfileSelectors.getProfile(state).threads[
-          ensureExists(threadIndexes.values().next().value)
+          ensureExists(getFirstItemFromSet(threadIndexes))
         ]
       : getMergedThread(state);
   const getStringTable: Selector<UniqueStringArray> = state =>

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -5,7 +5,7 @@
 // @flow
 import escapeStringRegexp from 'escape-string-regexp';
 import { createSelector } from 'reselect';
-import { ensureExists } from '../utils/flow';
+import { ensureExists, getFirstItemFromSet } from '../utils/flow';
 import { urlFromState } from '../app-logic/url-handling';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
 import { getThreadsKey } from '../profile-logic/profile-data';
@@ -105,9 +105,7 @@ export const getSelectedThreadsKey: Selector<ThreadsKey> = state =>
  */
 export const getFirstSelectedThreadIndex: Selector<ThreadIndex> = state =>
   ensureExists(
-    getSelectedThreadIndexes(state)
-      .values()
-      .next().value,
+    getFirstItemFromSet(getSelectedThreadIndexes(state)),
     'Expected to find at least one thread index in the selected thread indexes'
   );
 export const getTimelineType: Selector<TimelineType> = state =>

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -93,12 +93,13 @@ describe('ActiveTabTimeline', function() {
       if (track.type !== 'tab') {
         throw new Error('Expected a tab track.');
       }
-      const threadIndex = getFirstItemFromSet(track.threadIndexes);
+      const threadIndex = ensureExists(
+        getFirstItemFromSet(track.threadIndexes),
+        'Expected a thread index for given active tab global track'
+      );
 
-      if (threadIndex !== undefined) {
-        // The assertions are simpler if the GeckoMain tab thread is not already selected.
-        dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
-      }
+      // The assertions are simpler if the GeckoMain tab thread is not already selected.
+      dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
 
       const renderResult = render(
         <Provider store={store}>

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -24,7 +24,7 @@ import {
 } from '../../selectors/profile';
 import { getFirstSelectedThreadIndex } from '../../selectors/url-state';
 import { changeSelectedThreads } from '../../actions/profile-view';
-import { ensureExists } from '../../utils/flow';
+import { ensureExists, getFirstItemFromSet } from '../../utils/flow';
 
 describe('ActiveTabTimeline', function() {
   beforeEach(() => {
@@ -93,9 +93,9 @@ describe('ActiveTabTimeline', function() {
       if (track.type !== 'tab') {
         throw new Error('Expected a tab track.');
       }
-      const threadIndex = (track.threadIndexes.values().next().value: any);
+      const threadIndex = getFirstItemFromSet(track.threadIndexes);
 
-      if (threadIndex !== null) {
+      if (threadIndex !== undefined) {
         // The assertions are simpler if the GeckoMain tab thread is not already selected.
         dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
       }

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -93,7 +93,7 @@ describe('ActiveTabTimeline', function() {
       if (track.type !== 'tab') {
         throw new Error('Expected a tab track.');
       }
-      const threadIndex = track.mainThreadIndex;
+      const threadIndex = (track.threadIndexes.values().next().value: any);
 
       if (threadIndex !== null) {
         // The assertions are simpler if the GeckoMain tab thread is not already selected.

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -19,7 +19,10 @@ import type {
 } from 'firefox-profiler/types';
 
 import { assertExhaustiveCheck } from '../../../utils/flow';
-import { getFriendlyThreadName } from '../../../profile-logic/profile-data';
+import {
+  getFriendlyThreadName,
+  hasThreadKeys,
+} from '../../../profile-logic/profile-data';
 import { INSTANT } from 'firefox-profiler/app-logic/constants';
 
 /**
@@ -230,8 +233,9 @@ export function getHumanReadableActiveTabTracks(state: State): string[] {
       case 'tab': {
         // Only print the main track if we actually managed to find it.
         if (globalTrack.threadIndexes.size > 0) {
-          const selected = selectedThreadIndexes.has(
-            globalTrack.mainThreadIndex
+          const selected = hasThreadKeys(
+            selectedThreadIndexes,
+            globalTrack.threadsKey
           )
             ? ' SELECTED'
             : '';

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -452,7 +452,6 @@ describe('ctxId', function() {
     expect(globalTracks).toEqual([
       {
         type: 'tab',
-        mainThreadIndex: 0,
         threadIndexes: new Set([0]),
         threadsKey: 0,
       },

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -278,7 +278,6 @@ export type OriginsTimeline = Array<
  */
 export type ActiveTabMainTrack = {|
   type: 'tab',
-  mainThreadIndex: ThreadIndex,
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey,
 |};

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -182,3 +182,10 @@ export function ensureExists<T>(item: ?T, message: ?string): T {
   }
   return item;
 }
+
+/**
+ * Returns the first item from Set in a type friendly manner.
+ */
+export function getFirstItemFromSet<T>(set: Set<T>): T | void {
+  return set.values().next().value;
+}


### PR DESCRIPTION
We had a `mainThreadIndex` field for the active tab main track before. We were using this to handle the thread clicking and stuff when we didn't have the thread merging. But since we have thread merging now, we don't need to keep that main thread index anymore. We can directly use the threadIndexes set to compute all of these. This also fixes a clicking issue on a merged thread.

[Example profile currently:](https://profiler.firefox.com/public/p5nfhp8h4xf8qz2hfkhwpcx7qvcsg37rcyr417g/calltree/?profileName=cnn.com%20Nov%202020%2C%20WebDev%20mode&resources&thread=10&v=5&view=active-tab) Try to click on the main thread. It doesn't show the merged thread correctly on the call tree panel.
[Example profile on deploy preview](https://deploy-preview-3066--perf-html.netlify.app/public/p5nfhp8h4xf8qz2hfkhwpcx7qvcsg37rcyr417g/calltree/?profileName=cnn.com%20Nov%202020%2C%20WebDev%20mode&resources&thread=10&v=5&view=active-tab)