### PR TITLE
Include the transform stack for the combined thread in the URL, if multiple threads are selected

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -19,7 +19,10 @@ import {
   coerce,
   ensureExists,
 } from 'firefox-profiler/utils/flow';
-import { toValidCallTreeSummaryStrategy } from 'firefox-profiler/profile-logic/profile-data';
+import {
+  getThreadsKey,
+  toValidCallTreeSummaryStrategy,
+} from 'firefox-profiler/profile-logic/profile-data';
 import { oneLine } from 'common-tags';
 import type {
   UrlState,
@@ -33,7 +36,6 @@ import type {
   TrackIndex,
   CallNodePath,
   ThreadIndex,
-  TransformStacksPerThread,
   TimelineType,
 } from 'firefox-profiler/types';
 import {
@@ -270,6 +272,8 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
   }
 
   const { selectedThreads } = urlState.profileSpecific;
+  const selectedThreadsKey =
+    selectedThreads !== null ? getThreadsKey(selectedThreads) : null;
 
   let ctxId;
   let view;
@@ -383,11 +387,13 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       query.invertCallstack = urlState.profileSpecific.invertCallstack
         ? null
         : undefined;
-      if (selectedThreads !== null) {
+      if (
+        selectedThreadsKey !== null &&
+        urlState.profileSpecific.transforms[selectedThreadsKey]
+      ) {
         query.transforms =
           stringifyTransforms(
-            selectedThreads,
-            urlState.profileSpecific.transforms
+            urlState.profileSpecific.transforms[selectedThreadsKey]
           ) || undefined;
       }
       query.ctSummary =
@@ -522,6 +528,11 @@ export function stateFromLocation(
       ? decodeUintArrayFromUrlComponent(query.thread)
       : [];
 
+  const selectedThreads =
+    selectedThreadsList.length !== 0 ? new Set(selectedThreadsList) : null;
+  const selectedThreadsKey =
+    selectedThreads !== null ? getThreadsKey(selectedThreads) : null;
+
   // https://profiler.firefox.com/public/{hash}/calltree/
   const hasProfileHash = ['local', 'public'].includes(dataSource);
 
@@ -538,7 +549,10 @@ export function stateFromLocation(
     implementation = query.implementation;
   }
 
-  const transforms = parseTransforms(selectedThreadsList, query.transforms);
+  const transforms = {};
+  if (selectedThreadsKey !== null) {
+    transforms[selectedThreadsKey] = parseTransforms(query.transforms);
+  }
 
   let tabID = null;
   if (query.ctxId && Number.isInteger(Number(query.ctxId))) {
@@ -566,8 +580,7 @@ export function stateFromLocation(
       invertCallstack: query.invertCallstack === undefined ? false : true,
       showUserTimings: query.showUserTimings === undefined ? false : true,
       committedRanges: query.range ? parseCommittedRanges(query.range) : [],
-      selectedThreads:
-        selectedThreadsList.length === 0 ? null : new Set(selectedThreadsList),
+      selectedThreads,
       callTreeSearchString: query.search || '',
       markersSearchString: query.markerSearch || '',
       networkSearchString: query.networkSearch || '',
@@ -872,20 +885,17 @@ const _upgraders = {
       return;
     }
 
-    const transformStacksPerThread: TransformStacksPerThread = query.transforms
-      ? parseTransforms([selectedThread], query.transforms)
-      : {};
-
-    // At the time this upgrader was written, there was only one selected thread.
-    // Only upgrade the single transfrom.
-    const transforms = transformStacksPerThread[selectedThread];
+    const transforms = parseTransforms(query.transforms);
 
     if (!transforms || transforms.length === 0) {
       // We don't have any transforms to upgrade.
       return;
     }
 
+    // The transform stack is for the selected thread.
+    // At the time this upgrader was written, there was only one selected thread.
     const thread = profile.threads[selectedThread];
+
     for (let i = 0; i < transforms.length; i++) {
       const transform = transforms[i];
       if (
@@ -913,10 +923,7 @@ const _upgraders = {
       );
     }
 
-    processedLocation.query.transforms = stringifyTransforms(
-      new Set([selectedThread]),
-      transformStacksPerThread
-    );
+    processedLocation.query.transforms = stringifyTransforms(transforms);
   },
   [5]: ({ query }: ProcessedLocationBeforeUpgrade) => {
     // We changed how the ranges are serialized to the URLs. Before it was the
@@ -1010,6 +1017,18 @@ const _upgraders = {
     // verbose. And they get collapsed to the range syntax automatically.
     // Moreover, the new URL version ensures that we don't attempt to interpret
     // new URLs with old profiler versions.
+
+    // There was another change in this version: query.transforms now stores a
+    // different value when multiple threads are selected. Rather than storing
+    // a list of transform stacks for the individual threads, it now stores the
+    // transform stack for the combined thread.
+    // We can discard any transforms for individual threads because they're not
+    // affecting the current view; the current view displays the combined thread.
+    // And the old format of semicolon-separated transform stacks is no longer
+    // parsed.
+    if (query.transforms && query.transforms.includes(';')) {
+      delete query.transforms;
+    }
   },
 };
 

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -339,7 +339,9 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       stringifyCommittedRanges(urlState.profileSpecific.committedRanges) ||
       undefined,
     thread:
-      selectedThreads === null ? undefined : [...selectedThreads].join(','),
+      selectedThreads === null
+        ? undefined
+        : encodeUintSetForUrlComponent(selectedThreads),
     file: urlState.pathInZipFile || undefined,
     profiles: urlState.profilesToCompare || undefined,
     view,
@@ -516,7 +518,9 @@ export function stateFromLocation(
   const dataSource = ensureIsValidDataSource(pathParts[0]);
   const selectedThreadsList: ThreadIndex[] =
     // Either a single thread index, or a list separated by commas.
-    query.thread !== undefined ? query.thread.split(',').map(n => +n) : [];
+    query.thread !== undefined
+      ? decodeUintArrayFromUrlComponent(query.thread)
+      : [];
 
   // https://profiler.firefox.com/public/{hash}/calltree/
   const hasProfileHash = ['local', 'public'].includes(dataSource);
@@ -988,6 +992,10 @@ const _upgraders = {
           return `${pid}-${encodeUintArrayForUrlComponent(trackOrder)}`;
         })
         .join('~');
+    }
+    if (query.thread) {
+      const selectedThreads = new Set(query.thread.split(',').map(n => +n));
+      query.thread = encodeUintSetForUrlComponent(selectedThreads);
     }
 
     // In this version, uintarray-encoding started supporting a range syntax:

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -37,8 +37,7 @@ import type {
   ImplementationFilter,
   Transform,
   TransformType,
-  ThreadIndex,
-  TransformStacksPerThread,
+  TransformStack,
 } from 'firefox-profiler/types';
 
 /**
@@ -100,224 +99,197 @@ const SHORT_KEY_TO_TRANSFORM: { [string]: TransformType } = {};
  */
 
 /**
- * Every transform stack is per thread, and separated by a ";".
- * This first list matches the order of selected threads.
+ * Parses the transform stack that is applied to the selected thread,
+ * or to the set of selected threads.
  * Every transform is separated by the "~" character.
  * Each transform is made up of a tuple separated by "-"
  * The first value in the tuple is a short key of the transform type.
  *
  * e.g "f-js-xFFpUMl-i" or "f-cpp-0KV4KV5KV61KV7KV8K"
  */
-export function parseTransforms(
-  threadList: ThreadIndex[],
-  stringValue: string
-): TransformStacksPerThread {
-  if (!stringValue) {
-    return {};
+export function parseTransforms(transformString: string): TransformStack {
+  if (!transformString) {
+    return [];
   }
-  const transformStrings = stringValue.split(';');
-  const transformStacksPerThread = {};
-  for (let i = 0; i < transformStrings.length; i++) {
-    // Flow had some trouble with the `Transform | null` type, so use a forEach
-    // rather than a map.
-    const transforms = [];
-    const transformString = transformStrings[i];
-    const threadIndex = threadList[i];
-    transformStacksPerThread[threadIndex] = transforms;
+  const transforms = [];
 
-    transformString.split('~').forEach(s => {
-      const tuple = s.split('-');
-      const shortKey = tuple[0];
-      const type = convertToTransformType(SHORT_KEY_TO_TRANSFORM[shortKey]);
-      if (type === null) {
-        console.error(
-          'Unrecognized transform was passed to the URL.',
-          shortKey
-        );
-        return;
-      }
-      // This switch breaks down each transform into the minimum amount of data needed
-      // to represent it in the URL. Each transform has slightly different requirements
-      // as defined in src/types/transforms.js.
-      switch (type) {
-        case 'collapse-resource': {
-          // e.g. "cr-js-325-8"
-          const [
-            ,
-            implementation,
-            resourceIndexRaw,
-            collapsedFuncIndexRaw,
-          ] = tuple;
-          const resourceIndex = parseInt(resourceIndexRaw, 10);
-          const collapsedFuncIndex = parseInt(collapsedFuncIndexRaw, 10);
-          if (isNaN(resourceIndex) || isNaN(collapsedFuncIndex)) {
-            break;
-          }
-          if (resourceIndex >= 0) {
-            transforms.push({
-              type,
-              resourceIndex,
-              collapsedFuncIndex,
-              implementation: toValidImplementationFilter(implementation),
-            });
-          }
-
+  transformString.split('~').forEach(s => {
+    const tuple = s.split('-');
+    const shortKey = tuple[0];
+    const type = convertToTransformType(SHORT_KEY_TO_TRANSFORM[shortKey]);
+    if (type === null) {
+      console.error('Unrecognized transform was passed to the URL.', shortKey);
+      return;
+    }
+    // This switch breaks down each transform into the minimum amount of data needed
+    // to represent it in the URL. Each transform has slightly different requirements
+    // as defined in src/types/transforms.js.
+    switch (type) {
+      case 'collapse-resource': {
+        // e.g. "cr-js-325-8"
+        const [
+          ,
+          implementation,
+          resourceIndexRaw,
+          collapsedFuncIndexRaw,
+        ] = tuple;
+        const resourceIndex = parseInt(resourceIndexRaw, 10);
+        const collapsedFuncIndex = parseInt(collapsedFuncIndexRaw, 10);
+        if (isNaN(resourceIndex) || isNaN(collapsedFuncIndex)) {
           break;
         }
-        case 'collapse-direct-recursion': {
-          // e.g. "rec-js-325"
-          const [, implementation, funcIndexRaw] = tuple;
-          const funcIndex = parseInt(funcIndexRaw, 10);
-          if (isNaN(funcIndex) || funcIndex < 0) {
-            break;
-          }
+        if (resourceIndex >= 0) {
           transforms.push({
             type,
-            funcIndex,
+            resourceIndex,
+            collapsedFuncIndex,
             implementation: toValidImplementationFilter(implementation),
           });
+        }
+
+        break;
+      }
+      case 'collapse-direct-recursion': {
+        // e.g. "rec-js-325"
+        const [, implementation, funcIndexRaw] = tuple;
+        const funcIndex = parseInt(funcIndexRaw, 10);
+        if (isNaN(funcIndex) || funcIndex < 0) {
           break;
         }
-        case 'merge-function':
-        case 'focus-function':
-        case 'drop-function':
-        case 'collapse-function-subtree': {
-          // e.g. "mf-325"
-          const [, funcIndexRaw] = tuple;
-          const funcIndex = parseInt(funcIndexRaw, 10);
-          // Validate that the funcIndex makes sense.
-          if (!isNaN(funcIndex) && funcIndex >= 0) {
-            switch (type) {
-              case 'merge-function':
-                transforms.push({
-                  type: 'merge-function',
-                  funcIndex,
-                });
-                break;
-              case 'focus-function':
-                transforms.push({
-                  type: 'focus-function',
-                  funcIndex,
-                });
-                break;
-              case 'drop-function':
-                transforms.push({
-                  type: 'drop-function',
-                  funcIndex,
-                });
-                break;
-              case 'collapse-function-subtree':
-                transforms.push({
-                  type: 'collapse-function-subtree',
-                  funcIndex,
-                });
-                break;
-              default:
-                throw new Error('Unmatched transform.');
-            }
-          }
-          break;
-        }
-        case 'focus-subtree':
-        case 'merge-call-node': {
-          // e.g. "f-js-xFFpUMl-i" or "f-cpp-0KV4KV5KV61KV7KV8K"
-          const [
-            ,
-            implementationRaw,
-            serializedCallNodePath,
-            invertedRaw,
-          ] = tuple;
-          const implementation = toValidImplementationFilter(implementationRaw);
-          const callNodePath = decodeUintArrayFromUrlComponent(
-            serializedCallNodePath
-          );
-          const inverted = Boolean(invertedRaw);
-          // Flow requires a switch because it can't deduce the type string correctly.
+        transforms.push({
+          type,
+          funcIndex,
+          implementation: toValidImplementationFilter(implementation),
+        });
+        break;
+      }
+      case 'merge-function':
+      case 'focus-function':
+      case 'drop-function':
+      case 'collapse-function-subtree': {
+        // e.g. "mf-325"
+        const [, funcIndexRaw] = tuple;
+        const funcIndex = parseInt(funcIndexRaw, 10);
+        // Validate that the funcIndex makes sense.
+        if (!isNaN(funcIndex) && funcIndex >= 0) {
           switch (type) {
-            case 'focus-subtree':
+            case 'merge-function':
               transforms.push({
-                type: 'focus-subtree',
-                implementation,
-                callNodePath,
-                inverted,
+                type: 'merge-function',
+                funcIndex,
               });
               break;
-            case 'merge-call-node':
+            case 'focus-function':
               transforms.push({
-                type: 'merge-call-node',
-                implementation,
-                callNodePath,
+                type: 'focus-function',
+                funcIndex,
+              });
+              break;
+            case 'drop-function':
+              transforms.push({
+                type: 'drop-function',
+                funcIndex,
+              });
+              break;
+            case 'collapse-function-subtree':
+              transforms.push({
+                type: 'collapse-function-subtree',
+                funcIndex,
               });
               break;
             default:
               throw new Error('Unmatched transform.');
           }
-
-          break;
         }
-        default:
-          throw assertExhaustiveCheck(type);
+        break;
       }
-    });
-  }
-  return transformStacksPerThread;
+      case 'focus-subtree':
+      case 'merge-call-node': {
+        // e.g. "f-js-xFFpUMl-i" or "f-cpp-0KV4KV5KV61KV7KV8K"
+        const [
+          ,
+          implementationRaw,
+          serializedCallNodePath,
+          invertedRaw,
+        ] = tuple;
+        const implementation = toValidImplementationFilter(implementationRaw);
+        const callNodePath = decodeUintArrayFromUrlComponent(
+          serializedCallNodePath
+        );
+        const inverted = Boolean(invertedRaw);
+        // Flow requires a switch because it can't deduce the type string correctly.
+        switch (type) {
+          case 'focus-subtree':
+            transforms.push({
+              type: 'focus-subtree',
+              implementation,
+              callNodePath,
+              inverted,
+            });
+            break;
+          case 'merge-call-node':
+            transforms.push({
+              type: 'merge-call-node',
+              implementation,
+              callNodePath,
+            });
+            break;
+          default:
+            throw new Error('Unmatched transform.');
+        }
+
+        break;
+      }
+      default:
+        throw assertExhaustiveCheck(type);
+    }
+  });
+  return transforms;
 }
 
 /**
- * Each transform in the stack is separated by a ",".
- * Each thread is separated by a ";".
- * The thread order matches the selected thread indexes order.
+ * Each transform in the stack is separated by a "~".
  */
-export function stringifyTransforms(
-  selectedThreads: Set<ThreadIndex>,
-  transformStacksPerThread: TransformStacksPerThread
-): string {
-  // The iterator for the Set<ThreadIndex> will give the threads in the same order.
-  // The order itself is arbitrary, but it should be consistent across the stringify
-  // calls.
-  return [...selectedThreads]
-    .map(threadIndex =>
-      (transformStacksPerThread[threadIndex] || [])
-        .map(transform => {
-          const shortKey = TRANSFORM_TO_SHORT_KEY[transform.type];
-          if (!shortKey) {
-            throw new Error(
-              'Expected to be able to convert a transform into its short key.'
-            );
+export function stringifyTransforms(transformStack: TransformStack): string {
+  return transformStack
+    .map(transform => {
+      const shortKey = TRANSFORM_TO_SHORT_KEY[transform.type];
+      if (!shortKey) {
+        throw new Error(
+          'Expected to be able to convert a transform into its short key.'
+        );
+      }
+      // This switch breaks down each transform into shared groups of what data
+      // they need, as defined in src/types/transforms.js. For instance some transforms
+      // need only a funcIndex, while some care about the current implemention, or
+      // other pieces of data.
+      switch (transform.type) {
+        case 'merge-function':
+        case 'drop-function':
+        case 'collapse-function-subtree':
+        case 'focus-function':
+          return `${shortKey}-${transform.funcIndex}`;
+        case 'collapse-resource':
+          return `${shortKey}-${transform.implementation}-${transform.resourceIndex}-${transform.collapsedFuncIndex}`;
+        case 'collapse-direct-recursion':
+          return `${shortKey}-${transform.implementation}-${transform.funcIndex}`;
+        case 'focus-subtree':
+        case 'merge-call-node': {
+          let string = [
+            shortKey,
+            transform.implementation,
+            encodeUintArrayForUrlComponent(transform.callNodePath),
+          ].join('-');
+          if (transform.inverted) {
+            string += '-i';
           }
-          // This switch breaks down each transform into shared groups of what data
-          // they need, as defined in src/types/transforms.js. For instance some transforms
-          // need only a funcIndex, while some care about the current implemention, or
-          // other pieces of data.
-          switch (transform.type) {
-            case 'merge-function':
-            case 'drop-function':
-            case 'collapse-function-subtree':
-            case 'focus-function':
-              return `${shortKey}-${transform.funcIndex}`;
-            case 'collapse-resource':
-              return `${shortKey}-${transform.implementation}-${transform.resourceIndex}-${transform.collapsedFuncIndex}`;
-            case 'collapse-direct-recursion':
-              return `${shortKey}-${transform.implementation}-${transform.funcIndex}`;
-            case 'focus-subtree':
-            case 'merge-call-node': {
-              let string = [
-                shortKey,
-                transform.implementation,
-                encodeUintArrayForUrlComponent(transform.callNodePath),
-              ].join('-');
-              if (transform.inverted) {
-                string += '-i';
-              }
-              return string;
-            }
-            default:
-              throw assertExhaustiveCheck(transform);
-          }
-        })
-        .join('~')
-    )
-    .join(';');
+          return string;
+        }
+        default:
+          throw assertExhaustiveCheck(transform);
+      }
+    })
+    .join('~');
 }
 
 export type TransformLabeL10nIds = {|

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -16,7 +16,11 @@ import {
   getEmptyProfile,
   getEmptyStackTable,
 } from '../../../profile-logic/data-structures';
+
 /**
+ * Create a profile with three identical threads, with the frame tree and call
+ * tree shown below.
+ *
  * Note that this fixture doesn't use the `getProfileFromTextSamples()` function to
  * generate the profile, as it's testing the relationships between frames, and thus
  * cannot be generated from a list of functions.
@@ -37,7 +41,7 @@ import {
  */
 export default function getProfile(): Profile {
   const profile = getEmptyProfile();
-  const thread = getEmptyThread();
+  let thread = getEmptyThread();
   const funcNames = [
     'funcA',
     'funcB',
@@ -132,8 +136,17 @@ export default function getProfile(): Profile {
     length: 2,
   };
 
+  thread = Object.assign(thread, {
+    samples,
+    stackTable,
+    funcTable,
+    frameTable,
+  });
+
   profile.threads.push(
-    Object.assign(thread, { samples, stackTable, funcTable, frameTable })
+    thread,
+    Object.assign({}, thread),
+    Object.assign({}, thread)
   );
 
   return profile;

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -1178,7 +1178,7 @@ describe('url upgrading', function() {
           pathname:
             '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/calltree/',
           search:
-            '?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=5-3-4&localTrackOrderByPid=1234-1-0~345-2-0-1&hiddenLocalTracksByPid=678-2-3-0',
+            '?globalTrackOrder=5-0-1-2-3-4&hiddenGlobalTracks=5-3-4&localTrackOrderByPid=1234-1-0~345-2-0-1&hiddenLocalTracksByPid=678-2-3-0&thread=12',
           v: 5,
         },
         null
@@ -1209,6 +1209,25 @@ describe('url upgrading', function() {
       );
       expect(urlStateSelectors.getHiddenLocalTracksByPid(state)).toEqual(
         new Map([[678, new Set([0, 2, 3])]])
+      );
+      expect(urlStateSelectors.getSelectedThreadIndexesOrNull(state)).toEqual(
+        new Set([12])
+      );
+    });
+
+    it('parses version 5 with multiple selected threads (comma-separated)', function() {
+      const { getState } = _getStoreWithURL(
+        {
+          pathname:
+            '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/calltree/',
+          search: '?thread=3%2C12%2C7',
+          v: 5,
+        },
+        null
+      );
+      const state = getState();
+      expect(urlStateSelectors.getSelectedThreadIndexesOrNull(state)).toEqual(
+        new Set([3, 7, 12])
       );
     });
   });


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-3449--perf-html.netlify.app/public/hf63jgjy2xq73tf4ky47vecca9ep4ratxbhtv8r/flame-graph/?globalTrackOrder=0wc&hiddenGlobalTracks=1wb&localTrackOrderByPid=93583-h0wg~93666-0~93587-0~98137-60w5~98980-60w5~94545-60w5~98401-60w5~93590-60w5~93589-60w5~99514-60w5~99205-60w5~98911-60w5~99518-60w5&symbolServer=https%3A%2F%2Fsymbolication.stage.mozaws.net&thread=3w8&timelineType=cpu-category&transforms=df-7~ff-9&v=6) ([old URL](https://profiler.firefox.com/public/hf63jgjy2xq73tf4ky47vecca9ep4ratxbhtv8r/flame-graph/?globalTrackOrder=0-1-2-3-4-5-6-7-8-9-10-11-12&hiddenGlobalTracks=1-2-3-4-5-6-7-8-9-10-11&localTrackOrderByPid=93583-17-0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16~93666-0~93587-0~98137-6-0-1-2-3-4-5~98980-6-0-1-2-3-4-5~94545-6-0-1-2-3-4-5~98401-6-0-1-2-3-4-5~93590-6-0-1-2-3-4-5~93589-6-0-1-2-3-4-5~99514-6-0-1-2-3-4-5~99205-6-0-1-2-3-4-5~98911-6-0-1-2-3-4-5~99518-6-0-1-2-3-4-5~&thread=3%2C4%2C5%2C6%2C7%2C8&timelineType=cpu-category&transforms=%3B%3B%3B%3B%3B&v=5))


Fixes #3103.

When multiple threads are selected, we display a merged thread. When transforms are
added in this view, they affect the merged thread. The redux state separately stores
the transform stack for each individual thread, and also any transform stack for combined
threads, in a TransformStacksPerThread object. For example, if I have three threads, the
object might look like this:

```
{
  '0': transforms for thread 0,
  '1': transforms for thread 1,
  '0,2': transforms for the combination of threads 0 and 2
}
```

The URL does not store this full object, it only stores the transform stack for the
current view, i.e. the transform stack for the selected thread.

This wasn't working properly when multiple threads were selected: In the above example,
if threads 0 and 2 were selected, the URL was storing the transforms for the individual
threads 0 and 2. However, those transforms do not affect the merged thread, so they're not
relevant for the current view and should not be put into the URL.
Instead, the URL should store the transform for the merged thread '0,2'. This patch fixes
that. Doing this is simpler, too.

As a drive-by, this PR also changes the format of the `query.thread` argument, i.e. the way the set of selected threads is encoded in the URL. It now uses the compact uint array encoding.

This PR does not add a new URL version; it piggy-backs on version 6 which was added in PR #3419, because that PR has not been deployed yet so there shouldn't be any v6 URLs in circulation yet.