### PR TITLE
Add activeTab information to createGeckoProfile.

### DIFF
--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -874,6 +874,29 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device inform
         <span
           class="metaInfoLabel"
         >
+          Buffer Capacity:
+        </span>
+        8MB
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Duration:
+        </span>
+        Unlimited
+      </div>
+      <div
+        class="metaInfoSection"
+      />
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
           Symbols:
         </span>
         Profile is not symbolicated
@@ -1207,6 +1230,29 @@ exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not ma
         </span>
         38
       </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Capacity:
+        </span>
+        8MB
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer Duration:
+        </span>
+        Unlimited
+      </div>
+      <div
+        class="metaInfoSection"
+      />
       <div
         class="metaInfoRow"
       >

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -180,6 +180,8 @@ export function createGeckoProfile(): GeckoProfile {
     },
   ];
 
+  const tabID = 123;
+
   const parentProcessMeta: GeckoProfileFullMeta = {
     abi: 'x86_64-gcc3',
     appBuildID: '20181126165837',
@@ -234,7 +236,22 @@ export function createGeckoProfile(): GeckoProfile {
       eventDelay: 'ms',
       threadCPUDelta: 'ns',
     },
+    configuration: {
+      threads: [],
+      features: [],
+      capacity: 1000000,
+      activeTabID: tabID,
+    },
   };
+
+  const parentProcessPages = [
+    {
+      tabID: tabID,
+      innerWindowID: 111111,
+      url: 'URL',
+      embedderInnerWindowID: 0,
+    },
+  ];
 
   const [
     startIPCMarker,
@@ -295,7 +312,7 @@ export function createGeckoProfile(): GeckoProfile {
   const profile = {
     meta: parentProcessMeta,
     libs: [parentProcessBinary].concat(extraBinaries),
-    pages: [],
+    pages: parentProcessPages,
     counters: parentProcessCounters,
     profilerOverhead: parentProcessOverhead,
     pausedRanges: [],


### PR DESCRIPTION
createGeckoProfile is used in UrlManager.test.js which has a test
for /from-browser/?view=active-tab . At the moment, this test only
passes because it doesn't wait for the profile to be fully loaded.
Once the profile is fully loaded, we would find out that it doesn't
contain any activeTab information, and would switch to the full
profile view.
Including activeTab information in this profile means that this test
will keep passing once the URL setup flow is changed to wait for
from-browser profiles correctly.