### PR TITLE
Remove the "file" parameter when publishing a profile from a zip file

### DIFF
--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -109,6 +109,10 @@ async function storeJustPublishedProfileData(
     end: range.end - zeroAt,
   });
 
+  // We'll persist any computed profileName, because we may lose it otherwise
+  // (This is the case with zip files).
+  const profileName = getProfileNameForStorage(prepublishedState);
+
   // The url predictor returns the URL that would be serialized out of the state
   // resulting of the actions passed in argument.
   // We need this here because the action of storing the profile data in the DB
@@ -131,13 +135,14 @@ async function storeJustPublishedProfileData(
         profileToken,
         committedRanges,
         oldThreadIndexToNew,
+        profileName,
         null /* prepublished State */
       )
     );
   } else {
     // Predicts the URL we'll have after the process is finished.
     predictedUrl = urlPredictor(
-      profilePublished(profileToken, null /* prepublished State */)
+      profilePublished(profileToken, profileName, null /* prepublished State */)
     );
   }
 
@@ -149,7 +154,7 @@ async function storeJustPublishedProfileData(
       profileToken,
       jwtToken,
       publishedDate: new Date(),
-      name: getProfileNameForStorage(prepublishedState),
+      name: profileName,
       originHostname: profileFilterPageData
         ? profileFilterPageData.hostname
         : null,
@@ -220,6 +225,10 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
       });
       // Grab the original pre-published state, so that we can revert back to it if needed.
       const prePublishedState = getState();
+
+      // We'll persist any computed profileName in the URL, because we may lose
+      // it otherwise (This is the case with zip files).
+      const profileName = getProfileNameForStorage(prePublishedState);
 
       // Get the current generation of this request. It can be aborted midway through.
       // This way we can check inside this async function if we need to bail out early.
@@ -297,6 +306,7 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
             hash,
             committedRanges,
             oldThreadIndexToNew,
+            profileName,
             prePublishedState
           )
         );
