### PR TITLE
Make MenuButtons Localizable

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -13,6 +13,7 @@
 
 -firefox-brand-name = Firefox
 -profiler-brand-name = Firefox Profiler
+-firefox-nightly-brand-name = Firefox Nightly
 
 ## AppHeader
 
@@ -101,6 +102,144 @@ ListOfPublishedProfiles--uploaded-profile-information-list =
         [one] Manage this recording
        *[other] Manage these recordings
     }
+
+## MenuButtons Folder
+
+MenuButtons--index--profile-info-uploaded-label = Uploaded:
+MenuButtons--index--profile-info-uploaded-actions = Delete
+MenuButtons--index--meta-info-subtitle = Profile Information
+MenuButtons--index--meta-info-button-uploaded-profile =
+    .label = Uploaded Profile
+
+MenuButtons--index--meta-info-button-local-profile =
+    .label = Local Profile
+
+MenuButtons--index--full-view = Full View
+MenuButtons--index--cancel-upload = Cancel Upload
+MenuButtons--index--share-upload =
+    .label = Upload
+
+MenuButtons--index--share-re-upload =
+    .label = Re-upload
+
+MenuButtons--index--share-error-uploading =
+    .label = Error uploading
+
+MenuButtons--index--revert = Revert to Original Profile
+MenuButtons--index--docs = Docs
+
+MenuButtons--metaInfo--symbols = Symbols:
+MenuButtons--metaInfo--profile-symbolicated = Profile is symbolicated
+MenuButtons--metaInfo--profile-not-symbolicated = Profile is not symbolicated
+MenuButtons--metaInfo--resymbolicate-profile = Re-symbolicate profile
+MenuButtons--metaInfo--symbolicate-profile = Symbolicate profile
+MenuButtons--metaInfo--attempting-resymbolicate = Attempting to re-symbolicate profile
+MenuButtons--metaInfo--currently-symbolicating = Currently symbolicating profile
+MenuButtons--metaInfo--cpu = CPU:
+
+# Buffer Duration in Seconds in Meta Info Panel
+# Variable:
+#   $physicalCPUs (Number), $logicalCPUs (Number) - Number of Physical and Logical CPU Cores
+MenuButtons--metaInfo--physical-and-logical-cpu =
+    { $physicalCPUs ->
+        [one] { $physicalCPUs } physical core
+       *[other] { $physicalCPUs } physical cores
+    }, { $logicalCPUs ->
+        [one] { $logicalCPUs } logical core
+       *[other] { $logicalCPUs } logical cores
+    }
+
+# Buffer Duration in Seconds in Meta Info Panel
+# Variable:
+#   $physicalCPUs (Number) - Number of Physical CPU Cores
+MenuButtons--metaInfo--physical-cpu =
+    { $physicalCPUs ->
+        [one] { $physicalCPUs } physical core
+       *[other] { $physicalCPUs } physical cores
+    }
+
+# Buffer Duration in Seconds in Meta Info Panel
+# Variable:
+#   $logicalCPUs (Number) - Number of logical CPU Cores
+MenuButtons--metaInfo--logical-cpu =
+    { $logicalCPUs ->
+        [one] { $logicalCPUs } logical core
+       *[other] { $logicalCPUs } logical cores
+    }
+
+MenuButtons--metaInfo--recording-started = Recording started:
+MenuButtons--metaInfo--interval = Interval:
+MenuButtons--metaInfo--profile-version = Profile Version:
+MenuButtons--metaInfo--buffer-capacity = Buffer Capacity:
+MenuButtons--metaInfo--buffer-duration = Buffer Duration:
+
+# Buffer Duration in Seconds in Meta Info Panel
+# Variable:
+#   $configurationDuration (Number) - Configuration Duration in Seconds
+MenuButtons--metaInfo--buffer-duration-seconds =
+    { $configurationDuration ->
+        [one] { $configurationDuration } second
+       *[other] { $configurationDuration } seconds
+    }
+
+MenuButtons--metaInfo--buffer-duration-unlimited = Unlimited
+MenuButtons--metaInfo--application = Application
+MenuButtons--metaInfo--name-and-version = Name and version:
+MenuButtons--metaInfo--update-channel = Update Channel:
+MenuButtons--metaInfo--build-id = Build ID:
+MenuButtons--metaInfo--build-type = Build Type:
+MenuButtons--metaInfo--build-type-debug = Debug
+MenuButtons--metaInfo--build-type-opt = Opt
+MenuButtons--metaInfo--platform = Platform
+
+# OS means Operating System. This describes the platform a profile was captured on.
+MenuButtons--metaInfo--os = OS:
+
+# ABI means Application Binary Interface. This describes the platform a profile was captured on.
+MenuButtons--metaInfo--abi = ABI:
+MenuButtons--metaInfo--visual-metrics = Visual Metrics
+MenuButtons--metaInfo--speed-index = Speed Index:
+MenuButtons--metaInfo--perceptual-speed-index = Perceptual Speed Index:
+MenuButtons--metaInfo--contentful-speed-Index = Contentful Speed Index:
+MenuButtons--metaInfo-renderRowOfList-label-features = Features:
+MenuButtons--metaInfo-renderRowOfList-label-threads-filter = Threads Filter:
+MenuButtons--metaInfo-renderRowOfList-label-extensions = Extensions:
+
+MenuButtons--metaOverheadStatistics-subtitle = Profiler Overhead
+MenuButtons--metaOverheadStatistics-mean = Mean
+MenuButtons--metaOverheadStatistics-max = Max
+MenuButtons--metaOverheadStatistics-min = Min
+MenuButtons--metaOverheadStatistics-statkeys-overhead = Overhead
+MenuButtons--metaOverheadStatistics-statkeys-cleaning = Cleaning
+MenuButtons--metaOverheadStatistics-statkeys-counter = Counter
+MenuButtons--metaOverheadStatistics-statkeys-interval = Interval
+MenuButtons--metaOverheadStatistics-statkeys-lockings = Lockings
+MenuButtons--metaOverheadStatistics-overhead-duration = Overhead Durations:
+MenuButtons--metaOverheadStatistics-overhead-percentage = Overhead Percentage:
+MenuButtons--metaOverheadStatistics-profiled-duration = Profiled Duration:
+
+MenuButtons--permalink--button =
+    .label = Permalink
+
+MenuButtons--publish--renderCheckbox-label-hidden-threads = Include hidden threads
+MenuButtons--publish--renderCheckbox-label-hidden-time = Include hidden time range
+MenuButtons--publish--renderCheckbox-label-include-screenshots = Include screenshots
+MenuButtons--publish--renderCheckbox-label-resource = Include resource URLs and paths
+MenuButtons--publish--renderCheckbox-label-extension = Include extension information
+MenuButtons--publish--renderCheckbox-label-preference = Include preference values
+MenuButtons--publish--reupload-performance-profile = Re-upload Performance Profile
+MenuButtons--publish--share-performance-profile = Share Performance Profile
+MenuButtons--publish--info-description = Upload your profile and make it accessible to anyone with the link.
+MenuButtons--publish--info-description-default = By default, your personal data is removed.
+MenuButtons--publish--info-description-firefox-nightly = This profile is from { -firefox-nightly-brand-name }, so by default all information is included.
+MenuButtons--publish--include-additional-data = Include additional data that may be identifiable
+MenuButtons--publish--button-upload = Upload
+MenuButtons--publish--upload-title = Uploading profile…
+MenuButtons--publish--cancel-upload = Cancel Upload
+MenuButtons--publish--message-something-went-wrong = Uh oh, something went wrong when uploading the profile.
+MenuButtons--publish--message-try-again = Try again
+MenuButtons--publish--download = Download
+MenuButtons--publish--compressing = Compressing…
 
 ## ProfileRootMessage
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -103,15 +103,12 @@ ListOfPublishedProfiles--uploaded-profile-information-list =
        *[other] Manage these recordings
     }
 
