### PR TITLE
Fix for a rare issue where we'd get stuck in drag selection mode

### DIFF
--- a/src/components/shared/Draggable.js
+++ b/src/components/shared/Draggable.js
@@ -92,6 +92,10 @@ export class Draggable extends React.PureComponent<Props, State> {
     mouseMoveHandler: MouseEvent => void,
     mouseUpHandler: MouseEvent => void
   ) {
+    // Unregister any leftover old handlers, in case we didn't get a mouseup for the previous
+    // drag (e.g. when tab switching during a drag, or when ctrl+clicking on macOS).
+    this._uninstallMoveAndUpHandlers();
+
     this._handlers = { mouseMoveHandler, mouseUpHandler };
     window.addEventListener('mousemove', mouseMoveHandler, true);
     window.addEventListener('mouseup', mouseUpHandler, true);
@@ -102,6 +106,7 @@ export class Draggable extends React.PureComponent<Props, State> {
       const { mouseMoveHandler, mouseUpHandler } = this._handlers;
       window.removeEventListener('mousemove', mouseMoveHandler, true);
       window.removeEventListener('mouseup', mouseUpHandler, true);
+      this._handlers = null;
     }
   }
 

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -196,6 +196,10 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
     mouseMoveHandler: MouseHandler,
     mouseUpHandler: MouseHandler
   ) {
+    // Unregister any leftover old handlers, in case we didn't get a mouseup for the previous
+    // drag (e.g. when tab switching during a drag, or when ctrl+clicking on macOS).
+    this._uninstallMoveAndUpHandlers();
+
     this._handlers = { mouseMoveHandler, mouseUpHandler };
     window.addEventListener('mousemove', mouseMoveHandler, true);
     window.addEventListener('mouseup', mouseUpHandler, true);
@@ -206,6 +210,7 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
       const { mouseMoveHandler, mouseUpHandler } = this._handlers;
       window.removeEventListener('mousemove', mouseMoveHandler, true);
       window.removeEventListener('mouseup', mouseUpHandler, true);
+      this._handlers = null;
     }
   }
 


### PR DESCRIPTION
If you make a selection in the timeline by dragging, but switch tabs in the middle so that the mouseup doesn't go to the original tab, you're forever stuck in drag selection mode. Clicking or doing a new drag doesn't stop the old drag.
The fix is simple.