### PR TITLE
Display the Android device information in the metadata panel

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -220,6 +220,7 @@ MenuButtons--metaInfo--build-type = Build Type:
 MenuButtons--metaInfo--build-type-debug = Debug
 MenuButtons--metaInfo--build-type-opt = Opt
 MenuButtons--metaInfo--platform = Platform
+MenuButtons--metaInfo--device = Device:
 
 # OS means Operating System. This describes the platform a profile was captured on.
 MenuButtons--metaInfo--os = OS:

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -298,6 +298,16 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
           <Localized id="MenuButtons--metaInfo--platform">Platform</Localized>
         </h2>
         <div className="metaInfoSection">
+          {meta.device ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--device">
+                  Device:
+                </Localized>
+              </span>
+              {meta.device}
+            </div>
+          ) : null}
           {platformInformation ? (
             <div className="metaInfoRow">
               <span className="metaInfoLabel">

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1377,6 +1377,7 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
     updateChannel: geckoProfile.meta.updateChannel,
     markerSchema: processMarkerSchema(geckoProfile),
     sampleUnits: geckoProfile.meta.sampleUnits,
+    device: geckoProfile.meta.device,
   };
 
   const profilerOverhead: ProfilerOverhead[] = nullableProfilerOverhead.reduce(

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -435,6 +435,29 @@ describe('app/MenuButtons', function() {
       expect(getMetaInfoPanel()).toMatchSnapshot();
     });
 
+    it('matches the snapshot with device information', async () => {
+      // Using gecko profile because it has metadata and profilerOverhead data in it.
+      const profile = processGeckoProfile(createGeckoProfile());
+      profile.meta.device = 'Android Device';
+
+      const {
+        displayMetaInfoPanel,
+        getMetaInfoPanel,
+      } = await setupForMetaInfoPanel(profile);
+      displayMetaInfoPanel();
+
+      const renderedDevice = ensureExists(
+        screen.getByText(/Device:/).nextSibling
+      );
+
+      /* This rule needs to be disabled because `renderedDevice` is a text
+       * code, and this triggers
+       * https://github.com/testing-library/jest-dom/issues/306 */
+      /* eslint-disable-next-line jest-dom/prefer-to-have-text-content */
+      expect(renderedDevice.textContent).toBe('Android Device');
+      expect(getMetaInfoPanel()).toMatchSnapshot();
+    });
+
     it('with no statistics object should not make the app crash', async () => {
       // Using gecko profile because it has metadata and profilerOverhead data in it.
       const profile = processGeckoProfile(createGeckoProfile());

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -810,6 +810,335 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 </div>
 `;
 
+exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device information 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Recording started:
+        </span>
+        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Profile Version:
+        </span>
+        35
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is not symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox 48
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update Channel:
+        </span>
+        nightly
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build ID:
+        </span>
+        20181126165837
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build Type:
+        </span>
+        Debug
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Extensions:
+        </span>
+        <ul
+          class="metaInfoList"
+        >
+          <li
+            class="metaInfoListItem"
+          >
+            Form Autofill
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Firefox Screenshots
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Gecko Profiler
+          </li>
+        </ul>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Device:
+        </span>
+        Android Device
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          OS:
+        </span>
+        macOS 10.11
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          ABI:
+        </span>
+        x86_64-gcc3
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          CPU:
+        </span>
+        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+      </div>
+    </div>
+    <details>
+      <summary
+        class="arrowPanelSubTitle"
+      >
+        Profiler Overhead
+      </summary>
+      <div
+        class="arrowPanelSection"
+      >
+        <div
+          class="metaInfoGrid"
+        >
+          <div />
+          <div>
+            Mean
+          </div>
+          <div>
+            Max
+          </div>
+          <div>
+            Min
+          </div>
+          <div>
+            Overhead
+          </div>
+          <div>
+            227μs
+          </div>
+          <div>
+            410μs
+          </div>
+          <div>
+            38μs
+          </div>
+          <div>
+            Cleaning
+          </div>
+          <div>
+            54μs
+          </div>
+          <div>
+            100μs
+          </div>
+          <div>
+            7.0μs
+          </div>
+          <div>
+            Counter
+          </div>
+          <div>
+            59μs
+          </div>
+          <div>
+            105μs
+          </div>
+          <div>
+            12μs
+          </div>
+          <div>
+            Interval
+          </div>
+          <div>
+            857μs
+          </div>
+          <div>
+            1,000μs
+          </div>
+          <div>
+            0.000μs
+          </div>
+          <div>
+            Lockings
+          </div>
+          <div>
+            49μs
+          </div>
+          <div>
+            95μs
+          </div>
+          <div>
+            2.0μs
+          </div>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead Durations:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            1,586μs
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead Percentage:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            26,433%
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Profiled Duration:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            6.0μs
+          </span>
+        </div>
+      </div>
+    </details>
+  </div>
+</div>
+`;
+
 exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -66,6 +66,7 @@ Object {
     ],
     "configuration": undefined,
     "debug": false,
+    "device": undefined,
     "extensions": Object {
       "baseURL": Array [],
       "id": Array [],

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -357,6 +357,13 @@ export type GeckoProfileFullMeta = {|
   // The sampleUnits property landed in Firefox 86, and is only optional because
   // older profile versions may not have it. No upgrader was written for this change.
   sampleUnits?: SampleUnits,
+  // Information of the device that profile is captured from.
+  // Currently it's only present for Android devices and it includes brand and
+  // model names of that device.
+  // It's optional because profiles from non-Android devices and from older
+  // Firefox versions may not have it.
+  // This property landed in Firefox 88.
+  device?: string,
 |};
 
 export type GeckoProfileWithMeta<Meta> = {|

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -754,6 +754,13 @@ export type ProfileMeta = {|
   // The sampleUnits property landed in Firefox 86, and is only optional because
   // older profile versions may not have it. No upgrader was written for this change.
   sampleUnits?: SampleUnits,
+  // Information of the device that profile is captured from.
+  // Currently it's only present for Android devices and it includes brand and
+  // model names of that device.
+  // It's optional because profiles from non-Android devices and from older
+  // Firefox versions may not have it.
+  // This property landed in Firefox 88.
+  device?: string,
 |};
 
 /**


### PR DESCRIPTION
[Back-end bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1699646)

Now we have the device information for Android devices in the meta object after the back-end patch. We should preserve this field and display that in the metadata panel if present.

[Example profile](https://deploy-preview-3243--perf-html.netlify.app/public/8bdcecd6sp9540cqt1eprs4w3zvcjzj83vrhpnr/calltree/?globalTrackOrder=2-0-1&hiddenGlobalTracks=2&hiddenLocalTracksByPid=4727-4-3-0-1~4768-0&localTrackOrderByPid=4727-3-4-0-1-2~4768-1-2-0~&thread=4&timelineType=cpu-category&v=5)

Fixes #3226.