### PR TITLE
Fix the style for inputs and buttons when widget.disable-native-theme-for-content is enabled

### DIFF
--- a/res/css/photon/input.css
+++ b/res/css/photon/input.css
@@ -21,6 +21,7 @@
 .photon-input:focus:invalid {
   border: 1px solid var(--blue-50);
   box-shadow: 0 0 0 1px var(--blue-50), 0 0 0 4px var(--blue-50-a30);
+  outline: 0;
 }
 
 .photon-input:invalid:not(:placeholder-shown) {

--- a/src/components/app/CompareHome.css
+++ b/src/components/app/CompareHome.css
@@ -22,6 +22,7 @@
 }
 
 .compareHomeSubmitButton {
+  font-size: inherit; /* override the photon style to make it nicer with the rest of the form. */
   grid-column-start: span 2;
 }
 

--- a/src/components/app/CompareHome.js
+++ b/src/components/app/CompareHome.js
@@ -81,7 +81,7 @@ class CompareHomeImpl extends PureComponent<Props, State> {
             value={profile2}
           />
           <input
-            className="compareHomeSubmitButton"
+            className="compareHomeSubmitButton photon-button photon-button-primary"
             type="submit"
             value="Retrieve profiles"
           />

--- a/src/test/components/__snapshots__/CompareHome.test.js.snap
+++ b/src/test/components/__snapshots__/CompareHome.test.js.snap
@@ -91,7 +91,7 @@ exports[`app/CompareHome matches the snapshot 1`] = `
       value=""
     />
     <input
-      class="compareHomeSubmitButton"
+      class="compareHomeSubmitButton photon-button photon-button-primary"
       type="submit"
       value="Retrieve profiles"
     />


### PR DESCRIPTION
While looking at another problem I enabled the pref `widget.disable-native-theme-for-content` in Firefox. According to emilio, this will be enabled soonish for all OSes.
I realized that we have a few issues in the profiler UI when this is enabled, so I fixed them here.

In the process I made the button in the compare view a real photon button, and I made it primary, which makes sense in this case. The default styles for buttons are not great for now with the new widget configuration (see [bug 1689098](https://bugzilla.mozilla.org/show_bug.cgi?id=1689098)), even if I hope they'll be updated.

Deploy previews:
* [main UI](https://deploy-preview-3146--perf-html.netlify.com/compare/public/r31b5mgxawdex66f5y2c4abyz77p430xgczhs40/flame-graph/?globalTrackOrder=0-1-2&implementation=js&localTrackOrderByPid=13069-2-3-0-1~14089-0-1~&thread=3&v=5) (look at inputs, eg the search box, the permalink box). Please look also at other widgets and inputs, I may have missed something.
* [compare view](https://deploy-preview-3146--perf-html.netlify.com/compare/)

Inputs:
Before:
![image](https://user-images.githubusercontent.com/454175/106001573-692d0200-60b0-11eb-929d-981b4f40d82e.png)

After:
![image](https://user-images.githubusercontent.com/454175/106001650-806bef80-60b0-11eb-9772-5aeffbb45a21.png)

Compare view:
Before:
![image](https://user-images.githubusercontent.com/454175/106001779-aabdad00-60b0-11eb-9d0e-066e4b95c332.png)

After:
![image](https://user-images.githubusercontent.com/454175/106001717-97124680-60b0-11eb-8b50-2c69315d1fa6.png)
