### PR TITLE
Remove the unused `intl-pluralrules` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "escape-string-regexp": "^4.0.0",
     "gecko-profiler-demangle": "^0.3.3",
     "idb": "^6.1.2",
-    "intl-pluralrules": "^1.3.0",
     "jszip": "^3.7.1",
     "memoize-immutable": "^3.0.0",
     "mixedtuplemap": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6627,11 +6627,6 @@ interpret@^1.0.0, interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-intl-pluralrules@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/intl-pluralrules/-/intl-pluralrules-1.3.0.tgz#ed1a9b1a9fa25ac49453ed2e215e01e33be1458f"
-  integrity sha512-hFzGTkxCjyrwHvn4pWVoB3/cFk1RIOOKNFlcNvm37YjXsmdhIt2dU/Nwh9c9i95Xa248wDF1+bI71Q+yDlGPeA==
-
 ip-regex@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"


### PR DESCRIPTION
I think it's better to just remove this dependency since we are not using it anyway. It looks like all major browsers support it and we never got a complain about this so far. So I think it's fine to remove it and move on :)