### PR TITLE
Fix the call node max depth calculation

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -334,7 +334,10 @@ export const CallTree = explicitConnect<{||}, StateProps, DispatchProps>({
     disableOverscan: getPreviewSelection(state).isModifying,
     invertCallstack: getInvertCallstack(state),
     implementationFilter: getImplementationFilter(state),
-    callNodeMaxDepth: selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
+    // Use the filtered call node max depth, rather than the preview filtered call node
+    // max depth so that the width of the TreeView component is stable across preview
+    // selections.
+    callNodeMaxDepth: selectedThreadSelectors.getFilteredCallNodeMaxDepth(
       state
     ),
     weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -334,7 +334,9 @@ export const CallTree = explicitConnect<{||}, StateProps, DispatchProps>({
     disableOverscan: getPreviewSelection(state).isModifying,
     invertCallstack: getInvertCallstack(state),
     implementationFilter: getImplementationFilter(state),
-    callNodeMaxDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
+    callNodeMaxDepth: selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
+      state
+    ),
     weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),
   }),
   mapDispatchToProps: {

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -356,9 +356,9 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
     sampleIndexOffset: selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(
       state
     ),
-    maxStackDepth: selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
-      state
-    ),
+    // Use the filtered call node max depth, rather than the preview filtered one, so
+    // that the viewport height is stable across preview selections.
+    maxStackDepth: selectedThreadSelectors.getFilteredCallNodeMaxDepth(state),
     flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
     callTree: selectedThreadSelectors.getCallTree(state),
     timeRange: getCommittedRange(state),

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -356,7 +356,7 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
     sampleIndexOffset: selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(
       state
     ),
-    maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+    maxStackDepth: selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
       state
     ),
     flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
@@ -379,7 +379,9 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
       state
     ),
     pages: getPageList(state),
