### PR TITLE
Show the network chart on active tab view

### DIFF
--- a/src/selectors/per-thread/composed.js
+++ b/src/selectors/per-thread/composed.js
@@ -6,7 +6,6 @@
 import { createSelector } from 'reselect';
 
 import { tabSlugs, type TabSlug } from '../../app-logic/tabs-handling';
-import { getTimelineTrackOrganization } from '../url-state';
 
 import type {
   Selector,
@@ -60,13 +59,7 @@ export function getComposedSelectorsPerThread(
     threadSelectors.getThread,
     threadSelectors.getIsNetworkChartEmptyInFullRange,
     threadSelectors.getJsTracerTable,
-    getTimelineTrackOrganization,
-    (
-      { processType },
-      isNetworkChartEmpty,
-      jsTracerTable,
-      timelineTrackOrganization
-    ) => {
+    ({ processType }, isNetworkChartEmpty, jsTracerTable) => {
       if (processType === 'comparison') {
         // For a diffing tracks, we display only the calltree tab for now, because
         // other views make no or not much sense.
@@ -74,13 +67,8 @@ export function getComposedSelectorsPerThread(
       }
 
       let visibleTabs = tabSlugs;
-      if (
-        isNetworkChartEmpty ||
-        timelineTrackOrganization.type === 'active-tab'
-      ) {
-        // We either don't show the network chart if it's empty or we don't show it
-        // for now when we are in single tab mode. This is because we don't know
-        // which network request belongs to which page currently.
+      if (isNetworkChartEmpty) {
+        // Don't show the network chart if it's empty.
         visibleTabs = visibleTabs.filter(
           tabSlug => tabSlug !== 'network-chart'
         );

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -12,7 +12,9 @@ import {
   getNetworkMarkers,
   getProfileWithJsTracerEvents,
   getMergedProfileFromTextSamples,
+  addActiveTabInformationToProfile,
 } from '../fixtures/profiles/processed-profile';
+import { changeTimelineTrackOrganization } from 'firefox-profiler/actions/receive-profile';
 
 describe('getUsefulTabs', function() {
   it('hides the network chart and JS tracer when no data is in the thread', function() {
@@ -71,6 +73,38 @@ describe('getUsefulTabs', function() {
     });
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',
+    ]);
+  });
+
+  it('shows the network chart when network markers are present in the active tab view', function() {
+    const {
+      profile,
+      parentInnerWindowIDsWithChildren,
+      firstTabBrowsingContextID,
+    } = addActiveTabInformationToProfile(
+      getProfileWithMarkers(getNetworkMarkers())
+    );
+    // Adding the parent innerWindowID to the first thread's first sample, so
+    // this thread will be inluded in the active tab view.
+    profile.threads[0].frameTable.innerWindowID[0] = parentInnerWindowIDsWithChildren;
+    const { dispatch, getState } = storeWithProfile(profile);
+
+    // Switch to the active tab view.
+    dispatch(
+      changeTimelineTrackOrganization({
+        type: 'active-tab',
+        browsingContextID: firstTabBrowsingContextID,
+      })
+    );
+
+    // Check the tabs and make sure that the network chart is there.
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'calltree',
+      'flame-graph',
+      'stack-chart',
+      'marker-chart',
+      'marker-table',
+      'network-chart',
     ]);
   });
 });


### PR DESCRIPTION
Previously it was hidden because we didn't have the page information for network markers. But now we have this information now. We don't have a reason to hide it anymore.
Didn't include a test for this since it's a visual change.

[Deploy preview](https://deploy-preview-3126--perf-html.netlify.app/public/akz0yr64f56bk35gc82ww5dw6ejdmftxwjam0n0/network-chart/?thread=0&v=5&view=active-tab)