### PR TITLE
Rename getProfilesFromRawUrl to retrieveProfileForRawUrl.

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1535,7 +1535,7 @@ export function retrieveProfilesToCompare(
 // and loads the profile in that given location, then returns the profile data.
 // This function is being used to get the initial profile data before upgrading
 // the url and processing the UrlState.
-export function getProfilesFromRawUrl(
+export function retrieveProfileForRawUrl(
   location: Location
 ): ThunkAction<Promise<Profile | null>> {
   return async (dispatch, getState) => {

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -20,8 +20,8 @@ import {
   getIsHistoryReplaceState,
 } from 'firefox-profiler/app-logic/url-handling';
 import {
-  getProfilesFromRawUrl,
-  typeof getProfilesFromRawUrl as GetProfilesFromRawUrl,
+  retrieveProfileForRawUrl,
+  typeof retrieveProfileForRawUrl as RetrieveProfileForRawUrl,
 } from 'firefox-profiler/actions/receive-profile';
 import { ProfileLoaderAnimation } from './ProfileLoaderAnimation';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
@@ -43,7 +43,7 @@ type DispatchProps = {|
   +startFetchingProfiles: typeof startFetchingProfiles,
   +urlSetupDone: typeof urlSetupDone,
   +show404: typeof show404,
-  +getProfilesFromRawUrl: typeof getProfilesFromRawUrl,
+  +retrieveProfileForRawUrl: typeof retrieveProfileForRawUrl,
   +setupInitialUrlState: typeof setupInitialUrlState,
 |};
 
@@ -87,8 +87,8 @@ class UrlManagerImpl extends React.PureComponent<Props> {
     const { startFetchingProfiles, setupInitialUrlState, urlSetupDone } =
       this.props;
     // We have to wrap this because of the error introduced by upgrading to v0.96.0. See issue #1936.
-    const getProfilesFromRawUrl: WrapFunctionInDispatch<GetProfilesFromRawUrl> =
-      (this.props.getProfilesFromRawUrl: any);
+    const retrieveProfileForRawUrl: WrapFunctionInDispatch<RetrieveProfileForRawUrl> =
+      (this.props.retrieveProfileForRawUrl: any);
 
     // Notify the UI that we are starting to fetch profiles.
     startFetchingProfiles();
@@ -104,7 +104,7 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       // case of fatal errors in the process of retrieving and processing a
       // profile. To handle the latter case properly, we won't `pushState` if
       // we're in a FATAL_ERROR state.
-      const profile = await getProfilesFromRawUrl(window.location);
+      const profile = await retrieveProfileForRawUrl(window.location);
       setupInitialUrlState(window.location, profile);
     } catch (error) {
       // Complete the URL setup, as values can come from the user, so we should
@@ -238,7 +238,7 @@ export const UrlManager = explicitConnect<OwnProps, StateProps, DispatchProps>({
     urlSetupDone,
     show404,
     setupInitialUrlState,
-    getProfilesFromRawUrl,
+    retrieveProfileForRawUrl,
   },
   component: UrlManagerImpl,
 });

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -30,7 +30,7 @@ import {
   retrieveProfileFromFile,
   retrieveProfilesToCompare,
   _fetchProfile,
-  getProfilesFromRawUrl,
+  retrieveProfileForRawUrl,
   changeTimelineTrackOrganization,
 } from '../../actions/receive-profile';
 import { SymbolsNotFoundError } from '../../profile-logic/errors';
@@ -2087,7 +2087,7 @@ describe('actions/receive-profile', function () {
     });
   });
 
-  describe('getProfilesFromRawUrl', function () {
+  describe('retrieveProfileForRawUrl', function () {
     function fetch200Response(profile: string) {
       return {
         ok: true,
@@ -2129,7 +2129,7 @@ describe('actions/receive-profile', function () {
       jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       const store = blankStore();
-      await store.dispatch(getProfilesFromRawUrl(location));
+      await store.dispatch(retrieveProfileForRawUrl(location));
 
       // To find stupid mistakes more easily, check that we didn't get a fatal
       // error here. If we got one, let's rethrow the error.


### PR DESCRIPTION
"retrieve" instead of "get" so that it better reflects the fact that
it doesn't only return the profile; it kicks off the entire profile
loading process, dispatches various actions, and calls loadProfile once
the profile is available. This also is more similar to the other
"retrieveProfile*" functions it calls.

"for" instead of "from" because the URL that is passed to this function
is something like /public/HASH/?... - it's the URL of this web app, and
not the URL that the profile file needs to be fetched from.