### PR TITLE
"Evicted" sounds like they were thrown out to me. I think "tenured" w…

### DIFF
--- a/src/components/tooltip/GCMarker.js
+++ b/src/components/tooltip/GCMarker.js
@@ -54,7 +54,7 @@ export function getGCMinorDetails(
           <TooltipDetail label="Reason" key="GCMinor-Reason">
             {nursery.reason}
           </TooltipDetail>,
-          <TooltipDetail label="Bytes evicted" key="GCMinor-Bytes evicted">
+          <TooltipDetail label="Bytes tenured" key="GCMinor-Bytes tenured">
             {formatValueTotal(
               nursery.bytes_tenured,
               nursery.bytes_used,
@@ -64,7 +64,7 @@ export function getGCMinorDetails(
         );
         if (nursery.cells_tenured && nursery.cells_allocated_nursery) {
           details.push(
-            <TooltipDetail label="Cells evicted" key="GCMinor-Cells evicted">
+            <TooltipDetail label="Cells tenured" key="GCMinor-Cells tenured">
               {formatValueTotal(
                 nursery.cells_tenured,
                 nursery.cells_allocated_nursery,
@@ -148,7 +148,7 @@ export function getGCMinorDetails(
           if (nursery.strings_tenured && nursery.strings_deduplicated) {
             details.push(
               <TooltipDetail
-                label="Proportion of nursery-allocated strings that were deduplicated"
+                label="Strings deduplicated when tenuring"
                 key="GCMinor-strings_deduped"
               >
                 {formatValueTotal(

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -2138,14 +2138,14 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Bytes evicted
+      Bytes tenured
       :
     </div>
     1.30MB / 1.97MB (66%)
     <div
       class="tooltipLabel"
     >
-      Cells evicted
+      Cells tenured
       :
     </div>
     15.9K / 26.6K (60%)
@@ -2180,7 +2180,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Proportion of nursery-allocated strings that were deduplicated
+      Strings deduplicated when tenuring
       :
     </div>
     1,234 / 11.2K (11%)


### PR DESCRIPTION
…ould be more clear, even though it is GC jargon. "Surviving cells" would make more sense conventionally, but would also be a little more deceptive than "tenured" in the case of deduplicated strings. Those "survive", but all duplicates are resolved to a single tenured cell.

Oh, and my original description of the deduplication fraction is too long, and it doesn't sound good calling it a proportion when none of the other fractional values are.