### PR TITLE
Streamline from-browser initialization

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -45,6 +45,7 @@ import type {
   UploadedProfileInformation,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 
 export function changeSelectedTab(selectedTab: TabSlug): ThunkAction<void> {
   return (dispatch, getState) => {
@@ -121,7 +122,8 @@ export function setHasZoomedViaMousewheel() {
  */
 export function setupInitialUrlState(
   location: Location,
-  profile: Profile | null
+  profile: Profile | null,
+  browserConnection: BrowserConnection | null
 ): ThunkAction<void> {
   return (dispatch) => {
     let urlState;
@@ -157,7 +159,7 @@ export function setupInitialUrlState(
     // load process.
     withHistoryReplaceStateSync(() => {
       dispatch(updateUrlState(urlState));
-      dispatch(finalizeProfileView());
+      dispatch(finalizeProfileView(browserConnection));
       dispatch(urlSetupDone());
     });
   };

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -965,7 +965,9 @@ export async function doSymbolicateProfile(
   dispatch(doneSymbolicating());
 }
 
-export function retrieveProfileFromBrowser(): ThunkAction<Promise<void>> {
+export function retrieveProfileFromBrowser(
+  initialLoad: boolean = false
+): ThunkAction<Promise<BrowserConnection | null>> {
   return async (dispatch) => {
     try {
       // Attempt to establish a connection to the browser.
@@ -1017,10 +1019,12 @@ export function retrieveProfileFromBrowser(): ThunkAction<Promise<void>> {
         rawGeckoProfile
       );
       const profile = processGeckoProfile(unpackedProfile);
-      await dispatch(loadProfile(profile, { browserConnection }));
+      await dispatch(loadProfile(profile, { browserConnection }, initialLoad));
+      return browserConnection;
     } catch (error) {
       dispatch(fatalError(error));
       console.error(error);
+      return null;
     }
   };
 }
@@ -1508,9 +1512,12 @@ export function retrieveProfilesToCompare(
 // and loads the profile in that given location, then returns the profile data.
 // This function is being used to get the initial profile data before upgrading
 // the url and processing the UrlState.
-export function retrieveProfileForRawUrl(
-  location: Location
-): ThunkAction<Promise<Profile | null>> {
+export function retrieveProfileForRawUrl(location: Location): ThunkAction<
+  Promise<{|
+    profile: Profile | null,
+    browserConnection: BrowserConnection | null,
+  |}>
+> {
   return async (dispatch, getState) => {
     const pathParts = location.pathname.split('/').filter((d) => d);
     let possibleDataSource = pathParts[0];
@@ -1528,14 +1535,11 @@ export function retrieveProfileForRawUrl(
     }
     dispatch(setDataSource(dataSource));
 
+    let browserConnection = null;
+
     switch (dataSource) {
       case 'from-browser':
-        // We don't need to `await` the result because there's no url upgrading
-        // when retrieving the profile from the browser and we don't need to wait
-        // for the process. Moreover we don't want to wait for the end of
-        // symbolication and rather want to show the UI as soon as we get
-        // the profile data.
-        dispatch(retrieveProfileFromBrowser());
+        browserConnection = await dispatch(retrieveProfileFromBrowser(true));
         break;
       case 'public':
         await dispatch(retrieveProfileFromStore(pathParts[1], true));
@@ -1568,8 +1572,10 @@ export function retrieveProfileForRawUrl(
         );
     }
 
-    // Profile may be null only for the `from-browser` dataSource since we do
-    // not `await` for retrieveProfileFromBrowser function.
-    return getProfileOrNull(getState());
+    // Profile may be null if the response was a zip file.
+    return {
+      profile: getProfileOrNull(getState()),
+      browserConnection,
+    };
   };
 }

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -95,17 +95,21 @@ class UrlManagerImpl extends React.PureComponent<Props> {
 
     try {
       // Process the raw url and fetch the profile.
-      // We try to fetch the profile before setting the url state, because
-      // while processing and especially upgrading the url information we may
-      // need the profile data.
+      // We try to fetch the profile before setting the url state, because we
+      // may need the profile data during URL upgrading.
       //
-      // Also note the profile may be null for the `from-browser` dataSource since
-      // we do not `await` for retrieveProfileFromBrowser function, but also in
-      // case of fatal errors in the process of retrieving and processing a
-      // profile. To handle the latter case properly, we won't `pushState` if
-      // we're in a FATAL_ERROR state.
-      const profile = await retrieveProfileForRawUrl(window.location);
-      setupInitialUrlState(window.location, profile);
+      // In some cases, the returned profile will be null:
+      //  - If the response is a zip file (even if the URL tells us which file
+      //    to pick from the zip file).
+      //  - If a fatal error was encountered in the process of retrieving and
+      //    processing the profile.
+      //
+      // To handle the latter case properly, we won't `pushState` if we're in
+      // a FATAL_ERROR state.
+      const { profile, browserConnection } = await retrieveProfileForRawUrl(
+        window.location
+      );
+      setupInitialUrlState(window.location, profile, browserConnection);
     } catch (error) {
       // Complete the URL setup, as values can come from the user, so we should
       // still proceed with loading the app.

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -31,6 +31,7 @@ import {
 jest.mock('../../profile-logic/symbol-store');
 
 import { TextEncoder, TextDecoder } from 'util';
+import { simulateOldWebChannelAndFrameScript } from '../fixtures/mocks/web-channel';
 
 describe('UrlManager', function () {
   autoMockFullNavigation();
@@ -87,8 +88,8 @@ describe('UrlManager', function () {
     window.fetch = jest
       .fn()
       .mockRejectedValue(new Error('Simulated network error'));
-    window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
     window.TextDecoder = TextDecoder;
+    simulateOldWebChannelAndFrameScript(geckoProfiler);
   });
 
   afterEach(function () {


### PR DESCRIPTION
If the initial URL is `/from-browser/`, profile loading goes a rather different path compared to `/from-url/` and `/public/`. This PR fixes that discrepancy.

More in-depth description:

Symbolication happens in `finalizeProfileView`.
`finalizeProfileView` can only do symbolication with the help of the browser if it gets passed a `browserConnection`.
`finalizeProfileView` is called in two cases: For initial loads it's called from `setupInitialUrlState`, and for non-initial loads it's called from `loadProfile`.

Before this patch, the following was true:
 - `setupInitialUrlState` didn't have a `browserConnection`, so it couldn't pass a `browserConnection` to `finalizeProfileView`. Only `loadProfile` had a `browserConnection` that it could pass to `finalizeProfileView`.
 - So in order to get symbols from the browser, `finalizeProfileView` *had* to be called from `loadProfile`, even during initial load.
 - So the initialization flow for `from-browser` had to pass `initialLoad = false` even for the initial load - otherwise `loadProfile` wouldn't call `finalizeProfile`.
 - This means that, for `from-browser`, `finalizeProfileView` was always called twice during the initial load! First from `setupInitialUrlState`, and then again from `loadProfile`.
 - However, on the first call, `finalizeProfileView` did an early exit, because the call happened at a time when the profile in the redux state was still null.
 - Why was the profile null during the first call? Because `retrieveProfileForRawUrl` didn't await `retrieveProfileFromBrowser`, so `setupInitialUrlState` was called before the profile had been obtained.
 - This was the other reason why we were always passing `initialLoad = false` for `from-browser`: we were relying on that second call to `finalizeProfileView` (because the first call didn't do anything).

After this patch, the following is true:
 - For initial loads, we call `loadProfile` with `initialLoad = true` for all data sources now, including from-browser. So `loadProfile` no longer calls `finalizeProfile` during from-browser initial load. Now there is only one call to `finalizeProfile`: the one from `setupInitialUrlState`.
 - `retrieveProfileForRawUrl` now awaits `retrieveProfileFromBrowser`. This means that the profile in the redux state is non-null once `setupInitialUrlState` gets called.
 - This await does not cause us to block on symbolication, as intended: The call to `retrieveProfileFromBrowser` no longer includes symbolication, because we now call it with `initialLoad = true`, so its `loadProfile` call (which now gets `initialLoad = true`) doesn't call `finalizeProfileView`, which is what would kick off symbolication.
 - Since `retrieveProfileForRawUrl` now waits until the profile has been obtained, this also means that we now have a non-null profile at the point where we do URL upgrading even for from-browser. We don't really need that, but at least the code paths for the different data sources are now better aligned.
 - `setupInitialUrlState` now has the `browserConnection`, so it can pass it along to `finalizeProfileView`, and symbolication works as expected.

This PR also makes the following test fixes, to keep the tests passing:

 - UrlManager.test.js now also simulates the WebChannel. Otherwise, `retrieveProfileFromBrowser()` would time out waiting for the WebChannel. This function was already timing out during this test in the past, but we didn't notice it because nothing was waiting for that function to complete. The new `await` now puts `retrieveProfileFromBrowser()` on the critical path for some of the tests in this file, so this situation needs to be rectified.
 - receive-profile.test.js now checks for `PROFILE_LOADED` first and then calls `finalizeProfileView` in the `from-browser` test, just like it's already doing in the `/public/fakehash/` test. And since it now awaits `finalizeProfileView`, it means that it waits for symbolication to complete, and needs to expect that `profile.meta.symbolicated` is `true`.