### PR TITLE
Multiply the buffer capacity by 8 when rendering the metainfo pannel …

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -150,7 +150,8 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
             <>
               <div className="metaInfoRow">
                 <span className="metaInfoLabel">Buffer Capacity:</span>
-                {formatBytes(configuration.capacity)}
+                {/* The capacity is expressed in "entries", where 1 entry == 8 bytes. */
+                formatBytes(configuration.capacity * 8, 0)}
               </div>
               <div className="metaInfoRow">
                 <span className="metaInfoLabel">Buffer Duration:</span>

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -411,7 +411,9 @@ describe('app/MenuButtons', function() {
       profile.meta.configuration = {
         features: ['js', 'threads'],
         threads: ['GeckoMain', 'DOM Worker'],
-        capacity: Math.pow(2, 14),
+        // The capacity is expressed in entries, where 1 entry == 8 bytes.
+        // 128M entries is 1GB.
+        capacity: 128 * 1024 * 1024,
         duration: 20,
       };
 
@@ -420,6 +422,15 @@ describe('app/MenuButtons', function() {
         getMetaInfoPanel,
       } = await setupForMetaInfoPanel(profile);
       displayMetaInfoPanel();
+      const renderedCapacity = ensureExists(
+        screen.getByText(/Buffer Capacity/).nextSibling
+      );
+
+      /* This rule needs to be disabled because `renderedCapacity` is a text
+       * code, and this triggers
+       * https://github.com/testing-library/jest-dom/issues/306 */
+      /* eslint-disable-next-line jest-dom/prefer-to-have-text-content */
+      expect(renderedCapacity.textContent).toBe('1GB');
       expect(getMetaInfoPanel()).toMatchSnapshot();
     });
 

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -477,7 +477,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         >
           Buffer Capacity:
         </span>
-        16.0KB
+        1GB
       </div>
       <div
         class="metaInfoRow"

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -27,7 +27,7 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
     <span
       class="timelineTrackMemoryTooltipNumber"
     >
-      2.0B
+      2B
     </span>
      memory range in graph
   </div>

--- a/src/utils/format-numbers.js
+++ b/src/utils/format-numbers.js
@@ -167,16 +167,35 @@ export function ratioToCssPercent(ratio: number): string {
   return (ratio * 100).toFixed(4) + '%';
 }
 
-export function formatBytes(bytes: number): string {
+export function formatBytes(
+  bytes: number,
+  significantDigits: number = 3,
+  maxFractionalDigits: number = 2
+): string {
   if (bytes < 10000) {
     // Use singles up to 10,000.  I think 9,360B looks nicer than 9.36KB.
-    return formatNumber(bytes) + 'B';
+    // We use "0" for significantDigits because bytes will always be integers.
+    return formatNumber(bytes, 0) + 'B';
   } else if (bytes < 1024 * 1024) {
-    return formatNumber(bytes / 1024, 3, 2) + 'KB';
+    return (
+      formatNumber(bytes / 1024, significantDigits, maxFractionalDigits) + 'KB'
+    );
   } else if (bytes < 1024 * 1024 * 1024) {
-    return formatNumber(bytes / (1024 * 1024), 3, 2) + 'MB';
+    return (
+      formatNumber(
+        bytes / (1024 * 1024),
+        significantDigits,
+        maxFractionalDigits
+      ) + 'MB'
+    );
   }
-  return formatNumber(bytes / (1024 * 1024 * 1024), 3, 2) + 'GB';
+  return (
+    formatNumber(
+      bytes / (1024 * 1024 * 1024),
+      significantDigits,
+      maxFractionalDigits
+    ) + 'GB'
+  );
 }
 
 export function formatSI(num: number): string {


### PR DESCRIPTION
…(Fixes #3159)

This is an example profile with a 1GB buffer:
[production](https://profiler.firefox.com/public/a5e3dfdg34df0a9sezmpg4ahet417mr9fmhvea0/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-5&hiddenLocalTracksByPid=14192-0&localTrackOrderByPid=14192-2-0-1~14470-0~14411-0~&thread=6&v=5)
[deploy preview](https://deploy-preview-3168--perf-html.netlify.com/public/a5e3dfdg34df0a9sezmpg4ahet417mr9fmhvea0/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-5&hiddenLocalTracksByPid=14192-0&localTrackOrderByPid=14192-2-0-1~14470-0~14411-0~&thread=6&v=5)