### PR TITLE
Do not remove Java initializers when copying a function name

### DIFF
--- a/src/profile-logic/function-info.js
+++ b/src/profile-logic/function-info.js
@@ -50,10 +50,16 @@ export function removeTemplateInformation(functionName: string) {
   // templates can't occur before the name of a function, so this is certainly
   // an HTML tag like <script>.
   for (let i = 1; i < functionName.length; i++) {
-    // We also don't want to extract template-like information that start after
-    // a space, as that won't likely be a real template information and
-    // probably rather an HTML tag name.
-    if (functionName[i] === '<' && functionName[i - 1] !== ' ') {
+    // We also don't want to extract template-like information with these
+    // characteristics:
+    // - that start after a space, as that won't likely be a real template
+    //   information and probably rather an HTML tag name.
+    // - that start after a dot, as that will likely be a java initializer
+    if (
+      functionName[i] === '<' &&
+      functionName[i - 1] !== ' ' &&
+      functionName[i - 1] !== '.'
+    ) {
       if (depth === 0) {
         // Template information begins, save segment
         result += functionName.substr(start, i - start);

--- a/src/profile-logic/function-info.js
+++ b/src/profile-logic/function-info.js
@@ -42,41 +42,52 @@ export function stripFunctionArguments(functionCall: string): string {
 }
 
 export function removeTemplateInformation(functionName: string) {
+  // The result for this function. This works as an accumulator.
   let result = '';
+  // This keeps the depth in the tree of anchorness.
   let depth = 0;
-  let start = 0; // Start of a segment we'd like to keep
+  // This keeps the depth start of a template we'd like to remove. This is
+  // useful to find the end of this template. This is null if we're not removing
+  // any template yet.
+  let templateStartDepth: null | number = null;
+  // Start of a segment we'd like to keep
+  let start = 0;
+
   // We start the loop at i = 1 because we don't want to extract any
   // template-like information starting at the beginning of the string:
   // templates can't occur before the name of a function, so this is certainly
   // an HTML tag like <script>.
   for (let i = 1; i < functionName.length; i++) {
-    // We also don't want to extract template-like information with these
-    // characteristics:
-    // - that start after a space, as that won't likely be a real template
-    //   information and probably rather an HTML tag name.
-    // - that start after a dot, as that will likely be a java initializer
-    if (
-      functionName[i] === '<' &&
-      functionName[i - 1] !== ' ' &&
-      functionName[i - 1] !== '.'
-    ) {
-      if (depth === 0) {
-        // Template information begins, save segment
-        result += functionName.substr(start, i - start);
-        // Start a new segment here to not lose the rest of the string
-        // should we find no matching '>'
-        start = i;
+    if (functionName[i] === '<') {
+      if (functionName[i - 1] !== ' ' && functionName[i - 1] !== '.') {
+        // We also don't want to extract template-like information with these
+        // characteristics:
+        // - that start after a space, as that won't likely be a real template
+        //   information and probably rather an HTML tag name.
+        // - that start after a dot, as that will likely be a java initializer
+        if (templateStartDepth === null) {
+          // Template information begins, save segment
+          result += functionName.slice(start, i);
+          // Start a new segment here to not lose the rest of the string
+          // should we find no matching '>'
+          start = i;
+          // Remember the depth for this template start, so that we find the end
+          // of this template just fine.
+          templateStartDepth = depth;
+        }
       }
       depth++;
     } else if (functionName[i] === '>') {
       depth--;
-      if (depth === 0) {
+      if (depth === templateStartDepth) {
         // Template information ends, start of new segment
         start = i + 1;
+        // Reset the "are we removing some template" information.
+        templateStartDepth = null;
       }
     }
   }
-  result += functionName.substr(start);
+  result += functionName.slice(start);
   return result;
 }
 

--- a/src/test/unit/function-info.test.js
+++ b/src/test/unit/function-info.test.js
@@ -65,6 +65,13 @@ describe('remove-template-information', function() {
     fixture = 'starting handling <script>';
     expect(removeTemplateInformation(fixture)).toEqual(fixture);
   });
+
+  it('should not remove java initializer functions', function() {
+    // See issue https://github.com/firefox-devtools/profiler/issues/3199
+    const fixture =
+      'mozilla.components.support.locale.LocaleAwareAppCompatActivity.<init>';
+    expect(removeTemplateInformation(fixture)).toEqual(fixture);
+  });
 });
 
 describe('get-function-name', function() {

--- a/src/test/unit/function-info.test.js
+++ b/src/test/unit/function-info.test.js
@@ -72,6 +72,16 @@ describe('remove-template-information', function() {
       'mozilla.components.support.locale.LocaleAwareAppCompatActivity.<init>';
     expect(removeTemplateInformation(fixture)).toEqual(fixture);
   });
+
+  it('should remove template information that contains "false positive" templates', function() {
+    // This is a theoretical issue that we never encountered in the wild, but
+    // this is theoretically possible, so let's test it.
+    const fixture =
+      'mozilla.components.support.locale.LocaleAwareAppCompatActivity<TemplateInformation.<init>>';
+    const expected =
+      'mozilla.components.support.locale.LocaleAwareAppCompatActivity';
+    expect(removeTemplateInformation(fixture)).toEqual(expected);
+  });
 });
 
 describe('get-function-name', function() {


### PR DESCRIPTION
Fixes #3199

The issue is visible in the sidebar with the line selected by default:

Before:
![image](https://user-images.githubusercontent.com/454175/109821199-080bc780-7c36-11eb-8945-9f8d987374b3.png)
After:
![image](https://user-images.githubusercontent.com/454175/109821952-c92a4180-7c36-11eb-8422-f65e9a2db3ca.png)


[Production](https://profiler.firefox.com/public/atw81mheb8k5gvdr9vwwqj751j8n3v5mht662vr/calltree/?globalTrackOrder=3-0-1-2&hiddenGlobalTracks=2&hiddenLocalTracksByPid=9189-0~9476-0~9264-0&localTrackOrderByPid=9189-3-4-0-1-2~9476-1-0~9264-1-0~&profileName=WARM%20VIEW&range=2860m646~2920916u4485&search=%3Cinit%3E&thread=3&v=5)
[Deploy preview](https://deploy-preview-3202--perf-html.netlify.com/public/atw81mheb8k5gvdr9vwwqj751j8n3v5mht662vr/calltree/?globalTrackOrder=3-0-1-2&hiddenGlobalTracks=2&hiddenLocalTracksByPid=9189-0~9476-0~9264-0&localTrackOrderByPid=9189-3-4-0-1-2~9476-1-0~9264-1-0~&profileName=WARM%20VIEW&range=2860m646~2920916u4485&search=%3Cinit%3E&thread=3&v=5)

There are 2 commits for the 2 issues I'm fixing here:
1. First commit fixes #3199
2. Second commit fixes a theoretical issue with nested "real" and "false positive" templates

Hopefully looking at these 2 commits separately should make it clear what code change is for which issue.
