### PR TITLE
Make that ActivityGraph redraws properly on resizes

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -71,7 +71,6 @@ function _stopPropagation(e: TransitionEvent) {
 }
 
 class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
-  _resizeListener = () => this.forceUpdate();
   _fillsQuerier: null | ActivityFillGraphQuerier = null;
   _container: HTMLElement | null = null;
 
@@ -106,8 +105,6 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    window.addEventListener('resize', this._resizeListener);
-    this.forceUpdate(); // for initial size
     const container = this._container;
     if (container !== null) {
       // Stop the propagation of transitionend so we won't fire multiple events
@@ -117,7 +114,6 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this._resizeListener);
     const container = this._container;
     if (container !== null) {
       container.removeEventListener('transitionend', _stopPropagation);

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -19,6 +19,7 @@ import type {
   IndexIntoSamplesTable,
   CategoryList,
 } from 'firefox-profiler/types';
+import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
 
 import type { CategoryDrawStyles } from './ActivityGraphFills';
 
@@ -41,6 +42,7 @@ type CanvasProps = {|
   +onMouseUp: (SyntheticMouseEvent<HTMLCanvasElement>) => void,
   +enableCPUUsage: boolean,
   +maxThreadCPUDelta: number,
+  ...SizeProps,
 |};
 
 export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
@@ -102,12 +104,13 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       categories,
       enableCPUUsage,
       maxThreadCPUDelta,
+      width,
+      height,
     } = this.props;
 
-    const rect = canvas.getBoundingClientRect();
     const ctx = canvas.getContext('2d');
