### PR TITLE
Updated expand all menu item to include shortcut key.

### DIFF
--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -586,12 +586,13 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
         {showExpandAll ? (
           <>
             <Localized id="CallNodeContextMenu--expand-all">
-              <MenuItem
+              <MenuItemWithShortcut
                 onClick={this._handleClick}
                 data={{ type: 'expand-all' }}
+                shortcut="*"
               >
                 Expand all
-              </MenuItem>
+              </MenuItemWithShortcut>
             </Localized>
             <div className="react-contextmenu-separator" />
           </>
@@ -707,6 +708,20 @@ function TransformMenuItem(props: {|
       <span
         className={`react-contextmenu-icon callNodeContextMenuIcon${props.icon}`}
       />
+      <div className="react-contextmenu-item-content">{props.children}</div>
+      <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
+    </MenuItem>
+  );
+}
+
+function MenuItemWithShortcut(props: {|
+  +children: React.Node,
+  +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
+  +shortcut: string,
+  +data: { type: string },
+|}) {
+  return (
+    <MenuItem onClick={props.onClick} data={{ type: props.data.type }}>
       <div className="react-contextmenu-item-content">{props.children}</div>
       <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
     </MenuItem>

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -187,7 +187,16 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     role="menuitem"
     tabindex="-1"
   >
-    Expand all
+    <div
+      class="react-contextmenu-item-content"
+    >
+      Expand all
+    </div>
+    <kbd
+      class="callNodeContextMenuShortcut"
+    >
+      *
+    </kbd>
   </div>
   <div
     class="react-contextmenu-separator"


### PR DESCRIPTION
Hi all,

I've updated the Context menu to include the shortcut key "*" for the Expand All menu item.

I've created a new component which renders a menu item with a shortcut key, there was already a component similar to this but it's for transform menu items.

Fixes #3394 

Regards,

Duncan