### PR TITLE
Add a tooltip in the network track

### DIFF
--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -74,6 +74,8 @@ class NetworkCanvas extends PureComponent<CanvasProps> {
     const row = Math.floor(y / TRACK_NETWORK_ROW_HEIGHT);
     const rangeLength = rangeEnd - rangeStart;
     const time = rangeStart + (x / width) * rangeLength;
+    const minimumSize: CssPixels = 5;
+    const minimumDuration: Milliseconds = (minimumSize / width) * rangeLength;
 
     // Row i matches network timing's rows i, i + TRACK_NETWORK_ROW_REPEAT, i +
     // TRACK_NETWORK_ROW_REPEAT * 2, etc
@@ -96,7 +98,12 @@ class NetworkCanvas extends PureComponent<CanvasProps> {
       }
 
       const start = timingRow.start[indexInRow];
-      const end = timingRow.end[indexInRow];
+      let end = timingRow.end[indexInRow];
+
+      // Make it possible to hit the small markers.
+      if (end - start < minimumDuration) {
+        end = start + minimumDuration;
+      }
 
       if (end < time) {
         // The marker we found ends before this time.

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -155,6 +155,7 @@ class Network extends PureComponent<Props, State> {
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
           zeroAt={zeroAt}
+          width={containerWidth}
         />
       </div>
     );

--- a/src/components/timeline/VerticalIndicators.css
+++ b/src/components/timeline/VerticalIndicators.css
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.timelineVerticalIndicators {
+.timelineVerticalIndicatorsLine {
   --active-area-width: 4px;
 
   /* Setting the width to 1.5 makes it so that these indicators have slightly more visual
@@ -10,13 +10,6 @@
    * that is 3 device pixels wide. */
   --visible-width: 1.5px;
 
-  position: absolute;
-  overflow: hidden;
-  width: 100%;
-  height: 100%;
-}
-
-.timelineVerticalIndicatorsLine {
   position: absolute;
   top: 0;
   bottom: 0;

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -111,8 +111,6 @@ function setup() {
     </Provider>
   );
 
-  const verticalIndicators = screen.getByTestId('vertical-indicators');
-
   const getIndicatorLines = () =>
     screen.getAllByTestId('vertical-indicator-line');
 
@@ -134,7 +132,6 @@ function setup() {
     thread: profile.threads[0],
     store,
     getContextDrawCalls,
-    verticalIndicators,
     getIndicatorLines,
   };
 }

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -57,7 +57,12 @@ describe('timeline/TrackNetwork', function() {
     // Ensure we start out with 0.
     expect(getContextDrawCalls().length).toEqual(0);
 
-    // Send out the resize, and ensure we are drawing.
+    // Send out the resize with a width change.
+    // By changing the "fake" result of getBoundingClientRect, we ensure that
+    // the pure components rerender because their `width` props change.
+    HTMLElement.prototype.getBoundingClientRect.mockImplementation(() =>
+      getBoundingBox(GRAPH_WIDTH - 100, GRAPH_HEIGHT)
+    );
     window.dispatchEvent(new Event('resize'));
     expect(getContextDrawCalls().length > 0).toBe(true);
   });

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -81,35 +81,30 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
           class="timelineTrackNetworkCanvas"
         />
         <div
-          class="timelineVerticalIndicators"
-          data-testid="vertical-indicators"
-        >
-          <div
-            class="timelineVerticalIndicatorsLine"
-            data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--red-60); left: 0px;"
-          />
-          <div
-            class="timelineVerticalIndicatorsLine"
-            data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: #000; left: 0px;"
-          />
-          <div
-            class="timelineVerticalIndicatorsLine"
-            data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--blue-50); left: 0px;"
-          />
-          <div
-            class="timelineVerticalIndicatorsLine"
-            data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--grey-40); left: 0px;"
-          />
-          <div
-            class="timelineVerticalIndicatorsLine"
-            data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--green-60); left: 0px;"
-          />
-        </div>
+          class="timelineVerticalIndicatorsLine"
+          data-testid="vertical-indicator-line"
+          style="--vertical-indicator-color: var(--red-60); left: 0px;"
+        />
+        <div
+          class="timelineVerticalIndicatorsLine"
+          data-testid="vertical-indicator-line"
+          style="--vertical-indicator-color: #000; left: 0px;"
+        />
+        <div
+          class="timelineVerticalIndicatorsLine"
+          data-testid="vertical-indicator-line"
+          style="--vertical-indicator-color: var(--blue-50); left: 0px;"
+        />
+        <div
+          class="timelineVerticalIndicatorsLine"
+          data-testid="vertical-indicator-line"
+          style="--vertical-indicator-color: var(--grey-40); left: 0px;"
+        />
+        <div
+          class="timelineVerticalIndicatorsLine"
+          data-testid="vertical-indicator-line"
+          style="--vertical-indicator-color: var(--green-60); left: 0px;"
+        />
       </div>
     </div>
   </div>

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -406,34 +406,29 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
     width="0"
   />
   <div
