### PR TITLE
Silence a console warning on a test about active tab view

### DIFF
--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -316,7 +316,12 @@ describe('UrlManager', function() {
     expect(previousLocation).toEqual(window.location.href);
   });
 
-  it('persists view query string for `from-addon` data source', async function() {
+  it('persists view query string for `from-addon` data source ', async function() {
+    // This setup function doesn't add any profile to the state, so that's why
+    // it logs an error that says we don't have innerWindowID in this profile.
+    // We can safely ignore that part because we don't test this part of the
+    // codebase here. We only care about the timeline track organization.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const { getState, waitUntilUrlSetupPhase, createUrlManager } = setup(
       '/from-addon/?view=active-tab'
     );


### PR DESCRIPTION
It started to print the console.error after #3065 because before that, we weren't printing if there is any error. But now we do. It throws error because we don't have a profile, so active tab track calculation fails. We can ignore that part because we don't test it in this test case, we only care about the timeline track organization.