### PR TITLE
Rename from-addon to from-browser and forward old URLs.

### DIFF
--- a/docs-developer/loading-in-profiles.md
+++ b/docs-developer/loading-in-profiles.md
@@ -94,7 +94,7 @@ server.listen(PORT, err => {
 
 ### Directly from Firefox
 
-> `https://profiler.firefox.com/from-addon/`
+> `https://profiler.firefox.com/from-browser/`
 
 Firefox loads the profiles directly into the front-end through a WebChannel mechanism. This is done with the profile menu button, which can be enabled on the homepage of [profiler.firefox.com](https://profiler.firefox.com/)
 

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -117,7 +117,7 @@ export function setHasZoomedViaMousewheel() {
  * It takes the location and profile data, converts the location into url
  * state and then dispatches relevant actions to finalize the view.
  * `profile` parameter can be null when the data source can't provide the profile
- * and the url upgrader step is not needed (e.g. 'from-addon').
+ * and the url upgrader step is not needed (e.g. 'from-browser').
  */
 export function setupInitialUrlState(
   location: Location,

--- a/src/actions/publish.js
+++ b/src/actions/publish.js
@@ -335,13 +335,13 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
       } else {
         const dataSource = getDataSource(prePublishedState);
         const isUnpublished =
-          dataSource === 'unpublished' || dataSource === 'from-addon';
+          dataSource === 'unpublished' || dataSource === 'from-browser';
         dispatch(
           profilePublished(
             hash,
             profileName,
             // Only include the pre-published state if we want to be able to revert
-            // the profile. If we are viewing from-addon, then it's only a single
+            // the profile. If we are viewing from-browser, then it's only a single
             // profile.
             isUnpublished ? null : prePublishedState
           )

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1460,7 +1460,14 @@ export function getProfilesFromRawUrl(
 ): ThunkAction<Promise<Profile | null>> {
   return async (dispatch, getState) => {
     const pathParts = location.pathname.split('/').filter(d => d);
-    let dataSource = ensureIsValidDataSource(pathParts[0]);
+    let possibleDataSource = pathParts[0];
+
+    // Treat from-addon as from-browser, for compatibility with Firefox < 93.
+    if (possibleDataSource === 'from-addon') {
+      possibleDataSource = 'from-browser';
+    }
+
+    let dataSource = ensureIsValidDataSource(possibleDataSource);
     if (dataSource === 'from-file') {
       // Redirect to 'none' if `dataSource` is 'from-file' since initial urls can't
       // be 'from-file' and needs to be redirected to home page.
@@ -1469,7 +1476,7 @@ export function getProfilesFromRawUrl(
     dispatch(setDataSource(dataSource));
 
     switch (dataSource) {
-      case 'from-addon':
+      case 'from-browser':
         // We don't need to `await` the result because there's no url upgrading
         // when retrieving the profile from the browser and we don't need to wait
         // for the process. Moreover we don't want to wait for the end of
@@ -1508,7 +1515,7 @@ export function getProfilesFromRawUrl(
         );
     }
 
-    // Profile may be null only for the `from-addon` dataSource since we do
+    // Profile may be null only for the `from-browser` dataSource since we do
     // not `await` for retrieveProfileFromBrowser function.
     return getProfileOrNull(getState());
   };

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -119,7 +119,7 @@ function getPathParts(urlState: UrlState): string[] {
       return ['compare'];
     case 'uploaded-recordings':
       return ['uploaded-recordings'];
-    case 'from-addon':
+    case 'from-browser':
     case 'unpublished':
     case 'from-file':
       return [dataSource, urlState.selectedTab];
@@ -262,7 +262,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       break;
     case 'public':
     case 'local':
-    case 'from-addon':
+    case 'from-browser':
     case 'unpublished':
     case 'from-file':
     case 'from-url':
@@ -469,7 +469,7 @@ export function ensureIsValidDataSource(
   );
   switch (coercedDataSource) {
     case 'none':
-    case 'from-addon':
+    case 'from-browser':
     case 'unpublished':
     case 'from-file':
     case 'local':
@@ -500,7 +500,7 @@ type Location = {
  * Parse the window.location string to create the UrlState.
  *
  * `profile` parameter is nullable and optional. It's nullable because data sources
- * like from-addon can't upgrade a url for a freshly captured profile. So we need
+ * like from-browser can't upgrade a url for a freshly captured profile. So we need
  * to skip upgrading for these sources. It's also optional for both testing
  * purposes and for places where we would like to do the upgrading without
  * providing any profile.
@@ -761,11 +761,18 @@ export function upgradeLocationToCurrentVersion(
   processedLocation: ProcessedLocationBeforeUpgrade,
   profile?: Profile | null
 ): ProcessedLocation {
+  // Forward /from-addon to /from-browser immediately, outside of the versioning process.
+  // This ensures compatibility with Firefox versions < 93.
+  processedLocation.pathname = processedLocation.pathname.replace(
+    /^\/from-addon/,
+    '/from-browser'
+  );
+
   const urlVersion = +processedLocation.query.v || 0;
   if (profile === null || urlVersion === CURRENT_URL_VERSION) {
     // Do not upgrade when either profile data is null or url is on the latest
     // version already. Profile can be null only when the source could not provide
-    // that for upgrader and therefore upgrading step is not needed (e.g. 'from-addon').
+    // that for upgrader and therefore upgrading step is not needed (e.g. 'from-browser').
     return processedLocation;
   }
 

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -28,7 +28,7 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import { Localized } from '@fluent/react';
 
 const ERROR_MESSAGES_L10N_ID: { [string]: string } = Object.freeze({
-  'from-addon': 'AppViewRouter--error-message-unpublished',
+  'from-browser': 'AppViewRouter--error-message-unpublished',
   unpublished: 'AppViewRouter--error-message-unpublished',
   'from-file': 'AppViewRouter--error-message-from-file',
   local: 'AppViewRouter--error-message-local',
@@ -64,7 +64,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
         break;
       case 'uploaded-recordings':
         return <UploadedRecordingsHome />;
-      case 'from-addon':
+      case 'from-browser':
       case 'unpublished':
       case 'from-file':
       case 'local':

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -103,7 +103,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
       case 'public':
       case 'compare':
         return 'uploaded';
-      case 'from-addon':
+      case 'from-browser':
       case 'unpublished':
       case 'from-file':
       case 'local':

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -53,7 +53,7 @@ class ProfileLoaderImpl extends PureComponent<Props> {
       retrieveProfilesToCompare,
     } = this.props;
     switch (dataSource) {
-      case 'from-addon':
+      case 'from-browser':
         retrieveProfileFromBrowser();
         break;
       case 'from-file':

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -18,7 +18,7 @@ import type { AppViewState, State, DataSource } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 const LOADING_MESSAGES_L10N_ID: { [string]: string } = Object.freeze({
-  'from-addon': 'ProfileLoaderAnimation--loading-message-unpublished',
+  'from-browser': 'ProfileLoaderAnimation--loading-message-unpublished',
   unpublished: 'ProfileLoaderAnimation--loading-message-unpublished',
   'from-file': 'ProfileLoaderAnimation--loading-message-from-file',
   local: 'ProfileLoaderAnimation--loading-message-local',

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -146,7 +146,7 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
       case 'uploaded-recordings':
         return false;
       case 'from-file':
-      case 'from-addon':
+      case 'from-browser':
       case 'unpublished':
       case 'public':
       case 'from-url':
@@ -194,7 +194,7 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
         // These datasources have no profile loaded, we can update it right away.
         return true;
       case 'from-file':
-      case 'from-addon':
+      case 'from-browser':
       case 'unpublished':
         // We should not propose to reload the page for these data sources,
         // because we'd lose the data.

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -102,7 +102,7 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       // while processing and especially upgrading the url information we may
       // need the profile data.
       //
-      // Also note the profile may be null for the `from-addon` dataSource since
+      // Also note the profile may be null for the `from-browser` dataSource since
       // we do not `await` for retrieveProfileFromBrowser function, but also in
       // case of fatal errors in the process of retrieving and processing a
       // profile. To handle the latter case properly, we won't `pushState` if
@@ -140,20 +140,20 @@ class UrlManagerImpl extends React.PureComponent<Props> {
     // Profile sanitization and publishing can do weird things for the history API
     // and we could end up having unconsistent state.
     // That's why we prevent going back in history in these cases:
-    // 1 - between "from-addon" and "public" (in any direction)
+    // 1 - between "from-browser" and "public" (in any direction)
     // 2 - with the "public" datasource when the hash changes (this means the
     //     user once published again an already public profile, and then wants to go
     //     back).
     // But we want to accept the other interactions.
 
-    // 1. Do we move between "from-addon" and "public"?
-    const movesBetweenFromAddonAndPublic =
-      // from-addon -> public
-      (['from-addon', 'unpublished'].includes(previousUrlState.dataSource) &&
+    // 1. Do we move between "from-browser" and "public"?
+    const movesBetweenFromBrowserAndPublic =
+      // from-browser -> public
+      (['from-browser', 'unpublished'].includes(previousUrlState.dataSource) &&
         newUrlState.dataSource === 'public') ||
-      // or public -> from-addon
+      // or public -> from-browser
       (previousUrlState.dataSource === 'public' &&
-        ['from-addon', 'unpublished'].includes(newUrlState.dataSource));
+        ['from-browser', 'unpublished'].includes(newUrlState.dataSource));
 
     // 2. Do we move between 2 different hashes for a public profile
     const movesBetweenHashValues =
@@ -161,7 +161,7 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       newUrlState.dataSource === 'public' &&
       previousUrlState.hash !== newUrlState.hash;
 
-    if (movesBetweenFromAddonAndPublic || movesBetweenHashValues) {
+    if (movesBetweenFromBrowserAndPublic || movesBetweenHashValues) {
       window.history.replaceState(
         previousUrlState,
         document.title,

--- a/src/components/app/WindowTitle.js
+++ b/src/components/app/WindowTitle.js
@@ -60,7 +60,7 @@ class WindowTitleImpl extends PureComponent<Props> {
       case 'public':
       case 'local':
       case 'unpublished':
-      case 'from-addon':
+      case 'from-browser':
       case 'from-file':
       case 'from-url':
         if (profileNameFromUrl) {

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -108,7 +108,7 @@ describe('app/MenuButtons', function() {
     store.dispatch(
       updateUrlState(
         stateFromLocation({
-          pathname: '/from-addon',
+          pathname: '/from-browser',
           search: '',
           hash: '',
         })
@@ -316,7 +316,7 @@ describe('app/MenuButtons', function() {
       fireFullClick(revertButton);
       await waitForElementToBeRemoved(revertButton);
 
-      expect(getDataSource(getState())).toBe('from-addon');
+      expect(getDataSource(getState())).toBe('from-browser');
       expect(getHash(getState())).toBe('');
     });
 

--- a/src/test/components/ProfileViewer.test.js
+++ b/src/test/components/ProfileViewer.test.js
@@ -44,7 +44,7 @@ describe('ProfileViewer', function() {
     store.dispatch(
       updateUrlState(
         stateFromLocation({
-          pathname: '/from-addon',
+          pathname: '/from-browser',
           search: '',
           hash: '',
         })

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -86,7 +86,7 @@ describe('app/AppViewRouter', function() {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('does not try to retrieve a profile when moving from from-addon to public', function() {
+  it('does not try to retrieve a profile when moving from from-browser to public', function() {
     const {
       container,
       dispatch,
@@ -199,7 +199,7 @@ function setup() {
 
   function navigateToAddonLoadingPage() {
     const newUrlState = stateFromLocation({
-      pathname: '/from-addon/',
+      pathname: '/from-browser/',
       search: '',
       hash: '',
     });

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -76,7 +76,7 @@ describe('app/ServiceWorkerManager', () => {
 
     function navigateToAddonLoadingPage() {
       const newUrlState = stateFromLocation({
-        pathname: '/from-addon/',
+        pathname: '/from-browser/',
         search: '',
         hash: '',
       });
@@ -233,7 +233,7 @@ describe('app/ServiceWorkerManager', () => {
     });
   });
 
-  describe('with the `from-addon` datasource', () => {
+  describe('with the `from-browser` datasource', () => {
     it(`doesn't show a notice if updated after we were fully loaded`, async () => {
       process.env.NODE_ENV = 'production';
 
@@ -278,7 +278,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(
         ensureExists(container.querySelector('.photon-message-bar')).className
       ).toMatch(/\bphoton-message-bar-warning\b/);
-      // There's no reload button for the `from-addon` datasource.
+      // There's no reload button for the `from-browser` datasource.
       expect(queryByText(/reload/i)).not.toBeInTheDocument();
       expect(container.firstChild).toMatchSnapshot();
 

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -117,15 +117,26 @@ describe('UrlManager', function() {
     expect(getDataSource(getState())).toMatch('none');
   });
 
-  it('sets the data source to from-addon', async function() {
+  it('sets the data source to from-browser', async function() {
     const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup(
-      '/from-addon/'
+      '/from-browser/'
     );
     expect(getDataSource(getState())).toMatch('none');
     createUrlManager();
 
     await waitUntilUrlSetupPhase('done');
-    expect(getDataSource(getState())).toMatch('from-addon');
+    expect(getDataSource(getState())).toMatch('from-browser');
+  });
+
+  it('sets the data source to from-browser when coming from the legacy URL /from-addon', async function() {
+    const { getState, createUrlManager, waitUntilUrlSetupPhase } = setup(
+      '/from-addon'
+    );
+    expect(getDataSource(getState())).toMatch('none');
+    createUrlManager();
+
+    await waitUntilUrlSetupPhase('done');
+    expect(getDataSource(getState())).toMatch('from-browser');
   });
 
   it('redirects from-file back to no data source', async function() {
@@ -282,7 +293,7 @@ describe('UrlManager', function() {
       dispatch,
       createUrlManager,
       waitUntilUrlSetupPhase,
-    } = setup('/from-addon/');
+    } = setup('/from-browser/');
     createUrlManager();
     await waitUntilUrlSetupPhase('done');
 
@@ -322,14 +333,14 @@ describe('UrlManager', function() {
     expect(previousLocation).toEqual(window.location.href);
   });
 
-  it('persists view query string for `from-addon` data source ', async function() {
+  it('persists view query string for `from-browser` data source ', async function() {
     // This setup function doesn't add any profile to the state, so that's why
     // it logs an error that says we don't have innerWindowID in this profile.
     // We can safely ignore that part because we don't test this part of the
     // codebase here. We only care about the timeline track organization.
     jest.spyOn(console, 'error').mockImplementation(() => {});
     const { getState, waitUntilUrlSetupPhase, createUrlManager } = setup(
-      '/from-addon/?view=active-tab'
+      '/from-browser/?view=active-tab'
     );
     await createUrlManager();
     await waitUntilUrlSetupPhase('done');

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/AppViewRouter does not try to retrieve a profile when moving from from-addon to public 1`] = `<profile-viewer />`;
+exports[`app/AppViewRouter does not try to retrieve a profile when moving from from-browser to public 1`] = `<profile-viewer />`;
 
 exports[`app/AppViewRouter renders an home when the user pressed back after an error 1`] = `
 <div

--- a/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
+++ b/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
@@ -96,7 +96,7 @@ exports[`app/ServiceWorkerManager in the home, with the \`none\` datasource show
 </div>
 `;
 
-exports[`app/ServiceWorkerManager with the \`from-addon\` datasource shows a warning notice if updated before we were ready 1`] = `
+exports[`app/ServiceWorkerManager with the \`from-browser\` datasource shows a warning notice if updated before we were ready 1`] = `
 <div
   class="serviceworker-ready-notice-wrapper"
 >

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1956,10 +1956,10 @@ describe('actions/receive-profile', function() {
         hash: '',
       });
       await dispatch(finalizeProfileView());
-      const [, fromAddon, urlString] = urlFromState(
+      const [, fromUrl, urlString] = urlFromState(
         UrlStateSelectors.getUrlState(getState())
       ).split('/');
-      expect(fromAddon).toEqual('from-url');
+      expect(fromUrl).toEqual('from-url');
       expect(urlString).toEqual('https%3A%2F%2Ffakeurl.com%2Ffakeprofile.json');
     });
 
@@ -1986,17 +1986,17 @@ describe('actions/receive-profile', function() {
       expect(getView(getState()).phase).toBe('DATA_LOADED');
     });
 
-    it('retrieves profile from a `from-addon` data source and loads it', async function() {
+    it('retrieves profile from a `from-browser` data source and loads it', async function() {
       const { geckoProfile, getState, waitUntilPhase } = await setup(
         {
-          pathname: '/from-addon/',
+          pathname: '/from-browser/',
           search: '',
           hash: '',
         },
         0
       );
 
-      // Differently, `from-addon` calls the finalizeProfileView internally,
+      // Differently, `from-browser` calls the finalizeProfileView internally,
       // we don't need to call it again.
       await waitUntilPhase('DATA_LOADED');
       const processedProfile = processGeckoProfile(geckoProfile);
@@ -2005,10 +2005,10 @@ describe('actions/receive-profile', function() {
       );
     });
 
-    it('finishes symbolication for `from-addon` data source', async function() {
+    it('finishes symbolication for `from-browser` data source', async function() {
       const { waitUntilSymbolication } = await setup(
         {
-          pathname: '/from-addon/',
+          pathname: '/from-browser/',
           search: '',
           hash: '',
         },

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -39,9 +39,7 @@ export type DataSource =
   | 'from-file'
   // This datasource is used to fetch a profile from Firefox via a frame script.
   // This is the first entry-point when a profile is captured in the browser.
-  // In the past it was used by the Gecko Profiler add-on, hence the name.
-  // We intend to rename this to from-browser in the future.
-  | 'from-addon'
+  | 'from-browser'
   // This is used for profiles that have been shared / uploaded to the Profiler
   // Server.
   | 'public'
@@ -51,7 +49,7 @@ export type DataSource =
   | 'unpublished'
   // Reserved for future use. Once implemented, it would work as follows:
   // Whenever a non-public profile is loaded into the profiler, e.g. via
-  // from-addon or from-file, we want to store it in a local database
+  // from-browser or from-file, we want to store it in a local database
   // automatically, generate an ID for it, and redirect the URL to /local/{id}/.
   // This would make it so that the page can be reloaded, or restored after a
   // browser restart, without losing the profile.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,7 +160,7 @@ if (process.env.NODE_ENV === 'production') {
               // the user to be able to access them.
               return null;
             }
-            // 3. It's a URL like /from-addon/, or /public/.../?... .
+            // 3. It's a URL like /from-browser/, or /public/.../?... .
             // For those URLs we want to respond with index.html, which is
             // cached as the "/" URL.
             return url.origin + '/';


### PR DESCRIPTION
This patch converts everything to use `/from-browser` URLs instead of `/from-addon` URLs. But if somebody navigates to a `/from-addon` URL, we automatically redirect to `/from-browser`.
There are two different places that treat from-addon as from-browser: `getProfilesFromRawUrl` and `upgradeLocationToCurrentVersion`. I'm not sure if that's the best solution.
Also, I'm not sure if the added test is sufficient or whether we want another test that makes sure `from-addon` still works, and what that test would look like.