-## MenuButtons Folder
+## These strings are used for the buttons at the top of the profile viewer.
 
-MenuButtons--index--profile-info-uploaded-label = Uploaded:
-MenuButtons--index--profile-info-uploaded-actions = Delete
-MenuButtons--index--meta-info-subtitle = Profile Information
-MenuButtons--index--meta-info-button-uploaded-profile =
+MenuButtons--index--metaInfo-button-uploaded-profile =
     .label = Uploaded Profile
 
-MenuButtons--index--meta-info-button-local-profile =
+MenuButtons--index--metaInfo-button-local-profile =
     .label = Local Profile
 
 MenuButtons--index--full-view = Full View
@@ -128,6 +125,15 @@ MenuButtons--index--share-error-uploading =
 MenuButtons--index--revert = Revert to Original Profile
 MenuButtons--index--docs = Docs
 
+MenuButtons--permalink--button =
+    .label = Permalink
+
+## These strings are used in the panel containing the meta information about
+## the current profile.
+
+MenuButtons--index--profile-info-uploaded-label = Uploaded:
+MenuButtons--index--profile-info-uploaded-actions = Delete
+MenuButtons--index--metaInfo-subtitle = Profile Information
 MenuButtons--metaInfo--symbols = Symbols:
 MenuButtons--metaInfo--profile-symbolicated = Profile is symbolicated
 MenuButtons--metaInfo--profile-not-symbolicated = Profile is not symbolicated
@@ -137,7 +143,8 @@ MenuButtons--metaInfo--attempting-resymbolicate = Attempting to re-symbolicate p
 MenuButtons--metaInfo--currently-symbolicating = Currently symbolicating profile
 MenuButtons--metaInfo--cpu = CPU:
 
-# Buffer Duration in Seconds in Meta Info Panel
+# This string is used when we have the information about both physical and
+# logical CPU cores.
 # Variable:
 #   $physicalCPUs (Number), $logicalCPUs (Number) - Number of Physical and Logical CPU Cores
 MenuButtons--metaInfo--physical-and-logical-cpu =
@@ -149,7 +156,8 @@ MenuButtons--metaInfo--physical-and-logical-cpu =
        *[other] { $logicalCPUs } logical cores
     }
 
-# Buffer Duration in Seconds in Meta Info Panel
+# This string is used when we only have the information about the number of
+# physical CPU cores.
 # Variable:
 #   $physicalCPUs (Number) - Number of Physical CPU Cores
 MenuButtons--metaInfo--physical-cpu =
@@ -158,7 +166,8 @@ MenuButtons--metaInfo--physical-cpu =
        *[other] { $physicalCPUs } physical cores
     }
 
-# Buffer Duration in Seconds in Meta Info Panel
+# This string is used when we only have the information only the number of
+# logical CPU cores.
 # Variable:
 #   $logicalCPUs (Number) - Number of logical CPU Cores
 MenuButtons--metaInfo--logical-cpu =
