### PR TITLE
Remove the leftover TaskTracer related code/document

### DIFF
--- a/docs-developer/data-sources.md
+++ b/docs-developer/data-sources.md
@@ -28,15 +28,6 @@ The Gecko Profiler records marker data, but it doesn't include all of the marker
 * [Timeline C++ Implementation](https://dxr.mozilla.org/mozilla-central/source/docshell/base/timeline)
 * [Timeline Devtools JS Server](https://dxr.mozilla.org/mozilla-central/source/devtools/server/performance/timeline.js)
 
-## Task Tracer
-
-TaskTracer provides a way to trace the correlation between different Runnables across threads and processes. These Runnables are defined by `mozilla::Runnable`, and represent a task which can be dispatched to a thread for execution. Unlike sampling based profilers, TaskTracer can tell you where a Runnable is dispatched from, what its original source was, how long it waited in the event queue, and how long it took to execute.
-
-Source Events are usually some kinds of I/O events we're interested in, such as touch events, timer events, network events, etc. When a source event is created, TaskTracer records the entire chain of Runnables as they are dispatched to different threads and processes. It records latency, execution time, etc. for each Runnable that chains back to the original source event. There was an initial prototype of integrating this information into the Firefox Profiler, but it has since been removed and is available under the git tag [tasktracer-removal](https://github.com/firefox-devtools/profiler/releases/tag/tasktracer-removal).
-
-* [GeckoTaskTracer.h](https://dxr.mozilla.org/mozilla-central/source/tools/profiler/tasktracer/GeckoTaskTracer.h)
-* [Wiki](https://wiki.mozilla.org/TaskTracer)
-
 ## Tracelogger (unused in the Firefox Profiler)
 
 While the previous performance tools collect information about how Gecko runs as a whole, Tracelogger is specific to the SpiderMonkey engine. Tracelogger is not sample based, therefore it records every step that the SpiderMonkey engine performs to run a given chunk of JavaScript code. It's primarily used by JavaScript engineers, and includes a firehose of information often reaching into the several gigs of information. There is no current integration of this information with the Firefox Profiler.

--- a/src/test/fixtures/upgrades/processed-1.json
+++ b/src/test/fixtures/upgrades/processed-1.json
@@ -449,37 +449,5 @@
         "frameNumber": [null, null, null, null, null, null, null]
       }
     }
-  ],
-  "tasktracer": {
-    "taskTable": {
-      "length": 0,
-      "dispatchTime": [],
-      "sourceEventId": [],
-      "sourceEventType": [],
-      "parentTaskId": [],
-      "beginTime": [],
-      "processId": [],
-      "threadIndex": [],
-      "endTime": [],
-      "ipdlMsg": [],
-      "label": [],
-      "address": []
-    },
-    "tasksIdToTaskIndexMap": [],
-    "stringArray": [],
-    "addressTable": {
-      "length": 0,
-      "address": [],
-      "className": [],
-      "lib": []
-    },
-    "addressIndicesByLib": [],
-    "threadTable": {
-      "length": 0,
-      "tid": [],
-      "name": [],
-      "start": []
-    },
-    "tidToThreadIndexMap": []
-  }
+  ]
 }

--- a/src/test/fixtures/upgrades/processed-2.json
+++ b/src/test/fixtures/upgrades/processed-2.json
@@ -557,37 +557,5 @@
         "Load 32: https://github.com/rustwasm/wasm-bindgen/issues/4"
       ]
     }
-  ],
-  "tasktracer": {
-    "taskTable": {
-      "length": 0,
-      "dispatchTime": [],
-      "sourceEventId": [],
-      "sourceEventType": [],
-      "parentTaskId": [],
-      "beginTime": [],
-      "processId": [],
-      "threadIndex": [],
-      "endTime": [],
-      "ipdlMsg": [],
-      "label": [],
-      "address": []
-    },
-    "tasksIdToTaskIndexMap": [],
-    "addressTable": {
-      "length": 0,
-      "address": [],
-      "className": [],
-      "lib": []
-    },
-    "addressIndicesByLib": [],
-    "threadTable": {
-      "length": 0,
-      "tid": [],
-      "name": [],
-      "start": []
-    },
-    "tidToThreadIndexMap": [],
-    "stringArray": []
-  }
+  ]
 }

--- a/src/test/fixtures/upgrades/processed-3.json
+++ b/src/test/fixtures/upgrades/processed-3.json
@@ -1323,37 +1323,5 @@
       ],
       "pid": "Unknown Process 3"
     }
