### PR TITLE
Use ResizeObserver instead of the "resize" DOM event

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -424,6 +424,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
         hitTest={this._hitTest}
         onSelectItem={this._onSelectItem}
         onRightClick={this._onRightClick}
+        drawCanvasAfterRaf={false}
       />
     );
   }

--- a/src/components/shared/WithSize.js
+++ b/src/components/shared/WithSize.js
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import { findDOMNode } from 'react-dom';
 import type { CssPixels } from 'firefox-profiler/types';
+import { getResizeObserverWrapper } from 'firefox-profiler/utils/resize-observer-wrapper';
 
 type State = {|
   width: CssPixels,
@@ -53,7 +54,7 @@ export function withSize<
         throw new Error('Unable to find the DOMNode');
       }
       this._container = container;
-      window.addEventListener('resize', this._resizeListener);
+      getResizeObserverWrapper().subscribe(container, this._resizeListener);
       window.addEventListener(
         'visibilitychange',
         this._visibilityChangeListener
@@ -97,12 +98,16 @@ export function withSize<
     };
 
     componentWillUnmount() {
-      this._container = null;
-      window.removeEventListener('resize', this._resizeListener);
+      const container = this._container;
+      if (container) {
+        getResizeObserverWrapper().unsubscribe(container, this._resizeListener);
+      }
+
       window.removeEventListener(
         'visibilitychange',
         this._visibilityChangeListener
       );
+      this._container = null;
     }
 
     _updateSize(container: HTMLElement) {

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -152,6 +152,13 @@ describe('FlameGraph', function () {
     clickMenuItem('Copy function name');
     expect(copy).toHaveBeenLastCalledWith('A');
 
+    // The right click gesture triggered 2 redraws (one mousemove, one
+    // mousedown), but the tool findFillTextPosition ensures there's only one
+    // result and will throw otherwise.
+    // So let's flush the draw calls now. After running the timers
+    // afterwards the flame graph will redraw again (as a result of closing the
+    // menu and resetting the rightClickedCallNodeIndex).
+    flushDrawLog();
     jest.runAllTimers();
 
     // Try another node to make sure the menu can handle other nodes than the first.

--- a/src/test/components/SampleGraph.test.js
+++ b/src/test/components/SampleGraph.test.js
@@ -27,6 +27,7 @@ import {
   autoMockIntersectionObserver,
   triggerIntersectionObservers,
 } from '../fixtures/mocks/intersection-observer';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
 
 import type {
   Profile,
@@ -278,7 +279,7 @@ describe('SampleGraph with intersection observer', function () {
     // By changing the "fake" result of getBoundingClientRect, we ensure that
     // the pure components rerender because their `width` props change.
     setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
-    window.dispatchEvent(new Event('resize'));
+    triggerResizeObservers();
     drawCalls = getContextDrawCalls();
     // It should still be not drawn yet.
     expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -36,6 +36,7 @@ import {
   autoMockIntersectionObserver,
   triggerIntersectionObservers,
 } from '../fixtures/mocks/intersection-observer';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
 
 // The following constants determine the size of the drawn graph.
 const SAMPLE_COUNT = 8;
@@ -159,7 +160,7 @@ describe('ThreadActivityGraph', function () {
     // By changing the "fake" result of getBoundingClientRect, we ensure that
     // the pure components rerender because their `width` props change.
     setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
-    window.dispatchEvent(new Event('resize'));
+    triggerResizeObservers();
     const drawCalls = getContextDrawCalls();
     // We want to ensure that we redraw the activity graph and not something
     // else like the sample graph.
@@ -454,7 +455,7 @@ describe('ThreadActivityGraph with intersection observer', function () {
     // By changing the "fake" result of getBoundingClientRect, we ensure that
     // the pure components rerender because their `width` props change.
     setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
-    window.dispatchEvent(new Event('resize'));
+    triggerResizeObservers();
     drawCalls = getContextDrawCalls();
     // It should still be not drawn yet.
     expect(drawCalls.some(([operation]) => operation === 'beginPath')).toBe(

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -44,6 +44,7 @@ import {
   autoMockIntersectionObserver,
   triggerIntersectionObservers,
 } from '../fixtures/mocks/intersection-observer';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
 
 import type { CssPixels } from 'firefox-profiler/types';
 
@@ -405,7 +406,7 @@ describe('TimelineMarkers with intersection observer', function () {
     // By changing the "fake" result of getBoundingClientRect, we ensure that
     // the pure components rerender because their `width` props change.
     setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
-    window.dispatchEvent(new Event('resize'));
+    triggerResizeObservers();
     drawCalls = getContextDrawCalls();
     // It should still be not drawn yet.
     expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -37,6 +37,7 @@ import {
   autoMockIntersectionObserver,
   triggerIntersectionObservers,
 } from '../fixtures/mocks/intersection-observer';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
 
 // The following constants determine the size of the drawn graph.
 const SAMPLE_COUNT = 8;
@@ -286,7 +287,7 @@ describe('TrackMemory with intersection observer', function () {
     // By changing the "fake" result of getBoundingClientRect, we ensure that
     // the pure components rerender because their `width` props change.
     setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
-    window.dispatchEvent(new Event('resize'));
+    triggerResizeObservers();
     drawCalls = getContextDrawCalls();
     // It should still be not drawn yet.
     expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -26,6 +26,7 @@ import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import { changeSelectedNetworkMarker } from 'firefox-profiler/actions/profile-view';
 
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
 import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import {
@@ -71,14 +72,14 @@ describe('timeline/TrackNetwork', function () {
     // Flush out any existing draw calls.
     getContextDrawCalls();
     // Ensure we start out with 0.
-    expect(getContextDrawCalls().length).toEqual(0);
+    expect(getContextDrawCalls()).toHaveLength(0);
 
     // Send out the resize with a width change.
     // By changing the "fake" result of getBoundingClientRect, we ensure that
     // the pure components rerender because their `width` props change.
     setMockedElementSize({ width: GRAPH_WIDTH - 100, height: GRAPH_HEIGHT });
-    window.dispatchEvent(new Event('resize'));
-    expect(getContextDrawCalls().length > 0).toBe(true);
+    triggerResizeObservers();
+    expect(getContextDrawCalls()).not.toHaveLength(0);
   });
 
   it('draws differently a request and displays a tooltip when hovered', () => {

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -17,6 +17,7 @@ import { FlameGraph } from '../../components/flame-graph';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors';
 import { ensureExists, objectEntries } from '../../utils/flow';
 import { fireFullKeyPress } from '../fixtures/utils';
+import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import { ProfileCallTreeView } from '../../components/calltree/ProfileCallTreeView';
 import { StackChart } from 'firefox-profiler/components/stack-chart';
 import type {
@@ -209,6 +210,8 @@ const actions = {
     ).not.toBeNull();
   },
 };
+
+autoMockCanvasContext();
 
 describe('flame graph transform shortcuts', () => {
   for (const [name, action] of objectEntries(actions)) {

--- a/src/test/fixtures/mocks/resize-observer.js
+++ b/src/test/fixtures/mocks/resize-observer.js
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+/**
+ * Creating a mock resize observer type because Flow's ResizeObserver
+ * type is a bit obsolete.
+ */
+type MockResizeObserver = {|
+  observe: (HTMLElement, ResizeObserverOptions) => void,
+  unobserve: (HTMLElement) => void,
+  disconnect: () => void,
+|};
+
+type ResizeObserverBoxOptions =
+  | 'border-box'
+  | 'content-box'
+  | 'device-pixel-content-box';
+type ResizeObserverOptions = {|
+  box?: ResizeObserverBoxOptions,
+|};
+
+/**
+ * Type of the item we are going to keep for tracking observers.
+ */
+type Item = {|
+  callback: (ResizeObserverEntry[], MockResizeObserver) => void,
+  elements: Set<HTMLElement>,
+|};
+
+/**
+ * Tracked observers during the testing.
+ */
+const observers: Map<MockResizeObserver, Item> = new Map();
+
+/**
+ * Call this function inside a `describe` block to automatically define the
+ * resize observer.
+ */
+export function autoMockResizeObserver() {
+  beforeEach(() => {
+    (window: any).ResizeObserver = jest.fn((cb) => {
+      const item = {
+        callback: cb,
+        elements: new Set(),
+      };
+
+      const instance: MockResizeObserver = {
+        observe: jest.fn((element: HTMLElement) => {
+          item.elements.add(element);
+        }),
+        unobserve: jest.fn((element: HTMLElement) => {
+          item.elements.delete(element);
+        }),
+        disconnect: jest.fn(() => {
+          observers.delete(instance);
+        }),
+      };
+
+      observers.set(instance, item);
+
+      return instance;
+    });
+  });
+
+  afterEach(() => {
+    delete (window: any).ResizeObserver;
+    observers.clear();
+  });
+}
+
+function triggerSingleObserver(
+  observer: MockResizeObserver,
+  item: Item,
+  newSize: DOMRectReadOnly | void
+) {
+  const entries: ResizeObserverEntry[] = [];
+
+  for (const element of item.elements) {
+    const size = newSize ?? element.getBoundingClientRect();
+    entries.push(
+      ({
+        borderBoxSize: [{ blockSize: size.height, inlineSize: size.width }],
+        contentBoxSize: [{ blockSize: size.height, inlineSize: size.width }],
+        devicePixelContentBoxSize: [
+          {
+            blockSize: size.height,
+            inlineSize: size.width,
+          },
+        ],
+        contentRect: size,
+        target: element,
+      }: any)
+    );
+  }
+
+  // Trigger the ResizeObserver callback with all the entries.
+  item.callback(entries, observer);
+}
+
+/**
+ * Trigger resize observer callbacks.
+ * `newSize` defines the new size for all these elements (the same size for all
+ * of them, which is probably not accurate but good enough for tests).
+ */
+export function triggerResizeObservers({
+  newSize,
+}: {|
+  newSize?: DOMRectReadOnly,
+|} = {}) {
+  for (const [observer, item] of observers) {
+    triggerSingleObserver(observer, item, newSize);
+  }
+}

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -8,6 +8,9 @@ import '@testing-library/jest-dom';
 
 jest.mock('../utils/worker-factory');
 import * as WorkerFactory from '../utils/worker-factory';
+import { autoMockResizeObserver } from './fixtures/mocks/resize-observer';
+
+autoMockResizeObserver();
 
 afterEach(function () {
   // This `__shutdownWorkers` function only exists in the mocked test environment,

--- a/src/utils/resize-observer-wrapper.js
+++ b/src/utils/resize-observer-wrapper.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+// This implements a wrapper to the ResizeObserver API, so that only one copy of
+// a ResizeObserver exists. This is much more performant than having one
+// ResizeObserver for each use.
+// This was inspired by the code in https://github.com/jaredLunde/react-hook/blob/master/packages/resize-observer/src/index.tsx
+
+function createResizeObserverWrapper() {
+  // This keeps the list of callbacks for each observed element.
+  const callbacks: Map<Element, Set<() => mixed>> = new Map();
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const callbacksForElement = callbacks.get(entry.target);
+      if (callbacksForElement) {
+        callbacksForElement.forEach((callback) => callback());
+      }
+    }
+  });
+
+  return {
+    subscribe(element: HTMLElement, callback: () => mixed) {
+      const callbacksForElement = callbacks.get(element) ?? new Set();
+      callbacks.set(element, callbacksForElement);
+      callbacksForElement.add(callback);
+      resizeObserver.observe(element);
+    },
+    unsubscribe(element: HTMLElement, callback: () => mixed) {
+      const callbacksForElement = callbacks.get(element);
+      if (callbacksForElement) {
+        const wasDeleted = callbacksForElement.delete(callback);
+        if (!wasDeleted) {
+          console.warn(
+            `[ResizeObserverWrapper.unsubscribe] We tried to unregister an unknown callback.`
+          );
+        }
+        if (callbacksForElement.size === 0) {
+          callbacks.delete(element);
+          resizeObserver.unobserve(element);
+        }
+        if (callbacks.size === 0) {
+          // It's important to clean this up properly so that tests are behaving
+          // as expected.
+          _resizeObserverWrapper = null;
+        }
+      } else {
+        console.warn(
+          `[ResizeObserverWrapper.unsubscribe] We tried to unregister a callback for an element that wasn't registered in the first place. Ignoring...`
+        );
+      }
+    },
+  };
+}
+
+type ResizeObserverWrapper = {|
+  subscribe: (elt: HTMLElement, callback: () => mixed) => void,
+  unsubscribe: (elt: HTMLElement, callback: () => mixed) => void,
+|};
+
+let _resizeObserverWrapper: ResizeObserverWrapper | null = null;
+export function getResizeObserverWrapper(): ResizeObserverWrapper {
+  if (!_resizeObserverWrapper) {
+    _resizeObserverWrapper = createResizeObserverWrapper();
+  }
+
+  return _resizeObserverWrapper;
+}


### PR DESCRIPTION
This uses the ResizeObserver API in the `WithSize` and `Viewport` Higher-Order Component.

This has some visible changes:
1. This fixes an issue in the active tab view, that the activity graph wouldn't redraw when opening. [production](https://share.firefox.dev/3IJE1ad) / [deploy preview](https://deploy-preview-3439--perf-html.netlify.app/public/ewqgmdbj239xkdkcp3mpjcp9cf0a7zfnev57530/calltree/?implementation=js&range=6438m1693&resources&thread=x6&timelineType=cpu-category&v=6&view=active-tab)
2. Now when resizing the top or bottom view using the horizontal splitter, the bottom panel redraws right away. Previously it would redraw only after the gesture. [production](https://profiler.firefox.com/public/7syw68a9vsygdk54gtd68k485xafaqwecr10vk0/flame-graph/?globalTrackOrder=0w7&localTrackOrderByPid=18456-120~19232-0~25420-0~15180-0~11368-0~31928-0~1344-01~31684-p0wo&range=2709m1635~3370m188&symbolServer=https%3A%2F%2Fsymbolication.stage.mozaws.net&thread=7&timelineType=cpu-category&v=6) / [deploy preview](https://deploy-preview-3439--perf-html.netlify.app/public/7syw68a9vsygdk54gtd68k485xafaqwecr10vk0/flame-graph/?globalTrackOrder=0w7&localTrackOrderByPid=18456-120~19232-0~25420-0~15180-0~11368-0~31928-0~1344-01~31684-p0wo&range=2709m1635~3370m188&symbolServer=https%3A%2F%2Fsymbolication.stage.mozaws.net&thread=7&timelineType=cpu-category&v=6)
3. The second commit fixes a problem coming from the 2nd point above, where the flame graph would visibly stutter when resizing. With the second commit change, now this is very smooth.
   As a side note I think that we use `requestAnimationFrame` too much, but we should be careful when removing them, that's why I did it only for the flame graph here so that we can assess for other panels.
   Without the change in other panels, we see that the redraws "lags" a bit but this isn't as much a problem for these ones, because they're drawn "from the top", whereas the flame graph is drawn "from the bottom".

After this patch we could probably simplify some code that was ensuring we would redraw properly, with the `invalidatePanelLayout` action, and possibly all of the `panelLayoutGeneration`. For sure we could stop using it in some places, but I'm not sure this could be completely removed.