### PR TITLE
Fix screenshot stacking with respect to permalink overlay

### DIFF
--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -98,6 +98,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
                 }
           }
         >
+          <div id="screenshot-hover"></div>
           <div className="profileViewerTopBar">
             {hasZipFile ? (
               <button

--- a/src/components/shared/ButtonWithPanel/ArrowPanel.css
+++ b/src/components/shared/ButtonWithPanel/ArrowPanel.css
@@ -4,7 +4,7 @@
 
 .arrowPanelAnchor {
   position: absolute;
-  z-index: 10;
+  z-index: 5;
   top: 75%;
   left: 50%;
 }

--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -229,9 +229,9 @@ type HoverPreviewProps = {|
 const MAXIMUM_HOVER_SIZE = 350;
 
 class HoverPreview extends PureComponent<HoverPreviewProps> {
-  _overlayElement = ensureExists(
-    document.querySelector('#root-overlay'),
-    'Expected to find a root overlay element.'
+  _screenshotHoverElement = ensureExists(
+    document.querySelector('#screenshot-hover'),
+    'Expected to find a screenshot hover element.'
   );
 
   render() {
@@ -299,7 +299,7 @@ class HoverPreview extends PureComponent<HoverPreviewProps> {
           }}
         />
       </div>,
-      this._overlayElement
+      this._screenshotHoverElement
     );
   }
 }

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -25,8 +25,8 @@ import { storeWithProfile } from '../fixtures/stores';
 import {
   getBoundingBox,
   getMouseEvent,
-  addRootOverlayElement,
-  removeRootOverlayElement,
+  addScreenshotHoverlement,
+  removeScreenshotHoverElement,
   fireFullClick,
 } from '../fixtures/utils';
 import { getScreenshotTrackProfile } from '../fixtures/profiles/processed-profile';
@@ -42,8 +42,8 @@ const TOP = 7;
 describe('timeline/TrackScreenshots', function() {
   autoMockDomRect();
 
-  beforeEach(addRootOverlayElement);
-  afterEach(removeRootOverlayElement);
+  beforeEach(addScreenshotHoverlement);
+  afterEach(removeScreenshotHoverElement);
 
   it('matches the component snapshot', () => {
     const { container, unmount } = setup();

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -243,6 +243,27 @@ export function removeRootOverlayElement() {
   );
 }
 
+export function addScreenshotHoverlement() {
+  const div = document.createElement('div');
+  div.id = 'screenshot-hover';
+  ensureExists(
+    document.body,
+    'Expected the document.body to exist.'
+  ).appendChild(div);
+}
+
+export function removeScreenshotHoverElement() {
+  ensureExists(
+    document.body,
+    'Expected the document.body to exist.'
+  ).removeChild(
+    ensureExists(
+      document.querySelector('#screenshot-hover'),
+      'Expected to find a screenshot hover element to clean up.'
+    )
+  );
+}
+
 /**
  * You can't change <select>s by just clicking them using react-testing-library. This
  * utility makes it so that selects can be changed by the text that is in them.


### PR DESCRIPTION
This pull request changes the way screenshot-hover is rendered so that it has same parent stacking context as permalink, and therefore enables the stacking to be ordered by their z-index.
Fixes #1274