### PR TITLE
Make the rest of the header components and panel components localizable

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -54,6 +54,13 @@ CompareHome--form-label-profile2 = Profile 2:
 CompareHome--submit-button =
     .value = Retrieve profiles
 
+## DebugWarning
+
+DebugWarning--warning-message =
+    .message =
+    This profile was recorded in a build without release optimizations.
+    Performance observations might not apply to the release population.
+
 ## FooterLinks
 
 FooterLinks--legal = Legal

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -318,6 +318,20 @@ ProfileLoaderAnimation--loading-message-view-not-found =
 ProfileRootMessage--title = { -profiler-brand-name }
 ProfileRootMessage--additional = Back to home
 
+## ServiceWorkerManager
+
+ServiceWorkerManager--installing-button = Installing…
+ServiceWorkerManager--pending-button = Apply and reload
+ServiceWorkerManager--installed-button = Reload the application
+ServiceWorkerManager--updated-while-not-ready =
+    A new version of the application was applied before this page
+    was fully loaded. You might see malfunctions.
+ServiceWorkerManager--new-version-is-ready =
+    A new version of the application has been downloaded and is ready to use.
+ServiceWorkerManager--hide-notice-button =
+    .title = Hide the reload notice
+    .aria-label = Hide the reload notice
+
 ## UploadedRecordingsHome
 
 UploadedRecordingsHome--title = Uploaded Recordings

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -154,6 +154,13 @@ ListOfPublishedProfiles--uploaded-profile-information-list =
        *[other] Manage these recordings
     }
 
+## MarkerSettings
+
+MarkerSettings--panel-search =
+    .label = Filter Markers:
+    .title = Only display markers that match a certain name
+
+
 ## These strings are used for the buttons at the top of the profile viewer.
 
 MenuButtons--index--metaInfo-button-uploaded-profile =

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -61,6 +61,15 @@ DebugWarning--warning-message =
     This profile was recorded in a build without release optimizations.
     Performance observations might not apply to the release population.
 
+## Details
+
+Details--open-sidebar-button =
+    .title = Open the sidebar
+Details--close-sidebar-button =
+    .title = Close the sidebar
+Details--error-boundary-message =
+    .message = Uh oh, some unknown error happened in this panel.
+
 ## FooterLinks
 
 FooterLinks--legal = Legal

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -356,6 +356,33 @@ ServiceWorkerManager--hide-notice-button =
     .title = Hide the reload notice
     .aria-label = Hide the reload notice
 
+## StackSettings
+
+StackSettings--implementation-all-stacks = All stacks
+StackSettings--implementation-javascript = JavaScript
+StackSettings--implementation-native = Native
+
+StackSettings--summarize = Summarize:
+StackSettings--call-tree-strategy-timing = Timing Data
+    .title = Summarize using sampled stacks of executed code over time
+StackSettings--call-tree-strategy-js-allocations = JavaScript Allocations
+    .title = Summarize using bytes of JavaScript allocated (no de-allocations)
+StackSettings--call-tree-strategy-native-retained-allocations = Retained Memory
+    .title = Summarize using bytes of memory that were allocated, and never freed in the current preview selection
+StackSettings--call-tree-native-allocations = Allocated Memory
+    .title = Summarize using bytes of memory allocated
+StackSettings--call-tree-strategy-native-deallocations-memory = Deallocated Memory
+    .title = Summarize using bytes of memory deallocated, by the site where the memory was allocated
+StackSettings--call-tree-strategy-native-deallocations-sites = Deallocation Sites
+    .title = Summarize using bytes of memory deallocated, by the site where the memory was deallocated
+
+StackSettings--invert-call-stack = Invert call stack
+StackSettings--show-user-timing = Show user timing
+
+StackSettings--panel-search =
+    .label = Filter stacks:
+    .title = Only display stacks which contain a function whose name matches this substring
+
 ## TabBar
 
 TabBar--calltree-tab = Call Tree

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -279,6 +279,10 @@ ProfileDeleteButton--delete-button =
     .label = Delete
     .title = Click here to delete the profile { $smallProfileName }
 
+## ProfileFilterNavigator
+
+ProfileFilterNavigator--full-range = Full Range
+
 ## ProfileLoaderAnimation
 
 ProfileLoaderAnimation--loading-message-unpublished =

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -319,6 +319,11 @@ NetworkSettings--panel-search =
     .label = Filter Networks:
     .title = Only display network requests that match a certain name
 
+## PanelSearch
+
+PanelSearch--search-field-hint =
+    Did you know you can use the comma (,) to search using several terms?
+
 ## ProfileDeleteButton
 
 # This string is used on the tooltip of the published profile links delete button in uploaded recordings page.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -127,6 +127,11 @@ Home--additional-content-content = You can <strong>drag and drop</strong> a prof
 Home--compare-recordings-info = You can also compare recordings. <a>Open the comparing interface.</a>
 Home--recent-uploaded-recordings-title = Recent uploaded recordings
 
+## IdleSearchField
+
+IdleSearchField--search-input =
+    .placeholder = Enter filter terms
+
 ## ListOfPublishedProfiles
 
 # This string is used on the tooltip of the published profile links.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -308,6 +308,12 @@ MenuButtons--publish--message-try-again = Try again
 MenuButtons--publish--download = Download
 MenuButtons--publish--compressing = Compressing…
 
