### PR TITLE
Sanitize extension IDs out of ExtensionChild markers.

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1198,7 +1198,7 @@ export function sanitizeExtensionTextMarker(
   markerName: string,
   payload: TextMarkerPayload
 ): TextMarkerPayload {
-  if (markerName === 'ExtensionParent') {
+  if (['ExtensionParent', 'ExtensionChild'].includes(markerName)) {
     return {
       ...payload,
       name: payload.name.replace(/^.*, (api_(call|event): )/, '$1'),

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -312,14 +312,25 @@ describe('sanitizePII', function() {
             name: unsanitizedNameField,
           },
         ],
+        [
+          'ExtensionChild',
+          0,
+          1,
+          {
+            type: 'Text',
+            name: unsanitizedNameField,
+          },
+        ],
       ])
     );
 
-    const marker = sanitizedProfile.threads[0].markers.data[0];
-    if (!marker || marker.type !== 'Text') {
-      throw new Error('Expected a Text marker');
+    const markers = sanitizedProfile.threads[0].markers;
+    for (const marker of [markers.data[0], markers.data[1]]) {
+      if (!marker || marker.type !== 'Text') {
+        throw new Error('Expected a Text marker');
+      }
+      expect(marker.name).toBe(sanitizedNameField);
     }
-    expect(marker.name).toBe(sanitizedNameField);
   });
 
   it('should sanitize both URLs and extension ids inside Extension Suspend markers', function() {


### PR DESCRIPTION
Example sanitized profile: https://share.firefox.dev/2Vet8tE (same profile not sanitized: https://share.firefox.dev/3rA16VI)

This goes with the platform changes at https://phabricator.services.mozilla.com/D118529