### PR TITLE
Consume file and line information from the symbolication API

### DIFF
--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -21,6 +21,14 @@ export type AddressResult = {|
   name: string,
   // The offset (in bytes) between the start of the function and the address.
   functionOffset: number,
+  // The path of the file that contains the source code of the function that contains this address.
+  // Optional because the information may not be known by the symbolication source, or because
+  // the symbolication method does not expose it.
+  file?: string,
+  // The line number that contains the source code that generated the instructions at the address, optional.
+  // Optional because the information may not be known by the symbolication source, or because
+  // the symbolication method does not expose it.
+  line?: number,
 |};
 
 interface SymbolProvider {


### PR DESCRIPTION
This is just the first step, nothing is done with the information yet. It doesn't even get all the way into the symbolicated thread's function table.

The new implementation of the Mozilla symbolication server, which is currently available for testing on a staging server at https://symbolication.stage.mozaws.net/symbolicate/v5, has the ability to return file and line information.
The tracking bug for switching to this new implementation is https://bugzilla.mozilla.org/show_bug.cgi?id=1636210.