### PR TITLE
Log command outputs in l10n sync script and make 'git merge' safer 

### DIFF
--- a/bin/l10n-sync.js
+++ b/bin/l10n-sync.js
@@ -311,7 +311,9 @@ async function tryToSync(upstream /*: string */) /*: Promise<void> */ {
         'merge',
         `${upstream}/main`,
         '-m',
-        `${MERGE_COMMIT_MESSAGE} (${currentDate})`
+        `${MERGE_COMMIT_MESSAGE} (${currentDate})`,
+        // Force the merge command to create a merge commit instead of a fast-forward.
+        '--no-ff'
       );
 
       console.log(`>>> Pushing to ${upstream}'s l10n branch.`);

--- a/bin/l10n-sync.js
+++ b/bin/l10n-sync.js
@@ -48,7 +48,17 @@ async function logAndExec(
   ...args /*: string[] */
 ) /*: Promise<ExecFilePromiseResult> */ {
   console.log('[exec]', executable, args.join(' '));
-  return execFile(executable, args);
+  const result = await execFile(executable, args);
+
+  if (result.stdout.length) {
+    console.log('stdout:\n' + result.stdout.toString());
+  }
+
+  if (result.stderr.length) {
+    console.log('stderr:\n' + result.stderr.toString());
+  }
+
+  return result;
 }
 
 /**
@@ -67,7 +77,12 @@ function logAndPipeExec(...commands /*: string[][] */) /*: string */ {
       .execFileSync(executable, args, { input: prevOutput })
       .toString();
   }
-  return prevOutput.toString();
+
+  const output = prevOutput.toString();
+  if (output.length) {
+    console.log('stdout:\n' + output.toString());
+  }
+  return output;
 }
 
 /**
@@ -132,9 +147,7 @@ async function findUpstream() /*: Promise<string> */ {
     const gitRemoteResult = await logAndExec('git', 'remote', '-v');
 
     if (gitRemoteResult.stderr.length) {
-      throw new Error(
-        `'git remote' has stderr output: ${gitRemoteResult.stderr.toString()}`
-      );
+      throw new Error(`'git remote' failed to run.`);
     }
 
     const gitRemoteOutput = gitRemoteResult.stdout.toString();
@@ -303,17 +316,7 @@ async function tryToSync(upstream /*: string */) /*: Promise<void> */ {
 
       console.log(`>>> Pushing to ${upstream}'s l10n branch.`);
       await pauseWithMessageIfNecessary();
-      const pushResult = await logAndExec(
-        'git',
-        'push',
-        '--no-verify',
-        upstream,
-        'HEAD:l10n'
-      );
-
-      // Print the output of `git push` so user can see the result.
-      console.log(pushResult.stdout.toString());
-      console.log(pushResult.stderr.toString());
+      await logAndExec('git', 'push', '--no-verify', upstream, 'HEAD:l10n');
 
       console.log('>>> Going back to your previous banch.');
       await logAndExec('git', 'checkout', '-');


### PR DESCRIPTION
This PR does two things:
1. Adds logs for command outputs to `logAndExec` and `logAndPipeExec`.
2. Adds `-no-ff` option to 'git merge' to make it force for a merge commit.

Tested manually and it seems to work well.