### PR TITLE
Change how the mock for CanvasContext is done, and implement a simple…

### DIFF
--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -18,7 +18,7 @@ import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
 import { getBoundingBox, fireFullClick } from '../fixtures/utils';
 import { addActiveTabInformationToProfile } from '../fixtures/profiles/processed-profile';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import {
   getActiveTabGlobalTracks,
   getActiveTabResourceTracks,
@@ -28,6 +28,7 @@ import { changeSelectedThreads } from '../../actions/profile-view';
 import { ensureExists, getFirstItemFromSet } from '../../utils/flow';
 
 describe('ActiveTabTimeline', function() {
+  autoMockCanvasContext();
   beforeEach(() => {
     jest.spyOn(ReactDOM, 'findDOMNode').mockImplementation(() => {
       // findDOMNode uses nominal typing instead of structural (null | Element | Text), so
@@ -41,11 +42,6 @@ describe('ActiveTabTimeline', function() {
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(() => getBoundingBox(200, 300));
-
-    const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
   });
 
   it('should be rendered properly from the Timeline component', () => {

--- a/src/test/components/CPUGraph.test.js
+++ b/src/test/components/CPUGraph.test.js
@@ -11,7 +11,10 @@ import { render } from '@testing-library/react';
 import { enableExperimentalCPUGraphs } from 'firefox-profiler/actions/app';
 import { ensureExists } from 'firefox-profiler/utils/flow';
 import { TimelineTrackThread } from 'firefox-profiler/components/timeline/TrackThread';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
@@ -36,6 +39,8 @@ const GRAPH_WIDTH = PIXELS_PER_SAMPLE * SAMPLE_COUNT;
 const GRAPH_HEIGHT = 10;
 
 describe('CPUGraph', function() {
+  autoMockCanvasContext();
+
   function getSamplesProfile() {
     const profile = getProfileFromTextSamples(`
       A[cat:DOM]  A[cat:DOM]       A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]
@@ -60,11 +65,6 @@ describe('CPUGraph', function() {
     const store = storeWithProfile(profile);
     const { dispatch } = store;
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -93,7 +93,6 @@ describe('CPUGraph', function() {
 
     return {
       cpuGraphCanvas,
-      ctx,
     };
   }
 
@@ -103,7 +102,7 @@ describe('CPUGraph', function() {
   });
 
   it('matches the 2d canvas draw snapshot', () => {
-    const { ctx } = setup();
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    setup();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 });

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -14,7 +14,10 @@ import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { FlameGraph } from '../../components/flame-graph';
 import { CallNodeContextMenu } from '../../components/shared/CallNodeContextMenu';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getBoundingBox,
@@ -48,11 +51,12 @@ const GRAPH_WIDTH = 200;
 const GRAPH_HEIGHT = 300;
 
 describe('FlameGraph', function() {
+  autoMockCanvasContext();
   afterEach(removeRootOverlayElement);
   beforeEach(addRootOverlayElement);
 
   it('matches the snapshot', () => {
-    const { container, flushDrawLog } = setupFlameGraph();
+    const { container } = setupFlameGraph();
     const drawCalls = flushDrawLog();
 
     expect(container.firstChild).toMatchSnapshot();
@@ -219,15 +223,10 @@ describe('FlameGraph', function() {
 
 function setupFlameGraph() {
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
 
   jest
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
     .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
-
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
 
   const {
     profile,
@@ -338,14 +337,13 @@ function setupFlameGraph() {
   }
 
   function findFillTextPosition(fillText: string) {
-    return findFillTextPositionFromDrawLog(ctx.__flushDrawLog(), fillText);
+    return findFillTextPositionFromDrawLog(flushDrawLog(), fillText);
   }
 
   return {
     ...store,
     ...renderResult,
     funcNames,
-    ctx,
     moveMouse,
     rightClick,
     getTooltip,
@@ -353,6 +351,5 @@ function setupFlameGraph() {
     getContextMenu,
     clickMenuItem,
     findFillTextPosition,
-    flushDrawLog: () => ctx.__flushDrawLog(),
   };
 }

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -16,7 +16,7 @@ import { TimelineGlobalTrack } from '../../components/timeline/GlobalTrack';
 import { getGlobalTracks, getRightClickedTrack } from '../../selectors/profile';
 import { getFirstSelectedThreadIndex } from '../../selectors/url-state';
 import { ensureExists } from '../../utils/flow';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
@@ -27,6 +27,8 @@ import {
 } from '../fixtures/utils';
 
 describe('timeline/GlobalTrack', function() {
+  autoMockCanvasContext();
+
   /**
    *  getProfileWithNiceTracks() looks like: [
    *    'show [thread GeckoMain process]',   // Track index 0
@@ -64,9 +66,6 @@ describe('timeline/GlobalTrack', function() {
     const threadIndex = track.mainThreadIndex;
 
     // Some child components render to canvas.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(() => getBoundingBox(400, 400));

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -12,7 +12,10 @@ import {
   TIMELINE_MARGIN_RIGHT,
 } from '../../app-logic/constants';
 import { JsTracer } from '../../components/js-tracer';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -34,6 +37,7 @@ const GRAPH_WIDTH =
 const GRAPH_HEIGHT = 300;
 
 describe('StackChart', function() {
+  autoMockCanvasContext();
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 
@@ -45,11 +49,6 @@ describe('StackChart', function() {
     events: TestDefinedJsTracerEvent[],
   }) {
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -84,7 +83,6 @@ describe('StackChart', function() {
       ...renderResult,
       dispatch,
       getState,
-      ctx,
       flushRafCalls,
       getJsTracerChartCanvas,
       getChangeJsTracerSummaryCheckbox,
@@ -134,11 +132,11 @@ describe('StackChart', function() {
   });
 
   it('matches the snapshot a simple chart render', () => {
-    const { ctx } = setup({
+    setup({
       skipLoadingScreen: true,
       events: simpleTracerEvents,
     });
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 
   it('can change to a summary view', function() {
@@ -152,11 +150,11 @@ describe('StackChart', function() {
   });
 
   it('matches the snapshot for an inverted draw call', function() {
-    const { getChangeJsTracerSummaryCheckbox, ctx } = setup({
+    const { getChangeJsTracerSummaryCheckbox } = setup({
       skipLoadingScreen: true,
       events: simpleTracerEvents,
     });
     fireFullClick(getChangeJsTracerSummaryCheckbox());
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 });

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -27,7 +27,7 @@ import {
 } from '../../selectors/profile';
 import { ensureExists } from '../../utils/flow';
 import { getFirstSelectedThreadIndex } from '../../selectors/url-state';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import {
   getNetworkTrackProfile,
   getIPCTrackProfile,
@@ -49,6 +49,8 @@ import {
 const PID = 222;
 
 describe('timeline/LocalTrack', function() {
+  autoMockCanvasContext();
+
   describe('with a thread track', function() {
     it('matches the snapshot of a local track', () => {
       const { container } = setupThreadTrack();
@@ -162,10 +164,6 @@ function setup(
   // The assertions are simpler if this thread is not already selected.
   dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
 
-  // Some child components render to canvas.
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => mockCanvasContext());
   jest
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
     .mockImplementation(() => getBoundingBox(400, 400));

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -21,7 +21,10 @@ import { MaybeMarkerContextMenu } from '../../components/shared/MarkerContextMen
 import { changeSelectedTab } from '../../actions/app';
 import { ensureExists } from '../../utils/flow';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getProfileWithMarkers,
@@ -90,10 +93,6 @@ const MARKERS: TestDefinedMarkers = [
 
 function setupWithProfile(profile) {
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
 
   // Ideally we'd want this only on the Canvas and on ChartViewport, but this is
   // a lot easier to mock this everywhere.
@@ -132,12 +131,12 @@ function setupWithProfile(profile) {
     ...renderResult,
     ...store,
     flushRafCalls,
-    flushDrawLog: () => ctx.__flushDrawLog(),
     fireMouseEvent,
   };
 }
 
 describe('MarkerChart', function() {
+  autoMockCanvasContext();
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 
@@ -145,12 +144,7 @@ describe('MarkerChart', function() {
     window.devicePixelRatio = 2;
 
     const profile = getProfileWithMarkers([...MARKERS]);
-    const {
-      container,
-      flushRafCalls,
-      dispatch,
-      flushDrawLog,
-    } = setupWithProfile(profile);
+    const { container, flushRafCalls, dispatch } = setupWithProfile(profile);
 
     dispatch(changeSelectedTab('marker-chart'));
     flushRafCalls();
@@ -184,7 +178,7 @@ describe('MarkerChart', function() {
     ];
 
     const profile = getProfileWithMarkers(markers);
-    const { flushRafCalls, flushDrawLog } = setupWithProfile(profile);
+    const { flushRafCalls } = setupWithProfile(profile);
     flushRafCalls();
 
     const drawCalls = flushDrawLog();
@@ -215,12 +209,9 @@ describe('MarkerChart', function() {
     window.devicePixelRatio = 1;
 
     const profile = getProfileWithMarkers(MARKERS);
-    const {
-      flushRafCalls,
-      dispatch,
-      flushDrawLog,
-      fireMouseEvent,
-    } = setupWithProfile(profile);
+    const { flushRafCalls, dispatch, fireMouseEvent } = setupWithProfile(
+      profile
+    );
 
     dispatch(changeSelectedTab('marker-chart'));
     flushRafCalls();
@@ -262,12 +253,9 @@ describe('MarkerChart', function() {
     window.devicePixelRatio = 1;
 
     const profile = getProfileWithMarkers(MARKERS);
-    const {
-      flushRafCalls,
-      dispatch,
-      flushDrawLog,
-      fireMouseEvent,
-    } = setupWithProfile(profile);
+    const { flushRafCalls, dispatch, fireMouseEvent } = setupWithProfile(
+      profile
+    );
 
     dispatch(changeSelectedTab('marker-chart'));
     flushRafCalls();
@@ -308,7 +296,6 @@ describe('MarkerChart', function() {
       const {
         flushRafCalls,
         dispatch,
-        flushDrawLog,
         fireMouseEvent,
         container,
         getByRole,
@@ -429,7 +416,6 @@ describe('MarkerChart', function() {
       const {
         rightClick,
         mouseOver,
-        flushDrawLog,
         getContextMenu,
         findFillTextPosition,
       } = setupForContextMenus();
@@ -556,7 +542,7 @@ describe('MarkerChart', function() {
 
     it('renders lots of markers initially', function() {
       const profile = getProfileWithMarkers(MARKERS);
-      const { flushRafCalls, flushDrawLog } = setupWithProfile(profile);
+      const { flushRafCalls } = setupWithProfile(profile);
 
       flushRafCalls();
       const text = getFillTextCalls(flushDrawLog());
@@ -567,9 +553,7 @@ describe('MarkerChart', function() {
 
     it('renders only the marker that was searched for', function() {
       const profile = getProfileWithMarkers(MARKERS);
-      const { flushRafCalls, dispatch, flushDrawLog } = setupWithProfile(
-        profile
-      );
+      const { flushRafCalls, dispatch } = setupWithProfile(profile);
 
       // Flush out any existing draw calls.
       flushRafCalls();
@@ -657,12 +641,7 @@ describe('MarkerChart', function() {
 
     it('renders the marker chart and matches the snapshot', () => {
       window.devicePixelRatio = 2;
-      const {
-        dispatch,
-        flushRafCalls,
-        flushDrawLog,
-        container,
-      } = setupForActiveTab();
+      const { dispatch, flushRafCalls, container } = setupForActiveTab();
 
       dispatch(changeSelectedTab('marker-chart'));
       flushRafCalls();
@@ -677,12 +656,7 @@ describe('MarkerChart', function() {
     it('renders the hovered marker properly', () => {
       window.devicePixelRatio = 1;
 
-      const {
-        dispatch,
-        flushRafCalls,
-        flushDrawLog,
-        fireMouseEvent,
-      } = setupForActiveTab();
+      const { dispatch, flushRafCalls, fireMouseEvent } = setupForActiveTab();
 
       dispatch(changeSelectedTab('marker-chart'));
       flushRafCalls();
@@ -724,12 +698,7 @@ describe('MarkerChart', function() {
     it('does not render the hovered label', () => {
       window.devicePixelRatio = 1;
 
-      const {
-        dispatch,
-        flushRafCalls,
-        flushDrawLog,
-        fireMouseEvent,
-      } = setupForActiveTab();
+      const { dispatch, flushRafCalls, fireMouseEvent } = setupForActiveTab();
 
       dispatch(changeSelectedTab('marker-chart'));
       flushRafCalls();

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -25,7 +25,10 @@ import {
   TIMELINE_MARGIN_RIGHT,
 } from '../../app-logic/constants';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getProfileWithMarkers,
@@ -57,10 +60,6 @@ const NETWORK_MARKERS = (function() {
 
 function setupWithProfile(profile) {
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
 
   // Ideally we'd want this only on the Canvas and on ChartViewport, but this is
   // a lot easier to mock this everywhere.
@@ -123,7 +122,6 @@ function setupWithProfile(profile) {
     ...renderResult,
     ...store,
     flushRafCalls,
-    flushDrawLog: () => ctx.__flushDrawLog(),
     getUrlShorteningParts,
     getBarElements,
     getBarElementStyles,
@@ -140,8 +138,10 @@ function setupWithPayload(markers: TestDefinedMarkers) {
 }
 
 describe('NetworkChart', function() {
+  autoMockCanvasContext();
+
   it('renders NetworkChart correctly', () => {
-    const { flushDrawLog, container } = setupWithPayload([...NETWORK_MARKERS]);
+    const { container } = setupWithPayload([...NETWORK_MARKERS]);
 
     const drawCalls = flushDrawLog();
     expect(container.firstChild).toMatchSnapshot();

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -16,7 +16,7 @@ import { CallNodeContextMenu } from '../../components/shared/CallNodeContextMenu
 import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { ensureExists } from '../../utils/flow';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getBoundingBox,
@@ -46,11 +46,8 @@ import {
 
 import type { Profile } from 'firefox-profiler/types';
 
+autoMockCanvasContext();
 beforeEach(() => {
-  // Mock out the 2d canvas for the loupe view.
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => mockCanvasContext());
   // This makes the bounding box large enough so that we don't trigger
   // VirtualList's virtualization. We assert this above.
   jest

--- a/src/test/components/ProfileViewer.test.js
+++ b/src/test/components/ProfileViewer.test.js
@@ -18,10 +18,11 @@ import { stateFromLocation } from 'firefox-profiler/app-logic/url-handling';
 import { blankStore } from '../fixtures/stores';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { getBoundingBox } from '../fixtures/utils';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
 describe('ProfileViewer', function() {
+  autoMockCanvasContext();
   beforeEach(() => {
     jest.spyOn(ReactDOM, 'findDOMNode').mockImplementation(() => {
       // findDOMNode uses nominal typing instead of structural (null | Element | Text), so
@@ -35,11 +36,6 @@ describe('ProfileViewer', function() {
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(() => getBoundingBox(200, 300));
-
-    const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
   });
 
   function setup() {

--- a/src/test/components/README.md
+++ b/src/test/components/README.md
@@ -93,21 +93,12 @@ fireEvent(target, getMouseEvent({ pageX: 5 }));
 A lot of our components use the Canvas Context API to draw graphs and display
 data. To test this properly we developed a mock that can be used in this way:
 ```js
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 ...
-
-function setup() {
-  const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
-
-  return { flushDrawLogs: ctx.__flushDrawLogs };
-}
+autoMockCanvasContext();
 
 it('draws the right things to the screen', () => {
-  const { flushDrawLogs } = setup();
-  expect(flushDrawLogs()).toMatchSnapshot();
+  expect(window.__flushDrawLog()).toMatchSnapshot();
 });
 ```
 

--- a/src/test/components/Root-history.test.js
+++ b/src/test/components/Root-history.test.js
@@ -8,7 +8,7 @@ import * as React from 'react';
 
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { Root } from '../../components/app/Root';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import { getProfileUrlForHash } from '../../actions/receive-profile';
 import { blankStore } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
@@ -39,6 +39,7 @@ describe('Root with history', function() {
   |};
 
   autoMockFullNavigation();
+  autoMockCanvasContext();
 
   function setup(config: TestConfig) {
     const { profileHash } = config;
@@ -62,11 +63,6 @@ describe('Root with history', function() {
           'profile hash. This is needed to complete #1789.'
       );
     }
-
-    const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     const store = blankStore();
     const renderResult = render(<Root store={store} />);

--- a/src/test/components/SampleGraph.test.js
+++ b/src/test/components/SampleGraph.test.js
@@ -11,7 +11,10 @@ import { render } from '@testing-library/react';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import { ensureExists } from 'firefox-profiler/utils/flow';
 import { TimelineTrackThread } from 'firefox-profiler/components/timeline/TrackThread';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox, fireFullClick } from '../fixtures/utils';
@@ -42,6 +45,8 @@ function getSamplesPixelPosition(
 }
 
 describe('SampleGraph', function() {
+  autoMockCanvasContext();
+
   function getSamplesProfile() {
     return getProfileFromTextSamples(`
       A[cat:DOM]  A[cat:DOM]       A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]
@@ -56,11 +61,6 @@ describe('SampleGraph', function() {
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -112,7 +112,6 @@ describe('SampleGraph', function() {
       sampleGraphCanvas,
       clickSampleGraph,
       getCallNodePath,
-      ctx,
     };
   }
 
@@ -122,8 +121,8 @@ describe('SampleGraph', function() {
   });
 
   it('matches the 2d canvas draw snapshot', () => {
-    const { ctx } = setup();
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    setup();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 
   /**

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -17,7 +17,10 @@ import { MaybeMarkerContextMenu } from '../../components/shared/MarkerContextMen
 import { overlayFills } from '../../profile-logic/marker-styles';
 import { fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import {
@@ -35,11 +38,6 @@ import type { CssPixels } from 'firefox-profiler/types';
 
 function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
-
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
 
   // Ideally we'd want this only on the Canvas and on ChartViewport, but this is
   // a lot easier to mock this everywhere.
@@ -52,10 +50,6 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
     // will request more code to be run in later animation frames.
     flushRafCalls();
     flushRafCalls();
-  }
-
-  function flushDrawLog() {
-    return ctx.__flushDrawLog();
   }
 
   const profile = getProfileWithMarkers(...markersPerThread);
@@ -142,7 +136,6 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   }
 
   return {
-    flushDrawLog,
     flushRafTwice,
     rightClick,
     mouseOver,
@@ -153,20 +146,19 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
 }
 
 describe('TimelineMarkers', function() {
+  autoMockCanvasContext();
+
   it('renders correctly', () => {
     window.devicePixelRatio = 1;
 
-    const { container, flushDrawLog } = setupWithMarkers(
-      { rangeStart: 0, rangeEnd: 15 },
-      [
-        ['DOMEvent', 0, 10],
-        ['DOMEvent', 0, 10],
-        ['DOMEvent', 5, 15],
-        ['Paint', 2, 13],
-        ['Navigation', 2, 6],
-        ['Layout', 6, 8],
-      ]
-    );
+    const { container } = setupWithMarkers({ rangeStart: 0, rangeEnd: 15 }, [
+      ['DOMEvent', 0, 10],
+      ['DOMEvent', 0, 10],
+      ['DOMEvent', 5, 15],
+      ['Paint', 2, 13],
+      ['Navigation', 2, 6],
+      ['Layout', 6, 8],
+    ]);
 
     const drawCalls = flushDrawLog();
 
@@ -179,16 +171,13 @@ describe('TimelineMarkers', function() {
   it('does not render several dot markers in the same position', () => {
     window.devicePixelRatio = 2;
 
-    const { flushDrawLog } = setupWithMarkers(
-      { rangeStart: 0, rangeEnd: 15000 },
-      [
-        // 2 very close dot markers. They shouldn't be drawn both together.
-        ['DOMEvent', 5000],
-        ['DOMEvent', 5001],
-        // This is a longer marker starting at the same place, it should always be drawn
-        ['DOMEvent', 5001, 7000],
-      ]
-    );
+    setupWithMarkers({ rangeStart: 0, rangeEnd: 15000 }, [
+      // 2 very close dot markers. They shouldn't be drawn both together.
+      ['DOMEvent', 5000],
+      ['DOMEvent', 5001],
+      // This is a longer marker starting at the same place, it should always be drawn
+      ['DOMEvent', 5001, 7000],
+    ]);
 
     const drawCalls = flushDrawLog();
 
@@ -270,15 +259,13 @@ describe('TimelineMarkers', function() {
     });
 
     it('and still highlights other markers when hovering them', () => {
-      const {
-        rightClick,
-        mouseOver,
-        flushDrawLog,
-        getContextMenu,
-      } = setupWithMarkers({ rangeStart: 0, rangeEnd: 10 }, [
-        ['DOMEvent', 0, 3],
-        ['DOMEvent', 6, 10],
-      ]);
+      const { rightClick, mouseOver, getContextMenu } = setupWithMarkers(
+        { rangeStart: 0, rangeEnd: 10 },
+        [
+          ['DOMEvent', 0, 3],
+          ['DOMEvent', 6, 10],
+        ]
+      );
 
       // The "DOMEvent" marker is drawn from 0,0 to 5,60.
       rightClick({ x: 30, y: 2 });

--- a/src/test/components/TrackEventDelay.test.js
+++ b/src/test/components/TrackEventDelay.test.js
@@ -11,7 +11,10 @@ import { fireEvent } from '@testing-library/react';
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { TrackEventDelay } from '../../components/timeline/TrackEventDelay';
 import { ensureExists } from '../../utils/flow';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -49,11 +52,6 @@ describe('TrackEventDelay', function() {
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -99,12 +97,12 @@ describe('TrackEventDelay', function() {
       canvas,
       getTooltipContents,
       moveMouseAtEventDelay,
-      ctx,
       flushRafCalls,
       getEventDelayDot,
     };
   }
 
+  autoMockCanvasContext();
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 
@@ -114,9 +112,9 @@ describe('TrackEventDelay', function() {
   });
 
   it('matches the 2d canvas draw snapshot', () => {
-    const { ctx, flushRafCalls } = setup();
+    const { flushRafCalls } = setup();
     flushRafCalls();
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 
   it('can create a tooltip', function() {

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -13,7 +13,10 @@ import { fireEvent } from '@testing-library/react';
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { TrackMemory } from '../../components/timeline/TrackMemory';
 import { ensureExists } from '../../utils/flow';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -58,11 +61,6 @@ describe('TrackMemory', function() {
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -105,12 +103,12 @@ describe('TrackMemory', function() {
       canvas,
       getTooltipContents,
       moveMouseAtCounter,
-      ctx,
       flushRafCalls,
       getMemoryDot,
     };
   }
 
+  autoMockCanvasContext();
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 
@@ -120,9 +118,9 @@ describe('TrackMemory', function() {
   });
 
   it('matches the 2d canvas draw snapshot', () => {
-    const { ctx, flushRafCalls } = setup();
+    const { flushRafCalls } = setup();
     flushRafCalls();
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 
   it('can create a tooltip', function() {

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -14,7 +14,7 @@ import {
   TRACK_NETWORK_ROW_HEIGHT,
   TRACK_NETWORK_ROW_REPEAT,
 } from '../../app-logic/constants';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -31,6 +31,8 @@ import { ensureExists } from '../../utils/flow';
 // mimicks what is computed by the actual component.
 const GRAPH_WIDTH = 400;
 const GRAPH_HEIGHT = TRACK_NETWORK_ROW_HEIGHT * TRACK_NETWORK_ROW_REPEAT;
+
+autoMockCanvasContext();
 
 describe('timeline/TrackNetwork', function() {
   it('matches the component snapshot', () => {
@@ -96,10 +98,6 @@ function setup() {
 
   const { getState, dispatch } = store;
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
 
   jest
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -124,7 +122,7 @@ function setup() {
    */
   function getContextDrawCalls() {
     flushRafCalls();
-    return ctx.__flushDrawLog();
+    return (window: any).__flushDrawLog();
   }
 
   return {

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -20,7 +20,7 @@ import { Timeline } from '../../components/timeline';
 import { ensureExists } from '../../utils/flow';
 import { FULL_TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -42,6 +42,7 @@ const TOP = 7;
 
 describe('timeline/TrackScreenshots', function() {
   autoMockDomRect();
+  autoMockCanvasContext();
 
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
@@ -238,10 +239,6 @@ function setup(
   const store = storeWithProfile(profile);
   const { getState, dispatch } = store;
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
   let leftOffset = LEFT;
   let topOffset = TOP;
   jest

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -21,7 +21,10 @@ import { getPreviewSelection } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -50,6 +53,7 @@ const GRAPH_HEIGHT = 50;
 describe('timeline/TrackThread', function() {
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
+  autoMockCanvasContext();
 
   function getSamplesProfile() {
     return getProfileFromTextSamples(`
@@ -79,7 +83,6 @@ describe('timeline/TrackThread', function() {
     const { getState, dispatch } = store;
     const threadIndex = 0;
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
 
     type Coordinate = {| pageX: number, pageY: number |};
 
@@ -96,10 +99,6 @@ describe('timeline/TrackThread', function() {
       const [, x, y, w, h] = call;
       return { pageX: x + w * 0.5, pageY: y + h * 0.5 };
     }
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -150,7 +149,6 @@ describe('timeline/TrackThread', function() {
       threadIndex,
       stackGraphCanvas,
       markerCanvas,
-      ctx,
       getFillRectCenterByIndex,
     };
   }
@@ -161,8 +159,8 @@ describe('timeline/TrackThread', function() {
   });
 
   it('matches the 2d canvas draw snapshot', () => {
-    const { ctx } = setup(getSamplesProfile());
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    setup(getSamplesProfile());
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 
   it('can click a stack in the stack graph in normal call trees', function() {
@@ -170,11 +168,10 @@ describe('timeline/TrackThread', function() {
       getState,
       stackGraphCanvas,
       thread,
-      ctx,
       getFillRectCenterByIndex,
     } = setup(getSamplesProfile());
 
-    const log = ctx.__flushDrawLog();
+    const log = flushDrawLog();
 
     // Provide a quick helper for nicely asserting the call node path.
     const getCallNodePath = () =>
@@ -203,7 +200,6 @@ describe('timeline/TrackThread', function() {
       getState,
       stackGraphCanvas,
       thread,
-      ctx,
       getFillRectCenterByIndex,
     } = setup(getSamplesProfile());
 
@@ -218,9 +214,9 @@ describe('timeline/TrackThread', function() {
     function changeInvertCallstackAndGetDrawLog(value) {
       // We don't want a selected stack graph to change fillRect ordering.
       dispatch(changeSelectedCallNode(0, []));
-      ctx.__flushDrawLog();
+      flushDrawLog();
       dispatch(changeInvertCallstack(value));
-      return ctx.__flushDrawLog();
+      return flushDrawLog();
     }
 
     // Switch to "inverted" mode to test with this state
@@ -246,14 +242,14 @@ describe('timeline/TrackThread', function() {
   });
 
   it('can click a marker', function() {
-    const { getState, markerCanvas, ctx, getFillRectCenterByIndex } = setup(
+    const { getState, markerCanvas, getFillRectCenterByIndex } = setup(
       getMarkersProfile([
         ['DOMEvent', 0, 4],
         ['DOMEvent', 4, 8],
       ])
     );
 
-    const log = ctx.__flushDrawLog();
+    const log = flushDrawLog();
 
     function clickAndGetMarkerName(event) {
       fireFullClick(markerCanvas(), event);

--- a/src/test/components/TrackVisualProgress.test.js
+++ b/src/test/components/TrackVisualProgress.test.js
@@ -13,7 +13,10 @@ import { fireEvent } from '@testing-library/react';
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { TrackVisualProgress } from '../../components/timeline/TrackVisualProgress';
 import { ensureExists } from '../../utils/flow';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -58,11 +61,6 @@ describe('TrackVisualProgress', function() {
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;
     const flushRafCalls = mockRaf();
-    const ctx = mockCanvasContext();
-
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
@@ -104,12 +102,12 @@ describe('TrackVisualProgress', function() {
       canvas,
       getTooltipContents,
       moveMouseAtCounter,
-      ctx,
       flushRafCalls,
       getVisualProgressDot,
     };
   }
 
+  autoMockCanvasContext();
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 
@@ -119,9 +117,9 @@ describe('TrackVisualProgress', function() {
   });
 
   it('matches the 2d canvas draw snapshot', () => {
-    const { ctx, flushRafCalls } = setup();
+    const { flushRafCalls } = setup();
     flushRafCalls();
-    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+    expect(flushDrawLog()).toMatchSnapshot();
   });
 
   it('can create a tooltip', function() {

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -19,7 +19,7 @@ import { changeSidebarOpenState } from '../../actions/app';
 import explicitConnect from '../../utils/connect';
 import { ensureExists } from '../../utils/flow';
 
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
@@ -50,6 +50,8 @@ const MAX_VIEWPORT_HEIGHT = BOUNDING_BOX_HEIGHT * 3;
 const SMALL_MAX_VIEWPORT_HEIGHT = BOUNDING_BOX_HEIGHT * 0.2;
 
 describe('Viewport', function() {
+  autoMockCanvasContext();
+
   it('matches the component snapshot', () => {
     const { container, unmount } = setup();
     expect(container.firstChild).toMatchSnapshot();
@@ -624,11 +626,6 @@ function getBoundingBoxForViewport(override: $Shape<BoundingBoxOverride> = {}) {
 
 function setup(profileOverrides: MixedObject = {}) {
   const flushRafCalls = mockRaf();
-  const ctx = mockCanvasContext();
-
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
 
   jest
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -12,7 +12,7 @@ import * as UrlStateSelectors from '../../selectors/url-state';
 import * as ZippedProfileSelectors from '../../selectors/zipped-profiles';
 
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
-import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import {
   getBoundingBox,
   waitUntilState,
@@ -20,6 +20,8 @@ import {
 } from '../fixtures/utils';
 
 describe('calltree/ZipFileTree', function() {
+  autoMockCanvasContext();
+
   async function setup() {
     const { store } = await storeWithZipFile([
       'foo/bar/profile1.json',
@@ -28,11 +30,6 @@ describe('calltree/ZipFileTree', function() {
       // Use a file with a big depth to test the automatic expansion at load time.
       'boat/ship/new/anything/explore/yes/profile4.json',
     ]);
-
-    // Some child components render to canvas.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
 
     // This makes the bounding box large enough so that we don't trigger
     // VirtualList's virtualization.
@@ -128,14 +125,6 @@ describe('calltree/ZipFileTree', function() {
     });
 
     it('will show the ProfileViewer component when done processing', async () => {
-      // The full ProfileViewer component renders to a Canvas, which the jsdom API
-      // doesn't fully mock out.
-      jest
-        .spyOn(HTMLCanvasElement.prototype, 'getContext')
-        .mockImplementation(() => {
-          return mockCanvasContext();
-        });
-
       const {
         profileViewer,
         profile1OpenLink,

--- a/src/test/fixtures/mocks/canvas-context.js
+++ b/src/test/fixtures/mocks/canvas-context.js
@@ -6,7 +6,34 @@
 type MaybeFn = (any => any) | void;
 const identity = () => {};
 
-export default function mockCanvasContext() {
+export function autoMockCanvasContext() {
+  beforeEach(() => {
+    const ctx = mockCanvasContext();
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => ctx);
+
+    const anyWindow: any = window;
+    if (anyWindow.Path2D) {
+      throw new Error(
+        "This mock assumes Path2D isn't defined. Please fix this mock if this changes."
+      );
+    }
+    anyWindow.Path2D = MockPath2D;
+    anyWindow.__flushDrawLog = ctx.__flushDrawLog;
+  });
+
+  afterEach(() => {
+    delete (window: any).Path2D;
+    delete (window: any).__flushDrawLog;
+  });
+}
+
+export function flushDrawLog() {
+  return (window: any).__flushDrawLog();
+}
+
+function mockCanvasContext() {
   const log: Array<any> = [];
 
   /**
@@ -16,7 +43,19 @@ export default function mockCanvasContext() {
   function spyLog(name: string, fn: MaybeFn = identity) {
     // This function is extremely polymorphic and defies typing.
     return (jest.fn: any)((...args) => {
-      log.push([name, ...args]);
+      if (
+        (name === 'fill' || name === 'stroke') &&
+        args[0] instanceof MockPath2D
+      ) {
+        // This is a Path, so we'll insert operations so that everything looks
+        // like independent calls have been made.
+        const path = args[0];
+        log.push(['beginPath']);
+        log.push(...path.__operations);
+        log.push([name]);
+      } else {
+        log.push([name, ...args]);
+      }
       if (fn) {
         return fn(...args);
       }
@@ -24,7 +63,7 @@ export default function mockCanvasContext() {
     });
   }
 
-  return new Proxy(
+  const canvasContextInstance = new Proxy(
     {
       scale: spyLog('scale'),
       fill: spyLog('fill'),
@@ -57,4 +96,21 @@ export default function mockCanvasContext() {
       },
     }
   );
+
+  return canvasContextInstance;
+}
+
+// Only the function that we use so far are implemented here. Please add some
+// more when needed.
+class MockPath2D {
+  __operations = [];
+  moveTo(...args) {
+    this.__operations.push(['moveTo', ...args]);
+  }
+  lineTo(...args) {
+    this.__operations.push(['lineTo', ...args]);
+  }
+  arc(...args) {
+    this.__operations.push(['arc', ...args]);
+  }
 }


### PR DESCRIPTION
… mock for Path2D

In the patch for #3249 I make use of this object `Path2D` that we didn't implement in our canvas mock yet. So I did it in this separate PR.

I also simplified how to use the mock. Now we enable it using `autoMockCanvasContext()`, which registers `beforeEach` and `afterEach` functions. This was made necessary because I wanted to clean the new mock for `Path2D` after a test ends.
Therefore I also changed how we get the draw logs, I think it's also simpler now.

You should probably look at the file `canvas-context.js` first. Other changes are the updates to the test files to use the "new way".

I hope you'll like it!