### PR TITLE
Setup the en-US Translation for Tests

### DIFF
--- a/src/test/fixtures/testing-library.js
+++ b/src/test/fixtures/testing-library.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import fs from 'fs';
+import { LocalizationProvider, ReactLocalization } from '@fluent/react';
+import { lazilyParsedBundles } from '../../app-logic/l10n';
+
+function customRender(children: React$Element<any>, ...args: any) {
+  const messages = fs.readFileSync('./locales/en-US/app.ftl', 'UTF-8');
+  const bundles = lazilyParsedBundles([['en-US', messages]]);
+  const localization = new ReactLocalization(bundles);
+
+  return render(
+    <LocalizationProvider l10n={localization}>{children}</LocalizationProvider>,
+    ...args
+  );
+}
+
+// Reexport everything
+export * from '@testing-library/react';
+
+// override render method
+export { customRender as render };


### PR DESCRIPTION
While implementing localization the texts from the markup are suggested to be removed. But then we won't be able to validate the snapshots. This is the solution suggested by @julienw to fetch the default FTL (en-US) synchronously when we test. So that the snapshots are being compared with the texts fetched from the FTL, not the markups. And now we can safely remove the texts (which are localized) from the markups.

Ref #3183