### PR TITLE
WIP: Allow re-symbolication to use the WebChannel, take 2

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -45,6 +45,7 @@ import type {
   UploadedProfileInformation,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 
 export function changeSelectedTab(selectedTab: TabSlug): ThunkAction<void> {
   return (dispatch, getState) => {
@@ -121,7 +122,8 @@ export function setHasZoomedViaMousewheel() {
  */
 export function setupInitialUrlState(
   location: Location,
-  profile: Profile | null
+  profile: Profile | null,
+  browserConnection: BrowserConnection | null
 ): ThunkAction<void> {
   return (dispatch) => {
     let urlState;
@@ -157,7 +159,7 @@ export function setupInitialUrlState(
     // load process.
     withHistoryReplaceStateSync(() => {
       dispatch(updateUrlState(urlState));
-      dispatch(finalizeProfileView());
+      dispatch(finalizeProfileView(browserConnection));
       dispatch(urlSetupDone());
     });
   };

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -78,9 +78,10 @@ import type {
 
 import type { SymbolicationStepInfo } from '../profile-logic/symbolication';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
-import {
+import { createBrowserConnection } from '../app-logic/browser-connection';
+import type {
   BrowserConnection,
-  createBrowserConnection,
+  BrowserConnectionStatus,
 } from '../app-logic/browser-connection';
 import { querySupportsGetProfileAndSymbolicationViaWebChannel } from '../app-logic/web-channel';
 
@@ -991,17 +992,12 @@ export async function checkIfWebChannelUsableForSymbolication(): Promise<boolean
 }
 
 export function retrieveProfileFromBrowser(
+  browserConnectionStatus: BrowserConnectionStatus,
   initialLoad: boolean = false
-): ThunkAction<Promise<BrowserConnection | null>> {
+): ThunkAction<Promise<void>> {
   return async (dispatch) => {
     try {
-      // Attempt to establish a connection to the browser.
-      // Disable the userAgent check by supplying a fake userAgent that
-      // pretends we're Firefox. This will make us attempt to establish
-      // a connection to the WebChannel even if we're running in the test
-      // suite.
-      const connectionStatus = await createBrowserConnection('Firefox/123.0');
-      switch (connectionStatus.status) {
+      switch (browserConnectionStatus.status) {
         case 'ESTABLISHED':
           // Good. This is the normal case.
           break;
@@ -1009,19 +1005,21 @@ export function retrieveProfileFromBrowser(
         case 'NOT_FIREFOX':
           throw new Error('/from-browser only works in Firefox browsers');
         case 'WAITING':
-          throw new Error('unexpected WAITING from createBrowserConnection');
+          throw new Error(
+            'retrieveProfileFromBrowser should never be called while browserConnectionStatus is WAITING'
+          );
         case 'DENIED':
-          throw connectionStatus.error;
+          throw browserConnectionStatus.error;
         case 'TIMED_OUT':
           throw new Error(
             'Timed out when waiting for reply to WebChannel message'
           );
         default:
-          throw assertExhaustiveCheck(connectionStatus.status);
+          throw assertExhaustiveCheck(browserConnectionStatus.status);
       }
 
-      // Now we know that connectionStatus.status === 'ESTABLISHED'.
-      const browserConnection = connectionStatus.browserConnection;
+      // Now we know that browserConnectionStatus.status === 'ESTABLISHED'.
+      const browserConnection = browserConnectionStatus.browserConnection;
 
       // XXX update state to show that we're connected to the browser
 
@@ -1047,11 +1045,9 @@ export function retrieveProfileFromBrowser(
       );
       const profile = processGeckoProfile(unpackedProfile);
       await dispatch(loadProfile(profile, { browserConnection }, initialLoad));
-      return browserConnection;
     } catch (error) {
       dispatch(fatalError(error));
       console.error(error);
-      return null;
     }
   };
 }
@@ -1539,12 +1535,10 @@ export function retrieveProfilesToCompare(
 // and loads the profile in that given location, then returns the profile data.
 // This function is being used to get the initial profile data before upgrading
 // the url and processing the UrlState.
-export function retrieveProfileForRawUrl(location: Location): ThunkAction<
-  Promise<{|
-    profile: Profile | null,
-    browserConnection: BrowserConnection | null,
-  |}>
-> {
+export function retrieveProfileForRawUrl(
+  location: Location,
+  browserConnectionStatus?: BrowserConnectionStatus
+): ThunkAction<Promise<Profile | null>> {
   return async (dispatch, getState) => {
     const pathParts = location.pathname.split('/').filter((d) => d);
     let possibleDataSource = pathParts[0];
@@ -1562,11 +1556,16 @@ export function retrieveProfileForRawUrl(location: Location): ThunkAction<
     }
     dispatch(setDataSource(dataSource));
 
-    let browserConnection = null;
-
     switch (dataSource) {
       case 'from-browser':
-        browserConnection = await dispatch(retrieveProfileFromBrowser(true));
+        if (browserConnectionStatus === undefined) {
+          throw new Error(
+            'Error: all callers of this function should supply a browserConnectionStatus argument for from-browser'
+          );
+        }
+        await dispatch(
+          retrieveProfileFromBrowser(browserConnectionStatus, true)
+        );
         break;
       case 'public':
         await dispatch(retrieveProfileFromStore(pathParts[1], true));
@@ -1600,9 +1599,6 @@ export function retrieveProfileForRawUrl(location: Location): ThunkAction<
     }
 
     // Profile may be null if the response was a zip file.
-    return {
-      profile: getProfileOrNull(getState()),
-      browserConnection,
-    };
+    return getProfileOrNull(getState());
   };
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -78,7 +78,6 @@ import type {
 
 import type { SymbolicationStepInfo } from '../profile-logic/symbolication';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
-import { createBrowserConnection } from '../app-logic/browser-connection';
 import type {
   BrowserConnection,
   BrowserConnectionStatus,
@@ -1387,6 +1386,7 @@ function _fileReader(input: File) {
  */
 export function retrieveProfileFromFile(
   file: File,
+  browserConnection?: BrowserConnection,
   // Allow tests to inject a custom file reader to bypass the DOM APIs.
   fileReader: typeof _fileReader = _fileReader
 ): ThunkAction<Promise<void>> {
@@ -1419,19 +1419,6 @@ export function retrieveProfileFromFile(
         if (profile === undefined) {
           throw new Error('Unable to parse the profile.');
         }
-
-        // Attempt to establish a connection to the browser, for symbolication.
-        // Disable the userAgent check by supplying a fake userAgent that
-        // pretends we're Firefox. This will make us attempt to establish
-        // a connection to the WebChannel even if we're running in the test
-        // suite.
-        const browserConnectionStatus = await createBrowserConnection(
-          'Firefox/123.0'
-        );
-        const browserConnection =
-          browserConnectionStatus.status === 'ESTABLISHED'
-            ? browserConnectionStatus.browserConnection
-            : undefined;
 
         await withHistoryReplaceStateAsync(async () => {
           await dispatch(viewProfile(profile, { browserConnection }));

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -686,12 +686,14 @@ export function changeTimelineTrackOrganization(
  * provides the ability to kick off symbolication again after it has already been
  * attempted once.
  */
-export function resymbolicateProfile(): ThunkAction<Promise<void>> {
+export function resymbolicateProfile(
+  browserConnection: BrowserConnection | null
+): ThunkAction<Promise<void>> {
   return async (dispatch, getState) => {
     const symbolStore = getSymbolStore(
       dispatch,
       getSymbolServerUrl(getState()),
-      null
+      browserConnection
     );
     const profile = getProfile(getState());
     if (!symbolStore) {

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -23,6 +23,7 @@ import { UploadedRecordingsHome } from './UploadedRecordingsHome';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 
 import type { AppViewState, State, DataSource } from 'firefox-profiler/types';
+import type { BrowserConnectionStatus } from 'firefox-profiler/app-logic/browser-connection';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import { Localized } from '@fluent/react';
@@ -37,6 +38,10 @@ const ERROR_MESSAGES_L10N_ID: { [string]: string } = Object.freeze({
   compare: 'AppViewRouter--error-message-compare',
 });
 
+type AppViewRouterOwnProps = {|
+  browserConnectionStatus: BrowserConnectionStatus,
+|};
+
 type AppViewRouterStateProps = {|
   +view: AppViewState,
   +dataSource: DataSource,
@@ -44,11 +49,21 @@ type AppViewRouterStateProps = {|
   +hasZipFile: boolean,
 |};
 
-type AppViewRouterProps = ConnectedProps<{||}, AppViewRouterStateProps, {||}>;
+type AppViewRouterProps = ConnectedProps<
+  AppViewRouterOwnProps,
+  AppViewRouterStateProps,
+  {||}
+>;
 
 class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
   render() {
-    const { view, dataSource, profilesToCompare, hasZipFile } = this.props;
+    const {
+      view,
+      dataSource,
+      profilesToCompare,
+      hasZipFile,
+      browserConnectionStatus,
+    } = this.props;
     const phase = view.phase;
 
     // We're using a switch to assert that all values for the dataSource has
@@ -56,7 +71,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
     // error here if we forget to update this code.
     switch (dataSource) {
       case 'none':
-        return <Home />;
+        return <Home browserConnectionStatus={browserConnectionStatus} />;
       case 'compare':
         if (profilesToCompare === null) {
           return <CompareHome />;
@@ -119,7 +134,10 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
             id="AppViewRouter--route-not-found--home"
             attrs={{ specialMessage: true }}
           >
-            <Home specialMessage="The URL you tried to reach was not recognized." />
+            <Home
+              specialMessage="The URL you tried to reach was not recognized."
+              browserConnectionStatus={browserConnectionStatus}
+            />
           </Localized>
         );
     }
@@ -127,7 +145,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
 }
 
 export const AppViewRouter = explicitConnect<
-  {||},
+  AppViewRouterOwnProps,
   AppViewRouterStateProps,
   {||}
 >({

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -66,6 +66,11 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
     } = this.props;
     const phase = view.phase;
 
+    const browserConnection =
+      browserConnectionStatus.status === 'ESTABLISHED'
+        ? browserConnectionStatus.browserConnection
+        : null;
+
     // We're using a switch to assert that all values for the dataSource has
     // been checked. This is useful when we add a new dataSource, as Flow will
     // error here if we forget to update this code.
@@ -121,7 +126,11 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
         // The data is now loaded. This could be either a single profile, or a zip file
         // with multiple profiles. Only show the ZipFileViewer if the data loaded is a
         // Zip file, and there is no stored path into the zip file.
-        return hasZipFile ? <ZipFileViewer /> : <ProfileViewer />;
+        return hasZipFile ? (
+          <ZipFileViewer browserConnection={browserConnection} />
+        ) : (
+          <ProfileViewer browserConnection={browserConnection} />
+        );
       case 'TRANSITIONING_FROM_STALE_PROFILE':
         return null;
       case 'ROUTE_NOT_FOUND':

--- a/src/components/app/DragAndDrop.js
+++ b/src/components/app/DragAndDrop.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { retrieveProfileFromFile } from 'firefox-profiler/actions/receive-profile';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import explicitConnect from 'firefox-profiler/utils/connect';
-import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 
 import {
   startDragging,
@@ -32,6 +32,7 @@ function _dragPreventDefault(event: DragEvent) {
 type OwnProps = {|
   +className?: string,
   +children?: React.Node,
+  +browserConnection: BrowserConnection | null,
 |};
 
 type StateProps = {|
@@ -160,19 +161,10 @@ class DragAndDropImpl extends React.PureComponent<Props> {
 
     const { files } = event.dataTransfer;
     if (files.length > 0) {
-      // Attempt to establish a connection to the browser, for symbolication.
-      // Disable the userAgent check by supplying a fake userAgent that
-      // pretends we're Firefox. This will make us attempt to establish
-      // a connection to the WebChannel even if we're running in the test
-      // suite.
-      const browserConnectionStatus = await createBrowserConnection(
-        'Firefox/123.0'
+      this.props.retrieveProfileFromFile(
+        files[0],
+        this.props.browserConnection ?? undefined
       );
-      const browserConnection =
-        browserConnectionStatus.status === 'ESTABLISHED'
-          ? browserConnectionStatus.browserConnection
-          : undefined;
-      this.props.retrieveProfileFromFile(files[0], browserConnection);
     }
   };
 

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -17,7 +17,6 @@ import {
   retrieveProfileFromFile,
   triggerLoadingFromUrl,
 } from 'firefox-profiler/actions/receive-profile';
-import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import {
   queryIsMenuButtonEnabled,
@@ -26,6 +25,7 @@ import {
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+import type { BrowserConnectionStatus } from 'firefox-profiler/app-logic/browser-connection';
 
 import { Localized } from '@fluent/react';
 import './Home.css';
@@ -196,6 +196,7 @@ function InstructionTransition(props: { children: React.Node }) {
 
 type OwnHomeProps = {|
   +specialMessage?: string,
+  +browserConnectionStatus: BrowserConnectionStatus,
 |};
 
 type DispatchHomeProps = {|
@@ -451,18 +452,12 @@ class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
   }
 
   _onLoadProfileFromFileRequested = (file: File) => {
-    // Attempt to establish a connection to the browser, for symbolication.
-    // Disable the userAgent check by supplying a fake userAgent that
-    // pretends we're Firefox. This will make us attempt to establish
-    // a connection to the WebChannel even if we're running in the test
-    // suite.
-    createBrowserConnection('Firefox/123.0').then((browserConnectionStatus) => {
-      const browserConnection =
-        browserConnectionStatus.status === 'ESTABLISHED'
-          ? browserConnectionStatus.browserConnection
-          : undefined;
-      this.props.retrieveProfileFromFile(file, browserConnection);
-    });
+    const { browserConnectionStatus } = this.props;
+    const browserConnection =
+      browserConnectionStatus.status === 'ESTABLISHED'
+        ? browserConnectionStatus.browserConnection
+        : undefined;
+    this.props.retrieveProfileFromFile(file, browserConnection);
   };
 
   _onLoadProfileFromUrlRequested = (url: string) => {

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -26,6 +26,7 @@ import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import explicitConnect from 'firefox-profiler/utils/connect';
 
 import type { Profile, SymbolicationStatus } from 'firefox-profiler/types';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import './MetaInfo.css';
@@ -39,18 +40,27 @@ type DispatchProps = $ReadOnly<{|
   resymbolicateProfile: typeof resymbolicateProfile,
 |}>;
 
-type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+type OwnProps = {|
+  browserConnection: BrowserConnection | null,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 /**
  * This component formats the profile's meta information into a dropdown panel.
  */
 class MetaInfoPanelImpl extends React.PureComponent<Props> {
+  onResymbolicationButtonClick = () => {
+    const { browserConnection, resymbolicateProfile } = this.props;
+    resymbolicateProfile(browserConnection);
+  };
+
   /**
    * This method provides information about the symbolication status, and a button
    * to re-trigger symbolication.
    */
   renderSymbolication() {
-    const { profile, symbolicationStatus, resymbolicateProfile } = this.props;
+    const { profile, symbolicationStatus } = this.props;
     const isSymbolicated = profile.meta.symbolicated;
 
     switch (symbolicationStatus) {
@@ -74,7 +84,7 @@ class MetaInfoPanelImpl extends React.PureComponent<Props> {
             <div className="metaInfoRow">
               <span className="metaInfoLabel"></span>
               <button
-                onClick={resymbolicateProfile}
+                onClick={this.onResymbolicationButtonClick}
                 type="button"
                 className="photon-button photon-button-micro"
               >
@@ -414,7 +424,11 @@ function _formatDate(timestamp: number): string {
   return timestampDate;
 }
 
-export const MetaInfoPanel = explicitConnect<{||}, StateProps, DispatchProps>({
+export const MetaInfoPanel = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: (state) => ({
     profile: getProfile(state),
     symbolicationStatus: getSymbolicationStatus(state),

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -55,6 +55,7 @@ import type {
   TimelineTrackOrganization,
   UploadedProfileInformation,
 } from 'firefox-profiler/types';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
@@ -64,6 +65,8 @@ type OwnProps = {|
   // correctly (perhaps due to ES6 modules), so I just went with dependency injection
   // instead.
   injectedUrlShortener?: (string) => Promise<string>,
+
+  browserConnection: BrowserConnection | null,
 |};
 
 type StateProps = {|
@@ -172,7 +175,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
   }
 
   _renderMetaInfoPanel() {
-    const { currentProfileUploadedInformation } = this.props;
+    const { currentProfileUploadedInformation, browserConnection } = this.props;
     const { metaInfoPanelState } = this.state;
     switch (metaInfoPanelState) {
       case 'initial': {
@@ -188,7 +191,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
                   currentProfileUploadedInformation
                 )
               : null}
-            <MetaInfoPanel />
+            <MetaInfoPanel browserConnection={browserConnection} />
           </>
         );
       }

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -13,7 +13,6 @@ import {
   retrieveProfileOrZipFromUrl,
   retrieveProfilesToCompare,
 } from 'firefox-profiler/actions/receive-profile';
-import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import {
   getDataSource,
   getHash,
@@ -24,6 +23,7 @@ import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import type { DataSource } from 'firefox-profiler/types';
+import type { BrowserConnectionStatus } from 'firefox-profiler/app-logic/browser-connection';
 
 type StateProps = {|
   +dataSource: DataSource,
@@ -39,7 +39,11 @@ type DispatchProps = {|
   +retrieveProfilesToCompare: typeof retrieveProfilesToCompare,
 |};
 
-type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+type OwnProps = {|
+  +browserConnectionStatus: BrowserConnectionStatus,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class ProfileLoaderImpl extends PureComponent<Props> {
   _retrieveProfileFromDataSource = async () => {
@@ -52,12 +56,10 @@ class ProfileLoaderImpl extends PureComponent<Props> {
       retrieveProfileFromStore,
       retrieveProfileOrZipFromUrl,
       retrieveProfilesToCompare,
+      browserConnectionStatus,
     } = this.props;
     switch (dataSource) {
       case 'from-browser': {
-        const browserConnectionStatus = await createBrowserConnection(
-          'Firefox/123.0'
-        );
         retrieveProfileFromBrowser(browserConnectionStatus);
         break;
       }
@@ -104,7 +106,11 @@ class ProfileLoaderImpl extends PureComponent<Props> {
   }
 }
 
-export const ProfileLoader = explicitConnect<{||}, StateProps, DispatchProps>({
+export const ProfileLoader = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: (state) => ({
     dataSource: getDataSource(state),
     hash: getHash(state),

--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -13,6 +13,7 @@ import {
   retrieveProfileOrZipFromUrl,
   retrieveProfilesToCompare,
 } from 'firefox-profiler/actions/receive-profile';
+import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import {
   getDataSource,
   getHash,
@@ -41,7 +42,7 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class ProfileLoaderImpl extends PureComponent<Props> {
-  _retrieveProfileFromDataSource = () => {
+  _retrieveProfileFromDataSource = async () => {
     const {
       dataSource,
       hash,
@@ -53,9 +54,13 @@ class ProfileLoaderImpl extends PureComponent<Props> {
       retrieveProfilesToCompare,
     } = this.props;
     switch (dataSource) {
-      case 'from-browser':
-        retrieveProfileFromBrowser();
+      case 'from-browser': {
+        const browserConnectionStatus = await createBrowserConnection(
+          'Firefox/123.0'
+        );
+        retrieveProfileFromBrowser(browserConnectionStatus);
         break;
+      }
       case 'from-file':
         // retrieveProfileFromFile should already have been called
         break;

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -35,6 +35,7 @@ import classNames from 'classnames';
 import { DebugWarning } from 'firefox-profiler/components/app/DebugWarning';
 
 import type { CssPixels, IconWithClassName } from 'firefox-profiler/types';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import './ProfileViewer.css';
@@ -54,7 +55,11 @@ type DispatchProps = {|
   +invalidatePanelLayout: typeof invalidatePanelLayout,
 |};
 
-type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+type OwnProps = {|
+  +browserConnection: BrowserConnection | null,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class ProfileViewerImpl extends PureComponent<Props> {
   render() {
@@ -68,6 +73,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
       isHidingStaleProfile,
       hasSanitizedProfile,
       icons,
+      browserConnection,
     } = this.props;
 
     return (
@@ -116,7 +122,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
               // with actual content in them do.
             }
             <div className="profileViewerSpacer" />
-            <MenuButtons />
+            <MenuButtons browserConnection={browserConnection} />
             {isUploading ? (
               <div
                 className="menuButtonsPublishUploadBarInner"
@@ -147,7 +153,11 @@ class ProfileViewerImpl extends PureComponent<Props> {
   }
 }
 
-export const ProfileViewer = explicitConnect<{||}, StateProps, DispatchProps>({
+export const ProfileViewer = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: (state) => ({
     hasZipFile: getHasZipFile(state),
     timelineHeight: getTimelineHeight(state),

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -13,7 +13,9 @@ import { ProfileLoader } from './ProfileLoader';
 import { ServiceWorkerManager } from './ServiceWorkerManager';
 import { WindowTitle } from './WindowTitle';
 import { AppLocalizationProvider } from 'firefox-profiler/components/app/AppLocalizationProvider';
+import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 
+import type { BrowserConnectionStatus } from 'firefox-profiler/app-logic/browser-connection';
 import type { Store } from 'firefox-profiler/types';
 
 import './Root.css';
@@ -22,20 +24,39 @@ type RootProps = {
   store: Store,
 };
 
+type StateProps = {|
+  browserConnectionStatus: BrowserConnectionStatus,
+|};
+
 import { DragAndDrop } from './DragAndDrop';
 
-export class Root extends PureComponent<RootProps> {
+export class Root extends PureComponent<RootProps, StateProps> {
+  state = {
+    browserConnectionStatus: { status: 'WAITING' },
+  };
+
   render() {
     const { store } = this.props;
+    const { browserConnectionStatus } = this.state;
+
+    const browserConnection =
+      browserConnectionStatus.status === 'ESTABLISHED'
+        ? browserConnectionStatus.browserConnection
+        : null;
+
     return (
       <ErrorBoundary message="Uh oh, some error happened in profiler.firefox.com.">
         <Provider store={store}>
           <AppLocalizationProvider>
-            <DragAndDrop>
-              <UrlManager>
+            <DragAndDrop browserConnection={browserConnection}>
+              <UrlManager browserConnectionStatus={browserConnectionStatus}>
                 <ServiceWorkerManager />
-                <ProfileLoader />
-                <AppViewRouter />
+                <ProfileLoader
+                  browserConnectionStatus={browserConnectionStatus}
+                />
+                <AppViewRouter
+                  browserConnectionStatus={browserConnectionStatus}
+                />
                 <FooterLinks />
                 <WindowTitle />
               </UrlManager>
@@ -44,5 +65,11 @@ export class Root extends PureComponent<RootProps> {
         </Provider>
       </ErrorBoundary>
     );
+  }
+
+  componentDidMount() {
+    createBrowserConnection().then((browserConnectionStatus) => {
+      this.setState({ browserConnectionStatus });
+    });
   }
 }

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -104,8 +104,10 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       // case of fatal errors in the process of retrieving and processing a
       // profile. To handle the latter case properly, we won't `pushState` if
       // we're in a FATAL_ERROR state.
-      const profile = await retrieveProfileForRawUrl(window.location);
-      setupInitialUrlState(window.location, profile);
+      const { profile, browserConnection } = await retrieveProfileForRawUrl(
+        window.location
+      );
+      setupInitialUrlState(window.location, profile, browserConnection);
     } catch (error) {
       // Complete the URL setup, as values can come from the user, so we should
       // still proceed with loading the app.

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -27,6 +27,7 @@ import { ProfileViewer } from './ProfileViewer';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import type { ZipFileState } from 'firefox-profiler/types';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import type {
   ZipDisplayData,
   ZipFileTree,
@@ -55,7 +56,11 @@ type DispatchProps = {|
   +returnToZipFileList: typeof returnToZipFileList,
 |};
 
-type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+type OwnProps = {|
+  +browserConnection: BrowserConnection | null,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 type ZipFileRowDispatchProps = {|
   +viewProfileFromZip: typeof viewProfileFromZip,
@@ -234,6 +239,7 @@ class ZipFileViewerImpl extends React.PureComponent<Props> {
       changeExpandedZipFile,
       pathInZipFile,
       zipFileErrorMessage,
+      browserConnection,
     } = this.props;
 
     if (!zipFileTree) {
@@ -311,7 +317,7 @@ class ZipFileViewerImpl extends React.PureComponent<Props> {
           this._renderBackButton(),
         ]);
       case 'VIEW_PROFILE_IN_ZIP_FILE':
-        return <ProfileViewer />;
+        return <ProfileViewer browserConnection={browserConnection} />;
       default:
         (phase: empty);
         throw new Error('Unknown zip file phase.');
@@ -319,7 +325,11 @@ class ZipFileViewerImpl extends React.PureComponent<Props> {
   }
 }
 
-export const ZipFileViewer = explicitConnect<{||}, StateProps, DispatchProps>({
+export const ZipFileViewer = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: (state) => {
     const zipFileTree = getZipFileTree(state);
     if (zipFileTree === null) {

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -10,6 +10,7 @@ import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { Home } from '../../components/app/Home';
 import createStore from '../../app-logic/create-store';
 import { mockWebChannel } from '../fixtures/mocks/web-channel';
+import { createMockBrowserConnection } from '../fixtures/mocks/browser-connection';
 import { fireFullClick } from '../fixtures/utils';
 
 // ListOfPublishedProfiles depends on IDB and renders asynchronously, so we'll
@@ -34,9 +35,18 @@ let userAgent;
 describe('app/Home', function () {
   function setup(userAgentToConfigure: string) {
     userAgent = userAgentToConfigure;
+    const browserConnection = createMockBrowserConnection();
+    const browserConnectionStatus = {
+      status: 'ESTABLISHED',
+      browserConnection,
+    };
+
     const renderResults = render(
       <Provider store={createStore()}>
-        <Home specialMessage="This is a special message" />
+        <Home
+          specialMessage="This is a special message"
+          browserConnectionStatus={browserConnectionStatus}
+        />
       </Provider>
     );
 

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -119,7 +119,7 @@ describe('app/MenuButtons', function () {
       <Provider store={store}>
         <>
           <CurrentProfileUploadedInformationLoader />
-          <MenuButtons />
+          <MenuButtons browserConnection={null} />
         </>
       </Provider>
     );

--- a/src/test/components/MenuButtonsPermalinks.test.js
+++ b/src/test/components/MenuButtonsPermalinks.test.js
@@ -37,7 +37,10 @@ describe('<Permalink>', function () {
 
     const renderResult = render(
       <Provider store={store}>
-        <MenuButtons injectedUrlShortener={injectedUrlShortener} />
+        <MenuButtons
+          injectedUrlShortener={injectedUrlShortener}
+          browserConnection={null}
+        />
       </Provider>
     );
 

--- a/src/test/components/ProfileViewer.test.js
+++ b/src/test/components/ProfileViewer.test.js
@@ -54,7 +54,7 @@ describe('ProfileViewer', function () {
 
     const renderResult = render(
       <Provider store={store}>
-        <ProfileViewer />
+        <ProfileViewer browserConnection={null} />
       </Provider>
     );
 

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -80,7 +80,8 @@ describe('app/AppViewRouter', function () {
     navigateToFromBrowserProfileLoadingPage();
     dispatch(waitingForProfileFromBrowser());
     expect(container.firstChild).toMatchSnapshot();
-    expect(retrieveProfileFromBrowser).toBeCalled();
+    // We do not check that retrieveProfileFromBrowser gets called, because the call
+    // happens asynchronously.
 
     const { profile } = getProfileFromTextSamples(`A`);
     dispatch(viewProfile(profile));

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -65,6 +65,7 @@ import { TemporaryError } from '../../utils/errors';
 
 import { blankStore } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { createMockBrowserConnection } from '../fixtures/mocks/browser-connection';
 
 describe('app/AppViewRouter', function () {
   it('renders an initial home', function () {
@@ -181,11 +182,13 @@ function setup() {
   (retrieveProfilesToCompare: any).mockImplementation(() => async () => {});
 
   const store = blankStore();
+  const browserConnection = createMockBrowserConnection();
+  const browserConnectionStatus = { status: 'ESTABLISHED', browserConnection };
   const renderResult = render(
     <Provider store={store}>
       <>
-        <ProfileLoader />
-        <AppViewRouter />
+        <ProfileLoader browserConnectionStatus={browserConnectionStatus} />
+        <AppViewRouter browserConnectionStatus={browserConnectionStatus} />
       </>
     </Provider>
   );

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -31,6 +31,7 @@ import {
 jest.mock('../../profile-logic/symbol-store');
 
 import { TextEncoder, TextDecoder } from 'util';
+import { simulateOldWebChannelAndFrameScript } from '../fixtures/mocks/web-channel';
 
 describe('UrlManager', function () {
   autoMockFullNavigation();
@@ -74,6 +75,8 @@ describe('UrlManager', function () {
     return { dispatch, getState, createUrlManager, waitUntilUrlSetupPhase };
   }
 
+  let simulatedWebChannel;
+
   beforeEach(function () {
     const profileJSON = createGeckoProfile();
     const mockGetProfile = jest.fn().mockResolvedValue(profileJSON);
@@ -87,11 +90,12 @@ describe('UrlManager', function () {
     window.fetch = jest
       .fn()
       .mockRejectedValue(new Error('Simulated network error'));
-    window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
     window.TextDecoder = TextDecoder;
+    simulatedWebChannel = simulateOldWebChannelAndFrameScript(geckoProfiler);
   });
 
   afterEach(function () {
+    simulatedWebChannel.restoreOriginals();
     delete window.geckoProfilerPromise;
     delete window.TextDecoder;
     delete window.fetch;

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -23,6 +23,7 @@ import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profil
 import { CURRENT_URL_VERSION } from '../../app-logic/url-handling';
 import { autoMockFullNavigation } from '../fixtures/mocks/window-navigation';
 import { profilePublished } from 'firefox-profiler/actions/publish';
+import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import {
   changeCallTreeSearchString,
   setDataSource,
@@ -65,7 +66,9 @@ describe('UrlManager', function () {
     const createUrlManager = () =>
       render(
         <Provider store={store}>
-          <UrlManager>Contents</UrlManager>
+          <UrlManager browserConnectionStatus={browserConnectionStatus}>
+            Contents
+          </UrlManager>
         </Provider>
       );
 
@@ -76,8 +79,9 @@ describe('UrlManager', function () {
   }
 
   let simulatedWebChannel;
+  let browserConnectionStatus;
 
-  beforeEach(function () {
+  beforeEach(async function () {
     const profileJSON = createGeckoProfile();
     const mockGetProfile = jest.fn().mockResolvedValue(profileJSON);
 
@@ -92,6 +96,7 @@ describe('UrlManager', function () {
       .mockRejectedValue(new Error('Simulated network error'));
     window.TextDecoder = TextDecoder;
     simulatedWebChannel = simulateOldWebChannelAndFrameScript(geckoProfiler);
+    browserConnectionStatus = await createBrowserConnection('Firefox/123.0');
   });
 
   afterEach(function () {

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -34,7 +34,7 @@ describe('calltree/ZipFileTree', function () {
 
     const renderResult = render(
       <Provider store={store}>
-        <ZipFileViewer />
+        <ZipFileViewer browserConnection={null} />
       </Provider>
     );
     const { getState, dispatch } = store;

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -38,9 +38,17 @@ exports[`app/AppViewRouter renders an home when the user pressed back after an e
 </div>
 `;
 
-exports[`app/AppViewRouter renders an home when the user pressed back after an error 2`] = `<home />`;
+exports[`app/AppViewRouter renders an home when the user pressed back after an error 2`] = `
+<home
+  browserconnectionstatus="[object Object]"
+/>
+`;
 
-exports[`app/AppViewRouter renders an initial home 1`] = `<home />`;
+exports[`app/AppViewRouter renders an initial home 1`] = `
+<home
+  browserconnectionstatus="[object Object]"
+/>
+`;
 
 exports[`app/AppViewRouter renders temporary errors 1`] = `
 <div

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/AppViewRouter does not try to retrieve a profile when moving from from-browser to public 1`] = `<profile-viewer />`;
+exports[`app/AppViewRouter does not try to retrieve a profile when moving from from-browser to public 1`] = `
+<profile-viewer
+  browserconnection="[object Object]"
+/>
+`;
 
 exports[`app/AppViewRouter renders an home when the user pressed back after an error 1`] = `
 <div
@@ -175,7 +179,11 @@ exports[`app/AppViewRouter renders the addon loading page, and the profile view 
 </div>
 `;
 
-exports[`app/AppViewRouter renders the addon loading page, and the profile view after capturing 2`] = `<profile-viewer />`;
+exports[`app/AppViewRouter renders the addon loading page, and the profile view after capturing 2`] = `
+<profile-viewer
+  browserconnection="[object Object]"
+/>
+`;
 
 exports[`app/AppViewRouter renders the profile view 1`] = `
 <div
@@ -232,4 +240,8 @@ exports[`app/AppViewRouter renders the profile view 1`] = `
 </div>
 `;
 
-exports[`app/AppViewRouter renders the profile view 2`] = `<profile-viewer />`;
+exports[`app/AppViewRouter renders the profile view 2`] = `
+<profile-viewer
+  browserconnection="[object Object]"
+/>
+`;

--- a/src/test/fixtures/mocks/browser-connection.js
+++ b/src/test/fixtures/mocks/browser-connection.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
+
+export function createMockBrowserConnection(): BrowserConnection {
+  return {
+    getProfile: jest.fn().mockImplementation(async () => {
+      throw new Error('getProfile unimplemented on mock browserConnection');
+    }),
+    getSymbolTable: jest.fn().mockImplementation(async () => {
+      throw new Error('getProfile unimplemented on mock browserConnection');
+    }),
+    establishConnectionViaFrameScriptIfNeeded: jest
+      .fn()
+      .mockImplementation(async () => {
+        // Do nothing
+      }),
+  };
+}

--- a/src/test/fixtures/mocks/web-channel.js
+++ b/src/test/fixtures/mocks/web-channel.js
@@ -86,3 +86,103 @@ export function mockWebChannel() {
     },
   };
 }
+
+export function simulateOldWebChannelAndFrameScript(
+  geckoProfiler: $GeckoProfiler
+) {
+  const webChannel = mockWebChannel();
+
+  const { registerMessageToChromeListener, triggerResponse } = webChannel;
+  // Pretend that this browser does not support obtaining the profile via
+  // the WebChannel. This will trigger fallback to the frame script /
+  // geckoProfiler API.
+  registerMessageToChromeListener((message) => {
+    switch (message.type) {
+      case 'STATUS_QUERY': {
+        triggerResponse(
+          ({
+            type: 'STATUS_RESPONSE',
+            requestId: message.requestId,
+            menuButtonIsEnabled: true,
+          }: any)
+        );
+        break;
+      }
+      default: {
+        triggerResponse(
+          ({
+            error: `Unexpected message ${message.type}`,
+          }: any)
+        );
+        break;
+      }
+    }
+  });
+
+  // Simulate the frame script's geckoProfiler API.
+  window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
+
+  return webChannel;
+}
+
+export function simulateWebChannel(profileGetter: () => mixed) {
+  const webChannel = mockWebChannel();
+
+  const { registerMessageToChromeListener, triggerResponse } = webChannel;
+  async function simulateBrowserSide(message) {
+    switch (message.type) {
+      case 'STATUS_QUERY': {
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: {
+            menuButtonIsEnabled: true,
+            version: 1,
+          },
+        });
+        break;
+      }
+      case 'ENABLE_MENU_BUTTON': {
+        triggerResponse({
+          type: 'ERROR_RESPONSE',
+          requestId: message.requestId,
+          error:
+            'ENABLE_MENU_BUTTON is a valid message but not covered by this test.',
+        });
+        break;
+      }
+      case 'GET_PROFILE': {
+        const profile: ArrayBuffer | MixedObject = await profileGetter();
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: profile,
+        });
+        break;
+      }
+      case 'GET_SYMBOL_TABLE':
+      case 'QUERY_SYMBOLICATION_API': {
+        triggerResponse({
+          type: 'ERROR_RESPONSE',
+          requestId: message.requestId,
+          error: 'No symbol tables available',
+        });
+        break;
+      }
+      default: {
+        triggerResponse({
+          type: 'ERROR_RESPONSE',
+          requestId: message.requestId,
+          error: `Unexpected message ${message.type}`,
+        });
+        break;
+      }
+    }
+  }
+
+  registerMessageToChromeListener((message) => {
+    simulateBrowserSide(message);
+  });
+
+  return webChannel;
+}

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -21,6 +21,7 @@ import * as UrlStateSelectors from '../../selectors/url-state';
 import { getThreadSelectors } from '../../selectors/per-thread';
 import { getView } from '../../selectors/app';
 import { urlFromState } from '../../app-logic/url-handling';
+import { createBrowserConnection } from '../../app-logic/browser-connection';
 import {
   viewProfile,
   finalizeProfileView,
@@ -762,7 +763,10 @@ describe('actions/receive-profile', function () {
             'web-channel': setupWithWebChannel,
           }[setupWith];
           const { dispatch, getState } = setupFn(profileAs);
-          await dispatch(retrieveProfileFromBrowser());
+          const browserConnectionStatus = await createBrowserConnection(
+            'Firefox/123.0'
+          );
+          await dispatch(retrieveProfileFromBrowser(browserConnectionStatus));
           expect(console.warn).toHaveBeenCalledTimes(2);
 
           const state = getState();
@@ -786,7 +790,10 @@ describe('actions/receive-profile', function () {
     it('tries to symbolicate the received profile, frame script version', async () => {
       const { dispatch, geckoProfiler } = setupWithFrameScript();
 
-      await dispatch(retrieveProfileFromBrowser());
+      const browserConnectionStatus = await createBrowserConnection(
+        'Firefox/123.0'
+      );
+      await dispatch(retrieveProfileFromBrowser(browserConnectionStatus));
 
       expect(geckoProfiler.getSymbolTable).toHaveBeenCalledWith(
         'firefox',
@@ -804,7 +811,10 @@ describe('actions/receive-profile', function () {
     it('tries to symbolicate the received profile, webchannel version', async () => {
       const { dispatch } = setupWithWebChannel();
 
-      await dispatch(retrieveProfileFromBrowser());
+      const browserConnectionStatus = await createBrowserConnection(
+        'Firefox/123.0'
+      );
+      await dispatch(retrieveProfileFromBrowser(browserConnectionStatus));
 
       expect(window.fetch).toHaveBeenCalledWith(
         'https://symbols.mozilla.org/symbolicate/v5',
@@ -2035,8 +2045,16 @@ describe('actions/receive-profile', function () {
       jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       const store = blankStore();
-      const { browserConnection } = await store.dispatch(
-        retrieveProfileForRawUrl(location)
+      const browserConnectionStatus = await createBrowserConnection(
+        'Firefox/123.0'
+      );
+      const browserConnection =
+        browserConnectionStatus.status === 'ESTABLISHED'
+          ? browserConnectionStatus.browserConnection
+          : null;
+
+      await store.dispatch(
+        retrieveProfileForRawUrl(location, browserConnectionStatus)
       );
 
       // To find stupid mistakes more easily, check that we didn't get a fatal

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1419,7 +1419,16 @@ describe('actions/receive-profile', function () {
       // Load a profile from the supplied mockFileOptions.
       const file = mockFile(mockFileOptions);
       const { dispatch, getState } = blankStore();
-      await dispatch(retrieveProfileFromFile(file, mockFileReader));
+      const browserConnectionStatus = await createBrowserConnection(
+        'Firefox/123.0'
+      );
+      const browserConnection =
+        browserConnectionStatus.status === 'ESTABLISHED'
+          ? browserConnectionStatus.browserConnection
+          : undefined;
+      await dispatch(
+        retrieveProfileFromFile(file, browserConnection, mockFileReader)
+      );
       const view = getView(getState());
       return { getState, dispatch, view };
     }

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -71,7 +71,11 @@ import { expandUrl } from '../../utils/shorten-url';
 jest.mock('../../utils/shorten-url');
 
 import { TextEncoder, TextDecoder } from 'util';
-import { mockWebChannel } from '../fixtures/mocks/web-channel';
+import {
+  mockWebChannel,
+  simulateOldWebChannelAndFrameScript,
+  simulateWebChannel,
+} from '../fixtures/mocks/web-channel';
 
 function simulateSymbolStoreHasNoCache() {
   // SymbolStoreDB is a mock, but Flow doesn't know this. That's why we use
@@ -88,104 +92,6 @@ function simulateSymbolStoreHasNoCache() {
         )
       ),
   }));
-}
-
-function simulateOldWebChannelAndFrameScript(geckoProfiler) {
-  const webChannel = mockWebChannel();
-
-  const { registerMessageToChromeListener, triggerResponse } = webChannel;
-  // Pretend that this browser does not support obtaining the profile via
-  // the WebChannel. This will trigger fallback to the frame script /
-  // geckoProfiler API.
-  registerMessageToChromeListener((message) => {
-    switch (message.type) {
-      case 'STATUS_QUERY': {
-        triggerResponse(
-          ({
-            type: 'STATUS_RESPONSE',
-            requestId: message.requestId,
-            menuButtonIsEnabled: true,
-          }: any)
-        );
-        break;
-      }
-      default: {
-        triggerResponse(
-          ({
-            error: `Unexpected message ${message.type}`,
-          }: any)
-        );
-        break;
-      }
-    }
-  });
-
-  // Simulate the frame script's geckoProfiler API.
-  window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
-
-  return webChannel;
-}
-
-function simulateWebChannel(profileGetter) {
-  const webChannel = mockWebChannel();
-
-  const { registerMessageToChromeListener, triggerResponse } = webChannel;
-  async function simulateBrowserSide(message) {
-    switch (message.type) {
-      case 'STATUS_QUERY': {
-        triggerResponse({
-          type: 'SUCCESS_RESPONSE',
-          requestId: message.requestId,
-          response: {
-            menuButtonIsEnabled: true,
-            version: 1,
-          },
-        });
-        break;
-      }
-      case 'ENABLE_MENU_BUTTON': {
-        triggerResponse({
-          type: 'ERROR_RESPONSE',
-          requestId: message.requestId,
-          error:
-            'ENABLE_MENU_BUTTON is a valid message but not covered by this test.',
-        });
-        break;
-      }
-      case 'GET_PROFILE': {
-        const profile: ArrayBuffer | MixedObject = await profileGetter();
-        triggerResponse({
-          type: 'SUCCESS_RESPONSE',
-          requestId: message.requestId,
-          response: profile,
-        });
-        break;
-      }
-      case 'GET_SYMBOL_TABLE':
-      case 'QUERY_SYMBOLICATION_API': {
-        triggerResponse({
-          type: 'ERROR_RESPONSE',
-          requestId: message.requestId,
-          error: 'No symbol tables available',
-        });
-        break;
-      }
-      default: {
-        triggerResponse({
-          type: 'ERROR_RESPONSE',
-          requestId: message.requestId,
-          error: `Unexpected message ${message.type}`,
-        });
-        break;
-      }
-    }
-  }
-
-  registerMessageToChromeListener((message) => {
-    simulateBrowserSide(message);
-  });
-
-  return webChannel;
 }
 
 describe('actions/receive-profile', function () {


### PR DESCRIPTION
This PR supersedes #3504 and passes tests. However, the implementation is rather ugly. The `browserConnection` prop needs to be passed all the way down the following chain: `<Root>` -> `<AppViewRouter>` -> (`<ZipFileViewer>` ->) `<ProfileViewer>` -> `<MenuButtons>` -> `<MetaInfoPanel>`.

I'd love to hear suggestions for alternative approaches! I've considered the following:

 - Passing down a callback prop for the button click handler instead, e.g. `onResymbolicateButtonClick`.
 - Making more use of React children props, e.g. `<ZipFileViewer><ProfileViewer infoPanel={<MetaInfoPanel browserConnection={...} />}></ZipFileViewer>`
 - A global variable for the browserConnectionStatus. But global variables make tests really annoying, I'd like to avoid them if at all possible. We currently are in the global variable situation with window.geckoProfilerPromise and it is very annoying to deal with.
 - [React Context](https://reactjs.org/docs/context.html). I'm not sure this would actually solve the problem - you'd still need to pass down the context object that's returned by the call to `React.createContext()`, or put it in a global. It would make the testing situation easier, though. I also don't know how it interacts with connected components.
 - Putting the browserConnection in the redux state. I didn't really consider this because it's very strange to store something in the state that you call methods on. The state should be more like a plain-old-data object.

---

This PR makes the following workflow work:

 1. Capture a profile in local build A but save it without symbolicating, e.g. as a shutdown profile.
 2. Import the file into the profiler in Firefox build B, which cannot fully symbolicate it.
 3. Upload the profile in build B. Example result: https://share.firefox.dev/37WzwZF
 4. Load the public profile in build A.
 5. Re-symbolicate in build A. Example result: https://share.firefox.dev/3z4Agb1