@@ -218,8 +227,7 @@ MenuButtons--metaOverheadStatistics-overhead-duration = Overhead Durations:
 MenuButtons--metaOverheadStatistics-overhead-percentage = Overhead Percentage:
 MenuButtons--metaOverheadStatistics-profiled-duration = Profiled Duration:
 
-MenuButtons--permalink--button =
-    .label = Permalink
+## These strings are used in the publishing panel.
 
 MenuButtons--publish--renderCheckbox-label-hidden-threads = Include hidden threads
 MenuButtons--publish--renderCheckbox-label-hidden-time = Include hidden time range

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -4,6 +4,7 @@
 
 // @flow
 import * as React from 'react';
+import { Localized } from '@fluent/react';
 
 import { MetaOverheadStatistics } from './MetaOverheadStatistics';
 import {
@@ -57,10 +58,18 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
         return (
           <>
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Symbols:</span>
-              {isSymbolicated
-                ? 'Profile is symbolicated'
-                : 'Profile is not symbolicated'}
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--label">
+                  Symbols:
+                </Localized>
+              </span>
+              <Localized
+                id={
+                  isSymbolicated
+                    ? 'MenuButtons--metaInfo--profile-symbolicated'
+                    : 'MenuButtons--metaInfo--profile-not-symbolicated'
+                }
+              />
             </div>
             <div className="metaInfoRow">
               <span className="metaInfoLabel"></span>
@@ -69,9 +78,13 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
                 type="button"
                 className="photon-button photon-button-micro"
               >
-                {isSymbolicated
-                  ? 'Re-symbolicate profile'
-                  : 'Symbolicate profile'}
+                <Localized
+                  id={
+                    isSymbolicated
+                      ? 'MenuButtons--metaInfo--resymbolicate-profile'
+                      : 'MenuButtons--metaInfo--symbolicate-profile'
+                  }
+                />
               </button>
             </div>
           </>
@@ -79,10 +92,18 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
       case 'SYMBOLICATING':
         return (
           <div className="metaInfoRow">
-            <span className="metaInfoLabel">Symbols:</span>
-            {isSymbolicated
-              ? 'Attempting to re-symbolicate profile'
-              : 'Currently symbolicating profile'}
+            <span className="metaInfoLabel">
+              <Localized id="MenuButtons--metaInfo--symbols">
+                Symbols:
+              </Localized>
+            </span>
+            <Localized
+              id={
+                isSymbolicated
+                  ? 'MenuButtons--metaInfo--attempting-resymbolicate'
+                  : 'MenuButtons--metaInfo--currently-symbolicating'
+              }
+            />
           </div>
         );
       default:
@@ -100,28 +121,29 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
     const platformInformation = formatPlatform(meta);
 
     let cpuCount = null;
-    if (meta.physicalCPUs || meta.logicalCPUs) {
-      let physicalCPUs = null;
-      let logicalCPUs = null;
-      if (meta.physicalCPUs) {
-        physicalCPUs =
-          meta.physicalCPUs +
-          ' physical ' +
-          (meta.physicalCPUs === 1 ? 'core' : 'cores');
-      }
-      if (meta.logicalCPUs) {
-        logicalCPUs =
-          meta.logicalCPUs +
-          ' logical ' +
-          (meta.logicalCPUs === 1 ? 'core' : 'cores');
-      }
+    if (meta.physicalCPUs && meta.logicalCPUs) {
       cpuCount = (
-        <div className="metaInfoRow">
-          <span className="metaInfoLabel">CPU:</span>
-          {physicalCPUs}
-          {physicalCPUs && logicalCPUs ? ', ' : null}
-          {logicalCPUs}
-        </div>
+        <Localized
+          id="MenuButtons--metaInfo--physical-and-logical-cpu"
+          vars={{
+            physicalCPUs: meta.physicalCPUs,
+            logicalCPUs: meta.logicalCPUs,
+          }}
+        />
+      );
+    } else if (meta.physicalCPUs) {
+      cpuCount = (
+        <Localized
+          id="MenuButtons--metaInfo--physical-cpu"
+          vars={{ physicalCPUs: meta.physicalCPUs }}
+        />
+      );
+    } else if (meta.logicalCPUs) {
+      cpuCount = (
+        <Localized
+          id="MenuButtons--metaInfo--logical-cpu"
+          vars={{ logicalCPUs: meta.logicalCPUs }}
+        />
       );
     }
 
@@ -130,60 +152,111 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
         <div className="metaInfoSection">
           {meta.startTime ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Recording started:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--recording-started">
+                  Recording started:
+                </Localized>
+              </span>
               {_formatDate(meta.startTime)}
             </div>
           ) : null}
           {meta.interval ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Interval:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--interval">
+                  Interval:
+                </Localized>
+              </span>
               {formatTimestamp(meta.interval, 4, 1)}
             </div>
           ) : null}
           {meta.preprocessedProfileVersion ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Profile Version:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--profile-version">
+                  Profile Version:
+                </Localized>
+              </span>
               {meta.preprocessedProfileVersion}
             </div>
           ) : null}
           {configuration ? (
             <>
               <div className="metaInfoRow">
-                <span className="metaInfoLabel">Buffer Capacity:</span>
+                <span className="metaInfoLabel">
+                  <Localized id="MenuButtons--metaInfo--buffer-capacity">
+                    Buffer Capacity:
+                  </Localized>
+                </span>
                 {/* The capacity is expressed in "entries", where 1 entry == 8 bytes. */
                 formatBytes(configuration.capacity * 8, 0)}
               </div>
               <div className="metaInfoRow">
-                <span className="metaInfoLabel">Buffer Duration:</span>
-                {configuration.duration
-                  ? `${configuration.duration} seconds`
-                  : 'Unlimited'}
+                <span className="metaInfoLabel">
+                  <Localized id="MenuButtons--metaInfo--buffer-duration">
+                    Buffer Duration:
+                  </Localized>
+                </span>
+                {configuration.duration ? (
+                  <Localized
+                    id="MenuButtons--metaInfo--buffer-duration-seconds"
+                    vars={{ configurationDuration: configuration.duration }}
+                  >
+                    {'{$configurationDuration} seconds'}
+                  </Localized>
+                ) : (
+                  <Localized id="MenuButtons--metaInfo--buffer-duration-unlimited">
+                    Unlimited
+                  </Localized>
+                )}
               </div>
               <div className="metaInfoSection">
-                {_renderRowOfList('Features', configuration.features)}
-                {_renderRowOfList('Threads Filter', configuration.threads)}
+                {_renderRowOfList(
+                  'MenuButtons--metaInfo-renderRowOfList-label-features',
+                  configuration.features
+                )}
+                {_renderRowOfList(
+                  'MenuButtons--metaInfo-renderRowOfList-label-threads-filter',
+                  configuration.threads
+                )}
               </div>
             </>
           ) : null}
           {this.renderSymbolication()}
         </div>
