### PR TITLE
Handle the call node transform shortcuts also when the context menu is open

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -233,14 +233,21 @@ class CallTreeImpl extends PureComponent<Props> {
     );
   };
 
-  _onKeyDown = (
-    event: SyntheticKeyboardEvent<>,
-    callNodeIndex: IndexIntoCallNodeTable | null
-  ) => {
-    if (callNodeIndex !== null) {
-      const { handleCallNodeTransformShortcut, threadsKey } = this.props;
-      handleCallNodeTransformShortcut(event, threadsKey, callNodeIndex);
+  _onKeyDown = (event: SyntheticKeyboardEvent<>) => {
+    const {
+      selectedCallNodeIndex,
+      rightClickedCallNodeIndex,
+      handleCallNodeTransformShortcut,
+      threadsKey,
+    } = this.props;
+    const nodeIndex =
+      rightClickedCallNodeIndex !== null
+        ? rightClickedCallNodeIndex
+        : selectedCallNodeIndex;
+    if (nodeIndex === null) {
+      return;
     }
+    handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
   };
 
   procureInterestingInitialSelection() {

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -362,7 +362,7 @@ type TreeViewProps<DisplayData> = {|
   +onEnterKey?: NodeIndex => mixed,
   +rowHeight: CssPixels,
   +indentWidth: CssPixels,
-  +onKeyDown?: (SyntheticKeyboardEvent<>, null | NodeIndex) => void,
+  +onKeyDown?: (SyntheticKeyboardEvent<>) => void,
 |};
 
 export class TreeView<DisplayData: Object> extends React.PureComponent<
@@ -580,7 +580,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
 
   _onKeyDown = (event: SyntheticKeyboardEvent<>) => {
     if (this.props.onKeyDown) {
-      this.props.onKeyDown(event, this.props.selectedNodeId);
+      this.props.onKeyDown(event);
     }
 
     const hasModifier = event.ctrlKey || event.altKey;

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -141,12 +141,18 @@ class StackChartImpl extends React.PureComponent<Props> {
     const {
       threadsKey,
       selectedCallNodeIndex,
+      rightClickedCallNodeIndex,
       handleCallNodeTransformShortcut,
     } = this.props;
-    if (selectedCallNodeIndex === null) {
+
+    const nodeIndex =
+      rightClickedCallNodeIndex !== null
+        ? rightClickedCallNodeIndex
+        : selectedCallNodeIndex;
+    if (nodeIndex === null) {
       return;
     }
-    handleCallNodeTransformShortcut(event, threadsKey, selectedCallNodeIndex);
+    handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
   };
 
   componentDidMount() {

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -15,6 +15,7 @@ import { selectedThreadSelectors } from 'firefox-profiler/selectors';
 import { ensureExists } from '../../utils/flow';
 import { fireFullKeyPress } from '../fixtures/utils';
 import { ProfileCallTreeView } from '../../components/calltree/ProfileCallTreeView';
+import { StackChart } from 'firefox-profiler/components/stack-chart';
 import type {
   Transform,
   CallNodePath,
@@ -198,6 +199,28 @@ describe('CallTree transform shortcuts', () => {
       // take either a key as a string, or a full event if we need more
       // information like modifier keys.
       pressKey: pressKeyBuilder('treeViewBody'),
+      expectedCallNodePath: [A, B],
+      expectedFuncIndex: B,
+      expectedResourceIndex: 0,
+    };
+  });
+});
+
+describe('stack chart transform shortcuts', () => {
+  testTransformKeyboardShortcuts(() => {
+    const {
+      dispatch,
+      funcNames: { A, B },
+      getTransform,
+    } = setupStore(<StackChart />);
+
+    dispatch(changeSelectedCallNode(0, [A, B]));
+
+    return {
+      getTransform,
+      // take either a key as a string, or a full event if we need more
+      // information like modifier keys.
+      pressKey: pressKeyBuilder('stackChartContent'),
       expectedCallNodePath: [A, B],
       expectedFuncIndex: B,
       expectedResourceIndex: 0,

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -617,7 +617,7 @@ function _parseTextSamples(textSamples: string): Array<string[]> {
     )
   );
 
-  // Transpose the table to go from rows to columns.
+  // Transpose the table to go from columns to rows.
   return columnPositions.map((_, columnIndex) => {
     const column = [];
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -251,7 +251,7 @@ export type TransformDefinitions = {
    *      ↓
    *      C
    */
-  'collapse-direction-recursion': {|
+  'collapse-direct-recursion': {|
     +type: 'collapse-direct-recursion',
     +funcIndex: IndexIntoFuncTable,
     +implementation: ImplementationFilter,


### PR DESCRIPTION
I found it a bit weird that when the context menu is open, and so the shortcuts are displayed, that's the only moment they don't work :-)

Now they should work with the context menu open, in panels call tree / stack chart / flame graph.

[production](https://profiler.firefox.com/public/52d5d452191340ab79ac92b519bcac4479fc3ab9/flame-graph/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=19719-1-0~19908-0~&thread=4&v=5) / [deploy preview](https://deploy-preview-3294--perf-html.netlify.app/public/52d5d452191340ab79ac92b519bcac4479fc3ab9/flame-graph/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=19719-1-0~19908-0~&thread=4&v=5)

I changed the tests quite a lot, so it should be easier to look at the changes commit by commit, and possibly without whitespace changes:
* commit 1: the actually app code change
* commit 2: change how the tests are architectured, to make it easier to add a test for a 3rd panel (currently there are tests for 2 panels only)
* commit 3: add the tests for the stack chart, following #3268. (the real reason I worked on this initially 🤓)
* commit 4: add the tests for this code change