### PR TITLE
Make the context menus localizable

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -43,6 +43,73 @@ AppViewRouter--error-message-from-url =
 AppViewRouter--route-not-found--home =
     .specialMessage = The URL you tried to reach was not recognized.
 
+## CallNodeContextMenu
+## This is used as a context menu for the Call Tree, Flame Graph and Stack Chart
+## panels.
+
+CallNodeContextMenu--transform-merge-function = Merge function
+    .title =
+        Merging a function removes it from the profile, and assigns its time to the
+        function that called it. This happens anywhere the function was called in
+        the tree.
+CallNodeContextMenu--transform-merge-call-node = Merge node only
+    .title =
+        Merging a node removes it from the profile, and assigns its time to the
+        function's node that called it. It only removes the function from that
+        specific part of the tree. Any other places the function was called
+        will remain in the profile.
+
+# This is used as the context menu item to apply the "Focus on function" transform.
+# Variables:
+#   $isInverted (Number) - This is actually a boolean value to determine if the
+#     call tree is inverted or not. Currently there is no wayt o pass a boolean
+#     value with Localized component, that's why we are passing this as a number
+#     instead. 0 is for false and 1 is for true.
+CallNodeContextMenu--transform-focus-function =
+    { $isInverted ->
+        [0] Focus on function
+       *[other] Focus on function (inverted)
+    }
+    .title =
+        Focusing on a function will remove any sample that does not include that
+        function. In addition, it re-roots the call tree so that the function
+        is the only root of the tree. This can combine multiple function call sites
+        across a profile into one call node.
+CallNodeContextMenu--transform-focus-subtree = Focus on subtree only
+    .title =
+        Focusing on a subtree will remove any sample that does not include that
+        specific part of the call tree. It pulls out a branch of the call tree,
+        however it only does it for that single call node. All other calls
+        of the function are ignored.
+CallNodeContextMenu--transform-collapse-function-subtree = Collapse function
+    .title =
+        Collapsing a function will remove everything it called, and assign
+        all of the time to the function. This can help simplify a profile that
+        calls into code that does not need to be analyzed.
+
+# This is used as the context menu item to apply the "Collapse resource" transform.
+# Variables:
+#   $nameForResource (String) - Name of the resource to collapse.
+CallNodeContextMenu--transform-collapse-resource =
+    Collapse <strong>{ $nameForResource }</strong>
+    .title =
+        Collapsing a resource will flatten out of all the calls into that
+        resource into a single collapsed call node.
+CallNodeContextMenu--transform-collapse-direct-recursion = Collapse direct recursion
+    .title =
+        Collapsing direct recursion removes calls that repeatedly recurse into
+        the same function.
+CallNodeContextMenu--transform-drop-function = Drop samples with this function
+    .title =
+        Dropping samples removes their time from the profile. This is useful to
+        eliminate timing information that is not for the analysis.
+
+CallNodeContextMenu--expand-all = Expand all
+CallNodeContextMenu--searchfox = Look up the function name on Searchfox
+CallNodeContextMenu--copy-function-name = Copy function name
+CallNodeContextMenu--copy-script-url = Copy script URL
+CallNodeContextMenu--copy-stack = Copy stack
+
 ## CompareHome
 ## This is used in the page to compare two profiles.
 ## See: https://profiler.firefox.com/compare/

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -55,26 +55,21 @@ CallNodeContextMenu--transform-merge-function = Merge function
 CallNodeContextMenu--transform-merge-call-node = Merge node only
     .title =
         Merging a node removes it from the profile, and assigns its time to the
-        function's node that called it. It only removes the function from that
-        specific part of the tree. Any other places the function was called
+        function’s node that called it. It only removes the function from that
+        specific part of the tree. Any other places the function was called from
         will remain in the profile.
 
-# This is used as the context menu item to apply the "Focus on function" transform.
-# Variables:
-#   $isInverted (Number) - This is actually a boolean value to determine if the
-#     call tree is inverted or not. Currently there is no wayt o pass a boolean
-#     value with Localized component, that's why we are passing this as a number
-#     instead. 0 is for false and 1 is for true.
-CallNodeContextMenu--transform-focus-function =
-    { $isInverted ->
-        [0] Focus on function
-       *[other] Focus on function (inverted)
-    }
-    .title =
-        Focusing on a function will remove any sample that does not include that
-        function. In addition, it re-roots the call tree so that the function
-        is the only root of the tree. This can combine multiple function call sites
-        across a profile into one call node.
+# This is used as the context menu item title for "Focus on function" and "Focus
+# on function (inverted)" transforms.
+CallNodeContextMenu--transform-focus-function-title =
+    Focusing on a function will remove any sample that does not include that
+    function. In addition, it re-roots the call tree so that the function
+    is the only root of the tree. This can combine multiple function call sites
+    across a profile into one call node.
+CallNodeContextMenu--transform-focus-function = Focus on function
+    .title = { CallNodeContextMenu--transform-focus-function-title }
+CallNodeContextMenu--transform-focus-function-inverted = Focus on function (inverted)
+    .title = { CallNodeContextMenu--transform-focus-function-title }
 CallNodeContextMenu--transform-focus-subtree = Focus on subtree only
     .title =
         Focusing on a subtree will remove any sample that does not include that
@@ -93,7 +88,7 @@ CallNodeContextMenu--transform-collapse-function-subtree = Collapse function
 CallNodeContextMenu--transform-collapse-resource =
     Collapse <strong>{ $nameForResource }</strong>
     .title =
-        Collapsing a resource will flatten out of all the calls into that
+        Collapsing a resource will flatten out of all the calls to that
         resource into a single collapsed call node.
 CallNodeContextMenu--transform-collapse-direct-recursion = Collapse direct recursion
     .title =
@@ -105,6 +100,9 @@ CallNodeContextMenu--transform-drop-function = Drop samples with this function
         eliminate timing information that is not for the analysis.
 
 CallNodeContextMenu--expand-all = Expand all
+
+# Searchfox is a source code indexing tool for Mozilla Firefox.
+# See: https://searchfox.org/
 CallNodeContextMenu--searchfox = Look up the function name on Searchfox
 CallNodeContextMenu--copy-function-name = Copy function name
 CallNodeContextMenu--copy-script-url = Copy script URL
