### PR TITLE
Make it possible that android tracks are not hidden at load time

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -10,7 +10,7 @@ import type { MarkerPhase } from 'firefox-profiler/types';
 export const GECKO_PROFILE_VERSION = 24;
 
 // The current version of the "processed" profile format.
-export const PROCESSED_PROFILE_VERSION = 38;
+export const PROCESSED_PROFILE_VERSION = 39;
 
 // The following are the margin sizes for the left and right of the timeline. Independent
 // components need to share these values.

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -91,17 +91,6 @@ export function processThreadCPUDelta(
     return newThread;
   }
 
-  // Check to see the CPU delta numbers are all null and if they are, remove
-  // this array completely. For example on JVM threads, all the threadCPUDelta
-  // values will be null and therefore it will fail to paint the activity graph.
-  // Instead we should remove the whole array. This call will be quick for most
-  // of the cases because we usually have values at least in the second sample.
-  const hasCPUDeltaValues = threadCPUDelta.some((val) => val !== null);
-  if (!hasCPUDeltaValues) {
-    // Remove the threadCPUDelta array and return the new thread.
-    return _newThreadWithNewThreadCPUDelta(undefined);
-  }
-
   const newThreadCPUDelta: Array<number | null> = new Array(samples.length);
   const cpuDeltaTimeUnitMultiplier = getCpuDeltaTimeUnitMultiplier(
     sampleUnits.threadCPUDelta

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -861,11 +861,24 @@ function _processSamples(geckoSamples: GeckoSampleStruct): SamplesTable {
   const samples: SamplesTable = {
     stack: geckoSamples.stack,
     time: geckoSamples.time,
-    threadCPUDelta: geckoSamples.threadCPUDelta,
     weightType: 'samples',
     weight: null,
     length: geckoSamples.length,
   };
+
+  if (geckoSamples.threadCPUDelta) {
+    // Check to see the CPU delta numbers are all null and if they are, remove
+    // this array completely. For example on JVM threads, all the threadCPUDelta
+    // values will be null and therefore it will fail to paint the activity graph.
+    // Instead we should remove the whole array. This call will be quick for most
+    // of the cases because we usually have values at least in the second sample.
+    const hasCPUDeltaValues = geckoSamples.threadCPUDelta.some(
+      (val) => val !== null
+    );
+    if (hasCPUDeltaValues) {
+      samples.threadCPUDelta = geckoSamples.threadCPUDelta;
+    }
+  }
 
   if (geckoSamples.eventDelay) {
     samples.eventDelay = geckoSamples.eventDelay;

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2002,5 +2002,22 @@ const _upgraders = {
       }
     }
   },
+  [39]: (profile) => {
+    for (const thread of profile.threads) {
+      if (thread.samples.threadCPUDelta) {
+        // Check to see the CPU delta numbers are all null and if they are, remove
+        // this array completely. For example on JVM threads, all the threadCPUDelta
+        // values will be null and therefore it will fail to paint the activity graph.
+        // Instead we should remove the whole array. This call will be quick for most
+        // of the cases because we usually have values at least in the second sample.
+        const hasCPUDeltaValues = thread.samples.threadCPUDelta.some(
+          (val) => val !== null
+        );
+        if (!hasCPUDeltaValues) {
+          delete thread.samples.threadCPUDelta;
+        }
+      }
+    }
+  },
 };
 /* eslint-enable no-useless-computed-key */

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -122,7 +122,7 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete 
         >
           Profile Version:
         </span>
-        38
+        39
       </div>
       <div
         class="metaInfoRow"
@@ -251,7 +251,7 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete 
         >
           Profile Version:
         </span>
-        38
+        39
       </div>
       <div
         class="metaInfoRow"
@@ -354,7 +354,7 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile does not display the
         >
           Profile Version:
         </span>
-        38
+        39
       </div>
       <div
         class="metaInfoRow"
@@ -467,7 +467,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         >
           Profile Version:
         </span>
-        38
+        39
       </div>
       <div
         class="metaInfoRow"
@@ -866,7 +866,7 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device inform
         >
           Profile Version:
         </span>
-        38
+        39
       </div>
       <div
         class="metaInfoRow"
@@ -1228,7 +1228,7 @@ exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not ma
         >
           Profile Version:
         </span>
