### PR TITLE
Fix crash when sanitizing filenames in FileIO markers without filenames

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -138,7 +138,7 @@ export function getSearchFilteredMarkerIndexes(
       if (data.type === 'FileIO') {
         const { filename, operation, source, threadId } = data;
         if (
-          searchRegExp.test(filename) ||
+          searchRegExp.test(filename || '') ||
           searchRegExp.test(operation) ||
           searchRegExp.test(source) ||
           (threadId !== undefined && searchRegExp.test(threadId.toString()))
@@ -1149,6 +1149,10 @@ export function removePrefMarkerPreferenceValues(
 export function sanitizeFileIOMarkerFilenamePath(
   payload: FileIoPayload
 ): FileIoPayload {
+  if (!payload.filename) {
+    return payload;
+  }
+
   return {
     ...payload,
     filename: removeFilePath(payload.filename),

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -437,16 +437,28 @@ describe('sanitizePII', function() {
             },
           },
         ],
+        [
+          'FileIO',
+          5,
+          6,
+          {
+            type: 'FileIO',
+            source: 'PoisonIOInterposer',
+            operation: 'fsync',
+          },
+        ],
       ])
     );
     expect(sanitizedProfile.threads.length).toEqual(1);
     const thread = sanitizedProfile.threads[0];
-    expect(thread.markers.length).toEqual(2);
+    expect(thread.markers.length).toEqual(3);
 
     const marker1 = thread.markers.data[0];
     const marker2 = thread.markers.data[1];
+    // Note: the 3rd marker has no filename property, to check that we know how
+    // to handle this case, but otherwise we do no check on it.
 
-    // Marker filename fields should be there.
+    // Marker filename fields should be there in the 2 first markers.
     if (!marker1 || !marker1.filename || !marker2 || !marker2.filename) {
       throw new Error('Failed to find filename property in the payload');
     }

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -476,7 +476,7 @@ export type FileIoPayload = {|
   cause?: CauseBacktrace,
   source: string,
   operation: string,
-  filename: string,
+  filename?: string,
   // FileIO markers that are happening on the current thread don't have a threadId,
   // but they have threadId field if the markers belong to a different (potentially
   // non-profiled) thread.


### PR DESCRIPTION
This PR fixes a crash in the sanitizing process for paths and URLs. Indeed the `filename` property can be absent for FileIO markers now, while it wasn't the case before Markers 2.0.

Direct links with a profile with such markers:
* searching for "undefined": [main](https://profiler.firefox.com/public/vfcypadd5rt1w647ch05embegbfjjzfges7vfgr/marker-table/?globalTrackOrder=0&localTrackOrderByPid=94198-0~&markerSearch=undefined&thread=0&v=5) / [deploy preview](https://deploy-preview-3186--perf-html.netlify.app/public/vfcypadd5rt1w647ch05embegbfjjzfges7vfgr/marker-table/?globalTrackOrder=0&localTrackOrderByPid=94198-0~&markerSearch=undefined&thread=0&v=5) (with the preview there should be no result)
* try to share, sanitizing URLs: [main](https://profiler.firefox.com/public/vfcypadd5rt1w647ch05embegbfjjzfges7vfgr/) / [deploy preview](https://deploy-preview-3186--perf-html.netlify.app/public/vfcypadd5rt1w647ch05embegbfjjzfges7vfgr/) (uncheck this: ![image](https://user-images.githubusercontent.com/454175/108865481-914a4b00-75f3-11eb-97f7-40a786e037f1.png))
