### PR TITLE
Fix the typo in the DebugWarning component

### DIFF
--- a/src/components/app/DebugWarning.js
+++ b/src/components/app/DebugWarning.js
@@ -24,7 +24,7 @@ class DebugWarningImp extends PureComponent<Props> {
     return (
       <>
         {meta.debug ? (
-          <Warning message="This profile was recorded in a build without release optimizations. Performance obervations might not apply to the release population." />
+          <Warning message="This profile was recorded in a build without release optimizations. Performance observations might not apply to the release population." />
         ) : null}
       </>
     );


### PR DESCRIPTION
This came up during the Joy of Profiling open session :tada: 
Side note: We should also make it localized. I'm adding it to my todo list for this week.