+## NetworkSettings
+
+NetworkSettings--panel-search =
+    .label = Filter Networks:
+    .title = Only display network requests that match a certain name
+
 ## ProfileDeleteButton
 
 # This string is used on the tooltip of the published profile links delete button in uploaded recordings page.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -85,6 +85,7 @@ FullTimeline--stack-height = Stack height
 
 # This string is used as the text of the track selection button.
 # Displays the ratio of visible tracks count to total tracks count in the timeline.
+# We have spans here to make the numbers bold.
 # Variables:
 #   $visibleTrackCount (Number) - Visible track count in the timeline
 #   $totalTrackCount (Number) - Total track count in the timeline
@@ -128,11 +129,13 @@ Home--compare-recordings-info = You can also compare recordings. <a>Open the com
 Home--recent-uploaded-recordings-title = Recent uploaded recordings
 
 ## IdleSearchField
+## The component that is used for all the search inputs in the application.
 
 IdleSearchField--search-input =
     .placeholder = Enter filter terms
 
 ## JsTracerSettings
+## JSTracer is an experimental feature and it's currently disabled. See Bug 1565788.
 
 JsTracerSettings--show-only-self-time = Show only self time
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -58,8 +58,8 @@ CompareHome--submit-button =
 
 DebugWarning--warning-message =
     .message =
-    This profile was recorded in a build without release optimizations.
-    Performance observations might not apply to the release population.
+        This profile was recorded in a build without release optimizations.
+        Performance observations might not apply to the release population.
 
 ## Details
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -347,6 +347,16 @@ ServiceWorkerManager--hide-notice-button =
     .title = Hide the reload notice
     .aria-label = Hide the reload notice
 
+## TabBar
+
+TabBar--calltree-tab = Call Tree
+TabBar--flame-graph-tab = Flame Graph
+TabBar--stack-chart-tab = Stack Chart
+TabBar--marker-chart-tab = Marker Chart
+TabBar--marker-table-tab = Marker Table
+TabBar--network-tab = Network
+TabBar--js-tracer-tab = JS Tracer
+
 ## UploadedRecordingsHome
 
 UploadedRecordingsHome--title = Uploaded Recordings

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -132,6 +132,10 @@ Home--recent-uploaded-recordings-title = Recent uploaded recordings
 IdleSearchField--search-input =
     .placeholder = Enter filter terms
 
+## JsTracerSettings
+
+JsTracerSettings--show-only-self-time = Show only self time
+
 ## ListOfPublishedProfiles
 
 # This string is used on the tooltip of the published profile links.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -67,6 +67,21 @@ FooterLinks--legal = Legal
 FooterLinks--Privacy = Privacy
 FooterLinks--Cookies = Cookies
 
+## FullTimeline
+
+FullTimeline--graph-type = Graph type:
+FullTimeline--categories-with-cpu = Categories with CPU
+FullTimeline--categories = Categories
+FullTimeline--stack-height = Stack height
+
+# This string is used as the text of the track selection button.
+# Displays the ratio of visible tracks count to total tracks count in the timeline.
+# Variables:
+#   $visibleTrackCount (Number) - Visible track count in the timeline
+#   $totalTrackCount (Number) - Total track count in the timeline
+FullTimeline--tracks-visible =
+    <span>{ $visibleTrackCount }</span> / <span>{ $totalTrackCount }</span> tracks visible
+
 ## Home
 
 Home--upload-from-file-input-button = Load a profile from file

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -5,22 +5,22 @@
 // @flow
 
 /**
- * This object contains all our tab slugs with their associated title. This is
- * the "main list of tabs". This is in object form because that's how we can
- * easily derive the TabSlug type with Flow.
+ * This object contains all our tab slugs with their associated title l10n Ids.
+ * This is the "main list of tabs". This is in object form because that's how we
+ * can easily derive the TabSlug type with Flow.
  */
