### PR TITLE
Persist the implementation filter information in the URL for all panels

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -163,6 +163,7 @@ type BaseQuery = {|
   profiles: string[],
   profileName: string,
   view: string,
+  implementation: string,
   ...FullProfileSpecificBaseQuery,
   ...ActiveTabProfileSpecificBaseQuery,
   ...OriginsProfileSpecificBaseQuery,
@@ -172,7 +173,6 @@ type CallTreeQuery = {|
   ...BaseQuery,
   search: string, // "js::RunScript"
   invertCallstack: null | void,
-  implementation: string,
   ctSummary: string,
 |};
 
@@ -191,7 +191,6 @@ type StackChartQuery = {|
   search: string, // "js::RunScript"
   invertCallstack: null | void,
   showUserTimings: null | void,
-  implementation: string,
   ctSummary: string,
 |};
 
@@ -364,6 +363,10 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
     view,
     v: CURRENT_URL_VERSION,
     profileName: urlState.profileName || undefined,
+    implementation:
+      urlState.profileSpecific.implementation === 'combined'
+        ? undefined
+        : urlState.profileSpecific.implementation,
   }: BaseQueryShape);
 
   // Depending on which panel is active, also show tab-specific query parameters.
@@ -388,10 +391,6 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       query.invertCallstack = urlState.profileSpecific.invertCallstack
         ? null
         : undefined;
