### PR TITLE
Implement a context menu for the network track

### DIFF
--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -273,7 +273,7 @@ class Network extends PureComponent<Props, State> {
     }
   };
 
-  _onMouseDown = e => {
+  _onMouseDown = (e: SyntheticMouseEvent<>) => {
     if (e.button === 2) {
       // The right button is a contextual action. It is important that we call
       // the right click callback at mousedown so that the state is updated and
@@ -286,6 +286,11 @@ class Network extends PureComponent<Props, State> {
     const { threadIndex, changeRightClickedMarker } = this.props;
     const { hoveredMarkerIndex } = this.state;
     changeRightClickedMarker(threadIndex, hoveredMarkerIndex);
+  };
+
+  _onVerticalIndicatorRightClick = (markerIndex: MarkerIndex) => {
+    const { threadIndex, changeRightClickedMarker } = this.props;
+    changeRightClickedMarker(threadIndex, markerIndex);
   };
 
   render() {
@@ -339,6 +344,7 @@ class Network extends PureComponent<Props, State> {
             rangeEnd={rangeEnd}
             zeroAt={zeroAt}
             width={containerWidth}
+            onRightClick={this._onVerticalIndicatorRightClick}
           />
           {shouldShowTooltip && hoveredMarkerIndex !== null && hoveredMarker ? (
             <Tooltip mouseX={mouseX} mouseY={mouseY}>

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -310,6 +310,10 @@ class Network extends PureComponent<Props, State> {
     const { hoveredMarkerIndex, mouseX, mouseY } = this.state;
     const hoveredMarker =
       hoveredMarkerIndex === null ? null : getMarker(hoveredMarkerIndex);
+
+    // This is used for the tooltips of the network markers, but not for the
+    // vertical indicators. Indeed the vertical indicators tooltips are useful
+    // when the user changes the selection.
     const shouldShowTooltip =
       !isModifyingSelection && rightClickedMarkerIndex === null;
 
@@ -345,6 +349,7 @@ class Network extends PureComponent<Props, State> {
             zeroAt={zeroAt}
             width={containerWidth}
             onRightClick={this._onVerticalIndicatorRightClick}
+            shouldShowTooltip={rightClickedMarkerIndex === null}
           />
           {shouldShowTooltip && hoveredMarkerIndex !== null && hoveredMarker ? (
             <Tooltip mouseX={mouseX} mouseY={mouseY}>

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -9,6 +9,7 @@ import React, { PureComponent } from 'react';
 import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
 import { TooltipMarker } from 'firefox-profiler/components/tooltip/Marker';
 import { withSize } from 'firefox-profiler/components/shared/WithSize';
+import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
 import { VerticalIndicators } from './VerticalIndicators';
 
 import {
@@ -18,6 +19,8 @@ import {
   getPreviewSelection,
 } from 'firefox-profiler/selectors/profile';
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
+import { changeRightClickedMarker } from 'firefox-profiler/actions/profile-view';
+
 import {
   TRACK_NETWORK_ROW_HEIGHT,
   TRACK_NETWORK_ROW_REPEAT,
@@ -48,6 +51,7 @@ type CanvasProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +hoveredMarkerIndex: MarkerIndex | null,
+  +rightClickedMarkerIndex: MarkerIndex | null,
   +width: CssPixels,
   +networkTiming: MarkerTiming[],
   +onHoveredMarkerChange: (
@@ -147,6 +151,7 @@ class NetworkCanvas extends PureComponent<CanvasProps> {
       rangeEnd,
       networkTiming,
       hoveredMarkerIndex,
+      rightClickedMarkerIndex,
       width: containerWidth,
     } = this.props;
 
@@ -166,6 +171,7 @@ class NetworkCanvas extends PureComponent<CanvasProps> {
     ctx.lineWidth = rowHeight * 0.75;
 
     let hoveredPath = null;
+    let rightClickedPath = null;
     for (let rowIndex = 0; rowIndex < networkTiming.length; rowIndex++) {
       const timing = networkTiming[rowIndex];
       for (let timingIndex = 0; timingIndex < timing.length; timingIndex++) {
@@ -182,15 +188,23 @@ class NetworkCanvas extends PureComponent<CanvasProps> {
         if (timing.index[timingIndex] === hoveredMarkerIndex) {
           // Save the hovered path to draw it at the end, on top of everything else.
           hoveredPath = path;
+        } else if (timing.index[timingIndex] === rightClickedMarkerIndex) {
+          rightClickedPath = path;
         } else {
           ctx.stroke(path);
         }
       }
     }
 
-    if (hoveredPath) {
+    if (hoveredPath || rightClickedPath) {
       ctx.strokeStyle = HOVERED_STYLE;
-      ctx.stroke(hoveredPath);
+      if (hoveredPath) {
+        ctx.stroke(hoveredPath);
+      }
+
+      if (rightClickedPath) {
+        ctx.stroke(rightClickedPath);
+      }
     }
   }
 
@@ -220,12 +234,18 @@ type StateProps = {|
   +getMarker: MarkerIndex => Marker,
   +networkTiming: MarkerTiming[],
   +verticalMarkerIndexes: MarkerIndex[],
+  +rightClickedMarkerIndex: MarkerIndex | null,
 |};
-type DispatchProps = {||};
+
+type DispatchProps = {|
+  changeRightClickedMarker: typeof changeRightClickedMarker,
+|};
+
 type Props = {|
   ...ConnectedProps<OwnProps, StateProps, DispatchProps>,
   ...SizeProps,
 |};
+
 type State = {|
   +hoveredMarkerIndex: MarkerIndex | null,
   +mouseX: CssPixels,
@@ -253,6 +273,21 @@ class Network extends PureComponent<Props, State> {
     }
   };
 
+  _onMouseDown = e => {
+    if (e.button === 2) {
+      // The right button is a contextual action. It is important that we call
+      // the right click callback at mousedown so that the state is updated and
+      // the context menus are rendered before the mouseup/contextmenu events.
+      this._onRightClick();
+    }
+  };
+
+  _onRightClick = () => {
+    const { threadIndex, changeRightClickedMarker } = this.props;
+    const { hoveredMarkerIndex } = this.state;
+    changeRightClickedMarker(threadIndex, hoveredMarkerIndex);
+  };
+
   render() {
     const {
       pages,
@@ -265,11 +300,13 @@ class Network extends PureComponent<Props, State> {
       isModifyingSelection,
       threadIndex,
       width: containerWidth,
+      rightClickedMarkerIndex,
     } = this.props;
     const { hoveredMarkerIndex, mouseX, mouseY } = this.state;
     const hoveredMarker =
       hoveredMarkerIndex === null ? null : getMarker(hoveredMarkerIndex);
-    const shouldShowTooltip = !isModifyingSelection;
+    const shouldShowTooltip =
+      !isModifyingSelection && rightClickedMarkerIndex === null;
 
     return (
       <div
@@ -277,35 +314,44 @@ class Network extends PureComponent<Props, State> {
         style={{
           height: TRACK_NETWORK_HEIGHT,
         }}
+        onMouseDown={this._onMouseDown}
       >
-        <NetworkCanvas
-          rangeStart={rangeStart}
-          rangeEnd={rangeEnd}
-          networkTiming={networkTiming}
-          hoveredMarkerIndex={hoveredMarkerIndex}
-          width={containerWidth}
-          onHoveredMarkerChange={this._onHoveredMarkerChange}
-        />
-        <VerticalIndicators
-          verticalMarkerIndexes={verticalMarkerIndexes}
-          getMarker={getMarker}
-          pages={pages}
-          rangeStart={rangeStart}
-          rangeEnd={rangeEnd}
-          zeroAt={zeroAt}
-          width={containerWidth}
-        />
-        {shouldShowTooltip && hoveredMarkerIndex !== null && hoveredMarker ? (
-          <Tooltip mouseX={mouseX} mouseY={mouseY}>
-            <TooltipMarker
-              className="tooltipNetwork"
-              markerIndex={hoveredMarkerIndex}
-              marker={hoveredMarker}
-              threadsKey={threadIndex}
-              restrictHeightWidth={true}
-            />
-          </Tooltip>
-        ) : null}
+        <ContextMenuTrigger
+          id="MarkerContextMenu"
+          attributes={{
+            className: 'treeViewContextMenu',
+          }}
+        >
+          <NetworkCanvas
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            networkTiming={networkTiming}
+            hoveredMarkerIndex={hoveredMarkerIndex}
+            rightClickedMarkerIndex={rightClickedMarkerIndex}
+            width={containerWidth}
+            onHoveredMarkerChange={this._onHoveredMarkerChange}
+          />
+          <VerticalIndicators
+            verticalMarkerIndexes={verticalMarkerIndexes}
+            getMarker={getMarker}
+            pages={pages}
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            zeroAt={zeroAt}
+            width={containerWidth}
+          />
+          {shouldShowTooltip && hoveredMarkerIndex !== null && hoveredMarker ? (
+            <Tooltip mouseX={mouseX} mouseY={mouseY}>
+              <TooltipMarker
+                className="tooltipNetwork"
+                markerIndex={hoveredMarkerIndex}
+                marker={hoveredMarker}
+                threadsKey={threadIndex}
+                restrictHeightWidth={true}
+              />
+            </Tooltip>
+          ) : null}
+        </ContextMenuTrigger>
       </div>
     );
   }
@@ -330,7 +376,9 @@ export const TrackNetwork = explicitConnect<
       zeroAt: getZeroAt(state),
       isModifyingSelection: getPreviewSelection(state).isModifying,
       verticalMarkerIndexes: selectors.getTimelineVerticalMarkerIndexes(state),
+      rightClickedMarkerIndex: selectors.getRightClickedMarkerIndex(state),
     };
   },
+  mapDispatchToProps: { changeRightClickedMarker },
   component: withSize<Props>(Network),
 });

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -26,6 +26,7 @@ type Props = {|
   +rangeEnd: Milliseconds,
   +zeroAt: Milliseconds,
   +width: CssPixels,
+  +onRightClick: MarkerIndex => mixed,
 |};
 
 /**
@@ -33,6 +34,15 @@ type Props = {|
  * in the timeline.
  */
 export class VerticalIndicators extends React.PureComponent<Props> {
+  _onMouseDown = (e: SyntheticMouseEvent<HTMLDivElement>) => {
+    if (e.button === 2 && this.props.onRightClick && e.currentTarget) {
+      this.props.onRightClick(parseInt(e.currentTarget.dataset.markerIndex));
+    }
+    // We handled this event here, so let's avoid that it's handled also in the
+    // main canvas code and empty the state.
+    e.stopPropagation();
+  };
+
   render() {
     const {
       getMarker,
@@ -97,6 +107,8 @@ export class VerticalIndicators extends React.PureComponent<Props> {
           data-testid="vertical-indicator-line"
           style={{ '--vertical-indicator-color': color, left }}
           className="timelineVerticalIndicatorsLine"
+          onMouseDown={this._onMouseDown}
+          data-marker-index={markerIndex}
           tooltip={
             <>
               <div>

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -26,6 +26,7 @@ type Props = {|
   +rangeEnd: Milliseconds,
   +zeroAt: Milliseconds,
   +width: CssPixels,
+  +shouldShowTooltip: boolean,
   +onRightClick: MarkerIndex => mixed,
 |};
 
@@ -52,6 +53,7 @@ export class VerticalIndicators extends React.PureComponent<Props> {
       rangeEnd,
       zeroAt,
       width,
+      shouldShowTooltip,
     } = this.props;
     return verticalMarkerIndexes.map<React.Node>(markerIndex => {
       const marker = getMarker(markerIndex);
@@ -110,20 +112,24 @@ export class VerticalIndicators extends React.PureComponent<Props> {
           onMouseDown={this._onMouseDown}
           data-marker-index={markerIndex}
           tooltip={
-            <>
-              <div>
-                <span
-                  className="timelineVerticalIndicatorsSwatch"
-                  style={{ backgroundColor: color }}
-                />{' '}
-                {marker.name}
-                <span className="timelineVerticalIndicatorsDim">{' at '}</span>
-                <span className="timelineVerticalIndicatorsTime">
-                  {formatSeconds(marker.start - zeroAt)}
-                </span>{' '}
-              </div>
-              {url}
-            </>
+            shouldShowTooltip ? (
+              <>
+                <div>
+                  <span
+                    className="timelineVerticalIndicatorsSwatch"
+                    style={{ backgroundColor: color }}
+                  />{' '}
+                  {marker.name}
+                  <span className="timelineVerticalIndicatorsDim">
+                    {' at '}
+                  </span>
+                  <span className="timelineVerticalIndicatorsTime">
+                    {formatSeconds(marker.start - zeroAt)}
+                  </span>{' '}
+                </div>
+                {url}
+              </>
+            ) : null
           }
         />
       );

--- a/src/components/tooltip/DivWithTooltip.js
+++ b/src/components/tooltip/DivWithTooltip.js
@@ -7,6 +7,8 @@ import * as React from 'react';
 import { Tooltip } from './Tooltip';
 import type { CssPixels } from 'firefox-profiler/types';
 
+// This isn't an exact object on purpose, because we'll pass all other props to
+// the underlying <div>.
 type Props = {
   +tooltip: React.Node,
   +children?: React.Node,
@@ -55,13 +57,9 @@ export class DivWithTooltip extends React.PureComponent<Props, State> {
   };
 
   render() {
+    const { children, tooltip, ...containerProps } = this.props;
     const { mouseX, mouseY, isMouseOver } = this.state;
-    const { children, tooltip } = this.props;
     const shouldShowTooltip = isMouseOver;
-
-    // Pass through the props without the tooltip property.
-    const containerProps = Object.assign({}, this.props);
-    delete containerProps.tooltip;
 
     return (
       <div

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -81,36 +81,40 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
         class="timelineTrackNetwork"
         style="height: 35px;"
       >
-        <canvas
-          class="timelineTrackNetworkCanvas"
-          height="35"
-          width="400"
-        />
         <div
-          class="timelineVerticalIndicatorsLine"
-          data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
-        />
-        <div
-          class="timelineVerticalIndicatorsLine"
-          data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: #000; left: 200px;"
-        />
-        <div
-          class="timelineVerticalIndicatorsLine"
-          data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--blue-50); left: 200px;"
-        />
-        <div
-          class="timelineVerticalIndicatorsLine"
-          data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
-        />
-        <div
-          class="timelineVerticalIndicatorsLine"
-          data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
-        />
+          class="react-contextmenu-wrapper treeViewContextMenu"
+        >
+          <canvas
+            class="timelineTrackNetworkCanvas"
+            height="35"
+            width="400"
+          />
+          <div
+            class="timelineVerticalIndicatorsLine"
+            data-testid="vertical-indicator-line"
+            style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
+          />
+          <div
+            class="timelineVerticalIndicatorsLine"
+            data-testid="vertical-indicator-line"
+            style="--vertical-indicator-color: #000; left: 200px;"
+          />
+          <div
+            class="timelineVerticalIndicatorsLine"
+            data-testid="vertical-indicator-line"
+            style="--vertical-indicator-color: var(--blue-50); left: 200px;"
+          />
+          <div
+            class="timelineVerticalIndicatorsLine"
+            data-testid="vertical-indicator-line"
+            style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
+          />
+          <div
+            class="timelineVerticalIndicatorsLine"
+            data-testid="vertical-indicator-line"
+            style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -91,26 +91,31 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
           />
           <div
             class="timelineVerticalIndicatorsLine"
+            data-marker-index="10"
             data-testid="vertical-indicator-line"
             style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
           />
           <div
             class="timelineVerticalIndicatorsLine"
+            data-marker-index="11"
             data-testid="vertical-indicator-line"
             style="--vertical-indicator-color: #000; left: 200px;"
           />
           <div
             class="timelineVerticalIndicatorsLine"
+            data-marker-index="12"
             data-testid="vertical-indicator-line"
             style="--vertical-indicator-color: var(--blue-50); left: 200px;"
           />
           <div
             class="timelineVerticalIndicatorsLine"
+            data-marker-index="13"
             data-testid="vertical-indicator-line"
             style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
           />
           <div
             class="timelineVerticalIndicatorsLine"
+            data-marker-index="14"
             data-testid="vertical-indicator-line"
             style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
           />

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -700,26 +700,31 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
     />
     <div
       class="timelineVerticalIndicatorsLine"
+      data-marker-index="10"
       data-testid="vertical-indicator-line"
       style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
     />
     <div
       class="timelineVerticalIndicatorsLine"
+      data-marker-index="11"
       data-testid="vertical-indicator-line"
       style="--vertical-indicator-color: #000; left: 200px;"
     />
     <div
       class="timelineVerticalIndicatorsLine"
+      data-marker-index="12"
       data-testid="vertical-indicator-line"
       style="--vertical-indicator-color: var(--blue-50); left: 200px;"
     />
     <div
       class="timelineVerticalIndicatorsLine"
+      data-marker-index="13"
       data-testid="vertical-indicator-line"
       style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
     />
     <div
       class="timelineVerticalIndicatorsLine"
+      data-marker-index="14"
       data-testid="vertical-indicator-line"
       style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
     />

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -690,35 +690,39 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
   class="timelineTrackNetwork"
   style="height: 35px;"
 >
-  <canvas
-    class="timelineTrackNetworkCanvas"
-    height="35"
-    width="400"
-  />
   <div
-    class="timelineVerticalIndicatorsLine"
-    data-testid="vertical-indicator-line"
-    style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
-  />
-  <div
-    class="timelineVerticalIndicatorsLine"
-    data-testid="vertical-indicator-line"
-    style="--vertical-indicator-color: #000; left: 200px;"
-  />
-  <div
-    class="timelineVerticalIndicatorsLine"
-    data-testid="vertical-indicator-line"
-    style="--vertical-indicator-color: var(--blue-50); left: 200px;"
-  />
-  <div
-    class="timelineVerticalIndicatorsLine"
-    data-testid="vertical-indicator-line"
-    style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
-  />
-  <div
-    class="timelineVerticalIndicatorsLine"
-    data-testid="vertical-indicator-line"
-    style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
-  />
+    class="react-contextmenu-wrapper treeViewContextMenu"
+  >
+    <canvas
+      class="timelineTrackNetworkCanvas"
+      height="35"
+      width="400"
+    />
+    <div
+      class="timelineVerticalIndicatorsLine"
+      data-testid="vertical-indicator-line"
+      style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
+    />
+    <div
+      class="timelineVerticalIndicatorsLine"
+      data-testid="vertical-indicator-line"
+      style="--vertical-indicator-color: #000; left: 200px;"
+    />
+    <div
+      class="timelineVerticalIndicatorsLine"
+      data-testid="vertical-indicator-line"
+      style="--vertical-indicator-color: var(--blue-50); left: 200px;"
+    />
+    <div
+      class="timelineVerticalIndicatorsLine"
+      data-testid="vertical-indicator-line"
+      style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
+    />
+    <div
+      class="timelineVerticalIndicatorsLine"
+      data-testid="vertical-indicator-line"
+      style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
+    />
+  </div>
 </div>
 `;


### PR DESCRIPTION
This has 4 commits, it might be easier to look at commits separately, although the patch isn't big so looking at the full patch should work too!

This introduces context menus for both the requests and the vertical indicators.

Next step is to react on clicks!

[deploy preview](https://deploy-preview-3383--perf-html.netlify.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/network-chart/?globalTrackOrder=13-14-0-1-2-3-4-5-6-7-8-9-10-11-12&localTrackOrderByPid=29495-7-8-0-1-2-3-4-5-6~5123-0~29556-0~526-0~29603-0~29692-0-1~5023-0~5053-0-1~29650-0~29726-0~4975-0~29481-0~21926-1-0~&range=5663m2795&thread=14&v=5)
[deploy preview with more requests](https://deploy-preview-3383--perf-html.netlify.app/public/52d5d452191340ab79ac92b519bcac4479fc3ab9/network-chart/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=19719-1-0~19908-0~&thread=4&v=5)