-    class="timelineVerticalIndicators"
-    data-testid="vertical-indicators"
-  >
-    <div
-      class="timelineVerticalIndicatorsLine"
-      data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
-    />
-    <div
-      class="timelineVerticalIndicatorsLine"
-      data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: #000; left: 200px;"
-    />
-    <div
-      class="timelineVerticalIndicatorsLine"
-      data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--blue-50); left: 200px;"
-    />
-    <div
-      class="timelineVerticalIndicatorsLine"
-      data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
-    />
-    <div
-      class="timelineVerticalIndicatorsLine"
-      data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
-    />
-  </div>
+    class="timelineVerticalIndicatorsLine"
+    data-testid="vertical-indicator-line"
+    style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
+  />
+  <div
+    class="timelineVerticalIndicatorsLine"
+    data-testid="vertical-indicator-line"
+    style="--vertical-indicator-color: #000; left: 200px;"
+  />
+  <div
+    class="timelineVerticalIndicatorsLine"
+    data-testid="vertical-indicator-line"
+    style="--vertical-indicator-color: var(--blue-50); left: 200px;"
+  />
+  <div
+    class="timelineVerticalIndicatorsLine"
+    data-testid="vertical-indicator-line"
+    style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
+  />
+  <div
+    class="timelineVerticalIndicatorsLine"
+    data-testid="vertical-indicator-line"
+    style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
+  />
 </div>
 `;

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -32,6 +32,297 @@ exports[`VerticalIndicators displays tooltips 1`] = `
 </div>
 `;
 
+exports[`timeline/TrackNetwork draws differently a request and displays a tooltip when hovered 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="--tooltip-detail-max-width: 600px; left: 23px; top: 13px;"
+>
+  <div
+    class="tooltipMarker"
+    style="--tooltip-detail-max-width: 600px;"
+  >
+    <div
+      class="tooltipHeader"
+    >
+      <div
+        class="tooltipOneLine"
+      >
+        <div
+          class="tooltipTiming"
+        >
+          1ms
+        </div>
+        <div
+          class="tooltipTitle"
+        >
+          Load 0: https://mozilla.org
+        </div>
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Status
+        :
+      </div>
+      Response received
+      <div
+        class="tooltipLabel"
+      >
+        URL
+        :
+      </div>
+      <span
+        class="tooltipNetworkUrl"
+      >
+        https://mozilla.org
+      </span>
+      <div
+        class="tooltipLabel"
+      >
+        Priority
+        :
+      </div>
+      Normal(0)
+      <div
+        class="tooltipLabel"
+      >
+        MIME type
+        :
+      </div>
+      <div
+        class="tooltipNetworkMimeType"
+      >
+        <span
+          class="tooltipNetworkMimeTypeSwatch colored-square network-color-html"
+          title="text/html"
+        />
+        text/html
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Thread
+        :
+      </div>
+      Empty
+    </div>
+    <div
+      class="tooltipNetworkPhases network-color-html"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        HTTP response
+        :
+      </div>
+      <div
+        aria-label="Starting at 0.000 milliseconds, duration is 1.0 milliseconds"
+      >
+        1.0ms
+      </div>
+      <div
+        aria-hidden="true"
+        class="tooltipNetworkPhase"
+        style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`timeline/TrackNetwork draws differently a request and displays a tooltip when hovered 2`] = `
+Array [
+  Array [
+    "clearRect",
+    0,
+    0,
+    400,
+    35,
+  ],
+  Array [
+    "set strokeStyle",
+    "rgba(0, 127, 255, 0.3)",
+  ],
+  Array [
+    "set lineCap",
+    "round",
+  ],
+  Array [
+    "set lineWidth",
+    3.75,
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    6.666666666666673,
+    7.5,
+  ],
+  Array [
+    "lineTo",
+    73.33333333333331,
+    7.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    13.333333333333346,
+    12.5,
+  ],
+  Array [
+    "lineTo",
+    80.00000000000001,
+    12.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    19.99999999999999,
+    17.5,
+  ],
+  Array [
+    "lineTo",
+    86.66666666666666,
+    17.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    26.666666666666664,
+    22.5,
+  ],
+  Array [
+    "lineTo",
+    93.33333333333336,
+    22.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    33.333333333333336,
+    27.5,
+  ],
+  Array [
+    "lineTo",
+    100,
+    27.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    40.00000000000001,
+    32.5,
+  ],
+  Array [
+    "lineTo",
+    106.66666666666666,
+    32.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    46.66666666666668,
+    2.5,
+  ],
+  Array [
+    "lineTo",
+    113.33333333333336,
+    2.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    53.33333333333333,
+    7.5,
+  ],
+  Array [
+    "lineTo",
+    120,
+    7.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    60,
+    12.5,
+  ],
+  Array [
+    "lineTo",
+    126.6666666666667,
+    12.5,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "set strokeStyle",
+    "#0069aa",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    0,
+    2.5,
+  ],
+  Array [
+    "lineTo",
+    66.66666666666667,
+    2.5,
+  ],
+  Array [
+    "stroke",
+  ],
+]
+`;
+
 exports[`timeline/TrackNetwork matches the 2d context snapshot 1`] = `
 Array [
   Array [


### PR DESCRIPTION
There quite a lot of commits, but I believe you can look at them separately, and that should be easier.

Previews:
[deploy preview](https://deploy-preview-3249--perf-html.netlify.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/network-chart/?globalTrackOrder=13-14-0-1-2-3-4-5-6-7-8-9-10-11-12&localTrackOrderByPid=29495-7-8-0-1-2-3-4-5-6~5123-0~29556-0~526-0~29603-0~29692-0-1~5023-0~5053-0-1~29650-0~29726-0~4975-0~29481-0~21926-1-0~&range=5663m2795&thread=14&v=5)
[deploy preview with more requests](https://deploy-preview-3249--perf-html.netlify.app/public/52d5d452191340ab79ac92b519bcac4479fc3ab9/network-chart/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=19719-1-0~19908-0~&thread=4&v=5)

On this last deploy preview link, you can especially look at the behavior on the small network markers at the right of the track, as I implemented a special behavior for these.

![Screencast_11-06-2021_11:58:36 webm](https://user-images.githubusercontent.com/454175/121669374-8a651c80-caac-11eb-99fe-543bf3a731ea.gif)
