### PR TITLE
No issue: add link to FF Android profiler demo video.

### DIFF
--- a/docs-user/guide-remote-profiling.md
+++ b/docs-user/guide-remote-profiling.md
@@ -4,7 +4,7 @@ You can use the Firefox Profiler to investigate performance issues on Android, n
 
 In order to do so, you need both your phone with the mobile Gecko-based browser, and a machine running Firefox Desktop. You also need a USB connection between the two devices. Then you can use [about:debugging](https://developer.mozilla.org/en-US/docs/Tools/about:debugging) in Firefox Desktop to connect to the phone and control profiling from there. The result will be shown in Firefox Desktop.
 
-To see how easy it is to capture a profile on Android, check out [this 1 minute video demonstration](https://www.youtube.com/watch?v=TxAlQBv6-yg). For additional details and troubleshooting info, see below.
+[In this 1 minute video demonstration](https://www.youtube.com/watch?v=TxAlQBv6-yg) you can see the few steps needed to capture a profile from Fenix. For additional details and troubleshooting info, see below.
 
 ## Which mobile browser?
 

--- a/docs-user/guide-remote-profiling.md
+++ b/docs-user/guide-remote-profiling.md
@@ -4,6 +4,8 @@ You can use the Firefox Profiler to investigate performance issues on Android, n
 
 In order to do so, you need both your phone with the mobile Gecko-based browser, and a machine running Firefox Desktop. You also need a USB connection between the two devices. Then you can use [about:debugging](https://developer.mozilla.org/en-US/docs/Tools/about:debugging) in Firefox Desktop to connect to the phone and control profiling from there. The result will be shown in Firefox Desktop.
 
+To see how easy it is to capture a profile on Android, check out [this 1 minute video demonstration](https://www.youtube.com/watch?v=TxAlQBv6-yg). For additional details and troubleshooting info, see below.
+
 ## Which mobile browser?
 
 (The following is true as of August 2021.)


### PR DESCRIPTION
I passed a link to the docs and this video to a developer and they suggested I link to the video from the docs.