### PR TITLE
Do not render until l10n is ready

### DIFF
--- a/src/components/app/AppLocalizationProvider.js
+++ b/src/components/app/AppLocalizationProvider.js
@@ -48,7 +48,12 @@ class AppLocalizationProviderImpl extends React.PureComponent<Props> {
   }
 
   render() {
-    const { children, localization } = this.props;
+    const { primaryLocale, children, localization } = this.props;
+    if (!primaryLocale) {
+      // The localization isn't ready.
+      return null;
+    }
+
     return (
       <LocalizationProvider l10n={localization}>
         {children}

--- a/src/test/components/AppLocalizationProvider.test.js
+++ b/src/test/components/AppLocalizationProvider.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { ReactLocalization, Localized } from '@fluent/react';
 
-import { render } from 'firefox-profiler/test/fixtures/testing-library';
+import { render, screen } from '@testing-library/react';
 import { lazilyParsedBundles } from 'firefox-profiler/app-logic/l10n';
 import { AppLocalizationProvider } from 'firefox-profiler/components/app/AppLocalizationProvider';
 import {
@@ -84,9 +84,9 @@ describe('AppLocalizationProvider', () => {
     expect(getDirection(getState())).toEqual('ltr');
   });
 
-  it('renders its children', async () => {
+  it(`renders children only once the localization is ready`, async () => {
     const { store } = setup();
-    const { getByTestId } = render(
+    render(
       <Provider store={store}>
         <AppLocalizationProvider>
           <div data-testid="content-test-AppLocalizationProvider" />
@@ -95,7 +95,11 @@ describe('AppLocalizationProvider', () => {
     );
 
     expect(
-      getByTestId('content-test-AppLocalizationProvider')
+      screen.queryByTestId('content-test-AppLocalizationProvider')
+    ).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByTestId('content-test-AppLocalizationProvider')
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
While looking at https://github.com/firefox-devtools/profiler/pull/3213 I realized we have a flashing issue at load time.
The problem is that we're rendering the UI once before the localization is ready.
Because initializating the localization should be fast because cached by the service worker, we can wait until we're ready. Maybe in the future if we stop caching all FTL files in the service worker we'll have to be more clever, but that should do it for now.

I tried running `dispatch(setupLocalization(...))` in `index.js` but that wasn't good enough. I believe this patch works better. Tell me what you think!

Flashing is visible in the home page or the compare page, looking at the title (because the "dash" is different in the translation).

Links to preview:
* home page: [deploy preview](https://deploy-preview-3232--perf-html.netlify.app/) / [production](https://profiler.firefox.com/)
* compare view: [deploy preview](https://deploy-preview-3232--perf-html.netlify.app/compare/) / [production](https://profiler.firefox.com/compare/)

I do see a difference in loading the page, especially in the compare view. Can you tell me what you see?
On my computer loading the FTL file seems to take longer than it should, maybe because my main process is very busy with my 1500 tabs 😅

Not sure how we could make it much better. Part of the problem is that we wait until all the JS parsed and loaded before even starting to request the additional ftl file. Eventually we'll need to make the startup process more staged and asynchronous, but that's a ton of work :/