### PR TITLE
Make the width of tabBar items dynamic

### DIFF
--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -36,7 +36,7 @@
 .tabBarTab {
   position: relative;
   overflow: hidden;
-  width: 8em;
+  min-width: 8em;
   padding: 6px 4px;
   border: solid transparent;
   border-width: 0 1px 0 1px;


### PR DESCRIPTION
With the l10n work, there can be languages that have longer titles than 8em (ie, Italian). So instead of giving a static width, let it grow in case it needs more space.

For example, you can see the issue after changing Firefox locale to Italian here: https://l10n--perf-html.netlify.app/public/52d5d452191340ab79ac92b519bcac4479fc3ab9/calltree/?globalTrackOrder=0-1-2-3&localTrackOrderByPid=19719-1-0~19908-0~&thread=0&v=5

Before: 
![Screenshot from 2021-06-23 15-21-30](https://user-images.githubusercontent.com/466239/123104417-373d8300-d437-11eb-8cf8-dd85b41f186c.png)

After:
![Screenshot from 2021-06-23 15-21-48](https://user-images.githubusercontent.com/466239/123104449-3efd2780-d437-11eb-8a77-22293027793f.png)

See the first tab
