### PR TITLE
Fix a crash when pressing the back button in some situation

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -157,8 +157,8 @@ export function setupInitialUrlState(
     // load process.
     withHistoryReplaceStateSync(() => {
       dispatch(updateUrlState(urlState));
-      dispatch(urlSetupDone());
       dispatch(finalizeProfileView());
+      dispatch(urlSetupDone());
     });
   };
 }

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -200,17 +200,16 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       return;
     }
 
+    const oldUrl = window.location.pathname + window.location.search;
     const newUrl = urlFromState(urlState);
-    if (newUrl !== window.location.pathname + window.location.search) {
-      if (!getIsHistoryReplaceState()) {
-        // Push the URL state only when the url setup is done, and we haven't set
-        // a flag to only replace the state.
-        window.history.pushState(urlState, document.title, newUrl);
-      } else {
-        // Replace the URL state before the URL setup is done, and if we've specifically
-        // flagged to replace the URL state.
-        window.history.replaceState(urlState, document.title, newUrl);
-      }
+    if (!window.history.state || getIsHistoryReplaceState()) {
+      // Replace the URL state if we've specifically flagged to replace the URL
+      // state. This happens during the loading process. Also do it if we don't
+      // have an history state yet.
+      window.history.replaceState(urlState, document.title, newUrl);
+    } else if (newUrl !== oldUrl) {
+      // Push the URL state when we haven't set a flag to only replace the state.
+      window.history.pushState(urlState, document.title, newUrl);
     }
   }
 

--- a/src/test/fixtures/mocks/window-navigation.js
+++ b/src/test/fixtures/mocks/window-navigation.js
@@ -172,13 +172,14 @@ function mockWindowHistory() {
       return states.length;
     },
     scrollRestoration: 'auto',
-    state: null,
+    get state() {
+      return states[index] ?? null;
+    },
     back() {
       if (index <= 0) {
         return;
       }
       index--;
-      history.state = states[index];
       // $FlowExpectError Flow doesn't know about this internal property.
       window.location[internalLocationAssign](urls[index]);
       window.dispatchEvent(new Event('popstate'));
@@ -189,7 +190,6 @@ function mockWindowHistory() {
       }
       index++;
 
-      history.state = states[index];
       // $FlowExpectError Flow doesn't know about this internal property.
       window.location[internalLocationAssign](urls[index]);
       window.dispatchEvent(new Event('popstate'));

--- a/src/test/fixtures/mocks/window-navigation.js
+++ b/src/test/fixtures/mocks/window-navigation.js
@@ -42,6 +42,10 @@ import { coerceMatchingShape } from '../../../utils/flow';
 // window.history can change the inner location directly.
 const internalLocationAssign = Symbol.for('internalLocationAssign');
 
+// This symbol will be used in the mock for window.history so that we can reset
+// it from tests.
+const internalHistoryReset = Symbol.for('internalHistoryReset');
+
 /**
  * This mock creates a location API that allows for assigning to the location,
  * which we need to be able to do for certain tests.
@@ -164,9 +168,16 @@ function mockWindowLocation(location: string = 'http://localhost') {
 function mockWindowHistory() {
   const originalHistory = Object.getOwnPropertyDescriptor(window, 'history');
 
-  let states = [null];
-  let urls = [window.location.href];
-  let index = 0;
+  let states, urls, index;
+
+  function reset() {
+    states = [null];
+    urls = [window.location.href];
+    index = 0;
+  }
+
+  reset();
+
   const history = {
     get length() {
       return states.length;
@@ -223,6 +234,8 @@ function mockWindowHistory() {
 
       states[index] = newState;
     },
+    // $FlowExpectError Flow doesn't know about symbol properties sadly.
+    [internalHistoryReset]: reset,
   };
 
   // This "delete" call doesn't seem to be necessary, but better do it so that
@@ -273,4 +286,11 @@ export function autoMockFullNavigation() {
       cleanup = null;
     }
   });
+}
+
+export function resetHistoryWithUrl(url: string = window.location.href) {
+  // $FlowExpectError Flow doesn't know about this internal property.
+  window.location[internalLocationAssign](url);
+  // $FlowExpectError Flow doesn't know about this internal property.
+  window.history[internalHistoryReset]();
 }


### PR DESCRIPTION
Fixes #3524

STR:
1. Open [this profile](https://profiler.firefox.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/?globalTrackOrder=de0wc&localTrackOrderByPid=29495-780w6~5123-0~29556-0~526-0~29603-0~29692-01~5023-0~5053-01~29650-0~29726-0~4975-0~29481-0~21926-10&thread=e&v=6)
2. Click on another panel (eg Flame graph)
3. Click the "back button"

Then try with [this deploy preview](https://deploy-preview-3525--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/?globalTrackOrder=de0wc&localTrackOrderByPid=29495-780w6~5123-0~29556-0~526-0~29603-0~29692-01~5023-0~5053-01~29650-0~29726-0~4975-0~29481-0~21926-10&thread=e&v=6).

Compared to the comment in https://github.com/firefox-devtools/profiler/issues/3524#issuecomment-909265791, I finally implemented the second solution, as well as calling `replaceState` more often.

I tried the 3rd point (accepting `hiddenLocalTracksByPid` values with missing entries), this worked, but then... we had another similar problem with `localTrackOrderByPid` which was much more difficult to work around. So I abandoned this solution.

I did a few tests for various datasources (public, from-browser, from-file, from-url) and this seems to work fine too.
I found a weird issue with the compare datasource (after the first action, pressing "back" goes back to the page _before_ the initial page instead of the initial page) but this seems to happen on production too, so this isn't regressed by this patch.

Note that this is an indirect consequence of Markus' PR #3419: by making the URL generation more consistent, then at load time the URL wouldn't change as much as before, and the check `if (newUrl !== oldUrl)` that was passing before wouldn't pass afterwards.