### PR TITLE
Allow using the nullish coalescing operator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -52,6 +52,7 @@
         "loose": true
       }
     ],
+    ["@babel/plugin-proposal-nullish-coalescing-operator", { "useBuiltIns": true }],
     [
       "module-resolver",
       {

--- a/.babelrc
+++ b/.babelrc
@@ -52,7 +52,17 @@
         "loose": true
       }
     ],
-    ["@babel/plugin-proposal-nullish-coalescing-operator", { "useBuiltIns": true }],
+    [
+      // This plugin is configured by preset-env when needed... however because
+      // Webpack v4 doesn't understand this new syntaxe we need to
+      // unconditionally transpile it even for platforms that don't support it.
+      "@babel/plugin-proposal-nullish-coalescing-operator",
+      {
+        // The loose operation is when assuming that we don't use document.all.
+        // We should probably use the "assumptions" object in preset-env.
+        "loose": true
+      }
+    ],
     [
       "module-resolver",
       {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@babel/cli": "^7.14.3",
     "@babel/core": "^7.14.3",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-flow": "^7.13.13",
     "@babel/preset-react": "^7.13.13",

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -1128,8 +1128,7 @@ export function focusSubtree(
         if (stackMatchesUpTo === prefixDepth) {
           const newStackIndex = newStackTable.length++;
           const newStackPrefix = oldStackToNewStack.get(prefix);
-          newStackTable.prefix[newStackIndex] =
-            newStackPrefix !== undefined ? newStackPrefix : null;
+          newStackTable.prefix[newStackIndex] = newStackPrefix ?? null;
           newStackTable.frame[newStackIndex] = frame;
           newStackTable.category[newStackIndex] = category;
           newStackTable.subcategory[newStackIndex] = subcategory;

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -683,8 +683,7 @@ export const getRelevantPagesForActiveTab: Selector<Page[]> = createSelector(
       return _emptyRelevantPagesForActiveTab;
     }
 
-    const pages = pagesMap.get(activeTabID);
-    return pages !== undefined ? pages : _emptyRelevantPagesForActiveTab;
+    return pagesMap.get(activeTabID) ?? _emptyRelevantPagesForActiveTab;
   }
 );
 
@@ -737,7 +736,7 @@ export const getRelevantInnerWindowIDsForActiveTab: Selector<
     }
 
     const pageSet = pagesMap.get(activeTabID);
-    return pageSet !== undefined ? pageSet : new Set();
+    return pageSet ?? new Set();
   }
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,6 +346,14 @@
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.2.tgz#425b11dc62fc26939a2ab42cbba680bdf5734546"
+  integrity sha512-ebR0zU9OvI2N4qiAC38KIAK75KItpIPTpAtd2r4OZmMFeKbKJpUFLYP2EuDut82+BmYi8sz42B+TfTptJ9iG5Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.13.8":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz#3730a31dafd3c10d8ccd10648ed80a2ac5472ef3"


### PR DESCRIPTION
Hi, I have a wip patch where the ?? operator would be a good fit. It looks like we can't use it at the moment without some babel configuration changes, so I'm sending this PR to take care of that. I also converted a few example places to ??.

I'm not 100% sure about the .babelrc changes - does this require loose: true? If it were required, would something complain?