### PR TITLE
Remove noise from the call tree when native functions have file information

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2126,6 +2126,88 @@ export function getThreadProcessDetails(thread: Thread): string {
   return label;
 }
 
+export type ParsedFileNameFromSymbolication =
+  | {|
+      type: 'normal',
+      path: string,
+    |}
+  | {|
+      type: 'hg' | 'git',
+      repo: string,
+      path: string,
+      rev: string,
+    |}
+  | {|
+      type: 's3',
+      bucket: string,
+      digest: string,
+      path: string,
+    |};
+
+// For native code, the symbolication API returns special filenames that allow
+// you to find the exact source code that was used for the profiled build.
+//
+// Examples:
+// "hg:hg.mozilla.org/mozilla-central:widget/cocoa/nsAppShell.mm:997f00815e6bc28806b75448c8829f0259d2cb28"
+// "git:github.com/rust-lang/rust:library/std/src/sys/unix/thread.rs:53cb7b09b00cbea8754ffb78e7e3cb521cb8af4b"
+// "git:github.com/rust-lang/rust:../88f19c6dab716c6281af7602e30f413e809c5974//library/std/src/sys/windows/thread.rs:88f19c6dab716c6281af7602e30f413e809c5974"
+// "s3:gecko-generated-sources:a5d3747707d6877b0e5cb0a364e3cb9fea8aa4feb6ead138952c2ba46d41045297286385f0e0470146f49403e46bd266e654dfca986de48c230f3a71c2aafed4/ipc/ipdl/PBackgroundChild.cpp:"
+// "s3:gecko-generated-sources:4fd754dd7ca7565035aaa3357b8cd99959a2dddceba0fc2f7018ef99fd78ea63d03f9bf928afdc29873089ee15431956791130b97f66ab8fcb88ec75f4ba6b04/aarch64-apple-darwin/release/build/swgl-580c7d646d09cf59/out/ps_text_run_ALPHA_PASS_TEXTURE_2D.h:"
+//
+// This smart filename substitution is implemented here:
+// https://searchfox.org/mozilla-central/rev/f213971fbd82ada22c2c4e2072f729c3799ec563/toolkit/crashreporter/tools/symbolstore.py#605-636
+//
+// It should be noted that this doesn't work perfectly. Sometimes, the paths
+// returned by the symbolication API still contain the raw paths from the build
+// machines. Examples:
+//
+// MSVC CRT:
+//   "/builds/worker/workspace/obj-build/browser/app/f:/dd/vctools/crt/vcstartup/src/startup/exe_common.inl"
+// Linux system libraries:
+//   "/build/glibc-2ORdQG/glibc-2.27/csu/../csu/libc-start.c"
+//   or even just "glib/gmain.c"
+// Some rust stdlib functions: (https://bugzilla.mozilla.org/show_bug.cgi?id=1717973)
+//   "/builds/worker/fetches/rustc/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs"
+const repoPathRegex = /^(?<vcs>hg|git):(?<repo>[^:]*):(?<path>[^:]*):(?<rev>[0-9a-f]*)$/;
+const s3PathRegex = /^s3:(?<bucket>[^:]*):(?<digest>[0-9a-f]*)\/(?<path>[^:]*):$/;
+export function parseFileNameFromSymbolication(
+  file: string
+): ParsedFileNameFromSymbolication {
+  const repoMatch = repoPathRegex.exec(file);
+  if (repoMatch !== null && repoMatch.groups) {
+    const { vcs, repo, path, rev } = repoMatch.groups;
+    if (vcs !== 'hg' && vcs !== 'git') {
+      throw new Error(
+        'The regexp ensures that "vcs" is "hg" or "git", so this cannot happen.'
+      );
+    }
+    return {
+      type: vcs,
+      repo,
+      path,
+      rev,
+    };
+  }
+
+  const s3Match = s3PathRegex.exec(file);
+  if (s3Match !== null && s3Match.groups) {
+    const { bucket, digest, path } = s3Match.groups;
+    return {
+      type: 's3',
+      bucket,
+      digest,
+      path,
+    };
+  }
+
+  // At this point, it could be a local path (if this is a native function), or
+  // it could be an http/https/chrome URL (for JavaScript code).
+  return {
+    type: 'normal',
+    path: file,
+  };
+}
+
 // Determines which information to show in the "origin annotation" if both an
 // origin name and a filename are present.
 // A return value of true means "show both", false means "only show filename."
