### PR TITLE
Override the category bar fill color for grey.

### DIFF
--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -139,6 +139,11 @@
   background-color: var(--grey-50);
 }
 
+.sidebar-histogram-bar-color.category-color-grey {
+  /* The grey category color is the same our background color, choose a darker grey instead. */
+  background-color: var(--grey-50);
+}
+
 .sidebar-toggle {
   padding: 0;
   border: 0;


### PR DESCRIPTION
[Without fix](https://share.firefox.dev/3oKIP8A)
[Deploy preview](https://deploy-preview-3602--perf-html.netlify.app/public/h9da3g31zsdh0bsa3q9gnva3pghspk9kj2kgct8/calltree/?globalTrackOrder=0w2&hiddenGlobalTracks=12&hiddenLocalTracksByPid=87015-0wgiwm&localTrackOrderByPid=87015-lm0wk~87035-0~87020-01&range=2992m1934~3645m96&thread=0&timelineType=cpu-category&v=6)

The regular fill is the same as the bar background, so it doesn't show up.

Fixes #3599.