### PR TITLE
Compute correct relative addresses for kernel addresses.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
+    es2020: true,
     node: true,
   },
   parser: '@babel/eslint-parser',

--- a/src/profile-logic/address-locator.js
+++ b/src/profile-logic/address-locator.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+// Find an address in the list of libraries, and convert the address from
+// an absolute virtual memory address into a library-relative address.
+//
+// Note: This file is not covered by Flow because it uses BigInt, which Flow
+// does not support yet. https://github.com/facebook/flow/issues/6639
+//
+// We use BigInt for the absolute addresses because regular JS numbers cannot
+// accurately represent large unsigned 64 bit numbers. Specifically, calling
+// parseInt for a hex string with a number larger than 2^53 - 1 (0x1fffffffffffff)
+// will return an inaccurate JS number, i.e. a number which is "rounded" to some
+// multiple of a power of two. Then we will calculate lib-relative addresses
+// from those wrong rounded values, and then symbolication will return incorrect
+// information for those inaccurate relative addresses.
+//
+// So we first convert everything into BigInt, do the comparisons during the lookup
+// in BigInt, and then do the lookedUpAddress - libBaseAddress subtraction in BigInt,
+// and then convert the result to a JS number. The library-relative address can
+// always be represented accurately by a JS number, because libraries are always
+// small enough.
+
+export class AddressLocator {
+  _libs /* : Lib[] */;
+  _libRanges /* : Array<{| baseAddress: BigInt, start: BigInt, end: BigInt |}> */;
+
+  /**
+   * Create an AddressLocator for an array of libs.
+   * The libs array needs to be sorted in ascending address order, and the address
+   * ranges of the libraries need to be non-overlapping.
+   * @param {Libs[]} libs The array of libraries, ordered by start address.
+   */
+  constructor(libs) {
+    this._libs = libs;
+    this._libRanges = libs.map((lib) => {
+      const start = BigInt(lib.start);
+      const offset = BigInt(lib.offset);
+      const end = BigInt(lib.end);
+      return {
+        baseAddress: start - offset,
+        start: start,
+        end: end,
+      };
+    });
+  }
+
+  /**
+   * Return the library object that contains the address such that
+   * libRange.start <= address < libRange.end, or null if no such lib object exists.
+   * This also computes the relative address, without losing precision for large
+   * values.
+   * @param {string} addressHexString The address, as a hex string, including the leading "0x".
+   * @return {Object} The library object (and its index) if found, and the address relative to that library.
+   */
+  locateAddress(addressHexString) {
+    // Diagram of the various offsets and spaces:
+    //
+    //  process virtual memory
+    // |--------------------|======================|--------------------
+    //                      |  mapped lib segment  |
+    //         |------------|======================|--------|
+    //    baseAddress     start             ^     end
+    //         |<--offset-->|               |
+    //         |<-----relative address----->|
+    //                                      |
+    //                                  absolute address
+    //
+    const address = BigInt(addressHexString);
+    const libRanges = this._libRanges;
+    let left = 0;
+    let right = libRanges.length - 1;
+    while (left <= right) {
+      const mid = ((left + right) / 2) | 0;
+      if (address >= libRanges[mid].end) {
+        left = mid + 1;
+      } else if (address < libRanges[mid].start) {
+        right = mid - 1;
+      } else {
+        // Found a match!
+        const libIndex = mid;
+        const relativeAddress = address - libRanges[libIndex].baseAddress;
+        return {
+          lib: this._libs[libIndex],
+          libIndex,
+          relativeAddress: Number(relativeAddress),
+        };
+      }
+    }
+    return {
+      lib: null,
+      libIndex: null,
+      relativeAddress: parseInt(addressHexString, 16),
+    };
+  }
+}

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -5,7 +5,7 @@
 
 import { attemptToConvertChromeProfile } from './import/chrome';
 import { attemptToConvertDhat } from './import/dhat';
