### PR TITLE
Add "(index/total)" numbers to the eTLD+1 tracks with the multiple same sites

### DIFF
--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3086,6 +3086,23 @@ describe('getFriendlyThreadName', function () {
       'http://w3c.github.io',
     ]);
   });
+
+  it('adds indexes to the tracks with homonym eTLD+1 fields', function () {
+    const { getFriendlyThreadNames } = setup([
+      { name: 'GeckoMain', processType: 'default' },
+      { name: 'GeckoMain', 'eTLD+1': 'https://firefox.com' },
+      { name: 'GeckoMain', 'eTLD+1': 'https://firefox.com' },
+      { name: 'GeckoMain', 'eTLD+1': 'https://firefox.com' },
+      { name: 'GeckoMain', 'eTLD+1': 'http://w3c.github.io' },
+    ]);
+    expect(getFriendlyThreadNames()).toEqual([
+      'Parent Process',
+      'https://firefox.com (1/3)',
+      'https://firefox.com (2/3)',
+      'https://firefox.com (3/3)',
+      'http://w3c.github.io',
+    ]);
+  });
 });
 
 describe('counter selectors', function () {


### PR DESCRIPTION
This will make it easier to understand the tracks if there are more than one track with the same eTLD+1. 

Example profile: [production](https://share.firefox.dev/3AGBVU4) / [deploy preview](https://deploy-preview-3612--perf-html.netlify.app/public/49ttdhb4jhp46f6y500r5rn47zqmjnes6vp4g70/calltree/?globalTrackOrder=0ws&hiddenGlobalTracks=0wo&hiddenLocalTracksByPid=1891522-0~1892127-0~1892581-0wb~1892889-0wc~1891778-0wb~1892816-0wc&implementation=js&localTrackOrderByPid=1891522-230145~1893395-102~1892127-10~1891635-0~1893281-01~1892382-01~1891865-01~1891667-01~1892175-01~1892085-01~1893124-01~1891788-01~1892277-01~1891713-01~1891901-01~1892317-01~1891941-01~1891905-0w2~1893093-0w2~1891977-01~1892163-01~1892100-01~1892030-01~1891783-01~1892073-b0wac~1892581-cd0wbe~1892889-de0wcf~1891778-cd0wbe~1892816-de0wcf&thread=x8&timelineType=cpu-category&v=6)