### PR TITLE
Delete uploaded profiles without caching in redux

### DIFF
--- a/res/css/photon/confirm-dialog.css
+++ b/res/css/photon/confirm-dialog.css
@@ -45,3 +45,7 @@
   display: flex;
   gap: 8px;
 }
+
+.confirmDialogButtons > .photon-button {
+  flex: auto;
+}

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -295,3 +295,9 @@ export function enableEventDelayTracks(): ThunkAction<boolean> {
     return true;
   };
 }
+
+export function profileRemotelyDeleted(): Action {
+  // Ideally we should store the current profile data in a local indexeddb, and
+  // set the URL to /local/<indexeddb-key>.
+  return { type: 'PROFILE_REMOTELY_DELETED' };
+}

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -263,9 +263,8 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
       // Because we want to store the published profile even when the upload
       // generation changed, we store the data here, before the state is fully
       // updated, and we'll have to predict the state inside this function.
-      // Note that this function is asynchronous, we don't await it on purpose.
       // We catch all errors in this function.
-      storeJustPublishedProfileData(
+      await storeJustPublishedProfileData(
         hash,
         hashOrToken === hash ? null : hashOrToken,
         sanitizedInformation,

--- a/src/app-logic/published-profiles-store.js
+++ b/src/app-logic/published-profiles-store.js
@@ -159,9 +159,15 @@ export async function listAllProfileData(): Promise<ProfileData[]> {
  */
 export async function retrieveProfileData(
   profileToken: string
-): Promise<ProfileData | void> {
+): Promise<ProfileData | null> {
+  if (!profileToken) {
+    // If this is the empty string, let's skip the lookup.
+    return null;
+  }
+
   const db = await open();
-  return db.get(OBJECTSTORE_NAME, profileToken);
+  const result = await db.get(OBJECTSTORE_NAME, profileToken);
+  return result || null;
 }
 
 /**

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -127,7 +127,6 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
 
     return (
       <>
-        <h2 className="metaInfoSubTitle">Profile Information</h2>
         <div className="metaInfoSection">
           {meta.startTime ? (
             <div className="metaInfoRow">

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -107,3 +107,40 @@
 .menuButtonsRevertToFullView::before {
   background-image: url(firefox-profiler-res/img/svg/maximize-dark-12.svg);
 }
+
+.profileInfoUploadedActions {
+  padding: 8px 0 8px 40px; /* The 40px padding leaves the room for the cloud image */
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  font-size: 13px;
+}
+
+.profileInfoUploadedLabel {
+  padding-right: 8px;
+  color: var(--grey-50);
+}
+
+.profileInfoUploadedDate {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.profileInfoUploadedDate::before {
+  position: absolute;
+  left: -40px;
+  display: block;
+  width: 32px;
+  height: 32px;
+  background: url(firefox-profiler-res/img/svg/cloud-dark-12.svg) no-repeat left /
+    32px;
+  content: '';
+  opacity: 0.5;
+}
+
+.profileInfoUploadedActionsButtons {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+  gap: 8px;
+}

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -30,7 +30,11 @@ import {
   ProfileDeleteSuccess,
 } from 'firefox-profiler/components/app/ProfileDeleteButton';
 import { revertToPrePublishedState } from 'firefox-profiler/actions/publish';
-import { dismissNewlyPublished } from 'firefox-profiler/actions/app';
+import {
+  dismissNewlyPublished,
+  profileRemotelyDeleted,
+} from 'firefox-profiler/actions/app';
+
 import {
   getAbortFunction,
   getUploadPhase,
@@ -75,6 +79,7 @@ type DispatchProps = {|
   +dismissNewlyPublished: typeof dismissNewlyPublished,
   +revertToPrePublishedState: typeof revertToPrePublishedState,
   +changeTimelineTrackOrganization: typeof changeTimelineTrackOrganization,
+  +profileRemotelyDeleted: typeof profileRemotelyDeleted,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -125,10 +130,10 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
       case 'from-addon':
       case 'unpublished':
       case 'from-file':
+      case 'local':
         return 'local';
       case 'none':
       case 'uploaded-recordings':
-      case 'local':
         throw new Error(`The datasource ${dataSource} shouldn't happen here.`);
       default:
         throw assertExhaustiveCheck(dataSource);
@@ -142,6 +147,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
   };
 
   _onProfileDeleted = () => {
+    this.props.profileRemotelyDeleted();
     this.setState({
       metaInfoPanelState: 'profile-deleted',
     });
@@ -383,6 +389,7 @@ export const MenuButtons = explicitConnect<OwnProps, StateProps, DispatchProps>(
       dismissNewlyPublished,
       revertToPrePublishedState,
       changeTimelineTrackOrganization,
+      profileRemotelyDeleted,
     },
     component: MenuButtonsImpl,
   }

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -15,6 +15,7 @@ import { getProfileRootRange } from 'firefox-profiler/selectors/profile';
 import {
   getDataSource,
   getTimelineTrackOrganization,
+  getHash,
 } from 'firefox-profiler/selectors/url-state';
 import { getIsNewlyPublished } from 'firefox-profiler/selectors/app';
 
@@ -24,6 +25,10 @@ import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPa
 import { MetaInfoPanel } from 'firefox-profiler/components/app/MenuButtons/MetaInfo';
 import { MenuButtonsPublish } from 'firefox-profiler/components/app/MenuButtons/Publish';
 import { MenuButtonsPermalink } from 'firefox-profiler/components/app/MenuButtons/Permalink';
+import {
+  ProfileDeletePanel,
+  ProfileDeleteSuccess,
+} from 'firefox-profiler/components/app/ProfileDeleteButton';
 import { revertToPrePublishedState } from 'firefox-profiler/actions/publish';
 import { dismissNewlyPublished } from 'firefox-profiler/actions/app';
 import {
@@ -33,6 +38,10 @@ import {
 } from 'firefox-profiler/selectors/publish';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import { changeTimelineTrackOrganization } from 'firefox-profiler/actions/receive-profile';
+import {
+  retrieveProfileData,
+  type ProfileData,
+} from 'firefox-profiler/app-logic/published-profiles-store';
 
 import type {
   StartEndRange,
@@ -59,6 +68,7 @@ type StateProps = {|
   +hasPrePublishedState: boolean,
   +abortFunction: () => mixed,
   +timelineTrackOrganization: TimelineTrackOrganization,
+  +hash: string,
 |};
 
 type DispatchProps = {|
@@ -68,11 +78,42 @@ type DispatchProps = {|
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+type State = $ReadOnly<{|
+  storedProfileData: ProfileData | null,
+  metaInfoPanelState: 'initial' | 'delete-confirmation' | 'profile-deleted',
+|}>;
 
-class MenuButtonsImpl extends React.PureComponent<Props> {
+class MenuButtonsImpl extends React.PureComponent<Props, State> {
+  state = {
+    storedProfileData: null,
+    metaInfoPanelState: 'initial',
+  };
+
+  // This is responsible for caching the stored profile data in a local state so
+  // that we can access it synchronously during the rendering, when the panel is
+  // open.
+  async _updateCanBeDeletedState() {
+    // In tests we don't always have the indexeddb object. To avoid that we have
+    // to add it to a lot of tests, let's bail out in this case.
+    if (process.env.NODE_ENV === 'test' && window.indexedDB === undefined) {
+      return;
+    }
+
+    const { hash } = this.props;
+    const profileData = await retrieveProfileData(hash);
+    this.setState({ storedProfileData: profileData || null });
+  }
+
   componentDidMount() {
     // Clear out the newly published notice from the URL.
     this.props.dismissNewlyPublished();
+    this._updateCanBeDeletedState();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.hash !== this.props.hash) {
+      this._updateCanBeDeletedState();
+    }
   }
 
   _getUploadedStatus(dataSource: DataSource) {
@@ -94,6 +135,101 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
     }
   }
 
+  _deleteThisProfileOnServer = () => {
+    this.setState({
+      metaInfoPanelState: 'delete-confirmation',
+    });
+  };
+
+  _onProfileDeleted = () => {
+    this.setState({
+      metaInfoPanelState: 'profile-deleted',
+    });
+  };
+
+  _resetMetaInfoState = () => {
+    this.setState({
+      metaInfoPanelState: 'initial',
+    });
+  };
+
+  _renderUploadedProfileActions(storedProfileData: ProfileData) {
+    return (
+      <div className="profileInfoUploadedActions">
+        <div className="profileInfoUploadedDate">
+          <span className="profileInfoUploadedLabel">Uploaded:</span>
+          {_formatDate(storedProfileData.publishedDate)}
+        </div>
+        <div className="profileInfoUploadedActionsButtons">
+          <button
+            type="button"
+            className="photon-button photon-button-default photon-button-micro"
+            onClick={this._deleteThisProfileOnServer}
+            title={
+              storedProfileData.jwtToken === null
+                ? 'This profile cannot be deleted because we lack the authorization information.'
+                : null
+            }
+            disabled={storedProfileData.jwtToken === null}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  _renderMetaInfoPanel() {
+    const { metaInfoPanelState, storedProfileData } = this.state;
+    switch (metaInfoPanelState) {
+      case 'initial': {
+        return (
+          <>
+            <h2 className="metaInfoSubTitle">Profile Information</h2>
+            {storedProfileData
+              ? this._renderUploadedProfileActions(storedProfileData)
+              : null}
+            <MetaInfoPanel />
+          </>
+        );
+      }
+
+      case 'delete-confirmation': {
+        if (!storedProfileData) {
+          throw new Error(
+            `We're in the state "delete-confirmation" but there's no stored data for this profile, this should not happen.`
+          );
+        }
+
+        const { name, profileToken, jwtToken } = storedProfileData;
+
+        if (!jwtToken) {
+          throw new Error(
+            `We're in the state "delete-confirmation" but there's no JWT token for this profile, this should not happen.`
+          );
+        }
+
+        const slicedProfileToken = profileToken.slice(0, 6);
+        const profileName = name ? name : `Profile #${slicedProfileToken}`;
+        return (
+          <ProfileDeletePanel
+            profileName={profileName}
+            profileToken={profileToken}
+            jwtToken={jwtToken}
+            onProfileDeleted={this._onProfileDeleted}
+            onProfileDeleteCanceled={this._resetMetaInfoState}
+          />
+        );
+      }
+
+      case 'profile-deleted':
+        return <ProfileDeleteSuccess />;
+
+      default:
+        throw assertExhaustiveCheck(metaInfoPanelState);
+    }
+  }
+
   _renderMetaInfoButton() {
     const { dataSource } = this.props;
     const uploadedStatus = this._getUploadedStatus(dataSource);
@@ -103,8 +239,9 @@ class MenuButtonsImpl extends React.PureComponent<Props> {
         label={
           uploadedStatus === 'uploaded' ? 'Uploaded Profile' : 'Local Profile'
         }
+        onPanelClose={this._resetMetaInfoState}
         panelClassName="metaInfoPanel"
-        panelContent={<MetaInfoPanel />}
+        panelContent={this._renderMetaInfoPanel()}
       />
     );
   }
@@ -240,6 +377,7 @@ export const MenuButtons = explicitConnect<OwnProps, StateProps, DispatchProps>(
       hasPrePublishedState: getHasPrePublishedState(state),
       abortFunction: getAbortFunction(state),
       timelineTrackOrganization: getTimelineTrackOrganization(state),
+      hash: getHash(state),
     }),
     mapDispatchToProps: {
       dismissNewlyPublished,
@@ -249,3 +387,15 @@ export const MenuButtons = explicitConnect<OwnProps, StateProps, DispatchProps>(
     component: MenuButtonsImpl,
   }
 );
+
+function _formatDate(date: Date): string {
+  const timestampDate = date.toLocaleString(undefined, {
+    month: 'short',
+    year: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+  return timestampDate;
+}

--- a/src/components/app/ProfileDeleteButton.js
+++ b/src/components/app/ProfileDeleteButton.js
@@ -114,7 +114,7 @@ type PanelState = {|
   +error: Error | null,
 |};
 
-class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
+export class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
   state = { error: null, status: 'idle' };
 
   onConfirmDeletion = async () => {
@@ -172,11 +172,7 @@ class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
     const { status } = this.state;
 
     if (status === 'deleted') {
-      return (
-        <p className="profileDeleteButtonSuccess">
-          Successfully deleted uploaded data.
-        </p>
-      );
+      return <ProfileDeleteSuccess />;
     }
 
     return (
@@ -206,4 +202,12 @@ class ProfileDeletePanel extends PureComponent<PanelProps, PanelState> {
       </div>
     );
   }
+}
+
+export function ProfileDeleteSuccess(_props: {||}) {
+  return (
+    <p className="profileDeleteButtonSuccess">
+      Successfully deleted uploaded data.
+    </p>
+  );
 }

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -46,6 +46,8 @@ const dataSource: Reducer<DataSource> = (state = 'none', action) => {
       return 'public';
     case 'TRIGGER_LOADING_FROM_URL':
       return 'from-url';
+    case 'PROFILE_REMOTELY_DELETED':
+      return 'unpublished';
     case 'SET_DATA_SOURCE':
       return action.dataSource;
     default:
@@ -58,6 +60,8 @@ const hash: Reducer<string> = (state = '', action) => {
     case 'PROFILE_PUBLISHED':
     case 'SANITIZED_PROFILE_PUBLISHED':
       return action.hash;
+    case 'PROFILE_REMOTELY_DELETED':
+      return '';
     default:
       return state;
   }

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -36,7 +36,6 @@ import {
   ACTIVE_TAB_TIMELINE_MARGIN_LEFT,
 } from '../app-logic/constants';
 
-import type { TabSlug } from '../app-logic/tabs-handling';
 import type {
   AppState,
   AppViewState,
@@ -46,6 +45,7 @@ import type {
   ThreadsKey,
   ExperimentalFlags,
 } from 'firefox-profiler/types';
+import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 
 /**
  * Simple selectors into the app state.

--- a/src/test/components/ListOfPublishedProfiles.test.js
+++ b/src/test/components/ListOfPublishedProfiles.test.js
@@ -361,7 +361,7 @@ describe('ListOfPublishedProfiles', () => {
       // Click on the confirm button
       fireFullClick(getConfirmDeleteButton());
       await findByText(/successfully/i);
-      expect(await retrieveProfileData(profileToken)).toBe(undefined);
+      expect(await retrieveProfileData(profileToken)).toBe(null);
 
       // Clicking elsewhere should make the successful message disappear.
       fireFullClick((window: any));

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,65 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
-<div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Profile Information
-  </h2>
+<div
+  class="arrowPanel open metaInfoPanel"
+>
   <div
-    class="metaInfoSection"
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
   >
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
-      >
-        Recording started:
-      </span>
-      toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Interval:
-      </span>
-      1ms
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Profile Version:
-      </span>
-      33
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Buffer Capacity:
-      </span>
-      16.0KB
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Buffer Duration:
-      </span>
-      20 seconds
-    </div>
+      Profile Information
+    </h2>
     <div
       class="metaInfoSection"
     >
@@ -69,23 +24,9 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         <span
           class="metaInfoLabel"
         >
-          Features
-          :
+          Recording started:
         </span>
-        <ul
-          class="metaInfoList"
-        >
-          <li
-            class="metaInfoListItem"
-          >
-            js
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            threads
-          </li>
-        </ul>
+        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
       </div>
       <div
         class="metaInfoRow"
@@ -93,7 +34,171 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         <span
           class="metaInfoLabel"
         >
-          Threads Filter
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Capacity:
+        </span>
+        16.0KB
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Duration:
+        </span>
+        20 seconds
+      </div>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Features
+            :
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              js
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              threads
+            </li>
+          </ul>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Threads Filter
+            :
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              GeckoMain
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              DOM Worker
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is not symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox 48
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        nightly
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build ID:
+        </span>
+        20181126165837
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build Type:
+        </span>
+        Debug
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Extensions
           :
         </span>
         <ul
@@ -102,470 +207,383 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
           <li
             class="metaInfoListItem"
           >
-            GeckoMain
+            Form Autofill
           </li>
           <li
             class="metaInfoListItem"
           >
-            DOM Worker
+            Firefox Screenshots
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Gecko Profiler
           </li>
         </ul>
       </div>
     </div>
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
-      >
-        Symbols:
-      </span>
-      Profile is not symbolicated
-    </div>
+      Platform
+    </h2>
     <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      />
-      <button
-        class="photon-button photon-button-micro"
-        type="button"
-      >
-        Symbolicate profile
-      </button>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Application
-  </h2>
-  <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Name and version:
-      </span>
-      Firefox 48
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Update Channel:
-      </span>
-      nightly
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build ID:
-      </span>
-      20181126165837
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build Type:
-      </span>
-      Debug
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Extensions
-        :
-      </span>
-      <ul
-        class="metaInfoList"
-      >
-        <li
-          class="metaInfoListItem"
-        >
-          Form Autofill
-        </li>
-        <li
-          class="metaInfoListItem"
-        >
-          Firefox Screenshots
-        </li>
-        <li
-          class="metaInfoListItem"
-        >
-          Gecko Profiler
-        </li>
-      </ul>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Platform
-  </h2>
-  <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        OS:
-      </span>
-      macOS 10.11
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        ABI:
-      </span>
-      x86_64-gcc3
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        CPU:
-      </span>
-      4 physical cores
-      , 
-      8 logical cores
-    </div>
-  </div>
-  <details>
-    <summary
-      class="arrowPanelSubTitle"
-    >
-      Profiler Overhead
-    </summary>
-    <div
-      class="arrowPanelSection"
+      class="metaInfoSection"
     >
       <div
-        class="metaInfoGrid"
+        class="metaInfoRow"
       >
-        <div />
-        <div>
-          Mean
-        </div>
-        <div>
-          Max
-        </div>
-        <div>
-          Min
-        </div>
-        <div>
-          Overhead
-        </div>
-        <div>
-          227μs
-        </div>
-        <div>
-          410μs
-        </div>
-        <div>
-          38μs
-        </div>
-        <div>
-          Cleaning
-        </div>
-        <div>
-          54μs
-        </div>
-        <div>
-          100μs
-        </div>
-        <div>
-          7.0μs
-        </div>
-        <div>
-          Counter
-        </div>
-        <div>
-          59μs
-        </div>
-        <div>
-          105μs
-        </div>
-        <div>
-          12μs
-        </div>
-        <div>
-          Interval
-        </div>
-        <div>
-          857μs
-        </div>
-        <div>
-          1,000μs
-        </div>
-        <div>
-          0.000μs
-        </div>
-        <div>
-          Lockings
-        </div>
-        <div>
-          49μs
-        </div>
-        <div>
-          95μs
-        </div>
-        <div>
-          2.0μs
-        </div>
+        <span
+          class="metaInfoLabel"
+        >
+          OS:
+        </span>
+        macOS 10.11
       </div>
       <div
         class="metaInfoRow"
       >
         <span
-          class="metaInfoWideLabel"
+          class="metaInfoLabel"
         >
-          Overhead Durations:
+          ABI:
         </span>
-        <span
-          class="metaInfoValueRight"
-        >
-          1,586μs
-        </span>
+        x86_64-gcc3
       </div>
       <div
         class="metaInfoRow"
       >
         <span
-          class="metaInfoWideLabel"
+          class="metaInfoLabel"
         >
-          Overhead Percentage:
+          CPU:
         </span>
-        <span
-          class="metaInfoValueRight"
-        >
-          26,433%
-        </span>
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoWideLabel"
-        >
-          Profiled Duration:
-        </span>
-        <span
-          class="metaInfoValueRight"
-        >
-          6.0μs
-        </span>
+        4 physical cores
+        , 
+        8 logical cores
       </div>
     </div>
-  </details>
+    <details>
+      <summary
+        class="arrowPanelSubTitle"
+      >
+        Profiler Overhead
+      </summary>
+      <div
+        class="arrowPanelSection"
+      >
+        <div
+          class="metaInfoGrid"
+        >
+          <div />
+          <div>
+            Mean
+          </div>
+          <div>
+            Max
+          </div>
+          <div>
+            Min
+          </div>
+          <div>
+            Overhead
+          </div>
+          <div>
+            227μs
+          </div>
+          <div>
+            410μs
+          </div>
+          <div>
+            38μs
+          </div>
+          <div>
+            Cleaning
+          </div>
+          <div>
+            54μs
+          </div>
+          <div>
+            100μs
+          </div>
+          <div>
+            7.0μs
+          </div>
+          <div>
+            Counter
+          </div>
+          <div>
+            59μs
+          </div>
+          <div>
+            105μs
+          </div>
+          <div>
+            12μs
+          </div>
+          <div>
+            Interval
+          </div>
+          <div>
+            857μs
+          </div>
+          <div>
+            1,000μs
+          </div>
+          <div>
+            0.000μs
+          </div>
+          <div>
+            Lockings
+          </div>
+          <div>
+            49μs
+          </div>
+          <div>
+            95μs
+          </div>
+          <div>
+            2.0μs
+          </div>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead Durations:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            1,586μs
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead Percentage:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            26,433%
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Profiled Duration:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            6.0μs
+          </span>
+        </div>
+      </div>
+    </details>
+  </div>
 </div>
 `;
 
 exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
-<div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Profile Information
-  </h2>
+<div
+  class="arrowPanel open metaInfoPanel"
+>
   <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Recording started:
-      </span>
-      toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Interval:
-      </span>
-      1ms
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Profile Version:
-      </span>
-      33
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Symbols:
-      </span>
-      Profile is not symbolicated
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      />
-      <button
-        class="photon-button photon-button-micro"
-        type="button"
-      >
-        Symbolicate profile
-      </button>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Application
-  </h2>
+    class="arrowPanelArrow"
+  />
   <div
-    class="metaInfoSection"
+    class="arrowPanelContent"
   >
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
-      >
-        Name and version:
-      </span>
-      Firefox 48
-    </div>
+      Profile Information
+    </h2>
     <div
-      class="metaInfoRow"
+      class="metaInfoSection"
     >
-      <span
-        class="metaInfoLabel"
+      <div
+        class="metaInfoRow"
       >
-        Update Channel:
-      </span>
-      nightly
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build ID:
-      </span>
-      20181126165837
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Build Type:
-      </span>
-      Debug
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
-      >
-        Extensions
-        :
-      </span>
-      <ul
-        class="metaInfoList"
-      >
-        <li
-          class="metaInfoListItem"
+        <span
+          class="metaInfoLabel"
         >
-          Form Autofill
-        </li>
-        <li
-          class="metaInfoListItem"
+          Recording started:
+        </span>
+        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
         >
-          Firefox Screenshots
-        </li>
-        <li
-          class="metaInfoListItem"
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
         >
-          Gecko Profiler
-        </li>
-      </ul>
-    </div>
-  </div>
-  <h2
-    class="metaInfoSubTitle"
-  >
-    Platform
-  </h2>
-  <div
-    class="metaInfoSection"
-  >
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
       >
-        OS:
-      </span>
-      macOS 10.11
-    </div>
-    <div
-      class="metaInfoRow"
-    >
-      <span
-        class="metaInfoLabel"
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is not symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
       >
-        ABI:
-      </span>
-      x86_64-gcc3
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Symbolicate profile
+        </button>
+      </div>
     </div>
-    <div
-      class="metaInfoRow"
+    <h2
+      class="metaInfoSubTitle"
     >
-      <span
-        class="metaInfoLabel"
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
       >
-        CPU:
-      </span>
-      4 physical cores
-      , 
-      8 logical cores
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox 48
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        nightly
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build ID:
+        </span>
+        20181126165837
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build Type:
+        </span>
+        Debug
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Extensions
+          :
+        </span>
+        <ul
+          class="metaInfoList"
+        >
+          <li
+            class="metaInfoListItem"
+          >
+            Form Autofill
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Firefox Screenshots
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Gecko Profiler
+          </li>
+        </ul>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          OS:
+        </span>
+        macOS 10.11
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          ABI:
+        </span>
+        x86_64-gcc3
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          CPU:
+        </span>
+        4 physical cores
+        , 
+        8 logical cores
+      </div>
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,50 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MetaInfoPanel> Full View Button is present when we are in the active tab view 1`] = `
-<div>
-  <button
-    class="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertToFullView"
-    type="button"
-  >
-    Full View
-  </button>
-  <div
-    class="buttonWithPanel"
-  >
-    <button
-      aria-expanded="false"
-      class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-local"
-      type="button"
-    >
-      Local Profile
-    </button>
-  </div>
-  <div
-    class="buttonWithPanel"
-  >
-    <button
-      aria-expanded="false"
-      class="buttonWithPanelButton menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon"
-      type="button"
-    >
-      Upload
-    </button>
-  </div>
-  <a
-    class="menuButtonsButton menuButtonsButton-hasLeftBorder"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs
-    <i
-      class="open-in-new"
-    />
-  </a>
-</div>
-`;
-
-exports[`<MetaInfoPanel> matches the snapshot 1`] = `
+exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 <div>
   <h2
     class="metaInfoSubTitle"
@@ -429,7 +385,7 @@ exports[`<MetaInfoPanel> matches the snapshot 1`] = `
 </div>
 `;
 
-exports[`<MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
+exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
 <div>
   <h2
     class="metaInfoSubTitle"
@@ -1110,5 +1066,49 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       </button>
     </div>
   </form>
+</div>
+`;
+
+exports[`app/MenuButtons Full View Button is present when we are in the active tab view 1`] = `
+<div>
+  <button
+    class="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertToFullView"
+    type="button"
+  >
+    Full View
+  </button>
+  <div
+    class="buttonWithPanel"
+  >
+    <button
+      aria-expanded="false"
+      class="buttonWithPanelButton menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-local"
+      type="button"
+    >
+      Local Profile
+    </button>
+  </div>
+  <div
+    class="buttonWithPanel"
+  >
+    <button
+      aria-expanded="false"
+      class="buttonWithPanelButton menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon"
+      type="button"
+    >
+      Upload
+    </button>
+  </div>
+  <a
+    class="menuButtonsButton menuButtonsButton-hasLeftBorder"
+    href="/docs/"
+    target="_blank"
+    title="Open the documentation in a new window"
+  >
+    Docs
+    <i
+      class="open-in-new"
+    />
+  </a>
 </div>
 `;

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,5 +1,426 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile clicking on the button shows the confirmation 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <div
+      class="confirmDialog"
+    >
+      <h2
+        class="confirmDialogTitle"
+      >
+        Delete 
+        PROFILE
+      </h2>
+      <div
+        class="confirmDialogContent"
+      >
+        Are you sure you want to delete uploaded data for this profile? Links that were previously shared will no longer work.
+      </div>
+      <div
+        class="confirmDialogButtons"
+      >
+        <input
+          class="photon-button photon-button-default"
+          type="button"
+          value="Cancel"
+        />
+        <input
+          class="photon-button photon-button-destructive"
+          type="button"
+          value="Delete"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile confirming the delete should delete on the server and in the db 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <p
+      class="profileDeleteButtonSuccess"
+    >
+      Successfully deleted uploaded data.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete button if we have the uploaded data and some JWT token 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="profileInfoUploadedActions"
+    >
+      <div
+        class="profileInfoUploadedDate"
+      >
+        <span
+          class="profileInfoUploadedLabel"
+        >
+          Uploaded:
+        </span>
+        toLocaleString Sat, 04 Jul 2020 11:00:00 GMT
+      </div>
+      <div
+        class="profileInfoUploadedActionsButtons"
+      >
+        <button
+          class="photon-button photon-button-default photon-button-micro"
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Re-symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        release
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    />
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete button if we have the uploaded data but no JWT token 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="profileInfoUploadedActions"
+    >
+      <div
+        class="profileInfoUploadedDate"
+      >
+        <span
+          class="profileInfoUploadedLabel"
+        >
+          Uploaded:
+        </span>
+        toLocaleString Sat, 04 Jul 2020 11:00:00 GMT
+      </div>
+      <div
+        class="profileInfoUploadedActionsButtons"
+      >
+        <button
+          class="photon-button photon-button-default photon-button-micro"
+          disabled=""
+          title="This profile cannot be deleted because we lack the authorization information."
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Re-symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        release
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    />
+  </div>
+</div>
+`;
+
+exports[`app/MenuButtons <MetaInfoPanel> deleting a profile does not display the delete button if the profile is public but without uploaded data 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        33
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Re-symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        release
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    />
+  </div>
+</div>
+`;
+
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -737,7 +737,7 @@ describe('attemptToPublish', function() {
       // This is the first request, it hasn't been added because the request was
       // aborted before the end.
       const firstRequestData = await retrieveProfileData(BARE_PROFILE_TOKEN);
-      expect(firstRequestData).toBe(undefined);
+      expect(firstRequestData).toBe(null);
 
       // And now, checking that we can retrieve this data when retrieving the
       // full list. The second profile comes first because it was answered

--- a/src/test/unit/published-profiles-store.test.js
+++ b/src/test/unit/published-profiles-store.test.js
@@ -77,7 +77,7 @@ describe('published-profiles-store', function() {
     await setup();
 
     await deleteProfileData('PROFILE-2');
-    expect(await retrieveProfileData('PROFILE-2')).toBe(undefined);
+    expect(await retrieveProfileData('PROFILE-2')).toBe(null);
     expect(await listAllProfileData()).toEqual([
       expect.objectContaining({ profileToken: 'PROFILE-3' }),
       expect.objectContaining({ profileToken: 'PROFILE-1' }),

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -420,6 +420,9 @@ type UrlStateAction =
   | {|
       +type: 'TOGGLE_RESOURCES_PANEL',
       +selectedThreadIndexes: Set<ThreadIndex>,
+    |}
+  | {|
+      +type: 'PROFILE_REMOTELY_DELETED',
     |};
 
 type IconsAction =


### PR DESCRIPTION
This is a different implementation of #2639, where we don't cache the current data in redux but just locally in `MenuButtons/index.js`.