-  ],
-  "tasktracer": {
-    "taskTable": {
-      "length": 0,
-      "dispatchTime": [],
-      "sourceEventId": [],
-      "sourceEventType": [],
-      "parentTaskId": [],
-      "beginTime": [],
-      "processId": [],
-      "threadIndex": [],
-      "endTime": [],
-      "ipdlMsg": [],
-      "label": [],
-      "address": []
-    },
-    "tasksIdToTaskIndexMap": [],
-    "addressTable": {
-      "length": 0,
-      "address": [],
-      "className": [],
-      "lib": []
-    },
-    "addressIndicesByLib": [],
-    "threadTable": {
-      "length": 0,
-      "tid": [],
-      "name": [],
-      "start": []
-    },
-    "tidToThreadIndexMap": [],
-    "stringArray": []
-  }
+  ]
 }

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -11261,38 +11261,6 @@ Object {
     "toolkit": "cocoa",
     "version": 3,
   },
-  "tasktracer": Object {
-    "addressIndicesByLib": Array [],
-    "addressTable": Object {
-      "address": Array [],
-      "className": Array [],
-      "length": 0,
-      "lib": Array [],
-    },
-    "stringArray": Array [],
-    "taskTable": Object {
-      "address": Array [],
-      "beginTime": Array [],
-      "dispatchTime": Array [],
-      "endTime": Array [],
-      "ipdlMsg": Array [],
-      "label": Array [],
-      "length": 0,
-      "parentTaskId": Array [],
-      "processId": Array [],
-      "sourceEventId": Array [],
-      "sourceEventType": Array [],
-      "threadIndex": Array [],
-    },
-    "tasksIdToTaskIndexMap": Array [],
-    "threadTable": Object {
-      "length": 0,
-      "name": Array [],
-      "start": Array [],
-      "tid": Array [],
-    },
-    "tidToThreadIndexMap": Array [],
-  },
   "threads": Array [
     Object {
       "frameTable": Object {
@@ -12880,38 +12848,6 @@ Object {
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
     "version": 4,
-  },
-  "tasktracer": Object {
-    "addressIndicesByLib": Array [],
-    "addressTable": Object {
-      "address": Array [],
-      "className": Array [],
-      "length": 0,
-      "lib": Array [],
-    },
-    "stringArray": Array [],
-    "taskTable": Object {
-      "address": Array [],
-      "beginTime": Array [],
-      "dispatchTime": Array [],
-      "endTime": Array [],
-      "ipdlMsg": Array [],
-      "label": Array [],
-      "length": 0,
-      "parentTaskId": Array [],
-      "processId": Array [],
-      "sourceEventId": Array [],
-      "sourceEventType": Array [],
-      "threadIndex": Array [],
-    },
-    "tasksIdToTaskIndexMap": Array [],
-    "threadTable": Object {
-      "length": 0,
-      "name": Array [],
-      "start": Array [],
-      "tid": Array [],
-    },
-    "tidToThreadIndexMap": Array [],
   },
   "threads": Array [
     Object {
@@ -14679,38 +14615,6 @@ Object {
       "url": "about:blank",
     },
   ],
-  "tasktracer": Object {
-    "addressIndicesByLib": Array [],
-    "addressTable": Object {
-      "address": Array [],
-      "className": Array [],
-      "length": 0,
-      "lib": Array [],
-    },
-    "stringArray": Array [],
-    "taskTable": Object {
-      "address": Array [],
-      "beginTime": Array [],
-      "dispatchTime": Array [],
-      "endTime": Array [],
-      "ipdlMsg": Array [],
-      "label": Array [],
-      "length": 0,
-      "parentTaskId": Array [],
-      "processId": Array [],
-      "sourceEventId": Array [],
-      "sourceEventType": Array [],
-      "threadIndex": Array [],
-    },
-    "tasksIdToTaskIndexMap": Array [],
-    "threadTable": Object {
-      "length": 0,
-      "name": Array [],
-      "start": Array [],
-      "tid": Array [],
-    },
-    "tidToThreadIndexMap": Array [],
-  },
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -376,7 +376,6 @@ export type GeckoProfileWithMeta<Meta> = {|
   pages?: PageList,
   threads: GeckoThread[],
   pausedRanges: PausedRange[],
-  tasktracer?: MixedObject,
   processes: GeckoSubprocessProfile[],
   jsTracerDictionary?: string[],
 |};


### PR DESCRIPTION
Back-end bug that removes TaskTracer code: https://bugzilla.mozilla.org/show_bug.cgi?id=1715257

We were doing nothing with the data passed from Gecko since Cleopatra and old tag doesn't work either. It's safe to remove it from our codebase.