### PR TITLE
Create more compact URLs for profiles with lots of tracks, round 1

### DIFF
--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -4,8 +4,8 @@
 // @flow
 
 import {
-  uintArrayToString,
-  stringToUintArray,
+  encodeUintArrayForUrlComponent,
+  decodeUintArrayFromUrlComponent,
 } from '../utils/uintarray-encoding';
 import {
   toValidImplementationFilter,
@@ -228,7 +228,9 @@ export function parseTransforms(
             invertedRaw,
           ] = tuple;
           const implementation = toValidImplementationFilter(implementationRaw);
-          const callNodePath = stringToUintArray(serializedCallNodePath);
+          const callNodePath = decodeUintArrayFromUrlComponent(
+            serializedCallNodePath
+          );
           const inverted = Boolean(invertedRaw);
           // Flow requires a switch because it can't deduce the type string correctly.
           switch (type) {
@@ -302,7 +304,7 @@ export function stringifyTransforms(
               let string = [
                 shortKey,
                 transform.implementation,
-                uintArrayToString(transform.callNodePath),
+                encodeUintArrayForUrlComponent(transform.callNodePath),
               ].join('-');
               if (transform.inverted) {
                 string += '-i';

--- a/src/test/unit/uintarray-encoding.test.js
+++ b/src/test/unit/uintarray-encoding.test.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import {
+  decodeUintArrayFromUrlComponent,
+  encodeUintArrayForUrlComponent,
+} from '../../utils/uintarray-encoding';
+
+describe('UintArray encoding', function() {
+  const checks = [
+    // [array, encoding]
+    [[0], '0'],
+    [[9, 10], '9a'],
+    [[31, 167, 32, 33, 34], 'vB7x0wx2'],
+    [[6, 219, 218, 217, 216, 9, 10, 11, 12], '6CrwCo9wc'],
+    [[6, 4, 5, 6, 7, 6, 5, 4, 3, 2, 3, 4, 5], '64w7w2w5'],
+    [[366, 21, 21, 24, 31576, 27, 21, 13], 'Hello.World'],
+  ];
+
+  it('encodes correctly', function() {
+    for (const [arr, enc] of checks) {
+      expect(encodeUintArrayForUrlComponent(arr)).toBe(enc);
+    }
+  });
+
+  it('decodes correctly', function() {
+    for (const [arr, enc] of checks) {
+      expect(decodeUintArrayFromUrlComponent(enc)).toEqual(arr);
+    }
+  });
+
+  function roundTripEncoded(s) {
+    return encodeUintArrayForUrlComponent(decodeUintArrayFromUrlComponent(s));
+  }
+
+  it('removes redundant leading zeros', function() {
+    expect(roundTripEncoded('wa')).toEqual('a');
+    expect(roundTripEncoded('wawb')).toEqual('ab');
+    expect(roundTripEncoded('wawwwb')).toEqual('ab');
+    expect(roundTripEncoded('wawwwc')).toEqual('awc');
+  });
+
+  it('simplifies consecutive ranges', function() {
+    expect(roundTripEncoded('012345')).toEqual('0w5');
+    expect(roundTripEncoded('abcd012345432')).toEqual('awd0w5w2');
+  });
+});

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -41,7 +41,7 @@ import {
   addActiveTabInformationToProfile,
 } from './fixtures/profiles/processed-profile';
 import { selectedThreadSelectors } from '../selectors/per-thread';
-import { uintArrayToString } from '../utils/uintarray-encoding';
+import { encodeUintArrayForUrlComponent } from '../utils/uintarray-encoding';
 import {
   getActiveTabGlobalTracks,
   getActiveTabResourceTracks,
@@ -167,7 +167,7 @@ describe('url handling tracks', function() {
     });
 
     it('can reorder global tracks', function() {
-      const { getState } = initWithSearchParams('?globalTrackOrder=1-0');
+      const { getState } = initWithSearchParams('?globalTrackOrder=10');
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain tab]',
         '  - show [thread DOM Worker]',
@@ -187,13 +187,13 @@ describe('url handling tracks', function() {
     });
 
     it('will not accept invalid tracks in the thread order', function() {
-      const { getState } = initWithSearchParams('?globalTrackOrder=1-0');
+      const { getState } = initWithSearchParams('?globalTrackOrder=10');
       expect(urlStateSelectors.getGlobalTrackOrder(getState())).toEqual([1, 0]);
     });
 
     it('will not accept invalid hidden threads', function() {
       const { getState } = initWithSearchParams(
-        '?hiddenGlobalTracks=0-8-2-a&thread=1'
+        '?hiddenGlobalTracks=089&thread=1'
       );
       expect(urlStateSelectors.getHiddenGlobalTracks(getState())).toEqual(
         new Set([0])
@@ -203,9 +203,7 @@ describe('url handling tracks', function() {
 
   describe('local tracks', function() {
     it('can reorder local tracks', function() {
-      const { getState } = initWithSearchParams(
-        '?localTrackOrderByPid=222-1-0'
-      );
+      const { getState } = initWithSearchParams('?localTrackOrderByPid=222-10');
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain process] SELECTED',
         'show [thread GeckoMain tab]',
@@ -486,7 +484,7 @@ describe('ctxId', function() {
     const { getState } = _getStoreWithURL(
       {
         search:
-          '?ctxId=123&view=active-tab&globalTrackOrder=3-2-1-0&hiddenGlobalTracks=4-5&hiddenLocalTracksByPid=111-1&thread=0',
+          '?ctxId=123&view=active-tab&globalTrackOrder=3w0&hiddenGlobalTracks=45&hiddenLocalTracksByPid=111-1&thread=0',
       },
       profile
     );
@@ -875,7 +873,7 @@ describe('url upgrading', function() {
       ];
 
       // Upgrader
-      const callNodeString = uintArrayToString(callNodePathBefore);
+      const callNodeString = encodeUintArrayForUrlComponent(callNodePathBefore);
       // focus-subtree transform with js implementation filter.
       const transformString = 'f-js-' + callNodeString;
       const { query } = upgradeLocationToCurrentVersion(
@@ -900,7 +898,7 @@ describe('url upgrading', function() {
       ];
 
       const newTransformNodeString =
-        'f-js-' + uintArrayToString(callNodePathAfter);
+        'f-js-' + encodeUintArrayForUrlComponent(callNodePathAfter);
       expect(query.transforms).toEqual(newTransformNodeString);
     });
 
@@ -926,7 +924,7 @@ describe('url upgrading', function() {
       ];
 
       // Upgrader
-      const callNodeString = uintArrayToString(callNodePathBefore);
+      const callNodeString = encodeUintArrayForUrlComponent(callNodePathBefore);
       // focus-subtree transform with js implementation filter.
       const transformString = 'f-js-' + callNodeString;
       const { query } = upgradeLocationToCurrentVersion(
@@ -950,7 +948,7 @@ describe('url upgrading', function() {
       ];
 
       const newTransformNodeString =
-        'f-js-' + uintArrayToString(callNodePathAfter);
+        'f-js-' + encodeUintArrayForUrlComponent(callNodePathAfter);
       expect(query.transforms).toEqual(newTransformNodeString);
     });
 
@@ -977,7 +975,7 @@ describe('url upgrading', function() {
       ];
 
       // Upgrader
-      const callNodeString = uintArrayToString(callNodePathBefore);
+      const callNodeString = encodeUintArrayForUrlComponent(callNodePathBefore);
       // focus-subtree transform with js implementation filter.
       const transformString = 'f-js-' + callNodeString;
       const { query } = upgradeLocationToCurrentVersion(
@@ -1001,7 +999,7 @@ describe('url upgrading', function() {
       ];
 
       const newTransformNodeString =
-        'f-js-' + uintArrayToString(callNodePathAfter);
+        'f-js-' + encodeUintArrayForUrlComponent(callNodePathAfter);
       expect(query.transforms).toEqual(newTransformNodeString);
     });
 
@@ -1027,7 +1025,7 @@ describe('url upgrading', function() {
       ];
 
       // Upgrader
-      const callNodeString = uintArrayToString(callNodePathBefore);
+      const callNodeString = encodeUintArrayForUrlComponent(callNodePathBefore);
       // focus-subtree transform with js implementation filter.
       const transformString = 'f-js-' + callNodeString;
       const { query } = upgradeLocationToCurrentVersion(
@@ -1051,7 +1049,7 @@ describe('url upgrading', function() {
       ];
 
       const newTransformNodeString =
-        'f-js-' + uintArrayToString(callNodePathAfter);
+        'f-js-' + encodeUintArrayForUrlComponent(callNodePathAfter);
       expect(query.transforms).toEqual(newTransformNodeString);
     });
 
@@ -1077,7 +1075,7 @@ describe('url upgrading', function() {
       ];
 
       // Upgrader
-      const callNodeString = uintArrayToString(callNodePathBefore);
+      const callNodeString = encodeUintArrayForUrlComponent(callNodePathBefore);
       // focus-subtree transform with js implementation filter.
       const transformString = 'f-js-' + callNodeString;
       const { query } = upgradeLocationToCurrentVersion(
@@ -1101,7 +1099,7 @@ describe('url upgrading', function() {
       ];
 
       const newTransformNodeString =
-        'f-js-' + uintArrayToString(callNodePathAfter);
+        'f-js-' + encodeUintArrayForUrlComponent(callNodePathAfter);
       expect(query.transforms).toEqual(newTransformNodeString);
     });
   });
@@ -1173,6 +1171,48 @@ describe('url upgrading', function() {
     });
   });
 
+  describe('version 6: change encoding of fields with TrackIndex lists', function() {
+    it('parses version 5 correctly', function() {
+      const { getState } = _getStoreWithURL(
+        {
+          pathname:
+            '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/calltree/',
+          search:
+            '?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=5-3-4&localTrackOrderByPid=1234-1-0~345-2-0-1&hiddenLocalTracksByPid=678-2-3-0',
+          v: 5,
+        },
+        null
+      );
+      const state = getState();
+      expect(urlStateSelectors.getGlobalTrackOrder(state)).toEqual([
+        5,
+        0,
+        1,
+        2,
+        3,
+        4,
+      ]);
+      expect(urlStateSelectors.getHiddenGlobalTracks(state)).toEqual(
+        new Set([3, 4, 5])
+      );
+      expect(urlStateSelectors.getLocalTrackOrderByPid(state)).toEqual(
+        new Map([
+          [1234, [1, 0]],
+          [345, [2, 0, 1]],
+        ])
+      );
+      expect(urlStateSelectors.getLocalTrackOrderByPid(state)).toEqual(
+        new Map([
+          [1234, [1, 0]],
+          [345, [2, 0, 1]],
+        ])
+      );
+      expect(urlStateSelectors.getHiddenLocalTracksByPid(state)).toEqual(
+        new Map([[678, new Set([0, 2, 3])]])
+      );
+    });
+  });
+
   // More general checks
   it("won't run if the current version is specified", function() {
     const { getState } = _getStoreWithURL({
@@ -1203,7 +1243,7 @@ describe('url upgrading', function() {
 
 describe('URL serialization of the transform stack', function() {
   const transformString =
-    'f-combined-012~mcn-combined-234~f-js-345-i~mf-6~ff-7~cr-combined-8-9~' +
+    'f-combined-0w2~mcn-combined-2w4~f-js-3w5-i~mf-6~ff-7~cr-combined-8-9~' +
     'rec-combined-10~df-11~cfs-12';
   const { getState } = _getStoreWithURL({
     search: '?transforms=' + transformString,


### PR DESCRIPTION
Profiles with a lot of tracks, such as [this one](https://profiler.firefox.com/public/t3ze91m264bqp3gcgj8rzwebpyjhvw2885b3d30/calltree/?globalTrackOrder=183-184-185-186-187-188-189-190-191-192-193-194-195-196-197-198-199-182-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25-26-27-28-29-30-31-32-33-34-35-36-37-38-39-40-41-42-43-44-45-46-47-48-49-50-51-52-53-54-55-56-57-58-59-60-61-62-63-64-65-66-67-68-69-70-71-72-73-74-75-76-77-78-79-80-81-82-83-84-85-86-87-88-89-90-91-92-93-94-95-96-97-98-99-100-101-102-103-104-105-106-107-108-109-110-111-112-113-114-115-116-117-118-119-120-121-122-123-124-125-126-127-128-129-130-131-132-133-134-135-136-137-138-139-140-141-142-143-144-145-146-147-148-149-150-151-152-153-154-155-156-157-158-159-160-161-162-163-164-165-166-167-168-169-170-171-172-173-174-175-176-177-178-179-180-181-0&hiddenGlobalTracks=183-184-185-186-187-188-189-190-191-192-193-194-195-196-197-198-199-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18-19-20-21-22-23-24-25-26-27-28-29-30-31-32-33-34-35-36-37-38-39-40-41-42-43-44-45-46-47-48-49-50-51-52-53-54-55-56-57-58-59-60-61-62-63-64-65-66-67-68-69-70-71-72-73-74-75-76-77-78-79-80-81-82-83-84-85-86-87-88-89-90-91-92-93-94-95-96-97-98-99-100-101-102-103-104-105-106-107-108-109-110-111-112-113-114-115-116-117-118-119-120-121-122-123-124-125-126-127-128-129-130-131-132-133-134-135-136-137-138-139-140-141-142-143-144-145-146-147-148-149-150-151-152-153-154-155-156-157-158-159-160-161-162-163-164-165-166-167-168-169-170-171-172-173-174-175-176-177-178-179-180-181&hiddenLocalTracksByPid=1549-0-3-4-5-6-2-1-8-7~1593-2-3~1598-0-1~1602-0-1-2~1607-1&localTrackOrderByPid=1549-7-8-0-1-2-3-4-5-6~1560-0-1~1561-2-3-0-1~1564-0-1~1562-0-1~1563-2-3-0-1~1566-0~1565-0-1~1567-2-3-0-1~1572-0~1568-0-1~1570-0-1~1569-2-3-0-1~1571-2-3-0-1~1577-0~1573-1-2-0~1574-1-2-0~1576-0-1~1575-0-1~1580-0-1~1578-0-1~1579-0-1~1584-0~1582-0-1~1581-0-1~1583-0-1~1586-0-1~1585-0-1~1587-0-1~1588-0-1~1589-0-1~1595-0~1590-0-1~1591-3-4-0-1-2~1592-0-1~1594-0-1~1593-4-5-0-1-2-3~1603-0~1601-0~1597-0-1~1598-3-4-0-1-2~1606-0~1604-0-1~1600-0-1~1602-3-4-0-1-2~1605-3-4-0-1-2~1608-2-3-0-1~1607-2-3-0-1~1609-0-1~1611-0-1~1610-0-1~1616-0-1~1620-0~1618-0-1~1617-0-1~1619-0-1~1622-0-1~1621-0-1~1624-0-1~1623-0-1~1627-0~1628-0-1~1625-0-1~1626-0-1~1633-0~1631-0-1~1630-0-1~1636-0-1~1629-0-1~1632-0-1~1637-0-1~1640-0~1643-0~1644-0~1639-0-1~1638-0-1~1652-0~1653-0~1650-0-1~1641-0-1~1655-0-1~1654-0-1~1651-0-1~1656-0~1658-0-1~1657-0-1~1661-0-1~1660-0-1~1659-0-1~1662-0-1~1668-0-1~1663-0-1~1669-0-1~1670-0-1~1671-0~1672-0-1~1673-0-1~1674-0~1676-0~1677-0-1~1675-0-1~1679-0-1~1678-0-1~1680-0-1~1681-0-1~1682-0-1~1684-0~1683-0~1685-0~1686-0-1~1691-0~1687-0-1~1688-0-1~1689-0-1~1690-0-1~1693-0~1694-0-1~1692-0-1~1695-0-1~1696-0-1~1697-0-1~1698-0-1~1700-0-1~1699-0-1~1701-0-1~1702-0~1703-0~1704-0-1~1706-0-1~1705-0-1~1707-0-1~1708-0~1709-0-1~1710-0~1713-0~1712-0~1714-0-1~1711-0-1~1715-0~1716-0~1717-0-1~1722-0~1718-0-1~1720-0-1~1719-0-1~1730-0~1721-0-1~1727-0-1~1729-0-1~1728-0-1~1731-0-1~1732-0~1734-0-1~1735-0-1~1733-0-1~1736-0-1~1741-0~1742-0~1737-0-1~1738-0-1~1739-0-1~1740-0-1~1743-0-1~1744-0-1~1745-0-1~1746-0~1747-0-1~1749-0-1~1748-0-1~1754-0-1~1755-0-1~1761-0~1760-0~1757-0~1759-0~1758-0~1756-0-1~1596-0~1556-0~1559-0~1555-0~1558-0-1~&range=42646m45015~42646m2225~43622m97&thread=0&timelineType=cpu-category&v=5), sometimes can't get a shortened URL because the full URL is too long. In this example, the length is `3296`.

This PR is an initial attempt at cutting down on that length; for the example given above, it reduces the length to `1904`, so it saves about 40%.

It does that by contracting consecutive indexes like `2-3-4-5` to a range syntax `2_5`.

The next step would be to cut down on the length of `localTrackOrderByPid`. It would be great if we could only emit the local track orders that are different from the default. We do have the profile around, so we could probably compute the default order when stringifying the URL (or sooner) and cache it somewhere. But I haven't tried that in this PR.

Please review commits individually. This PR also includes the commit from #3418.