### PR TITLE
Add a .vscode/launch.json file.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        // Run the current file with Jest. Only works if the current tab is a test file.
+        {
+            "name": "Run Jest",
+            "type": "node",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": ["--runInBand", "${file}"],
+            "cwd": "${workspaceFolder}",
+            "internalConsoleOptions": "openOnSessionStart",
+            "request": "launch",
+            "outputCapture": "std",
+            "skipFiles": ["<node_internals>/**"],
+        },
+    ]
+}


### PR DESCRIPTION
This lets you debug a test file right inside VSCode. For example, you can do the following:

 1. Have a failing test and open the test file in VSCode.
 2. Set a breakpoint somewhere in the failing test.
 3. Press F5.

Now VSCode executes the file in Jest, and the breakpoint should be hit.
Now you can debug right inside VSCode.