### PR TITLE
Fix a few issues around the memory allocation feature

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -498,8 +498,8 @@ StackSettings--implementation-all-stacks = All stacks
 StackSettings--implementation-javascript = JavaScript
 StackSettings--implementation-native = Native
 
-StackSettings--summarize = Summarize:
-StackSettings--call-tree-strategy-timing = Timing Data
+StackSettings--use-data-source-label = Data source:
+StackSettings--call-tree-strategy-timing = Timings
     .title = Summarize using sampled stacks of executed code over time
 StackSettings--call-tree-strategy-js-allocations = JavaScript Allocations
     .title = Summarize using bytes of JavaScript allocated (no de-allocations)

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -160,7 +160,7 @@ class StackSettingsImpl extends PureComponent<Props> {
           {hasAllocations ? (
             <li className="stackSettingsListItem stackSettingsFilter">
               <label>
-                <Localized id="StackSettings--summarize">Summarize:</Localized>{' '}
+                <Localized id="StackSettings--use-data-source-label" />{' '}
                 <select
                   className="stackSettingsSelect"
                   onChange={this._onCallTreeSummaryStrategyChange}

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -41,7 +41,6 @@ import type {
 
 type OwnProps = {|
   +hideInvertCallstack?: true,
-  +disableCallTreeSummaryButtons?: true,
 |};
 
 type StateProps = {|
@@ -136,7 +135,6 @@ class StackSettingsImpl extends PureComponent<Props> {
       hasJsAllocations,
       hasNativeAllocations,
       canShowRetainedMemory,
-      disableCallTreeSummaryButtons,
       callTreeSummaryStrategy,
     } = this.props;
 
@@ -159,7 +157,7 @@ class StackSettingsImpl extends PureComponent<Props> {
               'cpp'
             )}
           </li>
-          {hasAllocations && !disableCallTreeSummaryButtons ? (
+          {hasAllocations ? (
             <li className="stackSettingsListItem stackSettingsFilter">
               <label>
                 <Localized id="StackSettings--summarize">Summarize:</Localized>{' '}

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -190,7 +190,7 @@ class StackChartImpl extends React.PureComponent<Props> {
         aria-labelledby="stack-chart-tab-button"
         onKeyDown={this._handleKeyDown}
       >
-        <StackSettings disableCallTreeSummaryButtons={true} />
+        <StackSettings />
         <TransformNavigator />
         {maxStackDepth === 0 && userTimings.length === 0 ? (
           <StackChartEmptyReasons />

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -4,7 +4,7 @@
 
 // @flow
 import type {
-  Thread,
+  SamplesLikeTable,
   Milliseconds,
   CallNodeInfo,
   CallNodeTable,
@@ -66,7 +66,7 @@ type LastSeen = {
  * Build a StackTimingByDepth table from a given thread.
  */
 export function getStackTimingByDepth(
-  thread: Thread,
+  samples: SamplesLikeTable,
   callNodeInfo: CallNodeInfo,
   maxDepth: number,
   interval: Milliseconds
@@ -87,9 +87,9 @@ export function getStackTimingByDepth(
   // Go through each sample, and push/pop it on the stack to build up
   // the stackTimingByDepth.
   let previousDepth = -1;
-  for (let i = 0; i < thread.samples.length; i++) {
-    const stackIndex = thread.samples.stack[i];
-    const sampleTime = thread.samples.time[i];
+  for (let i = 0; i < samples.length; i++) {
+    const stackIndex = samples.stack[i];
+    const sampleTime = samples.time[i];
 
     // If this stack index is null (for instance if it was filtered out) then pop back
     // down to the base stack.
@@ -114,21 +114,14 @@ export function getStackTimingByDepth(
         previousDepth,
         sampleTime
       );
-      _pushStacks(
-        thread,
-        callNodeTable,
-        lastSeen,
-        depth,
-        callNodeIndex,
-        sampleTime
-      );
+      _pushStacks(callNodeTable, lastSeen, depth, callNodeIndex, sampleTime);
       previousDepth = depth;
     }
   }
 
   // Pop the remaining stacks
-  const lastIndex = thread.samples.length - 1;
-  const endingTime = thread.samples.time[lastIndex] + interval;
+  const lastIndex = samples.length - 1;
+  const endingTime = samples.time[lastIndex] + interval;
   _popStacks(stackTimingByDepth, lastSeen, -1, previousDepth, endingTime);
 
   return stackTimingByDepth;
@@ -176,7 +169,6 @@ function _popStacks(
 }
 
 function _pushStacks(
-  thread: Thread,
   callNodeTable: CallNodeTable,
   lastSeen: LastSeen,
   depth: number,

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -217,7 +217,7 @@ export function getStackAndSampleSelectorsPerThread(
   );
 
   const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> = createSelector(
-    threadSelectors.getFilteredThread,
+    threadSelectors.getFilteredSamplesForCallTree,
     getCallNodeInfo,
     getFilteredCallNodeMaxDepth,
     ProfileSelectors.getProfileInterval,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -9,9 +9,15 @@ import MixedTupleMap from 'mixedtuplemap';
 import * as Transforms from '../../profile-logic/transforms';
 import * as UrlState from '../url-state';
 import * as ProfileData from '../../profile-logic/profile-data';
+import * as CallTree from '../../profile-logic/call-tree';
 import * as ProfileSelectors from '../profile';
 import * as JsTracer from '../../profile-logic/js-tracer';
 import * as Cpu from '../../profile-logic/cpu';
+import {
+  assertExhaustiveCheck,
+  ensureExists,
+  getFirstItemFromSet,
+} from '../../utils/flow';
 
 import type {
   Thread,
@@ -19,6 +25,7 @@ import type {
   JsTracerTable,
   SamplesTable,
   NativeAllocationsTable,
+  SamplesLikeTable,
   Selector,
   ThreadViewOptions,
   TransformStack,
@@ -28,10 +35,11 @@ import type {
   WeightType,
   EventDelayInfo,
   ThreadsKey,
+  CallTreeSummaryStrategy,
 } from 'firefox-profiler/types';
 
 import type { UniqueStringArray } from '../../utils/unique-string-array';
-import { ensureExists, getFirstItemFromSet } from '../../utils/flow';
+
 import { mergeThreads } from '../../profile-logic/merge-compare';
 import { defaultThreadViewOptions } from '../../reducers/profile-view';
 
@@ -222,6 +230,64 @@ export function getThreadSelectorsPerThread(
   );
 
   /**
+   * The CallTreeSummaryStrategy determines how the call tree summarizes the
+   * the current thread. By default, this is done by timing, but other
+   * methods are also available. This selectors also ensures that the current
+   * thread supports the last selected call tree summary strategy.
+   */
+  const getCallTreeSummaryStrategy: Selector<CallTreeSummaryStrategy> = createSelector(
+    getThread,
+    UrlState.getLastSelectedCallTreeSummaryStrategy,
+    (thread, lastSelectedCallTreeSummaryStrategy) => {
+      switch (lastSelectedCallTreeSummaryStrategy) {
+        case 'timing':
+          // Timing is valid everywhere.
+          break;
+        case 'js-allocations':
+          if (!thread.jsAllocations) {
+            // Attempting to view a thread with no JS allocations, switch back to timing.
+            return 'timing';
+          }
+          break;
+        case 'native-allocations':
+        case 'native-retained-allocations':
+        case 'native-deallocations-sites':
+        case 'native-deallocations-memory':
+          if (!thread.nativeAllocations) {
+            // Attempting to view a thread with no native allocations, switch back
+            // to timing.
+            return 'timing';
+          }
+          break;
+        default:
+          assertExhaustiveCheck(
+            lastSelectedCallTreeSummaryStrategy,
+            'Unhandled call tree sumary strategy.'
+          );
+      }
+      return lastSelectedCallTreeSummaryStrategy;
+    }
+  );
+
+  const getUnfilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
+    getThread,
+    getCallTreeSummaryStrategy,
+    CallTree.extractSamplesLikeTable
+  );
+
+  const getFilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
+    getFilteredThread,
+    getCallTreeSummaryStrategy,
+    CallTree.extractSamplesLikeTable
+  );
+
+  const getPreviewFilteredSamplesForCallTree: Selector<SamplesLikeTable> = createSelector(
+    getPreviewFilteredThread,
+    getCallTreeSummaryStrategy,
+    CallTree.extractSamplesLikeTable
+  );
+
+  /**
    * This selector returns the offset to add to a sampleIndex when accessing the
    * base thread, if your thread is a range filtered thread (all but the base
    * `getThread` or the last `getPreviewFilteredThread`).
@@ -374,6 +440,9 @@ export function getThreadSelectorsPerThread(
     getRangeFilteredThread,
     getRangeAndTransformFilteredThread,
     getPreviewFilteredThread,
+    getUnfilteredSamplesForCallTree,
+    getFilteredSamplesForCallTree,
+    getPreviewFilteredSamplesForCallTree,
     getSampleIndexOffsetFromCommittedRange,
     getSampleIndexOffsetFromPreviewRange,
     getFriendlyThreadName,
@@ -391,5 +460,6 @@ export function getThreadSelectorsPerThread(
     getTabFilteredThread,
     getActiveTabFilteredThread,
     getProcessedEventDelays,
+    getCallTreeSummaryStrategy,
   };
 }

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -293,9 +293,9 @@ export function getThreadSelectorsPerThread(
    * `getThread` or the last `getPreviewFilteredThread`).
    */
   const getSampleIndexOffsetFromCommittedRange: Selector<number> = createSelector(
-    getThread,
+    getUnfilteredSamplesForCallTree,
     ProfileSelectors.getCommittedRange,
-    ({ samples }, { start, end }) => {
+    (samples, { start, end }) => {
       const [beginSampleIndex] = ProfileData.getSampleIndexRangeForSelection(
         samples,
         start,
@@ -310,10 +310,10 @@ export function getThreadSelectorsPerThread(
    * base thread, if your thread is the preview filtered thread.
    */
   const getSampleIndexOffsetFromPreviewRange: Selector<number> = createSelector(
-    getFilteredThread,
+    getFilteredSamplesForCallTree,
     ProfileSelectors.getPreviewSelection,
     getSampleIndexOffsetFromCommittedRange,
-    ({ samples }, previewSelection, sampleIndexFromCommittedRange) => {
+    (samples, previewSelection, sampleIndexFromCommittedRange) => {
       if (!previewSelection.hasSelection) {
         return sampleIndexFromCommittedRange;
       }

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -505,13 +505,13 @@ describe('ProfileCallTreeView with JS Allocations', function() {
     ).toEqual('timing');
 
     // It switches to JS allocations.
-    changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
+    changeSelect({ from: 'Timings', to: 'JavaScript Allocations' });
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('js-allocations');
 
     // And finally it can be switched back.
-    changeSelect({ from: 'JavaScript Allocations', to: 'Timing Data' });
+    changeSelect({ from: 'JavaScript Allocations', to: 'Timings' });
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('timing');
@@ -524,7 +524,7 @@ describe('ProfileCallTreeView with JS Allocations', function() {
     expect(queryByText('Total Size (bytes)')).not.toBeInTheDocument();
     expect(queryByText('Self (bytes)')).not.toBeInTheDocument();
 
-    changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
+    changeSelect({ from: 'Timings', to: 'JavaScript Allocations' });
 
     // After clicking, they do.
     expect(getByText('Total Size (bytes)')).toBeTruthy();
@@ -533,7 +533,7 @@ describe('ProfileCallTreeView with JS Allocations', function() {
 
   it('matches the snapshot for JS allocations', function() {
     const { container } = setup();
-    changeSelect({ from: 'Timing Data', to: 'JavaScript Allocations' });
+    changeSelect({ from: 'Timings', to: 'JavaScript Allocations' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });
@@ -560,14 +560,14 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
     ).toEqual('timing');
 
     // Switch to native allocations.
-    changeSelect({ from: 'Timing Data', to: 'Allocated Memory' });
+    changeSelect({ from: 'Timings', to: 'Allocated Memory' });
 
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('native-allocations');
 
     // And finally it can be switched back.
-    changeSelect({ from: 'Allocated Memory', to: 'Timing Data' });
+    changeSelect({ from: 'Allocated Memory', to: 'Timings' });
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('timing');
@@ -580,7 +580,7 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
     expect(queryByText('Total Size (bytes)')).not.toBeInTheDocument();
     expect(queryByText('Self (bytes)')).not.toBeInTheDocument();
 
-    changeSelect({ from: 'Timing Data', to: 'Allocated Memory' });
+    changeSelect({ from: 'Timings', to: 'Allocated Memory' });
 
     // After changing to native allocations, they do.
     expect(getByText('Total Size (bytes)')).toBeTruthy();
@@ -594,13 +594,13 @@ describe('ProfileCallTreeView with unbalanced native allocations', function() {
 
   it('matches the snapshot for native allocations', function() {
     const { container } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Allocated Memory' });
+    changeSelect({ from: 'Timings', to: 'Allocated Memory' });
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('matches the snapshot for native deallocations', function() {
     const { container } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Deallocation Sites' });
+    changeSelect({ from: 'Timings', to: 'Deallocation Sites' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });
@@ -627,14 +627,14 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     ).toEqual('timing');
 
     // Switch to retained memory native allocations.
-    changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
+    changeSelect({ from: 'Timings', to: 'Retained Memory' });
 
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('native-retained-allocations');
 
     // And finally it can be switched back.
-    changeSelect({ from: 'Retained Memory', to: 'Timing Data' });
+    changeSelect({ from: 'Retained Memory', to: 'Timings' });
     expect(
       selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
     ).toEqual('timing');
@@ -647,7 +647,7 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
     expect(queryByText('Total Size (bytes)')).not.toBeInTheDocument();
     expect(queryByText('Self (bytes)')).not.toBeInTheDocument();
 
-    changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
+    changeSelect({ from: 'Timings', to: 'Retained Memory' });
 
     // After changing to retained allocations, they do.
     expect(getByText('Total Size (bytes)')).toBeTruthy();
@@ -656,13 +656,13 @@ describe('ProfileCallTreeView with balanced native allocations', function() {
 
   it('matches the snapshot for retained allocations', function() {
     const { container } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Retained Memory' });
+    changeSelect({ from: 'Timings', to: 'Retained Memory' });
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('matches the snapshot for deallocated memory', function() {
     const { container } = setup();
-    changeSelect({ from: 'Timing Data', to: 'Deallocated Memory' });
+    changeSelect({ from: 'Timings', to: 'Deallocated Memory' });
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -2565,8 +2565,8 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="colored-square category-color-yellow"
-                  title="JavaScript"
+                  class="colored-square category-color-purple"
+                  title="Layout"
                 />
                 <span
                   class="treeViewRowColumn treeViewMainColumn name"
@@ -2807,7 +2807,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 96px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -2884,15 +2884,15 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="-73%"
+                  title="-59%"
                 >
-                  -73%
+                  -59%
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn total"
-                  title="-30"
+                  title="-24"
                 >
-                  -30
+                  -24
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
@@ -2915,21 +2915,21 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="-73%"
+                  title="-41%"
                 >
-                  -73%
+                  -41%
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn total"
-                  title="-30"
+                  title="-17"
                 >
-                  -30
+                  -17
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  title="-13"
+                  title="—"
                 >
-                  -13
+                  —
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -2958,71 +2958,9 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns odd isSelected"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="-41%"
-                >
-                  -41%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
                   title="-17"
                 >
                   -17
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="-17"
-                >
-                  -17
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns even"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="-27%"
-                >
-                  -27%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="-11"
-                >
-                  -11
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -3037,7 +2975,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 96px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -3107,11 +3045,41 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 />
               </div>
               <div
-                aria-expanded="true"
-                aria-label="Fjs, total size is -30 bytes (-73%), self size is 0 bytes"
+                aria-expanded="false"
+                aria-label="C, total size is -24 bytes (-59%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="Fjs, total size is -17 bytes (-41%), self size is 0 bytes"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3137,11 +3105,10 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                 />
               </div>
               <div
-                aria-expanded="true"
-                aria-label="Gjs, total size is -30 bytes (-73%), self size is -13 bytes"
+                aria-label="Gjs, total size is -17 bytes (-41%), self size is -17 bytes"
                 aria-level="4"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
+                class="treeViewRow treeViewRowScrolledColumns even"
                 id="treeViewRow-6"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -3151,7 +3118,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton expanded canBeExpanded"
+                  class="treeRowToggleButton collapsed leaf"
                 />
                 <span
                   class="colored-square category-color-yellow"
@@ -3161,99 +3128,6 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   Gjs
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-expanded="true"
-                aria-label="Hjs, total size is -17 bytes (-41%), self size is 0 bytes"
-                aria-level="5"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
-                id="treeViewRow-7"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 40px;"
-                />
-                <span
-                  class="treeRowToggleButton expanded canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-yellow"
-                  title="JavaScript"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name"
-                >
-                  Hjs
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                >
-                  jQuery.js
-                </span>
-              </div>
-              <div
-                aria-label="I, total size is -17 bytes (-41%), self size is -17 bytes"
-                aria-level="6"
-                aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
-                id="treeViewRow-8"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 50px;"
-                />
-                <span
-                  class="treeRowToggleButton collapsed leaf"
-                />
-                <span
-                  class="colored-square category-color-yellow"
-                  title="JavaScript"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name"
-                >
-                  I
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                >
-                  libI.so
-                </span>
-              </div>
-              <div
-                aria-expanded="false"
-                aria-label="C, total size is -11 bytes (-27%), self size is 0 bytes"
-                aria-level="3"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
-                id="treeViewRow-2"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 20px;"
-                />
-                <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  C
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -845,7 +845,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 64px;"
+            style="height: 128px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -872,9 +872,71 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  title="-3"
+                  title="—"
                 >
-                  -3
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-100%"
+                >
+                  -100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-15"
+                >
+                  -15
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-80%"
+                >
+                  -80%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-12"
+                >
+                  -12
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -934,9 +996,71 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-47%"
+                >
+                  -47%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
                   title="-7"
                 >
                   -7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="-7"
+                >
+                  -7
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-20%"
+                >
+                  -20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-3"
+                >
+                  -3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -951,7 +1075,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 64px; min-width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -962,7 +1086,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             >
               <div
                 aria-expanded="true"
-                aria-label="A, total size is -15 bytes (-100%), self size is -3 bytes"
+                aria-label="A, total size is -15 bytes (-100%), self size is 0 bytes"
                 aria-level="1"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns even"
@@ -992,7 +1116,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
               </div>
               <div
                 aria-expanded="true"
-                aria-label="B, total size is -12 bytes (-80%), self size is -5 bytes"
+                aria-label="B, total size is -15 bytes (-100%), self size is 0 bytes"
                 aria-level="2"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns odd"
@@ -1021,7 +1145,131 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                 />
               </div>
               <div
-                aria-label="C, total size is -7 bytes (-47%), self size is -7 bytes"
+                aria-expanded="true"
+                aria-label="Fjs, total size is -12 bytes (-80%), self size is 0 bytes"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-yellow"
+                  title="JavaScript"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  Fjs
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="Gjs, total size is -12 bytes (-80%), self size is -5 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-yellow"
+                  title="JavaScript"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  Gjs
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="Hjs, total size is -7 bytes (-47%), self size is 0 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-7"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-yellow"
+                  title="JavaScript"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  Hjs
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  jQuery.js
+                </span>
+              </div>
+              <div
+                aria-label="I, total size is -7 bytes (-47%), self size is -7 bytes"
+                aria-level="6"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
+                id="treeViewRow-8"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 50px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-yellow"
+                  title="JavaScript"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  I
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  libI.so
+                </span>
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="C, total size is -3 bytes (-20%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns even"
@@ -1034,7 +1282,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed leaf"
+                  class="treeRowToggleButton collapsed canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -58,7 +58,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
         class="stackSettingsListItem stackSettingsFilter"
       >
         <label>
-          Summarize:
+          Data source:
            
           <select
             class="stackSettingsSelect"
@@ -67,7 +67,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
-              Timing Data
+              Timings
             </option>
             <option
               title="Summarize using bytes of JavaScript allocated (no de-allocations)"
@@ -702,7 +702,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         class="stackSettingsListItem stackSettingsFilter"
       >
         <label>
-          Summarize:
+          Data source:
            
           <select
             class="stackSettingsSelect"
@@ -711,7 +711,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
-              Timing Data
+              Timings
             </option>
             <option
               title="Summarize using bytes of memory that were allocated, and never freed in the current preview selection"
@@ -1364,7 +1364,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         class="stackSettingsListItem stackSettingsFilter"
       >
         <label>
-          Summarize:
+          Data source:
            
           <select
             class="stackSettingsSelect"
@@ -1373,7 +1373,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
-              Timing Data
+              Timings
             </option>
             <option
               title="Summarize using bytes of memory that were allocated, and never freed in the current preview selection"
@@ -2026,7 +2026,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         class="stackSettingsListItem stackSettingsFilter"
       >
         <label>
-          Summarize:
+          Data source:
            
           <select
             class="stackSettingsSelect"
@@ -2035,7 +2035,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
-              Timing Data
+              Timings
             </option>
             <option
               title="Summarize using bytes of memory allocated"
@@ -2676,7 +2676,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         class="stackSettingsListItem stackSettingsFilter"
       >
         <label>
-          Summarize:
+          Data source:
            
           <select
             class="stackSettingsSelect"
@@ -2685,7 +2685,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
               title="Summarize using sampled stacks of executed code over time"
               value="timing"
             >
-              Timing Data
+              Timings
             </option>
             <option
               title="Summarize using bytes of memory allocated"

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1382,38 +1382,35 @@ describe('transform native deallocations', function() {
     ).toEqual([
       '- A (total: -41, self: —)',
       '  - B (total: -41, self: —)',
-      '    - Fjs (total: -30, self: —)',
-      '      - Gjs (total: -30, self: -13)',
-      '        - Hjs (total: -17, self: —)',
-      '          - I (total: -17, self: -17)',
-      '    - C (total: -11, self: —)',
-      '      - D (total: -11, self: —)',
-      '        - E (total: -11, self: -11)',
+      '    - C (total: -24, self: —)',
+      '      - J (total: -24, self: -11)',
+      '        - K (total: -13, self: -13)',
+      '    - Fjs (total: -17, self: —)',
+      '      - Gjs (total: -17, self: -17)',
     ]);
   });
 
   it('is modified when performing a transform to the stacks', function() {
     const {
       profile,
-      funcNamesDict: { Fjs },
+      funcNamesDict: { J },
     } = getProfileWithUnbalancedNativeAllocations();
     const { dispatch, getState } = storeWithProfile(profile);
     dispatch(changeCallTreeSummaryStrategy('native-deallocations-sites'));
     dispatch(
       addTransformToStack(threadIndex, {
         type: 'focus-function',
-        funcIndex: Fjs,
+        funcIndex: J,
       })
     );
 
-    expect(
-      formatTree(selectedThreadSelectors.getCallTree(getState()))
-    ).toEqual([
-      '- Fjs (total: -30, self: —)',
-      '  - Gjs (total: -30, self: -13)',
-      '    - Hjs (total: -17, self: —)',
-      '      - I (total: -17, self: -17)',
-    ]);
+    expect(formatTree(selectedThreadSelectors.getCallTree(getState()))).toEqual(
+      [
+        // This comment so that prettier doesn't reformat this array.
+        '- J (total: -24, self: -11)',
+        '  - K (total: -13, self: -13)',
+      ]
+    );
   });
 });
 

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -134,13 +134,11 @@ describe('Native allocation call trees', function() {
       expect(formatTree(callTree)).toEqual([
         '- A (total: -41, self: —)',
         '  - B (total: -41, self: —)',
-        '    - Fjs (total: -30, self: —)',
-        '      - Gjs (total: -30, self: -13)',
-        '        - Hjs (total: -17, self: —)',
-        '          - I (total: -17, self: -17)',
-        '    - C (total: -11, self: —)',
-        '      - D (total: -11, self: —)',
-        '        - E (total: -11, self: -11)',
+        '    - C (total: -24, self: —)',
+        '      - J (total: -24, self: -11)',
+        '        - K (total: -13, self: -13)',
+        '    - Fjs (total: -17, self: —)',
+        '      - Gjs (total: -17, self: -17)',
       ]);
     });
 

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -79,9 +79,15 @@ describe('Native allocation call trees', function() {
       const callTree = selectedThreadSelectors.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
-        '- A (total: -15, self: -3)',
-        '  - B (total: -12, self: -5)',
-        '    - C (total: -7, self: -7)',
+        '- A (total: -15, self: —)',
+        '  - B (total: -15, self: —)',
+        '    - Fjs (total: -12, self: —)',
+        '      - Gjs (total: -12, self: -5)',
+        '        - Hjs (total: -7, self: —)',
+        '          - I (total: -7, self: -7)',
+        '    - C (total: -3, self: —)',
+        '      - D (total: -3, self: —)',
+        '        - E (total: -3, self: -3)',
       ]);
     });
 

--- a/src/test/unit/native-allocations.test.js
+++ b/src/test/unit/native-allocations.test.js
@@ -62,15 +62,17 @@ describe('Native allocation call trees', function() {
       const callTree = selectedThreadSelectors.getCallTree(getState());
 
       expect(formatTree(callTree)).toEqual([
-        '- A (total: -86, self: —)',
-        '  - B (total: -86, self: —)',
-        '    - Fjs (total: -64, self: —)',
-        '      - Gjs (total: -64, self: -28)',
-        '        - Hjs (total: -36, self: —)',
-        '          - I (total: -36, self: -36)',
-        '    - C (total: -22, self: —)',
-        '      - D (total: -22, self: —)',
-        '        - E (total: -22, self: -22)',
+        '- A (total: -89, self: —)',
+        '  - B (total: -89, self: —)',
+        '    - Fjs (total: -59, self: —)',
+        '      - Gjs (total: -59, self: -30)',
+        '        - Hjs (total: -29, self: —)',
+        '          - I (total: -29, self: -29)',
+        '    - C (total: -30, self: —)',
+        '      - D (total: -19, self: —)',
+        '        - E (total: -19, self: -19)',
+        '      - J (total: -11, self: -6)',
+        '        - K (total: -5, self: -5)',
       ]);
     });
 


### PR DESCRIPTION
This fixes a few things around the memory allocation feature.

I started looking at this with #3302, and that's how I found some problems with the current code.

Look at these cases:
* call tree in "deallocated memory" mode: [production](https://profiler.firefox.com/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/calltree/?ctSummary=native-deallocations-sites&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&implementation=js&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&thread=14&timelineType=cpu-category&v=5) (this just hangs) / [deploy preview](https://deploy-preview-3308--perf-html.netlify.app/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/calltree/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&implementation=js&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&thread=14&timelineType=cpu-category&v=5)
* call tree in "deallocated memory" mode again: [production](https://profiler.firefox.com/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/calltree/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&invertCallstack&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&thread=14&timelineType=cpu-category&v=5) / [deploy preview](https://deploy-preview-3308--perf-html.netlify.app/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/calltree/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&invertCallstack&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&thread=14&timelineType=cpu-category&v=5) <= these are inverted views, so the top level nodes should be the ones that allocated the most, but this doesn't make any sense in production, whereas it makes a lot of sense in the deploy preview. (remember this shows the allocation site for the deallocated memory)
* stack chart: [production](https://profiler.firefox.com/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/stack-chart/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&invertCallstack&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&thread=14&timelineType=cpu-category&v=5) is just broken / [deploy preview](https://deploy-preview-3308--perf-html.netlify.app/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/stack-chart/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&invertCallstack&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&thread=14&timelineType=cpu-category&v=5) just works (this was broken for __all__ memory data)
* call tree with a range: [production](https://profiler.firefox.com/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/calltree/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&invertCallstack&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&range=11462m3172&thread=14&timelineType=cpu-category&v=5) is broken / [deploy preview](https://deploy-preview-3308--perf-html.netlify.app/public/1d3ekymrdk1b2qkwe2gyvn9mzwdmamkkqvw35v8/calltree/?ctSummary=native-deallocations-memory&globalTrackOrder=0-1-2-3-4-5-6-7-8-9&hiddenGlobalTracks=1-2-3-4-5-6-8&hiddenLocalTracksByPid=31597-0-2-4-6~32136-0&invertCallstack&localTrackOrderByPid=31597-7-8-0-1-2-3-4-5-6~20939-0~31653-0~11801-0~31835-0~12044-0~31844-0~31742-0~32136-1-0~4276-0-1~&range=11462m3172&thread=14&timelineType=cpu-category&v=5) just works (this was broken for **all** memory data)

I also added the select box in the stack chart because this also affects this view, and I changed a few labels:
before: ![image](https://user-images.githubusercontent.com/454175/117059785-72b5ae00-ad20-11eb-9378-eb0bd3d21518.png)
after: ![image](https://user-images.githubusercontent.com/454175/117059495-266a6e00-ad20-11eb-9542-602a07374518.png)

Please look at individual commits!

Fixes #3302