-import { getContainingLibrary } from './symbolication';
+import { AddressLocator } from './address-locator';
 import { UniqueStringArray } from '../utils/unique-string-array';
 import {
   resourceTypes,
@@ -57,7 +57,6 @@ import type {
   Milliseconds,
   Microseconds,
   Address,
-  MemoryOffset,
   GeckoProfile,
   GeckoSubprocessProfile,
   GeckoThread,
@@ -159,7 +158,7 @@ type ExtractionInfo = {
   funcTable: FuncTable,
   resourceTable: ResourceTable,
   stringTable: UniqueStringArray,
-  libs: Lib[],
+  addressLocator: AddressLocator,
   libToResourceIndex: Map<Lib, IndexIntoResourceTable>,
   originToResourceIndex: Map<string, IndexIntoResourceTable>,
   libNameToResourceIndex: Map<IndexIntoStringTable, IndexIntoResourceTable>,
@@ -202,7 +201,7 @@ export function extractFuncsAndResourcesFromFrameLocations(
     funcTable,
     resourceTable,
     stringTable,
-    libs,
+    addressLocator: new AddressLocator(libs),
     libToResourceIndex: new Map(),
     originToResourceIndex: new Map(),
     libNameToResourceIndex: new Map(),
@@ -296,37 +295,51 @@ function _extractUnsymbolicatedFunction(
   if (!locationString.startsWith('0x')) {
     return null;
   }
-  const { libs, libToResourceIndex, resourceTable, funcTable, stringTable } =
-    extractionInfo;
+  const {
+    addressLocator,
+    libToResourceIndex,
+    resourceTable,
+    funcTable,
+    stringTable,
+  } = extractionInfo;
 
   let resourceIndex = -1;
   let addressRelativeToLib: Address = -1;
 
-  // The frame address, as observed in the profiled process. This address was
-  // valid in the (virtual memory) address space of the profiled process.
-  const address: MemoryOffset = parseInt(locationString.substr(2), 16);
+  try {
+    // The frame address, as observed in the profiled process. This address was
+    // valid in the (virtual memory) address space of the profiled process.
+    // It can be a very large u64 value, larger than Number.MAX_SAFE_INTEGER.
+    // To make sure we don't lose precision, we leave it as a hex string.
+    const addressHex = locationString;
 
-  // We want to turn this address into a library-relative offset.
-  // Look up to see if it falls into one of the libraries that were mapped into
-  // the profiled process, according to the libs list.
-  const lib = getContainingLibrary(libs, address);
-  if (lib) {
-    // Yes, we found the library whose mapping covers this address!
-    const libBaseAddress = lib.start - lib.offset;
-    addressRelativeToLib = address - libBaseAddress;
+    // We want to turn this address into a library-relative offset.
+    // Look up to see if it falls into one of the libraries that were mapped into
+    // the profiled process, according to the libs list.
+    // This call will throw if addressHex is not a valid hex number.
+    const { lib, libIndex, relativeAddress } =
+      addressLocator.locateAddress(addressHex);
+    if (lib !== null && libIndex !== null) {
+      // Yes, we found the library whose mapping covers this address!
+      addressRelativeToLib = relativeAddress;
 
-    resourceIndex = libToResourceIndex.get(lib);
-    if (resourceIndex === undefined) {
-      // This library doesn't exist in the libs array, insert it. This resou
-      // A lib resource is a systems-level compiled library, for example "XUL",
-      // "AppKit", or "CoreFoundation".
-      resourceIndex = resourceTable.length++;
-      resourceTable.lib[resourceIndex] = libs.indexOf(lib);
-      resourceTable.name[resourceIndex] = stringTable.indexForString(lib.name);
-      resourceTable.host[resourceIndex] = undefined;
-      resourceTable.type[resourceIndex] = resourceTypes.library;
-      libToResourceIndex.set(lib, resourceIndex);
+      resourceIndex = libToResourceIndex.get(lib);
+      if (resourceIndex === undefined) {
+        // This library doesn't exist in the libs array, insert it. This resou
+        // A lib resource is a systems-level compiled library, for example "XUL",
+        // "AppKit", or "CoreFoundation".
+        resourceIndex = resourceTable.length++;
+        resourceTable.lib[resourceIndex] = libIndex;
+        resourceTable.name[resourceIndex] = stringTable.indexForString(
+          lib.name
+        );
+        resourceTable.host[resourceIndex] = undefined;
+        resourceTable.type[resourceIndex] = resourceTypes.library;
+        libToResourceIndex.set(lib, resourceIndex);
+      }
     }
+  } catch (e) {
+    // Probably a hex parse error. Ignore.
   }
   // Add the function to the funcTable.
   const funcIndex = funcTable.length++;

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -14,13 +14,11 @@ import type {
   Profile,
   Thread,
   ThreadIndex,
-  Lib,
   IndexIntoFuncTable,
   IndexIntoFrameTable,
   IndexIntoResourceTable,
   IndexIntoNativeSymbolTable,
   IndexIntoLibs,
-  MemoryOffset,
   Address,
 } from 'firefox-profiler/types';
 import type {
@@ -220,35 +218,6 @@ export type SymbolicationStepInfo = {|
 export type FuncToFuncMap = Map<IndexIntoFuncTable, IndexIntoFuncTable>;
 
 type ThreadSymbolicationInfo = Map<LibKey, ThreadLibSymbolicationInfo>;
-
-/**
- * Return the library object that contains the address such that
- * rv.start <= address < rv.end, or null if no such lib object exists.
- * The libs array needs to be sorted in ascending address order, and the address
- * ranges of the libraries need to be non-overlapping.
- */
-export function getContainingLibrary(
-  libs: Lib[],
-  address: MemoryOffset
-): Lib | null {
-  if (isNaN(address)) {
-    return null;
-  }
-
-  let left = 0;
-  let right = libs.length - 1;
-  while (left <= right) {
-    const mid = ((left + right) / 2) | 0;
-    if (address >= libs[mid].end) {
-      left = mid + 1;
-    } else if (address < libs[mid].start) {
-      right = mid - 1;
-    } else {
-      return libs[mid];
-    }
-  }
-  return null;
-}
 
 /**
  * Like `new Map(iterableOfEntryPairs)`: Creates a map from an iterable of


### PR DESCRIPTION
[Profile with incorrect kernel symbols](https://share.firefox.dev/2ZlCKEZ)
[Profile with better kernel symbols](https://main--perf-html.netlify.app/public/hga564xm83thrz8khtnr554q5etnx0j7njze62r/calltree/?globalTrackOrder=01&localTrackOrderByPid=17968-0~29668-0&symbolServer=http%3A%2F%2F127.0.0.1%3A3000&thread=0&timelineType=cpu-category&v=6)

When profiling kernel code, we can end up with address values which
are larger than 2^53, for example `0xfffff80130408bb5`. Calling parseInt on a hex string with such a
large address loses precision and we end up with an imprecise address.
Then we convert that imprecise address to an incorrect relative address,
look up that relative address during symbolication, and get the wrong symbol.

This commit leaves the address in hex string form for longer,
and implements subtraction using a custom U64 class.

This might be overkill but I was having trouble integrating BigInt.

There's another potential source of trouble: In the libs array, lib.start and lib.end are also JSON numbers. It would be better if they were hex strings. To make that change, we'll need to increase the profile versions, so I'm leaving this for later. At the moment it happens to work because lib.start is often at least 4096-bytes aligned, so the "floating point rounding" in the JS number has no effect because the number is already "rounded".