### PR TITLE
Fix truncation behavior of long context menu labels.

### DIFF
--- a/src/components/shared/ContextMenu.css
+++ b/src/components/shared/ContextMenu.css
@@ -123,13 +123,17 @@
 /* Use this wrapper for a content that needs to take the available space or if
  * it contains other HTML elements (eg <strong>) */
 .react-contextmenu-item-content {
-  flex: auto;
+  overflow: hidden;
+  min-width: 0;
+  flex: 1;
+  text-overflow: ellipsis;
 }
 
 /* Use a span with this class to add an icon to an item. */
 .react-contextmenu-icon {
   width: 16px;
   height: 16px;
+  flex: none;
   background: center no-repeat;
   margin-inline-end: 8px;
   pointer-events: auto;


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-3594--perf-html.netlify.app//public/xmjkherb02227xdzfj5ff2r0n99qzwg5aw8e3w0/flame-graph/?globalTrackOrder=40w3&hiddenGlobalTracks=023&hiddenLocalTracksByPid=5960-0w4~22876-02wi~25360-0w4~0-0&localTrackOrderByPid=5960-0w4~22876-0wi~25360-0w4~0-0&range=9919m379&thread=6&v=6)

Fixes #3593.

Before:

<img width="942" alt="Screen Shot 2021-10-04 at 6 15 19 PM" src="https://user-images.githubusercontent.com/961291/135939440-19f11764-84f2-4243-9183-a5c96550955e.png">

After:

<img width="857" alt="Screen Shot 2021-10-04 at 7 51 10 PM" src="https://user-images.githubusercontent.com/961291/135939452-987016f3-1e49-49f2-b947-8c66b112e912.png">
