### PR TITLE
Use the new SelectedItem color in the TreeView.

### DIFF
--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -177,10 +177,21 @@
   opacity: 0.7;
 }
 
+/* stylelint-disable order/properties-order, declaration-block-no-duplicate-properties, value-keyword-case */
 .treeViewBody:focus .treeViewRow.isSelected {
-  background-color: highlight;
-  color: highlighttext;
+  /* Fallback for browsers that don't support SelectedItem */
+  background-color: Highlight;
+  color: HighlightText;
+
+  /* Safari's non-standard SelectedItem equivalent (until SelectedItem is implemented, https://bugs.webkit.org/show_bug.cgi?id=230007 ) */
+  background-color: -apple-system-selected-content-background;
+  color: -apple-system-alternate-selected-text;
+
+  /* The new standard color */
+  background-color: SelectedItem;
+  color: SelectedItemText;
 }
+/* stylelint-enable order/properties-order, declaration-block-no-duplicate-properties, value-keyword-case */
 
 .treeViewBody:focus .treeViewRow.isSelected a {
   color: inherit;


### PR DESCRIPTION
This color was recently introduced in https://github.com/w3c/csswg-drafts/issues/6008 ,
and implemented in Firefox in https://bugzilla.mozilla.org/show_bug.cgi?id=1693222 .

Without this change, the tree row selection color now looks too light on macOS.
It was always too light on macOS in Safari and Chrome.
This patch fixes Firefox and Safari. Chrome doesn't have a system color for
selected items on macOS, but it will start working once Chrome implements
SelectedItem.