### PR TITLE
Fix symbolication failures with new symbolication server

### DIFF
--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -138,21 +138,25 @@ function getV5ResultForLibRequest(
   for (let i = 0; i < addressInfo.length; i++) {
     const address = addressArray[i];
     const info = addressInfo[i];
+    let addressResult;
     if (info.function !== undefined && info.function_offset !== undefined) {
       const name = info.function;
       const functionOffset = parseInt(info.function_offset.substr(2), 16);
-      results.set(address, {
+      addressResult = {
         name,
         symbolAddress: address - functionOffset,
         file: info.file,
         line: info.line,
-      });
+      };
     } else {
-      throw new SymbolsNotFoundError(
-        `The result from the symbol server did not contain function information for address ${address}, even though found_modules was true for the library that this address belongs to`,
-        lib
-      );
+      // This can happen if the address is between functions, or before the first
+      // or after the last function.
+      addressResult = {
+        name: `<unknown at ${info.module_offset}>`,
+        symbolAddress: address,
+      };
     }
+    results.set(address, addressResult);
   }
   return results;
 }

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -50,6 +50,10 @@ export interface AbstractSymbolStore {
   ): Promise<void>;
 }
 
+// The Mozilla symbolication API has a limit of 10 jobs per request, so limit
+// the number of libraries we request in each chunk to that same number.
+const MAX_JOB_COUNT_PER_CHUNK = 10;
+
 // Look up the symbols for the given addresses in the symbol table.
 // The symbol table is given in the [addrs, index, buffer] format.
 // This format is documented at the SymbolTableAsTuple flow type definition.
@@ -120,9 +124,12 @@ export function readSymbolsFromSymbolTable(
 // sum(chunk.map(computeValue)) <= maxValue or chunk.length == 1.
 // The array is allowed to contain elements which are larger than the maximum
 // value on their own; such elements will get a single chunk for themselves.
+// Additionally, each chunk is limited to contain no more than maxChunkLength
+// elements.
 function _partitionIntoChunksOfMaxValue<T>(
   array: T[],
   maxValue: number,
+  maxChunkLength: number,
   computeValue: T => number
 ): T[][] {
   const chunks = [];
@@ -130,7 +137,11 @@ function _partitionIntoChunksOfMaxValue<T>(
     const elementValue = computeValue(element);
     // Find an existing chunk that still has enough "value space" left to
     // accomodate this element.
-    let chunk = chunks.find(({ value }) => value + elementValue <= maxValue);
+    let chunk = chunks.find(
+      ({ value, elements }) =>
+        value + elementValue <= maxValue &&
+        elements.length + 1 <= maxChunkLength
+    );
     if (chunk === undefined) {
       // If no chunk was found, create a new chunk.
       chunk = { value: 0, elements: [] };
@@ -285,9 +296,11 @@ export class SymbolStore {
     // all libraries is blocked on getting symbols for libxul, latency suffers.
     // On the other hand, if we fire off a separate request for each library,
     // latency also suffers because of per-request overhead and pipelining limits.
+    // We also limit each chunk to at most MAX_JOB_COUNT_PER_CHUNK libraries.
     const chunks = _partitionIntoChunksOfMaxValue(
       requestsForNonCachedLibs,
       10000,
+      MAX_JOB_COUNT_PER_CHUNK,
       ({ addresses }) => addresses.size
     );
 


### PR DESCRIPTION
When using the staging symbolication server at `https://symbolication.stage.mozaws.net/`, we sometimes encounter failures that we wouldn't have encountered for the same request to the production server:

 1. The new server has a limit of 10 jobs per request.
 2. The new server can leave some addresses unsymbolicated even if it has symbols for the library.

Both of these changes are legitimate and we can adapt our behavior to work with them.

Please only review the last two commits in this PR, the others are already in other PRs.