### PR TITLE
WIP: Allow re-symbolication to use the WebChannel

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -688,9 +688,11 @@ export function changeTimelineTrackOrganization(
  */
 export function resymbolicateProfile(): ThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
+    const shouldUseWebChannel = await checkIfWebChannelUsableForSymbolication();
     const symbolStore = getSymbolStore(
       dispatch,
-      getSymbolServerUrl(getState())
+      getSymbolServerUrl(getState()),
+      shouldUseWebChannel
     );
     const profile = getProfile(getState());
     if (!symbolStore) {

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -624,10 +624,11 @@ describe('app/MenuButtons', function() {
         expect(screen.getByText('Profile is symbolicated')).toBeInTheDocument();
         fireFullClick(screen.getByText('Re-symbolicate profile'));
 
-        expect(symbolicateProfile).toHaveBeenCalled();
         expect(
-          screen.getByText('Attempting to re-symbolicate profile')
+          await screen.findByText('Attempting to re-symbolicate profile')
         ).toBeInTheDocument();
+        expect(symbolicateProfile).toHaveBeenCalled();
+
         // No symbolicate button is available.
         expect(
           screen.queryByText('Symbolicate profile')
@@ -650,11 +651,12 @@ describe('app/MenuButtons', function() {
           screen.getByText('Profile is not symbolicated')
         ).toBeInTheDocument();
         fireFullClick(screen.getByText('Symbolicate profile'));
-        expect(symbolicateProfile).toHaveBeenCalled();
 
         expect(
-          screen.getByText('Currently symbolicating profile')
+          await screen.findByText('Currently symbolicating profile')
         ).toBeInTheDocument();
+        expect(symbolicateProfile).toHaveBeenCalled();
+
         // No symbolicate button is available.
         expect(
           screen.queryByText('Symbolicate profile')


### PR DESCRIPTION
The patch for this is super simple but doesn't pass tests, because it adds asynchronicity. I've temporarily given up on it.

This PR makes the following workflow work:
 1. Capture a profile in local build A but save it without symbolicating, e.g. as a shutdown profile.
 2. Import the file into the profiler in Firefox build B, which cannot fully symbolicate it.
 3. Upload the profile in build B. Example result: https://share.firefox.dev/37WzwZF
 4. Load the public profile in build A.
 5. Re-symbolicate in build A. Example result: https://share.firefox.dev/3z4Agb1