### PR TITLE
Don't hide the Renderer thread instead of the Compositor thread

### DIFF
--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -690,8 +690,10 @@ function _isThreadIdle(
 ): boolean {
   const thread = profile.threads[threadIndex];
   if (
-    // Don't hide the compositor.
-    thread.name === 'Compositor' ||
+    // Don't hide the Renderer thread. This is because Renderer thread is pretty
+    // useful for understanding the painting with WebRender and it's an important
+    // thread for the users.
+    thread.name === 'Renderer' ||
     // Don't hide the main thread of the parent process.
     (thread.name === 'GeckoMain' && thread.processType === 'default') ||
     // Don't hide the GPU thread on Windows.

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -336,11 +336,11 @@ describe('actions/receive-profile', function () {
       ]);
     });
 
-    it('will not hide the Compositor thread', function () {
+    it('will not hide the Renderer thread', function () {
       const store = blankStore();
       const { profile, idleThread, workThread } =
         getProfileWithIdleAndWorkThread();
-      idleThread.name = 'Compositor';
+      idleThread.name = 'Renderer';
       idleThread.processType = 'default';
       workThread.name = 'GeckoMain';
       workThread.processType = 'default';
@@ -348,7 +348,7 @@ describe('actions/receive-profile', function () {
       store.dispatch(viewProfile(profile));
       expect(getHumanReadableTracks(store.getState())).toEqual([
         'show [thread GeckoMain default] SELECTED',
-        '  - show [thread Compositor]',
+        '  - show [thread Renderer]',
       ]);
     });
 


### PR DESCRIPTION
Previously Compositor thread was always shown as default. Lately, especially with WebRender, this has changed and Renderer threads are more important compared to the Compositor threads now. So, it's safe to change this to directly show the Renderer thread instead. Ideally we should remove this additional logic, but it's good to keep them currently thinking that we still have the screenshot markers there.

I filed #3628 for removing this completely after moving the screenshot markers outside of this thread.

[Main branch](https://main--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/) / [Deploy preview](https://deploy-preview-3627--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/)