### PR TITLE
Fall back to full view if activeTabID or relevant pages are not found

### DIFF
--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -36,10 +36,12 @@ import { ensureExists } from '../../utils/flow';
 import {
   getProfileFromTextSamples,
   getProfileWithMarkers,
+  addActiveTabInformationToProfile,
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { fireFullClick } from '../fixtures/utils';
 import { storeWithProfile, blankStore } from '../fixtures/stores';
+import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 
 import type { Profile } from 'firefox-profiler/types';
 
@@ -680,7 +682,10 @@ describe('app/MenuButtons', function() {
 
   describe('Full View Button', function() {
     function setupForFullViewButton() {
-      return setup(storeWithProfile(createSimpleProfile().profile));
+      const { profile } = addActiveTabInformationToProfile(
+        getProfileWithNiceTracks()
+      );
+      return setup(storeWithProfile(profile));
     }
 
     it('is not present when we are in the full view already', () => {

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -15,7 +15,6 @@ import {
   getScreenshotTrackProfile,
   addActiveTabInformationToProfile,
   addMarkersToThreadWithCorrespondingSamples,
-  getProfileFromTextSamples,
 } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile, blankStore } from '../fixtures/stores';
 import { getView } from '../../selectors/app';
@@ -100,7 +99,9 @@ describe('ActiveTab', function() {
 
 describe('finalizeProfileView', function() {
   function setup({ search, noPages }: { search: string, noPages?: boolean }) {
-    const { profile } = getProfileFromTextSamples('A');
+    const { profile } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
     const newUrlState = stateFromLocation({
       pathname: '/public/FAKEHASH/calltree/',
       search: '?' + search,

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -98,7 +98,15 @@ describe('ActiveTab', function() {
 });
 
 describe('finalizeProfileView', function() {
-  function setup({ search, noPages }: { search: string, noPages?: boolean }) {
+  function setup({
+    search,
+    noPages,
+    activeTabID,
+  }: {
+    search: string,
+    noPages?: boolean,
+    activeTabID?: number | null,
+  }) {
     const { profile } = addActiveTabInformationToProfile(
       getProfileWithNiceTracks()
     );
@@ -110,6 +118,15 @@ describe('finalizeProfileView', function() {
 
     if (noPages) {
       delete profile.pages;
+    }
+
+    if (activeTabID !== undefined) {
+      // Update the activeTabID if it's explicitly provided.
+      profile.meta.configuration = {
+        ...profile.meta.configuration,
+        // null is represented by 0 for activeTab in the back-end.
+        activeTabID: activeTabID ?? 0,
+      };
     }
 
     // Create the store and dispatch the url state.
@@ -139,6 +156,33 @@ describe('finalizeProfileView', function() {
     const { getState } = setup({
       search: '?view=active-tab&v=5',
       noPages: true,
+    });
+
+    // Check if we can successfully finalized the profile view for full view.
+    expect(getView(getState()).phase).toBe('DATA_LOADED');
+    expect(getTimelineTrackOrganization(getState())).toEqual({
+      type: 'full',
+    });
+  });
+
+  it('switches back to full view if there is no `activeTabID` value', function() {
+    const { getState } = setup({
+      search: '?view=active-tab&v=5',
+      activeTabID: null,
+    });
+
+    // Check if we can successfully finalized the profile view for full view.
+    expect(getView(getState()).phase).toBe('DATA_LOADED');
+    expect(getTimelineTrackOrganization(getState())).toEqual({
+      type: 'full',
+    });
+  });
+
+  it('switches back to full view if there is no relevant page with the given `activeTabID` value', function() {
+    const activeTabIDWithNoRelevantPage = 99999;
+    const { getState } = setup({
+      search: '?view=active-tab&v=5',
+      activeTabID: activeTabIDWithNoRelevantPage,
     });
 
     // Check if we can successfully finalized the profile view for full view.

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -407,7 +407,10 @@ describe('profileName', function() {
 
 describe('ctxId', function() {
   it('serializes the ctxId in the URL', function() {
-    const { getState, dispatch } = _getStoreWithURL();
+    const { profile } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+    const { getState, dispatch } = _getStoreWithURL({}, profile);
     const tabID = 123;
 
     dispatch(changeTimelineTrackOrganization({ type: 'active-tab', tabID }));
@@ -417,9 +420,15 @@ describe('ctxId', function() {
   });
 
   it('reflects in the state from URL', function() {
-    const { getState } = _getStoreWithURL({
-      search: '?ctxId=123&view=active-tab',
-    });
+    const { profile } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+    const { getState } = _getStoreWithURL(
+      {
+        search: '?ctxId=123&view=active-tab',
+      },
+      profile
+    );
     expect(urlStateSelectors.getTimelineTrackOrganization(getState())).toEqual({
       type: 'active-tab',
       tabID: 123,
@@ -427,7 +436,10 @@ describe('ctxId', function() {
   });
 
   it('returns the full view when ctxId is not specified', function() {
-    const { getState } = _getStoreWithURL();
+    const { profile } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+    const { getState } = _getStoreWithURL({}, profile);
     expect(urlStateSelectors.getTimelineTrackOrganization(getState())).toEqual({
       type: 'full',
     });
@@ -468,10 +480,16 @@ describe('ctxId', function() {
   });
 
   it('should remove other full view url states if present', function() {
-    const { getState } = _getStoreWithURL({
-      search:
-        '?ctxId=123&view=active-tab&globalTrackOrder=3-2-1-0&hiddenGlobalTracks=4-5&hiddenLocalTracksByPid=111-1&thread=0',
-    });
+    const { profile } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+    const { getState } = _getStoreWithURL(
+      {
+        search:
+          '?ctxId=123&view=active-tab&globalTrackOrder=3-2-1-0&hiddenGlobalTracks=4-5&hiddenLocalTracksByPid=111-1&thread=0',
+      },
+      profile
+    );
 
     const newUrl = new URL(
       urlFromState(urlStateSelectors.getUrlState(getState())),
@@ -484,9 +502,15 @@ describe('ctxId', function() {
   });
 
   it('if not present in the URL, still manages to load the active tab view', function() {
-    const { getState } = _getStoreWithURL({
-      search: '?view=active-tab',
-    });
+    const { profile } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+    const { getState } = _getStoreWithURL(
+      {
+        search: '?view=active-tab',
+      },
+      profile
+    );
 
     expect(getView(getState()).phase).toEqual('DATA_LOADED');
     expect(urlStateSelectors.getTimelineTrackOrganization(getState())).toEqual({


### PR DESCRIPTION
Fixes #3386. 
You can reproduce it manually with running `MOZ_PROFILER_STARTUP=1` and capturing the profile on release.
It's hard to reproduce it otherwise but I've addes some tests that were failing before.