### PR TITLE
Implement a 'frontend only' marker schema for network markers, to hide them from the marker chart

### DIFF
--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -1301,6 +1301,9 @@ const _upgraders = {
       },
       {
         // The schema is mostly handled with custom logic.
+        // Note that profiles coming from recent Gecko engines won't have this.
+        // Having this here was a mistake when implementing the upgrader, but
+        // now that it's here we keep it to reduce confusion.
         name: 'Network',
         display: ['marker-table'],
         data: [],

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -61,6 +61,14 @@ export const markerSchemaFrontEndOnly: MarkerSchema[] = [
       { key: 'recvThreadName', label: 'To', format: 'string' },
     ],
   },
+  {
+    // The network markers are mostly handled with custom logic. But the
+    // `display` property is used to decide where to display these markers, and
+    // we need it to hide them from the marker chart.
+    name: 'Network',
+    display: ['marker-table'],
+    data: [],
+  },
 ];
 
 /**

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -1689,6 +1689,9 @@ const _upgraders = {
       },
       {
         // The schema is mostly handled with custom logic.
+        // Note that profiles coming from recent Gecko engines won't have this.
+        // Having this here was a mistake when implementing the upgrader, but
+        // now that it's here we keep it to reduce confusion.
         name: 'Network',
         display: ['marker-table'],
         data: [],

--- a/src/test/fixtures/profiles/marker-schema.js
+++ b/src/test/fixtures/profiles/marker-schema.js
@@ -176,10 +176,4 @@ export const markerSchemaForTests: MarkerSchema[] = [
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
     data: [{ key: 'name', label: 'Tick Reasons', format: 'string' }],
   },
-  {
-    // The schema is mostly handled with custom logic.
-    name: 'Network',
-    display: ['marker-table'],
-    data: [],
-  },
 ];

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -396,13 +396,6 @@ Object {
         ],
         "name": "RefreshDriverTick",
       },
-      Object {
-        "data": Array [],
-        "display": Array [
-          "marker-table",
-        ],
-        "name": "Network",
-      },
     ],
     "misc": "",
     "oscpu": "",

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-import { storeWithProfile } from '../fixtures/stores';
 import {
   selectedThreadSelectors,
   getMarkerSchemaByName,
 } from 'firefox-profiler/selectors';
+import { changeTimelineTrackOrganization } from 'firefox-profiler/actions/receive-profile';
+import { unserializeProfileOfArbitraryFormat } from 'firefox-profiler/profile-logic/process-profile';
+
 import {
   getUserTiming,
   getProfileWithMarkers,
@@ -14,7 +16,7 @@ import {
   type TestDefinedMarkers,
   getNetworkMarkers,
 } from '../fixtures/profiles/processed-profile';
-import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
+import { storeWithProfile } from '../fixtures/stores';
 
 describe('selectors/getMarkerChartTimingAndBuckets', function() {
   function getMarkerChartTimingAndBuckets(testMarkers: TestDefinedMarkers) {
@@ -325,7 +327,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function() {
 });
 
 describe('Marker schema filtering', function() {
-  function getMarkerNames(selector): string[] {
+  function getProfileForMarkerSchema() {
     // prettier-ignore
     const profile = getProfileWithMarkers([
       ['no payload',        0, null, null],
@@ -339,6 +341,10 @@ describe('Marker schema filtering', function() {
       ['RandomTracingMarker', 7, 8,  { type: 'tracing', category: 'RandomTracingMarker' }],
       ...getNetworkMarkers(),
     ]);
+    return profile;
+  }
+
+  function setup(profile) {
     const { getState } = storeWithProfile(profile);
     const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
     const markerSchemaByName = getMarkerSchemaByName(getState());
@@ -351,12 +357,17 @@ describe('Marker schema filtering', function() {
       );
     }
 
-    return selector(getState())
-      .map(getMarker)
-      .map(marker => marker.name);
+    function getMarkerNames(selector): string[] {
+      return selector(getState())
+        .map(getMarker)
+        .map(marker => marker.name);
+    }
+
+    return { getMarkerNames };
   }
 
   it('filters for getMarkerTableMarkerIndexes', function() {
+    const { getMarkerNames } = setup(getProfileForMarkerSchema());
     expect(
       getMarkerNames(selectedThreadSelectors.getMarkerTableMarkerIndexes)
     ).toEqual([
@@ -370,6 +381,189 @@ describe('Marker schema filtering', function() {
   });
 
   it('filters for getMarkerChartMarkerIndexes', function() {
+    const { getMarkerNames } = setup(getProfileForMarkerSchema());
+    expect(
+      getMarkerNames(selectedThreadSelectors.getMarkerChartMarkerIndexes)
+    ).toEqual([
+      'no payload',
+      'payload no schema',
+      'RefreshDriverTick',
+      // Notice: no network markers!
+      'UserTiming',
+      'RandomTracingMarker',
+    ]);
+  });
+
+  it('filters for MarkerChartMarkerIndexes also for profiles upgraded from version 32', async function() {
+    // This is a profile purposefully stuck at version 32.
+    const profile = {
+      meta: {
+        interval: 1,
+        startTime: 0,
+        abi: '',
+        misc: '',
+        oscpu: '',
+        platform: '',
+        processType: 0,
+        extensions: {
+          id: [],
+          name: [],
+          baseURL: [],
+          length: 0,
+        },
+        categories: [
+          {
+            name: 'Idle',
+            color: 'transparent',
+            subcategories: ['Other'],
+          },
+          {
+            name: 'Other',
+            color: 'grey',
+            subcategories: ['Other'],
+          },
+        ],
+        product: 'Firefox',
+        stackwalk: 0,
+        toolkit: '',
+        version: 21,
+        preprocessedProfileVersion: 32,
+        appBuildID: '',
+        sourceURL: '',
+        physicalCPUs: 0,
+        logicalCPUs: 0,
+        symbolicated: true,
+      },
+      pages: [],
+      threads: [
+        {
+          processType: 'default',
+          processStartupTime: 0,
+          processShutdownTime: null,
+          registerTime: 0,
+          unregisterTime: null,
+          pausedRanges: [],
+          name: 'Empty',
+          pid: 0,
+          tid: 0,
+          samples: {
+            weightType: 'samples',
+            weight: null,
+            eventDelay: [],
+            stack: [],
+            time: [],
+            length: 0,
+          },
+          markers: {
+            name: [0, 1, 2, 3, 4, 5, 5],
+            startTime: [0, 0, 0, 5, 7, 0, 0.5],
+            endTime: [null, null, null, 6, 8, 0.5, 1],
+            phase: [0, 0, 0, 1, 1, 1, 1],
+            category: [0, 0, 0, 0, 0, 0, 0],
+            data: [
+              null,
+              {
+                type: 'no schema marker',
+              },
+              {
+                type: 'Text',
+                name: 'RefreshDriverTick',
+              },
+              {
+                type: 'UserTiming',
+                name: 'name',
+                entryType: 'mark',
+              },
+              {
+                type: 'tracing',
+                category: 'RandomTracingMarker',
+              },
+              {
+                type: 'Network',
+                id: 0,
+                startTime: 0,
+                endTime: 0.5,
+                pri: 0,
+                status: 'STATUS_START',
+                URI: 'https://mozilla.org',
+              },
+              {
+                type: 'Network',
+                id: 0,
+                startTime: 0.5,
+                endTime: 1,
+                pri: 0,
+                status: 'STATUS_STOP',
+                URI: 'https://mozilla.org',
+                contentType: 'text/html',
+              },
+            ],
+            length: 7,
+          },
+          stackTable: {
+            frame: [],
+            prefix: [],
+            category: [],
+            subcategory: [],
+            length: 0,
+          },
+          frameTable: {
+            address: [],
+            category: [],
+            subcategory: [],
+            func: [],
+            innerWindowID: [],
+            implementation: [],
+            line: [],
+            column: [],
+            optimizations: [],
+            length: 0,
+          },
+          stringArray: [
+            'no payload',
+            'payload no schema',
+            'RefreshDriverTick',
+            'UserTiming',
+            'RandomTracingMarker',
+            'Load 0: https://mozilla.org',
+          ],
+          libs: [],
+          funcTable: {
+            address: [],
+            isJS: [],
+            relevantForJS: [],
+            name: [],
+            resource: [],
+            fileName: [],
+            lineNumber: [],
+            columnNumber: [],
+            length: 0,
+          },
+          resourceTable: {
+            lib: [],
+            name: [],
+            host: [],
+            type: [],
+            length: 0,
+          },
+        },
+      ],
+    };
+
+    const upgradedProfile = await unserializeProfileOfArbitraryFormat(profile);
+    const { getMarkerNames } = setup(upgradedProfile);
+
+    expect(
+      getMarkerNames(selectedThreadSelectors.getMarkerTableMarkerIndexes)
+    ).toEqual([
+      'no payload',
+      'payload no schema',
+      'RefreshDriverTick',
+      'Load 0: https://mozilla.org',
+      'UserTiming',
+      'RandomTracingMarker',
+    ]);
+
     expect(
       getMarkerNames(selectedThreadSelectors.getMarkerChartMarkerIndexes)
     ).toEqual([
@@ -383,6 +577,7 @@ describe('Marker schema filtering', function() {
   });
 
   it('filters for getTimelineOverviewMarkerIndexes', function() {
+    const { getMarkerNames } = setup(getProfileForMarkerSchema());
     expect(
       getMarkerNames(selectedThreadSelectors.getTimelineOverviewMarkerIndexes)
     ).toEqual(['RefreshDriverTick']);

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -376,6 +376,7 @@ describe('Marker schema filtering', function() {
       'no payload',
       'payload no schema',
       'RefreshDriverTick',
+      // Notice: no network markers!
       'UserTiming',
       'RandomTracingMarker',
     ]);


### PR DESCRIPTION
For a v33 profile: [Production](https://profiler.firefox.com/public/yy7fcwxky4k0zm6ws7tcakabbm97kdk4e4yzmj0/marker-chart/?globalTrackOrder=13-14-0-1-2-3-4-5-6-7-8-9-10-11-12&localTrackOrderByPid=22067-6-7-0-1-2-3-4-5~9678-1-0~9435-0~22169-0~22381-0~22331-0~22218-0~9414-0-1~9248-0~22226-0~8660-1-0~9578-1-2-0~9561-2-3-0-1~&markerSearch=network&thread=0&v=5) / [Deploy preview](https://deploy-preview-3216--perf-html.netlify.app/public/yy7fcwxky4k0zm6ws7tcakabbm97kdk4e4yzmj0/marker-chart/?globalTrackOrder=13-14-0-1-2-3-4-5-6-7-8-9-10-11-12&localTrackOrderByPid=22067-6-7-0-1-2-3-4-5~9678-1-0~9435-0~22169-0~22381-0~22331-0~22218-0~9414-0-1~9248-0~22226-0~8660-1-0~9578-1-2-0~9561-2-3-0-1~&markerSearch=network&thread=0&v=5)

See how the network markers disappear from the marker chart (these links have the "search" already set to "network").

For an older profile: [Production](https://profiler.firefox.com/public/8b2e92d6b9d9a506737fbed3d0fa5424e3b34a0c/marker-chart/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3164-1-2-0~12671-0~12665-0~12605-0~12558-0-1~&markerSearch=Network&profileName=plup%20plap&range=10757m868&thread=0&v=5) / [Deploy preview](https://deploy-preview-3216--perf-html.netlify.app/public/8b2e92d6b9d9a506737fbed3d0fa5424e3b34a0c/marker-chart/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2-3&localTrackOrderByPid=3164-1-2-0~12671-0~12665-0~12605-0~12558-0-1~&markerSearch=Network&profileName=plup%20plap&range=10757m868&thread=0&v=5)

There should be no difference in this case, because the upgrader adds the marker schema in this case, both before and after the patch.

For both profiles we should see them in the Marker Table though. It's not clear to me if this should stay this way, but this is an easy change if we want to remove them.

Note that there are 2 commits, that might be easier to look at them one by one.

Fixes #3144