### PR TITLE
Make categories optional in imported profiles

### DIFF
--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -210,6 +210,13 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       TEXT_CSS_PIXELS_OFFSET_START * devicePixelRatio;
     const textDevicePixelsOffsetTop =
       TEXT_CSS_PIXELS_OFFSET_TOP * devicePixelRatio;
+    let categoryForUserTiming = categories.findIndex(
+      category => category.name === 'JavaScript'
+    );
+    if (categoryForUserTiming === -1) {
+      // Default to the first item in the categories list.
+      categoryForUserTiming = 0;
+    }
 
     // Only draw the stack frames that are vertically within view.
     for (let depth = startDepth; depth < endDepth; depth++) {
@@ -318,8 +325,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
             const markerPayload = ((getMarker(markerIndex)
               .data: any): UserTimingMarkerPayload);
             text = markerPayload.name;
-            const categoryIndex = 0;
-            category = categories[categoryIndex];
+            category = categories[categoryForUserTiming];
             isSelected = selectedCallNodeIndex === markerIndex;
           }
 

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -295,8 +295,10 @@ export function getEmptyExtensions(): ExtensionTable {
 
 export function getDefaultCategories(): CategoryList {
   return [
-    { name: 'Idle', color: 'transparent', subcategories: ['Other'] },
+    // Make sure 'Other' is at index 0, as it's used as the category for stacks when no
+    // categories are provided by an imported (non-Gecko profiler) profile.
     { name: 'Other', color: 'grey', subcategories: ['Other'] },
+    { name: 'Idle', color: 'transparent', subcategories: ['Other'] },
     { name: 'Layout', color: 'purple', subcategories: ['Other'] },
     { name: 'JavaScript', color: 'yellow', subcategories: ['Other'] },
     { name: 'GC / CC', color: 'orange', subcategories: ['Other'] },

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -483,7 +483,9 @@ async function processTracingEvents(
     profileEvents = profileEvents.concat(cpuProfiles);
   }
 
-  const getFunctionInfo = makeFunctionInfoFinder(profile.meta.categories);
+  const getFunctionInfo = makeFunctionInfoFinder(
+    ensureExists(profile.meta.categories)
+  );
 
   const threadInfoByPidAndTid = new Map();
   const threadInfoByThread = new Map();
@@ -730,7 +732,7 @@ async function extractScreenshots(
     screenshots[0]
   );
 
-  const graphicsIndex = profile.meta.categories.findIndex(
+  const graphicsIndex = ensureExists(profile.meta.categories).findIndex(
     category => category.name === 'Graphics'
   );
 
@@ -812,7 +814,7 @@ function extractMarkers(
   eventsByName: Map<string, TracingEventUnion[]>,
   profile: Profile
 ) {
-  const otherCategoryIndex = profile.meta.categories.findIndex(
+  const otherCategoryIndex = ensureExists(profile.meta.categories).findIndex(
     category => category.name === 'Other'
   );
   if (otherCategoryIndex === -1) {

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -286,7 +286,7 @@ type TranslationMapForSamples = Map<
  * It returns a translation map that can be used in `adjustCategories` later.
  */
 function mergeCategories(
-  categoriesPerThread: CategoryList[]
+  categoriesPerThread: Array<CategoryList | void>
 ): {|
   categories: CategoryList,
   translationMaps: TranslationMapForCategories[],
@@ -298,6 +298,12 @@ function mergeCategories(
   categoriesPerThread.forEach(categories => {
     const translationMap = new Map();
     translationMaps.push(translationMap);
+
+    if (!categories) {
+      // Profiles that are imported may not have categories. Ignore it when attempting
+      // to merge categories.
+      return;
+    }
 
     categories.forEach((category, i) => {
       const { name } = category;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -224,6 +224,12 @@ const transforms: Reducer<TransformStacksPerThread> = (state = {}, action) => {
 
 const timelineType: Reducer<TimelineType> = (state = 'category', action) => {
   switch (action.type) {
+    case 'PROFILE_LOADED':
+      if (!action.profile.meta.categories) {
+        // An imported profile did not provide its own categories. Use the stack view instead.
+        return 'stack';
+      }
+      return state;
     case 'CHANGE_TIMELINE_TYPE':
       return action.timelineType;
     case 'VIEW_FULL_PROFILE':

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -17,6 +17,7 @@ import {
   correlateIPCMarkers,
 } from '../profile-logic/marker-data';
 import { markerSchemaFrontEndOnly } from '../profile-logic/marker-schema';
+import { getDefaultCategories } from 'firefox-profiler/profile-logic/data-structures';
 
 import type {
   Profile,
@@ -148,8 +149,6 @@ export const getProfileInterval: Selector<Milliseconds> = state =>
   getProfile(state).meta.interval;
 export const getPageList = (state: State): PageList | null =>
   getProfile(state).pages || null;
-export const getCategories: Selector<CategoryList> = state =>
-  getProfile(state).meta.categories;
 export const getDefaultCategory: Selector<IndexIntoCategoryList> = state =>
   getCategories(state).findIndex(c => c.color === 'grey');
 export const getThreads: Selector<Thread[]> = state =>
@@ -187,6 +186,18 @@ const getMarkerSchemaGecko: Selector<MarkerSchema[]> = state =>
 // See SampleUnits type definition for more information.
 export const getSampleUnits: Selector<SampleUnits | void> = state =>
   getMeta(state).sampleUnits;
+
+/**
+ * Firefox profiles will always have categories. However, imported profiles may not
+ * contain default categories. In this case, provide a default list.
+ */
+export const getCategories: Selector<CategoryList> = createSelector(
+  getProfile,
+  profile => {
+    const { categories } = profile.meta;
+    return categories ? categories : getDefaultCategories();
+  }
+);
 
 // Combine the marker schema from Gecko and the front-end. This allows the front-end
 // to generate markers such as the Jank markers, and display them.

--- a/src/test/components/CallTreeSidebar.test.js
+++ b/src/test/components/CallTreeSidebar.test.js
@@ -49,7 +49,10 @@ describe('CallTreeSidebar', function() {
       funcNamesDictPerThread: [{ C, D }],
     } = result;
     const layout = ensureExists(
-      profile.meta.categories.find(category => category.name === 'Layout'),
+      ensureExists(
+        profile.meta.categories,
+        'Expected to find categories.'
+      ).find(category => category.name === 'Layout'),
       'Could not find Layout category.'
     );
     const [{ frameTable, stackTable }] = profile.threads;

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -580,7 +580,7 @@ describe('MarkerChart', function() {
       flushRafCalls();
 
       const text = getFillTextCalls(flushDrawLog());
-      expect(text).toEqual(['Dot marker E', 'Idle']);
+      expect(text).toEqual(['Dot marker E', 'Other']);
     });
   });
 

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -42,11 +42,11 @@ function getSamplesPixelPosition(
 describe('ThreadActivityGraph', function() {
   function getSamplesProfile() {
     return getProfileFromTextSamples(`
-      A[cat:DOM]  A[cat:DOM]       A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]
-      B           B                B             B             B             B             B             B
-      C           C                H[cat:Other]  H[cat:Other]  H[cat:Other]  H[cat:Other]  H[cat:Other]  C
-      D           F[cat:Graphics]  I             I             I             I             I             F[cat:Graphics]
-      E           G                                                                                      G
+      A[cat:DOM]   A[cat:DOM]       A[cat:DOM]     A[cat:DOM]     A[cat:DOM]     A[cat:DOM]     A[cat:DOM]     A[cat:DOM]
+      B            B                B              B              B              B              B              B
+      C            C                H[cat:Layout]  H[cat:Layout]  H[cat:Layout]  H[cat:Layout]  H[cat:Layout]  C
+      D            F[cat:Graphics]  I              I              I              I              I              F[cat:Graphics]
+      E[cat:Idle]  G                                                                                           G
     `).profile;
   }
 

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -902,7 +902,7 @@ Array [
   ],
   Array [
     "fillText",
-    "Idle",
+    "Other",
     155,
     11,
   ],
@@ -1422,7 +1422,7 @@ Array [
   ],
   Array [
     "fillText",
-    "Idle",
+    "Other",
     5,
     11,
   ],

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -196,7 +196,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -221,7 +221,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -246,7 +246,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -711,7 +711,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -736,7 +736,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -761,7 +761,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -786,7 +786,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",
@@ -811,7 +811,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ededf060",
+    "#ffe90060",
   ],
   Array [
     "fillRect",

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -17,12 +17,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.25,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -37,12 +37,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.75,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -61,11 +61,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
@@ -77,11 +77,11 @@ Array [
           ],
           Array [
             0.5,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
@@ -159,12 +159,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -179,12 +179,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -203,11 +203,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
@@ -219,11 +219,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
@@ -1151,6 +1151,38 @@ Array [
     "#d7d7db",
   ],
   Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
     "beginPath",
   ],
   Array [
@@ -1803,38 +1835,6 @@ Array [
   ],
   Array [
     "fill",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe900",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a460",
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a4",
   ],
   Array [
     "set fillStyle",
@@ -2332,140 +2332,6 @@ Array [
     "#0060df",
   ],
   Array [
-    "beginPath",
-  ],
-  Array [
-    "moveTo",
-    0,
-    9.428571425378323,
-  ],
-  Array [
-    "lineTo",
-    1,
-    8.85714277625084,
-  ],
-  Array [
-    "lineTo",
-    2,
-    7.999999970197678,
-  ],
-  Array [
-    "lineTo",
-    3,
-    6.914285719394684,
-  ],
-  Array [
-    "lineTo",
-    4,
-    5.657142698764801,
-  ],
-  Array [
-    "lineTo",
-    5,
-    4.342857003211975,
-  ],
-  Array [
-    "lineTo",
-    6,
-    3.0857139825820923,
-  ],
-  Array [
-    "lineTo",
-    7,
-    1.9999998807907104,
-  ],
-  Array [
-    "lineTo",
-    8,
-    1.1428570747375488,
-  ],
-  Array [
-    "lineTo",
-    9,
-    0.5714285373687744,
-  ],
-  Array [
-    "lineTo",
-    10,
-    0.22857129573822021,
-  ],
-  Array [
-    "lineTo",
-    11,
-    0.05714297294616699,
-  ],
-  Array [
-    "lineTo",
-    12,
-    0,
-  ],
-  Array [
-    "lineTo",
-    11,
-    0,
-  ],
-  Array [
-    "lineTo",
-    10,
-    0,
-  ],
-  Array [
-    "lineTo",
-    9,
-    0,
-  ],
-  Array [
-    "lineTo",
-    8,
-    0,
-  ],
-  Array [
-    "lineTo",
-    7,
-    0,
-  ],
-  Array [
-    "lineTo",
-    6,
-    0.05714237689971924,
-  ],
-  Array [
-    "lineTo",
-    5,
-    0.22857129573822021,
-  ],
-  Array [
-    "lineTo",
-    4,
-    0.5714285373687744,
-  ],
-  Array [
-    "lineTo",
-    3,
-    1.3142859935760498,
-  ],
-  Array [
-    "lineTo",
-    2,
-    2.457142472267151,
-  ],
-  Array [
-    "lineTo",
-    1,
-    4.399999976158142,
-  ],
-  Array [
-    "lineTo",
-    0,
-    6.228571236133575,
-  ],
-  Array [
-    "closePath",
-  ],
-  Array [
-    "fill",
-  ],
-  Array [
     "set fillStyle",
     "#0060df60",
   ],
@@ -2629,12 +2495,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.25,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -2649,12 +2515,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.75,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -2673,11 +2539,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
@@ -2689,11 +2555,11 @@ Array [
           ],
           Array [
             0.5,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
@@ -2771,12 +2637,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -2791,12 +2657,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -2815,11 +2681,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
@@ -2831,11 +2697,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
@@ -3761,6 +3627,38 @@ Array [
   Array [
     "set fillStyle",
     "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
   ],
   Array [
     "beginPath",
@@ -4493,38 +4391,6 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe900",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a460",
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a4",
-  ],
-  Array [
-    "set fillStyle",
     "#6200a460",
   ],
   Array [
@@ -5017,140 +4883,6 @@ Array [
   Array [
     "set fillStyle",
     "#0060df",
-  ],
-  Array [
-    "beginPath",
-  ],
-  Array [
-    "moveTo",
-    0,
-    9.771428555250168,
-  ],
-  Array [
-    "lineTo",
-    1,
-    9.542857147753239,
-  ],
-  Array [
-    "lineTo",
-    2,
-    9.200000017881393,
-  ],
-  Array [
-    "lineTo",
-    3,
-    8.76571424305439,
-  ],
-  Array [
-    "lineTo",
-    4,
-    8.262857049703598,
-  ],
-  Array [
-    "lineTo",
-    5,
-    7.737142741680145,
-  ],
-  Array [
-    "lineTo",
-    6,
-    7.234285771846771,
-  ],
-  Array [
-    "lineTo",
-    7,
-    6.800000071525574,
-  ],
-  Array [
-    "lineTo",
-    8,
-    6.422857046127319,
-  ],
-  Array [
-    "lineTo",
-    9,
-    6.0914283990859985,
-  ],
-  Array [
-    "lineTo",
-    10,
-    5.748571455478668,
-  ],
-  Array [
-    "lineTo",
-    11,
-    5.3371429443359375,
-  ],
-  Array [
-    "lineTo",
-    12,
-    4.800000190734863,
-  ],
-  Array [
-    "lineTo",
-    11,
-    5.314285755157471,
-  ],
-  Array [
-    "lineTo",
-    10,
-    5.657142996788025,
-  ],
-  Array [
-    "lineTo",
-    9,
-    5.862857103347778,
-  ],
-  Array [
-    "lineTo",
-    8,
-    5.965714156627655,
-  ],
-  Array [
-    "lineTo",
-    7,
-    6.000000238418579,
-  ],
-  Array [
-    "lineTo",
-    6,
-    6.022857129573822,
-  ],
-  Array [
-    "lineTo",
-    5,
-    6.0914283990859985,
-  ],
-  Array [
-    "lineTo",
-    4,
-    6.228571534156799,
-  ],
-  Array [
-    "lineTo",
-    3,
-    6.525714099407196,
-  ],
-  Array [
-    "lineTo",
-    2,
-    6.98285698890686,
-  ],
-  Array [
-    "lineTo",
-    1,
-    7.759999930858612,
-  ],
-  Array [
-    "lineTo",
-    0,
-    8.49142849445343,
-  ],
-  Array [
-    "closePath",
-  ],
-  Array [
-    "fill",
   ],
   Array [
     "set fillStyle",

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -72,12 +72,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.25,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -92,12 +92,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.75,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -116,11 +116,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
@@ -132,11 +132,11 @@ Array [
           ],
           Array [
             0.5,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
@@ -214,12 +214,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -234,12 +234,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -258,11 +258,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
@@ -274,11 +274,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
@@ -3314,12 +3314,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.25,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -3334,12 +3334,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.75,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -3358,11 +3358,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
@@ -3374,11 +3374,11 @@ Array [
           ],
           Array [
             0.5,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
@@ -3456,12 +3456,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -3476,12 +3476,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -3500,11 +3500,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
@@ -3516,11 +3516,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
@@ -5416,12 +5416,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.25,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -5436,12 +5436,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
     0.75,
-    "transparent",
+    "#d7d7db60",
   ],
   Array [
     "addColorStop",
@@ -5460,11 +5460,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.25,
@@ -5476,11 +5476,11 @@ Array [
           ],
           Array [
             0.5,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
-            "transparent",
+            "#d7d7db60",
           ],
           Array [
             0.75,
@@ -5558,12 +5558,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -5578,12 +5578,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "transparent",
   ],
   Array [
     "addColorStop",
@@ -5602,11 +5602,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.25,
@@ -5618,11 +5618,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "transparent",
           ],
           Array [
             0.75,

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -9,6 +9,7 @@ import type {
   FrameTable,
   Profile,
 } from 'firefox-profiler/types';
+import { ensureExists } from 'firefox-profiler/utils/flow';
 
 import {
   getEmptyThread,
@@ -46,9 +47,10 @@ export default function getProfile(): Profile {
     'funcF',
   ].map(name => thread.stringTable.indexForString(name));
 
-  const categoryOther = profile.meta.categories.findIndex(
-    c => c.name === 'Other'
-  );
+  const categoryOther = ensureExists(
+    profile.meta.categories,
+    'Expected to find categories'
+  ).findIndex(c => c.name === 'Other');
 
   // Be explicit about table creation so flow errors are really readable.
   const funcTable: FuncTable = {

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -497,7 +497,10 @@ export function getProfileFromTextSamples(
   const profile = getEmptyProfile();
   // Provide a useful marker schema, rather than an empty one.
   profile.meta.markerSchema = markerSchemaForTests;
-  const categories = profile.meta.categories;
+  const categories = ensureExists(
+    profile.meta.categories,
+    'Expected to find categories.'
+  );
 
   const funcNamesPerThread = [];
   const funcNamesDictPerThread = [];

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -7,15 +7,15 @@ Object {
     "appBuildID": "",
     "categories": Array [
       Object {
-        "color": "transparent",
-        "name": "Idle",
+        "color": "grey",
+        "name": "Other",
         "subcategories": Array [
           "Other",
         ],
       },
       Object {
-        "color": "grey",
-        "name": "Other",
+        "color": "transparent",
+        "name": "Idle",
         "subcategories": Array [
           "Other",
         ],
@@ -822,15 +822,15 @@ Object {
       },
       "stackTable": Object {
         "category": Array [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
         ],
         "frame": Array [
           0,
@@ -1490,15 +1490,15 @@ Array [
     },
     "stackTable": Object {
       "category": Array [
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
       ],
       "frame": Array [
         0,
@@ -1900,9 +1900,9 @@ Array [
 
 exports[`snapshots of selectors/profile matches the last stored run of markerThreadSelectors.getMarkerChartTimingAndBuckets 1`] = `
 Array [
-  "Idle",
+  "Other",
   Object {
-    "bucket": "Idle",
+    "bucket": "Other",
     "end": Array [
       3,
     ],
@@ -1919,7 +1919,7 @@ Array [
     ],
   },
   Object {
-    "bucket": "Idle",
+    "bucket": "Other",
     "end": Array [
       4,
     ],
@@ -1936,7 +1936,7 @@ Array [
     ],
   },
   Object {
-    "bucket": "Idle",
+    "bucket": "Other",
     "end": Array [
       5,
     ],
@@ -2030,15 +2030,15 @@ Object {
     "totalTime": Object {
       "breakdownByCategory": Array [
         Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
           "entireCategoryValue": 2,
           "subcategoryBreakdown": Array [
             2,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
           ],
         },
         Object {
@@ -2093,15 +2093,15 @@ Object {
     "totalTime": Object {
       "breakdownByCategory": Array [
         Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
           "entireCategoryValue": 2,
           "subcategoryBreakdown": Array [
             2,
+          ],
+        },
+        Object {
+          "entireCategoryValue": 0,
+          "subcategoryBreakdown": Array [
+            0,
           ],
         },
         Object {
@@ -2155,14 +2155,14 @@ exports[`snapshots of selectors/profile matches the last stored run of selectedT
 Object {
   "callNodeTable": Object {
     "category": Int32Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "depth": Array [
       0,
@@ -2265,14 +2265,14 @@ CallTree {
   },
   "_callNodeTable": Object {
     "category": Int32Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "depth": Array [
       0,
@@ -2328,15 +2328,15 @@ CallTree {
   },
   "_categories": Array [
     Object {
-      "color": "transparent",
-      "name": "Idle",
+      "color": "grey",
+      "name": "Other",
       "subcategories": Array [
         "Other",
       ],
     },
     Object {
-      "color": "grey",
-      "name": "Other",
+      "color": "transparent",
+      "name": "Idle",
       "subcategories": Array [
         "Other",
       ],
@@ -2761,14 +2761,14 @@ Object {
   },
   "stackTable": Object {
     "category": Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "frame": Array [
       0,
@@ -2899,7 +2899,7 @@ Array [
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getJankMarkersForHeader 1`] = `
 Array [
   Object {
-    "category": 1,
+    "category": 0,
     "data": Object {
       "type": "Jank",
     },
@@ -3148,14 +3148,14 @@ Object {
   },
   "stackTable": Object {
     "category": Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "frame": Array [
       0,
@@ -3462,14 +3462,14 @@ Object {
   },
   "stackTable": Object {
     "category": Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "frame": Array [
       0,
@@ -3776,15 +3776,15 @@ Object {
   },
   "stackTable": Object {
     "category": Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "frame": Array [
       0,
@@ -4253,15 +4253,15 @@ Object {
   },
   "stackTable": Object {
     "category": Array [
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
     ],
     "frame": Array [
       0,

--- a/src/test/store/js-tracer.test.js
+++ b/src/test/store/js-tracer.test.js
@@ -120,7 +120,10 @@ describe('convertJsTracerToThread', function() {
       ['IonMonkey', 6, 18],
     ]);
     const existingThread = existingProfile.threads[0];
-    const categories = existingProfile.meta.categories;
+    const categories = ensureExists(
+      existingProfile.meta.categories,
+      'Expected to find categories.'
+    );
 
     const profile = getEmptyProfile();
     const jsTracer = ensureExists(existingThread.jsTracer);
@@ -152,7 +155,10 @@ describe('convertJsTracerToThread', function() {
       ['FuncB', 6, 18],
     ]);
     const existingThread = existingProfile.threads[0];
-    const categories = existingProfile.meta.categories;
+    const categories = ensureExists(
+      existingProfile.meta.categories,
+      'Expected to find categories'
+    );
     const jsTracer = ensureExists(existingThread.jsTracer);
     const thread = convertJsTracerToThread(
       existingThread,

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -96,7 +96,7 @@ describe('selectors/getMarkerChartTimingAndBuckets', function() {
       ) {
         throw new Error('Expected to find marker timing, but found a string');
       }
-      expect(category).toEqual('Idle');
+      expect(category).toEqual('Other');
       expect(markerTimingA.name).toBe('Marker Name A');
       expect(markerTimingB.name).toBe('Marker Name B');
     });
@@ -108,7 +108,7 @@ describe('selectors/getMarkerChartTimingAndBuckets', function() {
         ['Rasterize', 1, null, { category: 'Paint', type: 'tracing' }],
       ]);
       expect(markerTiming).toEqual([
-        'Idle',
+        'Other',
         {
           name: 'Rasterize',
           // First sample is captured at time 1, so this incomplete
@@ -117,7 +117,7 @@ describe('selectors/getMarkerChartTimingAndBuckets', function() {
           end: [1],
           index: [0],
           label: [''],
-          bucket: 'Idle',
+          bucket: 'Other',
           length: 1,
         },
       ]);

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3672,3 +3672,20 @@ describe('mouseTimePosition', function() {
     expect(ProfileViewSelectors.getMouseTimePosition(getState())).toBe(1000);
   });
 });
+
+describe('timeline type', function() {
+  it('should default to the category view', () => {
+    const { profile } = getProfileFromTextSamples('A');
+    const { getState } = storeWithProfile(profile);
+    expect(UrlStateSelectors.getTimelineType(getState())).toEqual('category');
+  });
+
+  it('should use the stack height view when using an imported profile', () => {
+    const { profile } = getProfileFromTextSamples('A');
+    delete profile.meta.categories;
+
+    // Load the store after mutating the profile.
+    const { getState } = storeWithProfile(profile);
+    expect(UrlStateSelectors.getTimelineType(getState())).toEqual('stack');
+  });
+});

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -2012,8 +2012,8 @@ describe('getTimingsForSidebar', () => {
           value: 5,
           breakdownByImplementation: { native: 2, baseline: 1, ion: 2 },
           breakdownByCategory: withSingleSubcategory([
-            1, // Idle
             0, // Other
+            1, // Idle
             1, // Layout
             3, // JavaScript
             0,
@@ -2143,8 +2143,8 @@ describe('getTimingsForSidebar', () => {
           breakdownByImplementation: { native: 2 },
 
           breakdownByCategory: withSingleSubcategory([
+            0, // Other
             1, // Idle
-            0,
             1, // Layout
             0,
             0,
@@ -2187,8 +2187,8 @@ describe('getTimingsForSidebar', () => {
         value: 2,
         breakdownByImplementation: { native: 1, ion: 1 },
         breakdownByCategory: withSingleSubcategory([
-          1, // Idle
           0, // Other
+          1, // Idle
           0, // Layout
           1, // JavaScript
           0,
@@ -2517,8 +2517,8 @@ describe('getTimingsForSidebar', () => {
               native: 2,
             },
             breakdownByCategory: withSingleSubcategory([
-              1, // Idle
               0, // Other
+              1, // Idle
               1, // Layout
               3, // JavaScript
               0,
@@ -2580,8 +2580,8 @@ describe('getTimingsForSidebar', () => {
             value: 2,
             breakdownByImplementation: { native: 2 },
             breakdownByCategory: withSingleSubcategory([
-              1, // Idle
               0, // Other
+              1, // Idle
               1, // Layout
               0,
               0,
@@ -2603,8 +2603,8 @@ describe('getTimingsForSidebar', () => {
             value: 1,
             breakdownByImplementation: { native: 1 },
             breakdownByCategory: withSingleSubcategory([
-              1, // Idle
               0,
+              1, // Idle
               0,
               0,
               0,
@@ -2633,8 +2633,8 @@ describe('getTimingsForSidebar', () => {
             value: 2,
             breakdownByImplementation: { native: 2 },
             breakdownByCategory: withSingleSubcategory([
-              1, // Idle
               0,
+              1, // Idle
               1, // Layout
               0,
               0,
@@ -2678,8 +2678,8 @@ describe('getTimingsForSidebar', () => {
             value: 5,
             breakdownByImplementation: { native: 2, ion: 2, baseline: 1 },
             breakdownByCategory: withSingleSubcategory([
+              0, // Other
               1, // Idle
-              0,
               1, // Layout
               3, // JavaScript
               0,
@@ -2718,8 +2718,8 @@ describe('getTimingsForSidebar', () => {
         value: 1,
         breakdownByImplementation: { ion: 1 },
         breakdownByCategory: withSingleSubcategory([
-          0, // Idle
           0, // Other
+          0, // Idle
           0, // Layout
           1, // JavaScript
           0,
@@ -2945,7 +2945,7 @@ describe('getTimingsForSidebar', () => {
       expect(timings.forPath).toEqual({
         selfTime: EMPTY_TIMING,
         totalTime: {
-          breakdownByCategory: withSingleSubcategory([0, 0, -1, 1, 0, 0, 0, 0]), // Idle, Other, Layout, JavaScript, etc.
+          breakdownByCategory: withSingleSubcategory([0, 0, -1, 1, 0, 0, 0, 0]), // Other, Idle, Layout, JavaScript, etc.
           breakdownByImplementation: {
             interpreter: 1,
             native: -1,

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -7,6 +7,7 @@ import type { Profile } from 'firefox-profiler/types';
 
 import { oneLineTrim } from 'common-tags';
 
+import { ensureExists } from 'firefox-profiler/utils/flow';
 import {
   getEmptyProfile,
   getEmptyThread,
@@ -154,8 +155,14 @@ describe('actions/receive-profile', function() {
       );
 
       const [idleThread, workThread] = profile.threads;
-      const idleCategoryIndex = profile.meta.categories.length;
-      profile.meta.categories.push({
+      const idleCategoryIndex = ensureExists(
+        profile.meta.categories,
+        'Expected to find categories'
+      ).length;
+      ensureExists(
+        profile.meta.categories,
+        'Expected to find categories.'
+      ).push({
         name: 'Idle',
         color: '#fff',
         subcategories: ['Other'],

--- a/src/test/unit/marker-schema.test.js
+++ b/src/test/unit/marker-schema.test.js
@@ -133,7 +133,7 @@ describe('marker schema labels', function() {
       'End: 5ms',
       'Duration: 3ms',
       'Name: TestDefinedMarker',
-      'Category: Idle',
+      'Category: Other',
     ]);
     expect(console.error).toBeCalledTimes(0);
   });

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -413,9 +413,10 @@ describe('process-profile', function() {
 describe('profile-data', function() {
   describe('createCallNodeTableAndFixupSamples', function() {
     const profile = processGeckoProfile(createGeckoProfile());
-    const defaultCategory = profile.meta.categories.findIndex(
-      c => c.name === 'Other'
-    );
+    const defaultCategory = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const thread = profile.threads[0];
     const { callNodeTable } = getCallNodeInfo(
       thread.stackTable,
@@ -462,7 +463,10 @@ describe('profile-data', function() {
       meta,
       threads: [thread],
     } = getCallNodeProfile();
-    const defaultCategory = meta.categories.findIndex(c => c.name === 'Other');
+    const defaultCategory = ensureExists(
+      meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const { callNodeTable, stackIndexToCallNodeIndex } = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
@@ -665,9 +669,10 @@ describe('symbolication', function() {
 
 describe('filter-by-implementation', function() {
   const profile = processGeckoProfile(createGeckoProfileWithJsTimings());
-  const defaultCategory = profile.meta.categories.findIndex(
-    c => c.name === 'Other'
-  );
+  const defaultCategory = ensureExists(
+    profile.meta.categories,
+    'Expected to find categories'
+  ).findIndex(c => c.name === 'Other');
   const thread = profile.threads[0];
 
   function stackIsJS(filteredThread, stackIndex) {
@@ -727,9 +732,10 @@ describe('get-sample-index-closest-to-time', function() {
         .fill('A')
         .join('  ')
     );
-    const defaultCategory = profile.meta.categories.findIndex(
-      c => c.name === 'Other'
-    );
+    const defaultCategory = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const thread = profile.threads[0];
     const { samples } = filterThreadByImplementation(
       thread,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -21,6 +21,7 @@ import {
 } from '../../profile-logic/profile-data';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import { formatTree, formatTreeIncludeCategories } from '../fixtures/utils';
+import { ensureExists } from 'firefox-profiler/utils/flow';
 
 import type { Profile } from 'firefox-profiler/types';
 
@@ -29,7 +30,11 @@ function callTreeFromProfile(
   threadIndex: number = 0
 ): CallTree {
   const thread = profile.threads[threadIndex];
-  const { interval, categories } = profile.meta;
+  const { interval } = profile.meta;
+  const categories = ensureExists(
+    profile.meta.categories,
+    'Expected to find categories'
+  );
   const defaultCategory = categories.findIndex(c => c.name === 'Other');
   const callNodeInfo = getCallNodeInfo(
     thread.stackTable,
@@ -85,9 +90,10 @@ describe('unfiltered call tree', function() {
   describe('computed counts and timings', function() {
     const profile = getProfile();
     const [thread] = profile.threads;
-    const defaultCategory = profile.meta.categories.findIndex(
-      c => c.name === 'Other'
-    );
+    const defaultCategory = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const callNodeInfo = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
@@ -118,9 +124,10 @@ describe('unfiltered call tree', function() {
   describe('roots and children for flame graph', function() {
     const profile = getProfile();
     const [thread] = profile.threads;
-    const defaultCategory = profile.meta.categories.findIndex(
-      c => c.name === 'Other'
-    );
+    const defaultCategory = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const callNodeInfo = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
@@ -386,9 +393,10 @@ describe('unfiltered call tree', function() {
   describe('getCallNodeIndexFromPath', function() {
     const profile = getProfile();
     const [thread] = profile.threads;
-    const defaultCategory = profile.meta.categories.findIndex(
-      c => c.name === 'Other'
-    );
+    const defaultCategory = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const { callNodeTable } = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
@@ -438,7 +446,11 @@ describe('inverted call tree', function() {
       E                Z           Y
                                    Z
     `).profile;
-    const { interval, categories } = profile.meta;
+    const { interval } = profile.meta;
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
     const defaultCategory = categories.findIndex(c => c.color === 'grey');
 
     // Check the non-inverted tree first.
@@ -615,8 +627,11 @@ describe('diffing trees', function() {
     const profile = getProfile();
 
     const thread = profile.threads[2];
-    const { interval, categories } = profile.meta;
-    const defaultCategory = categories.findIndex(c => c.name === 'Other');
+    const { interval } = profile.meta;
+    const defaultCategory = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    ).findIndex(c => c.name === 'Other');
     const callNodeInfo = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -86,6 +86,7 @@ export type Pid = number | string;
  */
 export type StackTable = {|
   frame: IndexIntoFrameTable[],
+  // Imported profiles may not have categories. In this case fill the array with 0s.
   category: IndexIntoCategoryList[],
   subcategory: IndexIntoSubcategoryListForCategory[],
   prefix: Array<IndexIntoStackTable | null>,
@@ -658,8 +659,11 @@ export type ProfileMeta = {|
   // The extensions property landed in Firefox 60, and is only optional because older
   // processed profile versions may not have it. No upgrader was written for this change.
   extensions?: ExtensionTable,
-  // The list of categories as provided by the platform.
-  categories: CategoryList,
+  // The list of categories as provided by the platform. The categories are present for
+  // all Firefox profiles, but imported profiles may not include any category support.
+  // The front-end will provide a default list of categories, but the saved profile
+  // will not include them.
+  categories?: CategoryList,
   // The name of the product, most likely "Firefox".
   product: 'Firefox' | string,
   // This value represents a boolean, but for some reason is written out as an int value.


### PR DESCRIPTION
I was trying to figure out a way in my dhat importer (PR #3128) to force the stack height view. The most logical way to me was to exclude the categories. This seemed the most logical way to say "this profile does not have any category information", and it can be used by any imported format.

I think this PR may be a little controversial, but I'd like to hear your feedback on this. I'm labeling it as discuss, but I would like to merge it if possible. This may conflict somewhat with Nazim's work, but it should be easy to rebase around.