### PR TITLE
Add a search filter to the timeline track context menu 

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -635,6 +635,9 @@ TrackContextMenu--hide-other-screenshots-tracks = Hide other Screenshots tracks
 TrackContextMenu--hide-track = Hide “{ $trackName }”
 TrackContextMenu--show-all-tracks = Show all tracks
 
+# This is used in the tracks context menu as a button to show all the tracks
+# below it.
+TrackContextMenu--show-all-tracks-below = Show all tracks below
 
 ## TrackSearchField
 ## The component that is used for the search input in the track context menu.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -635,6 +635,14 @@ TrackContextMenu--hide-other-screenshots-tracks = Hide other Screenshots tracks
 TrackContextMenu--hide-track = Hide “{ $trackName }”
 TrackContextMenu--show-all-tracks = Show all tracks
 
+
+## TrackSearchField
+## The component that is used for the search input in the track context menu.
+
+TrackSearchField--search-input =
+    .placeholder = Enter filter terms
+    .title = Only display tracks that match a certain text
+
 ## TransformNavigator
 ## Navigator for the applied transforms in the Call Tree, Flame Graph, and Stack
 ## Chart components.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -648,6 +648,55 @@ export function showAllTracks(): ThunkAction<void> {
 }
 
 /**
+ * This action makes the tracks that are provided visible.
+ */
+export function showProvidedTracks(
+  globalTracksToShow: Set<TrackIndex>,
+  localTracksByPidToShow: Map<Pid, Set<TrackIndex>>
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    sendAnalytics({
+      hitType: 'event',
+      eventCategory: 'timeline',
+      eventAction: 'show provided tracks',
+    });
+
+    // We need to check each global tracks and add their local tracks to the
+    // filter as well to make them visible.
+    const globalTracks = getGlobalTracks(getState());
+    for (const globalTrackIndex of globalTracksToShow) {
+      const globalTrack = globalTracks[globalTrackIndex];
+      if (!globalTrack.pid) {
+        // There is no local track for this one, skip it.
+        continue;
+      }
+
+      // Get all the local tracks and provided ones.
+      const localTracks = getLocalTracks(getState(), globalTrack.pid);
+      const localTracksToShow = localTracksByPidToShow.get(globalTrack.pid);
+      // Check if their lengths are the same. If not, we must add all the local
+      // track indexes.
+      if (
+        localTracksToShow === undefined ||
+        localTracks.length !== localTracksToShow.size
+      ) {
+        // If they don't match, automatically show all the local tracks.
+        localTracksByPidToShow.set(
+          globalTrack.pid,
+          new Set(localTracks.keys())
+        );
+      }
+    }
+
+    dispatch({
+      type: 'SHOW_PROVIDED_TRACKS',
+      globalTracksToShow,
+      localTracksByPidToShow,
+    });
+  };
+}
+
+/**
  * This action shows a specific global track.
  */
 export function showGlobalTrack(trackIndex: TrackIndex): ThunkAction<void> {

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -654,39 +654,12 @@ export function showProvidedTracks(
   globalTracksToShow: Set<TrackIndex>,
   localTracksByPidToShow: Map<Pid, Set<TrackIndex>>
 ): ThunkAction<void> {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     sendAnalytics({
       hitType: 'event',
       eventCategory: 'timeline',
       eventAction: 'show provided tracks',
     });
-
-    // We need to check each global tracks and add their local tracks to the
-    // filter as well to make them visible.
-    const globalTracks = getGlobalTracks(getState());
-    for (const globalTrackIndex of globalTracksToShow) {
-      const globalTrack = globalTracks[globalTrackIndex];
-      if (!globalTrack.pid) {
-        // There is no local track for this one, skip it.
-        continue;
-      }
-
-      // Get all the local tracks and provided ones.
-      const localTracks = getLocalTracks(getState(), globalTrack.pid);
-      const localTracksToShow = localTracksByPidToShow.get(globalTrack.pid);
-      // Check if their lengths are the same. If not, we must add all the local
-      // track indexes.
-      if (
-        localTracksToShow === undefined ||
-        localTracks.length !== localTracksToShow.size
-      ) {
-        // If they don't match, automatically show all the local tracks.
-        localTracksByPidToShow.set(
-          globalTrack.pid,
-          new Set(localTracks.keys())
-        );
-      }
-    }
 
     dispatch({
       type: 'SHOW_PROVIDED_TRACKS',

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -4,7 +4,6 @@
 
 // @flow
 import queryString from 'query-string';
-import escapeStringRegexp from 'escape-string-regexp';
 import {
   stringifyCommittedRanges,
   stringifyStartEnd,
@@ -1184,34 +1183,3 @@ function validateTimelineType(type: ?string): TimelineType {
       return 'category';
   }
 }
-
-/**
- * Divide a search string into several parts by splitting on comma.
- */
-export const splitSearchString = (searchString: string): string[] | null => {
-  if (!searchString) {
-    return null;
-  }
-  const result = searchString
-    .split(',')
-    .map((part) => part.trim())
-    .filter((part) => part);
-
-  if (result.length) {
-    return result;
-  }
-
-  return null;
-};
-
-/**
- * Concatenate an array of strings into a RegExp that matches on all
- * the strings.
- */
-export const stringsToRegExp = (strings: string[] | null): RegExp | null => {
-  if (!strings || !strings.length) {
-    return null;
-  }
-  const regexpStr = strings.map(escapeStringRegexp).join('|');
-  return new RegExp(regexpStr, 'gi');
-};

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -4,6 +4,7 @@
 
 // @flow
 import queryString from 'query-string';
+import escapeStringRegexp from 'escape-string-regexp';
 import {
   stringifyCommittedRanges,
   stringifyStartEnd,
@@ -1183,3 +1184,34 @@ function validateTimelineType(type: ?string): TimelineType {
       return 'category';
   }
 }
+
+/**
+ * Divide a search string into several parts by splitting on comma.
+ */
+export const splitSearchString = (searchString: string): string[] | null => {
+  if (!searchString) {
+    return null;
+  }
+  const result = searchString
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part);
+
+  if (result.length) {
+    return result;
+  }
+
+  return null;
+};
+
+/**
+ * Concatenate an array of strings into a RegExp that matches on all
+ * the strings.
+ */
+export const stringsToRegExp = (strings: string[] | null): RegExp | null => {
+  if (!strings || !strings.length) {
+    return null;
+  }
+  const regexpStr = strings.map(escapeStringRegexp).join('|');
+  return new RegExp(regexpStr, 'gi');
+};

--- a/src/components/shared/TrackSearchField.css
+++ b/src/components/shared/TrackSearchField.css
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-form.trackSearchField {
-  width: 100%;
-}
-
 .trackSearchField {
   position: relative; /* to properly position the button */
   display: inline-flex;
+
+  /* If context menu has long items, we should make sure to take the 100% of the width. */
+  width: 100%;
   flex-flow: row nowrap;
   align-items: center;
 }

--- a/src/components/shared/TrackSearchField.css
+++ b/src/components/shared/TrackSearchField.css
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+form.trackSearchField {
+  width: 100%;
+}
+
+.trackSearchField {
+  position: relative; /* to properly position the button */
+  display: inline-flex;
+  flex-flow: row nowrap;
+  align-items: center;
+}
+
+.photon-input.trackSearchFieldInput {
+  /* the chain class selectors are used here
+  to override the styling for the photon-input class */
+  width: calc(100% - 10px);
+  height: 25px;
+  padding: 0 18px 0 17px; /* right padding for the reset button, left padding for the search icon */
+  border: 0.5px solid #aaa;
+  margin: 0 5px;
+}
+
+.trackSearchFieldInput {
+  position: relative;
+  flex: 1;
+  margin: 0;
+  background: url(../../../res/img/svg/searchfield-icon.svg) 3px center
+    no-repeat white;
+  background-size: 11px 11px;
+}
+
+.trackSearchFieldButton {
+  position: absolute;
+
+  /* 5px is margin and the other 5px is the location inside the input */
+  right: 10px;
+  overflow: hidden;
+  width: 11px;
+  height: 11px;
+  padding: 0;
+  border: 0;
+  background: url(../../../res/img/svg/searchfield-cancel.svg) top left
+    no-repeat;
+  background-size: contain;
+  color: transparent;
+  -moz-user-focus: ignore;
+  vertical-align: middle;
+}
+
+.trackSearchFieldInput:invalid + .trackSearchFieldButton {
+  visibility: hidden;
+}

--- a/src/components/shared/TrackSearchField.js
+++ b/src/components/shared/TrackSearchField.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import classNames from 'classnames';
+import { Localized } from '@fluent/react';
+
+import './TrackSearchField.css';
+
+type Props = {|
+  +className: string,
+  +currentSearchString: string,
+  +onSearch: (string) => void,
+|};
+
+export class TrackSearchField extends React.PureComponent<Props> {
+  searchFieldInput: {| current: HTMLInputElement | null |} = React.createRef();
+  _onSearchFieldChange = (e: SyntheticEvent<HTMLInputElement>) => {
+    this.props.onSearch(e.currentTarget.value);
+  };
+
+  focus = () => {
+    if (this.searchFieldInput.current) {
+      this.searchFieldInput.current.focus();
+    }
+  };
+
+  _onFormSubmit(e: SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+  }
+
+  _onClearButtonClick = () => {
+    if (this.searchFieldInput.current) {
+      this.searchFieldInput.current.focus();
+    }
+
+    this.props.onSearch('');
+  };
+
+  render() {
+    const { currentSearchString, className } = this.props;
+    return (
+      <form
+        className={classNames('trackSearchField', className)}
+        onSubmit={this._onFormSubmit}
+      >
+        <Localized
+          id="TrackSearchField--search-input"
+          attrs={{ placeholder: true, title: true }}
+        >
+          <input
+            type="search"
+            name="search"
+            placeholder="Enter filter terms"
+            className="trackSearchFieldInput photon-input"
+            required="required"
+            title="Only display tracks that match a certain text"
+            value={currentSearchString}
+            onChange={this._onSearchFieldChange}
+            ref={this.searchFieldInput}
+            autoComplete="off"
+          />
+        </Localized>
+        <input
+          type="reset"
+          className="trackSearchFieldButton"
+          onClick={this._onClearButtonClick}
+          tabIndex={-1}
+        />
+      </form>
+    );
+  }
+}

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -217,25 +217,30 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
     }
 
     return (
-      <MenuItem
-        key={trackIndex}
-        preventClose={true}
-        data={{ trackIndex }}
-        onClick={this._toggleGlobalTrackVisibility}
-        attributes={{
-          className: classNames('timelineTrackContextMenuItem', {
-            checkable: true,
-            checked: !isHidden,
-          }),
-          title,
-        }}
-      >
-        <span>{globalTrackNames[trackIndex]}</span>
-        <span className="timelineTrackContextMenuSpacer" />
-        {track.type === 'process' && (
-          <span className="timelineTrackContextMenuPid">({track.pid})</span>
-        )}
-      </MenuItem>
+      <React.Fragment>
+        <MenuItem
+          key={trackIndex}
+          preventClose={true}
+          data={{ trackIndex }}
+          onClick={this._toggleGlobalTrackVisibility}
+          attributes={{
+            className: classNames('timelineTrackContextMenuItem', {
+              checkable: true,
+              checked: !isHidden,
+            }),
+            title,
+          }}
+        >
+          <span>{globalTrackNames[trackIndex]}</span>
+          <span className="timelineTrackContextMenuSpacer" />
+          {track.type === 'process' && (
+            <span className="timelineTrackContextMenuPid">({track.pid})</span>
+          )}
+        </MenuItem>
+        {track.type === 'process'
+          ? this.renderLocalTracks(trackIndex, track.pid)
+          : null}
+      </React.Fragment>
     );
   }
 
@@ -619,9 +624,6 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
             return (
               <div key={globalTrackIndex}>
                 {this.renderGlobalTrack(globalTrackIndex)}
-                {globalTrack.type === 'process'
-                  ? this.renderLocalTracks(globalTrackIndex, globalTrack.pid)
-                  : null}
               </div>
             );
           } else if (
@@ -631,9 +633,6 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
             return (
               <div key={globalTrackIndex}>
                 {this.renderGlobalTrack(globalTrackIndex)}
-                {globalTrack.type === 'process'
-                  ? this.renderLocalTracks(globalTrackIndex, globalTrack.pid)
-                  : null}
               </div>
             );
           } else if (
@@ -644,9 +643,6 @@ class TimelineTrackContextMenuImpl extends PureComponent<Props> {
               return (
                 <div key={globalTrackIndex}>
                   {this.renderGlobalTrack(globalTrackIndex)}
-                  {globalTrack.type === 'process'
-                    ? this.renderLocalTracks(globalTrackIndex, globalTrack.pid)
-                    : null}
                 </div>
               );
             }

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -90,9 +90,9 @@ type TimelineTrackContextMenuProps = ConnectedProps<
   DispatchProps
 >;
 
-type TimelineTrackContextMenuState = {
+type TimelineTrackContextMenuState = {|
   searchFilter: string,
-};
+|};
 
 class TimelineTrackContextMenuImpl extends PureComponent<
   TimelineTrackContextMenuProps,
@@ -335,8 +335,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       return null;
     }
 