-        <h2 className="metaInfoSubTitle">Application</h2>
+        <h2 className="metaInfoSubTitle">
+          <Localized id="MenuButtons--metaInfo--application">
+            Application
+          </Localized>
+        </h2>
         <div className="metaInfoSection">
           {meta.product ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Name and version:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--name-and-version">
+                  Name and version:
+                </Localized>
+              </span>
               {formatProductAndVersion(meta)}
             </div>
           ) : null}
           {meta.updateChannel ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Update Channel:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--update-channel">
+                  Update Channel:
+                </Localized>
+              </span>
               {meta.updateChannel}
             </div>
           ) : null}
           {meta.appBuildID ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Build ID:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--build-id">
+                  Build ID:
+                </Localized>
+              </span>
               {meta.sourceURL ? (
                 <a
                   href={meta.sourceURL}
@@ -200,47 +273,85 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
           ) : null}
           {meta.debug !== undefined ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">Build Type:</span>
-              {meta.debug ? 'Debug' : 'Opt'}
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--build-type">
+                  Build Type:
+                </Localized>
+              </span>
+              <Localized
+                id={
+                  meta.debug
+                    ? 'MenuButtons--metaInfo--build-type-debug'
+                    : 'MenuButtons--metaInfo--build-type-opt'
+                }
+              />
             </div>
           ) : null}
           {meta.extensions
-            ? _renderRowOfList('Extensions', meta.extensions.name)
+            ? _renderRowOfList(
+                'MenuButtons--metaInfo-renderRowOfList-label-extensions',
+                meta.extensions.name
+              )
             : null}
         </div>
-        <h2 className="metaInfoSubTitle">Platform</h2>
+        <h2 className="metaInfoSubTitle">
+          <Localized id="MenuButtons--metaInfo--platform">Platform</Localized>
+        </h2>
         <div className="metaInfoSection">
           {platformInformation ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">OS:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--os">OS:</Localized>
+              </span>
               {platformInformation}
             </div>
           ) : null}
           {meta.abi ? (
             <div className="metaInfoRow">
-              <span className="metaInfoLabel">ABI:</span>
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--abi">ABI:</Localized>
+              </span>
               {meta.abi}
             </div>
           ) : null}
-          {cpuCount}
+          {cpuCount ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--cpu">CPU:</Localized>
+              </span>
+              {cpuCount}
+            </div>
+          ) : null}
         </div>
         {meta.visualMetrics ? (
           <>
-            <h2 className="metaInfoSubTitle">Visual Metrics</h2>
+            <h2 className="metaInfoSubTitle">
+              <Localized id="MenuButtons--metaInfo--visual-metrics">
+                Visual Metrics
+              </Localized>
+            </h2>
             <div className="metaInfoSection">
               <div className="metaInfoRow">
-                <span className="visualMetricsLabel">Speed Index:</span>
+                <span className="visualMetricsLabel">
+                  <Localized id="MenuButtons--metaInfo--speed-index">
+                    Speed Index:
+                  </Localized>
+                </span>
                 {meta.visualMetrics.SpeedIndex}
               </div>
               <div className="metaInfoRow">
                 <span className="visualMetricsLabel">
-                  Perceptual Speed Index:
+                  <Localized id="MenuButtons--metaInfo--perceptual-speed-index">
+                    Perceptual Speed Index:
+                  </Localized>
                 </span>
                 {meta.visualMetrics.PerceptualSpeedIndex}
               </div>
               <div className="metaInfoRow">
                 <span className="visualMetricsLabel">
-                  Contentful Speed Index:
+                  <Localized id="MenuButtons--metaInfo--contentful-speed-Index">
+                    Contentful Speed Index:
+                  </Localized>
                 </span>
                 {meta.visualMetrics.ContentfulSpeedIndex}
               </div>
@@ -259,13 +370,15 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
   }
 }
 
