### PR TITLE
Slight simplification in symbolication code

### DIFF
--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -139,9 +139,11 @@ function getV5ResultForLibRequest(
     const address = addressArray[i];
     const info = addressInfo[i];
     if (info.function !== undefined && info.function_offset !== undefined) {
+      const name = info.function;
+      const functionOffset = parseInt(info.function_offset.substr(2), 16);
       results.set(address, {
-        name: info.function,
-        functionOffset: parseInt(info.function_offset.substr(2), 16),
+        name,
+        symbolAddress: address - functionOffset,
         file: info.file,
         line: info.line,
       });

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -19,8 +19,9 @@ export type LibSymbolicationRequest = {
 export type AddressResult = {|
   // The name of the function that this address belongs to.
   name: string,
-  // The offset (in bytes) between the start of the function and the address.
-  functionOffset: number,
+  // The address (relative to the library) where the function that
+  // contains this address starts, i.e. the address of the function symbol.
+  symbolAddress: number,
   // The path of the file that contains the source code of the function that contains this address.
   // Optional because the information may not be known by the symbolication source, or because
   // the symbolication method does not expose it.
@@ -98,12 +99,12 @@ export function readSymbolsFromSymbolTable(
         currentSymbolIndex = symbolIndex;
       }
       results.set(address, {
-        functionOffset: address - symbolTableAddrs[symbolIndex],
+        symbolAddress: symbolTableAddrs[symbolIndex],
         name: currentSymbol,
       });
     } else {
       results.set(address, {
-        functionOffset: address,
+        symbolAddress: 0,
         name: '<before first symbol>',
       });
     }

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -413,10 +413,8 @@ export function applySymbolicationStep(
   // to the same funcAddress.
   // We obtain the funcAddress from the symbolication information in resultsForLib:
   // resultsForLib does not only contain the name of the function; it also contains,
-  // for each address, the functionOffset:
-  // functionOffset = frameAddress - funcAddress.
-  // So we can do the inverse calculation: funcAddress = frameAddress - functionOffset.
-  // All frames with the same funcAddress are grouped into the same function.
+  // for each address, the symbolAddress.
+  // All frames with the same symbolAddress are grouped into the same function.
 
   for (const frameIndex of allFramesForThisLib) {
     const oldFrameFunc = oldFrameTable.func[frameIndex];
@@ -425,20 +423,16 @@ export function applySymbolicationStep(
     if (addressResult === undefined) {
       const oldSymbol = stringTable.getString(oldFuncTable.name[oldFrameFunc]);
       addressResult = {
-        functionOffset:
-          oldFrameTable.address[frameIndex] -
-          oldFuncTable.address[oldFrameFunc],
+        symbolAddress: oldFuncTable.address[oldFrameFunc],
         name: oldSymbol,
       };
     }
 
     // |address| is the original frame address that we found during
     // stackwalking, as a library-relative offset.
-    // |addressResult.functionOffset| is the offset between the start of
-    // the function and |address|.
     // |funcAddress| is the start of the function, as a library-relative
     // offset.
-    const funcAddress = address - addressResult.functionOffset;
+    const funcAddress = addressResult.symbolAddress;
     frameToFuncAddressMap.set(frameIndex, funcAddress);
     funcAddressToSymbolNameMap.set(funcAddress, addressResult.name);
 

--- a/src/test/fixtures/fake-symbol-store.js
+++ b/src/test/fixtures/fake-symbol-store.js
@@ -44,7 +44,7 @@ export class FakeSymbolStore {
           const index = bisectionRight(symbolTable.addrs, address) - 1;
           results.set(address, {
             name: symbolTable.syms[index],
-            functionOffset: address - symbolTable.addrs[index],
+            symbolAddress: symbolTable.addrs[index],
           });
         }
         successCb(request, results);

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -80,11 +80,11 @@ describe('SymbolStore', function() {
     expect(errorCallback).not.toHaveBeenCalled();
     expect(secondAndThirdSymbol.get(0xf01)).toEqual({
       name: 'second symbol',
-      functionOffset: 1,
+      symbolAddress: 0xf00,
     });
     expect(secondAndThirdSymbol.get(0x1a50)).toEqual({
       name: 'third symbol',
-      functionOffset: 0x50,
+      symbolAddress: 0x1a00,
     });
 
     const lib2 = { debugName: 'firefox2', breakpadId: 'dont-care2' };
@@ -101,11 +101,11 @@ describe('SymbolStore', function() {
     expect(errorCallback).not.toHaveBeenCalled();
     expect(firstAndLastSymbol.get(0x33)).toEqual({
       name: 'first symbol',
-      functionOffset: 0x33,
+      symbolAddress: 0,
     });
     expect(firstAndLastSymbol.get(0x2000)).toEqual({
       name: 'last symbol',
-      functionOffset: 0,
+      symbolAddress: 0x2000,
     });
 
     const libWithEmptyBreakpadId = {
@@ -238,19 +238,19 @@ describe('SymbolStore', function() {
     const lib2Symbols = ensureExists(symbolsPerLibrary.get(lib2));
     expect(lib1Symbols.get(0xf01)).toEqual({
       name: 'second symbol',
-      functionOffset: 1,
+      symbolAddress: 0xf00,
     });
     expect(lib1Symbols.get(0x1a50)).toEqual({
       name: 'third symbol',
-      functionOffset: 0x50,
+      symbolAddress: 0x1a00,
     });
     expect(lib2Symbols.get(0x33)).toEqual({
       name: 'first symbol',
-      functionOffset: 0x33,
+      symbolAddress: 0,
     });
     expect(lib2Symbols.get(0x2000)).toEqual({
       name: 'last symbol',
-      functionOffset: 0,
+      symbolAddress: 0x2000,
     });
 
     // Using another symbol store simulates a page reload


### PR DESCRIPTION
We were propagating the `functionOffset` a bit further than necessary. I think it's easier to understand if the symbolAddress is computed as early as possible.

symbolAddress + functionOffset = address

symbolAddress = address - functionOffset

Please only review the last commit of this PR, the rest is already in the other PRs.