### PR TITLE
Some refactoring in mozilla-symbolication-api.js

### DIFF
--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -114,8 +114,8 @@ export function requestSymbols(
       debugName,
       breakpadId,
     ]),
-    stacks: addressArrays.map((addressArray, libIndex) =>
-      addressArray.map(addr => [libIndex, addr])
+    stacks: addressArrays.map((addressArray, requestIndex) =>
+      addressArray.map(addr => [requestIndex, addr])
     ),
   };
 
@@ -127,7 +127,7 @@ export function requestSymbols(
     .then(response => response.json())
     .then(_ensureIsAPIResult);
 
-  return requests.map(async function(request, libIndex) {
+  return requests.map(async function(request, requestIndex) {
     const { lib } = request;
     const { debugName, breakpadId } = lib;
 
@@ -149,8 +149,8 @@ export function requestSymbols(
       );
     }
 
-    const addressInfo = json.stacks[libIndex];
-    const addressArray = addressArrays[libIndex];
+    const addressInfo = json.stacks[requestIndex];
+    const addressArray = addressArrays[requestIndex];
     if (addressInfo.length !== addressArray.length) {
       throw new SymbolsNotFoundError(
         'The result from the symbol server has an unexpected length.',

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -123,7 +123,9 @@ export function requestSymbols(
     body: JSON.stringify(body),
     method: 'POST',
     mode: 'cors',
-  }).then(response => response.json());
+  })
+    .then(response => response.json())
+    .then(_ensureIsAPIResult);
 
   return requests.map(async function(request, libIndex) {
     const { lib } = request;
@@ -131,7 +133,7 @@ export function requestSymbols(
 
     let json;
     try {
-      json = _ensureIsAPIResult(await jsonPromise).results[0];
+      json = (await jsonPromise).results[0];
     } catch (error) {
       throw new SymbolsNotFoundError(
         'There was a problem with the JSON returned by the symbolication API.',

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -12,7 +12,7 @@ import { SymbolsNotFoundError } from './errors';
 // Specifically, it uses version 5 of the API, which was implemented in
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1377479 .
 
-type APIFoundModules = {
+type APIFoundModulesV5 = {
   // For every requested library in the memoryMap, this object contains a string
   // key of the form `${debugName}/${breakpadId}`. The value is null if no
   // address with the module index was requested, and otherwise a boolean that
@@ -20,7 +20,7 @@ type APIFoundModules = {
   [string]: null | boolean,
 };
 
-type APIFrameInfo = {
+type APIFrameInfoV5 = {
   // The hex version of the address that we requested (e.g. "0x5ab").
   module_offset: string,
   // The debugName of the library that this frame was in.
@@ -34,20 +34,20 @@ type APIFrameInfo = {
   function_offset?: string,
 };
 
-type APIStack = APIFrameInfo[];
+type APIStackV5 = APIFrameInfoV5[];
 
-type APIJobResult = {
-  found_modules: APIFoundModules,
-  stacks: APIStack[],
+type APIJobResultV5 = {
+  found_modules: APIFoundModulesV5,
+  stacks: APIStackV5[],
 };
 
-type APIResult = {
-  results: APIJobResult[],
+type APIResultV5 = {
+  results: APIJobResultV5[],
 };
 
 // Make sure that the JSON blob we receive from the API conforms to our flow
 // type definition.
-function _ensureIsAPIResult(result: any): APIResult {
+function _ensureIsAPIResultV5(result: any): APIResultV5 {
   if (!(result instanceof Object) || !('results' in result)) {
     throw new Error('Expected an object with property `results`');
   }
@@ -99,7 +99,7 @@ function _ensureIsAPIResult(result: any): APIResult {
 function getV5ResultForLibRequest(
   request: LibSymbolicationRequest,
   addressArray: number[],
-  json: APIJobResult
+  json: APIJobResultV5
 ): Map<number, AddressResult> {
   const { lib } = request;
   const { debugName, breakpadId } = lib;
@@ -177,7 +177,7 @@ export function requestSymbols(
     mode: 'cors',
   })
     .then(response => response.json())
-    .then(_ensureIsAPIResult);
+    .then(_ensureIsAPIResultV5);
 
   return requestsWithAddressArrays.map(async function(
     { request, addressArray },

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -108,6 +108,9 @@ export function requestSymbols(
   requests: LibSymbolicationRequest[],
   symbolsUrl: string
 ): Array<Promise<Map<number, AddressResult>>> {
+  // For each request, turn its set of addresses into an array.
+  // We need there to be a defined order in each addressArray so that we can
+  // match the results to the request.
   const addressArrays = requests.map(({ addresses }) => Array.from(addresses));
   const body = {
     memoryMap: requests.map(({ lib: { debugName, breakpadId } }) => [


### PR DESCRIPTION
This PR contains some small refactorings but no behavior changes. The commits are written so that they can be reviewed individually.
These patches are extracted  from / inspired by the inline callstacks proof-of-concept.