-    // If a global track is explicitly filtered by search, we should show all of
-    // its children.
+    // If a global track is selected by search, we should show all of its children.
     const skipSearchFilterInChildren =
       searchFilteredGlobalTracks !== null && !isHiddenBySearch;
 
@@ -791,23 +790,18 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     if (
       // We need to focus the track search filter. But we can't use autoFocus
       // property because this context menu is already rendered and hidden during
-      // the load of the web page. So, when user clicks on the track context menu
-      // button, focus will be moved to that component and search filter will not
-      // be focused anymore. To fix this, we are manually calling the focus.
+      // the load of the web page.
       trackFieldElement
     ) {
-      // Allow time for React to let the event bubble up. Otherwise clicked button
-      // will steal the focus.
-      requestAnimationFrame(() => {
+      // Allow time for React contect menu to show itself first.
+      setTimeout(() => {
         trackFieldElement.focus();
       });
     }
   };
 
   _onHide = () => {
-    if (this.state.searchFilter) {
-      this.setState({ searchFilter: '' });
-    }
+    this.setState({ searchFilter: '' });
   };
 
   render() {

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -20,6 +20,7 @@ import {
   isThreadWithNoPaint,
   isContentThreadWithNoPaint,
 } from './profile-data';
+import { splitSearchString, stringsToRegExp } from '../app-logic/url-handling';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 
 /**
@@ -890,4 +891,197 @@ function _indexesAreValid(listLength: number, indexes: number[]) {
       .sort((a, b) => a - b) // sort numerically
       .every((value, arrayIndex) => value === arrayIndex)
   );
+}
+
+/**
+ * Get the search filter and return the search filtered global tracks.
+ * The search includes the fields like, track name, pid, tid, process type,
+ * process name, and eTLD+1.
+ */
+export function getSearchFilteredGlobalTracks(
+  tracks: GlobalTrack[],
+  globalTrackNames: string[],
+  threads: Thread[],
+  searchFilter: string
+): Set<TrackIndex> | null {
+  if (!searchFilter) {
+    // Nothing is filtered, returning null.
+    return null;
+  }
+  const searchRegExp = stringsToRegExp(splitSearchString(searchFilter));
+  if (!searchRegExp) {
+    // There is no search query, returning null.
+    return null;
+  }
+
+  const searchFilteredGlobalTracks = new Set();
+  for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
+    const globalTrack = tracks[trackIndex];
+
+    // Reset regexp for each iteration. Otherwise state from previous
+    // iterations can cause matches to fail if the search is global or
+    // sticky.
+    searchRegExp.lastIndex = 0;
+
+    switch (globalTrack.type) {
+      case 'process': {
+        const { mainThreadIndex } = globalTrack;
+        // Check the pid of the global track first.
+        if (searchRegExp.test(globalTrack.pid.toString())) {
+          searchFilteredGlobalTracks.add(trackIndex);
+          continue;
+        }
+
+        // Get the thread of the global track and check thread information.
+        if (mainThreadIndex !== null) {
+          const thread = threads[mainThreadIndex];
+
+          const threadName = globalTrackNames[trackIndex];
+          if (searchRegExp.test(threadName)) {
+            searchFilteredGlobalTracks.add(trackIndex);
+            continue;
+          }
+
+          const { tid } = thread;
+          if (tid && searchRegExp.test(tid.toString())) {
+            searchFilteredGlobalTracks.add(trackIndex);
+            continue;
+          }
+
+          if (searchRegExp.test(thread.processType)) {
+            searchFilteredGlobalTracks.add(trackIndex);
+            continue;
+          }
+
+          const { processName } = thread;
+          if (processName && searchRegExp.test(processName)) {
+            searchFilteredGlobalTracks.add(trackIndex);
+            continue;
+          }
+
+          const etldPlus1 = thread['eTLD+1'];
+          if (etldPlus1 && searchRegExp.test(etldPlus1)) {
+            searchFilteredGlobalTracks.add(trackIndex);
+            continue;
+          }
+        }
+
+        break;
+      }
+      case 'screenshots':
+      case 'visual-progress':
+      case 'perceptual-visual-progress':
+      case 'contentful-visual-progress': {
+        const { type } = globalTrack;
+        if (searchRegExp.test(type)) {
+          searchFilteredGlobalTracks.add(trackIndex);
+          continue;
+        }
+        break;
+      }
+      default:
+        throw assertExhaustiveCheck(globalTrack, 'Unhandled GlobalTrack type.');
+    }
+  }
+
+  return searchFilteredGlobalTracks;
+}
+
+/**
+ * Get the search filter and return the search filtered local tracks by Pid.
+ * The search includes the fields like, track name, pid, tid, process type,
+ * process name, and eTLD+1.
+ */
+export function getSearchFilteredLocalTracksByPid(
+  localTracksByPid: Map<Pid, LocalTrack[]>,
+  localTrackNamesByPid: Map<Pid, string[]>,
+  threads: Thread[],
+  searchFilter: string
+): Map<Pid, Set<TrackIndex>> | null {
+  if (!searchFilter) {
+    // Nothing is filtered, returning null.
+    return null;
+  }
+  const searchRegExp = stringsToRegExp(splitSearchString(searchFilter));
+  if (!searchRegExp) {
+    // There is no search query, returning null.
+    return null;
+  }
+
+  const searchFilteredLocalTracksByPid = new Map();
+  for (const [pid, tracks] of localTracksByPid) {
+    const searchFilteredLocalTracks = new Set();
+    const localTrackNames = localTrackNamesByPid.get(pid);
+    if (localTrackNames === undefined) {
+      throw new Error('Failed to get the local track names');
+    }
+
+    for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
+      const localTrack = tracks[trackIndex];
+      // Reset regexp for each iteration. Otherwise state from previous
+      // iterations can cause matches to fail if the search is global or
+      // sticky.
+      searchRegExp.lastIndex = 0;
+
+      if (searchRegExp.test(pid.toString())) {
+        searchFilteredLocalTracks.add(trackIndex);
+        continue;
+      }
+
+      switch (localTrack.type) {
+        case 'thread': {
+          const { threadIndex } = localTrack;
+          // Get the thread of the local track and check thread information.
+          const thread = threads[threadIndex];
+
+          const threadName = localTrackNames[trackIndex];
+          if (searchRegExp.test(threadName)) {
+            searchFilteredLocalTracks.add(trackIndex);
+            continue;
+          }
+
+          const { tid } = thread;
+          if (tid && searchRegExp.test(tid.toString())) {
+            searchFilteredLocalTracks.add(trackIndex);
+            continue;
+          }
+
+          if (searchRegExp.test(thread.processType)) {
+            searchFilteredLocalTracks.add(trackIndex);
+            continue;
+          }
+
+          const { processName } = thread;
+          if (processName && searchRegExp.test(processName)) {
+            searchFilteredLocalTracks.add(trackIndex);
+            continue;
+          }
+
+          const etldPlus1 = thread['eTLD+1'];
+          if (etldPlus1 && searchRegExp.test(etldPlus1)) {
+            searchFilteredLocalTracks.add(trackIndex);
+            continue;
+          }
+          break;
+        }
+        case 'network':
+        case 'memory':
+        case 'ipc':
+        case 'event-delay': {
+          const { type } = localTrack;
+          if (searchRegExp.test(type)) {
+            searchFilteredLocalTracks.add(trackIndex);
+            continue;
+          }
+          break;
+        }
+        default:
+          throw assertExhaustiveCheck(localTrack, 'Unhandled LocalTrack type.');
+      }
+    }
+
+    searchFilteredLocalTracksByPid.set(pid, searchFilteredLocalTracks);
+  }
+
+  return searchFilteredLocalTracksByPid;
 }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -20,7 +20,7 @@ import {
   isThreadWithNoPaint,
   isContentThreadWithNoPaint,
 } from './profile-data';
