### PR TITLE
 Support the new status ABORT as well as more information about a redirected request

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -493,7 +493,7 @@ export function deriveMarkersFromRawMarkerTable(
             openNetworkMarkers.set(data.id, rawMarkerIndex);
           } else {
             // End status can be any status other than 'STATUS_START'. They are
-            // either 'STATUS_STOP' or 'STATUS_REDIRECT'.
+            // either 'STATUS_STOP', 'STATUS_REDIRECT' or 'STATUS_ABORT'.
             const endData = data;
 
             const startIndex = openNetworkMarkers.get(data.id);

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -147,6 +147,110 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
 </div>
 `;
 
+exports[`TooltipMarker renders properly network markers that were aborted 1`] = `
+<div
+  class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1.4s
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1235: https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Request was aborted
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    Unresolved
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Normal(0)
+    <div
+      class="tooltipLabel"
+    >
+      Guessed MIME type
+      :
+    </div>
+    <div
+      class="tooltipNetworkMimeType"
+    >
+      <span
+        class="tooltipNetworkMimeTypeSwatch colored-square network-color-img"
+        title="image/jpeg"
+      />
+      image/jpeg
+    </div>
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-img"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 1,433 milliseconds"
+    >
+      1,433ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+    />
+  </div>
+</div>
+`;
+
 exports[`TooltipMarker renders properly network markers where content type is blank 1`] = `
 <div
   class="tooltipMarker propClass"
@@ -1219,7 +1323,463 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
 </div>
 `;
 
-exports[`TooltipMarker renders properly redirect network markers 1`] = `
+exports[`TooltipMarker renders properly redirect network markers for a internal redirection 1`] = `
+<div
+  class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        18.7s
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1234: http://www.wikia.com/
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Redirecting request
+    <div
+      class="tooltipLabel"
+    >
+      Redirection type
+      :
+    </div>
+    internal
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    any string could be here
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://www.wikia.com/
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Redirect URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Highest(-20)
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    0.000B
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-other"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 18,726 milliseconds"
+    >
+      18,726ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+    />
+  </div>
+</div>
+`;
+
+exports[`TooltipMarker renders properly redirect network markers for a permanent redirection 1`] = `
+<div
+  class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        18.7s
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1234: http://www.wikia.com/
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Redirecting request
+    <div
+      class="tooltipLabel"
+    >
+      Redirection type
+      :
+    </div>
+    permanent
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    any string could be here
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://www.wikia.com/
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Redirect URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Highest(-20)
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    0.000B
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-other"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 18,726 milliseconds"
+    >
+      18,726ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+    />
+  </div>
+</div>
+`;
+
+exports[`TooltipMarker renders properly redirect network markers for a temporary redirection 1`] = `
+<div
+  class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        18.7s
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1234: http://www.wikia.com/
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Redirecting request
+    <div
+      class="tooltipLabel"
+    >
+      Redirection type
+      :
+    </div>
+    temporary
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    any string could be here
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://www.wikia.com/
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Redirect URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Highest(-20)
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    0.000B
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-other"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 18,726 milliseconds"
+    >
+      18,726ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+    />
+  </div>
+</div>
+`;
+
+exports[`TooltipMarker renders properly redirect network markers for an internal redirection from a HSTS header 1`] = `
+<div
+  class="tooltipMarker propClass"
+  style="--tooltip-detail-max-width: 600px;"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        18.7s
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Load 1234: http://www.wikia.com/
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Status
+      :
+    </div>
+    Redirecting request
+    <div
+      class="tooltipLabel"
+    >
+      Redirection type
+      :
+    </div>
+    permanent (HTTP to HTTPS)
+    <div
+      class="tooltipLabel"
+    >
+      Cache
+      :
+    </div>
+    any string could be here
+    <div
+      class="tooltipLabel"
+    >
+      URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://www.wikia.com/
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Redirect URL
+      :
+    </div>
+    <span
+      class="tooltipNetworkUrl"
+    >
+      http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
+    </span>
+    <div
+      class="tooltipLabel"
+    >
+      Priority
+      :
+    </div>
+    Highest(-20)
+    <div
+      class="tooltipLabel"
+    >
+      Requested bytes
+      :
+    </div>
+    0.000B
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+  <div
+    class="tooltipNetworkPhases network-color-other"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      HTTP response
+      :
+    </div>
+    <div
+      aria-label="Starting at 0.000 milliseconds, duration is 18,726 milliseconds"
+    >
+      18,726ms
+    </div>
+    <div
+      aria-hidden="true"
+      class="tooltipNetworkPhase"
+      style="margin-left: 0%; margin-right: 0%; opacity: 1;"
+    />
+  </div>
+</div>
+`;
+
+exports[`TooltipMarker renders properly redirect network markers without additional redirection information 1`] = `
 <div
   class="tooltipMarker propClass"
   style="--tooltip-detail-max-width: 600px;"

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -420,7 +420,8 @@ export type NetworkPayload = {|
   id: number,
   pri: number, // priority of the load; always included as it can change
   count?: number, // Total size of transfer, if any
-  status: string,
+  // See all possible values in tools/profiler/core/platform.cpp
+  status: 'STATUS_START' | 'STATUS_STOP' | 'STATUS_REDIRECT',
   cache?: string,
   cause?: CauseBacktrace,
 

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -413,6 +413,12 @@ export type GCSliceMarkerPayload_Gecko = {|
  * that redirects are logged as well.
  */
 
+export type NetworkStatus =
+  | 'STATUS_START'
+  | 'STATUS_STOP'
+  | 'STATUS_REDIRECT'
+  | 'STATUS_ABORT';
+export type NetworkRedirectType = 'permanent' | 'temporary' | 'internal';
 export type NetworkPayload = {|
   type: 'Network',
   URI: string,
@@ -421,7 +427,11 @@ export type NetworkPayload = {|
   pri: number, // priority of the load; always included as it can change
   count?: number, // Total size of transfer, if any
   // See all possible values in tools/profiler/core/platform.cpp
-  status: 'STATUS_START' | 'STATUS_STOP' | 'STATUS_REDIRECT',
+  status: NetworkStatus,
+  // The following property is present since Gecko v91.
+  redirectType?: NetworkRedirectType,
+  // The following property is present since Gecko v91.
+  isHttpToHttpsRedirect?: boolean,
   cache?: string,
   cause?: CauseBacktrace,
 


### PR DESCRIPTION
This PR does 2 things:
* this supports a new ABORT end status (see https://bugzilla.mozilla.org/show_bug.cgi?id=1697901)
* this supports showing more information for redirected requests (see https://bugzilla.mozilla.org/show_bug.cgi?id=1715321)

There's currently no way to test it but I added test cases. We may have to change this code again in the future but this is a good baseline. There's also no need to bump the version because old profiles will still work with the change.