### PR TITLE
Find the correct selected track when we switch from active tab to full view

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -638,9 +638,9 @@ export function changeTimelineTrackOrganization(
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const profile = getProfile(getState());
-    // We are resetting the selected thread index, because we are not sure if
-    // the selected thread will be availabe in the next view.
-    const selectedThreadIndexes = new Set([0]);
+    // We are resetting the selected thread index and the url state, because we
+    // are not sure if the selected thread will be availabe in the next view.
+    const selectedThreadIndexes = null;
     dispatch({
       type: 'DATA_RELOAD',
     });


### PR DESCRIPTION
Previously we were selecting the first thread when we switch from the active tab view to the full view. And that was mostly the parent process. But in the end, it should select the best thread as selected like how we do when loading the profile in full view directly.

Example profiles:
Open the profile and click on the "Full View" button. See which thread is selected after the full view loads.

[Main branch](https://main--perf-html.netlify.app/public/rvbedpbwt3w38htwsp0pg4q2qxrzamhd1np5m7g/calltree/?thread=mp&timelineType=cpu-category&v=6&view=active-tab)
[Deploy preview](https://deploy-preview-3580--perf-html.netlify.app/public/rvbedpbwt3w38htwsp0pg4q2qxrzamhd1np5m7g/calltree/?thread=mp&timelineType=cpu-category&v=6&view=active-tab)