### PR TITLE
Enforce max-width: 600px for all tooltips

### DIFF
--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -1,5 +1,4 @@
 .backtrace {
-  max-width: var(--tooltip-detail-max-width);
   padding: 0;
   margin: 0;
 }

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -216,7 +216,9 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         <div className="tooltipLabel" key="file">
           Script URL:
         </div>,
-        fileNameURL,
+        <div className="tooltipDetailsUrl" key="fileVal">
+          {fileNameURL}
+        </div>,
       ];
     }
 
@@ -249,7 +251,9 @@ export class TooltipCallNode extends React.PureComponent<Props> {
             <div className="tooltipLabel" key="iframe">
               iframe URL:
             </div>,
-            <div key="iframeVal">{page.url}</div>,
+            <div className="tooltipDetailsUrl" key="iframeVal">
+              {page.url}
+            </div>,
           ];
 
           // Getting the embedder URL now.
@@ -271,7 +275,9 @@ export class TooltipCallNode extends React.PureComponent<Props> {
             <div className="tooltipLabel" key="page">
               Page URL:
             </div>,
-            <div key="pageVal">{page.url}</div>,
+            <div className="tooltipDetailsUrl" key="pageVal">
+              {page.url}
+            </div>,
           ];
         }
       }

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -391,14 +391,9 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
    * a short list of rendering strategies, in the order they appear.
    */
   render() {
-    const { className, restrictHeightWidth } = this.props;
+    const { className } = this.props;
     return (
-      <div
-        className={classNames('tooltipMarker', className)}
-        style={{
-          '--tooltip-detail-max-width': restrictHeightWidth ? '600px' : '100%',
-        }}
-      >
+      <div className={classNames('tooltipMarker', className)}>
         <div className="tooltipHeader">
           <div className="tooltipOneLine">
             {this._maybeRenderMarkerDuration()}

--- a/src/components/tooltip/NetworkMarker.css
+++ b/src/components/tooltip/NetworkMarker.css
@@ -51,7 +51,3 @@
 .tooltipNetworkMimeTypeSwatch {
   background-color: var(--marker-color);
 }
-
-.tooltipNetworkUrl {
-  word-break: break-word;
-}

--- a/src/components/tooltip/NetworkMarker.js
+++ b/src/components/tooltip/NetworkMarker.js
@@ -381,14 +381,14 @@ export function getNetworkMarkerDetails(
       {payload.cache}
     </TooltipDetail>,
     <TooltipDetail label="URL" key="Network-URL">
-      <span className="tooltipNetworkUrl">{payload.URI}</span>
+      <span className="tooltipDetailsUrl">{payload.URI}</span>
     </TooltipDetail>
   );
 
   if (payload.RedirectURI) {
     details.push(
       <TooltipDetail label="Redirect URL" key="Network-Redirect URL">
-        <span className="tooltipNetworkUrl">{payload.RedirectURI}</span>
+        <span className="tooltipDetailsUrl">{payload.RedirectURI}</span>
       </TooltipDetail>
     );
   }

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -2,13 +2,7 @@
   position: fixed;
   display: inline-block;
   overflow: hidden;
-
-  /**
-   * The VISUAL_MARGIN = 8 for the Tooltip is defined in src/components/tooltip/Tooltip.js.
-   * Both added together equals: 8px + 8px = 16px
-   */
-  max-width: calc(100% - 16px);
-  box-sizing: border-box;
+  max-width: 600px;
   padding: 8px;
   border: 1px solid #ccc;
   background-color: var(--grey-10);
@@ -69,7 +63,10 @@
   display: grid;
   padding-top: 5px;
   grid-gap: 2px 5px;
-  grid-template-columns: min-content auto;
+
+  /* Make the right column "definitely" sized (ignore its intrinsic size) by setting a min-width of 0.
+   * This stops long contents from overflowing the tooltip. */
+  grid-template-columns: min-content minmax(0, 1fr);
 }
 
 .tooltipDetailSeparator {
@@ -79,20 +76,11 @@
 }
 
 .tooltipDetailsUrl {
-  /* URLs can be really long, and it's disruptive when widths change rapidly
-   * this components. Define an arbitrary max-width in px to restrict this change.
-   * Set the variable to 100% to allow the full-width, e.g. in the sidebar. */
-  max-width: var(--tooltip-detail-max-width);
   word-break: break-all;
 }
 
 .tooltipDetailsDim {
   color: var(--grey-50);
-}
-
-.tooltipDetailsDescription {
-  /* Stop long descriptions from making the tooltip disruptively long. */
-  max-width: var(--tooltip-detail-max-width);
 }
 
 .tooltipLabel {

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -93,10 +93,6 @@ export class Tooltip extends React.PureComponent<Props> {
       <div
         className="tooltip"
         data-testid="tooltip"
-        style={{
-          /* This is the default max width, but can be redefined in children */
-          '--tooltip-detail-max-width': '600px',
-        }}
         ref={this._interiorElementRef}
       >
         {this.props.children}

--- a/src/test/components/Tooltip.test.js
+++ b/src/test/components/Tooltip.test.js
@@ -43,7 +43,6 @@ describe('shared/Tooltip', () => {
       expect(getTooltipStyle()).toEqual({
         left: `${MOUSE_OFFSET}px`,
         top: `${MOUSE_OFFSET}px`,
-        '--tooltip-detail-max-width': '600px',
       });
 
       const mouseX = 50;
@@ -53,7 +52,6 @@ describe('shared/Tooltip', () => {
       expect(getTooltipStyle()).toEqual({
         left: `${mouseX + MOUSE_OFFSET}px`,
         top: `${mouseY + MOUSE_OFFSET}px`,
-        '--tooltip-detail-max-width': '600px',
       });
     });
 
@@ -72,7 +70,6 @@ describe('shared/Tooltip', () => {
       expect(getTooltipStyle()).toEqual({
         left: `${expectedLeft}px`,
         top: `${expectedTop}px`,
-        '--tooltip-detail-max-width': '600px',
       });
     });
 
@@ -87,7 +84,6 @@ describe('shared/Tooltip', () => {
       expect(getTooltipStyle()).toEqual({
         left: `${expectedLeft}px`,
         top: `${expectedTop}px`,
-        '--tooltip-detail-max-width': '600px',
       });
     });
   });

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -21,7 +21,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 14px; top: 306px;"
+  style="left: 14px; top: 306px;"
 >
   <div
     class="tooltipCallNode"
@@ -152,7 +152,11 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
         >
           Script URL:
         </div>
-        path/to/file:10:100
+        <div
+          class="tooltipDetailsUrl"
+        >
+          path/to/file:10:100
+        </div>
       </div>
     </div>
   </div>
@@ -694,7 +698,7 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 80.66666666666666px; top: 226px;"
+  style="left: 80.66666666666666px; top: 226px;"
 >
   <div
     class="tooltipCallNode"
@@ -825,7 +829,11 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
         >
           Script URL:
         </div>
-        path/to/file:17:107
+        <div
+          class="tooltipDetailsUrl"
+        >
+          path/to/file:17:107
+        </div>
         <div
           class="tooltipLabel"
         >

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -256,11 +256,10 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 189px; top: 150px;"
+  style="left: 189px; top: 150px;"
 >
   <div
     class="tooltipMarker"
-    style="--tooltip-detail-max-width: 600px;"
   >
     <div
       class="tooltipHeader"
@@ -1081,11 +1080,10 @@ exports[`MarkerChart with active tab renders the hovered marker properly 2`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 102px; top: 38px;"
+  style="left: 102px; top: 38px;"
 >
   <div
     class="tooltipMarker"
-    style="--tooltip-detail-max-width: 600px;"
   >
     <div
       class="tooltipHeader"

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -9,7 +9,6 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
   >
     <div
       class="tooltipMarker"
-      style="--tooltip-detail-max-width: 100%;"
     >
       <div
         class="tooltipHeader"

--- a/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
@@ -4,7 +4,7 @@ exports[`SampleTooltipContents renders the sample tooltip properly 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
+  style="left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"
@@ -285,7 +285,7 @@ exports[`SampleTooltipContents renders the sample with "variable CPU cycles" CPU
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
+  style="left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"
@@ -397,7 +397,7 @@ exports[`SampleTooltipContents renders the sample with ns CPU usage information 
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
+  style="left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"
@@ -509,7 +509,7 @@ exports[`SampleTooltipContents renders the sample with µs CPU usage information
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 11px; top: 10px;"
+  style="left: 11px; top: 10px;"
 >
   <div
     class="tooltipDetails"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -865,11 +865,10 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 200.36363636363637px; top: 54px;"
+  style="left: 200.36363636363637px; top: 54px;"
 >
   <div
     class="tooltipMarker"
-    style="--tooltip-detail-max-width: 600px;"
   >
     <div
       class="tooltipHeader"

--- a/src/test/components/__snapshots__/Tooltip.test.js.snap
+++ b/src/test/components/__snapshots__/Tooltip.test.js.snap
@@ -4,7 +4,7 @@ exports[`shared/Tooltip is rendered appropriately 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 11px; top: 11px;"
+  style="left: 11px; top: 11px;"
 >
   <p>
     Lorem ipsum

--- a/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
@@ -124,7 +124,9 @@ exports[`TooltipCallNode with page information displays Page URL for iframe page
       >
         iframe URL:
       </div>
-      <div>
+      <div
+        class="tooltipDetailsUrl"
+      >
         https://iframe.example.com/
       </div>
       <div
@@ -192,7 +194,9 @@ exports[`TooltipCallNode with page information displays Page URL for non-iframe 
       >
         Page URL:
       </div>
-      <div>
+      <div
+        class="tooltipDetailsUrl"
+      >
         https://developer.mozilla.org/en-US/
       </div>
     </div>

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3,7 +3,6 @@
 exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -150,7 +149,6 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
 exports[`TooltipMarker renders properly network markers that were aborted 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -194,7 +192,7 @@ exports[`TooltipMarker renders properly network markers that were aborted 1`] = 
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
     </span>
@@ -254,7 +252,6 @@ exports[`TooltipMarker renders properly network markers that were aborted 1`] = 
 exports[`TooltipMarker renders properly network markers where content type is blank 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -298,7 +295,7 @@ exports[`TooltipMarker renders properly network markers where content type is bl
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
     </span>
@@ -426,7 +423,6 @@ exports[`TooltipMarker renders properly network markers where content type is bl
 exports[`TooltipMarker renders properly network markers where content type is missing 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -470,7 +466,7 @@ exports[`TooltipMarker renders properly network markers where content type is mi
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
     </span>
@@ -623,7 +619,6 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 1
 exports[`TooltipMarker renders properly network markers with a preconnect part 2`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -667,7 +662,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
     </span>
@@ -884,7 +879,6 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
 exports[`TooltipMarker renders properly network markers with a preconnect part containing only the domain lookup 2`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -928,7 +922,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
     </span>
@@ -1071,7 +1065,6 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
 exports[`TooltipMarker renders properly normal network markers 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1115,7 +1108,7 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       https://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625:*
     </span>
@@ -1326,7 +1319,6 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
 exports[`TooltipMarker renders properly redirect network markers for a Internal redirection 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1377,7 +1369,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Internal 
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://www.wikia.com/
     </span>
@@ -1388,7 +1380,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Internal 
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
     </span>
@@ -1440,7 +1432,6 @@ exports[`TooltipMarker renders properly redirect network markers for a Internal 
 exports[`TooltipMarker renders properly redirect network markers for a Permanent redirection 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1491,7 +1482,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Permanent
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://www.wikia.com/
     </span>
@@ -1502,7 +1493,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Permanent
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
     </span>
@@ -1554,7 +1545,6 @@ exports[`TooltipMarker renders properly redirect network markers for a Permanent
 exports[`TooltipMarker renders properly redirect network markers for a Temporary redirection 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1605,7 +1595,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Temporary
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://www.wikia.com/
     </span>
@@ -1616,7 +1606,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Temporary
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
     </span>
@@ -1668,7 +1658,6 @@ exports[`TooltipMarker renders properly redirect network markers for a Temporary
 exports[`TooltipMarker renders properly redirect network markers for an internal redirection from a HSTS header 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1719,7 +1708,7 @@ exports[`TooltipMarker renders properly redirect network markers for an internal
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://www.wikia.com/
     </span>
@@ -1730,7 +1719,7 @@ exports[`TooltipMarker renders properly redirect network markers for an internal
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
     </span>
@@ -1782,7 +1771,6 @@ exports[`TooltipMarker renders properly redirect network markers for an internal
 exports[`TooltipMarker renders properly redirect network markers without additional redirection information 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1826,7 +1814,7 @@ exports[`TooltipMarker renders properly redirect network markers without additio
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://www.wikia.com/
     </span>
@@ -1837,7 +1825,7 @@ exports[`TooltipMarker renders properly redirect network markers without additio
       :
     </div>
     <span
-      class="tooltipNetworkUrl"
+      class="tooltipDetailsUrl"
     >
       http://img.buzzfeed.com/buzzfeed-static/static/2018-04/29/11/tmp/buzzfeed-prod-web-02/tmp-name-2-18011-1525016782-0_dblwide.jpg?output-format=auto&output-quality=auto&resize=625
     </span>
@@ -1889,7 +1877,6 @@ exports[`TooltipMarker renders properly redirect network markers without additio
 exports[`TooltipMarker renders tooltips for various markers: Bailout_ShapeGuard after getelem on line 3666 of resource://foo.js -> resource://bar.js:3662-10 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1921,7 +1908,6 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout_ShapeGuard 
 exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1960,7 +1946,6 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: BailoutKind::ArgumentCheck at Uninitialized on line 388 of self-hosted:388-10 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -1992,7 +1977,6 @@ exports[`TooltipMarker renders tooltips for various markers: BailoutKind::Argume
 exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2050,7 +2034,6 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
 exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.6 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2107,7 +2090,6 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.6 1`] =
 exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.7 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2164,7 +2146,6 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.7 1`] =
 exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profiled thread)-114.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2495,7 +2476,6 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
 exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2819,7 +2799,6 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -2970,7 +2949,6 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
 exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3093,7 +3071,6 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
 exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3167,7 +3144,6 @@ exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = 
 exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3253,7 +3229,6 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3339,7 +3314,6 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-121 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: Invalidate http://mozilla.com/script.js:1234-10 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3371,7 +3345,6 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate http://m
 exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3410,7 +3383,6 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
 exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3456,7 +3428,6 @@ exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3495,7 +3466,6 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
 exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3539,7 +3509,6 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.
 exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3585,7 +3554,6 @@ exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] =
 exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.9 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3645,7 +3613,6 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
 exports[`TooltipMarker renders tooltips for various markers: RefreshObserver-122 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -3950,7 +3917,6 @@ exports[`TooltipMarker renders tooltips for various markers: RefreshObserver-122
 exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -4260,7 +4226,6 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -4598,7 +4563,6 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
 exports[`TooltipMarker renders tooltips for various markers: TimeToFirstInteractive (TTFI)-21.4 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -4637,7 +4601,6 @@ exports[`TooltipMarker renders tooltips for various markers: TimeToFirstInteract
 exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`] = `
 <div
   class="tooltipMarker propClass"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"
@@ -4703,7 +4666,6 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
 exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
 <div
   class="tooltipMarker"
-  style="--tooltip-detail-max-width: 600px;"
 >
   <div
     class="tooltipHeader"

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -4,7 +4,7 @@ exports[`VerticalIndicators displays tooltips 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 22px; top: 33px;"
+  style="left: 22px; top: 33px;"
 >
   <div>
     <span
@@ -36,11 +36,10 @@ exports[`timeline/TrackNetwork draws differently a request and displays a toolti
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="--tooltip-detail-max-width: 600px; left: 23px; top: 13px;"
+  style="left: 23px; top: 13px;"
 >
   <div
     class="tooltipMarker tooltipNetwork"
-    style="--tooltip-detail-max-width: 600px;"
   >
     <div
       class="tooltipHeader"
@@ -77,7 +76,7 @@ exports[`timeline/TrackNetwork draws differently a request and displays a toolti
         :
       </div>
       <span
-        class="tooltipNetworkUrl"
+        class="tooltipDetailsUrl"
       >
         https://mozilla.org
       </span>


### PR DESCRIPTION
[Current main](https://main--perf-html.netlify.app/public/p5h42hn050s6wyehmevjd6nq9rf30ss6ynan1f0/flame-graph/?globalTrackOrder=0w2&hiddenGlobalTracks=0&hiddenLocalTracksByPid=13188-1w3~25548-1&localTrackOrderByPid=14040-120~13188-30w2~25548-01&thread=6&timelineType=cpu-category&v=6)
[Deploy preview](https://deploy-preview-3480--perf-html.netlify.app/public/p5h42hn050s6wyehmevjd6nq9rf30ss6ynan1f0/flame-graph/?globalTrackOrder=0w2&hiddenGlobalTracks=0&hiddenLocalTracksByPid=13188-1w3~25548-1&localTrackOrderByPid=14040-120~13188-30w2~25548-01&thread=6&timelineType=cpu-category&v=6)

This patch removes the CSS variable --tooltip-detail-max-width. The
maximum width is no longer configurable on a per-tooltip basis or
overridable to different values for different parts of a tooltip.
Instead, all tooltips are constrained to the same width, 600px.
These freedoms weren't used anywhere; only flame graph tooltips were
unconstrained, probably by mistake.

With this patch, the max-width constraint is no longer applied to
individual "details" parts, such as a backtrace or a URL. Instead, the
max-width is applied on the root tooltip element, and the contents are
constrained via grid / flexbox, sometimes in combination with min-width:0.
The old implementation sometimes caused broken layouts where, for example,
the overall width of a network tooltip was set to 600px, and then the
backtrace inside the network tooltip had a max-width:600px which only
affected the right column of a two-column tooltip layout. This is now
fixed.

The patch also includes some changes to enforce consistent line breaking
of URLs in various tooltips.

The most obvious result from this patch is that tooltips in the Flame
Graph tab are now constrained. They weren't constrained before.