### PR TITLE
In ArrowPanel, wait for the animation timeout before calling onClose

### DIFF
--- a/src/components/shared/ButtonWithPanel/ArrowPanel.js
+++ b/src/components/shared/ButtonWithPanel/ArrowPanel.js
@@ -85,8 +85,8 @@ export class ArrowPanel extends React.PureComponent<Props, State> {
       this.props.onOpen();
     }
 
-    if (prevState.open && !this.state.open) {
-      // Closing
+    if (!this.state.open && prevState.isClosing && !this.state.isClosing) {
+      // Closing... but only after the animation.
       this.props.onClose();
     }
   }

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -97,6 +97,7 @@ describe('shared/ButtonWithPanel', () => {
       keyCode: 27,
       which: 27,
     });
+    jest.runAllTimers();
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -113,6 +114,7 @@ describe('shared/ButtonWithPanel', () => {
     );
     fireFullClick(newDiv);
 
+    jest.runAllTimers();
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
+++ b/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
@@ -44,24 +44,6 @@ exports[`shared/ButtonWithPanel opens the panel when the button is clicked and c
   >
     My Button
   </button>
-  <div
-    class="arrowPanelAnchor"
-  >
-    <div
-      class="arrowPanel panel"
-    >
-      <div
-        class="arrowPanelArrow"
-      />
-      <div
-        class="arrowPanelContent"
-      >
-        <div>
-          Panel content
-        </div>
-      </div>
-    </div>
-  </div>
 </div>
 `;
 
@@ -109,24 +91,6 @@ exports[`shared/ButtonWithPanel opens the panel when the button is clicked and c
   >
     My Button
   </button>
-  <div
-    class="arrowPanelAnchor"
-  >
-    <div
-      class="arrowPanel panel"
-    >
-      <div
-        class="arrowPanelArrow"
-      />
-      <div
-        class="arrowPanelContent"
-      >
-        <div>
-          Panel content
-        </div>
-      </div>
-    </div>
-  </div>
 </div>
 `;
 


### PR DESCRIPTION
Please look at the last commit only, as this is on top of #3069 that you reviewed today. I didn't want to include it there because this actually changes some behavior, and I wanted #3069 to not change the behavior.

#### The problem
By calling `onClose` too soon, the users of this panel are changing their states while the panel is still visible. Most of the time this isn't very visible, just sometimes some panels would disappear too fast. But in the "delete profile" work, the _content_ of a panel is changing because of this, and this is very visible.

#### Effect of this patch and deploy preview
This patch waits until the end of the animation before calling the `onClose` callback. We already had a local state tracking this so all I did is using it in the `componentDidUpdate` function.

You can see the effect of this especially in the uploaded recordings page. Indeed the "delete confirmation" panel was disappearing very fast, because we were setting some state too early. This was happening for both the "delete confirmation" panel and the "delete successful" message.

Other visible behavior changes should be very subtle. For example I believe that the buttons in the menubar would change their color after the animation now, while previously they were changing right at the start of the animation.

Here is the deploy preview for the recording page:
* [production](https://profiler.firefox.com/uploaded-recordings/)
* [deploy preview](https://deploy-preview-3083--perf-html.netlify.app/uploaded-recordings/)

Obviously you'll have to reupload a profile first so that it shows up in this view. [Here is a handy deploy preview link for a profile](https://deploy-preview-3083--perf-html.netlify.app/public/qnbs68w9m0xgeshq1sc51aks9zxfnkfzymbqy48/marker-chart/?globalTrackOrder=0&localTrackOrderByPid=30923-1-2-0~&markerSearch=ArrowPanel&thread=0&v=5).

(incidentally, because calling `onClose` is now asynchronous from the state cycle, maybe I wouldn't need to move all this to `componentDidUpdate`... But this is still probably cleaner.)
