### PR TITLE
Enable new locales that are mostly complete

### DIFF
--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -18,10 +18,14 @@ import {
 // branch in netlify.
 export const AVAILABLE_LOCALES: Array<string> = AVAILABLE_STAGING_LOCALES || [
   'de',
+  'el',
   'en-GB',
   'en-US',
+  'es-CL',
+  'ia',
   'it',
   'pt-BR',
+  'zh-CN',
   'zh-TW',
 ];
 export const DEFAULT_LOCALE = 'en-US';


### PR DESCRIPTION
es-CL (Spanish (Chile)), ia (Interlingua) and zh-CN (Chinese (China)) locales are 100% complete now. Also, I'm enabling el (Greek) locale as it's way above the enabling threshold we initially discussed. (It's 93% complete right now and we were thinking the 70% as our threshold.)

:tada: :tada: :tada: 

cc @flodolo 