### PR TITLE
Check marker phase and make sure that start/end times are valid while computing the timeline range

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -11,20 +11,20 @@ import {
   getEmptyUnbalancedNativeAllocationsTable,
   getEmptyBalancedNativeAllocationsTable,
 } from './data-structures';
-import { bisectionRight, bisectionLeft } from 'firefox-profiler/utils/bisect';
-import {
-  assertExhaustiveCheck,
-  ensureExists,
-  getFirstItemFromSet,
-} from '../utils/flow';
 import {
   INSTANT,
   INTERVAL,
   INTERVAL_START,
   INTERVAL_END,
 } from 'firefox-profiler/app-logic/constants';
-import { timeCode } from '../utils/time-code';
-import { hashPath } from '../utils/path';
+import { timeCode } from 'firefox-profiler/utils/time-code';
+import { hashPath } from 'firefox-profiler/utils/path';
+import { bisectionRight, bisectionLeft } from 'firefox-profiler/utils/bisect';
+import {
+  assertExhaustiveCheck,
+  ensureExists,
+  getFirstItemFromSet,
+} from 'firefox-profiler/utils/flow';
 
 import type {
   Profile,
@@ -65,7 +65,7 @@ import type {
   EventDelayInfo,
   ThreadsKey,
 } from 'firefox-profiler/types';
-import type { UniqueStringArray } from '../utils/unique-string-array';
+import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
 
 /**
  * Various helpers for dealing with the profile as a data structure.

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -13,6 +13,8 @@ import type {
 } from './units';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { MarkerPayload, MarkerSchema } from './markers';
+import type { MarkerPhase } from './gecko-profile';
+
 export type IndexIntoStackTable = number;
 export type IndexIntoSamplesTable = number;
 export type IndexIntoRawMarkerTable = number;
@@ -254,7 +256,7 @@ export type RawMarkerTable = {|
   name: IndexIntoStringTable[],
   startTime: Array<number | null>,
   endTime: Array<number | null>,
-  phase: number[],
+  phase: MarkerPhase[],
   category: IndexIntoCategoryList[],
   length: number,
 |};


### PR DESCRIPTION
Fixes #3172.

[Old profile range](https://share.firefox.dev/3ps8QX3)
[New profile range](https://deploy-preview-3173--perf-html.netlify.app/public/zm5xsfntjknjb464cx7s507w5kmye61adh4kwm0/calltree/?globalTrackOrder=8-0-1-2-3-4-5-6-7&localTrackOrderByPid=25580-1-2-0~27896-0~4952-3-0-1-2~24588-0~23196-0~25188-0~21304-0~15276-0-1~&thread=0&v=5) (new range is still a bit long but it's justified since we have a marker that starts there.)