### PR TITLE
Show the tooltip of the first marker in the thread

### DIFF
--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -495,7 +495,7 @@ class TimelineMarkersImplementation extends React.PureComponent<Props, State> {
             onMouseOut={this._onMouseOut}
           />
         </ContextMenuTrigger>
-        {shouldShowTooltip && hoveredMarkerIndex && hoveredMarker ? (
+        {shouldShowTooltip && hoveredMarkerIndex !== null && hoveredMarker ? (
           <Tooltip mouseX={mouseX} mouseY={mouseY}>
             <TooltipMarker
               markerIndex={hoveredMarkerIndex}


### PR DESCRIPTION
This was a bug I came across when I was looking into the back-end changes for the Java markers. I thought it was the sent profile data was corrupted, but in the end it turned out the front-end doesn't hover the first marker properly.

Hover over the marker in the AndroidUI thread:
[Example profile on production](https://share.firefox.dev/3guUlQB)
[Example profile with deploy preview](https://deploy-preview-3511--perf-html.netlify.app/public/h6bec3sraa2hjnz7wwmq3gmhq38j7zzn4vx5xc8/marker-chart/?globalTrackOrder=201&hiddenGlobalTracks=12&hiddenLocalTracksByPid=24184-0134~24219-0&localTrackOrderByPid=24184-340w2~24219-120&range=1036m1086~1262m227~1335m28&thread=3&timelineType=cpu-category&v=6)