-export const tabsWithTitle = {
-  calltree: 'Call Tree',
-  'flame-graph': 'Flame Graph',
-  'stack-chart': 'Stack Chart',
-  'marker-chart': 'Marker Chart',
-  'marker-table': 'Marker Table',
-  'network-chart': 'Network',
-  'js-tracer': 'JS Tracer',
+export const tabsWithTitleL10nId = {
+  calltree: 'TabBar--calltree-tab',
+  'flame-graph': 'TabBar--flame-graph-tab',
+  'stack-chart': 'TabBar--stack-chart-tab',
+  'marker-chart': 'TabBar--marker-chart-tab',
+  'marker-table': 'TabBar--marker-table-tab',
+  'network-chart': 'TabBar--network-tab',
+  'js-tracer': 'TabBar--js-tracer-tab',
 };
 
-export type TabSlug = $Keys<typeof tabsWithTitle>;
-export type TabWithTitle = {| name: TabSlug, title: string |};
+export type TabSlug = $Keys<typeof tabsWithTitleL10nId>;
+export type TabsWithTitleL10nId = {| name: TabSlug, title: string |};
 
 /**
  * This array contains the list of all tab slugs that we use as codes throughout
@@ -29,15 +29,15 @@ export type TabWithTitle = {| name: TabSlug, title: string |};
 export const tabSlugs: $ReadOnlyArray<TabSlug> =
   // getOwnPropertyNames is guaranteed to keep the order in which properties
   // were defined, and this order is important for us.
-  Object.getOwnPropertyNames(tabsWithTitle);
+  Object.getOwnPropertyNames(tabsWithTitleL10nId);
 
 /**
- * This array contains the same data as tabsWithTitle above, but in an ordered
+ * This array contains the same data as tabsWithTitleL10nId above, but in an ordered
  * array so that we can use it directly in some of our components.
  */
-export const tabsWithTitleArray: $ReadOnlyArray<TabWithTitle> = tabSlugs.map(
+export const tabsWithTitleL10nIdArray: $ReadOnlyArray<TabsWithTitleL10nId> = tabSlugs.map(
   tabSlug => ({
     name: tabSlug,
-    title: tabsWithTitle[tabSlug],
+    title: tabsWithTitleL10nId[tabSlug],
   })
 );

--- a/src/components/app/DebugWarning.js
+++ b/src/components/app/DebugWarning.js
@@ -5,6 +5,8 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
+
 import { Warning } from '../shared/Warning';
 import explicitConnect from '../../utils/connect';
 import { getMeta } from '../../selectors/profile';
@@ -24,7 +26,12 @@ class DebugWarningImp extends PureComponent<Props> {
     return (
       <>
         {meta.debug ? (
-          <Warning message="This profile was recorded in a build without release optimizations. Performance observations might not apply to the release population." />
+          <Localized
+            id="DebugWarning--warning-message"
+            attrs={{ message: true }}
+          >
+            <Warning message="This profile was recorded in a build without release optimizations. Performance observations might not apply to the release population." />
+          </Localized>
         ) : null}
       </>
     );

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -6,6 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
+import { Localized } from '@fluent/react';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { TabBar } from './TabBar';
@@ -67,20 +68,30 @@ class ProfileViewerImpl extends PureComponent<Props> {
     const { visibleTabs, selectedTab, isSidebarOpen } = this.props;
     const hasSidebar = selectSidebar(selectedTab) !== null;
     const extraButton = hasSidebar && (
-      <button
-        className={classNames(
-          'sidebar-open-close-button',
-          'photon-button',
-          'photon-button-ghost',
-          {
-            'sidebar-open-close-button-isopen': isSidebarOpen,
-            'sidebar-open-close-button-isclosed': !isSidebarOpen,
-          }
-        )}
-        title={isSidebarOpen ? 'Close the sidebar' : 'Open the sidebar'}
-        type="button"
-        onClick={this._onClickSidebarButton}
-      />
+      <Localized
+        id={
+          isSidebarOpen
+            ? 'Details--close-sidebar-button'
+            : 'Details--open-sidebar-button'
+        }
+        attrs={{ title: true }}
+        vars={{ isSidebarOpen: isSidebarOpen }}
+      >
+        <button
+          className={classNames(
+            'sidebar-open-close-button',
+            'photon-button',
+            'photon-button-ghost',
+            {
+              'sidebar-open-close-button-isopen': isSidebarOpen,
+              'sidebar-open-close-button-isclosed': !isSidebarOpen,
+            }
+          )}
+          title={isSidebarOpen ? 'Close the sidebar' : 'Open the sidebar'}
+          type="button"
+          onClick={this._onClickSidebarButton}
+        />
+      </Localized>
     );
 
     return (
@@ -91,22 +102,27 @@ class ProfileViewerImpl extends PureComponent<Props> {
           onSelectTab={this._onSelectTab}
           extraElements={extraButton}
         />
-        <ErrorBoundary
-          key={selectedTab}
-          message="Uh oh, some unknown error happened in this panel."
+        <Localized
+          id="Details--error-boundary-message"
+          attrs={{ message: true }}
         >
-          {
+          <ErrorBoundary
+            key={selectedTab}
+            message="Uh oh, some unknown error happened in this panel."
+          >
             {
-              calltree: <ProfileCallTreeView />,
-              'flame-graph': <FlameGraph />,
-              'stack-chart': <StackChart />,
-              'marker-chart': <MarkerChart />,
-              'marker-table': <MarkerTable />,
-              'network-chart': <NetworkChart />,
-              'js-tracer': <JsTracer />,
-            }[selectedTab]
-          }
-        </ErrorBoundary>
+              {
+                calltree: <ProfileCallTreeView />,
+                'flame-graph': <FlameGraph />,
+                'stack-chart': <StackChart />,
+                'marker-chart': <MarkerChart />,
+                'marker-table': <MarkerTable />,
+                'network-chart': <NetworkChart />,
+                'js-tracer': <JsTracer />,
+              }[selectedTab]
+            }
+          </ErrorBoundary>
+        </Localized>
         <CallNodeContextMenu />
         <MaybeMarkerContextMenu />
       </div>

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -6,6 +6,8 @@
 
 import React from 'react';
 import memoize from 'memoize-immutable';
+import { Localized } from '@fluent/react';
+
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { popCommittedRanges } from 'firefox-profiler/actions/profile-view';
 import {
@@ -66,7 +68,13 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
         ),
       };
     } else {
-      firstItem = { content: <>Full Range</> };
+      firstItem = {
+        content: (
+          <Localized id="ProfileFilterNavigator--full-range">
+            Full Range
+          </Localized>
+        ),
+      };
     }
 
     const itemsWithFirstElement = this._getItemsWithFirstElement(

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -4,6 +4,8 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
+
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import { getDataSource } from 'firefox-profiler/selectors/url-state';
@@ -253,12 +255,14 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
     switch (installStatus) {
       case 'installing':
         return (
-          <button
-            className="photon-button photon-button-micro photon-message-bar-action-button"
-            type="button"
-          >
-            Installing…
-          </button>
+          <Localized id="ServiceWorkerManager--installing-button">
+            <button
+              className="photon-button photon-button-micro photon-message-bar-action-button"
+              type="button"
+            >
+              Installing…
+            </button>
+          </Localized>
         );
       case 'idle':
         throw new Error(
@@ -266,24 +270,28 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
         );
       case 'pending':
         return (
-          <button
-            className="photon-button photon-button-micro photon-message-bar-action-button"
-            type="button"
-            onClick={this.applyServiceWorkerUpdate}
-          >
-            Apply and reload
-          </button>
+          <Localized id="ServiceWorkerManager--pending-button">
+            <button
+              className="photon-button photon-button-micro photon-message-bar-action-button"
+              type="button"
+              onClick={this.applyServiceWorkerUpdate}
+            >
+              Apply and reload
+            </button>
+          </Localized>
         );
       case 'installed':
         // Another tab applied the new service worker.
         return (
-          <button
-            className="photon-button photon-button-micro photon-message-bar-action-button"
-            type="button"
-            onClick={this.reloadPage}
-          >
-            Reload the application
-          </button>
+          <Localized id="ServiceWorkerManager--installed-button">
+            <button
+              className="photon-button photon-button-micro photon-message-bar-action-button"
+              type="button"
+              onClick={this.reloadPage}
+            >
+              Reload the application
+            </button>
+          </Localized>
         );
       default:
         throw assertExhaustiveCheck(installStatus);
@@ -307,18 +315,25 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
           <div className="photon-message-bar photon-message-bar-warning serviceworker-ready-notice">
             <div className="photon-message-bar-inner-content">
               <div className="photon-message-bar-inner-text">
-                A new version of the application was applied before this page
-                was fully loaded. You might see malfunctions.
+                <Localized id="ServiceWorkerManager--updated-while-not-ready">
+                  A new version of the application was applied before this page
+                  was fully loaded. You might see malfunctions.
+                </Localized>
               </div>
               {this._canUpdateServiceWorker() ? this.renderButton() : null}
             </div>
-            <button
-              aria-label="Hide the reload notice"
-              title="Hide the reload notice"
-              className="photon-button photon-message-bar-close-button"
-              type="button"
-              onClick={this._onCloseNotice}
-            />
+            <Localized
+              id="ServiceWorkerManager--hide-notice-button"
+              attrs={{ 'aria-label': true, title: true }}
+            >
+              <button
+                aria-label="Hide the reload notice"
+                title="Hide the reload notice"
+                className="photon-button photon-message-bar-close-button"
+                type="button"
+                onClick={this._onCloseNotice}
+              />
+            </Localized>
           </div>
         </div>
       );
@@ -335,18 +350,25 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
         <div className="photon-message-bar serviceworker-ready-notice">
           <div className="photon-message-bar-inner-content">
             <div className="photon-message-bar-inner-text">
-              A new version of the application has been downloaded and is ready
-              to use.
+              <Localized id="ServiceWorkerManager--new-version-is-ready">
+                A new version of the application has been downloaded and is
+                ready to use.
+              </Localized>
             </div>
             {this.renderButton()}
           </div>
-          <button
-            aria-label="Hide the reload notice"
-            title="Hide the reload notice"
-            className="photon-button photon-message-bar-close-button"
-            type="button"
-            onClick={this._onCloseNotice}
-          />
+          <Localized
+            id="ServiceWorkerManager--hide-notice-button"
+            attrs={{ 'aria-label': true, title: true }}
+          >
+            <button
+              aria-label="Hide the reload notice"
+              title="Hide the reload notice"
+              className="photon-button photon-message-bar-close-button"
+              type="button"
+              onClick={this._onCloseNotice}
+            />
+          </Localized>
         </div>
       </div>
     );

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -6,9 +6,10 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
+import { Localized } from '@fluent/react';
 
 import {
-  tabsWithTitle,
+  tabsWithTitleL10nId,
   type TabSlug,
 } from 'firefox-profiler/app-logic/tabs-handling';
 
@@ -60,22 +61,24 @@ export class TabBar extends React.PureComponent<Props> {
             >
               {/* adding a button for better keyboard navigation and
               adding ARIA attributes for screen reader support.*/}
-              <button
-                className="tabBarTabButton"
-                type="button"
-                // The tab's id attribute connects the tab to its tabpanel
-                // that has an aria-labelledby attribute of the same value.
-                // The id is not used for CSS styling.
-                id={`${tabSlug}-tab-button`}
-                role="tab"
-                aria-selected={tabSlug === selectedTabSlug}
-                // The control and content relationship is established
-                // with aria-controls attribute
-                // (the tabbanel has an id of the same value).
-                aria-controls={`${tabSlug}-tab`}
-              >
-                {tabsWithTitle[tabSlug]}
-              </button>
+              <Localized id={tabsWithTitleL10nId[tabSlug]}>
+                <button
+                  className="tabBarTabButton"
+                  type="button"
+                  // The tab's id attribute connects the tab to its tabpanel
+                  // that has an aria-labelledby attribute of the same value.
+                  // The id is not used for CSS styling.
+                  id={`${tabSlug}-tab-button`}
+                  role="tab"
+                  aria-selected={tabSlug === selectedTabSlug}
+                  // The control and content relationship is established
+                  // with aria-controls attribute
+                  // (the tabbanel has an id of the same value).
+                  aria-controls={`${tabSlug}-tab`}
+                >
+                  {tabsWithTitleL10nId[tabSlug]}
+                </button>
+              </Localized>
             </li>
           ))}
         </ol>

--- a/src/components/js-tracer/Settings.js
+++ b/src/components/js-tracer/Settings.js
@@ -12,6 +12,7 @@ import explicitConnect, {
 } from 'firefox-profiler/utils/connect';
 
 import './Settings.css';
+import { Localized } from '@fluent/react';
 
 type StateProps = {|
   +showJsTracerSummary: boolean,
@@ -41,7 +42,9 @@ class JsTracerSettingsImpl extends PureComponent<Props> {
                 onChange={this._onCheckboxChange}
                 checked={showJsTracerSummary}
               />
-              {' Show only self time'}
+              <Localized id="JsTracerSettings--show-only-self-time">
+                Show only self time
+              </Localized>
             </label>
           </li>
         </ul>

--- a/src/components/shared/IdleSearchField.js
+++ b/src/components/shared/IdleSearchField.js
@@ -5,6 +5,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
+import { Localized } from '@fluent/react';
 
 import './IdleSearchField.css';
 
@@ -109,19 +110,24 @@ export class IdleSearchField extends PureComponent<Props, State> {
         className={classNames('idleSearchField', className)}
         onSubmit={this._onFormSubmit}
       >
-        <input
-          type="search"
-          name="search"
-          placeholder="Enter filter terms"
-          className="idleSearchFieldInput photon-input"
-          required="required"
-          title={title}
-          value={this.state.value}
-          onChange={this._onSearchFieldChange}
-          onFocus={this._onSearchFieldFocus}
-          onBlur={this._onSearchFieldBlur}
-          ref={this._takeInputRef}
-        />
+        <Localized
+          id="IdleSearchField--search-input"
+          attrs={{ placeholder: true }}
+        >
+          <input
+            type="search"
+            name="search"
+            placeholder="Enter filter terms"
+            className="idleSearchFieldInput photon-input"
+            required="required"
+            title={title}
+            value={this.state.value}
+            onChange={this._onSearchFieldChange}
+            onFocus={this._onSearchFieldFocus}
+            onBlur={this._onSearchFieldBlur}
+            ref={this._takeInputRef}
+          />
+        </Localized>
         <input
           type="reset"
           className="idleSearchFieldButton"

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -5,6 +5,7 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { changeMarkersSearchString } from 'firefox-profiler/actions/profile-view';
@@ -35,13 +36,18 @@ class MarkerSettingsImpl extends PureComponent<Props> {
     return (
       <div className="markerSettings">
         <div className="markerSettingsSpacer" />
-        <PanelSearch
-          className="markerSettingsSearchField"
-          label="Filter Markers: "
-          title="Only display markers that match a certain name"
-          currentSearchString={searchString}
-          onSearch={this._onSearch}
-        />
+        <Localized
+          id="MarkerSettings--panel-search"
+          attrs={{ label: true, title: true }}
+        >
+          <PanelSearch
+            className="markerSettingsSearchField"
+            label="Filter Markers: "
+            title="Only display markers that match a certain name"
+            currentSearchString={searchString}
+            onSearch={this._onSearch}
+          />
+        </Localized>
       </div>
     );
   }

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -42,7 +42,7 @@ class MarkerSettingsImpl extends PureComponent<Props> {
         >
           <PanelSearch
             className="markerSettingsSearchField"
-            label="Filter Markers: "
+            label="Filter Markers:"
             title="Only display markers that match a certain name"
             currentSearchString={searchString}
             onSearch={this._onSearch}

--- a/src/components/shared/NetworkSettings.js
+++ b/src/components/shared/NetworkSettings.js
@@ -5,6 +5,7 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { changeNetworkSearchString } from 'firefox-profiler/actions/profile-view';
@@ -35,13 +36,18 @@ class NetworkSettingsImpl extends PureComponent<Props> {
     return (
       <div className="networkSettings">
         <div className="networkSettingsSpacer" />
-        <PanelSearch
-          className="networkSettingsSearchField"
-          label="Filter Networks: "
-          title="Only display network requests that match a certain name"
-          currentSearchString={searchString}
-          onSearch={this._onSearch}
-        />
+        <Localized
+          id="NetworkSettings--panel-search"
+          attrs={{ label: true, title: true }}
+        >
+          <PanelSearch
+            className="networkSettingsSearchField"
+            label="Filter Networks: "
+            title="Only display network requests that match a certain name"
+            currentSearchString={searchString}
+            onSearch={this._onSearch}
+          />
+        </Localized>
       </div>
     );
   }

--- a/src/components/shared/NetworkSettings.js
+++ b/src/components/shared/NetworkSettings.js
@@ -42,7 +42,7 @@ class NetworkSettingsImpl extends PureComponent<Props> {
         >
           <PanelSearch
             className="networkSettingsSearchField"
-            label="Filter Networks: "
+            label="Filter Networks:"
             title="Only display network requests that match a certain name"
             currentSearchString={searchString}
             onSearch={this._onSearch}

--- a/src/components/shared/PanelSearch.js
+++ b/src/components/shared/PanelSearch.js
@@ -43,7 +43,7 @@ export class PanelSearch extends React.PureComponent<Props, State> {
     return (
       <div className={classNames('panelSearchField', className)}>
         <label className="panelSearchFieldLabel">
-          {label}
+          {label + ' '}
           <IdleSearchField
             className="panelSearchFieldInput"
             title={title}

--- a/src/components/shared/PanelSearch.js
+++ b/src/components/shared/PanelSearch.js
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import { IdleSearchField } from './IdleSearchField';
 
 import './PanelSearch.css';
+import { Localized } from '@fluent/react';
 
 type Props = {|
   +className: string,
@@ -59,8 +60,10 @@ export class PanelSearch extends React.PureComponent<Props, State> {
               isDisplayed: showIntroduction,
             })}
           >
-            Did you know you can use the comma (,) to search using several
-            terms?
+            <Localized id="PanelSearch--search-field-hint">
+              Did you know you can use the comma (,) to search using several
+              terms?
+            </Localized>
           </div>
         </label>
       </div>

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -5,6 +5,8 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
+
 import {
   changeImplementationFilter,
   changeInvertCallstack,
@@ -94,7 +96,7 @@ class StackSettingsImpl extends PureComponent<Props> {
   };
 
   _renderImplementationRadioButton(
-    label: string,
+    labelL10Id: string,
     implementationFilter: ImplementationFilter
   ) {
     return (
@@ -108,20 +110,19 @@ class StackSettingsImpl extends PureComponent<Props> {
           onChange={this._onImplementationFilterChange}
           checked={this.props.implementationFilter === implementationFilter}
         />
-        {label}
+        <Localized id={labelL10Id}></Localized>
       </label>
     );
   }
 
   _renderCallTreeStrategyOption(
-    label: string,
-    strategy: CallTreeSummaryStrategy,
-    tooltip: string
+    labelL10nId: string,
+    strategy: CallTreeSummaryStrategy
   ) {
     return (
-      <option title={tooltip} key={strategy} value={strategy}>
-        {label}
-      </option>
+      <Localized id={labelL10nId} attrs={{ title: true }}>
+        <option key={strategy} value={strategy}></option>
+      </Localized>
     );
   }
 
@@ -145,57 +146,60 @@ class StackSettingsImpl extends PureComponent<Props> {
       <div className="stackSettings">
         <ul className="stackSettingsList">
           <li className="stackSettingsListItem stackSettingsFilter">
-            {this._renderImplementationRadioButton('All stacks', 'combined')}
-            {this._renderImplementationRadioButton('JavaScript', 'js')}
-            {this._renderImplementationRadioButton('Native', 'cpp')}
+            {this._renderImplementationRadioButton(
+              'StackSettings--implementation-all-stacks',
+              'combined'
+            )}
+            {this._renderImplementationRadioButton(
+              'StackSettings--implementation-javascript',
+              'js'
+            )}
+            {this._renderImplementationRadioButton(
+              'StackSettings--implementation-native',
+              'cpp'
+            )}
           </li>
           {hasAllocations && !disableCallTreeSummaryButtons ? (
             <li className="stackSettingsListItem stackSettingsFilter">
               <label>
-                Summarize:{' '}
+                <Localized id="StackSettings--summarize">Summarize:</Localized>{' '}
                 <select
                   className="stackSettingsSelect"
                   onChange={this._onCallTreeSummaryStrategyChange}
                   value={callTreeSummaryStrategy}
                 >
                   {this._renderCallTreeStrategyOption(
-                    'Timing Data',
-                    'timing',
-                    'Summarize using sampled stacks of executed code over time'
+                    'StackSettings--call-tree-strategy-timing',
+                    'timing'
                   )}
                   {hasJsAllocations
                     ? this._renderCallTreeStrategyOption(
-                        'JavaScript Allocations',
-                        'js-allocations',
-                        'Summarize using bytes of JavaScript allocated (no de-allocations)'
+                        'StackSettings--call-tree-strategy-js-allocations',
+                        'js-allocations'
                       )
                     : null}
                   {canShowRetainedMemory
                     ? this._renderCallTreeStrategyOption(
-                        'Retained Memory',
-                        'native-retained-allocations',
-                        'Summarize using bytes of memory that were allocated, and never freed in the current preview selection'
+                        'StackSettings--call-tree-strategy-native-retained-allocations',
+                        'native-retained-allocations'
                       )
                     : null}
                   {hasNativeAllocations
                     ? this._renderCallTreeStrategyOption(
-                        'Allocated Memory',
-                        'native-allocations',
-                        'Summarize using bytes of memory allocated'
+                        'StackSettings--call-tree-native-allocations',
+                        'native-allocations'
                       )
                     : null}
                   {canShowRetainedMemory
                     ? this._renderCallTreeStrategyOption(
-                        'Deallocated Memory',
-                        'native-deallocations-memory',
-                        'Summarize using bytes of memory deallocated, by the site where the memory was allocated'
+                        'StackSettings--call-tree-strategy-native-deallocations-memory',
+                        'native-deallocations-memory'
                       )
                     : null}
                   {hasNativeAllocations
                     ? this._renderCallTreeStrategyOption(
-                        'Deallocation Sites',
-                        'native-deallocations-sites',
-                        'Summarize using bytes of memory deallocated, by the site where the memory was deallocated'
+                        'StackSettings--call-tree-strategy-native-deallocations-sites',
+                        'native-deallocations-sites'
                       )
                     : null}
                 </select>
@@ -211,7 +215,9 @@ class StackSettingsImpl extends PureComponent<Props> {
                   onChange={this._onInvertCallstackClick}
                   checked={invertCallstack}
                 />
-                {' Invert call stack'}
+                <Localized id="StackSettings--invert-call-stack">
+                  Invert call stack
+                </Localized>
               </label>
             </li>
           )}
@@ -224,18 +230,25 @@ class StackSettingsImpl extends PureComponent<Props> {
                   onChange={this._onShowUserTimingsClick}
                   checked={showUserTimings}
                 />
-                {' Show user timing'}
+                <Localized id="StackSettings--show-user-timing">
+                  Show user timing
+                </Localized>
               </label>
             </li>
           )}
         </ul>
-        <PanelSearch
-          className="stackSettingsSearchField"
-          label="Filter stacks: "
-          title="Only display stacks which contain a function whose name matches this substring"
-          currentSearchString={currentSearchString}
-          onSearch={this._onSearch}
-        />
+        <Localized
+          id="StackSettings--panel-search"
+          attrs={{ label: true, title: true }}
+        >
+          <PanelSearch
+            className="stackSettingsSearchField"
+            label="Filter stacks: "
+            title="Only display stacks which contain a function whose name matches this substring"
+            currentSearchString={currentSearchString}
+            onSearch={this._onSearch}
+          />
+        </Localized>
       </div>
     );
   }

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -243,7 +243,7 @@ class StackSettingsImpl extends PureComponent<Props> {
         >
           <PanelSearch
             className="stackSettingsSearchField"
-            label="Filter stacks: "
+            label="Filter stacks:"
             title="Only display stacks which contain a function whose name matches this substring"
             currentSearchString={currentSearchString}
             onSearch={this._onSearch}

--- a/src/components/timeline/FullTimeline.js
+++ b/src/components/timeline/FullTimeline.js
@@ -6,6 +6,8 @@
 
 import * as React from 'react';
 import { showMenu } from 'react-contextmenu';
+import { Localized } from '@fluent/react';
+
 import { TimelineGlobalTrack } from './GlobalTrack';
 import { TimelineRuler } from './Ruler';
 import { TimelineSelection } from './Selection';
@@ -104,7 +106,7 @@ class TimelineSettingsGraphType extends React.PureComponent<{|
     return (
       <form>
         <div className="timelineSettingsToggle">
-          Graph type:{' '}
+          <Localized id="FullTimeline--graph-type">Graph type:</Localized>
           {isCPUUtilizationProvided ? (
             <label className="photon-label photon-label-micro timelineSettingsToggleLabel">
               <input
@@ -114,7 +116,9 @@ class TimelineSettingsGraphType extends React.PureComponent<{|
                 checked={timelineType === 'cpu-category'}
                 onChange={this._changeToCPUCategories}
               />
-              Categories with CPU
+              <Localized id="FullTimeline--categories-with-cpu">
+                Categories with CPU
+              </Localized>
             </label>
           ) : null}
           <label className="photon-label photon-label-micro timelineSettingsToggleLabel">
@@ -125,7 +129,7 @@ class TimelineSettingsGraphType extends React.PureComponent<{|
               checked={timelineType === 'category'}
               onChange={this._changeToCategories}
             />
-            Categories
+            <Localized id="FullTimeline--categories">Categories</Localized>
           </label>
           <label className="photon-label-micro timelineSettingsToggleLabel">
             <input
@@ -135,7 +139,7 @@ class TimelineSettingsGraphType extends React.PureComponent<{|
               checked={timelineType === 'stack'}
               onChange={this._changeToStacks}
             />
-            Stack height
+            <Localized id="FullTimeline--stack-height">Stack height</Localized>
           </label>
         </div>
       </form>
@@ -162,20 +166,31 @@ class TimelineSettingsHiddenTracks extends React.PureComponent<{|
     const { hiddenTrackCount } = this.props;
 
     return (
-      <button
-        type="button"
-        onClick={this._showMenu}
-        className="timelineSettingsHiddenTracks"
+      <Localized
+        id="FullTimeline--tracks-visible"
+        elems={{
+          span: <span className="timelineSettingsHiddenTracksNumber" />,
+        }}
+        vars={{
+          visibleTrackCount: hiddenTrackCount.total - hiddenTrackCount.hidden,
+          totalTrackCount: hiddenTrackCount.total,
+        }}
       >
-        <span className="timelineSettingsHiddenTracksNumber">
-          {hiddenTrackCount.total - hiddenTrackCount.hidden}
-        </span>
-        {' / '}
-        <span className="timelineSettingsHiddenTracksNumber">
-          {hiddenTrackCount.total}{' '}
-        </span>
-        tracks visible
-      </button>
+        <button
+          type="button"
+          onClick={this._showMenu}
+          className="timelineSettingsHiddenTracks"
+        >
+          <span className="timelineSettingsHiddenTracksNumber">
+            {hiddenTrackCount.total - hiddenTrackCount.hidden}
+          </span>
+          {' / '}
+          <span className="timelineSettingsHiddenTracksNumber">
+            {hiddenTrackCount.total}{' '}
+          </span>
+          tracks visible
+        </button>
+      </Localized>
     );
   }
 }

--- a/src/test/components/__snapshots__/JsTracer.test.js.snap
+++ b/src/test/components/__snapshots__/JsTracer.test.js.snap
@@ -353,7 +353,7 @@ exports[`StackChart matches the snapshot for the chart 1`] = `
             class="jsTracerSettingsCheckbox"
             type="checkbox"
           />
-           Show only self time
+          Show only self time
         </label>
       </li>
     </ul>
@@ -410,7 +410,7 @@ exports[`StackChart matches the snapshot for the loading screen 1`] = `
             class="jsTracerSettingsCheckbox"
             type="checkbox"
           />
-           Show only self time
+          Show only self time
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -88,7 +88,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -750,7 +750,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -1164,7 +1164,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -1814,7 +1814,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -2464,7 +2464,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -3084,7 +3084,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -3217,7 +3217,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -3350,7 +3350,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -3538,7 +3538,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -4156,7 +4156,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -4774,7 +4774,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -5392,7 +5392,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -5965,7 +5965,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -6538,7 +6538,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -6992,7 +6992,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>
@@ -7446,7 +7446,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
+++ b/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
@@ -109,7 +109,8 @@ exports[`app/ServiceWorkerManager with the \`from-addon\` datasource shows a war
       <div
         class="photon-message-bar-inner-text"
       >
-        A new version of the application was applied before this page was fully loaded. You might see malfunctions.
+        A new version of the application was applied before this page
+was fully loaded. You might see malfunctions.
       </div>
     </div>
     <button
@@ -135,7 +136,8 @@ exports[`app/ServiceWorkerManager with the \`public\` datasource shows a warning
       <div
         class="photon-message-bar-inner-text"
       >
-        A new version of the application was applied before this page was fully loaded. You might see malfunctions.
+        A new version of the application was applied before this page
+was fully loaded. You might see malfunctions.
       </div>
     </div>
     <button

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -64,7 +64,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
       <li
@@ -77,7 +77,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Show user timing
+          Show user timing
         </label>
       </li>
     </ul>
@@ -579,7 +579,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
       <li
@@ -592,7 +592,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Show user timing
+          Show user timing
         </label>
       </li>
     </ul>
@@ -1042,7 +1042,7 @@ exports[`StackChart matches the snapshot 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
       <li
@@ -1055,7 +1055,7 @@ exports[`StackChart matches the snapshot 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Show user timing
+          Show user timing
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -59,7 +59,7 @@ exports[`StackSettings matches the snapshot 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-           Invert call stack
+          Invert call stack
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -10,7 +10,6 @@ exports[`Timeline renders the header 1`] = `
       class="timelineSettingsToggle"
     >
       Graph type:
-       
       <label
         class="photon-label photon-label-micro timelineSettingsToggleLabel"
       >
@@ -41,16 +40,15 @@ exports[`Timeline renders the header 1`] = `
     <span
       class="timelineSettingsHiddenTracksNumber"
     >
-      4
+      ⁨4⁩
     </span>
      / 
     <span
       class="timelineSettingsHiddenTracksNumber"
     >
-      4
-       
+      ⁨4⁩
     </span>
-    tracks visible
+     tracks visible
   </button>
 </div>
 `;


### PR DESCRIPTION
This PR makes rest of the header components and main panel components localizable. It does not make the inner panel components localizable yet (like the lable inside the call tree and others) I think after this, we are going to be pretty good shape for localization.

Note: It could be easier to review it commit by commit.

Example profiles:
[Native + JS allocations example to test "summary" selection](https://deploy-preview-3241--perf-html.netlify.app/public/qwevfbv1vmhg56t7gar4460jj8kp3t8cjfq6ww8/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6&localTrackOrderByPid=3183-2-3-0-1~3244-0~3757-0~3281-0~60025-0~3395-0~7689-0~3383-0-1~3464-0~3388-0-1~3566-0~7815-0-1~3401-0-1~&thread=0&timelineType=cpu-category&v=5)
[JS Tracer axample to test that panel](https://deploy-preview-3241--perf-html.netlify.app/public/8fed9b4ab59d627c3d21cb512252aefbe9861d5a/js-tracer/?globalTrackOrder=0-1-2-3-4&hiddenGlobalTracks=1-2&localTrackOrderByPid=4844-1-0~5002-0~4897-0~&summary&thread=4&v=5)
[User timings profile to test the "show user timings" checkbox inside the stack chart](https://deploy-preview-3241--perf-html.netlify.app/public/zc5yp79743vspsmac21fzamrrfn8yv6bkq9t3n8/stack-chart/?globalTrackOrder=0&localTrackOrderByPid=14570-0-1~&thread=0&v=5)
[Profile from debug build to see the DebugWarning](https://deploy-preview-3241--perf-html.netlify.app/public/p2vvnx3j0p0k41zq6aj41vbpqaqe830j8xk8h1g/calltree/?thread=9%2C11&transforms=%3B&v=5&view=active-tab)

Unfortunately I don't think there is a way to test the ServiceWorkerManager component without changing the code (or really updating the PR the code after caching this version). I tried it locally though.


Known issue:
Look at the alignment of the filter text box:
![Screenshot from 2021-03-26 14-19-09](https://user-images.githubusercontent.com/466239/112637738-c211e000-8e3e-11eb-8593-132caa22cfa8.png)

When we enable the pseudo localization, the search bar is not aligned to right anymore. This is because the hint message below is longer than the search box and that's making the searchbox to slide left a bit. I dindn't want to solve this problem in this PR since it's unrelated to this PR. Filed #3247 for this.