-    samples: selectedThreadSelectors.getSamplesForCallTree(state),
+    samples: selectedThreadSelectors.getPreviewFilteredSamplesForCallTree(
+      state
+    ),
     unfilteredSamples: selectedThreadSelectors.getUnfilteredSamplesForCallTree(
       state
     ),

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -71,7 +71,7 @@ export const MaybeFlameGraph = explicitConnect<{||}, StateProps, DispatchProps>(
     mapStateToProps: state => {
       return {
         invertCallstack: getInvertCallstack(state),
-        maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+        maxStackDepth: selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
           state
         ),
       };

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -17,7 +17,7 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import './MaybeFlameGraph.css';
 
 type StateProps = {|
-  +maxStackDepth: number,
+  +isPreviewSelectionEmpty: boolean,
   +invertCallstack: boolean,
 |};
 type DispatchProps = {|
@@ -40,9 +40,9 @@ class MaybeFlameGraphImpl extends React.PureComponent<Props> {
   }
 
   render() {
-    const { maxStackDepth, invertCallstack } = this.props;
+    const { isPreviewSelectionEmpty, invertCallstack } = this.props;
 
-    if (maxStackDepth === 0) {
+    if (isPreviewSelectionEmpty) {
       return <FlameGraphEmptyReasons />;
     }
 
@@ -71,9 +71,9 @@ export const MaybeFlameGraph = explicitConnect<{||}, StateProps, DispatchProps>(
     mapStateToProps: state => {
       return {
         invertCallstack: getInvertCallstack(state),
-        maxStackDepth: selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
-          state
-        ),
+        isPreviewSelectionEmpty:
+          selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(state) ===
+          0,
       };
     },
     mapDispatchToProps: {

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -235,7 +235,7 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       thread: selectedThreadSelectors.getFilteredThread(state),
       // Use the raw WeightType here, as the stack chart does not use the call tree
       weightType: selectedThreadSelectors.getSamplesWeightType(state),
-      maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
+      maxStackDepth: selectedThreadSelectors.getFilteredCallNodeMaxDepth(state),
       combinedTimingRows,
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1787,18 +1787,25 @@ export function convertStackToCallNodePath(
  * If no samples are found, 0 is returned.
  */
 export function computeCallNodeMaxDepth(
-  thread: Thread,
+  samples: SamplesLikeTable,
   callNodeInfo: CallNodeInfo
 ): number {
-  if (
-    thread.samples.length === 0 ||
-    callNodeInfo.callNodeTable.depth.length === 0
-  ) {
+  if (samples.length === 0 || callNodeInfo.callNodeTable.depth.length === 0) {
     return 0;
   }
 
+  // Compute the depth on a per-sample basis. This is done since the callNodeInfo is
+  // computed for the filtered thread, but a samples-like table can use the preview
+  // filtered thread, which involves a subset of the total call nodes.
   let max = 0;
-  for (const depth of callNodeInfo.callNodeTable.depth) {
+  const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+    const stackIndex = samples.stack[sampleIndex];
+    if (stackIndex === null) {
+      continue;
+    }
+    const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
+    const depth = callNodeTable.depth[callNodeIndex];
     max = Math.max(max, depth);
   }
 

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1784,20 +1784,17 @@ export function convertStackToCallNodePath(
  * Returns the depth of the deepest call node, but with a one-based
  * depth instead of a zero-based.
  *
- * If no samples are found, 0 is returned.
+ * If there are no samples, or the stacks are all filtered out for the samples, then
+ * 0 is returned.
  */
 export function computeCallNodeMaxDepth(
   samples: SamplesLikeTable,
   callNodeInfo: CallNodeInfo
 ): number {
-  if (samples.length === 0 || callNodeInfo.callNodeTable.depth.length === 0) {
-    return 0;
-  }
-
   // Compute the depth on a per-sample basis. This is done since the callNodeInfo is
   // computed for the filtered thread, but a samples-like table can use the preview
   // filtered thread, which involves a subset of the total call nodes.
-  let max = 0;
+  let max = -1;
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
     const stackIndex = samples.stack[sampleIndex];

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -233,7 +233,7 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
     selectedThreadSelectors.getThread,
     selectedThreadSelectors.getSampleIndexOffsetFromPreviewRange,
     ProfileSelectors.getCategories,
-    selectedThreadSelectors.getSamplesForCallTree,
+    selectedThreadSelectors.getPreviewFilteredSamplesForCallTree,
     selectedThreadSelectors.getUnfilteredSamplesForCallTree,
     ProfileData.getTimingsForPath
   );

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -84,12 +84,6 @@ export function getStackAndSampleSelectorsPerThread(
     }
   );
 
-  const getCallNodeMaxDepth: Selector<number> = createSelector(
-    threadSelectors.getFilteredThread,
-    getCallNodeInfo,
-    ProfileData.computeCallNodeMaxDepth
-  );
-
   const getSelectedCallNodePath: Selector<CallNodePath> = createSelector(
     threadSelectors.getViewOptions,
     (threadViewOptions): CallNodePath => threadViewOptions.selectedCallNodePath
@@ -214,16 +208,34 @@ export function getStackAndSampleSelectorsPerThread(
     }
   );
 
-  const getSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
+  const getUnfilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
+    threadSelectors.getThread,
+    getCallTreeSummaryStrategy,
+    CallTree.extractSamplesLikeTable
+  );
+
+  const getFilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
+    threadSelectors.getFilteredThread,
+    getCallTreeSummaryStrategy,
+    CallTree.extractSamplesLikeTable
+  );
+
+  const getPreviewFilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
     threadSelectors.getPreviewFilteredThread,
     getCallTreeSummaryStrategy,
     CallTree.extractSamplesLikeTable
   );
 
-  const getUnfilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
-    threadSelectors.getThread,
-    getCallTreeSummaryStrategy,
-    CallTree.extractSamplesLikeTable
+  const getFilteredCallNodeMaxDepth: Selector<number> = createSelector(
+    getFilteredSamplesForCallTree,
+    getCallNodeInfo,
+    ProfileData.computeCallNodeMaxDepth
+  );
+
+  const getPreviewFilteredCallNodeMaxDepth: Selector<number> = createSelector(
+    getPreviewFilteredSamplesForCallTree,
+    getCallNodeInfo,
+    ProfileData.computeCallNodeMaxDepth
   );
 
   /**
@@ -233,12 +245,13 @@ export function getStackAndSampleSelectorsPerThread(
    * defaults to samples, which the Gecko Profiler outputs by default.
    */
   const getWeightTypeForCallTree: Selector<WeightType> = createSelector(
-    getSamplesForCallTree,
+    // The weight type is not changed by the filtering done on the profile.
+    getUnfilteredSamplesForCallTree,
     samples => samples.weightType || 'samples'
   );
 
   const getCallTreeCountsAndSummary: Selector<CallTree.CallTreeCountsAndSummary> = createSelector(
-    getSamplesForCallTree,
+    getPreviewFilteredSamplesForCallTree,
     getCallNodeInfo,
     ProfileSelectors.getProfileInterval,
     UrlState.getInvertCallstack,
@@ -257,7 +270,7 @@ export function getStackAndSampleSelectorsPerThread(
   );
 
   const getTracedTiming: Selector<TracedTiming | null> = createSelector(
-    getSamplesForCallTree,
+    getFilteredSamplesForCallTree,
     getCallNodeInfo,
     ProfileSelectors.getProfileInterval,
     UrlState.getInvertCallstack,
@@ -267,15 +280,9 @@ export function getStackAndSampleSelectorsPerThread(
   const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> = createSelector(
     threadSelectors.getFilteredThread,
     getCallNodeInfo,
-    getCallNodeMaxDepth,
+    getFilteredCallNodeMaxDepth,
     ProfileSelectors.getProfileInterval,
     StackTiming.getStackTimingByDepth
-  );
-
-  const getCallNodeMaxDepthForFlameGraph: Selector<number> = createSelector(
-    threadSelectors.getPreviewFilteredThread,
-    getCallNodeInfo,
-    ProfileData.computeCallNodeMaxDepth
   );
 
   const getFlameGraphTiming: Selector<FlameGraph.FlameGraphTiming> = createSelector(
@@ -307,9 +314,9 @@ export function getStackAndSampleSelectorsPerThread(
     unfilteredSamplesRange,
     getWeightTypeForCallTree,
     getCallNodeInfo,
-    getCallNodeMaxDepth,
-    getSamplesForCallTree,
     getUnfilteredSamplesForCallTree,
+    getFilteredSamplesForCallTree,
+    getPreviewFilteredSamplesForCallTree,
     getSelectedCallNodePath,
     getSelectedCallNodeIndex,
     getExpandedCallNodePaths,
@@ -320,7 +327,8 @@ export function getStackAndSampleSelectorsPerThread(
     getCallTree,
     getTracedTiming,
     getStackTimingByDepth,
-    getCallNodeMaxDepthForFlameGraph,
+    getFilteredCallNodeMaxDepth,
+    getPreviewFilteredCallNodeMaxDepth,
     getFlameGraphTiming,
     getRightClickedCallNodeIndex,
   };

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -4,7 +4,7 @@
 
 // @flow
 import * as React from 'react';
-import { fireEvent, within } from '@testing-library/react';
+import { fireEvent, within, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 // This module is mocked.
@@ -34,6 +34,7 @@ import {
   changeInvertCallstack,
   changeSelectedCallNode,
   commitRange,
+  updatePreviewSelection,
   changeImplementationFilter,
 } from '../../actions/profile-view';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
@@ -160,7 +161,7 @@ describe('FlameGraph', function() {
   });
 
   describe('EmptyReasons', () => {
-    it('shows reasons when a profile has no samples', () => {
+    it('matches the snapshot when a profile has no samples', () => {
       const profile = getEmptyProfile();
       const thread = getEmptyThread();
       thread.name = 'Empty Thread';
@@ -178,16 +179,22 @@ describe('FlameGraph', function() {
       expect(container.querySelector('.EmptyReasons')).toMatchSnapshot();
     });
 
-    it('shows reasons when samples are out of range', () => {
-      const { dispatch, container } = setupFlameGraph();
+    it('shows reasons when samples are not in the committed range', () => {
+      const { dispatch } = setupFlameGraph();
       dispatch(commitRange(5, 10));
-      expect(container.querySelector('.EmptyReasons')).toMatchSnapshot();
+      expect(
+        screen.getByText('Broaden the selected range to view samples.')
+      ).toBeTruthy();
     });
 
     it('shows reasons when samples have been completely filtered out', function() {
-      const { dispatch, container } = setupFlameGraph();
+      const { dispatch } = setupFlameGraph();
       dispatch(changeImplementationFilter('js'));
-      expect(container.querySelector('.EmptyReasons')).toMatchSnapshot();
+      expect(
+        screen.getByText(
+          'Try broadening the selected range, removing search terms, or call tree transforms to view samples.'
+        )
+      ).toBeTruthy();
     });
   });
 });

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -187,6 +187,24 @@ describe('FlameGraph', function() {
       ).toBeTruthy();
     });
 
+    it('shows reasons when samples are not in the preview range', () => {
+      const { dispatch } = setupFlameGraph();
+      dispatch(
+        updatePreviewSelection({
+          hasSelection: true,
+          isModifying: false,
+          selectionStart: 5,
+          selectionEnd: 10,
+        })
+      );
+
+      expect(
+        screen.getByText(
+          'Try broadening the selected range, removing search terms, or call tree transforms to view samples.'
+        )
+      ).toBeTruthy();
+    });
+
     it('shows reasons when samples have been completely filtered out', function() {
       const { dispatch } = setupFlameGraph();
       dispatch(changeImplementationFilter('js'));

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FlameGraph EmptyReasons shows reasons when a profile has no samples 1`] = `
+exports[`FlameGraph EmptyReasons matches the snapshot when a profile has no samples 1`] = `
 <div
   class="EmptyReasons"
 >
@@ -13,40 +13,6 @@ exports[`FlameGraph EmptyReasons shows reasons when a profile has no samples 1`]
   </h3>
   <p>
     This thread has no samples.
-  </p>
-</div>
-`;
-
-exports[`FlameGraph EmptyReasons shows reasons when samples are out of range 1`] = `
-<div
-  class="EmptyReasons"
->
-  <h3>
-    The 
-    flame graph
-     is empty for “
-    Empty
-    ”
-  </h3>
-  <p>
-    Broaden the selected range to view samples.
-  </p>
-</div>
-`;
-
-exports[`FlameGraph EmptyReasons shows reasons when samples have been completely filtered out 1`] = `
-<div
-  class="EmptyReasons"
->
-  <h3>
-    The 
-    flame graph
-     is empty for “
-    Empty
-    ”
-  </h3>
-  <p>
-    Try broadening the selected range, removing search terms, or call tree transforms to view samples.
   </p>
 </div>
 `;

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -289,7 +289,7 @@ describe('selectors/getCallNodeMaxDepthForFlameGraph', function() {
     `);
 
     const store = storeWithProfile(profile);
-    const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+    const allSamplesMaxDepth = selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
       store.getState()
     );
     expect(allSamplesMaxDepth).toEqual(4);
@@ -298,7 +298,7 @@ describe('selectors/getCallNodeMaxDepthForFlameGraph', function() {
   it('returns zero if there are no samples', function() {
     const { profile } = getProfileFromTextSamples(` `);
     const store = storeWithProfile(profile);
-    const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameGraph(
+    const allSamplesMaxDepth = selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
       store.getState()
     );
     expect(allSamplesMaxDepth).toEqual(0);

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1828,9 +1828,18 @@ describe('snapshots of selectors/profile', function() {
     ).toMatchSnapshot();
   });
 
-  it('matches the last stored run of selectedThreadSelector.getCallNodeMaxDepth', function() {
+  it('matches the last stored run of selectedThreadSelector.getFilteredCallNodeMaxDepth', function() {
     const { getState } = setupStore();
-    expect(selectedThreadSelectors.getCallNodeMaxDepth(getState())).toEqual(4);
+    expect(
+      selectedThreadSelectors.getFilteredCallNodeMaxDepth(getState())
+    ).toEqual(4);
+  });
+
+  it('matches the last stored run of selectedThreadSelector.getPreviewFilteredCallNodeMaxDepth', function() {
+    const { getState } = setupStore();
+    expect(
+      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(getState())
+    ).toEqual(4);
   });
 
   it('matches the last stored run of selectedThreadSelector.getSelectedCallNodePath', function() {


### PR DESCRIPTION
I have a few yak shaving PRs for my dhat importer in #3128. This is the first, which fixes some issues around the max depth calculation.

Notice the extra white space on the flame graph when moving the viewport to the top: https://share.firefox.dev/3qNCQ09
This is fixed when taking into account the preview filtered thread.

I went through all of the uses of the max depth, and ensured they were correct.

I'm flagging both Julien and Nazim for review, as I don't know your workloads right now, but I only need one person to look at it.