### PR TITLE
Put markers of the Test category first in the Marker Chart, as they a…

### DIFF
--- a/src/profile-logic/marker-timing.js
+++ b/src/profile-logic/marker-timing.js
@@ -133,12 +133,22 @@ export function getMarkerTimingAndBuckets(
   allMarkerTimings.sort((a, b) => {
     if (a.bucket !== b.bucket) {
       // Sort by buckets first.
+      // Show the 'Test' category first. Test markers are almost guaranteed to
+      // be the most relevant when they exist.
+      if (a.bucket === 'Test') {
+        return -1;
+      }
+      if (b.bucket === 'Test') {
+        return 1;
+      }
+      // Put the 'Other' category last.
       if (a.bucket === 'Other') {
         return 1;
       }
       if (b.bucket === 'Other') {
         return -1;
       }
+      // Sort alphabetically for the remaining categories.
       return a.bucket > b.bucket ? 1 : -1;
     }
     if (a.name === b.name) {


### PR DESCRIPTION
…re very relevant when they exist.

When profiling tests, we have lots of markers showing what the test was doing, but because the "Test" category starts with a "T", it gets displayed far down the list in the Marker Chart. Needing to scroll to that category every single time I profile a test is annoying for me. And yesterday in a discussion with Markus, I realized that he profiled some tests, and didn't find the Test markers (even though after I showed them to him, he said they would have helped him).

I don't think hardcoding the position of specific categories is a good long term solution to make the most relevant markers immediately visible, but as a short term solution, I think putting the Test category first is reasonable.