### PR TITLE
Get the url of first topmost non-chrome (if possible) frame for active tab

### DIFF
--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -59,7 +59,9 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
     if (filterPageData) {
       firstItem = (
         <>
-          <Icon iconUrl={filterPageData.favicon} />
+          {filterPageData.favicon ? (
+            <Icon iconUrl={filterPageData.favicon} />
+          ) : null}
           <span title={filterPageData.origin}>
             {filterPageData.hostname} (
             {getFormattedTimeLength(rootRange.end - rootRange.start)})

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2806,6 +2806,17 @@ export function extractProfileFilterPageData(
   }
 
   const pageUrl = filteredPages[0].url;
+
+  if (pageUrl.startsWith('about:')) {
+    // If we only have an `about:*` page, we should return early with a friendly
+    // origin and hostname. Otherwise the try block will fail.
+    return {
+      origin: pageUrl,
+      hostname: pageUrl,
+      favicon: null,
+    };
+  }
+
   try {
     const page = new URL(pageUrl);
     // FIXME(Bug 1620546): This is not ideal and we should get the favicon

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2784,15 +2784,24 @@ export function extractProfileFilterPageData(
     return null;
   }
 
-  // Getting the first page's innerWindowID and then getting its url.
-  const innerWindowID = [...relevantPages][0];
-  const filteredPages = pages.filter(
-    page => page.innerWindowID === innerWindowID
+  // Getting the pages that are relevant and a top-most frame.
+  let filteredPages = pages.filter(
+    page =>
+      // It's the top-most frame if `embedderInnerWindowID` is zero.
+      relevantPages.has(page.innerWindowID) && page.embedderInnerWindowID === 0
   );
 
-  if (filteredPages.length !== 1) {
-    // There should be only one page with the given innerWindowID, they are unique.
-    console.error(`Expected one page but ${filteredPages.length} found.`);
+  if (filteredPages.length > 1) {
+    // If there are more than one top-most page, it's also good to filter out the
+    // `about:` pages so user can see their url they are actually profiling.
+    filteredPages = filteredPages.filter(
+      page => !page.url.startsWith('about:')
+    );
+  }
+
+  if (filteredPages.length === 0) {
+    // There should be at least one relevant page.
+    console.error(`Expected a relevant page but couldn't find it.`);
     return null;
   }
 

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2788,7 +2788,7 @@ export function extractProfileFilterPageData(
   let filteredPages = pages.filter(
     page =>
       // It's the top-most frame if `embedderInnerWindowID` is zero.
-      relevantPages.has(page.innerWindowID) && page.embedderInnerWindowID === 0
+      page.embedderInnerWindowID === 0 && relevantPages.has(page.innerWindowID)
   );
 
   if (filteredPages.length > 1) {

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -974,4 +974,15 @@ describe('extractProfileFilterPageData', function() {
       favicon: 'https://profiler.firefox.com/favicon.ico',
     });
   });
+
+  it('extracts the page data when there is only about:blank as relevant page', function() {
+    const relevantPages = new Set([innerWindowIds.aboutBlank]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+    expect(pageData).toEqual({
+      origin: 'about:blank',
+      hostname: 'about:blank',
+      favicon: null,
+    });
+  });
 });

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -21,6 +21,7 @@ import {
   getCallNodeIndexFromPath,
   getTreeOrderComparator,
   getSamplesSelectedStates,
+  extractProfileFilterPageData,
 } from '../../profile-logic/profile-data';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import {
@@ -895,5 +896,82 @@ describe('getSamplesSelectedStates', function() {
     expect(comparator(4, 4)).toBe(0);
     expect(comparator(0, 2)).toBeLessThan(0);
     expect(comparator(2, 0)).toBeGreaterThan(0);
+  });
+});
+
+describe('extractProfileFilterPageData', function() {
+  const innerWindowIds = {
+    mozilla: 1,
+    aboutBlank: 2,
+    profiler: 3,
+    exampleSubFrame: 4,
+  };
+  // This is the `profile.pages` array.
+  const pages = [
+    {
+      tabID: 1111,
+      innerWindowID: innerWindowIds.mozilla,
+      url: 'https://www.mozilla.org',
+      embedderInnerWindowID: 0,
+    },
+    {
+      tabID: 2222,
+      innerWindowID: innerWindowIds.aboutBlank,
+      url: 'about:blank',
+      embedderInnerWindowID: 0,
+    },
+    {
+      tabID: 2222,
+      innerWindowID: innerWindowIds.profiler,
+      url: 'https://profiler.firefox.com/public/xyz',
+      embedderInnerWindowID: 0,
+    },
+    {
+      tabID: 2222,
+      innerWindowID: innerWindowIds.exampleSubFrame,
+      url: 'https://example.com/subframe',
+      // This is a subframe of the page above.
+      embedderInnerWindowID: innerWindowIds.profiler,
+    },
+  ];
+
+  it('extracts the page data when there is only one relevant page', function() {
+    // Adding only the https://www.mozilla.org page.
+    const relevantPages = new Set([innerWindowIds.mozilla]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+    expect(pageData).toEqual({
+      origin: 'https://www.mozilla.org',
+      hostname: 'www.mozilla.org',
+      favicon: 'https://www.mozilla.org/favicon.ico',
+    });
+  });
+
+  it('extracts the page data when there are multiple relevant page', function() {
+    const relevantPages = new Set([
+      innerWindowIds.profiler,
+      innerWindowIds.exampleSubFrame,
+    ]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+    expect(pageData).toEqual({
+      origin: 'https://profiler.firefox.com',
+      hostname: 'profiler.firefox.com',
+      favicon: 'https://profiler.firefox.com/favicon.ico',
+    });
+  });
+
+  it('extracts the page data when there are multiple relevant page with about:blank', function() {
+    const relevantPages = new Set([
+      innerWindowIds.aboutBlank,
+      innerWindowIds.profiler,
+    ]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+    expect(pageData).toEqual({
+      origin: 'https://profiler.firefox.com',
+      hostname: 'profiler.firefox.com',
+      favicon: 'https://profiler.firefox.com/favicon.ico',
+    });
   });
 });

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -905,6 +905,7 @@ describe('extractProfileFilterPageData', function() {
     aboutBlank: 2,
     profiler: 3,
     exampleSubFrame: 4,
+    unknown: 5,
   };
   // This is the `profile.pages` array.
   const pages = [
@@ -984,5 +985,27 @@ describe('extractProfileFilterPageData', function() {
       hostname: 'about:blank',
       favicon: null,
     });
+  });
+
+  it('fails to extract the page data when there is no profile data in common', function() {
+    // Ignore the error we output when it fails.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const relevantPages = new Set([innerWindowIds.unknown]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+
+    expect(pageData).toEqual(null);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('fails to extract the page data when there is only a sub frame', function() {
+    // Ignore the error we output when it fails.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const relevantPages = new Set([innerWindowIds.exampleSubFrame]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+
+    expect(pageData).toEqual(null);
+    expect(console.error).toHaveBeenCalled();
   });
 });

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -378,7 +378,7 @@ export type InitialSelectedTrackReference = HTMLElement;
 export type ProfileFilterPageData = {|
   origin: string,
   hostname: string,
-  favicon: string,
+  favicon: string | null,
 |};
 
 /**

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -432,10 +432,18 @@ export type CategoryList = Array<Category>;
  * The unique field for a page is innerWindowID.
  */
 export type Page = {|
+  // Tab ID of the page. This ID is the same for all the pages inside a tab's
+  // session history.
   tabID: TabID,
+  // ID of the JS `window` object in a `Document`. It's unique for every page.
   innerWindowID: InnerWindowID,
+  // Url of this page.
   url: string,
-  // 0 means no embedder
+  // Each page describes a frame in websites. A frame can either be the top-most
+  // one or inside of another one. For the children frames, `embedderInnerWindowID`
+  // points to the innerWindowID of the parent (embedder). It's `0` if there is
+  // no embedder, which means that it's the top-most frame. That way all pages
+  // can create a tree of pages that can be navigated.
   embedderInnerWindowID: number,
 |};
 


### PR DESCRIPTION
Previously, it wasn't getting the topmost frame, which means that it could actually get an iframe url, and also it wasn't ignoring the chrome urls. Now we can get the real url we would like to see there.

Notice the urls on top left corner:
[Current example](https://profiler.firefox.com/public/3wsftk963daa1dy66340eata5jvsa4x3ng18rv8/calltree/?thread=17%2C19&transforms=%3B&v=5&view=active-tab)
[Deploy preview](https://deploy-preview-3120--perf-html.netlify.app/public/3wsftk963daa1dy66340eata5jvsa4x3ng18rv8/calltree/?thread=17%2C19&transforms=%3B&v=5&view=active-tab)