### PR TITLE
Add the performance l10n team as code owner for FTL files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# FTL files will be reviewed by the l10n team
+# Only the english locale should be reviewed from github, the others locales are
+# committed directly through pontoon.
+/locales/en-US/**/*.ftl @firefox-devtools/performance-l10n


### PR DESCRIPTION
I followed the [github documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners), I hope this will work fine :-)