@@ -330,6 +340,7 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
         dispatch(
           profilePublished(
             hash,
+            profileName,
             // Only include the pre-published state if we want to be able to revert
             // the profile. If we are viewing from-addon, then it's only a single
             // profile.
@@ -380,6 +391,7 @@ export function profileSanitized(
   hash: string,
   committedRanges: StartEndRange[] | null,
   oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex> | null,
+  profileName: string,
   prePublishedState: State | null
 ): Action {
   return {
@@ -387,6 +399,7 @@ export function profileSanitized(
     hash,
     committedRanges,
     oldThreadIndexToNew,
+    profileName,
     prePublishedState,
   };
 }
@@ -396,6 +409,7 @@ export function profileSanitized(
  */
 export function profilePublished(
   hash: string,
+  profileName: string,
   // If we're publishing from a URL or Zip file, then offer to revert to the previous
   // state.
   prePublishedState: State | null
@@ -403,6 +417,7 @@ export function profilePublished(
   return {
     type: 'PROFILE_PUBLISHED',
     hash,
+    profileName,
     prePublishedState,
   };
 }

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -11,13 +11,12 @@ import {
   changeSelectedZipFile,
   changeExpandedZipFile,
   viewProfileFromZip,
+  viewProfileFromPathInZipFile,
   returnToZipFileList,
-  showErrorForNoFileInZip,
 } from 'firefox-profiler/actions/zipped-profiles';
 import {
   getZipFileState,
   getZipFileTree,
-  getZipFileTable,
   getZipFileMaxDepth,
   getSelectedZipFileIndex,
   getExpandedZipFileIndexes,
@@ -30,7 +29,6 @@ import { ProfileViewer } from './ProfileViewer';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import type { ZipFileState } from 'firefox-profiler/types';
 import type {
-  ZipFileTable,
   ZipDisplayData,
   ZipFileTree,
   IndexIntoZipFileTable,
@@ -42,7 +40,6 @@ type StateProps = {|
   +zipFileState: ZipFileState,
   +pathInZipFile: string | null,
   +zipFileTree: ZipFileTree,
-  +zipFileTable: ZipFileTable,
   +zipFileMaxDepth: number,
   +selectedZipFileIndex: IndexIntoZipFileTable | null,
   // In practice this should never contain null, but needs to support the
@@ -55,8 +52,8 @@ type DispatchProps = {|
   +changeSelectedZipFile: typeof changeSelectedZipFile,
   +changeExpandedZipFile: typeof changeExpandedZipFile,
   +viewProfileFromZip: typeof viewProfileFromZip,
+  +viewProfileFromPathInZipFile: typeof viewProfileFromPathInZipFile,
   +returnToZipFileList: typeof returnToZipFileList,
-  +showErrorForNoFileInZip: typeof showErrorForNoFileInZip,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -167,10 +164,8 @@ class ZipFileViewerImpl extends React.PureComponent<Props> {
     const {
       pathInZipFile,
       zipFileState,
-      viewProfileFromZip,
-      zipFileTable,
+      viewProfileFromPathInZipFile,
       returnToZipFileList,
-      showErrorForNoFileInZip,
     } = this.props;
     if (pathInZipFile !== zipFileState.pathInZipFile) {
       // The UrlState and ZipFileState are out of sync, they need to be
@@ -183,12 +178,7 @@ class ZipFileViewerImpl extends React.PureComponent<Props> {
       } else {
         // The UrlState was updated to view a zip file, but we haven't
         // started doing that.
-        const zipFileIndex = zipFileTable.path.indexOf(pathInZipFile);
-        if (zipFileIndex === -1) {
-          showErrorForNoFileInZip(pathInZipFile);
-        } else {
-          viewProfileFromZip(zipFileIndex);
-        }
+        viewProfileFromPathInZipFile(pathInZipFile);
       }
     }
     if (
@@ -343,16 +333,9 @@ export const ZipFileViewer = explicitConnect<{||}, StateProps, DispatchProps>({
         'The zipFileTree should exist if the ZipFileViewer is mounted.'
       );
     }
-    const zipFileTable = getZipFileTable(state);
-    if (zipFileTable === null) {
-      throw new Error(
-        'The zipFileTable should exist if the ZipFileViewer is mounted.'
-      );
-    }
     return {
       zipFileState: getZipFileState(state),
       pathInZipFile: getPathInZipFileFromUrl(state),
-      zipFileTable: zipFileTable,
       zipFileTree,
       zipFileMaxDepth: getZipFileMaxDepth(state),
       selectedZipFileIndex: getSelectedZipFileIndex(state),
@@ -364,8 +347,8 @@ export const ZipFileViewer = explicitConnect<{||}, StateProps, DispatchProps>({
     changeSelectedZipFile,
     changeExpandedZipFile,
     viewProfileFromZip,
+    viewProfileFromPathInZipFile,
     returnToZipFileList,
-    showErrorForNoFileInZip,
   },
   component: ZipFileViewerImpl,
 });

--- a/src/profile-logic/zip-files.js
+++ b/src/profile-logic/zip-files.js
@@ -238,3 +238,31 @@ export function procureInitialInterestingExpandedNodes(
 
   return expansions;
 }
+
+// This function extracts a profile name from the path of a file inside a zip.
+export function getProfileNameFromZipPath(path: string): string {
+  // This regular expression keeps only the 2 last parts of a path.
+  // Here are some examples:
+  //   profile1.json -> profile1.json
+  //   directory/profile1.json -> directory/profile1.json
+  //   very/deep/directory/structure/profile1.json -> structure/profile1.json
+  //
+  // The logic for this regexp is that we match "not slash characters"
+  // between slash characters. Also there may be no directory path so the
+  // first element is optional.
+  //
+  //                           --- a non capturing group
+  //                           |  --- several "no slash" characters
+  //                           |  |   --- 1 "slash" character
+  //                           |  |   |  --- this first group is optional
+  //                           |  |   |  | --- several "no slash" characters again
+  //                           |  |   |  | |   --- all this at the end of the string
+  //                           v  v   v  v v   v
+  const directoryAndPathRe = /(?:[^/]+\/)?[^/]+$/;
+  const matchResult = directoryAndPathRe.exec(path);
+  if (matchResult !== null) {
+    return matchResult[0];
+  }
+
+  return '';
+}

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -397,12 +397,16 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
   }
 };
 
+// If you update this reducer, please don't forget to update the profileName
+// reducer below as well.
 const pathInZipFile: Reducer<string | null> = (state = null, action) => {
   switch (action.type) {
     // Update the URL the moment the zip file is starting to be
     // processed, not when it is viewed. The processing is async.
     case 'PROCESS_PROFILE_FROM_ZIP_FILE':
       return action.pathInZipFile ? action.pathInZipFile : null;
+    case 'PROFILE_PUBLISHED': // Removes the file information when publishing.
+    case 'SANITIZED_PROFILE_PUBLISHED':
     case 'RETURN_TO_ZIP_FILE_LIST':
       return null;
     default:
@@ -412,6 +416,8 @@ const pathInZipFile: Reducer<string | null> = (state = null, action) => {
 
 const profileName: Reducer<string | null> = (state = null, action) => {
   switch (action.type) {
+    case 'PROFILE_PUBLISHED':
+    case 'SANITIZED_PROFILE_PUBLISHED':
     case 'CHANGE_PROFILE_NAME':
       return action.profileName;
     default:

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -9,6 +9,7 @@ import { ensureExists, getFirstItemFromSet } from '../utils/flow';
 import { urlFromState } from '../app-logic/url-handling';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
 import { getThreadsKey } from '../profile-logic/profile-data';
+import { getProfileNameFromZipPath } from 'firefox-profiler/profile-logic/zip-files';
 
 import type {
   ThreadIndex,
@@ -276,10 +277,7 @@ export const getFileNameInZipFilePath: Selector<string | null> = createSelector(
   getPathInZipFileFromUrl,
   pathInZipFile => {
     if (pathInZipFile) {
-      const matchResult = pathInZipFile.match(/(?:[^/]+\/)?[^/]+$/);
-      if (matchResult !== null) {
-        return matchResult[0];
-      }
+      return getProfileNameFromZipPath(pathInZipFile);
     }
     return null;
   }

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -283,7 +283,7 @@ describe('UrlManager', function() {
     expect(window.history.length).toBe(1);
 
     // Now the user publishes.
-    dispatch(profilePublished('SOME_HASH', null));
+    dispatch(profilePublished('SOME_HASH', '', null));
     expect(getDataSource(getState())).toMatch('public');
     expect(getHash(getState())).toMatch('SOME_HASH');
     expect(window.history.length).toBe(2);
@@ -300,7 +300,7 @@ describe('UrlManager', function() {
     expect(window.history.length).toBe(2);
 
     // Now let's publish again
-    dispatch(profilePublished('SOME_OTHER_HASH', null));
+    dispatch(profilePublished('SOME_OTHER_HASH', '', null));
     expect(getDataSource(getState())).toMatch('public');
     expect(getHash(getState())).toMatch('SOME_OTHER_HASH');
 

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -31,6 +31,7 @@ import {
   getSelectedTab,
   getDataSource,
   getProfileNameWithDefault,
+  getPathInZipFileFromUrl,
   getHash,
   getTransformStack,
 } from '../../selectors/url-state';
@@ -500,6 +501,7 @@ describe('attemptToPublish', function() {
       // Check that the initial state makes sense for viewing a zip file.
       expect(getHasZipFile(getState())).toEqual(true);
       expect(getDataSource(getState())).toEqual('from-file');
+      expect(getProfileNameWithDefault(getState())).toEqual('profile1.json');
 
       // Upload the profile.
       const publishAttempt = dispatch(attemptToPublish());
@@ -530,6 +532,7 @@ describe('attemptToPublish', function() {
       // Now check that we are reporting as being a public single profile.
       expect(getHasZipFile(getState())).toEqual(false);
       expect(getDataSource(getState())).toEqual('public');
+      expect(getPathInZipFileFromUrl(getState())).toEqual(null);
       expect(getProfileNameWithDefault(getState())).toEqual('profile1.json');
 
       // Revert the profile.

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -337,6 +337,7 @@ type UrlStateAction =
   | {|
       +type: 'PROFILE_PUBLISHED',
       +hash: string,
+      +profileName: string,
       +prePublishedState: State | null,
     |}
   | {| +type: 'CHANGE_SELECTED_TAB', +selectedTab: TabSlug |}
@@ -407,6 +408,7 @@ type UrlStateAction =
       +hash: string,
       +committedRanges: StartEndRange[] | null,
       +oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex> | null,
+      +profileName: string,
       +prePublishedState: State | null,
     |}
   | {|


### PR DESCRIPTION
This also persists the profile name in the URL when publishing a profile, so that we don't lose it.

A last commit reuses the function `viewProfileFromPathInZipFile` (that's used in tests only currently) to simplify a bit of code in the zip file viewer.

STR:
1. open [this link](https://profiler.firefox.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FcIbMgcNlTTmj5ldUrVUzFw%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_raptor-wasm-godot-firefox.zip/calltree/?file=var%2Ffolders%2Fqm%2Ftf865h8d6m78ndmh4g56w7bh000017%2FT%2FtmpAYaMhU%2Fraptor-wasm-godot-firefox_pagecycle_1.profile&globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4-5&localTrackOrderByPid=959-1-2-0~967-0~961-0~968-0~966-0~964-0-1~963-0-1~&thread=7&v=5)
2. publish

=> notice how the URL still has the `file` parameter.

Now do it again with [the deploy preview](https://deploy-preview-3095--perf-html.netlify.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FcIbMgcNlTTmj5ldUrVUzFw%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_raptor-wasm-godot-firefox.zip/calltree/?file=var%2Ffolders%2Fqm%2Ftf865h8d6m78ndmh4g56w7bh000017%2FT%2FtmpAYaMhU%2Fraptor-wasm-godot-firefox_pagecycle_1.profile&globalTrackOrder=0-1-2-3-4-5-6&hiddenGlobalTracks=1-2-3-4-5&localTrackOrderByPid=959-1-2-0~967-0~961-0~968-0~966-0~964-0-1~963-0-1~&thread=7&v=5).

=> no `file` parameter, but the profile name is still correct.

Fixes #1387