-import { splitSearchString, stringsToRegExp } from '../app-logic/url-handling';
+import { splitSearchString, stringsToRegExp } from '../utils/string';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 
 /**

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -127,6 +127,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     // Timeline: (fallthrough)
     case 'HIDE_GLOBAL_TRACK':
     case 'SHOW_ALL_TRACKS':
+    case 'SHOW_PROVIDED_TRACKS':
     case 'SHOW_GLOBAL_TRACK':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -347,6 +347,15 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
     }
     case 'SHOW_ALL_TRACKS':
       return new Set();
+    case 'SHOW_PROVIDED_TRACKS': {
+      const hiddenGlobalTracks = new Set(state);
+      // Remove all the provided global tracks from the hidden global tracks.
+      action.globalTracksToShow.forEach(
+        Set.prototype.delete,
+        hiddenGlobalTracks
+      );
+      return hiddenGlobalTracks;
+    }
     case 'SHOW_GLOBAL_TRACK': {
       const hiddenGlobalTracks = new Set(state);
       hiddenGlobalTracks.delete(action.trackIndex);
@@ -379,6 +388,23 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
       const hiddenLocalTracksByPid = new Map(state);
       for (const key of hiddenLocalTracksByPid) {
         hiddenLocalTracksByPid.set(key[0], new Set());
+      }
+      return hiddenLocalTracksByPid;
+    }
+    case 'SHOW_PROVIDED_TRACKS': {
+      const hiddenLocalTracksByPid = new Map();
+      // Go through the local tracks and make the provided ones visible.
+      for (const [pid, hiddenLocalTracks] of state.entries()) {
+        const newHiddenLocalTracks = new Set(hiddenLocalTracks);
+        // Remove all provided local tracks.
+        const localTracks = action.localTracksByPidToShow.get(pid);
+
+        if (!localTracks) {
+          throw new Error('Failed to find the local tracks');
+        }
+
+        localTracks.forEach(Set.prototype.delete, newHiddenLocalTracks);
+        hiddenLocalTracksByPid.set(pid, newHiddenLocalTracks);
       }
       return hiddenLocalTracksByPid;
     }

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -3,10 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import escapeStringRegexp from 'escape-string-regexp';
 import { createSelector } from 'reselect';
 import { ensureExists, getFirstItemFromSet } from '../utils/flow';
-import { urlFromState } from '../app-logic/url-handling';
+import {
+  urlFromState,
+  splitSearchString,
+  stringsToRegExp,
+} from '../app-logic/url-handling';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
 import { getThreadsKey } from '../profile-logic/profile-data';
 import { getProfileNameFromZipPath } from 'firefox-profiler/profile-logic/zip-files';
@@ -159,37 +162,6 @@ export const getLocalTrackOrder: DangerousSelectorWithArguments<
     getLocalTrackOrderByPid(state).get(pid),
     'Unable to get the track order from the given pid'
   );
-
-/**
- * Divide a search string into several parts by splitting on comma.
- */
-const splitSearchString = (searchString: string): string[] | null => {
-  if (!searchString) {
-    return null;
-  }
-  const result = searchString
-    .split(',')
-    .map((part) => part.trim())
-    .filter((part) => part);
-
-  if (result.length) {
-    return result;
-  }
-
-  return null;
-};
-
-/**
- * Concatenate an array of strings into a RegExp that matches on all
- * the strings.
- */
-const stringsToRegExp = (strings: string[] | null): RegExp | null => {
-  if (!strings || !strings.length) {
-    return null;
-  }
-  const regexpStr = strings.map(escapeStringRegexp).join('|');
-  return new RegExp(regexpStr, 'gi');
-};
 
 /**
  * Search strings filter a thread to only samples that match the strings.

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -5,15 +5,12 @@
 // @flow
 import { createSelector } from 'reselect';
 import { ensureExists, getFirstItemFromSet } from '../utils/flow';
-import {
-  urlFromState,
-  splitSearchString,
-  stringsToRegExp,
-} from '../app-logic/url-handling';
+import { urlFromState } from '../app-logic/url-handling';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
 import { getThreadsKey } from '../profile-logic/profile-data';
 import { getProfileNameFromZipPath } from 'firefox-profiler/profile-logic/zip-files';
 import { SYMBOL_SERVER_URL } from '../app-logic/constants';
+import { splitSearchString, stringsToRegExp } from '../utils/string';
 
 import type {
   ThreadIndex,

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -6,6 +6,7 @@
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
+import { fireEvent } from '@testing-library/react';
 
 import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
 import { ensureExists } from '../../utils/flow';
@@ -435,6 +436,125 @@ describe('timeline/TrackContextMenu', function () {
         '  - show [thread DOM Worker]',
         '  - hide [thread Style]',
       ]);
+    });
+  });
+
+  describe('track search', function () {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    function setupAllTracks() {
+      const results = setup();
+      const selectTrackFilterInput = () =>
+        ((screen.getByPlaceholderText(
+          /Enter filter terms/
+        ): any): HTMLInputElement);
+
+      return {
+        ...results,
+        selectTrackFilterInput,
+      };
+    }
+
+    it('can filter a single global track', () => {
+      const { selectTrackFilterInput } = setupAllTracks();
+      const searchText = 'GeckoMain';
+      const input = selectTrackFilterInput();
+
+      // Check if all the tracks are visible at first.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+
+      fireEvent.change(input, {
+        target: { value: searchText },
+      });
+
+      jest.runAllTimers();
+
+      // Check if only the GeckoMain is in the document and not the others.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.queryByText('Content Process')).not.toBeInTheDocument();
+      expect(screen.queryByText('Style')).not.toBeInTheDocument();
+    });
+
+    it('can filter a global track with its local track', () => {
+      const { selectTrackFilterInput } = setupAllTracks();
+      const searchText = 'Content Process';
+      const input = selectTrackFilterInput();
+
+      // Check if all the tracks are visible at first.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+
+      fireEvent.change(input, {
+        target: { value: searchText },
+      });
+
+      jest.runAllTimers();
+
+      // Check if only Content Process and its children are in the document.
+      expect(screen.queryByText('GeckoMain')).not.toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+    });
+
+    it('can filter a local track with its global track', () => {
+      const { selectTrackFilterInput } = setupAllTracks();
+      const searchText = 'Style';
+      const input = selectTrackFilterInput();
+
+      // Check if all the tracks are visible at first.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+
+      fireEvent.change(input, {
+        target: { value: searchText },
+      });
+
+      jest.runAllTimers();
+
+      // Check if only Content Process and its children are in the document.
+      expect(screen.queryByText('GeckoMain')).not.toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+    });
+
+    it('can filter a track with pid or processType', () => {
+      const { selectTrackFilterInput } = setupAllTracks();
+      let searchText = '111'; // pid of GeckoMain
+      const input = selectTrackFilterInput();
+
+      // Check if all the tracks are visible at first.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+
+      fireEvent.change(input, {
+        target: { value: searchText },
+      });
+
+      jest.runAllTimers();
+
+      // Check if only GeckoMain is in the document.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.queryByText('Content Process')).not.toBeInTheDocument();
+      expect(screen.queryByText('Style')).not.toBeInTheDocument();
+
+      searchText = 'tab'; // processType of Content Process
+      fireEvent.change(input, {
+        target: { value: searchText },
+      });
+
+      jest.runAllTimers();
+
+      // Check if Content Process and its children are in the document.
+      expect(screen.queryByText('GeckoMain')).not.toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
     });
   });
 });

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -208,7 +208,7 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it('shows a global track', () => {
+    it('shows a local track', () => {
       const {
         getState,
         selectAllTracksBelowItem,

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -33,6 +33,10 @@ import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
 
 describe('timeline/TrackContextMenu', function () {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   /**
    *  getProfileWithNiceTracks() looks like: [
    *    'show [thread GeckoMain process]',
@@ -51,12 +55,21 @@ describe('timeline/TrackContextMenu', function () {
       </Provider>
     );
 
+    const changeSearchFilter = (searchText: string) => {
+      fireEvent.change(screen.getByPlaceholderText(/Enter filter terms/), {
+        target: { value: searchText },
+      });
+
+      jest.runAllTimers();
+    };
+
     return {
       ...renderResult,
       dispatch,
       getState,
       profile,
       store,
+      changeSearchFilter,
     };
   }
 
@@ -112,10 +125,6 @@ describe('timeline/TrackContextMenu', function () {
   });
 
   describe('show all tracks below', function () {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-
     function setupAllTracks() {
       const results = setup();
       const selectAllTracksBelowItem = () =>
@@ -128,19 +137,10 @@ describe('timeline/TrackContextMenu', function () {
         fireFullClick(screen.getByText('Style'));
       };
 
-      const changeSearchFilter = (searchText: string) => {
-        fireEvent.change(screen.getByPlaceholderText(/Enter filter terms/), {
-          target: { value: searchText },
-        });
-
-        jest.runAllTimers();
-      };
-
       return {
         ...results,
         selectAllTracksBelowItem,
         hideAllTracks,
-        changeSearchFilter,
       };
     }
 
@@ -602,36 +602,16 @@ describe('timeline/TrackContextMenu', function () {
   });
 
   describe('track search', function () {
-    beforeEach(() => {
-      jest.useFakeTimers();
-    });
-
-    function setupAllTracks() {
-      const results = setup();
-      const selectTrackFilterInput = () =>
-        ((screen.getByPlaceholderText(
-          /Enter filter terms/
-        ): any): HTMLInputElement);
-
-      return {
-        ...results,
-        selectTrackFilterInput,
-      };
-    }
-
     it('can filter a single global track', () => {
-      const { selectTrackFilterInput } = setupAllTracks();
+      const { changeSearchFilter } = setup();
       const searchText = 'GeckoMain';
-      const input = selectTrackFilterInput();
 
       // Check if all the tracks are visible at first.
       expect(screen.getByText('GeckoMain')).toBeInTheDocument();
       expect(screen.getByText('Content Process')).toBeInTheDocument();
       expect(screen.getByText('Style')).toBeInTheDocument();
 
-      fireEvent.change(input, {
-        target: { value: searchText },
-      });
+      changeSearchFilter(searchText);
 
       jest.runAllTimers();
 
@@ -642,18 +622,15 @@ describe('timeline/TrackContextMenu', function () {
     });
 
     it('can filter a global track with its local track', () => {
-      const { selectTrackFilterInput } = setupAllTracks();
+      const { changeSearchFilter } = setup();
       const searchText = 'Content Process';
-      const input = selectTrackFilterInput();
 
       // Check if all the tracks are visible at first.
       expect(screen.getByText('GeckoMain')).toBeInTheDocument();
       expect(screen.getByText('Content Process')).toBeInTheDocument();
       expect(screen.getByText('Style')).toBeInTheDocument();
 
-      fireEvent.change(input, {
-        target: { value: searchText },
-      });
+      changeSearchFilter(searchText);
 
       jest.runAllTimers();
 
@@ -664,18 +641,15 @@ describe('timeline/TrackContextMenu', function () {
     });
 
     it('can filter a local track with its global track', () => {
-      const { selectTrackFilterInput } = setupAllTracks();
+      const { changeSearchFilter } = setup();
       const searchText = 'Style';
-      const input = selectTrackFilterInput();
 
       // Check if all the tracks are visible at first.
       expect(screen.getByText('GeckoMain')).toBeInTheDocument();
       expect(screen.getByText('Content Process')).toBeInTheDocument();
       expect(screen.getByText('Style')).toBeInTheDocument();
 
-      fireEvent.change(input, {
-        target: { value: searchText },
-      });
+      changeSearchFilter(searchText);
 
       jest.runAllTimers();
 
@@ -686,18 +660,15 @@ describe('timeline/TrackContextMenu', function () {
     });
 
     it('can filter a track with pid or processType', () => {
-      const { selectTrackFilterInput } = setupAllTracks();
+      const { changeSearchFilter } = setup();
       let searchText = '111'; // pid of GeckoMain
-      const input = selectTrackFilterInput();
 
       // Check if all the tracks are visible at first.
       expect(screen.getByText('GeckoMain')).toBeInTheDocument();
       expect(screen.getByText('Content Process')).toBeInTheDocument();
       expect(screen.getByText('Style')).toBeInTheDocument();
 
-      fireEvent.change(input, {
-        target: { value: searchText },
-      });
+      changeSearchFilter(searchText);
 
       jest.runAllTimers();
 
@@ -707,9 +678,7 @@ describe('timeline/TrackContextMenu', function () {
       expect(screen.queryByText('Style')).not.toBeInTheDocument();
 
       searchText = 'tab'; // processType of Content Process
-      fireEvent.change(input, {
-        target: { value: searchText },
-      });
+      changeSearchFilter(searchText);
 
       jest.runAllTimers();
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -228,6 +228,11 @@ type ProfileAction =
       +type: 'SHOW_ALL_TRACKS',
     |}
   | {|
+      +type: 'SHOW_PROVIDED_TRACKS',
+      +globalTracksToShow: Set<TrackIndex>,
+      +localTracksByPidToShow: Map<Pid, Set<TrackIndex>>,
+    |}
+  | {|
       +type: 'SHOW_GLOBAL_TRACK',
       +trackIndex: TrackIndex,
     |}

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -4,6 +4,8 @@
 
 // @flow
 
+import escapeStringRegexp from 'escape-string-regexp';
+
 // Initializing this RegExp outside of removeURLs because that function is in a
 // hot path during sanitization and it's good to avoid the initialization of the
 // RegExp which is costly.
@@ -75,3 +77,34 @@ export function removeFilePath(
 
   return redactedText + pathSeparator + filePath.slice(lastSeparatorIndex + 1);
 }
+
+/**
+ * Divide a search string into several parts by splitting on comma.
+ */
+export const splitSearchString = (searchString: string): string[] | null => {
+  if (!searchString) {
+    return null;
+  }
+  const result = searchString
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part);
+
+  if (result.length) {
+    return result;
+  }
+
+  return null;
+};
+
+/**
+ * Concatenate an array of strings into a RegExp that matches on all
+ * the strings.
+ */
+export const stringsToRegExp = (strings: string[] | null): RegExp | null => {
+  if (!strings || !strings.length) {
+    return null;
+  }
+  const regexpStr = strings.map(escapeStringRegexp).join('|');
+  return new RegExp(regexpStr, 'gi');
+};


### PR DESCRIPTION
Fixes #3575.

This PR adds a search filter to the track context menu. And also changes the "show all tracks" button to "show all tracks below" when a search text is entered. This should help on showing a subset of tracks more easily.

The new search filter:
![Screenshot from 2021-11-03 10-50-03](https://user-images.githubusercontent.com/466239/140039569-3d875d87-e238-435a-acd4-dc663767a622.png)

Some example profiles to test it with:
[Profile 1](https://deploy-preview-3634--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/)
[Profile 2](https://deploy-preview-3634--perf-html.netlify.app/public/k82sqxse5qw5zq2yk0dvsfxpvy41rga7jz8g320/)
[Profile 3](https://deploy-preview-3634--perf-html.netlify.app/public/yypb94qpr72dc7dve5fsaxte7885zerqwfthmkg/)