@@ -2175,6 +2257,10 @@ export function getOriginAnnotationForFunc(
   let fileName;
   if (fileNameIndex !== null) {
     fileName = stringTable.getString(fileNameIndex);
+
+    // Strip off any filename decorations from symbolication.
+    fileName = parseFileNameFromSymbolication(fileName).path;
+
     const lineNumber = funcTable.lineNumber[funcIndex];
     if (lineNumber !== null) {
       fileName += ':' + lineNumber;

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -102,6 +102,17 @@ describe('calltree/ProfileCallTreeView', function() {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('renders an unfiltered call tree with filenames', () => {
+    const { profile } = getProfileFromTextSamples(`
+      A[file:hg:hg.mozilla.org/mozilla-central:widget/cocoa/nsAppShell.mm:997f00815e6bc28806b75448c8829f0259d2cb28]
+      B[file:git:github.com/rust-lang/rust:library/std/src/sys/unix/thread.rs:53cb7b09b00cbea8754ffb78e7e3cb521cb8af4b]
+      C[lib:libC.so][file:s3:gecko-generated-sources:a5d3747707d6877b0e5cb0a364e3cb9fea8aa4feb6ead138952c2ba46d41045297286385f0e0470146f49403e46bd266e654dfca986de48c230f3a71c2aafed4/ipc/ipdl/PBackgroundChild.cpp:]
+      D[lib:libD.so]
+    `);
+    const { container } = setup(profile);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it('renders an inverted call tree', () => {
     const profileForInvertedTree = getProfileFromTextSamples(`
       A  A               A

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -4905,6 +4905,456 @@ for understanding where time was actually spent in a program."
 </div>
 `;
 
+exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filenames 1`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Sort by the time spent in a call node, ignoring its children."
+          >
+            Invert call stack
+          </span>
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      data-index="0"
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete “⁨Empty⁩”
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn total"
+        title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+      >
+        Total (samples)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn self"
+        title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+      >
+        Self
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-3"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 80px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 80px; min-width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, running count is 1 sample (100%), self count is 0 samples"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  widget/cocoa/nsAppShell.mm
+                </span>
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, running count is 1 sample (100%), self count is 0 samples"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  library/std/src/sys/unix/thread.rs
+                </span>
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="C, running count is 1 sample (100%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  ipc/ipdl/PBackgroundChild.cpp
+                </span>
+              </div>
+              <div
+                aria-label="D, running count is 1 sample (100%), self count is 1 sample"
+                aria-level="4"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  libD.so
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`calltree/ProfileCallTreeView renders call tree with some search strings 1`] = `
 <div
   aria-labelledby="calltree-tab-button"

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -688,6 +688,17 @@ function _findLibNameFromFuncName(funcNameWithModifier: string): string | null {
 
   return null;
 }
+function _findFileNameFromFuncName(
+  funcNameWithModifier: string
+): string | null {
+  const findFileNameResult = /\[file:([^\]]+)\]/.exec(funcNameWithModifier);
+  if (findFileNameResult) {
+    const fileName = findFileNameResult[1];
+    return fileName;
+  }
+
+  return null;
+}
 
 function _buildThreadFromTextOnlyStacks(
   textOnlyStacks: Array<string[]>,
@@ -764,6 +775,12 @@ function _buildThreadFromTextOnlyStacks(
       }
 
       funcTable.resource[funcIndex] = resourceIndex;
+
+      // Find the file name from the function name
+      const fileName = _findFileNameFromFuncName(funcNameWithModifier);
+      if (fileName) {
+        funcTable.fileName[funcIndex] = stringTable.indexForString(fileName);
+      }
 
       // Find the wanted jit type from the function name
       const jitType = _findJitTypeFromFuncName(funcNameWithModifier);


### PR DESCRIPTION
Example profile: https://share.firefox.dev/2T1Y5AB

In profiles that were symbolicated with the new symbol server, and which have filenames for native functions, the way we display the filename in the call tree isn't great at the moment. For example, in the profile given above, we have:

```
base::Thread::ThreadMain() XUL: hg:hg.mozilla.org/mozilla-central:ipc/chromium/src/base/thread.cc:997f00815e6bc28806b75448c8829f0259d2cb28
```

This PR makes it so that we display the following instead:

```
base::Thread::ThreadMain() ipc/chromium/src/base/thread.cc
```

[Deploy preview](https://deploy-preview-3416--perf-html.netlify.app/public/hf63jgjy2xq73tf4ky47vecca9ep4ratxbhtv8r/calltree/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10-11-12&hiddenLocalTracksByPid=93583-17-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16&localTrackOrderByPid=93583-17-0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16~93666-0~93587-0~98137-6-0-1-2-3-4-5~98980-6-0-1-2-3-4-5~94545-6-0-1-2-3-4-5~98401-6-0-1-2-3-4-5~93590-6-0-1-2-3-4-5~93589-6-0-1-2-3-4-5~99514-6-0-1-2-3-4-5~99205-6-0-1-2-3-4-5~98911-6-0-1-2-3-4-5~99518-6-0-1-2-3-4-5~&range=877m32&symbolServer=https%3A%2F%2Fsymbolication.stage.mozaws.net&thread=1&timelineType=cpu-category&v=5)