@@ -543,13 +541,13 @@ TrackContextMenu--only-show-this-process-group = Only show this process group
 # This is used as the context menu item to show only the given track.
 # Variables:
 #   $trackName (String) - Name of the selected track to isolate.
-TrackContextMenu--only-show-track = Only show "{ $trackName }"
+TrackContextMenu--only-show-track = Only show “{ $trackName }”
 TrackContextMenu--hide-other-screenshot-tracks = Hide other screenshot tracks
 
 # This is used as the context menu item to hide the given track.
 # Variables:
 #   $trackName (String) - Name of the selected track to hide.
-TrackContextMenu--hide-track = Hide "{ $trackName }"
+TrackContextMenu--hide-track = Hide “{ $trackName }”
 TrackContextMenu--show-all-tracks = Show all tracks
 
 ## UploadedRecordingsHome

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -534,6 +534,24 @@ TabBar--marker-table-tab = Marker Table
 TabBar--network-tab = Network
 TabBar--js-tracer-tab = JS Tracer
 
+## TrackContextMenu
+## This is used as a context menu for timeline to organize the tracks in the
+## analysis UI.
+
+TrackContextMenu--only-show-this-process-group = Only show this process group
+
+# This is used as the context menu item to show only the given track.
+# Variables:
+#   $trackName (String) - Name of the selected track to isolate.
+TrackContextMenu--only-show-track = Only show "{ $trackName }"
+TrackContextMenu--hide-other-screenshot-tracks = Hide other screenshot tracks
+
+# This is used as the context menu item to hide the given track.
+# Variables:
+#   $trackName (String) - Name of the selected track to hide.
+TrackContextMenu--hide-track = Hide "{ $trackName }"
+TrackContextMenu--show-all-tracks = Show all tracks
+
 ## UploadedRecordingsHome
 ## This is the page that displays all the profiles that user has uploaded.
 ## See: https://profiler.firefox.com/uploaded-recordings/

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -542,7 +542,7 @@ TrackContextMenu--only-show-this-process-group = Only show this process group
 # Variables:
 #   $trackName (String) - Name of the selected track to isolate.
 TrackContextMenu--only-show-track = Only show “{ $trackName }”
-TrackContextMenu--hide-other-screenshot-tracks = Hide other screenshot tracks
+TrackContextMenu--hide-other-screenshots-tracks = Hide other Screenshots tracks
 
 # This is used as the context menu item to hide the given track.
 # Variables:

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -88,7 +88,7 @@ CallNodeContextMenu--transform-collapse-function-subtree = Collapse function
 CallNodeContextMenu--transform-collapse-resource =
     Collapse <strong>{ $nameForResource }</strong>
     .title =
-        Collapsing a resource will flatten out of all the calls to that
+        Collapsing a resource will flatten out all the calls to that
         resource into a single collapsed call node.
 CallNodeContextMenu--transform-collapse-direct-recursion = Collapse direct recursion
     .title =
@@ -97,7 +97,7 @@ CallNodeContextMenu--transform-collapse-direct-recursion = Collapse direct recur
 CallNodeContextMenu--transform-drop-function = Drop samples with this function
     .title =
         Dropping samples removes their time from the profile. This is useful to
-        eliminate timing information that is not for the analysis.
+        eliminate timing information that is not relevant for the analysis.
 
 CallNodeContextMenu--expand-all = Expand all
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -245,6 +245,27 @@ ListOfPublishedProfiles--uploaded-profile-information-list =
        *[other] Manage these recordings
     }
 
+
+## MarkerContextMenu
+## This is used as a context menu for the Marker Chart, Marker Table and Network
+## panels.
+
+MarkerContextMenu--set-selection-from-duration = Set selection from marker’s duration
+MarkerContextMenu--start-selection-here = Start selection here
+MarkerContextMenu--end-selection-here = End selection here
+MarkerContextMenu--start-selection-at-marker-start =
+    Start selection at marker’s <strong>start</strong>
+MarkerContextMenu--start-selection-at-marker-end =
+    Start selection at marker’s <strong>end</strong>
+MarkerContextMenu--end-selection-at-marker-start =
+    End selection at marker’s <strong>start</strong>
+MarkerContextMenu--end-selection-at-marker-end =
+    End selection at marker’s <strong>end</strong>
+MarkerContextMenu--copy-description = Copy description
+MarkerContextMenu--copy-call-stack = Copy call stack
+MarkerContextMenu--copy-url = Copy URL
+MarkerContextMenu--copy-full-payload = Copy full payload
+
 ## MarkerSettings
 ## This is used in all panels related to markers.
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@fluent/bundle": "^0.16.0",
     "@fluent/langneg": "^0.5.0",
-    "@fluent/react": "^0.13.0",
+    "@fluent/react": "^0.13.1",
     "array-move": "^3.0.1",
     "array-range": "^1.0.1",
     "clamp": "^1.0.1",

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -458,11 +458,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
             icon="Merge"
             onClick={this._handleClick}
             transform="merge-function"
-            title={oneLine`
-              Merging a function removes it from the profile, and assigns its time to the
-              function that called it. This happens anywhere the function was called in
-              the tree.
-            `}
+            title=""
           >
             Merge function
           </TransformMenuItem>
@@ -478,12 +474,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
               icon="Merge"
               onClick={this._handleClick}
               transform="merge-call-node"
-              title={oneLine`
-                Merging a node removes it from the profile, and assigns its time to the
-                function's node that called it. It only removes the function from that
-                specific part of the tree. Any other places the function was called from
-                will remain in the profile.
-            `}
+              title=""
             >
               Merge node only
             </TransformMenuItem>
@@ -503,12 +494,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
             icon="Focus"
             onClick={this._handleClick}
             transform="focus-function"
-            title={oneLine`
-              Focusing on a function will remove any sample that does not include that
-              function. In addition, it re-roots the call tree so that the function
-              is the only root of the tree. This can combine multiple function call sites
-              across a profile into one call node.
-          `}
+            title=""
           >
             {inverted ? 'Focus on function (inverted)' : 'Focus on function'}
           </TransformMenuItem>
