### PR TITLE
Add a test to cover publishing and reverting using the publishing panel

### DIFF
--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -96,7 +96,10 @@ async function storeJustPublishedProfileData(
   prepublishedState: State
 ): Promise<void> {
   if (process.env.NODE_ENV === 'test' && !window.indexedDB) {
-    // bailout early in tests
+    // In tests where we're not especially testing this behavior, we may still
+    // want to test behavior related to publication. In that case we won't
+    // always have the indexeddb mock, so let's opt-out of the indexeddb-related
+    // behavior.
     return;
   }
 
@@ -298,9 +301,18 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
           )
         );
 
-        // At this moment, we don't have the profile data in state anymore.
+        // At this moment, we don't have the profile data in state anymore,
+        // because the action profileSanitized will reset all the state of
+        // profile-view, including the profile data. In the future we may want
+        // to fix this (for example move the profile data in another reducer, or
+        // keep the profile state when resetting the state).
+        // This still works because it also sets the "phase" state to
+        // "TRANSITIONING_FROM_STALE_PROFILE" that avoids rendering anything
+        // (see AppViewRouter).
         // viewProfile below needs to synchronously dispatch the new profile
-        // again.
+        // again so that the user doesn't see a glitch. This is still most
+        // probably a performance problem because all components are unmounted
+        // and mounted again.
 
         // Swap out the URL state, since the view profile calculates all of the default
         // settings. If we don't do this then we can go back in history to where we

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -95,6 +95,11 @@ async function storeJustPublishedProfileData(
   sanitizedInformation,
   prepublishedState: State
 ): Promise<void> {
+  if (process.env.NODE_ENV === 'test' && !window.indexedDB) {
+    // bailout early in tests
+    return;
+  }
+
   const zeroAt = getZeroAt(prepublishedState);
   const adjustRange = range => ({
     start: range.start - zeroAt,
@@ -292,6 +297,11 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
             prePublishedState
           )
         );
+
+        // At this moment, we don't have the profile data in state anymore.
+        // viewProfile below needs to synchronously dispatch the new profile
+        // again.
+
         // Swap out the URL state, since the view profile calculates all of the default
         // settings. If we don't do this then we can go back in history to where we
         // are trying to view a profile without valid view settings.

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -4,7 +4,14 @@
 
 // @flow
 import * as React from 'react';
+
 import { MetaOverheadStatistics } from './MetaOverheadStatistics';
+import {
+  getProfile,
+  getSymbolicationStatus,
+} from 'firefox-profiler/selectors/profile';
+import { resymbolicateProfile } from 'firefox-profiler/actions/receive-profile';
+
 import {
   formatBytes,
   formatTimestamp,
@@ -14,23 +21,29 @@ import {
   formatPlatform,
 } from 'firefox-profiler/profile-logic/profile-metainfo';
 
-import type { Profile, SymbolicationStatus } from 'firefox-profiler/types';
-
-import { typeof resymbolicateProfile } from 'firefox-profiler/actions/receive-profile';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import explicitConnect from 'firefox-profiler/utils/connect';
+
+import type { Profile, SymbolicationStatus } from 'firefox-profiler/types';
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import './MetaInfo.css';
 
-type Props = {|
-  +profile: Profile,
-  +symbolicationStatus: SymbolicationStatus,
-  +resymbolicateProfile: resymbolicateProfile,
-|};
+type StateProps = $ReadOnly<{|
+  profile: Profile,
+  symbolicationStatus: SymbolicationStatus,
+|}>;
+
+type DispatchProps = $ReadOnly<{|
+  resymbolicateProfile: typeof resymbolicateProfile,
+|}>;
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 /**
  * This component formats the profile's meta information into a dropdown panel.
  */
-export class MetaInfoPanel extends React.PureComponent<Props> {
+class MetaInfoPanelImpl extends React.PureComponent<Props> {
   /**
    * This method provides information about the symbolication status, and a button
    * to re-trigger symbolication.
@@ -275,3 +288,14 @@ function _formatDate(timestamp: number): string {
   });
   return timestampDate;
 }
+
+export const MetaInfoPanel = explicitConnect<{||}, StateProps, DispatchProps>({
+  mapStateToProps: state => ({
+    profile: getProfile(state),
+    symbolicationStatus: getSymbolicationStatus(state),
+  }),
+  mapDispatchToProps: {
+    resymbolicateProfile,
+  },
+  component: MetaInfoPanelImpl,
+});

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -11,11 +11,7 @@ import './index.css';
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from 'firefox-profiler/utils/connect';
-import {
-  getProfile,
-  getProfileRootRange,
-  getSymbolicationStatus,
-} from 'firefox-profiler/selectors/profile';
+import { getProfileRootRange } from 'firefox-profiler/selectors/profile';
 import {
   getDataSource,
   getTimelineTrackOrganization,
@@ -36,18 +32,12 @@ import {
   getHasPrePublishedState,
 } from 'firefox-profiler/selectors/publish';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
-
-import {
-  resymbolicateProfile,
-  changeTimelineTrackOrganization,
-} from 'firefox-profiler/actions/receive-profile';
+import { changeTimelineTrackOrganization } from 'firefox-profiler/actions/receive-profile';
 
 import type {
   StartEndRange,
-  Profile,
   DataSource,
   UploadPhase,
-  SymbolicationStatus,
   TimelineTrackOrganization,
 } from 'firefox-profiler/types';
 
@@ -62,13 +52,11 @@ type OwnProps = {|
 |};
 
 type StateProps = {|
-  +profile: Profile,
   +rootRange: StartEndRange,
   +dataSource: DataSource,
   +isNewlyPublished: boolean,
   +uploadPhase: UploadPhase,
   +hasPrePublishedState: boolean,
-  +symbolicationStatus: SymbolicationStatus,
   +abortFunction: () => mixed,
   +timelineTrackOrganization: TimelineTrackOrganization,
 |};
@@ -76,7 +64,6 @@ type StateProps = {|
 type DispatchProps = {|
   +dismissNewlyPublished: typeof dismissNewlyPublished,
   +revertToPrePublishedState: typeof revertToPrePublishedState,
-  +resymbolicateProfile: typeof resymbolicateProfile,
   +changeTimelineTrackOrganization: typeof changeTimelineTrackOrganization,
 |};
 
@@ -108,12 +95,7 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
   }
 
   _renderMetaInfoButton() {
-    const {
-      profile,
-      symbolicationStatus,
-      resymbolicateProfile,
-      dataSource,
-    } = this.props;
+    const { dataSource } = this.props;
     const uploadedStatus = this._getUploadedStatus(dataSource);
     return (
       <ButtonWithPanel
@@ -122,13 +104,7 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
           uploadedStatus === 'uploaded' ? 'Uploaded Profile' : 'Local Profile'
         }
         panelClassName="metaInfoPanel"
-        panelContent={
-          <MetaInfoPanel
-            profile={profile}
-            symbolicationStatus={symbolicationStatus}
-            resymbolicateProfile={resymbolicateProfile}
-          />
-        }
+        panelContent={<MetaInfoPanel />}
       />
     );
   }
@@ -257,20 +233,17 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
 export const MenuButtons = explicitConnect<OwnProps, StateProps, DispatchProps>(
   {
     mapStateToProps: state => ({
-      profile: getProfile(state),
       rootRange: getProfileRootRange(state),
       dataSource: getDataSource(state),
       isNewlyPublished: getIsNewlyPublished(state),
       uploadPhase: getUploadPhase(state),
       hasPrePublishedState: getHasPrePublishedState(state),
-      symbolicationStatus: getSymbolicationStatus(state),
       abortFunction: getAbortFunction(state),
       timelineTrackOrganization: getTimelineTrackOrganization(state),
     }),
     mapDispatchToProps: {
       dismissNewlyPublished,
       revertToPrePublishedState,
-      resymbolicateProfile,
       changeTimelineTrackOrganization,
     },
     component: MenuButtonsImpl,

--- a/src/components/shared/ButtonWithPanel/ArrowPanel.js
+++ b/src/components/shared/ButtonWithPanel/ArrowPanel.js
@@ -40,7 +40,6 @@ export class ArrowPanel extends React.PureComponent<Props, State> {
     }
 
     this.setState({ open: true });
-    this.props.onOpen();
   }
 
   close() {
@@ -51,8 +50,6 @@ export class ArrowPanel extends React.PureComponent<Props, State> {
       const openGeneration = state.openGeneration + 1;
 
       setTimeout(this._onCloseAnimationFinish(openGeneration), 400);
-
-      this.props.onClose();
 
       return { open: false, isClosing: true, openGeneration };
     });
@@ -79,6 +76,20 @@ export class ArrowPanel extends React.PureComponent<Props, State> {
       e.stopPropagation();
     }
   };
+
+  // We're calling open and close callbacks in componentDidUpdate because they
+  // often run side-effects, so we want them out of the render phase.
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (!prevState.open && this.state.open) {
+      // Opening
+      this.props.onOpen();
+    }
+
+    if (prevState.open && !this.state.open) {
+      // Closing
+      this.props.onClose();
+    }
+  }
 
   render() {
     const { className, children } = this.props;

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -23,18 +23,8 @@ import { mockDate } from 'firefox-profiler/test/fixtures/mocks/date';
 import { fireFullClick } from 'firefox-profiler/test/fixtures/utils';
 import { Response } from 'firefox-profiler/test/fixtures/mocks/response';
 
-import 'fake-indexeddb/auto';
-import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
-
-function resetIndexedDb() {
-  // This is the recommended way to reset the IDB state between test runs, but
-  // neither flow nor eslint like that we assign to indexedDB directly, for
-  // different reasons.
-  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
-  indexedDB = new FDBFactory();
-}
-beforeEach(resetIndexedDb);
-afterEach(resetIndexedDb);
+import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
+autoMockIndexedDB();
 
 const listOfProfileInformations = [
   {

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -33,8 +33,10 @@ import { fireFullClick } from '../fixtures/utils';
 
 import type { Profile } from 'firefox-profiler/types';
 
-import 'fake-indexeddb/auto';
-import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
+// We need IndexedDB to get a SymbolStore that's necessary for symbolication
+// to even start, in some of the tests for this file.
+import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
+autoMockIndexedDB();
 
 // We mock profile-store but we want the real error, so that we can simulate it.
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';
@@ -59,18 +61,6 @@ jest.mock('firefox-profiler/profile-logic/symbolication');
 
 // Mock hash
 const hash = 'c5e53f9ab6aecef926d4be68c84f2de550e2ac2f';
-
-// We need IndexedDB to get a SymbolStore that's necessary for symbolication
-// to even start, in some of the tests for this file.
-function resetIndexedDb() {
-  // This is the recommended way to reset the IDB state between test runs, but
-  // neither flow nor eslint like that we assign to indexedDB directly, for
-  // different reasons.
-  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
-  indexedDB = new FDBFactory();
-}
-beforeEach(resetIndexedDb);
-afterEach(resetIndexedDb);
 
 describe('app/MenuButtons', function() {
   function mockUpload() {

--- a/src/test/components/UploadedRecordingsHome.test.js
+++ b/src/test/components/UploadedRecordingsHome.test.js
@@ -13,18 +13,8 @@ import { storeProfileData } from 'firefox-profiler/app-logic/published-profiles-
 import { blankStore } from '../fixtures/stores';
 import { mockDate } from '../fixtures/mocks/date';
 
-import 'fake-indexeddb/auto';
-import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
-
-function resetIndexedDb() {
-  // This is the recommended way to reset the IDB state between test runs, but
-  // neither flow nor eslint like that we assign to indexedDB directly, for
-  // different reasons.
-  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
-  indexedDB = new FDBFactory();
-}
-beforeEach(resetIndexedDb);
-afterEach(resetIndexedDb);
+import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
+autoMockIndexedDB();
 
 describe('UploadedRecordingsHome', () => {
   function setup() {

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -615,6 +615,85 @@ exports[`<MetaInfoPanel> with no statistics object should not make the app crash
 </div>
 `;
 
+exports[`app/MenuButtons <Publish> can publish and revert 1`] = `
+<body>
+  <div>
+    <button
+      class="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertButton"
+      type="button"
+    >
+      Revert to Original Profile
+    </button>
+    <div
+      class="buttonWithPanel"
+    >
+      <button
+        aria-expanded="false"
+        class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-uploaded"
+        type="button"
+      >
+        Uploaded Profile
+      </button>
+    </div>
+    <div
+      class="buttonWithPanel"
+    >
+      <button
+        aria-expanded="false"
+        class="buttonWithPanelButton menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon"
+        type="button"
+      >
+        Re-upload
+      </button>
+    </div>
+    <div
+      class="buttonWithPanel open"
+    >
+      <button
+        aria-expanded="true"
+        class="buttonWithPanelButton menuButtonsButton menuButtonsButton-hasIcon menuButtonsPermalinkButtonButton"
+        type="button"
+      >
+        Permalink
+      </button>
+      <div
+        class="arrowPanelAnchor"
+      >
+        <div
+          class="arrowPanel open menuButtonsPermalinkPanel"
+        >
+          <div
+            class="arrowPanelArrow"
+          />
+          <div
+            class="arrowPanelContent"
+          >
+            <input
+              class="menuButtonsPermalinkTextField photon-input"
+              data-testid="MenuButtonsPermalink-input"
+              readonly=""
+              type="text"
+              value="https://profiler.firefox.com/"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <a
+      class="menuButtonsButton menuButtonsButton-hasLeftBorder"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
+    >
+      Docs
+      <i
+        class="open-in-new"
+      />
+    </a>
+  </div>
+</body>
+`;
+
 exports[`app/MenuButtons <Publish> matches the snapshot for an error 1`] = `
 <div
   class="menuButtonsPublishUpload"

--- a/src/test/fixtures/mocks/indexeddb.js
+++ b/src/test/fixtures/mocks/indexeddb.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// This file implements a fake indexeddb database using the fake-indexeddb
+// library.
+
+import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
+
+function resetIndexedDb() {
+  // This is the recommended way to reset the IDB state between test runs, but
+  // neither flow nor eslint like that we assign to indexedDB directly, for
+  // different reasons.
+  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
+  indexedDB = new FDBFactory();
+}
+
+export function autoMockIndexedDB() {
+  // This require has a side-effect that's not possible to have with a function
+  // call, and that we want to happen only when calling autoMockIndexedDB.
+  // That's why we require it instead of importing.
+  require('fake-indexeddb/auto');
+
+  beforeEach(resetIndexedDb);
+  afterEach(resetIndexedDb);
+}

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -48,8 +48,6 @@ import {
   commitRange,
 } from '../../actions/profile-view';
 
-import 'fake-indexeddb/auto';
-import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
 import {
   retrieveProfileData,
   listAllProfileData,
@@ -57,22 +55,15 @@ import {
 
 import type { Store } from 'firefox-profiler/types';
 
+import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
+autoMockIndexedDB();
+
 // We mock profile-store but we want the real error, so that we can simulate it.
 import { uploadBinaryProfileData } from '../../profile-logic/profile-store';
 jest.mock('../../profile-logic/profile-store');
 const { UploadAbortedError } = jest.requireActual(
   '../../profile-logic/profile-store'
 );
-
-function resetIndexedDb() {
-  // This is the recommended way to reset the IDB state between test runs, but
-  // neither flow nor eslint like that we assign to indexedDB directly, for
-  // different reasons.
-  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
-  indexedDB = new FDBFactory();
-}
-beforeEach(resetIndexedDb);
-afterEach(resetIndexedDb);
 
 describe('getCheckedSharingOptions', function() {
   describe('default filtering by channel', function() {

--- a/src/test/unit/published-profiles-store.test.js
+++ b/src/test/unit/published-profiles-store.test.js
@@ -7,9 +7,6 @@
 // Main use cases of storing profiles are tested in the publish flow
 // (test/store/publish.test.js). In this file we'll test more specific cases.
 
-import 'fake-indexeddb/auto';
-import FDBFactory from 'fake-indexeddb/lib/FDBFactory';
-
 import {
   storeProfileData,
   listAllProfileData,
@@ -18,15 +15,8 @@ import {
   type ProfileData,
 } from 'firefox-profiler/app-logic/published-profiles-store';
 
-function resetIndexedDb() {
-  // This is the recommended way to reset the IDB state between test runs, but
-  // neither flow nor eslint like that we assign to indexedDB directly, for
-  // different reasons.
-  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
-  indexedDB = new FDBFactory();
-}
-beforeEach(resetIndexedDb);
-afterEach(resetIndexedDb);
+import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
+autoMockIndexedDB();
 
 describe('published-profiles-store', function() {
   async function storeGenericProfileData(overrides: $Shape<ProfileData>) {


### PR DESCRIPTION
In this patch, the initial goal is to add a test to cover publishing and reverting using the UI. Especially I was surprised that in #3029 moving the revert button didn't fail any test.

#### The problem

But doing that I got a problem: indeed during this process, if we sanitize the profile, at one moment, `getProfile` fails, because we first reset the profile-view state in:
https://github.com/firefox-devtools/profiler/blob/144758c017b06f761374f249ebe07e8bdd7a8fbf/src/reducers/profile-view.js#L622-L627
and only then set the profile again by calling `viewProfile`:
https://github.com/firefox-devtools/profiler/blob/144758c017b06f761374f249ebe07e8bdd7a8fbf/src/actions/publish.js#L286-L303

In-between, because `<MenuButtons>` calls `getProfile`, we crash. In the "real" project, this doesn't happen, because we use another state to prevent rendering in this state:
https://github.com/firefox-devtools/profiler/blob/144758c017b06f761374f249ebe07e8bdd7a8fbf/src/components/app/AppViewRouter.js#L104-L105

#### Solutions?
There were a few solutions:
1. Change `AppViewRouter` to render `children` in the `DATA_LOADED` phase instead of hardcoding the component:
https://github.com/firefox-devtools/profiler/blob/144758c017b06f761374f249ebe07e8bdd7a8fbf/src/components/app/AppViewRouter.js#L99-L103
   This would need to connect the Root component, or extract this `hasZipFile` conditioning rendering to another connected component.
   Then in tests we could use `AppViewRouter` with only `<MenuButtons>`

2. Change `AppViewRouter` to take an optional prop `renderComponent`. It would use this prop to render if present, and otherwise use the hardcoded viewers. This would avoid changing too many other code, at the price of more complexity. Also test-specific properties aren't really a good idea.

3. Implement a hack in tests with a special test-specific component that would _only_ check this phase. In short, implement the same behavior as `AppViewRouter` but much simpler.

But none of them sounded really good.

#### Solution!
Then I got another idea: eliminate the need of using `getProfile` in the first place. And that's indeed possible: it's used only in the `MetaInfoPanel`, so all we need is making `MetaInfoPanel` a connected component, so that it would take this information directly from the state instead of getting it from props. That's the solution I used here, and this is the first and second commit.
There are 2 commits because updating the test proved more difficult than I initially thought (turns out that testing non-connected components is super easy compared to connected component involving a full store 😫). I also wanted to retain all previous testcases.

#### OK now, what were we doing again?
Then in the 3rd commit, you'll find the new test.

You'll see that in all tests I decided to use the `screen` object instead of using the render result's functions. This is much easier to use indeed.

I'll also be adding a few more inline comments to highlight the thought process in some locations.

I suggest looking at commits separately, that should be easier like that.

#### Deploy preview
There should be no behavior change with this patch.

[main](https://main--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&thread=0&v=5)
[deploy preview](https://deploy-preview-3069--perf-html.netlify.app/public/82c7f2e3bc71f8d23cfd7d625073517bdb6133c7/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&thread=0&v=5)