### PR TITLE
Switch many uses of mouseup to use click instead.

### DIFF
--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -172,12 +172,12 @@ export class ChartCanvas<HoveredItem> extends React.Component<
       // The right button is a contextual action.
       // It is important that we call the right click callback at mousedown so
       // that the state is updated and the context menus are rendered before the
-      // mouseup/contextmenu events.
+      // contextmenu events.
       this.props.onRightClick(this.state.hoveredItem);
     }
   };
 
-  _onMouseUp = (e: SyntheticMouseEvent<>) => {
+  _onClick = (e: SyntheticMouseEvent<>) => {
     if (this._mouseMovedWhileClicked) {
       return;
     }
@@ -311,7 +311,7 @@ export class ChartCanvas<HoveredItem> extends React.Component<
           className={className}
           ref={this._takeCanvasRef}
           onMouseDown={this._onMouseDown}
-          onMouseUp={this._onMouseUp}
+          onClick={this._onClick}
           onMouseMove={this._onMouseMove}
           onMouseOut={this._onMouseOut}
           onDoubleClick={this._onDoubleClick}

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -139,7 +139,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
     return fillsQuerier.getSampleAndCpuRatioAtClick(x, y, time);
   }
 
-  _onMouseUp = (event: SyntheticMouseEvent<HTMLCanvasElement>) => {
+  _onClick = (event: SyntheticMouseEvent<HTMLCanvasElement>) => {
     const sampleState = this._getSampleAtMouseEvent(event);
     if (sampleState !== null) {
       this.props.onSampleClick(event, sampleState.sample);
@@ -191,7 +191,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
           treeOrderSampleComparator={treeOrderSampleComparator}
           categories={categories}
           passFillsQuerier={this._setFillsQuerier}
-          onMouseUp={this._onMouseUp}
+          onClick={this._onClick}
           enableCPUUsage={enableCPUUsage}
           maxThreadCPUDelta={maxThreadCPUDelta}
           width={width}

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -39,7 +39,7 @@ type CanvasProps = {|
   ) => number,
   +categories: CategoryList,
   +passFillsQuerier: ActivityFillGraphQuerier => void,
-  +onMouseUp: (SyntheticMouseEvent<HTMLCanvasElement>) => void,
+  +onClick: (SyntheticMouseEvent<HTMLCanvasElement>) => void,
   +enableCPUUsage: boolean,
   +maxThreadCPUDelta: number,
   ...SizeProps,
@@ -194,9 +194,9 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
   }
 
   render() {
-    const { className, trackName, onMouseUp } = this.props;
+    const { className, trackName, onClick } = this.props;
     return (
-      <canvas className={className} ref={this._canvas} onMouseUp={onMouseUp}>
+      <canvas className={className} ref={this._canvas} onClick={onClick}>
         <h2>Activity Graph for {trackName}</h2>
         <p>This graph shows a visual chart of thread activity.</p>
       </canvas>

--- a/src/components/shared/thread/HeightGraph.js
+++ b/src/components/shared/thread/HeightGraph.js
@@ -232,7 +232,7 @@ export class ThreadHeightGraph extends PureComponent<Props> {
     drawSamples(idleSamples, lighterBlue);
   }
 
-  _onMouseUp = (event: SyntheticMouseEvent<>) => {
+  _onClick = (event: SyntheticMouseEvent<>) => {
     const canvas = this._canvas;
     if (canvas) {
       const { rangeStart, rangeEnd, thread, interval } = this.props;
@@ -269,7 +269,7 @@ export class ThreadHeightGraph extends PureComponent<Props> {
             'threadHeightGraphCanvas'
           )}
           ref={this._takeCanvasRef}
-          onMouseUp={this._onMouseUp}
+          onClick={this._onClick}
         >
           <h2>Stack Graph for {trackName}</h2>
           <p>This graph charts the stack height of each sample.</p>

--- a/src/components/shared/thread/SampleGraph.js
+++ b/src/components/shared/thread/SampleGraph.js
@@ -194,7 +194,7 @@ export class ThreadSampleGraph extends PureComponent<Props> {
     drawSamples(idleSamples, lighterBlue);
   }
 
-  _onMouseUp = (event: SyntheticMouseEvent<>) => {
+  _onClick = (event: SyntheticMouseEvent<>) => {
     const canvas = this._canvas;
     if (canvas) {
       const { rangeStart, rangeEnd, thread } = this.props;
@@ -230,7 +230,7 @@ export class ThreadSampleGraph extends PureComponent<Props> {
             'threadSampleGraphCanvas'
           )}
           ref={this._takeCanvasRef}
-          onMouseUp={this._onMouseUp}
+          onClick={this._onClick}
         >
           <h2>Stack Graph for {trackName}</h2>
           <p>This graph charts the stack height of each sample.</p>

--- a/src/components/timeline/ActiveTabResourceTrack.js
+++ b/src/components/timeline/ActiveTabResourceTrack.js
@@ -58,7 +58,7 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
     };
   }
 
-  _onMouseUp = (
+  _onClick = (
     clickedArea: 'timelineTrackResourceLabel' | 'timelineTrackRow'
   ) => (event: MouseEvent) => {
     const { isSelected } = this.props;
@@ -176,11 +176,11 @@ class ActiveTabResourceTrackComponent extends PureComponent<Props, State> {
             selected: isSelected,
             opened: isOpen,
           })}
-          onMouseUp={this._onMouseUp('timelineTrackRow')}
+          onClick={this._onClick('timelineTrackRow')}
         >
           <div
             className="timelineTrackResourceLabel"
-            onMouseUp={this._onMouseUp('timelineTrackResourceLabel')}
+            onClick={this._onClick('timelineTrackResourceLabel')}
           >
             <span>{trackLabel}</span> {resourceTrack.name}
           </div>

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -286,7 +286,7 @@ class GlobalTrackComponent extends PureComponent<Props> {
           className={classNames('timelineTrackRow timelineTrackGlobalRow', {
             selected: isSelected,
           })}
-          onMouseUp={this._selectCurrentTrack}
+          onClick={this._selectCurrentTrack}
         >
           <ContextMenuTrigger
             id="TimelineTrackContextMenu"

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -169,7 +169,7 @@ class LocalTrackComponent extends PureComponent<Props> {
           className={classNames('timelineTrackRow timelineTrackLocalRow', {
             selected: isSelected,
           })}
-          onMouseUp={this._selectCurrentTrack}
+          onClick={this._selectCurrentTrack}
         >
           <ContextMenuTrigger
             id="TimelineTrackContextMenu"


### PR DESCRIPTION
[Without fix](https://share.firefox.dev/3znuxwR)
[Deploy preview](https://deploy-preview-3452--perf-html.netlify.app/public/hf63jgjy2xq73tf4ky47vecca9ep4ratxbhtv8r/stack-chart/?globalTrackOrder=0wc&hiddenGlobalTracks=1wb&localTrackOrderByPid=93583-h0wg~93666-0~93587-0~98137-60w5~98980-60w5~94545-60w5~98401-60w5~93590-60w5~93589-60w5~99514-60w5~99205-60w5~98911-60w5~99518-60w5&range=403m387&thread=0&timelineType=cpu-category&v=6)

Fixes #3451.

Click has the advantage that it only fires if the corresponding mousedown
also occured over this element. That means that it does not fire if the
mouse was dragged in from outside this element.
Using click instead of mouseup avoids unintentionally switching the
selected thread when panning a chart, for example.

I'm not sure why many of these used mouseup to begin with.
It's possible that I had something in mind when I created the first
components with mouseup, and that whatever I was thinking no longer
applies. Most of the components that are using mouseup today are
probably using it because other existing components were using it.

But it is possible that we will find certain interactions which are
broken by this patch. I've done some testing but not a huge amount, and
would appreciate more testing.