### PR TITLE
Add the new property redirectId to the network marker's payload

### DIFF
--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -434,6 +434,10 @@ export type NetworkPayload = {|
   // The following property is present only when this marker is for a
   // redirection. Note it is present since Gecko v91 only.
   isHttpToHttpsRedirect?: boolean,
+  // When present in a redirect marker, this is the id of the next request,
+  // started because of the redirection. Note it is present since Gecko v91
+  // only.
+  redirectId?: number,
   cache?: string,
   cause?: CauseBacktrace,
 


### PR DESCRIPTION
This is a small patch to expose the new property added in https://bugzilla.mozilla.org/show_bug.cgi?id=1717414.

No user-visible change with this patch. I initially thought of putting it in the tooltip, but because the id wasn't present, I decided to not display the redirect id either.

In the future we'll want to at least highlight the related requests, but that's more work than what I want to do right now.