### PR TITLE
Clarify DataSource type, and make 'unpublished' only about deleted profiles rather than an alias for from-addon

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1470,7 +1470,6 @@ export function getProfilesFromRawUrl(
 
     switch (dataSource) {
       case 'from-addon':
-      case 'unpublished':
         // We don't need to `await` the result because there's no url upgrading
         // when retrieving the profile from the addon and we don't need to wait
         // for the process. Moreover we don't want to wait for the end of
@@ -1499,6 +1498,7 @@ export function getProfilesFromRawUrl(
       case 'none':
       case 'from-file':
       case 'local':
+      case 'unpublished':
         // There is no profile to download for these datasources.
         break;
       default:

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -54,7 +54,6 @@ class ProfileLoaderImpl extends PureComponent<Props> {
     } = this.props;
     switch (dataSource) {
       case 'from-addon':
-      case 'unpublished':
         retrieveProfileFromAddon();
         break;
       case 'from-file':
@@ -74,6 +73,7 @@ class ProfileLoaderImpl extends PureComponent<Props> {
         }
         break;
       case 'uploaded-recordings':
+      case 'unpublished':
       case 'none':
         // nothing to do
         break;

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -33,19 +33,41 @@ import type { CssPixels, StartEndRange, Milliseconds } from './units';
 
 export type DataSource =
   | 'none'
+  // This is used when the profile is loaded from a local file, via drag and
+  // drop or via a file input. Reloading a URL with this data source cannot
+  // work automatically because the file would need to be picked again.
   | 'from-file'
-  //  This datasource is used to fetch a profile from Firefox. This used to be
-  //  handled by an addon, hence the name, but now this is all inside Firefox.
+  // This datasource is used to fetch a profile from Firefox via a frame script.
+  // This is the first entry-point when a profile is captured in the browser.
+  // In the past it was used by the Gecko Profiler add-on, hence the name.
+  // We intend to rename this to from-browser in the future.
   | 'from-addon'
-  // This is an alias for 'from-addon' until we phase that one out. We
-  // introduced it when implementing the "delete profile" functionality, because
-  // `from-addon` didn't suit this use-case well. In the future we want to
-  // completely replace `from-addon` with this one.
-  | 'unpublished'
-  | 'local'
+  // This is used for profiles that have been shared / uploaded to the Profiler
+  // Server.
   | 'public'
+  // This is used after a public profile is deleted / unpublished.
+  // In the future, we may want to use the "local" data source for this, and
+  // remove "unpublished".
+  | 'unpublished'
+  // Reserved for future use. Once implemented, it would work as follows:
+  // Whenever a non-public profile is loaded into the profiler, e.g. via
+  // from-addon or from-file, we want to store it in a local database
+  // automatically, generate an ID for it, and redirect the URL to /local/{id}/.
+  // This would make it so that the page can be reloaded, or restored after a
+  // browser restart, without losing the profile.
+  | 'local'
+  // This is used to load profiles from a URL. It is used in two scenarios:
+  //  - For public profiles which are hosted on a different server than the
+  //    regular profiler server, for example for profiles that are captured
+  //    automatically in Firefox CI.
+  //  - With a localhost URL, in order to import profiles from a locally running
+  //    script.
   | 'from-url'
+  // This is used when comparing two profiles. The displayed profile is a
+  // comparison profile created from two input profiles.
   | 'compare'
+  // This is a page which displays a list of profiles that were uploaded from
+  // this browser, and allows deleting / unpublishing those profiles.
   | 'uploaded-recordings';
 
 export type TimelineType = 'stack' | 'category' | 'cpu-category';


### PR DESCRIPTION
At the moment we have an `unpublished` data source which we treat as an alias for `from-addon`. I think that's a bit strange. Why as an alias for `from-addon`? We have multiple other non-public data sources, i.e. data sources that get the profile from a place that's not the Profiler Server: `from-file` and `from-url`. Why treat `from-addon` specially?

This was introduced in PR #3082. The description of PR says "as we discussed on Matrix", referring to the following conversation: 

```
<julienw> so, when I delete a profile, currently I'm changing the datasource to.... local. I wasn't sure (maybe "from-addon" is better?) but this seems to work fine. Any advice?
<julienw> I wasn't sure because I was afraid of bugs because we weren't using it at all before
<gregtatum> julienw: well, from-addon is a lie right now, as there is no addon
<gregtatum> just in general
<gregtatum> This may be the time to write that sweet URL upgrader :D
<gregtatum> from-addon -> un-published or something
<julienw> ah yeah that's also right :D
<julienw> i was thinking (when I was getting asleep) yesterday that adding a /local/ dataSource would be pretty easy
<gregtatum> Yeah, you gave us all the infrastructure to do it
<julienw> maybe we should just use /local/ actually :)
<gregtatum> I see a semantic difference, where local would be mean that this profile actually is saved locally
<gregtatum> where you could visit the url in the future
<julienw> yeah
<julienw> but I can think that we might want to save it automatically after getting it from firefox
<gregtatum> Yeah, seems reasonable to do it
<julienw> and delete it when publishing
<gregtatum> Although... that's more work
<julienw> yep
<julienw> :)
<gregtatum> But it's the correct thing to do
<julienw> this is "just" saving it as an auto-incremented key and a value that would be the processed profile
<julienw> or should we save the raw gecko profile? Not sure :)
<gregtatum> I'd save the processed I think
<julienw> then the URL would be <domain>/local/<key>/
<gregtatum> mmm... tasty
<gregtatum> Where do you list the local profiles, and how do they expire?
<gregtatum> Keep N latest?
<gregtatum> Keep a byte-maximum?
<gregtatum> I mean, keeping the 5 latest or so as a first step could be nice
<julienw> yeah we probably need a list then... ideally we could see in the same view all local and uploaded ones
<julienw> in that case /uploaded-recordings doesn't seem right, maybe /recordings is better
<julienw> 🌈 so much brainstorm 🌈
<gregtatum> Yeah, that sounds right
<gregtatum> Maybe we do the lazy thing first and add a un-published key that is equivalent to from-addon
<gregtatum> Then in initial URL set-up with an injected profile, move from-addon to un-published
<julienw> one question: why the dash in "un-published" ?
<julienw> for now I used "local" and this seems to work perfectly in the profile viewer view at least
<gregtatum> Ah, I guess it's not needed, is it?
<gregtatum> I would still reserve local for future uses, although I guess it's a good way to check that things will work
<julienw> yeah
```

I think the following would make more sense:

 - Use `unpublished` only after unpublishing a public profile.
 - Rename `from-addon` to `from-browser`, and automatically redirect old `from-addon` URLs to `from-browser`.
 - Once we have `local`:
     - `from-browser` and `from-file` will automatically redirect to `local`
     - unpublishing a profile will go to `local`
     - `unpublished` will no longer be used
 
How does that sound, @julienw?