### PR TITLE
Do not display negative timestamps for marker's causes

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -311,13 +311,19 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
         <TooltipDetailSeparator key="backtrace-separator" />,
         <TooltipDetail label="Stack" key="backtrace">
           <div className="tooltipDetailsBackTrace">
-            <h2 className="tooltipBackTraceTitle">
-              {data.type === 'Styles' || marker.name === 'Reflow'
-                ? `First invalidated ${formatTimestamp(
-                    causeAge
-                  )} before the flush, at:`
-                : `Triggered ${formatTimestamp(causeAge)} ago, at:`}
-            </h2>
+            {/* The cause's time might be later than the marker's start. For
+                example this happens in some usual cases when the cause is
+                captured right when setting the end marker for tracing pairs of
+                markers. */
+            causeAge > 0 ? (
+              <h2 className="tooltipBackTraceTitle">
+                {data.type === 'Styles' || marker.name === 'Reflow'
+                  ? `First invalidated ${formatTimestamp(
+                      causeAge
+                    )} before the flush, at:`
+                  : `Triggered ${formatTimestamp(causeAge)} ago, at:`}
+              </h2>
+            ) : null}
             <Backtrace
               maxStacks={restrictHeightWidth ? 20 : Infinity}
               stackIndex={cause.stack}

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -433,6 +433,19 @@ describe('TooltipMarker', function() {
           sampleEndTimeUs: 3632674500,
         },
       ],
+      [
+        'RefreshObserver',
+        122,
+        126,
+        {
+          type: 'Text',
+          name: 'Scrollbar fade animation [Style]',
+          cause: {
+            time: 125, // This time is later than the marker's start time
+            stack: funcNames.indexOf('nsRefreshDriver::AddStyleFlushObserver'),
+          },
+        },
+      ],
     ]);
     const store = storeWithProfile(profile);
     const state = store.getState();

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -2834,11 +2834,6 @@ exports[`TooltipMarker renders tooltips for various markers: RefreshObserver-122
     <div
       class="tooltipDetailsBackTrace"
     >
-      <h2
-        class="tooltipBackTraceTitle"
-      >
-        Triggered -3,000,000ns ago, at:
-      </h2>
       <ul
         class="backtrace"
       >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -2782,6 +2782,233 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
 </div>
 `;
 
+exports[`TooltipMarker renders tooltips for various markers: RefreshObserver-122 1`] = `
+<div
+  class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        4ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        RefreshObserver
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Details
+      :
+    </div>
+    Scrollbar fade animation [Style]
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Main Thread
+    <div
+      class="tooltipDetailSeparator"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Stack
+      :
+    </div>
+    <div
+      class="tooltipDetailsBackTrace"
+    >
+      <h2
+        class="tooltipBackTraceTitle"
+      >
+        Triggered -3,000,000ns ago, at:
+      </h2>
+      <ul
+        class="backtrace"
+      >
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsRefreshDriver::AddStyleFlushObserver
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::GeckoRestyleManager::PostRestyleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::GeckoRestyleManager::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::PresShell::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsDocument::ContentStateChanged
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::dom::Element::RemoveStates
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::EventStateManager::UpdateAncestorState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::EventStateManager::SetContentState
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::EventStateManager::NotifyMouseOut
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::EventStateManager::GenerateMouseEnterExit
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::EventStateManager::PreHandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::PresShell::HandleEventInternal
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::PresShell::HandlePositionedEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          mozilla::PresShell::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsViewManager::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsView::HandleEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsChildView::DispatchEvent
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          ChildViewMouseTracker::MouseMoved
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsAppShell::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        <li
+          class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+        >
+          nsAppStartup::Run
+          <em
+            class="backtraceStackFrameOrigin"
+          />
+        </li>
+        …
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
 <div
   class="tooltipMarker propClass"

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -500,6 +500,7 @@ export type UserTimingMarkerPayload = {|
 export type TextMarkerPayload = {|
   type: 'Text',
   name: string,
+  cause?: CauseBacktrace,
 |};
 
 // ph: 'X' in the Trace Event Format
@@ -697,7 +698,6 @@ export type MarkerPayload_Gecko =
   | GPUMarkerPayload
   | NetworkPayload
   | UserTimingMarkerPayload
-  | TextMarkerPayload
   | LogMarkerPayload
   | DOMEventMarkerPayload
   | GCMinorMarkerPayload
@@ -719,5 +719,6 @@ export type MarkerPayload_Gecko =
   | $ReplaceCauseWithStack<FileIoPayload>
   | $ReplaceCauseWithStack<PaintProfilerMarkerTracing>
   | $ReplaceCauseWithStack<StyleMarkerPayload>
+  | $ReplaceCauseWithStack<TextMarkerPayload>
   // Payloads can be null.
   | null;


### PR DESCRIPTION
Fixes #2982

I split the work in 2 commits:
* the first commit shows the issue in a snapshot
* the second commit makes it clear what this fixes, with the snapshot change

Here are direct links:
* [Production](https://profiler.firefox.com/public/kf560fda643a3zv4trgx3xt7jd3c54xnezvfg8r/marker-table/?globalTrackOrder=3-4-5-0-1-2&hiddenLocalTracksByPid=32643-0-2-3-4&localTrackOrderByPid=32643-6-7-0-1-2-3-4-5~32648-0~32649-0~&markerSearch=refresh&thread=0&v=5)
* [Deploy preview](https://deploy-preview-3224--perf-html.netlify.com/public/kf560fda643a3zv4trgx3xt7jd3c54xnezvfg8r/marker-table/?globalTrackOrder=3-4-5-0-1-2&hiddenLocalTracksByPid=32643-0-2-3-4&localTrackOrderByPid=32643-6-7-0-1-2-3-4-5~32648-0~32649-0~&markerSearch=refresh&thread=0&v=5)

You'll see that `RefreshObserver` markers have their negative timestamps removed, but `RefreshDriverTick` markers still have positive timestamps.

Examples of problematic markers:
* `ChromeUtils.import` <= [this uses a RAII with stack capture](https://searchfox.org/mozilla-central/rev/526a5089c61db85d4d43eb0e46edaf1f632e853a/js/xpconnect/loader/mozJSComponentLoader.cpp#1212). The stack is captured when the end marker is added (at the end of scope), but the start marker is added right away. So the stack will always happen after the marker start. This is probably the same for all RAII with stack capture.
* `RefreshObserver` <= [this uses a start time saved from before we add the marker](https://searchfox.org/mozilla-central/rev/526a5089c61db85d4d43eb0e46edaf1f632e853a/layout/base/nsRefreshDriver.cpp#1228-1233), so here as well the cause will always be later than the marker's start.

You can also search `Reflow` markers that still have this mention when they should.