### PR TITLE
Persist the selected panel also when the user in the compare view

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -116,7 +116,12 @@ function getPathParts(urlState: UrlState): string[] {
     case 'none':
       return [];
     case 'compare':
-      return ['compare'];
+      // Special handling for CompareHome: we shouldn't append anything but the
+      // dataSource when the user is on the comparison form.
+      if (urlState.profilesToCompare === null) {
+        return ['compare'];
+      }
+      return ['compare', urlState.selectedTab];
     case 'uploaded-recordings':
       return ['uploaded-recordings'];
     case 'from-browser':

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -1597,6 +1597,13 @@ describe('compare', function() {
     );
     expect(resultingUrl).toMatch(`profiles[]=${encodeURIComponent(url1)}`);
     expect(resultingUrl).toMatch(`profiles[]=${encodeURIComponent(url2)}`);
+    expect(resultingUrl).toMatch('/calltree/');
+
+    store.dispatch(changeSelectedTab('flame-graph'));
+    const newResultingUrl = urlFromState(
+      urlStateSelectors.getUrlState(store.getState())
+    );
+    expect(newResultingUrl).toMatch('/flame-graph/');
   });
 });
 


### PR DESCRIPTION
Fixes #3527

STR1:
1. Open a comparing view (for example https://share.firefox.dev/38snoA3)
2. Click on another tab.
3. Reload the page (either with the reload button, or pressing enter in the address bar)

=> we're back to the first view of step 1, instead of the changed view of step 2.

STR2:
1. Open a comparing view (for example https://share.firefox.dev/38snoA3)
2. Click on another tab.
3. Press back

=> this goes back to whatever page was here _before_ we loaded the profiler.


Try with the [deploy preview](https://deploy-preview-3528--perf-html.netlify.app/compare/?globalTrackOrder=3w60w2&hiddenGlobalTracks=2&profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2F36d6d200bb8ec4eff5a90044dc066063703edf6a%2Fmarker-chart%2F%3FglobalTrackOrder%3D450w3%26localTrackOrderByPid%3D39199-0~39202-0~39200-0~39201-0%26thread%3D0%26v%3D6&profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2F36d6d200bb8ec4eff5a90044dc066063703edf6a%2Fmarker-chart%2F%3FglobalTrackOrder%3D450w3%26localTrackOrderByPid%3D39199-0~39202-0~39200-0~39201-0%26thread%3D0%26v%3D6&thread=1&v=6)

Note that because of #3525 is not included in this PR, there will be a crash when pressing back in STR2 with the deploy preview. You can still try pressing "back" after changing the tab several times.