### PR TITLE
Merge start/end interval data. Fixes #3609.

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -26,6 +26,7 @@ import type {
   InnerWindowID,
   Marker,
   MarkerIndex,
+  MarkerPayload,
   IPCSharedData,
   IPCMarkerPayload,
   NetworkPayload,
@@ -445,6 +446,21 @@ export function deriveMarkersFromRawMarkerTable(
     markers.push(marker);
   }
 
+  // In the case of separate markers for the start and end of an interval,
+  // merge the payloads together, with the end data overriding the start.
+  function mergeIntervalData(
+    startData: MarkerPayload,
+    endData: MarkerPayload
+  ): MarkerPayload {
+    if (!startData && !endData) {
+      return null;
+    }
+    return ({
+      ...startData,
+      ...endData,
+    }: any);
+  }
+
   // We don't add a screenshot marker as we find it, because to know its
   // duration we need to wait until the next one or the end of the profile. So
   // we keep it here.
@@ -732,7 +748,7 @@ export function deriveMarkersFromRawMarkerTable(
               name: stringTable.getString(name),
               end: endTime,
               category,
-              data: rawMarkers.data[startIndex],
+              data: mergeIntervalData(rawMarkers.data[startIndex], data),
             });
           } else {
             // No matching "start" marker has been encountered before this "end".

--- a/src/test/unit/__snapshots__/marker-data.test.js.snap
+++ b/src/test/unit/__snapshots__/marker-data.test.js.snap
@@ -51,7 +51,7 @@ Array [
     "category": 0,
     "data": Object {
       "eventType": "mouseout",
-      "latency": 7,
+      "latency": 8,
       "type": "DOMEvent",
     },
     "end": 10,

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -102,18 +102,36 @@ describe('Derive markers from Gecko phase markers', function () {
         startTime: 5,
         endTime: null,
         phase: INTERVAL_START,
+        data: {
+          category: 'CC',
+          type: 'tracing',
+          first: 'Hello',
+          second: 'World',
+        },
       },
       {
         startTime: null,
         endTime: 6,
         phase: INTERVAL_END,
+        data: {
+          category: 'CC',
+          type: 'tracing',
+          first: 'Goodbye',
+          desc: 'O Cruel',
+        },
       },
     ]);
 
     expect(markers).toEqual([
       {
         category: 0,
-        data: null,
+        data: {
+          category: 'CC',
+          type: 'tracing',
+          first: 'Goodbye',
+          desc: 'O Cruel',
+          second: 'World',
+        },
         end: 6,
         name: 'TestDefinedMarker',
         start: 5,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -194,6 +194,9 @@ export type ArbitraryEventTracing = {|
 export type CcMarkerTracing = {|
   type: 'tracing',
   category: 'CC',
+  first?: string,
+  desc?: string,
+  second?: string,
 |};
 
 export type PhaseTimes<Unit> = { [phase: string]: Unit };


### PR DESCRIPTION
Perhaps this is overly simplistic, but it gives me what I want. I had to update a snapshot because there was a DOMEvent with conflicting `latency` data on the start and end. I could have made the start data override the end, but I figure that in general you will know more at the end of the interval than at the beginning. So if it makes sense to have conflicting values, I would expect the later one to override the earlier.