### PR TITLE
Set `loose` option to true for @babel/plugin-proposal-private-methods plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -44,6 +44,15 @@
       }
     ],
     [
+      "@babel/plugin-proposal-private-methods",
+      {
+        // Like `plugin-proposal-class-properties`, `loose` option is being used
+        // inside of this plugin as well. These plugins must have the same value,
+        // therefore it's set to true here.
+        "loose": true
+      }
+    ],
+    [
       "module-resolver",
       {
         "alias": {


### PR DESCRIPTION
After the changes in the babel config, I started to get this warning:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```
It's printing this many times when we run `yarn start` for example. It's good to silence this so we don't have to see it all the time.
Tested the UI after this change and I don't see any problem.