-      query.implementation =
-        urlState.profileSpecific.implementation === 'combined'
-          ? undefined
-          : urlState.profileSpecific.implementation;
       if (selectedThreads !== null) {
         query.transforms =
           stringifyTransforms(

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { oneLineTrim } from 'common-tags';
-import * as urlStateReducers from '../selectors/url-state';
+import * as urlStateSelectors from '../selectors/url-state';
 import {
   changeCallTreeSearchString,
   changeMarkersSearchString,
@@ -133,7 +133,7 @@ describe('selectedThread', function() {
 
   it('selects the right thread when receiving a profile from web', function() {
     const { getState } = setup(1);
-    expect(urlStateReducers.getSelectedThreadIndexes(getState())).toEqual(
+    expect(urlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
       new Set([1])
     );
   });
@@ -142,7 +142,7 @@ describe('selectedThread', function() {
     const { getState } = setup(100);
 
     // "2" is the content process' main tab
-    expect(urlStateReducers.getSelectedThreadIndexes(getState())).toEqual(
+    expect(urlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
       new Set([2])
     );
   });
@@ -186,14 +186,14 @@ describe('url handling tracks', function() {
 
     it('will not accept invalid tracks in the thread order', function() {
       const { getState } = initWithSearchParams('?globalTrackOrder=1-0');
-      expect(urlStateReducers.getGlobalTrackOrder(getState())).toEqual([1, 0]);
+      expect(urlStateSelectors.getGlobalTrackOrder(getState())).toEqual([1, 0]);
     });
 
     it('will not accept invalid hidden threads', function() {
       const { getState } = initWithSearchParams(
         '?hiddenGlobalTracks=0-8-2-a&thread=1'
       );
-      expect(urlStateReducers.getHiddenGlobalTracks(getState())).toEqual(
+      expect(urlStateSelectors.getHiddenGlobalTracks(getState())).toEqual(
         new Set([0])
       );
     });
@@ -291,18 +291,18 @@ describe('url handling tracks', function() {
 describe('search strings', function() {
   it('properly handles the call tree search string stacks with 1 item', function() {
     const { getState } = _getStoreWithURL({ search: '?search=string' });
-    expect(urlStateReducers.getCurrentSearchString(getState())).toBe('string');
-    expect(urlStateReducers.getSearchStrings(getState())).toEqual(['string']);
+    expect(urlStateSelectors.getCurrentSearchString(getState())).toBe('string');
+    expect(urlStateSelectors.getSearchStrings(getState())).toEqual(['string']);
   });
 
   it('properly handles the call tree search string stacks with several items', function() {
     const { getState } = _getStoreWithURL({
       search: '?search=string,foo,%20bar',
     });
-    expect(urlStateReducers.getCurrentSearchString(getState())).toBe(
+    expect(urlStateSelectors.getCurrentSearchString(getState())).toBe(
       'string,foo, bar'
     );
-    expect(urlStateReducers.getSearchStrings(getState())).toEqual([
+    expect(urlStateSelectors.getSearchStrings(getState())).toEqual([
       'string',
       'foo',
       'bar',
@@ -313,19 +313,19 @@ describe('search strings', function() {
     const { getState } = _getStoreWithURL({
       search: '?markerSearch=otherString',
     });
-    expect(urlStateReducers.getMarkersSearchString(getState())).toBe(
+    expect(urlStateSelectors.getMarkersSearchString(getState())).toBe(
       'otherString'
     );
   });
 
   it('properly handles showUserTimings strings', function() {
     const { getState } = _getStoreWithURL({ search: '' });
-    expect(urlStateReducers.getShowUserTimings(getState())).toBe(false);
+    expect(urlStateSelectors.getShowUserTimings(getState())).toBe(false);
   });
 
   it('defaults to not showing user timings', function() {
     const { getState } = _getStoreWithURL();
-    expect(urlStateReducers.getShowUserTimings(getState())).toBe(false);
+    expect(urlStateSelectors.getShowUserTimings(getState())).toBe(false);
   });
 
   it('serializes the call tree search strings in the URL', function() {
@@ -337,7 +337,7 @@ describe('search strings', function() {
 
     ['calltree', 'stack-chart', 'flame-graph'].forEach(tabSlug => {
       dispatch(changeSelectedTab(tabSlug));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).toContain(
         `search=${encodeURIComponent(callTreeSearchString)}`
@@ -354,7 +354,7 @@ describe('search strings', function() {
 
     ['marker-chart', 'marker-table'].forEach(tabSlug => {
       dispatch(changeSelectedTab(tabSlug));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).toContain(`markerSearch=${markerSearchString}`);
     });
@@ -367,7 +367,7 @@ describe('search strings', function() {
 
     dispatch(changeNetworkSearchString(networkSearchString));
     dispatch(changeSelectedTab('network-chart'));
-    const urlState = urlStateReducers.getUrlState(getState());
+    const urlState = urlStateSelectors.getUrlState(getState());
     const queryString = getQueryStringFromUrlState(urlState);
     expect(queryString).toContain(`networkSearch=${networkSearchString}`);
   });
@@ -379,7 +379,7 @@ describe('profileName', function() {
     const profileName = 'Good Profile';
 
     dispatch(changeProfileName(profileName));
-    const urlState = urlStateReducers.getUrlState(getState());
+    const urlState = urlStateSelectors.getUrlState(getState());
     const queryString = getQueryStringFromUrlState(urlState);
     expect(queryString).toContain(
       `profileName=${encodeURIComponent(profileName)}`
@@ -390,14 +390,14 @@ describe('profileName', function() {
     const { getState } = _getStoreWithURL({
       search: '?profileName=XXX',
     });
-    expect(urlStateReducers.getProfileNameFromUrl(getState())).toBe('XXX');
-    expect(urlStateReducers.getProfileNameWithDefault(getState())).toBe('XXX');
+    expect(urlStateSelectors.getProfileNameFromUrl(getState())).toBe('XXX');
+    expect(urlStateSelectors.getProfileNameWithDefault(getState())).toBe('XXX');
   });
 
   it('provides default values for when no profile name is given', function() {
     const { getState } = _getStoreWithURL();
-    expect(urlStateReducers.getProfileNameFromUrl(getState())).toBe(null);
-    expect(urlStateReducers.getProfileNameWithDefault(getState())).toBe(
+    expect(urlStateSelectors.getProfileNameFromUrl(getState())).toBe(null);
+    expect(urlStateSelectors.getProfileNameWithDefault(getState())).toBe(
       'Firefox'
     );
   });
@@ -411,7 +411,7 @@ describe('ctxId', function() {
     dispatch(
       changeTimelineTrackOrganization({ type: 'active-tab', browsingContextID })
     );
-    const urlState = urlStateReducers.getUrlState(getState());
+    const urlState = urlStateSelectors.getUrlState(getState());
     const queryString = getQueryStringFromUrlState(urlState);
     expect(queryString).toContain(`ctxId=${browsingContextID}`);
   });
@@ -420,7 +420,7 @@ describe('ctxId', function() {
     const { getState } = _getStoreWithURL({
       search: '?ctxId=123&view=active-tab',
     });
-    expect(urlStateReducers.getTimelineTrackOrganization(getState())).toEqual({
+    expect(urlStateSelectors.getTimelineTrackOrganization(getState())).toEqual({
       type: 'active-tab',
       browsingContextID: 123,
     });
@@ -428,7 +428,7 @@ describe('ctxId', function() {
 
   it('returns the full view when ctxId is not specified', function() {
     const { getState } = _getStoreWithURL();
-    expect(urlStateReducers.getTimelineTrackOrganization(getState())).toEqual({
+    expect(urlStateSelectors.getTimelineTrackOrganization(getState())).toEqual({
       type: 'full',
     });
   });
@@ -474,7 +474,7 @@ describe('ctxId', function() {
     });
 
     const newUrl = new URL(
-      urlFromState(urlStateReducers.getUrlState(getState())),
+      urlFromState(urlStateSelectors.getUrlState(getState())),
       'https://profiler.firefox.com'
     );
     // The url states that are relevant to full view should be stripped out.
@@ -489,7 +489,7 @@ describe('ctxId', function() {
     });
 
     expect(getView(getState()).phase).toEqual('DATA_LOADED');
-    expect(urlStateReducers.getTimelineTrackOrganization(getState())).toEqual({
+    expect(urlStateSelectors.getTimelineTrackOrganization(getState())).toEqual({
       type: 'active-tab',
       browsingContextID: null,
     });
@@ -500,7 +500,7 @@ describe('committed ranges', function() {
   describe('serialization', () => {
     it('serializes when there is no range', () => {
       const { getState } = _getStoreWithURL();
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).not.toContain(`range=`);
     });
@@ -509,7 +509,7 @@ describe('committed ranges', function() {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1514.587845, 25300));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).toContain(`range=1514m23786`); // 1.514s + 23786ms
     });
@@ -518,7 +518,7 @@ describe('committed ranges', function() {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1510.58, 1519.59));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).toContain(`range=1510m10`); // 1.510s + 10ms
     });
@@ -527,7 +527,7 @@ describe('committed ranges', function() {
       const { getState, dispatch } = _getStoreWithURL();
 
       dispatch(commitRange(1514, 1514));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       // In the following regexp we want to especially assert that the duration
       // isn't 0. That's why there's this negative look-ahead assertion.
@@ -541,7 +541,7 @@ describe('committed ranges', function() {
 
       dispatch(commitRange(1514.587845, 25300));
       dispatch(commitRange(1800, 1800.1));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
 
       // 1- 1.5145s + 23786ms
@@ -552,7 +552,7 @@ describe('committed ranges', function() {
     it('serializes when there is a small range', () => {
       const { getState, dispatch } = _getStoreWithURL();
       dispatch(commitRange(1000.08, 1000.09));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).toContain(`range=1000080u10`); // 1s and 80µs + 10µs
     });
@@ -560,7 +560,7 @@ describe('committed ranges', function() {
     it('serializes when there is a very small range', () => {
       const { getState, dispatch } = _getStoreWithURL();
       dispatch(commitRange(1000.00008, 1000.0001));
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       expect(queryString).toContain(`range=1000000080n20`); // 1s and 80ns + 20ns
     });
@@ -569,14 +569,14 @@ describe('committed ranges', function() {
   describe('parsing', () => {
     it('deserializes when there is no range', () => {
       const { getState } = _getStoreWithURL();
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([]);
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
     });
 
     it('deserializes when there is 1 range', () => {
       const { getState } = _getStoreWithURL({
         search: '?range=1600m5000',
       });
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 1600, end: 6600 },
       ]);
     });
@@ -585,7 +585,7 @@ describe('committed ranges', function() {
       const { getState } = _getStoreWithURL({
         search: '?range=1600m5000~2245m24',
       });
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 1600, end: 6600 },
         { start: 2245, end: 2269 },
       ]);
@@ -595,7 +595,7 @@ describe('committed ranges', function() {
       const { getState } = _getStoreWithURL({
         search: '?range=1678900u100',
       });
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 1678.9, end: 1679 },
       ]);
     });
@@ -605,7 +605,7 @@ describe('committed ranges', function() {
         search: '?range=1678123900n100',
       });
 
-      const [committedRange] = urlStateReducers.getAllCommittedRanges(
+      const [committedRange] = urlStateSelectors.getAllCommittedRanges(
         getState()
       );
       expect(committedRange.start).toBeCloseTo(1678.1239);
@@ -617,7 +617,7 @@ describe('committed ranges', function() {
       const { getState } = _getStoreWithURL({
         search: '?range=invalid~2245m24',
       });
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 2245, end: 2269 },
       ]);
       expect(console.error).toHaveBeenCalled();
@@ -632,7 +632,7 @@ describe('committed ranges', function() {
 
       ranges.forEach(({ start, end }) => dispatch(commitRange(start, end)));
 
-      const urlState = urlStateReducers.getUrlState(getState());
+      const urlState = urlStateSelectors.getUrlState(getState());
       const queryString = getQueryStringFromUrlState(urlState);
       return queryString;
     }
@@ -652,7 +652,7 @@ describe('committed ranges', function() {
         { start: 1800.00008, end: 1800.0001 },
       ]);
 
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 1514, end: 25300 },
         { start: 1800, end: 1800.1 },
         { start: 1800.00008, end: 1800.0001 },
@@ -662,7 +662,7 @@ describe('committed ranges', function() {
     it('will round values near the threshold', () => {
       const { getState } = setup([{ start: 50000, end: 50009.9 }]);
 
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 50000, end: 50010 },
       ]);
     });
@@ -670,7 +670,7 @@ describe('committed ranges', function() {
     it('supports negative start values', () => {
       const { getState } = setup([{ start: -1000, end: 1000 }]);
 
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: -1000, end: 1000 },
       ]);
     });
@@ -678,7 +678,7 @@ describe('committed ranges', function() {
     it('supports zero start values', () => {
       const { getState } = setup([{ start: 0, end: 1000 }]);
 
-      expect(urlStateReducers.getAllCommittedRanges(getState())).toEqual([
+      expect(urlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 1000 },
       ]);
     });
@@ -733,7 +733,7 @@ describe('url upgrading', function() {
         pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/timeline/',
         v: 1,
       });
-      expect(urlStateReducers.getSelectedTab(getState())).toBe('stack-chart');
+      expect(urlStateSelectors.getSelectedTab(getState())).toBe('stack-chart');
     });
 
     it('switches to the marker-table when given a markers tab', function() {
@@ -741,7 +741,7 @@ describe('url upgrading', function() {
         pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/markers/',
         v: false,
       });
-      expect(urlStateReducers.getSelectedTab(getState())).toBe('marker-table');
+      expect(urlStateSelectors.getSelectedTab(getState())).toBe('marker-table');
     });
   });
 
@@ -752,7 +752,7 @@ describe('url upgrading', function() {
         search: '?hidePlatformDetails',
         v: 2,
       });
-      expect(urlStateReducers.getImplementationFilter(getState())).toBe('js');
+      expect(urlStateSelectors.getImplementationFilter(getState())).toBe('js');
     });
   });
 
@@ -1018,7 +1018,7 @@ describe('url upgrading', function() {
       const { getState } = _getStoreWithURL({
         v: 4,
       });
-      const committedRanges = urlStateReducers.getAllCommittedRanges(
+      const committedRanges = urlStateSelectors.getAllCommittedRanges(
         getState()
       );
       expect(committedRanges).toEqual([]);
@@ -1030,7 +1030,7 @@ describe('url upgrading', function() {
         v: 4,
       });
 
-      const committedRanges = urlStateReducers.getAllCommittedRanges(
+      const committedRanges = urlStateSelectors.getAllCommittedRanges(
         getState()
       );
       expect(committedRanges).toEqual([{ start: 1451, end: 1453 }]);
@@ -1042,7 +1042,7 @@ describe('url upgrading', function() {
         v: 4,
       });
 
-      const committedRanges = urlStateReducers.getAllCommittedRanges(
+      const committedRanges = urlStateSelectors.getAllCommittedRanges(
         getState()
       );
       expect(committedRanges).toEqual([
@@ -1057,7 +1057,7 @@ describe('url upgrading', function() {
         v: 4,
       });
 
-      const committedRanges = urlStateReducers.getAllCommittedRanges(
+      const committedRanges = urlStateSelectors.getAllCommittedRanges(
         getState()
       );
       expect(committedRanges).toEqual([{ start: 0, end: 278 }]);
@@ -1072,7 +1072,7 @@ describe('url upgrading', function() {
         v: 4,
       });
 
-      const committedRanges = urlStateReducers.getAllCommittedRanges(
+      const committedRanges = urlStateSelectors.getAllCommittedRanges(
         getState()
       );
       expect(committedRanges).toEqual([{ start: 1451, end: 1453 }]);
@@ -1094,7 +1094,7 @@ describe('url upgrading', function() {
     // state of the application, so we won't have 'markers' as result.
     // We should change this to something more meaningful when we have eg
     // converters that reuse query names.
-    expect(urlStateReducers.getSelectedTab(getState())).not.toBe(
+    expect(urlStateSelectors.getSelectedTab(getState())).not.toBe(
       'marker-table'
     );
   });
@@ -1171,7 +1171,7 @@ describe('URL serialization of the transform stack', function() {
   });
 
   it('re-serializes the focus subtree transforms', function() {
-    const urlState = urlStateReducers.getUrlState(getState());
+    const urlState = urlStateSelectors.getUrlState(getState());
     const queryString = getQueryStringFromUrlState(urlState);
     expect(queryString).toContain(`transforms=${transformString}`);
   });
@@ -1208,7 +1208,7 @@ describe('compare', function() {
       /* no profile */ null
     );
 
-    expect(urlStateReducers.getProfilesToCompare(store.getState())).toEqual([
+    expect(urlStateSelectors.getProfilesToCompare(store.getState())).toEqual([
       url1,
       url2,
     ]);
@@ -1221,13 +1221,13 @@ describe('compare', function() {
     );
 
     const initialUrl = urlFromState(
-      urlStateReducers.getUrlState(store.getState())
+      urlStateSelectors.getUrlState(store.getState())
     );
     expect(initialUrl).toEqual('/compare/');
 
     store.dispatch(changeProfilesToCompare([url1, url2]));
     const resultingUrl = urlFromState(
-      urlStateReducers.getUrlState(store.getState())
+      urlStateSelectors.getUrlState(store.getState())
     );
     expect(resultingUrl).toMatch(`profiles[]=${encodeURIComponent(url1)}`);
     expect(resultingUrl).toMatch(`profiles[]=${encodeURIComponent(url2)}`);
@@ -1241,7 +1241,7 @@ describe('uploaded-recordings', function() {
       /* no profile */ null
     );
 
-    expect(urlStateReducers.getDataSource(store.getState())).toEqual(
+    expect(urlStateSelectors.getDataSource(store.getState())).toEqual(
       'uploaded-recordings'
     );
   });
@@ -1249,20 +1249,20 @@ describe('uploaded-recordings', function() {
   it('serializes uploaded-recordings URLs', () => {
     const store = _getStoreWithURL({ pathname: '/' }, /* no profile */ null);
     const initialUrl = urlFromState(
-      urlStateReducers.getUrlState(store.getState())
+      urlStateSelectors.getUrlState(store.getState())
     );
     expect(initialUrl).toEqual('/');
 
     store.dispatch(setDataSource('uploaded-recordings'));
     const resultingUrl = urlFromState(
-      urlStateReducers.getUrlState(store.getState())
+      urlStateSelectors.getUrlState(store.getState())
     );
     expect(resultingUrl).toEqual('/uploaded-recordings/');
   });
 });
 
 describe('last requested call tree summary strategy', function() {
-  const { getLastSelectedCallTreeSummaryStrategy } = urlStateReducers;
+  const { getLastSelectedCallTreeSummaryStrategy } = urlStateSelectors;
 
   it('defaults to timing', function() {
     const { getState } = _getStoreWithURL();

--- a/src/types/libdef/npm-custom/jest_v26.x.x.js
+++ b/src/types/libdef/npm-custom/jest_v26.x.x.js
@@ -986,7 +986,7 @@ declare var describe: {
    * @param {table} table of Test
    */
   each(
-    ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    table: Array<Array<mixed> | mixed>
   ): (
     name: JestTestName,
     fn?: (...args: Array<any>) => ?Promise<mixed>,
@@ -1023,7 +1023,7 @@ declare var it: {
       timeout?: number
     ): void,
     each(
-      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+      table: Array<Array<mixed> | mixed>
     ): (
       name: JestTestName,
       fn?: (...args: Array<any>) => ?Promise<mixed>,
@@ -1066,7 +1066,7 @@ declare var it: {
    * @param {table} table of Test
    */
   each(
-    ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    table: Array<Array<mixed> | mixed>
   ): (
     name: JestTestName,
     fn?: (...args: Array<any>) => ?Promise<mixed>,


### PR DESCRIPTION
I realized that we were persisting the implementation filter information only for the panels "call tree", "flame graph" and "stack chart". However this information is used also in the marker tooltips now that we display stacks.
Of course it would be nice to be able to change this value also from these other panels, but this PR only focuses on the persistence in the URL.

The first commit is only a technical renaming and happens in the test file only.

STR:
1. Open [this profile](https://profiler.firefox.com/public/ep0k4v09yz6sn6299nx82r9t29bfsn8z0yxv2z8/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&implementation=js&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&profileName=foo%20bar&range=3128875u1070&thread=11&v=5).
2. Click on the "marker chart" tab.
3. Hover on the "Reflow" marker and notice the stack contains only javascript frames.
4. Reload the page.
5. Hover on the marker and notice the stack contains native frames => KO.

Now try again with [this deploy preview](https://deploy-preview-3136--perf-html.netlify.app/public/ep0k4v09yz6sn6299nx82r9t29bfsn8z0yxv2z8/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9&implementation=js&localTrackOrderByPid=32027-1-2-0~12629-0~12149-0~11755-0~11945-0~12533-0~11798-0~11862-0~12083-0~12118-0~12298-0-1~&profileName=foo%20bar&range=3128875u1070&thread=11&v=5).
