### PR TITLE
Improve WebChannel mocking

### DIFF
--- a/src/test/fixtures/mocks/web-channel.js
+++ b/src/test/fixtures/mocks/web-channel.js
@@ -86,3 +86,103 @@ export function mockWebChannel() {
     },
   };
 }
+
+export function simulateOldWebChannelAndFrameScript(
+  geckoProfiler: $GeckoProfiler
+) {
+  const webChannel = mockWebChannel();
+
+  const { registerMessageToChromeListener, triggerResponse } = webChannel;
+  // Pretend that this browser does not support obtaining the profile via
+  // the WebChannel. This will trigger fallback to the frame script /
+  // geckoProfiler API.
+  registerMessageToChromeListener((message) => {
+    switch (message.type) {
+      case 'STATUS_QUERY': {
+        triggerResponse(
+          ({
+            type: 'STATUS_RESPONSE',
+            requestId: message.requestId,
+            menuButtonIsEnabled: true,
+          }: any)
+        );
+        break;
+      }
+      default: {
+        triggerResponse(
+          ({
+            error: `Unexpected message ${message.type}`,
+          }: any)
+        );
+        break;
+      }
+    }
+  });
+
+  // Simulate the frame script's geckoProfiler API.
+  window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
+
+  return webChannel;
+}
+
+export function simulateWebChannel(profileGetter: () => mixed) {
+  const webChannel = mockWebChannel();
+
+  const { registerMessageToChromeListener, triggerResponse } = webChannel;
+  async function simulateBrowserSide(message) {
+    switch (message.type) {
+      case 'STATUS_QUERY': {
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: {
+            menuButtonIsEnabled: true,
+            version: 1,
+          },
+        });
+        break;
+      }
+      case 'ENABLE_MENU_BUTTON': {
+        triggerResponse({
+          type: 'ERROR_RESPONSE',
+          requestId: message.requestId,
+          error:
+            'ENABLE_MENU_BUTTON is a valid message but not covered by this test.',
+        });
+        break;
+      }
+      case 'GET_PROFILE': {
+        const profile: ArrayBuffer | MixedObject = await profileGetter();
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: profile,
+        });
+        break;
+      }
+      case 'GET_SYMBOL_TABLE':
+      case 'QUERY_SYMBOLICATION_API': {
+        triggerResponse({
+          type: 'ERROR_RESPONSE',
+          requestId: message.requestId,
+          error: 'No symbol tables available',
+        });
+        break;
+      }
+      default: {
+        triggerResponse({
+          type: 'ERROR_RESPONSE',
+          requestId: message.requestId,
+          error: `Unexpected message ${message.type}`,
+        });
+        break;
+      }
+    }
+  }
+
+  registerMessageToChromeListener((message) => {
+    simulateBrowserSide(message);
+  });
+
+  return webChannel;
+}

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -71,7 +71,11 @@ import { expandUrl } from '../../utils/shorten-url';
 jest.mock('../../utils/shorten-url');
 
 import { TextEncoder, TextDecoder } from 'util';
-import { mockWebChannel } from '../fixtures/mocks/web-channel';
+import {
+  mockWebChannel,
+  simulateOldWebChannelAndFrameScript,
+  simulateWebChannel,
+} from '../fixtures/mocks/web-channel';
 
 function simulateSymbolStoreHasNoCache() {
   // SymbolStoreDB is a mock, but Flow doesn't know this. That's why we use
@@ -88,104 +92,6 @@ function simulateSymbolStoreHasNoCache() {
         )
       ),
   }));
-}
-
-function simulateOldWebChannelAndFrameScript(geckoProfiler) {
-  const webChannel = mockWebChannel();
-
-  const { registerMessageToChromeListener, triggerResponse } = webChannel;
-  // Pretend that this browser does not support obtaining the profile via
-  // the WebChannel. This will trigger fallback to the frame script /
-  // geckoProfiler API.
-  registerMessageToChromeListener((message) => {
-    switch (message.type) {
-      case 'STATUS_QUERY': {
-        triggerResponse(
-          ({
-            type: 'STATUS_RESPONSE',
-            requestId: message.requestId,
-            menuButtonIsEnabled: true,
-          }: any)
-        );
-        break;
-      }
-      default: {
-        triggerResponse(
-          ({
-            error: `Unexpected message ${message.type}`,
-          }: any)
-        );
-        break;
-      }
-    }
-  });
-
-  // Simulate the frame script's geckoProfiler API.
-  window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
-
-  return webChannel;
-}
-
-function simulateWebChannel(profileGetter) {
-  const webChannel = mockWebChannel();
-
-  const { registerMessageToChromeListener, triggerResponse } = webChannel;
-  async function simulateBrowserSide(message) {
-    switch (message.type) {
-      case 'STATUS_QUERY': {
-        triggerResponse({
-          type: 'SUCCESS_RESPONSE',
-          requestId: message.requestId,
-          response: {
-            menuButtonIsEnabled: true,
-            version: 1,
-          },
-        });
-        break;
-      }
-      case 'ENABLE_MENU_BUTTON': {
-        triggerResponse({
-          type: 'ERROR_RESPONSE',
-          requestId: message.requestId,
-          error:
-            'ENABLE_MENU_BUTTON is a valid message but not covered by this test.',
-        });
-        break;
-      }
-      case 'GET_PROFILE': {
-        const profile: ArrayBuffer | MixedObject = await profileGetter();
-        triggerResponse({
-          type: 'SUCCESS_RESPONSE',
-          requestId: message.requestId,
-          response: profile,
-        });
-        break;
-      }
-      case 'GET_SYMBOL_TABLE':
-      case 'QUERY_SYMBOLICATION_API': {
-        triggerResponse({
-          type: 'ERROR_RESPONSE',
-          requestId: message.requestId,
-          error: 'No symbol tables available',
-        });
-        break;
-      }
-      default: {
-        triggerResponse({
-          type: 'ERROR_RESPONSE',
-          requestId: message.requestId,
-          error: `Unexpected message ${message.type}`,
-        });
-        break;
-      }
-    }
-  }
-
-  registerMessageToChromeListener((message) => {
-    simulateBrowserSide(message);
-  });
-
-  return webChannel;
 }
 
 describe('actions/receive-profile', function () {


### PR DESCRIPTION
This PR has two commits which improve the mock WebChannel which we use in tests: The code is moved to a different file, it no longer breaks other uses of window.dispatchEvent, and it adds a way to clean up after the test.