### PR TITLE
Add a custom symbol server URL as a URL parameter, ?symbolServer=https://localhost:8000/

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -97,6 +97,18 @@ export const PROFILER_SERVER_ORIGIN = 'https://api.profiler.firefox.com';
 // This is your local server:
 // export const PROFILER_SERVER_ORIGIN = 'http://localhost:5252';
 
+// SYMBOL_SERVER_URL
+// -----------------
+// Can be overridden with the URL parameter `symbolServer=SERVERURL`.
+// You can change this to the staging server `https://symbolication.stage.mozaws.net`,
+// or run a local symbol server (for example using profiler-symbol-server [1])
+// and set it to e.g. 'http://localhost:8000/'.
+//
+// [1] https://github.com/mstange/profiler-symbol-server/
+
+// This is the default server.
+export const SYMBOL_SERVER_URL = 'https://symbols.mozilla.org';
+
 // See the MarkerPhase type for more information.
 export const INSTANT: MarkerPhase = 0;
 export const INTERVAL: MarkerPhase = 1;

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -163,6 +163,7 @@ type BaseQuery = {|
   transforms: string,
   profiles: string[],
   profileName: string,
+  symbolServer: string,
   view: string,
   implementation: string,
   ...FullProfileSpecificBaseQuery,
@@ -367,6 +368,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
     view,
     v: CURRENT_URL_VERSION,
     profileName: urlState.profileName || undefined,
+    symbolServer: urlState.symbolServerUrl || undefined,
     implementation:
       urlState.profileSpecific.implementation === 'combined'
         ? undefined
@@ -563,6 +565,7 @@ export function stateFromLocation(
     selectedTab: toValidTabSlug(pathParts[selectedTabPathPart]) || 'calltree',
     pathInZipFile: query.file || null,
     profileName: query.profileName,
+    symbolServerUrl: query.symbolServer || null,
     timelineTrackOrganization: validateTimelineTrackOrganization(
       query.view,
       tabID

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -105,7 +105,8 @@ function _ensureIsAPIResult(result: any): APIResult {
 // to indicate failure status for each library independently. Under the hood,
 // only one request is made to the server.
 export function requestSymbols(
-  requests: LibSymbolicationRequest[]
+  requests: LibSymbolicationRequest[],
+  symbolsUrl: string
 ): Array<Promise<Map<number, AddressResult>>> {
   const addressArrays = requests.map(({ addresses }) => Array.from(addresses));
   const body = {
@@ -118,7 +119,7 @@ export function requestSymbols(
     ),
   };
 
-  const jsonPromise = fetch('https://symbols.mozilla.org/symbolicate/v5', {
+  const jsonPromise = fetch(symbolsUrl + '/symbolicate/v5', {
     body: JSON.stringify(body),
     method: 'POST',
     mode: 'cors',

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -488,6 +488,13 @@ const isResourcesPanelOpen: Reducer<boolean> = (state = false, action) => {
 };
 
 /**
+ * This value is only set from the URL and never changed.
+ */
+const symbolServerUrl: Reducer<string | null> = (state = null) => {
+  return state;
+};
+
+/**
  * These values are specific to an individual full profile.
  */
 const fullProfileSpecific = combineReducers({
@@ -572,6 +579,7 @@ const urlStateReducer: Reducer<UrlState> = wrapReducerInResetter(
     profileSpecific,
     profileName,
     timelineTrackOrganization,
+    symbolServerUrl,
   })
 );
 

--- a/src/test/__snapshots__/url-handling.test.js.snap
+++ b/src/test/__snapshots__/url-handling.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`symbolServerUrl will allow a a subdirectory path on an allowed https host 1`] = `Array []`;
+
+exports[`symbolServerUrl will allow an allowed https host 1`] = `Array []`;
+
+exports[`symbolServerUrl will error when switching to an allowed but non-https host 1`] = `
+Array [
+  Array [
+    "HTTPS is required for non-localhost symbol servers. Rejecting http://symbols.mozilla.org/ and defaulting to https://symbols.mozilla.org.",
+  ],
+]
+`;
+
+exports[`symbolServerUrl will error when switching to an invalid host 1`] = `
+Array [
+  Array [
+    "The symbol server URL was not valid. Rejecting invalid and defaulting to https://symbols.mozilla.org.",
+    [TypeError: Invalid URL: invalid],
+  ],
+]
+`;
+
+exports[`symbolServerUrl will error when switching to an unknown host 1`] = `
+Array [
+  Array [
+    "The symbol server URL was not in the list of allowed domains. Rejecting https://symbols.mozilla.org.example.com/symbols and defaulting to https://symbols.mozilla.org.",
+  ],
+]
+`;
+
+exports[`symbolServerUrl will strip the trailing slash on an allowed https host 1`] = `Array []`;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -283,6 +283,7 @@ export type UrlState = {|
   +profileName: string | null,
   +timelineTrackOrganization: TimelineTrackOrganization,
   +profileSpecific: ProfileSpecificUrlState,
+  +symbolServerUrl: string | null,
 |};
 
 /**


### PR DESCRIPTION
This allows profiling symbols with a local symbol server. I'm planning to use this in https://github.com/mstange/profiler-symbol-server (which we could use for mochitest / raptor / browsertime symbolication in the future), and in https://github.com/mstange/perfrecord/ , which is a stand-alone macOS profiler.

This PR is a re-implementation of #2492. I've kept Greg as the co-author. I've made the following changes:

 - The URL state selector is called `getSymbolServerUrl` instead of `getSymbolStoreUrl`.
 - The `/symbolicate/v5` is not part of the URL. The URL only contains the origin, and then our symbolication code appends the `/symbolicate/v5` at the end. This is more future-proof. For example, once there is a `v6`, we'll want to request v6 first and then fall back to v5. Or if we add APIs to the symbol server to request source code or assembly, those will use the same server but different URLs (maybe `/source/v1` and `/asm/v1`).
 - I've added `127.0.0.1` and `0.0.0.0` to the allowed localhost hosts.
 - I've added `symbolication.stage.mozaws.net` to the allowed hosts - this is the new staging symbolication server
 - I've also addressed the review comments in the old PR: HTTPS requirement for non-localhost, and one comment