### PR TITLE
Improve the requestAnimationFrame mock, to automatically trigger all new callbacks

### DIFF
--- a/src/test/components/CPUGraph.test.js
+++ b/src/test/components/CPUGraph.test.js
@@ -15,7 +15,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
 import { storeWithProfile } from '../fixtures/stores';
 import {

--- a/src/test/components/EmptyThreadIndicator.test.js
+++ b/src/test/components/EmptyThreadIndicator.test.js
@@ -12,7 +12,7 @@ import {
   getIndicatorPositions,
 } from '../../components/timeline/EmptyThreadIndicator';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { getElementWithFixedSize } from '../fixtures/mocks/element-size';
 
 import type { StartEndRange } from 'firefox-profiler/types';

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -42,7 +42,7 @@ import {
   findFillTextPositionFromDrawLog,
 } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
 
 import type { CssPixels } from 'firefox-profiler/types';

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -18,7 +18,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   addRootOverlayElement,

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -66,11 +66,6 @@ describe('StackChart', function() {
     const { container } = renderResult;
 
     if (skipLoadingScreen) {
-      // Have React show the loading screen.
-      flushRafCalls();
-      // Have React show our new component, and schedule a draw call.
-      flushRafCalls();
-      // Now flush once more to actually draw to the screen.
       flushRafCalls();
     }
 
@@ -100,8 +95,6 @@ describe('StackChart', function() {
       events: simpleTracerEvents,
     });
     expect(getJsTracerChartCanvas()).toBeFalsy();
-    // Flush twice, as the canvas defers until after React updates.
-    flushRafCalls();
     flushRafCalls();
     expect(getJsTracerChartCanvas()).toBeTruthy();
   });

--- a/src/test/components/KeyboardShortcut.test.js
+++ b/src/test/components/KeyboardShortcut.test.js
@@ -11,7 +11,7 @@ import createStore from 'firefox-profiler/app-logic/create-store';
 import { KeyboardShortcut } from 'firefox-profiler/components/app/KeyboardShortcut';
 import { fireFullKeyPress } from 'firefox-profiler/test/fixtures/utils';
 import { coerce } from 'firefox-profiler/utils/flow';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 
 describe('app/KeyboardShortcut', function() {
   function setup() {

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -45,7 +45,7 @@ import {
   fireFullClick,
   fireFullContextMenu,
 } from '../fixtures/utils';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
 
 import type {

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -38,7 +38,7 @@ import {
   fireFullClick,
   fireFullContextMenu,
 } from '../fixtures/utils';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
 
 const NETWORK_MARKERS = (function() {

--- a/src/test/components/ProfileViewer.test.js
+++ b/src/test/components/ProfileViewer.test.js
@@ -18,7 +18,7 @@ import { stateFromLocation } from 'firefox-profiler/app-logic/url-handling';
 import { blankStore } from '../fixtures/stores';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import {
   autoMockElementSize,
   getElementWithFixedSize,

--- a/src/test/components/SampleGraph.test.js
+++ b/src/test/components/SampleGraph.test.js
@@ -15,7 +15,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -39,7 +39,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getMouseEvent,

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -24,7 +24,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -422,9 +422,6 @@ describe('Timeline', function() {
       </Provider>
     );
 
-    // We need to flush twice since when the first flush is run, it
-    // will request more code to be run in later animation frames.
-    flushRafCalls();
     flushRafCalls();
 
     const drawCalls = flushDrawLog();

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -15,7 +15,7 @@ import {
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
 import { autoMockDomRect } from 'firefox-profiler/test/fixtures/mocks/domrect.js';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import {
   autoMockElementSize,
   getElementWithFixedSize,

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -43,13 +43,6 @@ import type { CssPixels } from 'firefox-profiler/types';
 function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   const flushRafCalls = mockRaf();
 
-  function flushRafTwice() {
-    // We need to flush twice since when the first flush is run, it
-    // will request more code to be run in later animation frames.
-    flushRafCalls();
-    flushRafCalls();
-  }
-
   const profile = getProfileWithMarkers(...markersPerThread);
 
   const renderResult = render(
@@ -66,7 +59,7 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
     </Provider>
   );
 
-  flushRafTwice();
+  flushRafCalls();
 
   function getContextMenu() {
     return ensureExists(
@@ -124,17 +117,16 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
     fireMouseEvent('mousemove', positioningOptions);
     fireFullContextMenu(canvas, positioningOptions);
 
-    flushRafTwice();
+    flushRafCalls();
   }
 
   function mouseOver(where: { x: CssPixels, y: CssPixels }) {
     const positioningOptions = getPositioningOptions(where);
     fireMouseEvent('mousemove', positioningOptions);
-    flushRafTwice();
+    flushRafCalls();
   }
 
   return {
-    flushRafTwice,
     rightClick,
     mouseOver,
     getContextMenu,

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -35,7 +35,7 @@ import {
   fireFullClick,
   fireFullContextMenu,
 } from '../fixtures/utils';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
 
 import type { CssPixels } from 'firefox-profiler/types';

--- a/src/test/components/TrackEventDelay.test.js
+++ b/src/test/components/TrackEventDelay.test.js
@@ -17,7 +17,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   addRootOverlayElement,

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -18,7 +18,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   addRootOverlayElement,

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -20,7 +20,7 @@ import {
 import { ensureExists } from 'firefox-profiler/utils/flow';
 
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getMouseEvent,

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -21,7 +21,7 @@ import { ensureExists } from '../../utils/flow';
 import { FULL_TRACK_SCREENSHOT_HEIGHT } from '../../app-logic/constants';
 
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   getMouseEvent,

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -118,8 +118,6 @@ describe('timeline/TrackThread', function() {
 
     // WithSize uses requestAnimationFrame
     flushRafCalls();
-    // The size update then schedules another rAF draw call for canvas components.
-    flushRafCalls();
 
     const stackGraphCanvas = () =>
       ensureExists(

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -25,7 +25,7 @@ import {
   autoMockCanvasContext,
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   addRootOverlayElement,

--- a/src/test/components/TrackVisualProgress.test.js
+++ b/src/test/components/TrackVisualProgress.test.js
@@ -18,7 +18,7 @@ import {
   flushDrawLog,
 } from '../fixtures/mocks/canvas-context';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
   addRootOverlayElement,

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -698,7 +698,10 @@ function setup(profileOverrides: MixedObject = {}) {
   function depressKey(code: string, duration: Milliseconds) {
     jest.spyOn(performance, 'now').mockReturnValue(0);
     fireEvent.keyDown(viewportContainer(), { code });
-    flushRafCalls([duration]);
+    // we run requestAnimationFrame callbacks only once here: indeed Viewport
+    // will schedule callbacks as long as the keyup event isn't sent, and we'd
+    // go into an infinite loop.
+    flushRafCalls({ timestamps: [duration], once: true });
     fireEvent.keyUp(viewportContainer(), { code });
     flushRafCalls();
   }

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -24,7 +24,7 @@ import {
   autoMockElementSize,
   setMockedElementSize,
 } from '../fixtures/mocks/element-size';
-import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 

--- a/src/test/components/__snapshots__/CPUGraph.test.js.snap
+++ b/src/test/components/__snapshots__/CPUGraph.test.js.snap
@@ -70,6 +70,23 @@ Array [
     "set fillStyle",
     "#c5e1fe",
   ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    10,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
 ]
 `;
 

--- a/src/test/components/__snapshots__/JsTracer.test.js.snap
+++ b/src/test/components/__snapshots__/JsTracer.test.js.snap
@@ -153,11 +153,313 @@ Array [
     5,
     11,
   ],
+  Array [
+    "set font",
+    "10px sans-serif",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    150,
+    1,
+    200,
+    13,
+  ],
+  Array [
+    "measureText",
+    "https://mozilla.org",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "https://mozilla.org",
+    153,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    160,
+    17,
+    179,
+    13,
+  ],
+  Array [
+    "measureText",
+    "Interpreter",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "Interpreter",
+    163,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    339,
+    18,
+    0.9999999999999745,
+    11,
+  ],
+  Array [
+    "fillRect",
+    170,
+    33,
+    160,
+    13,
+  ],
+  Array [
+    "measureText",
+    "IonMonkey",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "IonMonkey",
+    173,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf0",
+  ],
+  Array [
+    "fillRect",
+    149,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    0,
+    15,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    31,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    47,
+    365,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "measureText",
+    "Tracing Information",
+  ],
+  Array [
+    "fillText",
+    "Tracing Information",
+    5,
+    11,
+  ],
 ]
 `;
 
 exports[`StackChart matches the snapshot for an inverted draw call 1`] = `
 Array [
+  Array [
+    "set font",
+    "10px sans-serif",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    150,
+    1,
+    200,
+    13,
+  ],
+  Array [
+    "measureText",
+    "https://mozilla.org",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "https://mozilla.org",
+    153,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    160,
+    17,
+    179,
+    13,
+  ],
+  Array [
+    "measureText",
+    "Interpreter",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "Interpreter",
+    163,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    339,
+    18,
+    0.9999999999999745,
+    11,
+  ],
+  Array [
+    "fillRect",
+    170,
+    33,
+    160,
+    13,
+  ],
+  Array [
+    "measureText",
+    "IonMonkey",
+  ],
+  Array [
+    "set fillStyle",
+    "white",
+  ],
+  Array [
+    "fillText",
+    "IonMonkey",
+    173,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#ededf0",
+  ],
+  Array [
+    "fillRect",
+    149,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    0,
+    15,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    31,
+    365,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    47,
+    365,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "measureText",
+    "Tracing Information",
+  ],
+  Array [
+    "fillText",
+    "Tracing Information",
+    5,
+    11,
+  ],
   Array [
     "set font",
     "10px sans-serif",

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -38,7 +38,7 @@ exports[`MarkerChart context menus displays when right clicking on a marker 1`] 
 <nav
   class="react-contextmenu markerContextMenu react-contextmenu--visible"
   role="menu"
-  style="position: fixed; opacity: 0; pointer-events: none;"
+  style="position: fixed; opacity: 1; pointer-events: auto; top: 27px; left: 153px;"
   tabindex="-1"
 >
   <div

--- a/src/test/components/__snapshots__/SampleGraph.test.js.snap
+++ b/src/test/components/__snapshots__/SampleGraph.test.js.snap
@@ -90,6 +90,23 @@ Array [
     10,
     10,
   ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    10,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
 ]
 `;
 

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -2475,6 +2475,23 @@ Array [
     10,
     10,
   ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    10,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
 ]
 `;
 
@@ -4962,6 +4979,23 @@ Array [
     0,
     10,
     10,
+  ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    10,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
   ],
 ]
 `;
@@ -7451,6 +7485,23 @@ Array [
     6.666666666666667,
     10,
   ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    10,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
 ]
 `;
 
@@ -9431,6 +9482,23 @@ Array [
     10,
   ],
   Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    10,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
     "set fillStyle",
     "#003eaa",
   ],
@@ -10173,6 +10241,8 @@ exports[`ThreadActivityGraph matches the component snapshot 1`] = `
     >
       <canvas
         class="timelineMarkersCanvas"
+        height="10"
+        width="80"
       />
     </div>
   </div>

--- a/src/test/components/__snapshots__/TrackEventDelay.test.js.snap
+++ b/src/test/components/__snapshots__/TrackEventDelay.test.js.snap
@@ -842,6 +842,8 @@ exports[`TrackEventDelay matches the component snapshot when event delay tracks 
   >
     <canvas
       class="timelineTrackEventDelayCanvas"
+      height="40"
+      width="80"
     />
     <div
       class="timelineEmptyThreadIndicator"

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -153,6 +153,8 @@ exports[`TrackMemory matches the component snapshot 1`] = `
     >
       <canvas
         class="timelineMarkersCanvas"
+        height="10"
+        width="80"
       />
     </div>
   </div>
@@ -161,6 +163,8 @@ exports[`TrackMemory matches the component snapshot 1`] = `
   >
     <canvas
       class="timelineTrackMemoryCanvas"
+      height="25"
+      width="80"
     />
     <div
       class="timelineEmptyThreadIndicator"

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -694,7 +694,7 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
   <canvas
     class="timelineTrackNetworkCanvas"
     height="35"
-    width="0"
+    width="400"
   />
   <div
     class="timelineVerticalIndicatorsLine"

--- a/src/test/components/__snapshots__/TrackVisualProgress.test.js.snap
+++ b/src/test/components/__snapshots__/TrackVisualProgress.test.js.snap
@@ -147,6 +147,8 @@ exports[`TrackVisualProgress matches the component snapshot 1`] = `
   >
     <canvas
       class="timelineTrackVisualProgressCanvas"
+      height="40"
+      width="70"
     />
   </div>
 </div>

--- a/src/test/fixtures/mocks/request-animation-frame.js
+++ b/src/test/fixtures/mocks/request-animation-frame.js
@@ -4,10 +4,27 @@
 
 // @flow
 
+/*
+ * Tests don't have access to the requestionAnimationFrame API, so this file
+ * provides a mock for it.
+ * Please have a look at the extended comment below for more information about
+ * how to use this mock.
+ */
+
+import { stripIndent } from 'common-tags';
+
+function stripThisFileFromErrorStack(stack: string) {
+  const stacks = stack.split('\n');
+  const filteredStacks = stacks.filter(
+    stack => !stack.includes('/request-animation-frame.js')
+  );
+  return filteredStacks.join('\n');
+}
+
 /**
- * Tests don't have access to the requestionAnimationFrame API, so this function
- * provides a mock for it. It holds on to all queued calls, and the returned function
- * will flush and execute all of the calls in the order they were received.
+ * This function provides a mock for requestAnimationFrame. It holds on to all
+ * queued calls, and the returned function will flush and execute all of the
+ * calls in the order they were received.
  *
  * It uses jest.spyOn, which will automatically clear itself after the test is run.
  *
@@ -19,19 +36,83 @@
  *    });
  *    flushRafCalls();
  *
+ * By default this will also repeatedly call requests chained during the
+ * callback, but only 5 times at most, and will throw after that. If you want to
+ * call the callbacks only once, you can pass { once: true } to flushRafCalls:
+ *
+ *    flushRafCalls({ once: true })
+ *
+ * Normally timestamps are passed to the callbacks. By default this mock doesn't
+ * do that, but you can pass the timestamps to use with the "timestamps"
+ * parameter:
+ *
+ *    flushRafCalls({ timestamps: [10000, 10100] });
+ *
  */
+
 export function mockRaf() {
-  let fns = [];
+  let requests = [];
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(fn => {
-    fns.push(fn);
+    requests.push({
+      func: fn,
+      stack: stripThisFileFromErrorStack(new Error().stack),
+    });
   });
 
-  return (timestamps: number[] = []) => {
-    const oldFns = fns;
-    fns = [];
-    for (const fn of oldFns) {
-      const arg = timestamps.shift();
-      fn(arg);
+  return function flushRafCalls(
+    { timestamps, once }: $Shape<{| timestamps: number[], once: boolean |}> = {
+      timestamps: [],
+      once: false,
+    }
+  ) {
+    let maxLoops = once ? 1 : 5;
+    while (requests.length && maxLoops-- > 0) {
+      const oldrequests = requests;
+      requests = [];
+
+      while (oldrequests.length) {
+        const request = oldrequests.shift();
+        const arg = timestamps.shift();
+        request.func.call(null, arg);
+      }
+    }
+
+    if (maxLoops <= 0 && !once) {
+      if (requests.length === 1) {
+        const error = new Error(stripIndent`
+          We found a possible infinite loop using requestAnimationFrame.
+          If this is expected, you can pass "{once: true}" to "flushRafCalls" to avoid this throw.
+          This error's stack is where the last AnimationFrame was requested.
+        `);
+        error.stack = requests[0].stack;
+        throw error;
+      }
+
+      // More than 1 request.
+
+      const lastRequest = requests.pop();
+      const remainingRequestFirstStacks = requests.map((request, i) => {
+        const stackLines = request.stack.split('\n');
+        const firstLineFromProject = stackLines.find(line =>
+          line.includes('/src/')
+        );
+        const reportedFirstLine = firstLineFromProject || stackLines[0];
+
+        // Remove the first characteres so that jest's stack handling doesn't
+        // merge this in the other stack.
+        return reportedFirstLine.replace(/^\s*at/, `${i + 1} `);
+      });
+
+      const error = new Error(stripIndent`
+        We found a possible infinite loop using requestAnimationFrame.
+        If this is expected, you can pass "{once: true}" to "flushRafCalls".
+        This error's stack is where the last AnimationFrame was requested, but there ${
+          requests.length > 1 ? 'are' : 'is'
+        } ${requests.length} more:
+        ${remainingRequestFirstStacks.join('\n')}
+      `);
+      error.stack = lastRequest.stack;
+      throw error;
     }
   };
 }

--- a/src/test/fixtures/mocks/request-animation-frame.js
+++ b/src/test/fixtures/mocks/request-animation-frame.js
@@ -20,7 +20,7 @@
  *    flushRafCalls();
  *
  */
-export default function mockRaf() {
+export function mockRaf() {
   let fns = [];
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(fn => {
     fns.push(fn);


### PR DESCRIPTION
Please don't look at the first commit, this is PR #3435.

The incentive for this patch is that we shouldn't have to know how much time we should call `flushRafCalls` (depending on how `requestAnimationFrame` is used in components). So now `flushRafCalls` will repeatedly call new callbacks, but will stop after 5 times. When stopping it will throw with a stack that will make it easy to find infinite loops, like the one fixed in PR #3435.

I especially like that there are more stuff appended to existing draw snapshots, or that we have some actual size information to some canvas, thanks to this patch. We clearly see that we'll depend less on some internal implementation.