### PR TITLE
Enable pseudo localizations and support the direction and lang attributes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -5,6 +5,7 @@
 // @flow
 import * as app from './app';
 import * as icons from './icons';
+import * as l10n from './l10n';
 import * as profileView from './profile-view';
 import * as publish from './publish';
 import * as receiveProfile from './receive-profile';
@@ -14,6 +15,7 @@ export default Object.assign(
   {},
   app,
   icons,
+  l10n,
   profileView,
   publish,
   receiveProfile,

--- a/src/actions/l10n.js
+++ b/src/actions/l10n.js
@@ -12,7 +12,8 @@ import {
   DEFAULT_LOCALE,
   fetchMessages,
   lazilyParsedBundles,
-} from '../app-logic/l10n';
+  getLocaleDirection,
+} from 'firefox-profiler/app-logic/l10n';
 
 /**
  * Notify that translations for the UI are being fetched.
@@ -26,10 +27,16 @@ export function requestL10n(): Action {
 /**
  * Receive translations for a locale.
  */
-export function receiveL10n(localization: Localization): Action {
+export function receiveL10n(
+  localization: Localization,
+  primaryLocale: string,
+  direction: 'ltr' | 'rtl'
+): Action {
   return {
     type: 'RECEIVE_L10N',
     localization: localization,
+    primaryLocale,
+    direction,
   };
 }
 
@@ -41,7 +48,7 @@ export function receiveL10n(localization: Localization): Action {
  */
 export function setupLocalization(
   locales: Array<string>,
-  pseudoStrategy?: string
+  pseudoStrategy?: 'accented' | 'bidi'
 ): ThunkAction<Promise<void>> {
   return async dispatch => {
     dispatch(requestL10n());
@@ -52,9 +59,13 @@ export function setupLocalization(
       defaultLocale: DEFAULT_LOCALE,
     });
 
-    const fetchedMessages = await fetchMessages(languages[0]);
+    // It's important to note that `languages` is the result of the negotiation,
+    // and can be different than `locales`.
+    const primaryLocale = languages[0];
+    const fetchedMessages = await fetchMessages(primaryLocale);
     const bundles = lazilyParsedBundles([fetchedMessages], pseudoStrategy);
     const localization = new ReactLocalization(bundles);
-    dispatch(receiveL10n(localization));
+    const direction = getLocaleDirection(primaryLocale, pseudoStrategy);
+    dispatch(receiveL10n(localization, primaryLocale, direction));
   };
 }

--- a/src/actions/l10n.js
+++ b/src/actions/l10n.js
@@ -40,7 +40,8 @@ export function receiveL10n(localization: Localization): Action {
  * later it dispacthes the translations and updates the state
  */
 export function setupLocalization(
-  locales: Array<string>
+  locales: Array<string>,
+  pseudoStrategy?: string
 ): ThunkAction<Promise<void>> {
   return async dispatch => {
     dispatch(requestL10n());
@@ -52,7 +53,7 @@ export function setupLocalization(
     });
 
     const fetchedMessages = await fetchMessages(languages[0]);
-    const bundles = lazilyParsedBundles([fetchedMessages]);
+    const bundles = lazilyParsedBundles([fetchedMessages], pseudoStrategy);
     const localization = new ReactLocalization(bundles);
     dispatch(receiveL10n(localization));
   };

--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -5,6 +5,7 @@
 // @flow
 
 import { FluentBundle, FluentResource } from '@fluent/bundle';
+import { PSEUDO_STRATEGIES } from 'firefox-profiler/utils/l10n-pseudo';
 
 export const AVAILABLE_LOCALES: Array<string> = ['en-US'];
 export const DEFAULT_LOCALE = 'en-US';
@@ -25,11 +26,17 @@ export async function fetchMessages(locale: string): Promise<[string, string]> {
  * preferences.
  */
 export function* lazilyParsedBundles(
-  fetchedMessages: Array<[string, string]>
+  fetchedMessages: Array<[string, string]>,
+  pseudoStrategy?: 'accented' | 'bidi'
 ): Generator<FluentBundle, void, void> {
+  const transform = pseudoStrategy
+    ? PSEUDO_STRATEGIES[pseudoStrategy]
+    : undefined;
   for (const [locale, messages] of fetchedMessages) {
     const resource = new FluentResource(messages);
-    const bundle = new FluentBundle(locale);
+    const bundle = new FluentBundle(locale, {
+      transform,
+    });
     bundle.addResource(resource);
     yield bundle;
   }

--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -5,10 +5,21 @@
 // @flow
 
 import { FluentBundle, FluentResource } from '@fluent/bundle';
-import { PSEUDO_STRATEGIES } from 'firefox-profiler/utils/l10n-pseudo';
+import {
+  PSEUDO_STRATEGIES,
+  PSEUDO_STRATEGIES_DIRECTION,
+} from 'firefox-profiler/utils/l10n-pseudo';
 
+// This contains the locales we support. Don't forget to update the array
+// RTL_LOCALES when adding a RTL locale, if necessary.
 export const AVAILABLE_LOCALES: Array<string> = ['en-US'];
 export const DEFAULT_LOCALE = 'en-US';
+
+// This array contains only the locales that are RTL (Right-To-Left).
+// This list has been copied from the l20n library in the Firefox OS project
+// (ancestor of Fluent):
+// https://github.com/mozilla-b2g/gaia/blob/975a35c0f5010df341e96d6c5ec60217f5347412/shared/js/intl/l20n-client.js#L31-L35
+const RTL_LOCALES = ['ar', 'he', 'fa', 'ps', 'ur'];
 
 /**
  * Fetches ftl file of different locales.
@@ -40,4 +51,21 @@ export function* lazilyParsedBundles(
     bundle.addResource(resource);
     yield bundle;
   }
+}
+
+/**
+ * From a language string and a pseudoStrategy, this returns which direction the
+ * document should be in.
+ */
+export function getLocaleDirection(
+  language: string,
+  pseudoStrategy?: 'accented' | 'bidi'
+): 'ltr' | 'rtl' {
+  if (pseudoStrategy && pseudoStrategy in PSEUDO_STRATEGIES_DIRECTION) {
+    return PSEUDO_STRATEGIES_DIRECTION[pseudoStrategy];
+  }
+
+  // The language can be simple like "fr" but also more precise like "fr-FR".
+  const tag = language.split('-')[0];
+  return RTL_LOCALES.includes(tag) ? 'rtl' : 'ltr';
 }

--- a/src/reducers/l10n.js
+++ b/src/reducers/l10n.js
@@ -37,9 +37,29 @@ const localization: Reducer<ReactLocalization> = (
   }
 };
 
+const primaryLocale: Reducer<string | null> = (state = null, action) => {
+  switch (action.type) {
+    case 'RECEIVE_L10N':
+      return action.primaryLocale;
+    default:
+      return state;
+  }
+};
+
+const direction: Reducer<'ltr' | 'rtl'> = (state = 'ltr', action) => {
+  switch (action.type) {
+    case 'RECEIVE_L10N':
+      return action.direction;
+    default:
+      return state;
+  }
+};
+
 const l10nReducer: Reducer<L10nState> = combineReducers({
   l10nFetchingPhase,
   localization,
+  primaryLocale,
+  direction,
 });
 
 export default l10nReducer;

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -4,6 +4,7 @@
 
 // @flow
 export * from './app';
+export * from './l10n';
 export * from './per-thread';
 export * from './profile';
 export * from './url-state';

--- a/src/selectors/l10n.js
+++ b/src/selectors/l10n.js
@@ -16,3 +16,7 @@ export const getL10nFetchingPhase: Selector<L10nFetchingPhase> = state =>
   getL10nState(state).l10nFetchingPhase;
 export const getLocalization: Selector<Localization> = state =>
   getL10nState(state).localization;
+export const getPrimaryLocale: Selector<string | null> = state =>
+  getL10nState(state).primaryLocale;
+export const getDirection: Selector<'ltr' | 'rtl'> = state =>
+  getL10nState(state).direction;

--- a/src/test/components/AppLocalizationProvider.test.js
+++ b/src/test/components/AppLocalizationProvider.test.js
@@ -11,6 +11,8 @@ import { Provider } from 'react-redux';
 import {
   getL10nFetchingPhase,
   getLocalization,
+  getPrimaryLocale,
+  getDirection,
 } from 'firefox-profiler/selectors/l10n';
 import { lazilyParsedBundles } from 'firefox-profiler/app-logic/l10n';
 import { requestL10n, receiveL10n } from 'firefox-profiler/actions/l10n';
@@ -69,9 +71,11 @@ describe('AppLocalizationProvider', () => {
     ];
     const bundles = lazilyParsedBundles([resource]);
     const testLocalization = new ReactLocalization(bundles);
-    dispatch(receiveL10n(testLocalization));
+    dispatch(receiveL10n(testLocalization, 'en-US', 'ltr'));
     expect(getL10nFetchingPhase(getState())).toBe('done-fetching');
     expect(getLocalization(getState())).toEqual(testLocalization);
+    expect(getPrimaryLocale(getState())).toEqual('en-US');
+    expect(getDirection(getState())).toEqual('ltr');
   });
 
   it('renders its children', async () => {

--- a/src/test/unit/__snapshots__/window-console.test.js.snap
+++ b/src/test/unit/__snapshots__/window-console.test.js.snap
@@ -32,6 +32,7 @@ Array [
 %cwindow.dispatch%c - The function to dispatch a Redux action to change the state.
 %cwindow.actions%c - All the actions that can be dispatched to change the state.
 %cwindow.experimental%c - The object that holds flags of all the experimental features.
+%cwindow.togglePseudoLocalization%c - Enable pseudo localizations by passing \\"accented\\" or \\"bidi\\" to this function, or disable using no parameters.
 
 The profile format is documented here:
 %chttps://github.com/firefox-devtools/profiler/blob/main/docs-developer/processed-profile-format.md%c
@@ -39,6 +40,8 @@ The profile format is documented here:
 The CallTree class's source code is available here:
 %chttps://github.com/firefox-devtools/profiler/blob/main/src/profile-logic/call-tree.js%c",
     "font-size: 130%;",
+    "",
+    "font-weight: bold;",
     "",
     "font-weight: bold;",
     "",

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -505,7 +505,12 @@ type CurrentProfileUploadedInformationAction = {|
 
 type L10nAction =
   | {| +type: 'REQUEST_L10N' |}
-  | {| +type: 'RECEIVE_L10N', +localization: Localization |};
+  | {|
+      +type: 'RECEIVE_L10N',
+      +localization: Localization,
+      +primaryLocale: string,
+      +direction: 'ltr' | 'rtl',
+    |};
 
 export type Action =
   | ProfileAction

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -295,6 +295,8 @@ export type L10nFetchingPhase =
 export type L10nState = {|
   +l10nFetchingPhase: L10nFetchingPhase,
   +localization: Localization,
+  +primaryLocale: string | null,
+  +direction: 'ltr' | 'rtl',
 |};
 
 export type IconState = Set<string>;

--- a/src/utils/l10n-pseudo.js
+++ b/src/utils/l10n-pseudo.js
@@ -108,3 +108,8 @@ export const PSEUDO_STRATEGIES = {
   accented: transformString.bind(null, ACCENTED_MAP, true, '', ''),
   bidi: transformString.bind(null, FLIPPED_MAP, false, '\u202e', '\u202c'),
 };
+
+export const PSEUDO_STRATEGIES_DIRECTION = {
+  accented: 'ltr',
+  bidi: 'rtl',
+};

--- a/src/utils/l10n-pseudo.js
+++ b/src/utils/l10n-pseudo.js
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// Stolen from https://hg.mozilla.org/mozilla-central/file/a1f74e8c8fb72390d22054d6b00c28b1a32f6c43/intl/l10n/L10nRegistry.jsm#l425
+/**
+ * Pseudolocalizations
+ *
+ * PSEUDO_STRATEGIES is a dict of strategies to be used to modify a
+ * context in order to create pseudolocalizations.  These can be used by
+ * developers to test the localizability of their code without having to
+ * actually speak a foreign language.
+ *
+ * Currently, the following pseudolocales are supported:
+ *
+ *   accented - Ȧȧƈƈḗḗƞŧḗḗḓ Ḗḗƞɠŀīīşħ
+ *
+ *     In Accented English all Latin letters are replaced by accented
+ *     Unicode counterparts which don't impair the readability of the content.
+ *     This allows developers to quickly test if any given string is being
+ *     correctly displayed in its 'translated' form.  Additionally, simple
+ *     heuristics are used to make certain words longer to better simulate the
+ *     experience of international users.
+ *
+ *   bidi - ɥsıʅƃuƎ ıpıԐ
+ *
+ *     Bidi English is a fake RTL locale.  All words are surrounded by
+ *     Unicode formatting marks forcing the RTL directionality of characters.
+ *     In addition, to make the reversed text easier to read, individual
+ *     letters are flipped.
+ *
+ *     Note: The name above is hardcoded to be RTL in case code editors have
+ *     trouble with the RLO and PDF Unicode marks.  In reality, it should be
+ *     surrounded by those marks as well.
+ *
+ * See https://bugzil.la/1450781 for more information.
+ *
+ * In this implementation we use code points instead of inline unicode characters
+ * because the encoding of JSM files mangles them otherwise.
+ */
+
+const ACCENTED_MAP = {
+  // ȦƁƇḒḖƑƓĦĪĴĶĿḾȠǾƤɊŘŞŦŬṼẆẊẎẐ
+  // prettier-ignore
+  "caps": [550, 385, 391, 7698, 7702, 401, 403, 294, 298, 308, 310, 319, 7742, 544, 510, 420, 586, 344, 350, 358, 364, 7804, 7814, 7818, 7822, 7824],
+  // ȧƀƈḓḗƒɠħīĵķŀḿƞǿƥɋřşŧŭṽẇẋẏẑ
+  // prettier-ignore
+  "small": [551, 384, 392, 7699, 7703, 402, 608, 295, 299, 309, 311, 320, 7743, 414, 511, 421, 587, 345, 351, 359, 365, 7805, 7815, 7819, 7823, 7825]
+};
+
+const FLIPPED_MAP = {
+  // ∀ԐↃᗡƎℲ⅁HIſӼ⅂WNOԀÒᴚS⊥∩ɅMX⅄Z
+  // prettier-ignore
+  "caps": [8704, 1296, 8579, 5601, 398, 8498, 8513, 72, 73, 383, 1276, 8514, 87, 78, 79, 1280, 210, 7450, 83, 8869, 8745, 581, 77, 88, 8516, 90],
+  // ɐqɔpǝɟƃɥıɾʞʅɯuodbɹsʇnʌʍxʎz
+  // prettier-ignore
+  "small": [592, 113, 596, 112, 477, 607, 387, 613, 305, 638, 670, 645, 623, 117, 111, 100, 98, 633, 115, 647, 110, 652, 653, 120, 654, 122]
+};
+
+function transformString(
+  map,
+  elongate = false,
+  prefix = '',
+  postfix = '',
+  msg: string
+) {
+  // Exclude access-keys and other single-char messages
+  if (msg.length === 1) {
+    return msg;
+  }
+  // XML entities (&#x202a;) and XML tags.
+  const reExcluded = /(&[#\w]+;|<\s*.+?\s*>)/;
+
+  const parts = msg.split(reExcluded);
+  const modified = parts.map(part => {
+    if (reExcluded.test(part)) {
+      return part;
+    }
+    return (
+      prefix +
+      part.replace(/[a-z]/gi, ch => {
+        const cc = ch.charCodeAt(0);
+        if (cc >= 97 && cc <= 122) {
+          const newChar = String.fromCodePoint(map.small[cc - 97]);
+          // duplicate "a", "e", "o" and "u" to emulate ~30% longer text
+          if (
+            elongate &&
+            (cc === 97 || cc === 101 || cc === 111 || cc === 117)
+          ) {
+            return newChar + newChar;
+          }
+          return newChar;
+        }
+        if (cc >= 65 && cc <= 90) {
+          return String.fromCodePoint(map.caps[cc - 65]);
+        }
+        return ch;
+      }) +
+      postfix
+    );
+  });
+  return modified.join('');
+}
+
+export const PSEUDO_STRATEGIES = {
+  accented: transformString.bind(null, ACCENTED_MAP, true, '', ''),
+  bidi: transformString.bind(null, FLIPPED_MAP, false, '\u202e', '\u202c'),
+};

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -74,6 +74,33 @@ export function addDataToWindowObject(
     },
   };
 
+  target.togglePseudoLocalization = function(pseudoStrategy?: string) {
+    if (
+      pseudoStrategy !== undefined &&
+      pseudoStrategy !== 'accented' &&
+      pseudoStrategy !== 'bidi'
+    ) {
+      console.log(stripIndent`
+        ❗ The pseudo strategy "${pseudoStrategy}" is unknown.
+        💡 Valid strategies are: "accented" or "bidi".
+        Please try again 😊
+      `);
+      return;
+    }
+
+    dispatch(actions.setupLocalization(navigator.languages, pseudoStrategy));
+    if (pseudoStrategy) {
+      console.log(stripIndent`
+        ✅ The pseudo strategy "${pseudoStrategy}" is now enabled for the localization.
+        👉 To disable it, you can call togglePseudoLocalization() again without a parameter.
+      `);
+    } else {
+      console.log(stripIndent`
+        ✅ The pseudo strategy is now disabled.
+      `);
+    }
+  };
+
   target.getState = getState;
   target.selectors = selectorsForConsole;
   target.dispatch = dispatch;
@@ -129,6 +156,7 @@ export function logFriendlyPreamble() {
       %cwindow.dispatch%c - The function to dispatch a Redux action to change the state.
       %cwindow.actions%c - All the actions that can be dispatched to change the state.
       %cwindow.experimental%c - The object that holds flags of all the experimental features.
+      %cwindow.togglePseudoLocalization%c - Enable pseudo localizations by passing "accented" or "bidi" to this function, or disable using no parameters.
 
       The profile format is documented here:
       %chttps://github.com/firefox-devtools/profiler/blob/main/docs-developer/processed-profile-format.md%c
@@ -164,6 +192,9 @@ export function logFriendlyPreamble() {
     bold,
     reset,
     // "window.experimental"
+    bold,
+    reset,
+    // "window.togglePseudoLocalization"
     bold,
     reset,
     // "processed-profile-format.md"


### PR DESCRIPTION
The goal for this PR is double:
1. support pseudo localizations, so that reviewing localization patches is easier.
2. support RTL. This wasn't urgent but I thought that it's better to support it when enabling the "bidi" pseudolocale.

There are 3 commits, it should be easier to review them one by one. Reviewing the PR all together should be doable as well: a lot of files are changed but that's a lot of small changes because of the redux state change.

Using the [deploy preview](https://deploy-preview-3188--perf-html.netlify.com/), you can go to the console and type `togglePseudoLocalization('accented')` or `togglePseudoLocalization('bidi')` to have one or the other. Just typing `togglePseudoLocalization()` will disable it.

However without any localization nothing will be visible yet, except the direction and lang attributes being set on the document.