### PR TITLE
Show the `eTLD+1` of Isolated Web Content Processes as their track name

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1032,6 +1032,7 @@ function _processThread(
 
   const newThread: Thread = {
     name: thread.name,
+    'eTLD+1': thread['eTLD+1'],
     processType: thread.processType,
     processName:
       typeof thread.processName === 'string' ? thread.processName : '',

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2046,6 +2046,11 @@ export function getFriendlyThreadName(
 
   switch (thread.name) {
     case 'GeckoMain': {
+      if (thread['eTLD+1']) {
+        // Return the host name if it's provided by the back-end and it's not sanitized.
+        return thread['eTLD+1'];
+      }
+
       if (thread.processName) {
         // If processName is present, use that as it should contain a friendly name.
         // We want to use that for the GeckoMain thread because it is shown as the

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2109,14 +2109,18 @@ export function getFriendlyThreadName(
   return label;
 }
 
-export function getThreadProcessDetails(thread: Thread): string {
-  let label = `thread: "${thread.name}"`;
+export function getThreadProcessDetails(
+  thread: Thread,
+  friendlyThreadName: string
+): string {
+  let label = `${friendlyThreadName}\n`;
+  label += `Thread: "${thread.name}"`;
   if (thread.tid !== undefined) {
     label += ` (${thread.tid})`;
   }
 
   if (thread.processType) {
-    label += `\nprocess: "${thread.processType}"`;
+    label += `\nProcess: "${thread.processType}"`;
     if (thread.pid !== undefined) {
       label += ` (${thread.pid})`;
     }

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -330,6 +330,12 @@ function sanitizeThreadPII(
     }
   }
 
+  if (PIIToBeRemoved.shouldRemoveUrls && newThread['eTLD+1']) {
+    // Remove the domain name of the isolated content process if it's provided
+    // from the back-end.
+    delete newThread['eTLD+1'];
+  }
+
   // Remove the old stringTable and markerTable and replace it
   // with new updated ones.
   newThread.stringTable = new UniqueStringArray(stringArray);

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -618,10 +618,15 @@ export function getGlobalTrackName(
         // The pid is a number, make a label for it.
         return `Process ${pid}`;
       }
+
+      // Getting the friendly thread name and removing the scheme in case we
+      // have any eTLD+1 returned. This can happen if the thread is an Isolated
+      // Web Content process' main thread that has an `eTLD+1` field. Removing the
+      // scheme to fit the complete url in this limited space in the timeline.
       return getFriendlyThreadName(
         threads,
         threads[globalTrack.mainThreadIndex]
-      );
+      ).replace(/^https?:\/\//i, '');
     }
     case 'screenshots':
       return 'Screenshots';

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -355,6 +355,7 @@ export function getThreadSelectorsPerThread(
 
   const getThreadProcessDetails: Selector<string> = createSelector(
     getThread,
+    getFriendlyThreadName,
     ProfileData.getThreadProcessDetails
   );
 

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -9,8 +9,9 @@ exports[`timeline/GlobalTrack matches the snapshot of a global process track 1`]
   >
     <div
       class="react-contextmenu-wrapper timelineTrackLabel timelineTrackGlobalGrippy"
-      title="thread: \\"GeckoMain\\" (0)
-process: \\"tab\\" (222)"
+      title="Content Process
+Thread: \\"GeckoMain\\" (0)
+Process: \\"tab\\" (222)"
     >
       <button
         class="timelineTrackNameButton"
@@ -124,8 +125,9 @@ process: \\"tab\\" (222)"
       >
         <div
           class="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-          title="thread: \\"DOM Worker\\" (0)
-process: \\"tab\\" (222)"
+          title="DOM Worker
+Thread: \\"DOM Worker\\" (0)
+Process: \\"tab\\" (222)"
         >
           <button
             class="timelineTrackNameButton"
@@ -203,8 +205,9 @@ process: \\"tab\\" (222)"
       >
         <div
           class="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-          title="thread: \\"Style\\" (0)
-process: \\"tab\\" (222)"
+          title="Style
+Thread: \\"Style\\" (0)
+Process: \\"tab\\" (222)"
         >
           <button
             class="timelineTrackNameButton"
@@ -315,8 +318,9 @@ exports[`timeline/GlobalTrack matches the snapshot of a global process track wit
       >
         <div
           class="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-          title="thread: \\"NoMain\\" (0)
-process: \\"default\\" (5555)"
+          title="NoMain
+Thread: \\"NoMain\\" (0)
+Process: \\"default\\" (5555)"
         >
           <button
             class="timelineTrackNameButton"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -135,8 +135,9 @@ exports[`timeline/LocalTrack with a thread track matches the snapshot of a local
   >
     <div
       class="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
-      title="thread: \\"DOM Worker\\" (0)
-process: \\"tab\\" (222)"
+      title="DOM Worker
+Thread: \\"DOM Worker\\" (0)
+Process: \\"tab\\" (222)"
     >
       <button
         class="timelineTrackNameButton"

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -4392,8 +4392,9 @@ Object {
 `;
 
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getThreadProcessDetails 1`] = `
-"thread: \\"Thread with samples\\" (0)
-process: \\"default\\" (0)"
+"Thread with samples
+Thread: \\"Thread with samples\\" (0)
+Process: \\"default\\" (0)"
 `;
 
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getViewOptions 1`] = `

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3073,6 +3073,19 @@ describe('getFriendlyThreadName', function () {
       'C (2/2)',
     ]);
   });
+
+  it('uses the eTLD+1 field if provided', function () {
+    const { getFriendlyThreadNames } = setup([
+      { name: 'GeckoMain', processType: 'default' },
+      { name: 'GeckoMain', 'eTLD+1': 'https://firefox.com' },
+      { name: 'GeckoMain', 'eTLD+1': 'http://w3c.github.io' },
+    ]);
+    expect(getFriendlyThreadNames()).toEqual([
+      'Parent Process',
+      'https://firefox.com',
+      'http://w3c.github.io',
+    ]);
+  });
 });
 
 describe('counter selectors', function () {

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -55,6 +55,7 @@ Object {
   "profilerOverhead": Array [],
   "threads": Array [
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -425,6 +426,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -638,6 +640,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -851,6 +854,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -1364,6 +1368,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -1610,6 +1615,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -1954,6 +1960,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2136,6 +2143,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2347,6 +2355,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2562,6 +2571,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2773,6 +2783,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -3043,6 +3054,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -3999,6 +4011,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -4955,6 +4968,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -5915,6 +5929,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -6875,6 +6890,7 @@ Object {
       "unregisterTime": null,
     },
     Object {
+      "eTLD+1": undefined,
       "frameTable": Object {
         "address": Array [
           -1,

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -229,6 +229,12 @@ export type GeckoStackStruct = {|
 
 export type GeckoThread = {|
   name: string,
+  // The eTLD+1 of the isolated content process if provided by the back-end.
+  // It will be undefined if:
+  // - Fission is not enabled.
+  // - It's not an isolated content process.
+  // - It's a profile from an older Firefox which doesn't include this field (introduced in Firefox 80).
+  'eTLD+1'?: string,
   registerTime: number,
   processType: string,
   processName?: string,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -601,6 +601,13 @@ export type Thread = {|
   unregisterTime: Milliseconds | null,
   pausedRanges: PausedRange[],
   name: string,
+  // The eTLD+1 of the isolated content process if provided by the back-end.
+  // It will be undefined if:
+  // - Fission is not enabled.
+  // - It's not an isolated content process.
+  // - It's a sanitized profile.
+  // - It's a profile from an older Firefox which doesn't include this field (introduced in Firefox 80).
+  'eTLD+1'?: string,
   processName?: string,
   isJsTracer?: boolean,
   pid: Pid,


### PR DESCRIPTION
Fixes #3573.
This PR does 3 things, which are seperated by commits:
1. Add the `eTLD+1` field to the thread and sanitize it when needed
2. Show the `eTLD+1` field as the friendly thread name if provided
Isolated content processes will show up like this with Fission:
![Screenshot from 2021-09-22 15-56-30](https://user-images.githubusercontent.com/466239/134357713-b7172fa9-56cf-4787-92f9-b2ffd58bf581.png)
3. Include the friendly thread name in the timeline title text 
This fixes both the the profiles without and with `eTLD+1`.
For example, previously, it wasn't possible to see the full name in the title when you hover it. This is the old title:
![Screenshot from 2021-09-22 16-01-36](https://user-images.githubusercontent.com/466239/134358277-bf49bdd2-d996-4b3d-bdd5-87a444d57837.png)
Now, it's possible to see the full name:
![Screenshot from 2021-09-22 15-58-17](https://user-images.githubusercontent.com/466239/134358327-595c2764-581b-4683-9791-f852db227917.png)
Also, in case the domain is too long, the domain will be shown in the title:
![Screenshot from 2021-09-22 15-56-57](https://user-images.githubusercontent.com/466239/134358677-a0206e24-eacc-44f2-a3ca-b7ba8b1b47d4.png)

[Example profile captured with this deploy preview](https://deploy-preview-3570--perf-html.netlify.app/public/sy2vtje3hmwf5x6dkk0b08gtf2a782z0y3rnamr/calltree/?globalTrackOrder=0w5a96w8&hiddenGlobalTracks=0w58&hiddenLocalTracksByPid=121271-0w5~121394-0&localTrackOrderByPid=121271-450w3~121907-0~121394-0~121770-0~121500-0~121840-0~121574-0~121568-0~121472-0~121603-01&thread=d&timelineType=cpu-category&v=6)

