### PR TITLE
Initialize the RegExp for removeURLs function outside of it

### DIFF
--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -63,7 +63,7 @@ export function sanitizePII(
     if (PIIToBeRemoved.shouldRemoveUrls) {
       pages = profile.pages.map((page, pageIndex) =>
         Object.assign({}, page, {
-          url: removeURLs(page.url, true, `<Page #${pageIndex}>`),
+          url: removeURLs(page.url, `<Page #${pageIndex}>`),
         })
       );
     } else {

--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -142,12 +142,9 @@ describe('utils/string', function() {
       expect(removeURLs(string)).toEqual('Image Load - moz-page-thumb://<URL>');
     });
 
-    it('should or should not remove moz-extension URLs depending on its parameter', () => {
-      let string = 'moz-extension://foo/bar/index.js';
+    it('should remove moz-extension URLs', () => {
+      const string = 'moz-extension://foo/bar/index.js';
       expect(removeURLs(string)).toEqual('moz-extension://<URL>');
-
-      string = 'moz-extension://foo/bar/index.js';
-      expect(removeURLs(string, false)).toEqual(string);
     });
   });
 

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -4,15 +4,10 @@
 
 // @flow
 
-/**
- * Takes a string and returns the string with public URLs removed.
- * It doesn't remove the URLs like `chrome://..` because they are internal URLs
- * and they shouldn't be removed.
- */
-export function removeURLs(
-  string: string,
-  redactedText: string = '<URL>'
-): string {
+// Initializing this RegExp outside of removeURLs because that function is in a
+// hot path during sanitization and it's good to avoid the initialization of the
+// RegExp which is costly.
+const REMOVE_URLS_REGEXP = (function() {
   const protocols = [
     'http',
     'https',
@@ -21,7 +16,8 @@ export function removeURLs(
     'moz-extension',
     'moz-page-thumb',
   ];
-  const regExp = new RegExp(
+
+  return new RegExp(
     `\\b((?:${protocols.join('|')})://)/?[^\\s/$.?#][^\\s)]*`,
     //    ^                              ^          ^
     //    |                              |          Matches any characters except
@@ -33,7 +29,18 @@ export function removeURLs(
     //    Matches URL schemes we need to sanitize.
     'gi'
   );
-  return string.replace(regExp, '$1' + redactedText);
+})();
+
+/**
+ * Takes a string and returns the string with public URLs removed.
+ * It doesn't remove the URLs like `chrome://..` because they are internal URLs
+ * and they shouldn't be removed.
+ */
+export function removeURLs(
+  string: string,
+  redactedText: string = '<URL>'
+): string {
+  return string.replace(REMOVE_URLS_REGEXP, '$1' + redactedText);
 }
 
 /**

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -11,13 +11,16 @@
  */
 export function removeURLs(
   string: string,
-  removeExtensions: boolean = true,
   redactedText: string = '<URL>'
 ): string {
-  const protocols = ['http', 'https', 'ftp', 'file', 'moz-page-thumb'];
-  if (removeExtensions) {
-    protocols.push('moz-extension');
-  }
+  const protocols = [
+    'http',
+    'https',
+    'ftp',
+    'file',
+    'moz-extension',
+    'moz-page-thumb',
+  ];
   const regExp = new RegExp(
     `\\b((?:${protocols.join('|')})://)/?[^\\s/$.?#][^\\s)]*`,
     //    ^                              ^          ^


### PR DESCRIPTION
Fixes #3274.
This PR memoizes the `RegExp` inside the removeURLs function and removes the unused `removeExtensions` parameter since we don't need it anymore.

[For testing the publishing without URLs](https://deploy-preview-3276--perf-html.netlify.app/public/7y9prh6xpezzmepgb2m8sz6sx5b82m9pa9c9ar8/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7&localTrackOrderByPid=68073-7-8-0-1-2-3-4-5-6~68078-0~68085-0~68084-0~68079-0~68075-0~68080-0~68076-0~&search=https&thread=14&timelineType=cpu-category&transforms=f-combined-01234PhPiWhWiPhWjWkWlWmWnxG6WpWqWrWsWtxG7xG8xG9xGaxGbxGcxGdxGexGfxCpxCqyOryOsyOtyOuyOvyP0yP1yP2yP3yP4yP5yP6yP7yP6yP8yP6yP9yPayP6yP9yPayP6yP9yPayP6yP9yPayP6yPcyP6yP9yPayP6yP9yPayP6yP9yPayP6yP9yPayP6yPdyP6yP9yPayP6yP9yPayP6yP9yPayP6yP9yPayP6yPdyP6yP9yPayP6yP9yPayP6yP9yPayP6yP7yP6yP9yPayP6yP3yP9yPfyPgyPhyPiyPjyPkyPlyPmyPnyPoyPp&v=5)