@@ -523,12 +509,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
             icon="Focus"
             onClick={this._handleClick}
             transform="focus-subtree"
-            title={oneLine`
-              Focusing on a subtree will remove any sample that does not include that
-              specific part of the call tree. It pulls out a branch of the call tree,
-              however it only does it for that single call node. All other calls
-              of the function are ignored.
-          `}
+            title=""
           >
             Focus on subtree only
           </TransformMenuItem>
@@ -543,11 +524,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
             icon="Collapse"
             onClick={this._handleClick}
             transform="collapse-function-subtree"
-            title={oneLine`
-              Collapsing a function will remove everything it called, and assign
-              all of the time to the function. This can help simplify a profile that
-              calls into code that does not need to be analyzed.
-          `}
+            title=""
           >
             Collapse function
           </TransformMenuItem>
@@ -565,10 +542,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
               icon="Collapse"
               onClick={this._handleClick}
               transform="collapse-resource"
-              title={oneLine`
-                Collapsing a resource will flatten out of all the calls to that
-                resource into a single collapsed call node.
-            `}
+              title=""
             >
               Collapse <strong>{nameForResource}</strong>
             </TransformMenuItem>
@@ -585,10 +559,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
               icon="Collapse"
               onClick={this._handleClick}
               transform="collapse-direct-recursion"
-              title={oneLine`
-                Collapsing direct recursion removes calls that repeatedly recurse into
-                the same function.
-            `}
+              title=""
             >
               Collapse direct recursion
             </TransformMenuItem>
@@ -604,10 +575,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
             icon="Drop"
             onClick={this._handleClick}
             transform="drop-function"
-            title={oneLine`
-              Dropping samples removes their time from the profile. This is useful to
-              eliminate timing information that is not for the analysis.
-          `}
+            title=""
           >
             Drop samples with this function
           </TransformMenuItem>

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -481,7 +481,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
               title={oneLine`
                 Merging a node removes it from the profile, and assigns its time to the
                 function's node that called it. It only removes the function from that
-                specific part of the tree. Any other places the function was called
+                specific part of the tree. Any other places the function was called from
                 will remain in the profile.
             `}
             >
@@ -491,12 +491,12 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
         )}
 
         <Localized
-          id="CallNodeContextMenu--transform-focus-function"
+          id={
+            inverted
+              ? 'CallNodeContextMenu--transform-focus-function-inverted'
+              : 'CallNodeContextMenu--transform-focus-function'
+          }
           attrs={{ title: true }}
-          // @fluent/react doesn't support boolean values as variables yet.
-          // We are converting it to number to check it in the ftl string.
-          // See: https://github.com/projectfluent/fluent.js/issues/543
-          vars={{ isInverted: Number(inverted) }}
         >
           <TransformMenuItem
             shortcut="f"
@@ -566,7 +566,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
               onClick={this._handleClick}
               transform="collapse-resource"
               title={oneLine`
-                Collapsing a resource will flatten out of all the calls into that
+                Collapsing a resource will flatten out of all the calls to that
                 resource into a single collapsed call node.
             `}
             >

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -5,6 +5,8 @@
 // @flow
 import * as React from 'react';
 import { MenuItem } from 'react-contextmenu';
+import { Localized } from '@fluent/react';
+
 import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { funcHasRecursiveCall } from 'firefox-profiler/profile-logic/transforms';
