### PR TITLE
Enable 3 more locales that are above the threshold

### DIFF
--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -24,7 +24,10 @@ export const AVAILABLE_LOCALES: Array<string> = AVAILABLE_STAGING_LOCALES || [
   'es-CL',
   'ia',
   'it',
+  'nl',
   'pt-BR',
+  'sv-SE',
+  'uk',
   'zh-CN',
   'zh-TW',
 ];


### PR DESCRIPTION
The new locales are Dutch (nl), Swedish (sv-SE) and Ukrainian (uk).

cc @flodolo.