### PR TITLE
Add a new datasource "unpublished" as an alias to "from-addon"

### DIFF
--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -302,15 +302,16 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
           dispatch(viewProfile(profile));
         });
       } else {
+        const dataSource = getDataSource(prePublishedState);
+        const isUnpublished =
+          dataSource === 'unpublished' || dataSource === 'from-addon';
         dispatch(
           profilePublished(
             hash,
             // Only include the pre-published state if we want to be able to revert
             // the profile. If we are viewing from-addon, then it's only a single
             // profile.
-            getDataSource(prePublishedState) === 'from-addon'
-              ? null
-              : prePublishedState
+            isUnpublished ? null : prePublishedState
           )
         );
       }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -37,7 +37,7 @@ import {
 import {
   withHistoryReplaceStateAsync,
   stateFromLocation,
-  getDataSourceFromPathParts,
+  ensureIsValidDataSource,
 } from 'firefox-profiler/app-logic/url-handling';
 import {
   initializeLocalTrackOrderByPid,
@@ -1401,7 +1401,7 @@ export function getProfilesFromRawUrl(
 > {
   return async (dispatch, getState) => {
     const pathParts = location.pathname.split('/').filter(d => d);
-    let dataSource = getDataSourceFromPathParts(pathParts);
+    let dataSource = ensureIsValidDataSource(pathParts[0]);
     if (dataSource === 'from-file') {
       // Redirect to 'none' if `dataSource` is 'from-file' since initial urls can't
       // be 'from-file' and needs to be redirected to home page.
@@ -1412,6 +1412,7 @@ export function getProfilesFromRawUrl(
     let shouldSetupInitialUrlState = true;
     switch (dataSource) {
       case 'from-addon':
+      case 'unpublished':
         shouldSetupInitialUrlState = false;
         // We don't need to `await` the result because there's no url upgrading
         // when retrieving the profile from the addon and we don't need to wait

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -16,6 +16,7 @@ import {
 import {
   assertExhaustiveCheck,
   toValidTabSlug,
+  coerce,
   ensureExists,
 } from 'firefox-profiler/utils/flow';
 import { toValidCallTreeSummaryStrategy } from 'firefox-profiler/profile-logic/profile-data';
@@ -111,13 +112,12 @@ function getPathParts(urlState: UrlState): string[] {
     case 'uploaded-recordings':
       return ['uploaded-recordings'];
     case 'from-addon':
-      return ['from-addon', urlState.selectedTab];
+    case 'unpublished':
     case 'from-file':
-      return ['from-file', urlState.selectedTab];
-    case 'local':
-      return ['local', urlState.hash, urlState.selectedTab];
+      return [dataSource, urlState.selectedTab];
     case 'public':
-      return ['public', urlState.hash, urlState.selectedTab];
+    case 'local':
+      return [dataSource, urlState.hash, urlState.selectedTab];
     case 'from-url':
       return [
         'from-url',
@@ -255,6 +255,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
     case 'public':
     case 'local':
     case 'from-addon':
+    case 'unpublished':
     case 'from-file':
     case 'from-url':
       break;
@@ -461,21 +462,30 @@ export function urlFromState(urlState: UrlState): string {
   return pathname + (qString ? '?' + qString : '');
 }
 
-export function getDataSourceFromPathParts(pathParts: string[]): DataSource {
-  const str = pathParts[0] || 'none';
-  // With this switch, flow is able to understand that we return a valid value
-  switch (str) {
+export function ensureIsValidDataSource(
+  possibleDataSource: string | void
+): DataSource {
+  // By casting `possibleDataSource` to a DataSource beforehand, we let Flow
+  // enforce that we look at all possible values.
+  const coercedDataSource = coerce<string, DataSource>(
+    possibleDataSource || 'none'
+  );
+  switch (coercedDataSource) {
     case 'none':
     case 'from-addon':
+    case 'unpublished':
     case 'from-file':
     case 'local':
     case 'public':
     case 'from-url':
     case 'compare':
     case 'uploaded-recordings':
-      return str;
+      return coercedDataSource;
     default:
-      throw new Error(`Unexpected data source ${str}`);
+      throw assertExhaustiveCheck(
+        coercedDataSource,
+        `Unexpected data source ${coercedDataSource}`
+      );
   }
 }
 
@@ -505,7 +515,7 @@ export function stateFromLocation(
   );
 
   const pathParts = pathname.split('/').filter(d => d);
-  const dataSource = getDataSourceFromPathParts(pathParts);
+  const dataSource = ensureIsValidDataSource(pathParts[0]);
   const selectedThreadsList: ThreadIndex[] =
     // Either a single thread index, or a list separated by commas.
     query.thread !== undefined ? query.thread.split(',').map(n => +n) : [];

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -27,7 +27,8 @@ import type { AppViewState, State, DataSource } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 const ERROR_MESSAGES: { [string]: string } = Object.freeze({
-  'from-addon': "Couldn't retrieve the profile from the Firefox.",
+  'from-addon': "Couldn't retrieve the profile from Firefox.",
+  unpublished: "Couldn't retrieve the profile from Firefox.",
   'from-file': "Couldn't read the file or parse the profile in it.",
   local: 'Not implemented yet.',
   public: 'Could not download the profile.',
@@ -63,6 +64,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
       case 'uploaded-recordings':
         return <UploadedRecordingsHome />;
       case 'from-addon':
+      case 'unpublished':
       case 'from-file':
       case 'local':
       case 'public':

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -95,6 +95,7 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
       case 'from-url':
         return 'uploaded';
       case 'from-addon':
+      case 'unpublished':
       case 'from-file':
         return 'local';
       case 'none':

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -54,6 +54,7 @@ class ProfileLoaderImpl extends PureComponent<Props> {
     } = this.props;
     switch (dataSource) {
       case 'from-addon':
+      case 'unpublished':
         retrieveProfileFromAddon().catch(e => console.error(e));
         break;
       case 'from-file':

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -17,6 +17,7 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 const LOADING_MESSAGES: { [string]: string } = Object.freeze({
   'from-addon': 'Importing the profile directly from Firefox...',
+  unpublished: 'Importing the profile directly from Firefox...',
   'from-file': 'Reading the file and processing the profile...',
   local: 'Not implemented yet.',
   public: 'Downloading and processing the profile...',

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -145,6 +145,7 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
         return false;
       case 'from-file':
       case 'from-addon':
+      case 'unpublished':
       case 'public':
       case 'from-url':
       case 'compare':
@@ -192,6 +193,7 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
         return true;
       case 'from-file':
       case 'from-addon':
+      case 'unpublished':
         // We should not propose to reload the page for these data sources,
         // because we'd lose the data.
         return false;

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -156,11 +156,11 @@ class UrlManagerImpl extends React.PureComponent<Props> {
     // 1. Do we move between "from-addon" and "public"?
     const movesBetweenFromAddonAndPublic =
       // from-addon -> public
-      (previousUrlState.dataSource === 'from-addon' &&
+      (['from-addon', 'unpublished'].includes(previousUrlState.dataSource) &&
         newUrlState.dataSource === 'public') ||
       // or public -> from-addon
       (previousUrlState.dataSource === 'public' &&
-        newUrlState.dataSource === 'from-addon');
+        ['from-addon', 'unpublished'].includes(newUrlState.dataSource));
 
     // 2. Do we move between 2 different hashes for a public profile
     const movesBetweenHashValues =

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -34,7 +34,14 @@ import type { CssPixels, StartEndRange, Milliseconds } from './units';
 export type DataSource =
   | 'none'
   | 'from-file'
+  //  This datasource is used to fetch a profile from Firefox. This used to be
+  //  handled by an addon, hence the name, but now this is all inside Firefox.
   | 'from-addon'
+  // This is an alias for 'from-addon' until we phase that one out. We
+  // introduced it when implementing the "delete profile" functionality, because
+  // `from-addon` didn't suit this use-case well. In the future we want to
+  // completely replace `from-addon` with this one.
+  | 'unpublished'
   | 'local'
   | 'public'
   | 'from-url'


### PR DESCRIPTION
As we discussed on Matrix!

I didn't add any test because of the plan is to retire `from-addon` later, we'll be able to convert all existing tests to `unpublished`.

There shouldn't be any visible change. I tested capturing with this code to make sure that at least the `from-addon` dataSource wasn't broken.

I wasn't sure which deploy-preview URL to use, but here is the home: [deploy-preview](https://deploy-preview-3082--perf-html.netlify.app/)