@@ -447,151 +449,210 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
 
     return (
       <>
-        <TransformMenuItem
-          shortcut="m"
-          icon="Merge"
-          onClick={this._handleClick}
-          transform="merge-function"
-          title={oneLine`
-            Merging a function removes it from the profile, and assigns its time to the
-            function that called it. This happens anywhere the function was called in
-            the tree.
-          `}
+        <Localized
+          id="CallNodeContextMenu--transform-merge-function"
+          attrs={{ title: true }}
         >
-          Merge function
-        </TransformMenuItem>
-
-        {inverted ? null : (
           <TransformMenuItem
-            shortcut="M"
+            shortcut="m"
             icon="Merge"
             onClick={this._handleClick}
-            transform="merge-call-node"
+            transform="merge-function"
             title={oneLine`
-              Merging a node removes it from the profile, and assigns its time to the
-              function's node that called it. It only removes the function from that
-              specific part of the tree. Any other places the function was called
-              will remain in the profile.
+              Merging a function removes it from the profile, and assigns its time to the
+              function that called it. This happens anywhere the function was called in
+              the tree.
             `}
           >
-            Merge node only
+            Merge function
           </TransformMenuItem>
+        </Localized>
+
+        {inverted ? null : (
+          <Localized
+            id="CallNodeContextMenu--transform-merge-call-node"
+            attrs={{ title: true }}
+          >
+            <TransformMenuItem
+              shortcut="M"
+              icon="Merge"
+              onClick={this._handleClick}
+              transform="merge-call-node"
+              title={oneLine`
+                Merging a node removes it from the profile, and assigns its time to the
+                function's node that called it. It only removes the function from that
+                specific part of the tree. Any other places the function was called
+                will remain in the profile.
+            `}
+            >
+              Merge node only
+            </TransformMenuItem>
+          </Localized>
         )}
 
-        <TransformMenuItem
-          shortcut="f"
-          icon="Focus"
-          onClick={this._handleClick}
-          transform="focus-function"
-          title={oneLine`
-            Focusing on a function will remove any sample that does not include that
-            function. In addition, it re-roots the call tree so that the function
-            is the only root of the tree. This can combine multiple function call sites
-            across a profile into one call node.
-          `}
+        <Localized
+          id="CallNodeContextMenu--transform-focus-function"
+          attrs={{ title: true }}
+          // @fluent/react doesn't support boolean values as variables yet.
+          // We are converting it to number to check it in the ftl string.
+          // See: https://github.com/projectfluent/fluent.js/issues/543
+          vars={{ isInverted: Number(inverted) }}
         >
-          {inverted ? 'Focus on function (inverted)' : 'Focus on function'}
-        </TransformMenuItem>
-
-        <TransformMenuItem
-          shortcut="F"
-          icon="Focus"
-          onClick={this._handleClick}
-          transform="focus-subtree"
-          title={oneLine`
-            Focusing on a subtree will remove any sample that does not include that
-            specific part of the call tree. It pulls out a branch of the call tree,
-            however it only does it for that single call node. All other calls
-            of the function are ignored.
-          `}
-        >
-          Focus on subtree only
-        </TransformMenuItem>
-
-        <TransformMenuItem
-          shortcut="c"
-          icon="Collapse"
-          onClick={this._handleClick}
-          transform="collapse-function-subtree"
-          title={oneLine`
-            Collapsing a function will remove everything it called, and assign
-            all of the time to the function. This can help simplify a profile that
-            calls into code that does not need to be analyzed.
-          `}
-        >
-          Collapse function
-        </TransformMenuItem>
-
-        {nameForResource ? (
           <TransformMenuItem
-            shortcut="C"
+            shortcut="f"
+            icon="Focus"
+            onClick={this._handleClick}
+            transform="focus-function"
+            title={oneLine`
+              Focusing on a function will remove any sample that does not include that
+              function. In addition, it re-roots the call tree so that the function
+              is the only root of the tree. This can combine multiple function call sites
+              across a profile into one call node.
+          `}
+          >
+            {inverted ? 'Focus on function (inverted)' : 'Focus on function'}
+          </TransformMenuItem>
+        </Localized>
+
+        <Localized
+          id="CallNodeContextMenu--transform-focus-subtree"
+          attrs={{ title: true }}
+        >
+          <TransformMenuItem
+            shortcut="F"
+            icon="Focus"
+            onClick={this._handleClick}
+            transform="focus-subtree"
+            title={oneLine`
+              Focusing on a subtree will remove any sample that does not include that
+              specific part of the call tree. It pulls out a branch of the call tree,
+              however it only does it for that single call node. All other calls
+              of the function are ignored.
+          `}
+          >
+            Focus on subtree only
+          </TransformMenuItem>
+        </Localized>
+
+        <Localized
+          id="CallNodeContextMenu--transform-collapse-function-subtree"
+          attrs={{ title: true }}
+        >
+          <TransformMenuItem
+            shortcut="c"
             icon="Collapse"
             onClick={this._handleClick}
-            transform="collapse-resource"
+            transform="collapse-function-subtree"
             title={oneLine`
-              Collapsing a resource will flatten out of all the calls into that
-              resource into a single collapsed call node.
-            `}
+              Collapsing a function will remove everything it called, and assign
+              all of the time to the function. This can help simplify a profile that
+              calls into code that does not need to be analyzed.
+          `}
           >
-            Collapse <strong>{nameForResource}</strong>
+            Collapse function
           </TransformMenuItem>
+        </Localized>
+
+        {nameForResource ? (
+          <Localized
+            id="CallNodeContextMenu--transform-collapse-resource"
+            attrs={{ title: true }}
+            vars={{ nameForResource: nameForResource }}
+            elems={{ strong: <strong /> }}
+          >
+            <TransformMenuItem
+              shortcut="C"
+              icon="Collapse"
+              onClick={this._handleClick}
+              transform="collapse-resource"
+              title={oneLine`
+                Collapsing a resource will flatten out of all the calls into that
+                resource into a single collapsed call node.
+            `}
+            >
+              Collapse <strong>{nameForResource}</strong>
+            </TransformMenuItem>
+          </Localized>
         ) : null}
 
         {this.isRecursiveCall() ? (
-          <TransformMenuItem
-            shortcut="r"
-            icon="Collapse"
-            onClick={this._handleClick}
-            transform="collapse-direct-recursion"
-            title={oneLine`
-              Collapsing direct recursion removes calls that repeatedly recurse into
-              the same function.
-            `}
+          <Localized
+            id="CallNodeContextMenu--transform-collapse-direct-recursion"
+            attrs={{ title: true }}
           >
-            Collapse direct recursion
-          </TransformMenuItem>
+            <TransformMenuItem
+              shortcut="r"
+              icon="Collapse"
+              onClick={this._handleClick}
+              transform="collapse-direct-recursion"
+              title={oneLine`
+                Collapsing direct recursion removes calls that repeatedly recurse into
+                the same function.
+            `}
+            >
+              Collapse direct recursion
+            </TransformMenuItem>
+          </Localized>
         ) : null}
 
-        <TransformMenuItem
-          shortcut="d"
-          icon="Drop"
-          onClick={this._handleClick}
-          transform="drop-function"
-          title={oneLine`
-            Dropping samples removes their time from the profile. This is useful to
-            eliminate timing information that is not for the analysis.
-          `}
+        <Localized
+          id="CallNodeContextMenu--transform-drop-function"
+          attrs={{ title: true }}
         >
-          Drop samples with this function
-        </TransformMenuItem>
+          <TransformMenuItem
+            shortcut="d"
+            icon="Drop"
+            onClick={this._handleClick}
+            transform="drop-function"
+            title={oneLine`
+              Dropping samples removes their time from the profile. This is useful to
+              eliminate timing information that is not for the analysis.
+          `}
+          >
+            Drop samples with this function
+          </TransformMenuItem>
+        </Localized>
 
         <div className="react-contextmenu-separator" />
 
         {showExpandAll ? (
           <>
-            <MenuItem onClick={this._handleClick} data={{ type: 'expand-all' }}>
-              Expand all
-            </MenuItem>
+            <Localized id="CallNodeContextMenu--expand-all">
+              <MenuItem
+                onClick={this._handleClick}
+                data={{ type: 'expand-all' }}
+              >
+                Expand all
+              </MenuItem>
+            </Localized>
             <div className="react-contextmenu-separator" />
           </>
         ) : null}
-        <MenuItem onClick={this._handleClick} data={{ type: 'searchfox' }}>
-          Look up the function name on Searchfox
-        </MenuItem>
-        <MenuItem
-          onClick={this._handleClick}
-          data={{ type: 'copy-function-name' }}
-        >
-          Copy function name
-        </MenuItem>
-        {isJS ? (
-          <MenuItem onClick={this._handleClick} data={{ type: 'copy-url' }}>
-            Copy script URL
+        <Localized id="CallNodeContextMenu--searchfox">
+          <MenuItem onClick={this._handleClick} data={{ type: 'searchfox' }}>
+            Look up the function name on Searchfox
           </MenuItem>
+        </Localized>
+        <Localized id="CallNodeContextMenu--copy-function-name">
+          <MenuItem
+            onClick={this._handleClick}
+            data={{ type: 'copy-function-name' }}
+          >
+            Copy function name
+          </MenuItem>
+        </Localized>
+        {isJS ? (
+          <Localized id="CallNodeContextMenu--copy-script-url">
+            <MenuItem onClick={this._handleClick} data={{ type: 'copy-url' }}>
+              Copy script URL
+            </MenuItem>
+          </Localized>
         ) : null}
-        <MenuItem onClick={this._handleClick} data={{ type: 'copy-stack' }}>
-          Copy stack
-        </MenuItem>
+        <Localized id="CallNodeContextMenu--copy-stack">
+          <MenuItem onClick={this._handleClick} data={{ type: 'copy-stack' }}>
+            Copy stack
+          </MenuItem>
+        </Localized>
       </>
     );
   }
@@ -673,7 +734,7 @@ function TransformMenuItem(props: {|
     <MenuItem
       onClick={props.onClick}
       data={{ type: props.transform }}
-      attributes={{ title: props.title }}
+      attributes={{ title: oneLine`${props.title}` }}
     >
       <span
         className={`react-contextmenu-icon callNodeContextMenuIcon${props.icon}`}

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -5,6 +5,7 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { MenuItem } from 'react-contextmenu';
+import { Localized } from '@fluent/react';
 
 import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
@@ -269,18 +270,24 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
           disabled={this._isZeroDurationMarker(marker)}
         >
           <span className="react-contextmenu-icon markerContextMenuIconSetSelectionFromMarker" />
-          Set selection from marker’s duration
+          <Localized id="MarkerContextMenu--set-selection-from-duration">
+            Set selection from marker’s duration
+          </Localized>
         </MenuItem>
         <div className="react-contextmenu-separator" />
         {this._isZeroDurationMarker(marker) ? (
           <>
             <MenuItem onClick={this.setStartRangeFromMarkerStart}>
               <span className="react-contextmenu-icon markerContextMenuIconStartSelectionHere" />
-              Start selection here
+              <Localized id="MarkerContextMenu--start-selection-here">
+                Start selection here
+              </Localized>
             </MenuItem>
             <MenuItem onClick={this.setEndRangeFromMarkerEnd}>
               <span className="react-contextmenu-icon markerContextMenuIconEndSelectionHere" />
-              End selection here
+              <Localized id="MarkerContextMenu--end-selection-here">
+                End selection here
+              </Localized>
             </MenuItem>
           </>
         ) : (
@@ -288,7 +295,14 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
             <MenuItem onClick={this.setStartRangeFromMarkerStart}>
               <span className="react-contextmenu-icon markerContextMenuIconStartSelectionAtMarkerStart" />
               <div className="react-contextmenu-item-content">
-                Start selection at marker’s <strong>start</strong>
+                <Localized
+                  id="MarkerContextMenu--start-selection-at-marker-start"
+                  elems={{ strong: <strong /> }}
+                >
+                  <>
+                    Start selection at marker’s <strong>start</strong>
+                  </>
+                </Localized>
               </div>
             </MenuItem>
             <MenuItem
@@ -297,7 +311,14 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
             >
               <span className="react-contextmenu-icon markerContextMenuIconStartSelectionAtMarkerEnd" />
               <div className="react-contextmenu-item-content">
-                Start selection at marker’s <strong>end</strong>
+                <Localized
+                  id="MarkerContextMenu--start-selection-at-marker-end"
+                  elems={{ strong: <strong /> }}
+                >
+                  <>
+                    Start selection at marker’s <strong>end</strong>
+                  </>
+                </Localized>
               </div>
             </MenuItem>
             <div className="react-contextmenu-separator" />
@@ -307,13 +328,27 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
             >
               <span className="react-contextmenu-icon markerContextMenuIconEndSelectionAtMarkerStart" />
               <div className="react-contextmenu-item-content">
-                End selection at marker’s <strong>start</strong>
+                <Localized
+                  id="MarkerContextMenu--end-selection-at-marker-start"
+                  elems={{ strong: <strong /> }}
+                >
+                  <>
+                    End selection at marker’s <strong>start</strong>
+                  </>
+                </Localized>
               </div>
             </MenuItem>
             <MenuItem onClick={this.setEndRangeFromMarkerEnd}>
               <span className="react-contextmenu-icon markerContextMenuIconEndSelectionAtMarkerEnd" />
               <div className="react-contextmenu-item-content">
-                End selection at marker’s <strong>end</strong>
+                <Localized
+                  id="MarkerContextMenu--end-selection-at-marker-end"
+                  elems={{ strong: <strong /> }}
+                >
+                  <>
+                    End selection at marker’s <strong>end</strong>
+                  </>
+                </Localized>
               </div>
             </MenuItem>
           </>
@@ -322,23 +357,29 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
         <div className="react-contextmenu-separator" />
         <MenuItem onClick={this.copyMarkerDescription}>
           <span className="react-contextmenu-icon markerContextMenuIconCopyDescription" />
-          Copy description
+          <Localized id="MarkerContextMenu--copy-description">
+            Copy description
+          </Localized>
         </MenuItem>
         {data && data.cause ? (
           <MenuItem onClick={this.copyMarkerCause}>
             <span className="react-contextmenu-icon markerContextMenuIconCopyStack" />
-            Copy call stack
+            <Localized id="MarkerContextMenu--copy-call-stack">
+              Copy call stack
+            </Localized>
           </MenuItem>
         ) : null}
         {data && data.type === 'Network' ? (
           <MenuItem onClick={this.copyUrl}>
             <span className="react-contextmenu-icon markerContextMenuIconCopyUrl" />
-            Copy URL
+            <Localized id="MarkerContextMenu--copy-url">Copy URL</Localized>
           </MenuItem>
         ) : null}
         <MenuItem onClick={this.copyMarkerJSON}>
           <span className="react-contextmenu-icon markerContextMenuIconCopyPayload" />
-          Copy full payload
+          <Localized id="MarkerContextMenu--copy-full-payload">
+            Copy full payload
+          </Localized>
         </MenuItem>
       </ContextMenu>
     );

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -294,32 +294,28 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
           <>
             <MenuItem onClick={this.setStartRangeFromMarkerStart}>
               <span className="react-contextmenu-icon markerContextMenuIconStartSelectionAtMarkerStart" />
-              <div className="react-contextmenu-item-content">
-                <Localized
-                  id="MarkerContextMenu--start-selection-at-marker-start"
-                  elems={{ strong: <strong /> }}
-                >
-                  <>
-                    Start selection at marker’s <strong>start</strong>
-                  </>
-                </Localized>
-              </div>
+              <Localized
+                id="MarkerContextMenu--start-selection-at-marker-start"
+                elems={{ strong: <strong /> }}
+              >
+                <div className="react-contextmenu-item-content">
+                  Start selection at marker’s <strong>start</strong>
+                </div>
+              </Localized>
             </MenuItem>
             <MenuItem
               onClick={this.setStartRangeFromMarkerEnd}
               disabled={markerEnd > selectionEnd}
             >
               <span className="react-contextmenu-icon markerContextMenuIconStartSelectionAtMarkerEnd" />
-              <div className="react-contextmenu-item-content">
-                <Localized
-                  id="MarkerContextMenu--start-selection-at-marker-end"
-                  elems={{ strong: <strong /> }}
-                >
-                  <>
-                    Start selection at marker’s <strong>end</strong>
-                  </>
-                </Localized>
-              </div>
+              <Localized
+                id="MarkerContextMenu--start-selection-at-marker-end"
+                elems={{ strong: <strong /> }}
+              >
+                <div className="react-contextmenu-item-content">
+                  Start selection at marker’s <strong>end</strong>
+                </div>
+              </Localized>
             </MenuItem>
             <div className="react-contextmenu-separator" />
             <MenuItem
@@ -327,29 +323,25 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
               disabled={selectionStart > markerStart}
             >
               <span className="react-contextmenu-icon markerContextMenuIconEndSelectionAtMarkerStart" />
-              <div className="react-contextmenu-item-content">
-                <Localized
-                  id="MarkerContextMenu--end-selection-at-marker-start"
-                  elems={{ strong: <strong /> }}
-                >
-                  <>
-                    End selection at marker’s <strong>start</strong>
-                  </>
-                </Localized>
-              </div>
+              <Localized
+                id="MarkerContextMenu--end-selection-at-marker-start"
+                elems={{ strong: <strong /> }}
+              >
+                <div className="react-contextmenu-item-content">
+                  End selection at marker’s <strong>start</strong>
+                </div>
+              </Localized>
             </MenuItem>
             <MenuItem onClick={this.setEndRangeFromMarkerEnd}>
               <span className="react-contextmenu-icon markerContextMenuIconEndSelectionAtMarkerEnd" />
-              <div className="react-contextmenu-item-content">
-                <Localized
-                  id="MarkerContextMenu--end-selection-at-marker-end"
-                  elems={{ strong: <strong /> }}
-                >
-                  <>
-                    End selection at marker’s <strong>end</strong>
-                  </>
-                </Localized>
-              </div>
+              <Localized
+                id="MarkerContextMenu--end-selection-at-marker-end"
+                elems={{ strong: <strong /> }}
+              >
+                <div className="react-contextmenu-item-content">
+                  End selection at marker’s <strong>end</strong>
+                </div>
+              </Localized>
             </MenuItem>
           </>
         )}

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -421,9 +421,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
           id="TrackContextMenu--only-show-track"
           vars={{ trackName: rightClickedTrackName }}
         >
-          <>
-            Only show {`“${this.getRightClickedTrackName(rightClickedTrack)}”`}
-          </>
+          <>Only show {`“${rightClickedTrackName}”`}</>
         </Localized>
       </MenuItem>
     );
@@ -472,9 +470,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
           id="TrackContextMenu--only-show-track"
           vars={{ trackName: rightClickedTrackName }}
         >
-          <>
-            Only show {`“${this.getRightClickedTrackName(rightClickedTrack)}”`}
-          </>
+          <>Only show {`“rightClickedTrackName}”`}</>
         </Localized>
       </MenuItem>
     );

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -510,8 +510,8 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
     const isDisabled = this.getVisibleScreenshotTracks().length <= 1;
     return (
       <MenuItem onClick={this._isolateScreenshot} disabled={isDisabled}>
-        <Localized id="TrackContextMenu--hide-other-screenshot-tracks">
-          Hide other screenshot tracks
+        <Localized id="TrackContextMenu--hide-other-screenshots-tracks">
+          Hide other Screenshots tracks
         </Localized>
       </MenuItem>
     );

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -422,7 +422,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
           vars={{ trackName: rightClickedTrackName }}
         >
           <>
-            Only show {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+            Only show {`“${this.getRightClickedTrackName(rightClickedTrack)}”`}
           </>
         </Localized>
       </MenuItem>
@@ -473,7 +473,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
           vars={{ trackName: rightClickedTrackName }}
         >
           <>
-            Only show {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+            Only show {`“${this.getRightClickedTrackName(rightClickedTrack)}”`}
           </>
         </Localized>
       </MenuItem>
@@ -543,7 +543,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
             id="TrackContextMenu--hide-track"
             vars={{ trackName: rightClickedTrackName }}
           >
-            <>Hide {`"${rightClickedTrackName}"`}</>
+            <>Hide {`“${rightClickedTrackName}”`}</>
           </Localized>
         </MenuItem>
       );
@@ -559,7 +559,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
           id="TrackContextMenu--hide-track"
           vars={{ trackName: rightClickedTrackName }}
         >
-          <>Hide {`"${rightClickedTrackName}"`}</>
+          <>Hide {`“${rightClickedTrackName}”`}</>
         </Localized>
       </MenuItem>
     );

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -5,6 +5,8 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { ContextMenu, MenuItem } from 'react-contextmenu';
+import { Localized } from '@fluent/react';
+
 import './TrackContextMenu.css';
 import {
   hideGlobalTrack,
@@ -360,7 +362,9 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
 
     return (
       <MenuItem onClick={this._isolateProcess} disabled={isDisabled}>
-        Only show this process group
+        <Localized id="TrackContextMenu--only-show-this-process-group">
+          Only show this process group
+        </Localized>
       </MenuItem>
     );
   }
@@ -407,9 +411,20 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
       // Is there only one visible global track?
       globalTracks.length - hiddenGlobalTracks.size === 1;
 
+    const rightClickedTrackName = this.getRightClickedTrackName(
+      rightClickedTrack
+    );
+
     return (
       <MenuItem onClick={this._isolateProcessMainThread} disabled={isDisabled}>
-        Only show {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+        <Localized
+          id="TrackContextMenu--only-show-track"
+          vars={{ trackName: rightClickedTrackName }}
+        >
+          <>
+            Only show {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+          </>
+        </Localized>
       </MenuItem>
     );
   }
@@ -447,9 +462,20 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
       // Is there only one local track left?
       localTrackOrder.length - hiddenLocalTracks.size === 1;
 
+    const rightClickedTrackName = this.getRightClickedTrackName(
+      rightClickedTrack
+    );
+
     return (
       <MenuItem onClick={this._isolateLocalTrack} disabled={isDisabled}>
-        Only show {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+        <Localized
+          id="TrackContextMenu--only-show-track"
+          vars={{ trackName: rightClickedTrackName }}
+        >
+          <>
+            Only show {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+          </>
+        </Localized>
       </MenuItem>
     );
   }
@@ -488,7 +514,9 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
     const isDisabled = this.getVisibleScreenshotTracks().length <= 1;
     return (
       <MenuItem onClick={this._isolateScreenshot} disabled={isDisabled}>
-        Hide other screenshot tracks
+        <Localized id="TrackContextMenu--hide-other-screenshot-tracks">
+          Hide other screenshot tracks
+        </Localized>
       </MenuItem>
     );
   }
@@ -499,6 +527,10 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
       return null;
     }
     const trackIndex = rightClickedTrack.trackIndex;
+    const rightClickedTrackName = this.getRightClickedTrackName(
+      rightClickedTrack
+    );
+
     if (rightClickedTrack.type === 'global') {
       return (
         <MenuItem
@@ -507,7 +539,12 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
           data={rightClickedTrack}
           onClick={this._toggleGlobalTrackVisibility}
         >
-          Hide {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+          <Localized
+            id="TrackContextMenu--hide-track"
+            vars={{ trackName: rightClickedTrackName }}
+          >
+            <>Hide {`"${rightClickedTrackName}"`}</>
+          </Localized>
         </MenuItem>
       );
     }
@@ -518,7 +555,12 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
         data={rightClickedTrack}
         onClick={this._toggleLocalTrackVisibility}
       >
-        Hide {`"${this.getRightClickedTrackName(rightClickedTrack)}"`}
+        <Localized
+          id="TrackContextMenu--hide-track"
+          vars={{ trackName: rightClickedTrackName }}
+        >
+          <>Hide {`"${rightClickedTrackName}"`}</>
+        </Localized>
       </MenuItem>
     );
   }
@@ -537,7 +579,9 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
     return (
       <React.Fragment>
         <MenuItem onClick={this._showAllTracks} disabled={isDisabled}>
-          Show all tracks
+          <Localized id="TrackContextMenu--show-all-tracks">
+            Show all tracks
+          </Localized>
         </MenuItem>
         <div className="react-contextmenu-separator" />
       </React.Fragment>

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -136,7 +136,7 @@ describe('timeline/TrackContextMenu', function() {
         getByText(/Only show “\u2068Content Process\u2069”/);
       const trackItem = () => getByText('Content Process');
       const isolateScreenshotTrack = () =>
-        getByText(/Hide other screenshot tracks/);
+        getByText(/Hide other Screenshots tracks/);
       // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
       const hideContentProcess = () =>
         getByText(/Hide “\u2068Content Process\u2069”/);

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -131,12 +131,15 @@ describe('timeline/TrackContextMenu', function() {
       dispatch(changeRightClickedTrack(trackReference));
 
       const isolateProcessItem = () => getByText(/Only show this process/);
+      // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
       const isolateProcessMainThreadItem = () =>
-        getByText(/Only show "Content Process"/);
+        getByText(/Only show "\u2068Content Process\u2069"/);
       const trackItem = () => getByText('Content Process');
       const isolateScreenshotTrack = () =>
         getByText(/Hide other screenshot tracks/);
-      const hideContentProcess = () => getByText(/Hide "Content Process"/);
+      // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
+      const hideContentProcess = () =>
+        getByText(/Hide "\u2068Content Process\u2069"/);
 
       return {
         ...results,
@@ -300,8 +303,10 @@ describe('timeline/TrackContextMenu', function() {
       dispatch(changeSelectedThreads(new Set([threadIndex])));
       dispatch(changeRightClickedTrack(trackReference));
 
-      const isolateLocalTrackItem = () => getByText('Only show "DOM Worker"');
-      const hideDOMWorker = () => getByText('Hide "DOM Worker"');
+      // Fluent adds isolation characters \u2068 and \u2069 around DOM Worker.
+      const isolateLocalTrackItem = () =>
+        getByText('Only show "\u2068DOM Worker\u2069"');
+      const hideDOMWorker = () => getByText('Hide "\u2068DOM Worker\u2069"');
       const trackItem = () => getByText('DOM Worker');
 
       return {

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -133,13 +133,13 @@ describe('timeline/TrackContextMenu', function() {
       const isolateProcessItem = () => getByText(/Only show this process/);
       // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
       const isolateProcessMainThreadItem = () =>
-        getByText(/Only show "\u2068Content Process\u2069"/);
+        getByText(/Only show “\u2068Content Process\u2069”/);
       const trackItem = () => getByText('Content Process');
       const isolateScreenshotTrack = () =>
         getByText(/Hide other screenshot tracks/);
       // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
       const hideContentProcess = () =>
-        getByText(/Hide "\u2068Content Process\u2069"/);
+        getByText(/Hide “\u2068Content Process\u2069”/);
 
       return {
         ...results,
@@ -305,8 +305,8 @@ describe('timeline/TrackContextMenu', function() {
 
       // Fluent adds isolation characters \u2068 and \u2069 around DOM Worker.
       const isolateLocalTrackItem = () =>
-        getByText('Only show "\u2068DOM Worker\u2069"');
-      const hideDOMWorker = () => getByText('Hide "\u2068DOM Worker\u2069"');
+        getByText('Only show “\u2068DOM Worker\u2069”');
+      const hideDOMWorker = () => getByText('Hide “\u2068DOM Worker\u2069”');
       const trackItem = () => getByText('DOM Worker');
 
       return {

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -33,7 +33,7 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Merging a node removes it from the profile, and assigns its time to the function's node that called it. It only removes the function from that specific part of the tree. Any other places the function was called will remain in the profile."
+    title="Merging a node removes it from the profile, and assigns its time to the function’s node that called it. It only removes the function from that specific part of the tree. Any other places the function was called from will remain in the profile."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconMerge"
@@ -117,7 +117,7 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Collapsing a resource will flatten out of all the calls into that resource into a single collapsed call node."
+    title="Collapsing a resource will flatten out of all the calls to that resource into a single collapsed call node."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconCollapse"

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -127,7 +127,7 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     >
       Collapse 
       <strong>
-        XUL
+        ⁨XUL⁩
       </strong>
     </div>
     <kbd

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -117,7 +117,7 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Collapsing a resource will flatten out of all the calls to that resource into a single collapsed call node."
+    title="Collapsing a resource will flatten out all the calls to that resource into a single collapsed call node."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconCollapse"
@@ -162,7 +162,7 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not for the analysis."
+    title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not relevant for the analysis."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconDrop"

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -21,7 +21,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Hide "⁨Screenshots⁩"
+    Hide “⁨Screenshots⁩”
   </div>
   <div
     class="react-contextmenu-separator"
@@ -58,7 +58,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Only show "⁨Content Process⁩"
+    Only show “⁨Content Process⁩”
   </div>
   <div
     aria-disabled="false"
@@ -74,7 +74,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Hide "⁨Content Process⁩"
+    Hide “⁨Content Process⁩”
   </div>
   <div
     class="react-contextmenu-separator"
@@ -134,7 +134,7 @@ exports[`timeline/TrackContextMenu selected global track network track will be d
     role="menuitem"
     tabindex="-1"
   >
-    Hide "⁨Process 0⁩"
+    Hide “⁨Process 0⁩”
   </div>
   <div>
     <div
@@ -191,7 +191,7 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
     role="menuitem"
     tabindex="-1"
   >
-    Only show "⁨DOM Worker⁩"
+    Only show “⁨DOM Worker⁩”
   </div>
   <div
     aria-disabled="false"
@@ -199,7 +199,7 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
     role="menuitem"
     tabindex="-1"
   >
-    Hide "⁨DOM Worker⁩"
+    Hide “⁨DOM Worker⁩”
   </div>
   <div
     class="react-contextmenu-separator"

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -13,7 +13,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Hide other screenshot tracks
+    Hide other Screenshots tracks
   </div>
   <div
     aria-disabled="false"

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -21,8 +21,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Hide 
-    "Screenshots"
+    Hide "⁨Screenshots⁩"
   </div>
   <div
     class="react-contextmenu-separator"
@@ -59,8 +58,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Only show 
-    "Content Process"
+    Only show "⁨Content Process⁩"
   </div>
   <div
     aria-disabled="false"
@@ -76,8 +74,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Hide 
-    "Content Process"
+    Hide "⁨Content Process⁩"
   </div>
   <div
     class="react-contextmenu-separator"
@@ -137,8 +134,7 @@ exports[`timeline/TrackContextMenu selected global track network track will be d
     role="menuitem"
     tabindex="-1"
   >
-    Hide 
-    "Process 0"
+    Hide "⁨Process 0⁩"
   </div>
   <div>
     <div
@@ -195,8 +191,7 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
     role="menuitem"
     tabindex="-1"
   >
-    Only show 
-    "DOM Worker"
+    Only show "⁨DOM Worker⁩"
   </div>
   <div
     aria-disabled="false"
@@ -204,8 +199,7 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
     role="menuitem"
     tabindex="-1"
   >
-    Hide 
-    "DOM Worker"
+    Hide "⁨DOM Worker⁩"
   </div>
   <div
     class="react-contextmenu-separator"

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,14 +999,14 @@
   resolved "https://registry.yarnpkg.com/@fluent/langneg/-/langneg-0.5.0.tgz#de448070efa16c8fb6cc4af1629663f01e10689b"
   integrity sha512-jv0g3YO5byz29HXEE6DBzAog60q726mwV2nIoekEX590JVh+mbd6/ZXT5/l4mN2BMlrelzyscCTffKI4XScVtg==
 
-"@fluent/react@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@fluent/react/-/react-0.13.0.tgz#cf2652d56fe22072dfeb30dcd2e03650fb913f88"
-  integrity sha512-NdITFI7eqecpb2Ty+I9g2BKxbzhdBKoKm8eU3/vnmBhGDeFgkS/aACSHF3gV2rL87JW9A+h4Ih1ympWp8OqqxQ==
+"@fluent/react@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@fluent/react/-/react-0.13.1.tgz#c6337f6031220baf78c08c9f31d2c6ded4531508"
+  integrity sha512-0hvWZojJgc97J1V2nI2COvStjKOD3blYGk1EPdDyhK+OhddsZR4Gp9S1c4cOdxNjLYbz1sBwBOMOKP+tY6Zarg==
   dependencies:
     "@fluent/sequence" "0.5.0"
     cached-iterable "^0.2.1"
-    prop-types "^15.6.0"
+    prop-types "^15.7.2"
 
 "@fluent/sequence@0.5.0":
   version "0.5.0"
@@ -10414,7 +10414,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
So this is going to be the last PR for our i18n process. After this, we should be ready for the l10n process :tada: .
Call node context menu ended up being a bit text heavy with the titles :/