-        38
+        39
       </div>
       <div
         class="metaInfoRow"

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -401,7 +401,7 @@ Object {
     "oscpu": "",
     "physicalCPUs": 0,
     "platform": "",
-    "preprocessedProfileVersion": 38,
+    "preprocessedProfileVersion": 39,
     "processType": 0,
     "product": "Firefox",
     "sourceURL": "",

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -38,7 +38,7 @@ Object {
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,
-    "preprocessedProfileVersion": 38,
+    "preprocessedProfileVersion": 39,
     "processType": 0,
     "product": "Firefox",
     "sampleUnits": undefined,
@@ -313,7 +313,6 @@ Object {
           7,
           8,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592839.818,
           2574592839.836,
@@ -579,7 +578,6 @@ Object {
           2,
           2,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592843.0039997,
           2574592843.027,
@@ -793,7 +791,6 @@ Object {
           2,
           1,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592868.3659997,
           2574592868.39,
@@ -1212,7 +1209,6 @@ Object {
           8,
           13,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592869.355,
           2574592869.37,
@@ -1542,7 +1538,6 @@ Object {
           2,
           4,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592877.46,
           2574592877.474,
@@ -1854,7 +1849,6 @@ Object {
           7,
           8,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592878.268,
           2574592878.282,
@@ -2092,7 +2086,6 @@ Object {
           1,
           0,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592938.803,
           2574592938.827,
@@ -2296,7 +2289,6 @@ Object {
           2,
           1,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592945.456,
           2574592945.4709997,
@@ -2508,7 +2500,6 @@ Object {
           2,
           3,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592945.7780004,
           2574592945.79,
@@ -2724,7 +2715,6 @@ Object {
           2,
           1,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592946.053,
           2574592946.069,
@@ -2957,7 +2947,6 @@ Object {
           10,
           10,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592948.093,
           2574592948.128,
@@ -3708,7 +3697,6 @@ Object {
           33,
           32,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592948.301,
           2574592948.32,
@@ -4665,7 +4653,6 @@ Object {
           33,
           32,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592948.3170004,
           2574592948.3269997,
@@ -5622,7 +5609,6 @@ Object {
           33,
           34,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592948.38,
           2574592948.391,
@@ -6583,7 +6569,6 @@ Object {
           33,
           34,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592948.3989997,
           2574592948.4100003,
@@ -7326,7 +7311,6 @@ Object {
         "stack": Array [
           19,
         ],
-        "threadCPUDelta": undefined,
         "time": Array [
           2574592949.428,
         ],
@@ -10901,7 +10885,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 38,
+    "preprocessedProfileVersion": 39,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -12585,7 +12569,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 38,
+    "preprocessedProfileVersion": 39,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -14421,7 +14405,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 38,
+    "preprocessedProfileVersion": 39,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,

--- a/src/test/unit/cpu.test.js
+++ b/src/test/unit/cpu.test.js
@@ -38,15 +38,8 @@ describe('processThreadCPUDelta', function () {
     return { profile, thread, processedThread };
   }
 
-  it('removes the threadCPUDelta array if all of its values are null', function () {
-    const { processedThread } = setup([null, null, null, null, null, null]);
-    expect(processedThread.samples.threadCPUDelta).toBe(undefined);
-  });
-
-  it('does not remove the values if there is at least one non-null value ', function () {
-    const { processedThread } = setup([null, null, null, null, 0.1]);
-    // We do the processing for null elements, see the following test for a more specific assertion.
-    expect(processedThread.samples.threadCPUDelta).not.toBe(undefined);
+  it('throws if all of its values are null', function () {
+    expect(() => setup([null, null, null, null, null, null])).toThrow();
   });
 
   it('throws if there are no threadCPUDelta values', function () {

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -592,6 +592,58 @@ describe('gecko samples table processing', function () {
   });
 });
 
+describe('threadCPUDelta processing', function () {
+  it('removes threadCPUDelta data when the array is filled with null values', () => {
+    const geckoProfile = createGeckoProfile();
+    const geckoSamples = geckoProfile.threads[0].samples;
+    const geckoSchema = geckoSamples.schema;
+    if (!geckoSchema.threadCPUDelta) {
+      throw new Error(
+        'This test works with threads that can contain threadCPUDelta data.'
+      );
+    }
+
+    // Fill the threadCPUDelta with null values.
+    for (const item of geckoSamples.data) {
+      // $FlowExpectError because Flow thinks this access can be out of bounds, but it is not.
+      item[geckoSchema.threadCPUDelta] = null;
+    }
+
+    // Process the profile.
+    const processedProfile = processGeckoProfile(geckoProfile);
+    const processedSamples = processedProfile.threads[0].samples;
+
+    // Check that the threadCPUdelta array has been removed.
+    expect(processedSamples.threadCPUDelta).not.toBeDefined();
+  });
+
+  it('keeps threadCPUDelta data when the array contains at least one non-null value', () => {
+    const geckoProfile = createGeckoProfile();
+    const geckoSamples = geckoProfile.threads[0].samples;
+    const geckoSchema = geckoSamples.schema;
+    if (!geckoSchema.threadCPUDelta) {
+      throw new Error(
+        'This test works with threads that can contain threadCPUDelta data.'
+      );
+    }
+
+    // Fill the threadCPUDelta with null values except the first.
+    for (const item of geckoSamples.data) {
+      // $FlowExpectError because Flow thinks this access can be out of bounds, but it is not.
+      item[geckoSchema.threadCPUDelta] = null;
+    }
+    // $FlowExpectError same reason as above
+    geckoSamples.data[0][geckoSchema.threadCPUDelta] = 2;
+
+    // Process the profile.
+    const processedProfile = processGeckoProfile(geckoProfile);
+    const processedSamples = processedProfile.threads[0].samples;
+
+    // Check that the threadCPUdelta array has been removed.
+    expect(processedSamples.threadCPUDelta).toBeDefined();
+  });
+});
+
 describe('profile meta processing', function () {
   it('keeps the sampleUnits object successfully', function () {
     const geckoProfile = createGeckoProfile();


### PR DESCRIPTION
Fixes #3651

The problem was that we were removing empty threadCPUDelta arrays at the wrong code location, so we still had them when deciding when a thread should be idle, and therefore we were always going through the CPU-based decision function. In this patch we do it at processing time, and we also upgrade previous profiles so that they still behave properly, so that now we use the sample-based decision function for these threads.

Here are the links for the profile in bug #3651:
[production](https://profiler.firefox.com/public/r2gn1w828xdjtfcr6ddf5cqsp7nrmnmb0541s9g/)
[deploy preview](https://deploy-preview-3655--perf-html.netlify.app/public/r2gn1w828xdjtfcr6ddf5cqsp7nrmnmb0541s9g/)
(check that the first Android UI thread is now properly displayed).

I also checked that this was working properly when capturing from a Firefox for Android instance.