### PR TITLE
Fix the rendering issues related to the first sample in activity graph

### DIFF
--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -25,7 +25,7 @@ type CPUProps = CpuRatioInTimeRange;
 type RestProps = {|
   +sampleIndex: IndexIntoSamplesTable,
   +categories: CategoryList,
-  +fullThread: Thread,
+  +rangeFilteredThread: Thread,
 |};
 
 type Props = {|
@@ -61,8 +61,8 @@ class SampleTooltipCPUContents extends React.PureComponent<CPUProps> {
  */
 class SampleTooltipRestContents extends React.PureComponent<RestProps> {
   render() {
-    const { sampleIndex, fullThread, categories } = this.props;
-    const { samples, stackTable } = fullThread;
+    const { sampleIndex, rangeFilteredThread, categories } = this.props;
+    const { samples, stackTable } = rangeFilteredThread;
     const stackIndex = samples.stack[sampleIndex];
     if (stackIndex === null) {
       return 'No stack information';
@@ -88,7 +88,7 @@ class SampleTooltipRestContents extends React.PureComponent<RestProps> {
         <Backtrace
           maxStacks={20}
           stackIndex={stackIndex}
-          thread={fullThread}
+          thread={rangeFilteredThread}
           implementationFilter="combined"
           categories={categories}
         />
@@ -106,7 +106,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
     const {
       cpuRatioInTimeRange,
       sampleIndex,
-      fullThread,
+      rangeFilteredThread,
       categories,
     } = this.props;
     return (
@@ -119,7 +119,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
         )}
         <SampleTooltipRestContents
           sampleIndex={sampleIndex}
-          fullThread={fullThread}
+          rangeFilteredThread={rangeFilteredThread}
           categories={categories}
         />
       </>

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -30,7 +30,7 @@ import type {
 export type Props = {|
   +className: string,
   +trackName: string,
-  +fullThread: Thread,
+  +rangeFilteredThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -149,7 +149,7 @@ export class ThreadActivityGraph extends React.PureComponent<Props, State> {
 
   render() {
     const {
-      fullThread,
+      rangeFilteredThread,
       categories,
       trackName,
       interval,
@@ -174,7 +174,7 @@ export class ThreadActivityGraph extends React.PureComponent<Props, State> {
             'threadActivityGraphCanvas'
           )}
           trackName={trackName}
-          fullThread={fullThread}
+          rangeFilteredThread={rangeFilteredThread}
           interval={interval}
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
@@ -191,7 +191,7 @@ export class ThreadActivityGraph extends React.PureComponent<Props, State> {
             <SampleTooltipContents
               sampleIndex={hoveredPixelState.sample}
               cpuRatioInTimeRange={hoveredPixelState.cpuRatioInTimeRange}
-              fullThread={fullThread}
+              rangeFilteredThread={rangeFilteredThread}
               categories={categories}
             />
           </Tooltip>

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -30,10 +30,12 @@ import type {
 export type Props = {|
   +className: string,
   +trackName: string,
+  +fullThread: Thread,
   +rangeFilteredThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
+  +sampleIndexOffset: number,
   +onSampleClick: (
     event: SyntheticMouseEvent<>,
     sampleIndex: IndexIntoSamplesTable
@@ -149,12 +151,14 @@ export class ThreadActivityGraph extends React.PureComponent<Props, State> {
 
   render() {
     const {
+      fullThread,
       rangeFilteredThread,
       categories,
       trackName,
       interval,
       rangeStart,
       rangeEnd,
+      sampleIndexOffset,
       samplesSelectedStates,
       treeOrderSampleComparator,
       maxThreadCPUDelta,
@@ -174,10 +178,12 @@ export class ThreadActivityGraph extends React.PureComponent<Props, State> {
             'threadActivityGraphCanvas'
           )}
           trackName={trackName}
+          fullThread={fullThread}
           rangeFilteredThread={rangeFilteredThread}
           interval={interval}
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
+          sampleIndexOffset={sampleIndexOffset}
           samplesSelectedStates={samplesSelectedStates}
           treeOrderSampleComparator={treeOrderSampleComparator}
           categories={categories}

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -25,7 +25,7 @@ import type { CategoryDrawStyles } from './ActivityGraphFills';
 type CanvasProps = {|
   +className: string,
   +trackName: string,
-  +fullThread: Thread,
+  +rangeFilteredThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -89,7 +89,7 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
 
   drawCanvas(canvas: HTMLCanvasElement) {
     const {
-      fullThread,
+      rangeFilteredThread,
       interval,
       rangeStart,
       rangeEnd,
@@ -110,7 +110,7 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
     const { fills, fillsQuerier } = computeActivityGraphFills({
       canvasPixelWidth,
       canvasPixelHeight,
-      fullThread,
+      rangeFilteredThread,
       interval,
       rangeStart,
       rangeEnd,

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -25,10 +25,12 @@ import type { CategoryDrawStyles } from './ActivityGraphFills';
 type CanvasProps = {|
   +className: string,
   +trackName: string,
+  +fullThread: Thread,
   +rangeFilteredThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
+  +sampleIndexOffset: number,
   +samplesSelectedStates: null | SelectedState[],
   +treeOrderSampleComparator: (
     IndexIntoSamplesTable,
@@ -89,10 +91,12 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
 
   drawCanvas(canvas: HTMLCanvasElement) {
     const {
+      fullThread,
       rangeFilteredThread,
       interval,
       rangeStart,
       rangeEnd,
+      sampleIndexOffset,
       samplesSelectedStates,
       treeOrderSampleComparator,
       categories,
@@ -110,10 +114,12 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
     const { fills, fillsQuerier } = computeActivityGraphFills({
       canvasPixelWidth,
       canvasPixelHeight,
+      fullThread,
       rangeFilteredThread,
       interval,
       rangeStart,
       rangeEnd,
+      sampleIndexOffset,
       samplesSelectedStates,
       enableCPUUsage,
       maxThreadCPUDelta,

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -34,10 +34,12 @@ import type { HoveredPixelState } from './ActivityGraph';
 type RenderedComponentSettings = {|
   +canvasPixelWidth: DevicePixels,
   +canvasPixelHeight: DevicePixels,
+  +fullThread: Thread,
   +rangeFilteredThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
+  +sampleIndexOffset: number,
   +xPixelsPerMs: number,
   +enableCPUUsage: boolean,
   +maxThreadCPUDelta: number,
@@ -207,10 +209,12 @@ export class ActivityGraphFillComputer {
    */
   _accumulateSampleCategories() {
     const {
+      fullThread,
       rangeFilteredThread: { samples, stackTable },
       interval,
       greyCategoryIndex,
       enableCPUUsage,
+      sampleIndexOffset,
     } = this.renderedComponentSettings;
 
     if (samples.length === 0) {
@@ -220,6 +224,14 @@ export class ActivityGraphFillComputer {
 
     let prevSampleTime = samples.time[0] - interval;
     let sampleTime = samples.time[0];
+
+    if (sampleIndexOffset > 0) {
+      // If sampleIndexOffset is greater than zero, it means that we are zoomed
+      // in the timeline and we are seeing a portion of it. In that case,
+      // rangeFilteredThread will not have the information of the first previous
+      // sample. So we need to get that information from the full thread.
+      prevSampleTime = fullThread.samples.time[sampleIndexOffset - 1];
+    }
 
     // Go through the samples and accumulate the category into the percentageBuffers.
     const { threadCPUDelta } = samples;
@@ -238,10 +250,9 @@ export class ActivityGraphFillComputer {
         // step and eliminating all the null values.
         const cpuDeltaBefore = ensureExists(threadCPUDelta[i]);
         const cpuDeltaAfter = ensureExists(threadCPUDelta[i + 1]);
-        const intervalDistribution =
-          i === 0 ? 1 : (samples.time[i] - samples.time[i - 1]) / interval;
+        const intervalDistribution = (sampleTime - prevSampleTime) / interval;
         const nextIntervalDistribution =
-          (samples.time[i + 1] - samples.time[i]) / interval;
+          (nextSampleTime - sampleTime) / interval;
 
         // Figure out the CPU usage "per interval". This is needed for cases
         // where we have some missing samples. For example:
@@ -281,13 +292,29 @@ export class ActivityGraphFillComputer {
         : greyCategoryIndex;
 
     let cpuBeforeSample = null;
-    if (enableCPUUsage && threadCPUDelta && threadCPUDelta[lastIdx] !== null) {
-      const cpuDelta = threadCPUDelta[lastIdx];
-      const intervalDistribution =
-        lastIdx === 0
-          ? 1
-          : (samples.time[lastIdx] - samples.time[lastIdx - 1]) / interval;
-      cpuBeforeSample = cpuDelta / intervalDistribution;
+    let cpuAfterSample = null;
+    if (enableCPUUsage && threadCPUDelta) {
+      const cpuDeltaBefore = ensureExists(threadCPUDelta[lastIdx]);
+      const intervalDistribution = (sampleTime - prevSampleTime) / interval;
+      cpuBeforeSample = cpuDeltaBefore / intervalDistribution;
+
+      const nextIdxInFullThread = sampleIndexOffset + lastIdx + 1;
+      if (nextIdxInFullThread < fullThread.samples.length) {
+        // Since we are zoomed in the timeline, rangeFilteredThread will not
+        // have the information of the next sample. So we need to get that
+        // information from the full thread.
+        const cpuDeltaAfter = ensureExists(
+          ensureExists(fullThread.samples.threadCPUDelta)[nextIdxInFullThread]
+        );
+        const nextIntervalDistribution =
+          (fullThread.samples.time[nextIdxInFullThread] - sampleTime) /
+          interval;
+        cpuAfterSample = cpuDeltaAfter / nextIntervalDistribution;
+      } else {
+        // If we don't have this information in the full thread, simply use the
+        // previous CPU delta.
+        cpuAfterSample = cpuBeforeSample;
+      }
     }
 
     this._accumulateInCategory(
@@ -297,9 +324,7 @@ export class ActivityGraphFillComputer {
       sampleTime,
       sampleTime + interval,
       cpuBeforeSample,
-      // There is no cpuAfterSample for this since this is the last sample.
-      // Assigning the same CPU delta value to it.
-      cpuBeforeSample
+      cpuAfterSample
     );
   }
 

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -34,7 +34,7 @@ import type { HoveredPixelState } from './ActivityGraph';
 type RenderedComponentSettings = {|
   +canvasPixelWidth: DevicePixels,
   +canvasPixelHeight: DevicePixels,
-  +fullThread: Thread,
+  +rangeFilteredThread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -207,7 +207,7 @@ export class ActivityGraphFillComputer {
    */
   _accumulateSampleCategories() {
     const {
-      fullThread: { samples, stackTable },
+      rangeFilteredThread: { samples, stackTable },
       interval,
       greyCategoryIndex,
       enableCPUUsage,
@@ -486,7 +486,7 @@ export class ActivityFillGraphQuerier {
   ): HoveredPixelState | null {
     const {
       canvasPixelWidth,
-      fullThread: { samples, stackTable },
+      rangeFilteredThread: { samples, stackTable },
       greyCategoryIndex,
     } = this.renderedComponentSettings;
     const devicePixelRatio = canvasPixelWidth / canvasBoundingRect.width;
@@ -550,7 +550,7 @@ export class ActivityFillGraphQuerier {
     samplesAtThisPixel: $ReadOnlyArray<SampleContributionToPixel>
   ): CpuRatioInTimeRange | null {
     const {
-      fullThread: { samples },
+      rangeFilteredThread: { samples },
       interval,
     } = this.renderedComponentSettings;
 
@@ -711,7 +711,7 @@ export class ActivityFillGraphQuerier {
     xPixel: number
   ): [IndexIntoSamplesTable, IndexIntoSamplesTable] {
     const {
-      fullThread: { samples },
+      rangeFilteredThread: { samples },
       rangeStart,
       xPixelsPerMs,
     } = this.renderedComponentSettings;
@@ -747,7 +747,7 @@ export class ActivityFillGraphQuerier {
     sample: IndexIntoSamplesTable
   ): number {
     const {
-      fullThread: { samples },
+      rangeFilteredThread: { samples },
       rangeStart,
     } = this.renderedComponentSettings;
     const kernelPos = xPixel - SMOOTHING_RADIUS;

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -76,7 +76,7 @@ type OwnProps = {|
 |};
 
 type StateProps = {|
-  +fullThread: Thread,
+  +rangeFilteredThread: Thread,
   +filteredThread: Thread,
   +tabFilteredThread: Thread,
   +callNodeInfo: CallNodeInfo,
@@ -187,7 +187,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
   render() {
     const {
       filteredThread,
-      fullThread,
+      rangeFilteredThread,
       tabFilteredThread,
       threadsKey,
       interval,
@@ -266,7 +266,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               className="threadActivityGraph"
               trackName={trackName}
               interval={interval}
-              fullThread={fullThread}
+              rangeFilteredThread={rangeFilteredThread}
               rangeStart={rangeStart}
               rangeEnd={rangeEnd}
               onSampleClick={this._onSampleClick}
@@ -290,7 +290,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               onSampleClick={this._onSampleClick}
             />
             {isExperimentalCPUGraphsEnabled &&
-            fullThread.samples.threadCPUDelta !== undefined ? (
+            rangeFilteredThread.samples.threadCPUDelta !== undefined ? (
               <ThreadCPUGraph
                 className="threadCPUGraph"
                 trackName={trackName}
@@ -394,16 +394,16 @@ export const TimelineTrackThread = explicitConnect<
     )
       ? selectors.getSelectedCallNodeIndex(state)
       : null;
-    const fullThread = selectors.getRangeFilteredThread(state);
+    const rangeFilteredThread = selectors.getRangeFilteredThread(state);
     const timelineType = getTimelineType(state);
     const enableCPUUsage =
       timelineType === 'cpu-category' &&
-      fullThread.samples.threadCPUDelta !== undefined;
+      rangeFilteredThread.samples.threadCPUDelta !== undefined;
 
     return {
       invertCallstack: getInvertCallstack(state),
       filteredThread: selectors.getFilteredThread(state),
-      fullThread,
+      rangeFilteredThread,
       tabFilteredThread: selectors.getTabFilteredThread(state),
       callNodeInfo: selectors.getCallNodeInfo(state),
       selectedCallNodeIndex,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -76,6 +76,7 @@ type OwnProps = {|
 |};
 
 type StateProps = {|
+  +fullThread: Thread,
   +rangeFilteredThread: Thread,
   +filteredThread: Thread,
   +tabFilteredThread: Thread,
@@ -85,6 +86,7 @@ type StateProps = {|
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
+  +sampleIndexOffset: number,
   +categories: CategoryList,
   +timelineType: TimelineType,
   +hasFileIoMarkers: boolean,
@@ -186,6 +188,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
 
   render() {
     const {
+      fullThread,
       filteredThread,
       rangeFilteredThread,
       tabFilteredThread,
@@ -193,6 +196,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       interval,
       rangeStart,
       rangeEnd,
+      sampleIndexOffset,
       callNodeInfo,
       selectedCallNodeIndex,
       unfilteredSamplesRange,
@@ -266,9 +270,11 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               className="threadActivityGraph"
               trackName={trackName}
               interval={interval}
+              fullThread={fullThread}
               rangeFilteredThread={rangeFilteredThread}
               rangeStart={rangeStart}
               rangeEnd={rangeEnd}
+              sampleIndexOffset={sampleIndexOffset}
               onSampleClick={this._onSampleClick}
               categories={categories}
               samplesSelectedStates={samplesSelectedStates}
@@ -394,16 +400,17 @@ export const TimelineTrackThread = explicitConnect<
     )
       ? selectors.getSelectedCallNodeIndex(state)
       : null;
-    const rangeFilteredThread = selectors.getRangeFilteredThread(state);
+    const fullThread = selectors.getCPUProcessedThread(state);
     const timelineType = getTimelineType(state);
     const enableCPUUsage =
       timelineType === 'cpu-category' &&
-      rangeFilteredThread.samples.threadCPUDelta !== undefined;
+      fullThread.samples.threadCPUDelta !== undefined;
 
     return {
       invertCallstack: getInvertCallstack(state),
+      fullThread,
       filteredThread: selectors.getFilteredThread(state),
-      rangeFilteredThread,
+      rangeFilteredThread: selectors.getRangeFilteredThread(state),
       tabFilteredThread: selectors.getTabFilteredThread(state),
       callNodeInfo: selectors.getCallNodeInfo(state),
       selectedCallNodeIndex,
@@ -411,6 +418,9 @@ export const TimelineTrackThread = explicitConnect<
       interval: getProfileInterval(state),
       rangeStart: committedRange.start,
       rangeEnd: committedRange.end,
+      sampleIndexOffset: selectors.getSampleIndexOffsetFromCommittedRange(
+        state
+      ),
       categories: getCategories(state),
       timelineType,
       hasFileIoMarkers:

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -61,7 +61,8 @@ export function computeMaxThreadCPUDelta(
  */
 export function processThreadCPUDelta(
   thread: Thread,
-  sampleUnits: SampleUnits
+  sampleUnits: SampleUnits,
+  profileInterval: Milliseconds
 ): Thread {
   const { samples } = thread;
   const { threadCPUDelta } = samples;
@@ -121,10 +122,13 @@ export function processThreadCPUDelta(
       // and this issue doesn't occur.
       case 'µs':
       case 'ns': {
-        const intervalUs =
-          (samples.time[i] - samples.time[i - 1]) * cpuDeltaTimeUnitMultiplier;
-        if (threadCPUDeltaValue > intervalUs) {
-          newThreadCPUDelta[i] = intervalUs;
+        const intervalInThreadCPUDeltaUnit =
+          i === 0
+            ? profileInterval * cpuDeltaTimeUnitMultiplier
+            : (samples.time[i] - samples.time[i - 1]) *
+              cpuDeltaTimeUnitMultiplier;
+        if (threadCPUDeltaValue > intervalInThreadCPUDeltaUnit) {
+          newThreadCPUDelta[i] = intervalInThreadCPUDeltaUnit;
         } else {
           newThreadCPUDelta[i] = threadCPUDeltaValue;
         }

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -116,12 +116,13 @@ export function getThreadSelectorsPerThread(
   const getCPUProcessedThread: Selector<Thread> = createSelector(
     getThread,
     ProfileSelectors.getSampleUnits,
-    (thread, sampleUnits) =>
+    ProfileSelectors.getProfileInterval,
+    (thread, sampleUnits, profileInterval) =>
       thread.samples === null ||
       thread.samples.threadCPUDelta === undefined ||
       !sampleUnits
         ? thread
-        : Cpu.processThreadCPUDelta(thread, sampleUnits)
+        : Cpu.processThreadCPUDelta(thread, sampleUnits, profileInterval)
   );
 
   const getTabFilteredThread: Selector<Thread> = createSelector(

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -258,13 +258,12 @@ describe('ThreadActivityGraph', function() {
       // Make sure that all the lineTo operations are inside the activity graph
       // rectangle. There should not be any sample that starts or ends outside
       // of the graph.
-      // FIXME: This should return `true` instead! The next commit should fix this!
       expect(
         lineToOperations.every(
           ([, x, y]) =>
             x >= 0 && x <= GRAPH_WIDTH && y >= 0 && y <= GRAPH_HEIGHT
         )
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 });

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -259,11 +259,16 @@ describe('ThreadActivityGraph', function() {
       // rectangle. There should not be any sample that starts or ends outside
       // of the graph.
       expect(
-        lineToOperations.every(
+        lineToOperations.filter(
           ([, x, y]) =>
-            x >= 0 && x <= GRAPH_WIDTH && y >= 0 && y <= GRAPH_HEIGHT
+            x < 0 ||
+            x > GRAPH_WIDTH ||
+            y < 0 ||
+            y > GRAPH_HEIGHT ||
+            isNaN(x) ||
+            isNaN(y)
         )
-      ).toBe(true);
+      ).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
This PR is about fixing the rendering of two the first and last sample. This problem's root cause was two things actually:
1. A bug in the CPU delta processing step, where we get NaN values for the first sample interval
2. We were sending the only range filtered thread to the activity graph. Because of that, we didn't know the time before the first sample in that range. And CPU usage after that range. I solved it by sending a non-filtered thread _in addition to_ the filtered thread. My first idea was to replace the filtered thread with unfiltered one, but unfortunately it wasn't working properly since the whole thread pipeline was designed to filter with the range first. Some call node computations are unfortunately very hard to change without changing the whole pipeline. Right now we are doing the range filtering very early in the pipeline (which makes sense) we need to change this ordering if we need to make it work, but I afraid that there is going to be performance impact.

To check the first sample:
[Production](https://share.firefox.dev/2SH1N27)
[Deploy preview](https://deploy-preview-3319--perf-html.netlify.app/public/07ssba14pm3vnacv8fcfjtnnban4hwvfqxzag90/calltree/?globalTrackOrder=12-0-1-2-3-4-5-6-7-8-9-10-11&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10-12&localTrackOrderByPid=36639-2-3-0-1~36653-0~36646-0~36649-0~36650-0~36664-0~36648-0~39224-0~36652-0~39238-0~36651-0~39254-0-1~&range=3438m650~3438m202~3438m56&thread=0&timelineType=cpu-category&v=5)

To check the last sample (there is no rendering issue, but we were simply using the previos cpu delta before for the second half of the sample. Now we are getting the next sample's cpu delta properly):
[Production](https://share.firefox.dev/3biwuRz)
[Deploy preview](https://deploy-preview-3319--perf-html.netlify.app/public/07ssba14pm3vnacv8fcfjtnnban4hwvfqxzag90/calltree/?globalTrackOrder=12-0-1-2-3-4-5-6-7-8-9-10-11&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10-12&localTrackOrderByPid=36639-2-3-0-1~36653-0~36646-0~36649-0~36650-0~36664-0~36648-0~39224-0~36652-0~39238-0~36651-0~39254-0-1~&range=3438m650~3438m202~3507m22~3523011u4349&thread=0&timelineType=cpu-category&v=5)

It would be also good to look at it commit by commit especially since there are some commits from the previous PR. The first PR needs to be landed first and then we should land this.