### PR TITLE
Remove the unused canvas mock in the test for the NetworkChart

### DIFF
--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -25,10 +25,6 @@ import {
   TIMELINE_MARGIN_RIGHT,
 } from '../../app-logic/constants';
 
-import {
-  autoMockCanvasContext,
-  flushDrawLog,
-} from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getProfileWithMarkers,
@@ -138,14 +134,9 @@ function setupWithPayload(markers: TestDefinedMarkers) {
 }
 
 describe('NetworkChart', function() {
-  autoMockCanvasContext();
-
   it('renders NetworkChart correctly', () => {
     const { container } = setupWithPayload([...NETWORK_MARKERS]);
-
-    const drawCalls = flushDrawLog();
     expect(container.firstChild).toMatchSnapshot();
-    expect(drawCalls).toMatchSnapshot();
   });
 
   it('displays a context menu when right clicking', () => {

--- a/src/test/components/__snapshots__/NetworkChart.test.js.snap
+++ b/src/test/components/__snapshots__/NetworkChart.test.js.snap
@@ -483,5 +483,3 @@ exports[`NetworkChart renders NetworkChart correctly 1`] = `
   </div>
 </div>
 `;
-
-exports[`NetworkChart renders NetworkChart correctly 2`] = `Array []`;


### PR DESCRIPTION
This is a simple passing-by fix :-)

A long time ago, the network chart used to use the same canvas-based component as the marker chart. When this was changed the test was never updated.