### PR TITLE
Use the WebChannel to obtain the profile and symbolication information

### DIFF
--- a/src/app-logic/web-channel.js
+++ b/src/app-logic/web-channel.js
@@ -3,54 +3,115 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+import type { SymbolTableAsTuple } from '../profile-logic/symbol-store-db';
+import type { MixedObject } from 'firefox-profiler/types';
+
 /**
  * This file is in charge of handling the message managing between profiler.firefox.com
  * and the browser internals. This is done through a WebChannel mechanism. This mechanism
  * allows us to safely send messages between the browser and an allowed domain.
  */
 
-/**
- * The messages are typed as an object so that the "type" field can be extracted
- * using the $Keys utility type.
- */
-type MessageToBrowserObject = {|
-  STATUS_QUERY: {| type: 'STATUS_QUERY', requestId: number |},
-  ENABLE_MENU_BUTTON: {| type: 'ENABLE_MENU_BUTTON', requestId: number |},
+export type MessageToBrowser = {|
+  requestId: number,
+|} & Request;
+
+export type Request =
+  | StatusQueryRequest
+  | EnableMenuButtonRequest
+  | GetProfileRequest
+  | GetSymbolTableRequest
+  | QuerySymbolicationApiRequest;
+
+type StatusQueryRequest = {| type: 'STATUS_QUERY' |};
+type EnableMenuButtonRequest = {| type: 'ENABLE_MENU_BUTTON' |};
+type GetProfileRequest = {| type: 'GET_PROFILE' |};
+type GetSymbolTableRequest = {|
+  type: 'GET_SYMBOL_TABLE',
+  debugName: string,
+  breakpadId: string,
+|};
+type QuerySymbolicationApiRequest = {|
+  type: 'QUERY_SYMBOLICATION_API',
+  path: string,
+  requestJson: string,
 |};
 
-/**
- * The messages are typed as an object so that the "type" field can be extracted
- * using the $Keys utility type.
- */
-type MessageFromBrowserObject = {|
-  STATUS_RESPONSE: {|
-    type: 'STATUS_RESPONSE',
-    menuButtonIsEnabled: boolean,
-    requestId: number,
-  |},
-  ENABLE_MENU_BUTTON_DONE: {|
-    type: 'ENABLE_MENU_BUTTON_DONE',
-    requestId: number,
-  |},
+export type MessageFromBrowser<R: ResponseFromBrowser> =
+  | OutOfBandErrorMessageFromBrowser
+  | ErrorResponseMessageFromBrowser
+  | SuccessResponseMessageFromBrowser<R>;
+
+type OutOfBandErrorMessageFromBrowser = {|
+  errno: number,
+  error: string,
 |};
 
-// Extract out the different values. Exported for tests.
-export type MessageToBrowser = $Values<MessageToBrowserObject>;
-export type MessageFromBrowser = $Values<MessageFromBrowserObject>;
-export type MessageFromBrowserTypes = $Keys<MessageFromBrowserObject>;
+type ErrorResponseMessageFromBrowser = {|
+  type: 'ERROR_RESPONSE',
+  requestId: number,
+  error: string,
+|};
+
+type SuccessResponseMessageFromBrowser<R: ResponseFromBrowser> = {
+  type: 'SUCCESS_RESPONSE',
+  requestId: number,
+  response: R,
+};
+
+export type ResponseFromBrowser =
+  | StatusQueryResponse
+  | EnableMenuButtonResponse
+  | GetProfileResponse
+  | GetSymbolTableResponse
+  | QuerySymbolicationApiResponse;
+
+type StatusQueryResponse = {|
+  menuButtonIsEnabled: boolean,
+  // The version indicates which message types are supported by the browser.
+  // No version:
+  //   Shipped in Firefox 76.
+  //   Supports the following message types:
+  //    - STATUS_QUERY
+  //    - ENABLE_MENU_BUTTON
+  // Version 1:
+  //   Shipped in Firefox 93.
+  //   Adds support for the following message types:
+  //    - GET_PROFILE
+  //    - GET_SYMBOL_TABLE
+  //    - QUERY_SYMBOLICATION_API
+  version?: number,
+|};
+type EnableMenuButtonResponse = void;
+type GetProfileResponse = ArrayBuffer | MixedObject;
+type GetSymbolTableResponse = SymbolTableAsTuple;
+type QuerySymbolicationApiResponse = string;
+
+// Manually declare all pairs of request + response for Flow.
+/* eslint-disable no-redeclare */
+declare function _sendMessageWithResponse(
+  StatusQueryRequest
+): Promise<StatusQueryResponse>;
+declare function _sendMessageWithResponse(
+  EnableMenuButtonRequest
+): Promise<EnableMenuButtonResponse>;
+declare function _sendMessageWithResponse(
+  GetProfileRequest
+): Promise<GetProfileResponse>;
+declare function _sendMessageWithResponse(
+  GetSymbolTableRequest
+): Promise<GetSymbolTableResponse>;
+declare function _sendMessageWithResponse(
+  QuerySymbolicationApiRequest
+): Promise<QuerySymbolicationApiResponse>;
+/* eslint-enable no-redeclare */
 
 /**
  * Ask the browser if the menu button is enabled.
  */
 export async function queryIsMenuButtonEnabled(): Promise<boolean> {
-  type ExpectedResponse = $PropertyType<
-    MessageFromBrowserObject,
-    'STATUS_RESPONSE'
-  >;
-
-  const response: ExpectedResponse = await _sendMessageWithResponse({
+  const response = await _sendMessageWithResponse({
     type: 'STATUS_QUERY',
-    requestId: _requestId++,
   });
 
   return response.menuButtonIsEnabled;
@@ -60,18 +121,53 @@ export async function queryIsMenuButtonEnabled(): Promise<boolean> {
  * Enable the profiler menu button.
  */
 export async function enableMenuButton(): Promise<void> {
-  type ExpectedResponse = $PropertyType<
-    MessageFromBrowserObject,
-    'ENABLE_MENU_BUTTON_DONE'
-  >;
-
-  await _sendMessageWithResponse<ExpectedResponse>({
+  await _sendMessageWithResponse({
     type: 'ENABLE_MENU_BUTTON',
-    requestId: _requestId++,
   });
 
   // The response does not return any additional information other than we know
   // the request was handled.
+}
+
+/**
+ * Ask the browser if the web channel supports getting the profile and symbolication.
+ */
+export async function querySupportsGetProfileAndSymbolicationViaWebChannel(): Promise<boolean> {
+  const response = await _sendMessageWithResponse({
+    type: 'STATUS_QUERY',
+  });
+
+  return response.version ? response.version >= 1 : false;
+}
+
+export async function getSymbolTableViaWebChannel(
+  debugName: string,
+  breakpadId: string
+): Promise<SymbolTableAsTuple> {
+  return _sendMessageWithResponse({
+    type: 'GET_SYMBOL_TABLE',
+    debugName,
+    breakpadId,
+  });
+}
+
+export async function getProfileViaWebChannel(): Promise<
+  ArrayBuffer | MixedObject
+> {
+  return _sendMessageWithResponse({
+    type: 'GET_PROFILE',
+  });
+}
+
+export async function querySymbolicationApiViaWebChannel(
+  path: string,
+  requestJson: string
+): Promise<string> {
+  return _sendMessageWithResponse({
+    type: 'QUERY_SYMBOLICATION_API',
+    path,
+    requestJson,
+  });
 }
 
 /**
@@ -86,7 +182,7 @@ const LOG_STYLE = 'font-weight: bold; color: #0a6';
 /**
  * Send a message to the browser through the WebChannel.
  */
-function _sendMessage(message) {
+function _sendMessage(message: MessageToBrowser) {
   if (process.env.NODE_ENV === 'development') {
     console.log(`[webchannel] %csending "${message.type}"`, LOG_STYLE, message);
   }
@@ -103,20 +199,59 @@ function _sendMessage(message) {
 
 let _requestId = 0;
 
-function _sendMessageWithResponse<Returns: MessageFromBrowser>(
-  messageToBrowser: MessageToBrowser
-): Promise<Returns> {
+export class WebChannelError extends Error {
+  name = 'WebChannelError';
+  errno: number;
+  constructor(rawError: OutOfBandErrorMessageFromBrowser) {
+    super(`${rawError.error} (errno: ${rawError.errno})`);
+    this.errno = rawError.errno;
+  }
+}
+
+// eslint-disable-next-line no-redeclare
+function _sendMessageWithResponse(
+  Request: Request
+): Promise<ResponseFromBrowser> {
+  const requestId = _requestId++;
+  const type = Request.type;
+
   return new Promise((resolve, reject) => {
     function listener(event) {
-      const { id, message: messageFromBrowser } = event.detail;
+      const { id, message } = event.detail;
 
       // Don't trust the message too much, and do some checking for known properties.
       if (
         id === 'profiler.firefox.com' &&
-        messageFromBrowser &&
-        typeof messageFromBrowser === 'object'
+        message &&
+        typeof message === 'object'
       ) {
-        if (typeof messageFromBrowser.error === 'string') {
+        _fixupOldResponseMessageIfNeeded(message);
+
+        // Make the type system assume that we have the right message.
+        const messageFromBrowser: MessageFromBrowser<ResponseFromBrowser> = (message: any);
+
+        if (messageFromBrowser.type) {
+          if (messageFromBrowser.requestId === requestId) {
+            if (process.env.NODE_ENV === 'development') {
+              console.log(
+                `[webchannel] %creceived response to "${type}"`,
+                LOG_STYLE,
+                messageFromBrowser
+              );
+            }
+            window.removeEventListener(
+              'WebChannelMessageToContent',
+              listener,
+              true
+            );
+
+            if (messageFromBrowser.type === 'SUCCESS_RESPONSE') {
+              resolve(messageFromBrowser.response);
+            } else {
+              reject(new Error(messageFromBrowser.error));
+            }
+          }
+        } else if (typeof messageFromBrowser.error === 'string') {
           // There was some kind of error with the message. This is expected for older
           // versions of Firefox that don't have this WebChannel set up yet, or
           // if the about:config preference points to a different URL.
@@ -129,27 +264,7 @@ function _sendMessageWithResponse<Returns: MessageFromBrowser>(
             listener,
             true
           );
-          reject(messageFromBrowser);
-        } else if (
-          messageToBrowser.requestId === messageFromBrowser.requestId
-        ) {
-          if (process.env.NODE_ENV === 'development') {
-            console.log(
-              `[webchannel] %creceived "${String(messageFromBrowser.type)}"`,
-              LOG_STYLE,
-              messageFromBrowser
-            );
-          }
-          window.removeEventListener(
-            'WebChannelMessageToContent',
-            listener,
-            true
-          );
-
-          resolve(
-            // Make the type system assume that we have the right message.
-            (messageFromBrowser: any)
-          );
+          reject(new WebChannelError(messageFromBrowser));
         }
       } else {
         reject(new Error('A malformed WebChannel event was received.'));
@@ -163,6 +278,24 @@ function _sendMessageWithResponse<Returns: MessageFromBrowser>(
 
     window.addEventListener('WebChannelMessageToContent', listener, true);
 
-    _sendMessage(messageToBrowser);
+    // Add the requestId to the message.
+    _sendMessage(
+      ({
+        requestId,
+        ...Request,
+      }: any)
+    );
   });
+}
+
+// This can be removed once the oldest supported Firefox ESR version is 93 or newer.
+function _fixupOldResponseMessageIfNeeded(message: MixedObject) {
+  if (message.type === 'STATUS_RESPONSE') {
+    const { menuButtonIsEnabled } = message;
+    message.type = 'SUCCESS_RESPONSE';
+    message.response = { menuButtonIsEnabled };
+  } else if (message.type === 'ENABLE_MENU_BUTTON_DONE') {
+    message.type = 'SUCCESS_RESPONSE';
+    message.response = undefined;
+  }
 }

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -61,9 +61,11 @@ describe('app/Home', function() {
 
     // Respond back from the browser that the menu button is not yet enabled.
     triggerResponse({
-      type: 'STATUS_RESPONSE',
-      menuButtonIsEnabled: false,
+      type: 'SUCCESS_RESPONSE',
       requestId: getLastRequestId(),
+      response: {
+        menuButtonIsEnabled: false,
+      },
     });
     await findByTestId('home-enable-popup-instructions');
 
@@ -71,8 +73,9 @@ describe('app/Home', function() {
 
     // Respond back from the browser that the menu button was enabled.
     triggerResponse({
-      type: 'ENABLE_MENU_BUTTON_DONE',
+      type: 'SUCCESS_RESPONSE',
       requestId: getLastRequestId(),
+      response: undefined,
     });
     await findByTestId('home-record-instructions');
   });

--- a/src/test/fixtures/mocks/web-channel.js
+++ b/src/test/fixtures/mocks/web-channel.js
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-import type { MessageFromBrowser } from '../../../app-logic/web-channel';
+
+import type {
+  ResponseFromBrowser,
+  MessageFromBrowser,
+} from '../../../app-logic/web-channel';
 
 /**
  * Mock out the WebChannel, a Firefox internal mechanism that allows us to
@@ -35,8 +39,8 @@ export function mockWebChannel() {
     messagesSentToBrowser.push(JSON.parse(event.detail));
   });
 
-  function triggerResponse(
-    message: MessageFromBrowser | {| errno: number, error: string |}
+  function triggerResponse<R: ResponseFromBrowser>(
+    message: MessageFromBrowser<R>
   ) {
     for (const listener of listeners.slice()) {
       listener({


### PR DESCRIPTION
This PR adds support for a new WebChannel version, and uses it for obtaining the profile and for getting symbol information, if run on a Firefox version which supports the new WebChannel functionality.

The Firefox side of this is https://bugzilla.mozilla.org/show_bug.cgi?id=1625309 .

This PR needs to land first. Once it is deployed, the Firefox side can land. And in Firefox we can completely remove the frame script, because we only need to support the most recent version of the front-end.