-    const canvasPixelWidth = Math.round(rect.width * window.devicePixelRatio);
-    const canvasPixelHeight = Math.round(rect.height * window.devicePixelRatio);
+    const canvasPixelWidth = Math.round(width * window.devicePixelRatio);
+    const canvasPixelHeight = Math.round(height * window.devicePixelRatio);
     canvas.width = canvasPixelWidth;
     canvas.height = canvasPixelHeight;
 

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -502,15 +502,13 @@ export class ActivityFillGraphQuerier {
   getSampleAndCpuRatioAtClick(
     cssX: CssPixels,
     cssY: CssPixels,
-    time: Milliseconds,
-    canvasBoundingRect: ClientRect
+    time: Milliseconds
   ): HoveredPixelState | null {
     const {
-      canvasPixelWidth,
       rangeFilteredThread: { samples, stackTable },
       greyCategoryIndex,
     } = this.renderedComponentSettings;
-    const devicePixelRatio = canvasPixelWidth / canvasBoundingRect.width;
+    const { devicePixelRatio } = window;
     const deviceX = Math.round(cssX * devicePixelRatio);
     const deviceY = Math.round(cssY * devicePixelRatio);
     const categoryUnderMouse = this._categoryAtDevicePixel(deviceX, deviceY);

--- a/src/test/components/ActiveTabTimeline.test.js
+++ b/src/test/components/ActiveTabTimeline.test.js
@@ -31,6 +31,7 @@ import {
   autoMockElementSize,
   getElementWithFixedSize,
 } from '../fixtures/mocks/element-size';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 
 describe('ActiveTabTimeline', function() {
   autoMockCanvasContext();
@@ -39,7 +40,7 @@ describe('ActiveTabTimeline', function() {
     jest
       .spyOn(ReactDOM, 'findDOMNode')
       .mockImplementation(() =>
-        getElementWithFixedSize({ width: 300, height: 300 })
+        getElementWithFixedSize({ width: 200, height: 300 })
       );
   });
 
@@ -58,11 +59,14 @@ describe('ActiveTabTimeline', function() {
       })
     );
 
+    // WithSize uses requestAnimationFrame
+    const flushRafCalls = mockRaf();
     const { container } = render(
       <Provider store={store}>
         <Timeline />
       </Provider>
     );
+    flushRafCalls();
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -97,6 +101,9 @@ describe('ActiveTabTimeline', function() {
       // The assertions are simpler if the GeckoMain tab thread is not already selected.
       dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
 
+      // WithSize uses requestAnimationFrame
+      const flushRafCalls = mockRaf();
+
       const renderResult = render(
         <Provider store={store}>
           <TimelineActiveTabGlobalTrack
@@ -106,6 +113,8 @@ describe('ActiveTabTimeline', function() {
           />
         </Provider>
       );
+      flushRafCalls();
+
       const { container } = renderResult;
 
       const getGlobalTrackRow = () =>
@@ -180,6 +189,9 @@ describe('ActiveTabTimeline', function() {
       const { getState, dispatch } = store;
       const resourceTracks = getActiveTabResourceTracks(getState());
 
+      // WithSize uses requestAnimationFrame
+      const flushRafCalls = mockRaf();
+
       const renderResult = render(
         <Provider store={store}>
           <TimelineActiveTabResourcesPanel
@@ -188,6 +200,8 @@ describe('ActiveTabTimeline', function() {
           />
         </Provider>
       );
+
+      flushRafCalls();
 
       const getResourcesPanelHeader = () => screen.getByText(/Resources/);
       const getResourceFrameTrack = () => screen.queryByText(/IFrame:/);
@@ -203,6 +217,7 @@ describe('ActiveTabTimeline', function() {
         getResourceFrameTrack,
         mainThreadIndex,
         resourceThreadIndex,
+        flushRafCalls,
       };
     }
 
@@ -212,8 +227,9 @@ describe('ActiveTabTimeline', function() {
     });
 
     it('matches the snapshot of a resources panel when opened', () => {
-      const { container, getResourcesPanelHeader } = setup();
+      const { container, getResourcesPanelHeader, flushRafCalls } = setup();
       fireFullClick(getResourcesPanelHeader());
+      flushRafCalls();
       expect(container.firstChild).toMatchSnapshot();
     });
 
@@ -223,11 +239,16 @@ describe('ActiveTabTimeline', function() {
     });
 
     it('clicking on the header opens the resources panel', () => {
-      const { getResourcesPanelHeader, getResourceFrameTrack } = setup();
+      const {
+        getResourcesPanelHeader,
+        getResourceFrameTrack,
+        flushRafCalls,
+      } = setup();
       const resourcesPanelHeader = getResourcesPanelHeader();
       expect(getResourceFrameTrack()).toBeFalsy();
 
       fireFullClick(resourcesPanelHeader);
+      flushRafCalls();
       expect(getResourceFrameTrack()).toBeTruthy();
     });
 
@@ -283,6 +304,9 @@ describe('ActiveTabTimeline', function() {
       const { getState, dispatch } = store;
       const resourceTracks = getActiveTabResourceTracks(getState());
       const trackIndex = 1;
+
+      // WithSize uses requestAnimationFrame
+      const flushRafCalls = mockRaf();
       const renderResult = render(
         <Provider store={store}>
           <TimelineActiveTabResourceTrack
@@ -292,6 +316,7 @@ describe('ActiveTabTimeline', function() {
           />
         </Provider>
       );
+      flushRafCalls();
 
       const { container } = renderResult;
       const resourcePage = ensureExists(profile.pages)[2];

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -22,6 +22,7 @@ import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profil
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick, fireFullContextMenu } from '../fixtures/utils';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 
 describe('timeline/GlobalTrack', function() {
   autoMockCanvasContext();
@@ -69,6 +70,8 @@ describe('timeline/GlobalTrack', function() {
       dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
     }
 
+    // WithSize uses requestAnimationFrame
+    const flushRafCalls = mockRaf();
     const renderResult = render(
       <Provider store={store}>
         <TimelineGlobalTrack
@@ -78,6 +81,7 @@ describe('timeline/GlobalTrack', function() {
         />
       </Provider>
     );
+    flushRafCalls();
     const { container } = renderResult;
 
     const getGlobalTrackLabel = () =>

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -39,6 +39,7 @@ import {
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick, fireFullContextMenu } from '../fixtures/utils';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 
 // In getProfileWithNiceTracks, the two pids are 111 and 222 for the
 // "GeckoMain process" and "GeckoMain tab" respectively. Use 222 since it has
@@ -162,6 +163,8 @@ function setup(
   // The assertions are simpler if this thread is not already selected.
   dispatch(changeSelectedThreads(new Set([threadIndex + 1])));
 
+  // WithSize uses requestAnimationFrame
+  const flushRafCalls = mockRaf();
   const renderResult = render(
     <Provider store={store}>
       <TimelineLocalTrack
@@ -172,6 +175,7 @@ function setup(
       />
     </Provider>
   );
+  flushRafCalls();
 
   const { container } = renderResult;
 

--- a/src/test/components/SampleTooltipContents.test.js
+++ b/src/test/components/SampleTooltipContents.test.js
@@ -21,6 +21,7 @@ import {
 } from '../fixtures/utils';
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 
 import type {
   Profile,
@@ -85,6 +86,8 @@ describe('SampleTooltipContents', function() {
     const store = storeWithProfile(profile);
     const threadsKey = 0;
 
+    // WithSize uses requestAnimationFrame
+    const flushRafCalls = mockRaf();
     const { container } = render(
       <Provider store={store}>
         <TimelineTrackThread
@@ -94,6 +97,7 @@ describe('SampleTooltipContents', function() {
         />
       </Provider>
     );
+    flushRafCalls();
 
     const canvas = ensureExists(
       container.querySelector('.threadActivityGraphCanvas'),
@@ -103,13 +107,14 @@ describe('SampleTooltipContents', function() {
     fireEvent(
       canvas,
       getMouseEvent('mousemove', {
-        pageX: getSamplesPixelPosition(
+        offsetX: getSamplesPixelPosition(
           hoveredSampleIndex,
           hoveredSamplePosition
         ),
-        pageY: GRAPH_HEIGHT * 0.9,
+        offsetY: GRAPH_HEIGHT * 0.9,
       })
     );
+    flushRafCalls();
 
     const getTooltip = () =>
       ensureExists(

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -62,6 +62,10 @@ describe('ThreadActivityGraph', function() {
     const threadIndex = 0;
     const flushRafCalls = mockRaf();
 
+    /**
+     * The ThreadActivityGraph is not a connected component. It's easiest to
+     * test it as once it's connected to the Redux store in TimelineTrackThread.
+     */
     const renderResult = render(
       <Provider store={store}>
         <TimelineTrackThread
@@ -88,8 +92,8 @@ describe('ThreadActivityGraph', function() {
       graphHeightPercentage: number
     ) {
       fireFullClick(activityGraphCanvas, {
-        pageX: getSamplesPixelPosition(index),
-        pageY: GRAPH_HEIGHT * graphHeightPercentage,
+        offsetX: getSamplesPixelPosition(index),
+        offsetY: GRAPH_HEIGHT * graphHeightPercentage,
       });
     }
 
@@ -200,99 +204,93 @@ describe('ThreadActivityGraph', function() {
     expect(flushDrawLog()).toMatchSnapshot();
   });
 
-  /**
-   * The ThreadActivityGraph is not a connected component. It's easiest to test it
-   * as once it's connected to the Redux store in the SelectedActivityGraph.
-   */
-  describe('ThreadActivityGraph', function() {
-    it('selects the full call node path when clicked', function() {
-      const { clickActivityGraph, getCallNodePath } = setup();
+  it('selects the full call node path when clicked', function() {
+    const { clickActivityGraph, getCallNodePath } = setup();
 
-      // The full call node at this sample is:
-      //  A -> B -> C -> F -> G
-      clickActivityGraph(1, 0.2);
-      expect(getCallNodePath()).toEqual(['A', 'B', 'C', 'F', 'G']);
+    // The full call node at this sample is:
+    //  A -> B -> C -> F -> G
+    clickActivityGraph(1, 0.2);
+    expect(getCallNodePath()).toEqual(['A', 'B', 'C', 'F', 'G']);
 
-      // The full call node at this sample is:
-      //  A -> B -> H -> I
-      clickActivityGraph(1, 0.8);
-      expect(getCallNodePath()).toEqual(['A', 'B', 'H', 'I']);
-    });
+    // The full call node at this sample is:
+    //  A -> B -> H -> I
+    clickActivityGraph(1, 0.8);
+    expect(getCallNodePath()).toEqual(['A', 'B', 'H', 'I']);
+  });
 
-    it('will redraw even when there are no samples in range', function() {
-      const { dispatch } = setup();
-      flushDrawLog();
+  it('will redraw even when there are no samples in range', function() {
+    const { dispatch } = setup();
+    flushDrawLog();
 
-      // Commit a thin range which contains no samples
-      dispatch(commitRange(0.5, 0.6));
-      const drawCalls = flushDrawLog();
-      // We use the presence of 'globalCompositeOperation' to know
-      // whether the canvas was redrawn or not.
-      expect(drawCalls.map(([fn]) => fn)).toContain(
-        'set globalCompositeOperation'
-      );
-    });
+    // Commit a thin range which contains no samples
+    dispatch(commitRange(0.5, 0.6));
+    const drawCalls = flushDrawLog();
+    // We use the presence of 'globalCompositeOperation' to know
+    // whether the canvas was redrawn or not.
+    expect(drawCalls.map(([fn]) => fn)).toContain(
+      'set globalCompositeOperation'
+    );
+  });
 
-    it('will compute the percentage properly even though it is in a commited range with missing samples', function() {
-      const MS_TO_NS_MULTIPLIER = 1000000;
-      const profile = getSamplesProfile();
-      profile.meta.interval = 1;
-      profile.meta.sampleUnits = {
-        time: 'ms',
-        eventDelay: 'ms',
-        threadCPUDelta: 'ns',
-      };
+  it('will compute the percentage properly even though it is in a commited range with missing samples', function() {
+    const MS_TO_NS_MULTIPLIER = 1000000;
+    const profile = getSamplesProfile();
+    profile.meta.interval = 1;
+    profile.meta.sampleUnits = {
+      time: 'ms',
+      eventDelay: 'ms',
+      threadCPUDelta: 'ns',
+    };
 
-      // We are creating a profile which has 8ms missing sample area in it.
-      // It's starting between the sample 2 and 3.
-      profile.threads[0].samples.threadCPUDelta = [
-        null,
-        0.4 * MS_TO_NS_MULTIPLIER,
-        0.1 * MS_TO_NS_MULTIPLIER,
-        4 * MS_TO_NS_MULTIPLIER, // It's 50% CPU because the actual interval is 8ms.
-        1 * MS_TO_NS_MULTIPLIER,
-        0.2 * MS_TO_NS_MULTIPLIER,
-        0.8 * MS_TO_NS_MULTIPLIER,
-        0.3 * MS_TO_NS_MULTIPLIER,
-      ];
-      profile.threads[0].samples.time = [
-        0,
-        1,
-        2,
-        10, // For this sample, the interval is 8ms since there are missing samples.
-        11,
-        12,
-        13,
-        14,
-      ];
+    // We are creating a profile which has 8ms missing sample area in it.
+    // It's starting between the sample 2 and 3.
+    profile.threads[0].samples.threadCPUDelta = [
+      null,
+      0.4 * MS_TO_NS_MULTIPLIER,
+      0.1 * MS_TO_NS_MULTIPLIER,
+      4 * MS_TO_NS_MULTIPLIER, // It's 50% CPU because the actual interval is 8ms.
+      1 * MS_TO_NS_MULTIPLIER,
+      0.2 * MS_TO_NS_MULTIPLIER,
+      0.8 * MS_TO_NS_MULTIPLIER,
+      0.3 * MS_TO_NS_MULTIPLIER,
+    ];
+    profile.threads[0].samples.time = [
+      0,
+      1,
+      2,
+      10, // For this sample, the interval is 8ms since there are missing samples.
+      11,
+      12,
+      13,
+      14,
+    ];
 
-      const { dispatch } = setup(profile);
-      flushDrawLog();
+    const { dispatch } = setup(profile);
+    flushDrawLog();
 
-      // Commit a range that starts right after the missing sample.
-      dispatch(commitRange(9, 14));
+    // Commit a range that starts right after the missing sample.
+    dispatch(commitRange(9, 14));
 
-      const drawCalls = flushDrawLog();
-      // Activity graph uses lineTo to draw the lines for the samples.
-      const lineToOperations = drawCalls.filter(
-        ([operation]) => operation === 'lineTo'
-      );
+    const drawCalls = flushDrawLog();
+    // Activity graph uses lineTo to draw the lines for the samples.
+    const lineToOperations = drawCalls.filter(
+      ([operation]) => operation === 'lineTo'
+    );
 
-      expect(lineToOperations.length).toBeGreaterThan(0);
-      // Make sure that all the lineTo operations are inside the activity graph
-      // rectangle. There should not be any sample that starts or ends outside
-      // of the graph.
-      expect(
-        lineToOperations.filter(
-          ([, x, y]) =>
-            x < 0 ||
-            x > GRAPH_WIDTH ||
-            y < 0 ||
-            y > GRAPH_HEIGHT ||
-            isNaN(x) ||
-            isNaN(y)
-        )
-      ).toEqual([]);
-    });
+    expect(lineToOperations.length).toBeGreaterThan(0);
+    // Make sure that all the lineTo operations are inside the activity graph
+    // rectangle. There should not be any sample that starts or ends outside
+    // of the graph.
+    expect(
+      lineToOperations.filter(
+        ([, x, y]) =>
+          x < 0 ||
+          x > GRAPH_WIDTH ||
+          y < 0 ||
+          y > GRAPH_HEIGHT ||
+          isNaN(x) ||
+          isNaN(y)
+      )
+    ).toEqual([]);
   });
 });

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -48,11 +48,15 @@ describe('Timeline multiple thread selection', function() {
     const profile = getProfileWithNiceTracks();
     const store = storeWithProfile(profile);
 
+    // We need a properly laid out ActivityGraph for some of the operations in
+    // tests.
+    const flushRafCalls = mockRaf();
     const renderResult = render(
       <Provider store={store}>
         <Timeline />
       </Provider>
     );
+    flushRafCalls();
 
     return { ...renderResult, ...store };
   }
@@ -163,7 +167,7 @@ describe('Timeline multiple thread selection', function() {
       null
     );
 
-    fireFullClick(activityGraph, { pageX: 50, pageY: 50 });
+    fireFullClick(activityGraph, { offsetX: 50, offsetY: 50 });
 
     expect(getHumanReadableTracks(getState())).toEqual([
       'show [thread GeckoMain process]',
@@ -406,7 +410,7 @@ describe('Timeline', function() {
     jest
       .spyOn(ReactDOM, 'findDOMNode')
       .mockImplementation(() =>
-        getElementWithFixedSize({ width: 300, height: 300 })
+        getElementWithFixedSize({ width: 200, height: 300 })
       );
   });
 

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -59,6 +59,8 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
             >
               <canvas
                 class="timelineMarkersCanvas"
+                height="300"
+                width="200"
               />
             </div>
           </div>
@@ -71,6 +73,8 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
             >
               <canvas
                 class="timelineMarkersCanvas"
+                height="300"
+                width="200"
               />
             </div>
           </div>
@@ -152,6 +156,8 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
             >
               <canvas
                 class="timelineMarkersCanvas"
+                height="300"
+                width="200"
               />
             </div>
           </div>
@@ -225,6 +231,8 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="300"
+              width="200"
             />
           </div>
         </div>
@@ -297,6 +305,8 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="300"
+              width="200"
             />
           </div>
         </div>
@@ -376,6 +386,8 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
                 >
                   <canvas
                     class="timelineMarkersCanvas"
+                    height="300"
+                    width="200"
                   />
                 </div>
               </div>
@@ -401,7 +413,38 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
   >
     <ol
       class="timelineRulerContainer"
-    />
+    >
+      <li
+        class="timelineRulerNotch"
+        style="left: 0px;"
+      >
+        <span
+          class="timelineRulerNotchText"
+        >
+          0.0000s
+        </span>
+      </li>
+      <li
+        class="timelineRulerNotch"
+        style="left: 100px;"
+      >
+        <span
+          class="timelineRulerNotchText"
+        >
+          0.0005s
+        </span>
+      </li>
+      <li
+        class="timelineRulerNotch"
+        style="left: 200px;"
+      >
+        <span
+          class="timelineRulerNotchText"
+        >
+          0.0010s
+        </span>
+      </li>
+    </ol>
   </div>
   <div
     class="overflowEdgeIndicator timelineOverflowEdgeIndicator"
@@ -485,6 +528,8 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                       >
                         <canvas
                           class="timelineMarkersCanvas"
+                          height="300"
+                          width="200"
                         />
                       </div>
                     </div>
@@ -497,6 +542,8 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                       >
                         <canvas
                           class="timelineMarkersCanvas"
+                          height="300"
+                          width="200"
                         />
                       </div>
                     </div>

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -40,6 +40,8 @@ process: \\"tab\\" (222)"
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="400"
+              width="400"
             />
           </div>
         </div>
@@ -52,6 +54,8 @@ process: \\"tab\\" (222)"
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="400"
+              width="400"
             />
           </div>
         </div>
@@ -64,6 +68,8 @@ process: \\"tab\\" (222)"
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="400"
+              width="400"
             />
           </div>
         </div>
@@ -143,6 +149,8 @@ process: \\"tab\\" (222)"
               >
                 <canvas
                   class="timelineMarkersCanvas"
+                  height="400"
+                  width="400"
                 />
               </div>
             </div>
@@ -220,6 +228,8 @@ process: \\"tab\\" (222)"
               >
                 <canvas
                   class="timelineMarkersCanvas"
+                  height="400"
+                  width="400"
                 />
               </div>
             </div>
@@ -330,6 +340,8 @@ process: \\"default\\" (5555)"
               >
                 <canvas
                   class="timelineMarkersCanvas"
+                  height="400"
+                  width="400"
                 />
               </div>
             </div>

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -34,6 +34,8 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="400"
+              width="400"
             />
           </div>
         </div>
@@ -42,6 +44,8 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
         >
           <canvas
             class="timelineTrackMemoryCanvas"
+            height="25"
+            width="400"
           />
           <div
             class="timelineEmptyThreadIndicator"
@@ -79,31 +83,33 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
       >
         <canvas
           class="timelineTrackNetworkCanvas"
+          height="35"
+          width="400"
         />
         <div
           class="timelineVerticalIndicatorsLine"
           data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--red-60); left: 0px;"
+          style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
         />
         <div
           class="timelineVerticalIndicatorsLine"
           data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: #000; left: 0px;"
+          style="--vertical-indicator-color: #000; left: 200px;"
         />
         <div
           class="timelineVerticalIndicatorsLine"
           data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--blue-50); left: 0px;"
+          style="--vertical-indicator-color: var(--blue-50); left: 200px;"
         />
         <div
           class="timelineVerticalIndicatorsLine"
           data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--grey-40); left: 0px;"
+          style="--vertical-indicator-color: var(--grey-40); left: 266.6666666666667px;"
         />
         <div
           class="timelineVerticalIndicatorsLine"
           data-testid="vertical-indicator-line"
-          style="--vertical-indicator-color: var(--green-60); left: 0px;"
+          style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
         />
       </div>
     </div>
@@ -145,6 +151,8 @@ process: \\"tab\\" (222)"
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="400"
+              width="400"
             />
           </div>
         </div>
@@ -223,6 +231,8 @@ exports[`timeline/LocalTrack with an IPC track matches the snapshot of the IPC t
           >
             <canvas
               class="timelineMarkersCanvas"
+              height="400"
+              width="400"
             />
           </div>
         </div>

--- a/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
@@ -4,7 +4,7 @@ exports[`SampleTooltipContents renders the sample tooltip properly 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 21px; top: 10px;"
+  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"
@@ -285,7 +285,7 @@ exports[`SampleTooltipContents renders the sample with "variable CPU cycles" CPU
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 41px; top: 10px;"
+  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"
@@ -397,7 +397,7 @@ exports[`SampleTooltipContents renders the sample with ns CPU usage information 
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 41px; top: 10px;"
+  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"
@@ -509,7 +509,7 @@ exports[`SampleTooltipContents renders the sample with µs CPU usage information
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 41px; top: 10px;"
+  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -1183,6 +1183,226 @@ Array [
     "#6200a4",
   ],
   Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    -5,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    5,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    15,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    25,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    35,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    45,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    55,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    65,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
     "beginPath",
   ],
   Array [
@@ -2388,94 +2608,6 @@ Array [
     Object {},
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    -5,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    5,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    15,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    25,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    35,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    45,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    55,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    65,
-    0,
-    10,
-    10,
-  ],
-  Array [
     "clearRect",
     0,
     0,
@@ -3632,6 +3764,226 @@ Array [
       width="4"
     />,
     "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    -5,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    5,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    15,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    25,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    35,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    45,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    55,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    65,
+    0,
+    10,
+    10,
   ],
   Array [
     "set globalCompositeOperation",
@@ -4893,94 +5245,6 @@ Array [
     Object {},
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    -5,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    5,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    15,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    25,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    35,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    45,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    55,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    65,
-    0,
-    10,
-    10,
-  ],
-  Array [
     "clearRect",
     0,
     0,
@@ -6137,6 +6401,226 @@ Array [
       width="4"
     />,
     "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    -3.3333333333333335,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    3.3333333333333335,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    10,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    43.333333333333336,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    50,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    56.666666666666664,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    63.333333333333336,
+    0,
+    6.666666666666667,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    70.00000000000001,
+    0,
+    6.666666666666667,
+    10,
   ],
   Array [
     "set globalCompositeOperation",
@@ -7398,94 +7882,6 @@ Array [
     Object {},
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    -3.3333333333333335,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    3.3333333333333335,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    10,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    43.333333333333336,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    50,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    56.666666666666664,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    63.333333333333336,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    70.00000000000001,
-    0,
-    6.666666666666667,
-    10,
-  ],
-  Array [
     "clearRect",
     0,
     0,
@@ -8656,6 +9052,160 @@ Array [
     "#d7d7db",
   ],
   Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    -5,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    35,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
     "beginPath",
   ],
   Array [
@@ -9458,28 +10008,6 @@ Array [
   Array [
     "set fillStyle",
     Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    -5,
-    0,
-    10,
-    10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    35,
-    0,
-    10,
-    10,
   ],
   Array [
     "clearRect",

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -1204,6 +1204,2839 @@ Array [
     "#d7d7db",
   ],
   Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "transparent",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#6200a460",
+          ],
+          Array [
+            0.25,
+            "#6200a460",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#6200a460",
+          ],
+          Array [
+            0.75,
+            "#6200a460",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#ffe90060",
+          ],
+          Array [
+            0.25,
+            "#ffe90060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#ffe90060",
+          ],
+          Array [
+            0.75,
+            "#ffe90060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#ff940060",
+          ],
+          Array [
+            0.25,
+            "#ff940060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#ff940060",
+          ],
+          Array [
+            0.75,
+            "#ff940060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#45a1ff60",
+          ],
+          Array [
+            0.25,
+            "#45a1ff60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#45a1ff60",
+          ],
+          Array [
+            0.75,
+            "#45a1ff60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "transparent",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#6200a460",
+          ],
+          Array [
+            0.25,
+            "#6200a460",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#6200a460",
+          ],
+          Array [
+            0.75,
+            "#6200a460",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#ffe90060",
+          ],
+          Array [
+            0.25,
+            "#ffe90060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#ffe90060",
+          ],
+          Array [
+            0.75,
+            "#ffe90060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#ff940060",
+          ],
+          Array [
+            0.25,
+            "#ff940060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#ff940060",
+          ],
+          Array [
+            0.75,
+            "#ff940060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#45a1ff60",
+          ],
+          Array [
+            0.25,
+            "#45a1ff60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#45a1ff60",
+          ],
+          Array [
+            0.75,
+            "#45a1ff60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    -5,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    17.22222222222222,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    39.44444444444444,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    61.66666666666666,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    83.88888888888889,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    106.11111111111111,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    128.33333333333331,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    150.55555555555554,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    172.77777777777777,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    83.88888888888889,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    106.11111111111111,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    128.33333333333331,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    83.88888888888889,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    106.11111111111111,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    128.33333333333331,
+    0,
+    10,
+    300,
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
     "beginPath",
   ],
   Array [
@@ -3298,1140 +6131,970 @@ Array [
     Object {},
   ],
   Array [
-    "scale",
-    1,
-    1,
+    "set globalCompositeOperation",
+    "lighter",
   ],
   Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
+    "set fillStyle",
     "#d7d7db60",
   ],
   Array [
-    "addColorStop",
-    0.25,
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    70,
+    300,
+  ],
+  Array [
+    "lineTo",
+    71,
+    300,
+  ],
+  Array [
+    "lineTo",
+    72,
+    300,
+  ],
+  Array [
+    "lineTo",
+    73,
+    300,
+  ],
+  Array [
+    "lineTo",
+    74,
+    300,
+  ],
+  Array [
+    "lineTo",
+    75,
+    300,
+  ],
+  Array [
+    "lineTo",
+    76,
+    300,
+  ],
+  Array [
+    "lineTo",
+    77,
+    300,
+  ],
+  Array [
+    "lineTo",
+    78,
+    300,
+  ],
+  Array [
+    "lineTo",
+    79,
+    300,
+  ],
+  Array [
+    "lineTo",
+    80,
+    300,
+  ],
+  Array [
+    "lineTo",
+    81,
+    300,
+  ],
+  Array [
+    "lineTo",
+    82,
+    300,
+  ],
+  Array [
+    "lineTo",
+    83,
+    300,
+  ],
+  Array [
+    "lineTo",
+    84,
+    300,
+  ],
+  Array [
+    "lineTo",
+    85,
+    300,
+  ],
+  Array [
+    "lineTo",
+    86,
+    300,
+  ],
+  Array [
+    "lineTo",
+    87,
+    300,
+  ],
+  Array [
+    "lineTo",
+    88,
+    300,
+  ],
+  Array [
+    "lineTo",
+    89,
+    300,
+  ],
+  Array [
+    "lineTo",
+    90,
+    300,
+  ],
+  Array [
+    "lineTo",
+    91,
+    300,
+  ],
+  Array [
+    "lineTo",
+    92,
+    300,
+  ],
+  Array [
+    "lineTo",
+    93,
+    300,
+  ],
+  Array [
+    "lineTo",
+    94,
+    300,
+  ],
+  Array [
+    "lineTo",
+    95,
+    300,
+  ],
+  Array [
+    "lineTo",
+    96,
+    300,
+  ],
+  Array [
+    "lineTo",
+    97,
+    300,
+  ],
+  Array [
+    "lineTo",
+    98,
+    300,
+  ],
+  Array [
+    "lineTo",
+    99,
+    300,
+  ],
+  Array [
+    "lineTo",
+    100,
+    300,
+  ],
+  Array [
+    "lineTo",
+    101,
+    300,
+  ],
+  Array [
+    "lineTo",
+    102,
+    300,
+  ],
+  Array [
+    "lineTo",
+    103,
+    300,
+  ],
+  Array [
+    "lineTo",
+    104,
+    300,
+  ],
+  Array [
+    "lineTo",
+    105,
+    300,
+  ],
+  Array [
+    "lineTo",
+    106,
+    300,
+  ],
+  Array [
+    "lineTo",
+    107,
+    300,
+  ],
+  Array [
+    "lineTo",
+    108,
+    300,
+  ],
+  Array [
+    "lineTo",
+    109,
+    300,
+  ],
+  Array [
+    "lineTo",
+    110,
+    300,
+  ],
+  Array [
+    "lineTo",
+    111,
+    300,
+  ],
+  Array [
+    "lineTo",
+    112,
+    300,
+  ],
+  Array [
+    "lineTo",
+    113,
+    300,
+  ],
+  Array [
+    "lineTo",
+    114,
+    300,
+  ],
+  Array [
+    "lineTo",
+    115,
+    300,
+  ],
+  Array [
+    "lineTo",
+    116,
+    300,
+  ],
+  Array [
+    "lineTo",
+    117,
+    300,
+  ],
+  Array [
+    "lineTo",
+    118,
+    300,
+  ],
+  Array [
+    "lineTo",
+    119,
+    300,
+  ],
+  Array [
+    "lineTo",
+    120,
+    300,
+  ],
+  Array [
+    "lineTo",
+    121,
+    300,
+  ],
+  Array [
+    "lineTo",
+    122,
+    300,
+  ],
+  Array [
+    "lineTo",
+    123,
+    300,
+  ],
+  Array [
+    "lineTo",
+    124,
+    300,
+  ],
+  Array [
+    "lineTo",
+    125,
+    300,
+  ],
+  Array [
+    "lineTo",
+    126,
+    300,
+  ],
+  Array [
+    "lineTo",
+    127,
+    300,
+  ],
+  Array [
+    "lineTo",
+    128,
+    300,
+  ],
+  Array [
+    "lineTo",
+    129,
+    300,
+  ],
+  Array [
+    "lineTo",
+    130,
+    300,
+  ],
+  Array [
+    "lineTo",
+    131,
+    300,
+  ],
+  Array [
+    "lineTo",
+    132,
+    300,
+  ],
+  Array [
+    "lineTo",
+    133,
+    300,
+  ],
+  Array [
+    "lineTo",
+    134,
+    300,
+  ],
+  Array [
+    "lineTo",
+    135,
+    300,
+  ],
+  Array [
+    "lineTo",
+    136,
+    300,
+  ],
+  Array [
+    "lineTo",
+    137,
+    300,
+  ],
+  Array [
+    "lineTo",
+    138,
+    300,
+  ],
+  Array [
+    "lineTo",
+    139,
+    300,
+  ],
+  Array [
+    "lineTo",
+    140,
+    300,
+  ],
+  Array [
+    "lineTo",
+    141,
+    300,
+  ],
+  Array [
+    "lineTo",
+    142,
+    300,
+  ],
+  Array [
+    "lineTo",
+    143,
+    300,
+  ],
+  Array [
+    "lineTo",
+    144,
+    300,
+  ],
+  Array [
+    "lineTo",
+    145,
+    300,
+  ],
+  Array [
+    "lineTo",
+    146,
+    300,
+  ],
+  Array [
+    "lineTo",
+    147,
+    300,
+  ],
+  Array [
+    "lineTo",
+    148,
+    300,
+  ],
+  Array [
+    "lineTo",
+    149,
+    300,
+  ],
+  Array [
+    "lineTo",
+    150,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    300,
+  ],
+  Array [
+    "lineTo",
+    152,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    299.23809519968927,
+  ],
+  Array [
+    "lineTo",
+    150,
+    295.99999990314245,
+  ],
+  Array [
+    "lineTo",
+    149,
+    288.5714281350374,
+  ],
+  Array [
+    "lineTo",
+    148,
+    275.2380944788456,
+  ],
+  Array [
+    "lineTo",
+    147,
+    254.2857125401497,
+  ],
+  Array [
+    "lineTo",
+    146,
+    225.52380859851837,
+  ],
+  Array [
+    "lineTo",
+    145,
+    190.66666066646576,
+  ],
+  Array [
+    "lineTo",
+    144,
+    152.1904706954956,
+  ],
+  Array [
+    "lineTo",
+    143,
+    113.5237991809845,
+  ],
+  Array [
+    "lineTo",
+    142,
+    78.09523344039917,
+  ],
+  Array [
+    "lineTo",
+    141,
+    48.571425676345825,
+  ],
+  Array [
+    "lineTo",
+    140,
+    26.666665077209473,
+  ],
+  Array [
+    "lineTo",
+    139,
+    12.57142424583435,
+  ],
+  Array [
+    "lineTo",
+    138,
+    4.571431875228882,
+  ],
+  Array [
+    "lineTo",
+    137,
+    0.952380895614624,
+  ],
+  Array [
+    "lineTo",
+    136,
+    0,
+  ],
+  Array [
+    "lineTo",
+    135,
+    0,
+  ],
+  Array [
+    "lineTo",
+    134,
+    0,
+  ],
+  Array [
+    "lineTo",
+    133,
+    0,
+  ],
+  Array [
+    "lineTo",
+    132,
+    0,
+  ],
+  Array [
+    "lineTo",
+    131,
+    0,
+  ],
+  Array [
+    "lineTo",
+    130,
+    0,
+  ],
+  Array [
+    "lineTo",
+    129,
+    0,
+  ],
+  Array [
+    "lineTo",
+    128,
+    0,
+  ],
+  Array [
+    "lineTo",
+    127,
+    0,
+  ],
+  Array [
+    "lineTo",
+    126,
+    0,
+  ],
+  Array [
+    "lineTo",
+    125,
+    0,
+  ],
+  Array [
+    "lineTo",
+    124,
+    0,
+  ],
+  Array [
+    "lineTo",
+    123,
+    0,
+  ],
+  Array [
+    "lineTo",
+    122,
+    0,
+  ],
+  Array [
+    "lineTo",
+    121,
+    0,
+  ],
+  Array [
+    "lineTo",
+    120,
+    0,
+  ],
+  Array [
+    "lineTo",
+    119,
+    0,
+  ],
+  Array [
+    "lineTo",
+    118,
+    0,
+  ],
+  Array [
+    "lineTo",
+    117,
+    0,
+  ],
+  Array [
+    "lineTo",
+    116,
+    0,
+  ],
+  Array [
+    "lineTo",
+    115,
+    0,
+  ],
+  Array [
+    "lineTo",
+    114,
+    0,
+  ],
+  Array [
+    "lineTo",
+    113,
+    0,
+  ],
+  Array [
+    "lineTo",
+    112,
+    0,
+  ],
+  Array [
+    "lineTo",
+    111,
+    0,
+  ],
+  Array [
+    "lineTo",
+    110,
+    0,
+  ],
+  Array [
+    "lineTo",
+    109,
+    0,
+  ],
+  Array [
+    "lineTo",
+    108,
+    0,
+  ],
+  Array [
+    "lineTo",
+    107,
+    0,
+  ],
+  Array [
+    "lineTo",
+    106,
+    0,
+  ],
+  Array [
+    "lineTo",
+    105,
+    0,
+  ],
+  Array [
+    "lineTo",
+    104,
+    0,
+  ],
+  Array [
+    "lineTo",
+    103,
+    0,
+  ],
+  Array [
+    "lineTo",
+    102,
+    0,
+  ],
+  Array [
+    "lineTo",
+    101,
+    0,
+  ],
+  Array [
+    "lineTo",
+    100,
+    0,
+  ],
+  Array [
+    "lineTo",
+    99,
+    0,
+  ],
+  Array [
+    "lineTo",
+    98,
+    0,
+  ],
+  Array [
+    "lineTo",
+    97,
+    0,
+  ],
+  Array [
+    "lineTo",
+    96,
+    0,
+  ],
+  Array [
+    "lineTo",
+    95,
+    0,
+  ],
+  Array [
+    "lineTo",
+    94,
+    0,
+  ],
+  Array [
+    "lineTo",
+    93,
+    0,
+  ],
+  Array [
+    "lineTo",
+    92,
+    0,
+  ],
+  Array [
+    "lineTo",
+    91,
+    0,
+  ],
+  Array [
+    "lineTo",
+    90,
+    0,
+  ],
+  Array [
+    "lineTo",
+    89,
+    0,
+  ],
+  Array [
+    "lineTo",
+    88,
+    0,
+  ],
+  Array [
+    "lineTo",
+    87,
+    0,
+  ],
+  Array [
+    "lineTo",
+    86,
+    0,
+  ],
+  Array [
+    "lineTo",
+    85,
+    0,
+  ],
+  Array [
+    "lineTo",
+    84,
+    1.3333261013031006,
+  ],
+  Array [
+    "lineTo",
+    83,
+    5.714285373687744,
+  ],
+  Array [
+    "lineTo",
+    82,
+    14.857149124145508,
+  ],
+  Array [
+    "lineTo",
+    81,
+    30.47618865966797,
+  ],
+  Array [
+    "lineTo",
+    80,
+    54.28571105003357,
+  ],
+  Array [
+    "lineTo",
+    79,
+    85.33333539962769,
+  ],
+  Array [
+    "lineTo",
+    78,
+    121.90475463867188,
+  ],
+  Array [
+    "lineTo",
+    77,
+    160.95238029956818,
+  ],
+  Array [
+    "lineTo",
+    76,
+    199.04761612415314,
+  ],
+  Array [
+    "lineTo",
+    75,
+    232.76190161705017,
+  ],
+  Array [
+    "lineTo",
+    74,
+    259.99999791383743,
+  ],
+  Array [
+    "lineTo",
+    73,
+    279.0476180613041,
+  ],
+  Array [
+    "lineTo",
+    72,
+    290.8571429550648,
+  ],
+  Array [
+    "lineTo",
+    71,
+    297.14285703375936,
+  ],
+  Array [
+    "lineTo",
+    70,
+    299.61904759984463,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
     "#d7d7db60",
   ],
   Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
+    "set fillStyle",
+    Object {},
   ],
   Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#d7d7db60",
-          ],
-          Array [
-            0.25,
-            "#d7d7db60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#d7d7db60",
-          ],
-          Array [
-            0.75,
-            "#d7d7db60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "transparent",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#6200a460",
-          ],
-          Array [
-            0.25,
-            "#6200a460",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#6200a460",
-          ],
-          Array [
-            0.75,
-            "#6200a460",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
     "#ffe90060",
   ],
   Array [
-    "addColorStop",
-    0.25,
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
     "#ffe90060",
   ],
   Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
+    "set fillStyle",
+    Object {},
   ],
   Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#ffe90060",
-          ],
-          Array [
-            0.25,
-            "#ffe90060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#ffe90060",
-          ],
-          Array [
-            0.75,
-            "#ffe90060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
+    "#6200a460",
   ],
   Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#ff940060",
-          ],
-          Array [
-            0.25,
-            "#ff940060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#ff940060",
-          ],
-          Array [
-            0.75,
-            "#ff940060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
+    "#6200a4",
   ],
   Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#45a1ff60",
-          ],
-          Array [
-            0.25,
-            "#45a1ff60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#45a1ff60",
-          ],
-          Array [
-            0.75,
-            "#45a1ff60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
+    "#6200a460",
   ],
   Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
+    "set fillStyle",
+    Object {},
   ],
   Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
+    "set fillStyle",
     "#12bc0060",
   ],
   Array [
-    "addColorStop",
-    0.25,
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
     "#12bc0060",
   ],
   Array [
-    "addColorStop",
-    0.25,
-    "transparent",
+    "set fillStyle",
+    Object {},
   ],
   Array [
-    "addColorStop",
-    0.5,
-    "transparent",
+    "set fillStyle",
+    "#0060df60",
   ],
   Array [
-    "addColorStop",
-    0.5,
-    "#12bc0060",
+    "set fillStyle",
+    "#0060df",
   ],
   Array [
-    "addColorStop",
-    0.75,
-    "#12bc0060",
+    "set fillStyle",
+    "#0060df60",
   ],
   Array [
-    "addColorStop",
-    0.75,
-    "transparent",
+    "set fillStyle",
+    Object {},
   ],
   Array [
-    "addColorStop",
-    1,
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
     "transparent",
   ],
   Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#12bc0060",
-          ],
-          Array [
-            0.25,
-            "#12bc0060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#12bc0060",
-          ],
-          Array [
-            0.75,
-            "#12bc0060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
     "transparent",
   ],
   Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#0060df60",
-          ],
-          Array [
-            0.25,
-            "#0060df60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#0060df60",
-          ],
-          Array [
-            0.75,
-            "#0060df60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
+    "transparent",
   ],
   Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
+    "set fillStyle",
+    Object {},
   ],
   Array [
     "set globalCompositeOperation",
@@ -5400,2277 +8063,10 @@ Array [
     Object {},
   ],
   Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#d7d7db60",
-          ],
-          Array [
-            0.25,
-            "#d7d7db60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#d7d7db60",
-          ],
-          Array [
-            0.75,
-            "#d7d7db60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "transparent",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#6200a460",
-          ],
-          Array [
-            0.25,
-            "#6200a460",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#6200a460",
-          ],
-          Array [
-            0.75,
-            "#6200a460",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#ffe90060",
-          ],
-          Array [
-            0.25,
-            "#ffe90060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#ffe90060",
-          ],
-          Array [
-            0.75,
-            "#ffe90060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#ff940060",
-          ],
-          Array [
-            0.25,
-            "#ff940060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#ff940060",
-          ],
-          Array [
-            0.75,
-            "#ff940060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#45a1ff60",
-          ],
-          Array [
-            0.25,
-            "#45a1ff60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#45a1ff60",
-          ],
-          Array [
-            0.75,
-            "#45a1ff60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#12bc0060",
-          ],
-          Array [
-            0.25,
-            "#12bc0060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#12bc0060",
-          ],
-          Array [
-            0.75,
-            "#12bc0060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#0060df60",
-          ],
-          Array [
-            0.25,
-            "#0060df60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#0060df60",
-          ],
-          Array [
-            0.75,
-            "#0060df60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "set globalCompositeOperation",
-    "lighter",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db60",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db",
-  ],
-  Array [
-    "beginPath",
-  ],
-  Array [
-    "moveTo",
-    70,
-    300,
-  ],
-  Array [
-    "lineTo",
-    71,
-    300,
-  ],
-  Array [
-    "lineTo",
-    72,
-    300,
-  ],
-  Array [
-    "lineTo",
-    73,
-    300,
-  ],
-  Array [
-    "lineTo",
-    74,
-    300,
-  ],
-  Array [
-    "lineTo",
-    75,
-    300,
-  ],
-  Array [
-    "lineTo",
-    76,
-    300,
-  ],
-  Array [
-    "lineTo",
-    77,
-    300,
-  ],
-  Array [
-    "lineTo",
-    78,
-    300,
-  ],
-  Array [
-    "lineTo",
-    79,
-    300,
-  ],
-  Array [
-    "lineTo",
-    80,
-    300,
-  ],
-  Array [
-    "lineTo",
-    81,
-    300,
-  ],
-  Array [
-    "lineTo",
-    82,
-    300,
-  ],
-  Array [
-    "lineTo",
-    83,
-    300,
-  ],
-  Array [
-    "lineTo",
-    84,
-    300,
-  ],
-  Array [
-    "lineTo",
-    85,
-    300,
-  ],
-  Array [
-    "lineTo",
-    86,
-    300,
-  ],
-  Array [
-    "lineTo",
-    87,
-    300,
-  ],
-  Array [
-    "lineTo",
-    88,
-    300,
-  ],
-  Array [
-    "lineTo",
-    89,
-    300,
-  ],
-  Array [
-    "lineTo",
-    90,
-    300,
-  ],
-  Array [
-    "lineTo",
-    91,
-    300,
-  ],
-  Array [
-    "lineTo",
-    92,
-    300,
-  ],
-  Array [
-    "lineTo",
-    93,
-    300,
-  ],
-  Array [
-    "lineTo",
-    94,
-    300,
-  ],
-  Array [
-    "lineTo",
-    95,
-    300,
-  ],
-  Array [
-    "lineTo",
-    96,
-    300,
-  ],
-  Array [
-    "lineTo",
-    97,
-    300,
-  ],
-  Array [
-    "lineTo",
-    98,
-    300,
-  ],
-  Array [
-    "lineTo",
-    99,
-    300,
-  ],
-  Array [
-    "lineTo",
-    100,
-    300,
-  ],
-  Array [
-    "lineTo",
-    101,
-    300,
-  ],
-  Array [
-    "lineTo",
-    102,
-    300,
-  ],
-  Array [
-    "lineTo",
-    103,
-    300,
-  ],
-  Array [
-    "lineTo",
-    104,
-    300,
-  ],
-  Array [
-    "lineTo",
-    105,
-    300,
-  ],
-  Array [
-    "lineTo",
-    106,
-    300,
-  ],
-  Array [
-    "lineTo",
-    107,
-    300,
-  ],
-  Array [
-    "lineTo",
-    108,
-    300,
-  ],
-  Array [
-    "lineTo",
-    109,
-    300,
-  ],
-  Array [
-    "lineTo",
-    110,
-    300,
-  ],
-  Array [
-    "lineTo",
-    111,
-    300,
-  ],
-  Array [
-    "lineTo",
-    112,
-    300,
-  ],
-  Array [
-    "lineTo",
-    113,
-    300,
-  ],
-  Array [
-    "lineTo",
-    114,
-    300,
-  ],
-  Array [
-    "lineTo",
-    115,
-    300,
-  ],
-  Array [
-    "lineTo",
-    116,
-    300,
-  ],
-  Array [
-    "lineTo",
-    117,
-    300,
-  ],
-  Array [
-    "lineTo",
-    118,
-    300,
-  ],
-  Array [
-    "lineTo",
-    119,
-    300,
-  ],
-  Array [
-    "lineTo",
-    120,
-    300,
-  ],
-  Array [
-    "lineTo",
-    121,
-    300,
-  ],
-  Array [
-    "lineTo",
-    122,
-    300,
-  ],
-  Array [
-    "lineTo",
-    123,
-    300,
-  ],
-  Array [
-    "lineTo",
-    124,
-    300,
-  ],
-  Array [
-    "lineTo",
-    125,
-    300,
-  ],
-  Array [
-    "lineTo",
-    126,
-    300,
-  ],
-  Array [
-    "lineTo",
-    127,
-    300,
-  ],
-  Array [
-    "lineTo",
-    128,
-    300,
-  ],
-  Array [
-    "lineTo",
-    129,
-    300,
-  ],
-  Array [
-    "lineTo",
-    130,
-    300,
-  ],
-  Array [
-    "lineTo",
-    131,
-    300,
-  ],
-  Array [
-    "lineTo",
-    132,
-    300,
-  ],
-  Array [
-    "lineTo",
-    133,
-    300,
-  ],
-  Array [
-    "lineTo",
-    134,
-    300,
-  ],
-  Array [
-    "lineTo",
-    135,
-    300,
-  ],
-  Array [
-    "lineTo",
-    136,
-    300,
-  ],
-  Array [
-    "lineTo",
-    137,
-    300,
-  ],
-  Array [
-    "lineTo",
-    138,
-    300,
-  ],
-  Array [
-    "lineTo",
-    139,
-    300,
-  ],
-  Array [
-    "lineTo",
-    140,
-    300,
-  ],
-  Array [
-    "lineTo",
-    141,
-    300,
-  ],
-  Array [
-    "lineTo",
-    142,
-    300,
-  ],
-  Array [
-    "lineTo",
-    143,
-    300,
-  ],
-  Array [
-    "lineTo",
-    144,
-    300,
-  ],
-  Array [
-    "lineTo",
-    145,
-    300,
-  ],
-  Array [
-    "lineTo",
-    146,
-    300,
-  ],
-  Array [
-    "lineTo",
-    147,
-    300,
-  ],
-  Array [
-    "lineTo",
-    148,
-    300,
-  ],
-  Array [
-    "lineTo",
-    149,
-    300,
-  ],
-  Array [
-    "lineTo",
-    150,
-    300,
-  ],
-  Array [
-    "lineTo",
-    151,
-    300,
-  ],
-  Array [
-    "lineTo",
-    152,
-    300,
-  ],
-  Array [
-    "lineTo",
-    151,
-    299.23809519968927,
-  ],
-  Array [
-    "lineTo",
-    150,
-    295.99999990314245,
-  ],
-  Array [
-    "lineTo",
-    149,
-    288.5714281350374,
-  ],
-  Array [
-    "lineTo",
-    148,
-    275.2380944788456,
-  ],
-  Array [
-    "lineTo",
-    147,
-    254.2857125401497,
-  ],
-  Array [
-    "lineTo",
-    146,
-    225.52380859851837,
-  ],
-  Array [
-    "lineTo",
-    145,
-    190.66666066646576,
-  ],
-  Array [
-    "lineTo",
-    144,
-    152.1904706954956,
-  ],
-  Array [
-    "lineTo",
-    143,
-    113.5237991809845,
-  ],
-  Array [
-    "lineTo",
-    142,
-    78.09523344039917,
-  ],
-  Array [
-    "lineTo",
-    141,
-    48.571425676345825,
-  ],
-  Array [
-    "lineTo",
-    140,
-    26.666665077209473,
-  ],
-  Array [
-    "lineTo",
-    139,
-    12.57142424583435,
-  ],
-  Array [
-    "lineTo",
-    138,
-    4.571431875228882,
-  ],
-  Array [
-    "lineTo",
-    137,
-    0.952380895614624,
-  ],
-  Array [
-    "lineTo",
-    136,
-    0,
-  ],
-  Array [
-    "lineTo",
-    135,
-    0,
-  ],
-  Array [
-    "lineTo",
-    134,
-    0,
-  ],
-  Array [
-    "lineTo",
-    133,
-    0,
-  ],
-  Array [
-    "lineTo",
-    132,
-    0,
-  ],
-  Array [
-    "lineTo",
-    131,
-    0,
-  ],
-  Array [
-    "lineTo",
-    130,
-    0,
-  ],
-  Array [
-    "lineTo",
-    129,
-    0,
-  ],
-  Array [
-    "lineTo",
-    128,
-    0,
-  ],
-  Array [
-    "lineTo",
-    127,
-    0,
-  ],
-  Array [
-    "lineTo",
-    126,
-    0,
-  ],
-  Array [
-    "lineTo",
-    125,
-    0,
-  ],
-  Array [
-    "lineTo",
-    124,
-    0,
-  ],
-  Array [
-    "lineTo",
-    123,
-    0,
-  ],
-  Array [
-    "lineTo",
-    122,
-    0,
-  ],
-  Array [
-    "lineTo",
-    121,
-    0,
-  ],
-  Array [
-    "lineTo",
-    120,
-    0,
-  ],
-  Array [
-    "lineTo",
-    119,
-    0,
-  ],
-  Array [
-    "lineTo",
-    118,
-    0,
-  ],
-  Array [
-    "lineTo",
-    117,
-    0,
-  ],
-  Array [
-    "lineTo",
-    116,
-    0,
-  ],
-  Array [
-    "lineTo",
-    115,
-    0,
-  ],
-  Array [
-    "lineTo",
-    114,
-    0,
-  ],
-  Array [
-    "lineTo",
-    113,
-    0,
-  ],
-  Array [
-    "lineTo",
-    112,
-    0,
-  ],
-  Array [
-    "lineTo",
-    111,
-    0,
-  ],
-  Array [
-    "lineTo",
-    110,
-    0,
-  ],
-  Array [
-    "lineTo",
-    109,
-    0,
-  ],
-  Array [
-    "lineTo",
-    108,
-    0,
-  ],
-  Array [
-    "lineTo",
-    107,
-    0,
-  ],
-  Array [
-    "lineTo",
-    106,
-    0,
-  ],
-  Array [
-    "lineTo",
-    105,
-    0,
-  ],
-  Array [
-    "lineTo",
-    104,
-    0,
-  ],
-  Array [
-    "lineTo",
-    103,
-    0,
-  ],
-  Array [
-    "lineTo",
-    102,
-    0,
-  ],
-  Array [
-    "lineTo",
-    101,
-    0,
-  ],
-  Array [
-    "lineTo",
-    100,
-    0,
-  ],
-  Array [
-    "lineTo",
-    99,
-    0,
-  ],
-  Array [
-    "lineTo",
-    98,
-    0,
-  ],
-  Array [
-    "lineTo",
-    97,
-    0,
-  ],
-  Array [
-    "lineTo",
-    96,
-    0,
-  ],
-  Array [
-    "lineTo",
-    95,
-    0,
-  ],
-  Array [
-    "lineTo",
-    94,
-    0,
-  ],
-  Array [
-    "lineTo",
-    93,
-    0,
-  ],
-  Array [
-    "lineTo",
-    92,
-    0,
-  ],
-  Array [
-    "lineTo",
-    91,
-    0,
-  ],
-  Array [
-    "lineTo",
-    90,
-    0,
-  ],
-  Array [
-    "lineTo",
-    89,
-    0,
-  ],
-  Array [
-    "lineTo",
-    88,
-    0,
-  ],
-  Array [
-    "lineTo",
-    87,
-    0,
-  ],
-  Array [
-    "lineTo",
-    86,
-    0,
-  ],
-  Array [
-    "lineTo",
-    85,
-    0,
-  ],
-  Array [
-    "lineTo",
-    84,
-    1.3333261013031006,
-  ],
-  Array [
-    "lineTo",
-    83,
-    5.714285373687744,
-  ],
-  Array [
-    "lineTo",
-    82,
-    14.857149124145508,
-  ],
-  Array [
-    "lineTo",
-    81,
-    30.47618865966797,
-  ],
-  Array [
-    "lineTo",
-    80,
-    54.28571105003357,
-  ],
-  Array [
-    "lineTo",
-    79,
-    85.33333539962769,
-  ],
-  Array [
-    "lineTo",
-    78,
-    121.90475463867188,
-  ],
-  Array [
-    "lineTo",
-    77,
-    160.95238029956818,
-  ],
-  Array [
-    "lineTo",
-    76,
-    199.04761612415314,
-  ],
-  Array [
-    "lineTo",
-    75,
-    232.76190161705017,
-  ],
-  Array [
-    "lineTo",
-    74,
-    259.99999791383743,
-  ],
-  Array [
-    "lineTo",
-    73,
-    279.0476180613041,
-  ],
-  Array [
-    "lineTo",
-    72,
-    290.8571429550648,
-  ],
-  Array [
-    "lineTo",
-    71,
-    297.14285703375936,
-  ],
-  Array [
-    "lineTo",
-    70,
-    299.61904759984463,
-  ],
-  Array [
-    "closePath",
-  ],
-  Array [
-    "fill",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe900",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a460",
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a4",
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a460",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#12bc0060",
-  ],
-  Array [
-    "set fillStyle",
-    "#12bc00",
-  ],
-  Array [
-    "set fillStyle",
-    "#12bc0060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#0060df60",
-  ],
-  Array [
-    "set fillStyle",
-    "#0060df",
-  ],
-  Array [
-    "set fillStyle",
-    "#0060df60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#ff940060",
-  ],
-  Array [
-    "set fillStyle",
-    "#ff9400",
-  ],
-  Array [
-    "set fillStyle",
-    "#ff940060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff60",
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    -5,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    17.22222222222222,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    39.44444444444444,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    61.66666666666666,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    83.88888888888889,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    106.11111111111111,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    128.33333333333331,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    150.55555555555554,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    172.77777777777777,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    83.88888888888889,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    106.11111111111111,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    128.33333333333331,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    83.88888888888889,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    106.11111111111111,
-    0,
-    10,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    128.33333333333331,
-    0,
-    10,
-    300,
-  ],
-  Array [
     "clearRect",
     0,
     0,
-    300,
+    200,
     300,
   ],
   Array [
@@ -7687,7 +8083,7 @@ Array [
     "clearRect",
     0,
     0,
-    300,
+    200,
     300,
   ],
   Array [
@@ -7704,7 +8100,7 @@ Array [
     "clearRect",
     0,
     0,
-    300,
+    200,
     300,
   ],
   Array [


### PR DESCRIPTION
Please only look at the last 4 commits.

STR:
1. Start with a small window. (I usually use the devtools docked to the right)
2. Open a profile (for example https://profiler.firefox.com/public/qjdvpxjrshayrh6fj1metx8ebkqxbz08tqxce5g/stack-chart/?globalTrackOrder=0&localTrackOrderByPid=10190-01&range=436m701&thread=0&timelineType=cpu-category&v=6)
3. Increase the width of the window

=> See how the ActivityGraph is pixelated.

Then try again with the [deploy preview](https://deploy-preview-3438--perf-html.netlify.app/public/qjdvpxjrshayrh6fj1metx8ebkqxbz08tqxce5g/stack-chart/?globalTrackOrder=0&localTrackOrderByPid=10190-01&range=436m701&thread=0&timelineType=cpu-category&v=6).

While working on tests, I realized that we were actually forcing an update on resizes in ActivityGraph...  but because we weren't changing the various values we passed to ActivityGraphCanvas which is a PureComponent, that component itself wouldn't update.
Therefore I think this bug is actually a regression of when we extracted the canvas to a separate component in PR #2907.

To fix this issue, I added the `WithSize` higher-order component to `ActivityGraphCanvas`, and also removed the previous failing code.