-function _renderRowOfList(label: string, data: string[]): React.Node {
+function _renderRowOfList(labelL10nId: string, data: string[]): React.Node {
   if (!data.length) {
     return null;
   }
   return (
     <div className="metaInfoRow">
-      <span className="metaInfoLabel">{label}:</span>
+      <span className="metaInfoLabel">
+        <Localized id={labelL10nId} />
+      </span>
       <ul className="metaInfoList">
         {data.map(d => (
           <li className="metaInfoListItem" key={d}>

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -59,7 +59,7 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
           <>
             <div className="metaInfoRow">
               <span className="metaInfoLabel">
-                <Localized id="MenuButtons--metaInfo--label">
+                <Localized id="MenuButtons--metaInfo--symbols">
                   Symbols:
                 </Localized>
               </span>

--- a/src/components/app/MenuButtons/MetaOverheadStatistics.js
+++ b/src/components/app/MenuButtons/MetaOverheadStatistics.js
@@ -4,6 +4,8 @@
 
 // @flow
 import * as React from 'react';
+import { Localized } from '@fluent/react';
+
 import {
   formatMicroseconds,
   formatPercent,
@@ -47,6 +49,14 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
       'Interval',
       'Lockings',
     ];
+    //l10nId's for statKeys
+    const statKeysL10nId = {
+      Overhead: 'MenuButtons--metaOverheadStatistics-statkeys-overhead',
+      Cleaning: 'MenuButtons--metaOverheadStatistics-statkeys-cleaning',
+      Counter: 'MenuButtons--metaOverheadStatistics-statkeys-counter',
+      Interval: 'MenuButtons--metaOverheadStatistics-statkeys-interval',
+      Lockings: 'MenuButtons--metaOverheadStatistics-statkeys-lockings',
+    };
 
     for (const overhead of profilerOverhead) {
       const { statistics } = overhead;
@@ -84,16 +94,34 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
 
     return calculatedStats.size > 0 ? (
       <details>
-        <summary className="arrowPanelSubTitle">Profiler Overhead</summary>
+        <summary className="arrowPanelSubTitle">
+          <Localized id="MenuButtons--metaOverheadStatistics-subtitle">
+            Profiler Overhead
+          </Localized>
+        </summary>
         <div className="arrowPanelSection">
           <div className="metaInfoGrid">
             <div />
-            <div>Mean</div>
-            <div>Max</div>
-            <div>Min</div>
+            <div>
+              <Localized id="MenuButtons--metaOverheadStatistics-mean">
+                Mean
+              </Localized>
+            </div>
+            <div>
+              <Localized id="MenuButtons--metaOverheadStatistics-max">
+                Max
+              </Localized>
+            </div>
+            <div>
+              <Localized id="MenuButtons--metaOverheadStatistics-min">
+                Min
+              </Localized>
+            </div>
             {[...calculatedStats].map(([key, val]) => (
               <React.Fragment key={key}>
-                <div>{key}</div>
+                <div>
+                  <Localized id={statKeysL10nId[key]} />
+                </div>
                 <div>{formatMicroseconds(val.mean)}</div>
                 <div>{formatMicroseconds(val.max)}</div>
                 <div>{formatMicroseconds(val.min)}</div>
@@ -103,7 +131,11 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
 
           {overheadDurations !== 0 ? (
             <div className="metaInfoRow">
-              <span className="metaInfoWideLabel">Overhead Durations:</span>
+              <span className="metaInfoWideLabel">
+                <Localized id="MenuButtons--metaOverheadStatistics-overhead-duration">
+                  Overhead Durations:
+                </Localized>
+              </span>
               <span className="metaInfoValueRight">
                 {formatMicroseconds(overheadDurations / totalSamplingCount)}
               </span>
@@ -111,7 +143,11 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
           ) : null}
           {overheadPercentage !== 0 ? (
             <div className="metaInfoRow">
-              <span className="metaInfoWideLabel">Overhead Percentage:</span>
+              <span className="metaInfoWideLabel">
+                <Localized id="MenuButtons--metaOverheadStatistics-overhead-percentage">
+                  Overhead Percentage:
+                </Localized>
+              </span>
               <span className="metaInfoValueRight">
                 {formatPercent(overheadPercentage / totalSamplingCount)}
               </span>
@@ -119,7 +155,11 @@ export class MetaOverheadStatistics extends React.PureComponent<Props> {
           ) : null}
           {profiledDuration !== 0 ? (
             <div className="metaInfoRow">
-              <span className="metaInfoWideLabel">Profiled Duration:</span>
+              <span className="metaInfoWideLabel">
+                <Localized id="MenuButtons--metaOverheadStatistics-profiled-duration">
+                  Profiled Duration:
+                </Localized>
+              </span>
               <span className="metaInfoValueRight">
                 {formatMicroseconds(profiledDuration / totalSamplingCount)}
               </span>

--- a/src/components/app/MenuButtons/Permalink.js
+++ b/src/components/app/MenuButtons/Permalink.js
@@ -9,6 +9,7 @@ import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPa
 import * as UrlUtils from 'firefox-profiler/utils/shorten-url';
 
 import './Permalink.css';
+import { Localized } from '@fluent/react';
 
 type Props = {|
   +isNewlyPublished: boolean,
@@ -70,25 +71,27 @@ export class MenuButtonsPermalink extends React.PureComponent<Props, State> {
 
   render() {
     return (
-      <ButtonWithPanel
-        buttonClassName="menuButtonsButton menuButtonsButton-hasIcon menuButtonsPermalinkButtonButton"
-        ref={this._takePermalinkButtonRef}
-        label="Permalink"
-        initialOpen={this.props.isNewlyPublished}
-        onPanelOpen={this._shortenUrlAndFocusTextFieldOnCompletion}
-        onPanelClose={this._onPermalinkPanelClose}
-        panelClassName="menuButtonsPermalinkPanel"
-        panelContent={
-          <input
-            data-testid="MenuButtonsPermalink-input"
-            type="text"
-            className="menuButtonsPermalinkTextField photon-input"
-            value={this.state.shortUrl}
-            readOnly="readOnly"
-            ref={this._takePermalinkTextFieldRef}
-          />
-        }
-      />
+      <Localized id="MenuButtons--permalink--button" attrs={{ label: true }}>
+        <ButtonWithPanel
+          buttonClassName="menuButtonsButton menuButtonsButton-hasIcon menuButtonsPermalinkButtonButton"
+          ref={this._takePermalinkButtonRef}
+          label="Permalink"
+          initialOpen={this.props.isNewlyPublished}
+          onPanelOpen={this._shortenUrlAndFocusTextFieldOnCompletion}
+          onPanelClose={this._onPermalinkPanelClose}
+          panelClassName="menuButtonsPermalinkPanel"
+          panelContent={
+            <input
+              data-testid="MenuButtonsPermalink-input"
+              type="text"
+              className="menuButtonsPermalinkTextField photon-input"
+              value={this.state.shortUrl}
+              readOnly="readOnly"
+              ref={this._takePermalinkTextFieldRef}
+            />
+          }
+        />
+      </Localized>
     );
   }
 }

--- a/src/components/app/MenuButtons/Publish.js
+++ b/src/components/app/MenuButtons/Publish.js
@@ -43,6 +43,7 @@ import type {
 } from 'firefox-profiler/types';
 
 import './Publish.css';
+import { Localized } from '@fluent/react';
 
 type OwnProps = {|
   +isRepublish?: boolean,
@@ -87,7 +88,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
       this.props.toggleCheckedSharingOptions('includePreferenceValues'),
   };
 
-  _renderCheckbox(slug: $Keys<CheckedSharingOptions>, label: string) {
+  _renderCheckbox(slug: $Keys<CheckedSharingOptions>, labelL10nId: string) {
     const { checkedSharingOptions } = this.props;
     const toggle = this._toggles[slug];
     return (
@@ -99,7 +100,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
           onChange={toggle}
           checked={checkedSharingOptions[slug]}
         />
-        {label}
+        <Localized id={labelL10nId} />
       </label>
     );
   }
@@ -120,39 +121,62 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
         <form className="menuButtonsPublishContent" onSubmit={attemptToPublish}>
           <div className="menuButtonsPublishIcon" />
           <h1 className="menuButtonsPublishTitle">
-            {isRepublish
-              ? 'Re-upload Performance Profile'
-              : 'Share Performance Profile'}
+            {isRepublish ? (
+              <Localized id="MenuButtons--publish--reupload-performance-profile">
+                Re-upload Performance Profile
+              </Localized>
+            ) : (
+              <Localized id="MenuButtons--publish--share-performance-profile">
+                Share Performance Profile
+              </Localized>
+            )}
           </h1>
           <p className="menuButtonsPublishInfoDescription">
-            Upload your profile and make it accessible to anyone with the link.
-            {shouldSanitizeByDefault
-              ? ' By default, your personal data is removed.'
-              : ' This profile is from Firefox Nightly, so by default all information is included.'}
+            <Localized id="MenuButtons--publish--info-description">
+              Upload your profile and make it accessible to anyone with the
+              link.
+            </Localized>{' '}
+            {shouldSanitizeByDefault ? (
+              <Localized id="MenuButtons--publish--info-description-default">
+                By default, your personal data is removed.
+              </Localized>
+            ) : (
+              <Localized id="MenuButtons--publish--info-description-firefox-nightly">
+                This profile is from Firefox Nightly, so by default all
+                information is included.
+              </Localized>
+            )}
           </p>
-          <h3>Include additional data that may be identifiable</h3>
+          <h3>
+            <Localized id="MenuButtons--publish--include-additional-data">
+              Include additional data that may be identifiable
+            </Localized>
+          </h3>
           <div className="menuButtonsPublishDataChoices">
             {this._renderCheckbox(
               'includeHiddenThreads',
-              'Include hidden threads'
+              'MenuButtons--publish--renderCheckbox-label-hidden-threads'
             )}
             {this._renderCheckbox(
               'includeFullTimeRange',
-              'Include hidden time range'
+              'MenuButtons--publish--renderCheckbox-label-hidden-time'
             )}
-            {this._renderCheckbox('includeScreenshots', 'Include screenshots')}
+            {this._renderCheckbox(
+              'includeScreenshots',
+              'MenuButtons--publish--renderCheckbox-label-include-screenshots'
+            )}
             {this._renderCheckbox(
               'includeUrls',
-              'Include resource URLs and paths'
+              'MenuButtons--publish--renderCheckbox-label-resource'
             )}
             {this._renderCheckbox(
               'includeExtension',
-              'Include extension information'
+              'MenuButtons--publish--renderCheckbox-label-extension'
             )}
             {shouldShowPreferenceOption
               ? this._renderCheckbox(
                   'includePreferenceValues',
-                  'Include preference values'
+                  'MenuButtons--publish--renderCheckbox-label-preference'
                 )
               : null}
           </div>
@@ -167,7 +191,9 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
               className="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
             >
               <span className="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload" />
-              Upload
+              <Localized id="MenuButtons--publish--button-upload">
+                Upload
+              </Localized>
             </button>
           </div>
         </form>
@@ -207,7 +233,9 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
       >
         <div className="menuButtonsPublishUploadTop">
           <div className="menuButtonsPublishUploadTitle">
-            Uploading profile…
+            <Localized id="MenuButtons--publish--upload-title">
+              Uploading profile…
+            </Localized>
           </div>
           <div className="menuButtonsPublishUploadPercentage">
             {uploadProgressString}
@@ -230,7 +258,9 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
             className="photon-button photon-button-default menuButtonsPublishButton menuButtonsPublishButtonsCancelUpload"
             onClick={abortFunction}
           >
-            Cancel Upload
+            <Localized id="MenuButtons--publish--cancel-upload">
+              Cancel Upload
+            </Localized>
           </button>
         </div>
       </div>
@@ -260,14 +290,18 @@ class MenuButtonsPublishImpl extends React.PureComponent<PublishProps> {
       >
         <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">
           <div className="photon-message-bar-inner-text">
-            Uh oh, something went wrong when uploading the profile.
+            <Localized id="MenuButtons--publish--message-something-went-wrong">
+              Uh oh, something went wrong when uploading the profile.
+            </Localized>
           </div>
           <button
             className="photon-button photon-button-micro photon-message-bar-action-button"
             type="button"
             onClick={resetUploadState}
           >
-            Try again
+            <Localized id="MenuButtons--publish--message-try-again">
+              Try again
+            </Localized>
           </button>
         </div>
         <div className="menuButtonsPublishError">{message}</div>
@@ -453,7 +487,8 @@ class DownloadButton extends React.PureComponent<
           className={className}
         >
           <span className="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgDownload" />
-          Download <DownloadSize downloadSizePromise={downloadSizePromise} />
+          <Localized id="MenuButtons--publish--download">Download</Localized>{' '}
+          <DownloadSize downloadSizePromise={downloadSizePromise} />
         </BlobUrlLink>
       );
     }
@@ -463,7 +498,9 @@ class DownloadButton extends React.PureComponent<
         type="button"
         className={classNames(className, 'menuButtonsPublishButtonDisabled')}
       >
-        Compressing…
+        <Localized id="MenuButtons--publish--compressing">
+          Compressing…
+        </Localized>
       </button>
     );
   }

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -176,7 +176,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
         return (
           <>
             <h2 className="metaInfoSubTitle">
-              <Localized id="MenuButtons--index--meta-info-subtitle">
+              <Localized id="MenuButtons--index--metaInfo-subtitle">
                 Profile Information
               </Localized>
             </h2>
@@ -239,8 +239,8 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
     const uploadedStatus = this._getUploadedStatus(dataSource);
     const labelL10nId =
       uploadedStatus === 'uploaded'
-        ? 'MenuButtons--index--meta-info-button-uploaded-profile'
-        : 'MenuButtons--index--meta-info-button-local-profile';
+        ? 'MenuButtons--index--metaInfo-button-uploaded-profile'
+        : 'MenuButtons--index--metaInfo-button-local-profile';
 
     return (
       <Localized id={labelL10nId} attrs={{ label: true }}>

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -10,6 +10,8 @@ import './index.css';
 
 import * as React from 'react';
 import classNames from 'classnames';
+import { Localized } from '@fluent/react';
+
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { getProfileRootRange } from 'firefox-profiler/selectors/profile';
 import {
@@ -138,7 +140,11 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
     return (
       <div className="profileInfoUploadedActions">
         <div className="profileInfoUploadedDate">
-          <span className="profileInfoUploadedLabel">Uploaded:</span>
+          <span className="profileInfoUploadedLabel">
+            <Localized id="MenuButtons--index--profile-info-uploaded-label">
+              Uploaded:
+            </Localized>
+          </span>
           {_formatDate(currentProfileUploadedInformation.publishedDate)}
         </div>
         <div className="profileInfoUploadedActionsButtons">
@@ -153,7 +159,9 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
             }
             disabled={currentProfileUploadedInformation.jwtToken === null}
           >
-            Delete
+            <Localized id="MenuButtons--index--profile-info-uploaded-actions">
+              Delete
+            </Localized>
           </button>
         </div>
       </div>
@@ -167,7 +175,11 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
       case 'initial': {
         return (
           <>
-            <h2 className="metaInfoSubTitle">Profile Information</h2>
+            <h2 className="metaInfoSubTitle">
+              <Localized id="MenuButtons--index--meta-info-subtitle">
+                Profile Information
+              </Localized>
+            </h2>
             {currentProfileUploadedInformation
               ? this._renderUploadedProfileActions(
                   currentProfileUploadedInformation
@@ -225,16 +237,22 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
   _renderMetaInfoButton() {
     const { dataSource } = this.props;
     const uploadedStatus = this._getUploadedStatus(dataSource);
+    const labelL10nId =
+      uploadedStatus === 'uploaded'
+        ? 'MenuButtons--index--meta-info-button-uploaded-profile'
+        : 'MenuButtons--index--meta-info-button-local-profile';
+
     return (
-      <ButtonWithPanel
-        buttonClassName={`menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-${uploadedStatus}`}
-        label={
-          uploadedStatus === 'uploaded' ? 'Uploaded Profile' : 'Local Profile'
-        }
-        onPanelClose={this._resetMetaInfoState}
-        panelClassName="metaInfoPanel"
-        panelContent={this._renderMetaInfoPanel()}
-      />
+      <Localized id={labelL10nId} attrs={{ label: true }}>
+        <ButtonWithPanel
+          buttonClassName={`menuButtonsButton menuButtonsMetaInfoButtonButton menuButtonsButton-hasIcon menuButtonsMetaInfoButtonButton-${uploadedStatus}`}
+          // The empty string value for the label following will be replaced by the <Localized /> wrapper.
+          label=""
+          onPanelClose={this._resetMetaInfoState}
+          panelClassName="metaInfoPanel"
+          panelContent={this._renderMetaInfoPanel()}
+        />
+      </Localized>
     );
   }
 
@@ -254,7 +272,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
         className="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertToFullView"
         onClick={this._changeTimelineTrackOrganizationToFull}
       >
-        Full View
+        <Localized id="MenuButtons--index--full-view">Full View</Localized>
       </button>
     );
   }
@@ -272,7 +290,9 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
           className="menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon menuButtonsShareButtonButton-uploading"
           onClick={abortFunction}
         >
-          Cancel Upload
+          <Localized id="MenuButtons--index--cancel-upload">
+            Cancel Upload
+          </Localized>
         </button>
       );
     }
@@ -281,27 +301,30 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
     const isRepublish = uploadedStatus === 'uploaded';
     const isError = uploadPhase === 'error';
 
-    let label = 'Upload';
+    let labelL10nId = 'MenuButtons--index--share-upload';
     if (isRepublish) {
-      label = 'Re-upload';
+      labelL10nId = 'MenuButtons--index--share-re-upload';
     }
 
     if (isError) {
-      label = 'Error uploading';
+      labelL10nId = 'MenuButtons--index--share-error-uploading';
     }
 
     return (
-      <ButtonWithPanel
-        buttonClassName={classNames(
-          'menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon',
-          {
-            menuButtonsShareButtonError: isError,
-          }
-        )}
-        panelClassName="menuButtonsPublishPanel"
-        label={label}
-        panelContent={<MenuButtonsPublish isRepublish={isRepublish} />}
-      />
+      <Localized id={labelL10nId} attrs={{ label: true }}>
+        <ButtonWithPanel
+          buttonClassName={classNames(
+            'menuButtonsButton menuButtonsShareButtonButton menuButtonsButton-hasIcon',
+            {
+              menuButtonsShareButtonError: isError,
+            }
+          )}
+          panelClassName="menuButtonsPublishPanel"
+          // The value for the label following will be replaced
+          label=""
+          panelContent={<MenuButtonsPublish isRepublish={isRepublish} />}
+        />
+      </Localized>
     );
   }
 
@@ -332,7 +355,9 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
         className="menuButtonsButton menuButtonsButton-hasIcon menuButtonsRevertButton"
         onClick={revertToPrePublishedState}
       >
-        Revert to Original Profile
+        <Localized id="MenuButtons--index--revert">
+          Revert to Original Profile
+        </Localized>
       </button>
     );
   }
@@ -351,7 +376,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
           className="menuButtonsButton menuButtonsButton-hasLeftBorder"
           title="Open the documentation in a new window"
         >
-          Docs
+          <Localized id="MenuButtons--index--docs">Docs</Localized>
           <i className="open-in-new" />
         </a>
       </>

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -487,7 +487,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         >
           Buffer Duration:
         </span>
-        20 seconds
+        ⁨20⁩ seconds
       </div>
       <div
         class="metaInfoSection"
@@ -498,8 +498,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
           <span
             class="metaInfoLabel"
           >
-            Features
-            :
+            Features:
           </span>
           <ul
             class="metaInfoList"
@@ -522,8 +521,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
           <span
             class="metaInfoLabel"
           >
-            Threads Filter
-            :
+            Threads Filter:
           </span>
           <ul
             class="metaInfoList"
@@ -619,8 +617,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         <span
           class="metaInfoLabel"
         >
-          Extensions
-          :
+          Extensions:
         </span>
         <ul
           class="metaInfoList"
@@ -679,9 +676,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         >
           CPU:
         </span>
-        4 physical cores
-        , 
-        8 logical cores
+        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
       </div>
     </div>
     <details>
@@ -941,8 +936,7 @@ exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not ma
         <span
           class="metaInfoLabel"
         >
-          Extensions
-          :
+          Extensions:
         </span>
         <ul
           class="metaInfoList"
@@ -1001,9 +995,7 @@ exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not ma
         >
           CPU:
         </span>
-        4 physical cores
-        , 
-        8 logical cores
+        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
       </div>
     </div>
   </div>
@@ -1223,7 +1215,8 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
       class="menuButtonsPublishInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
-       By default, your personal data is removed.
+       
+      By default, your personal data is removed.
     </p>
     <h3>
       Include additional data that may be identifiable
@@ -1324,7 +1317,8 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       class="menuButtonsPublishInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
-       This profile is from Firefox Nightly, so by default all information is included.
+       
+      This profile is from ⁨Firefox Nightly⁩, so by default all information is included.
     </p>
     <h3>
       Include additional data that may be identifiable
@@ -1430,7 +1424,8 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       class="menuButtonsPublishInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
-       By default, your personal data is removed.
+       
+      By default, your personal data is removed.
     </p>
     <h3>
       Include additional data that may be identifiable


### PR DESCRIPTION
The components related to MenuButtons are made localizable with the default en-US FTL.

**The tests are not passing because it requires this PR #3204 to be merged first as some of the FTL texts (variables) are needed to be fetched from the FTL to match the snapshots.

Ref Issue #3094 