### PR TITLE
Ignore the dist directory when flow-checking the project

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,8 +6,9 @@ module.name_mapper='^firefox-profiler\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 module.name_mapper.extension='ftl' -> '<PROJECT_ROOT>/src/types/mocks/ftl.js'
 
 [ignore]
-.*node_modules/.*
-res/before-load.js
+<PROJECT_ROOT>/node_modules/.*
+<PROJECT_ROOT>/res/before-load\.js
+<PROJECT_ROOT>/dist/.*
 
 [libs]
 src/types/libdef


### PR DESCRIPTION
I had a local `dist` directory with the generated service worker (`yarn build-prod` does that), and as a result Flow prevented me from pushing because it was finding problems. So here is the change for that. I also slightly changed the format for the existing entries.

Here is the documentation about this file: https://flow.org/en/docs/config/ignore/