### PR TITLE
Change the hovering logic of track context menu pid to more keyboard friendly one

### DIFF
--- a/src/components/timeline/TrackContextMenu.css
+++ b/src/components/timeline/TrackContextMenu.css
@@ -19,7 +19,7 @@
   color: var(--grey-90-a60);
 }
 
-.react-contextmenu-item:hover .timelineTrackContextMenuPid {
+.react-contextmenu-item--selected .timelineTrackContextMenuPid {
   color: #fff;
 }
 


### PR DESCRIPTION
This is a pretty small PR that changes the hovering/highlighting logic of the track context menu pid. It's only a css change, so I didn't include any tests.

STR: 
1. Open up a profile (example profile: [production](https://share.firefox.dev/3HOXCX9) - [deploy preview](https://deploy-preview-3666--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-1wr&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6))
2. Open the main track context menu.
3. Use down arrow key to highlight a global track.
4. See the color of the pid.

Before:
<img width="264" alt="Screen Shot 2021-11-23 at 1 58 36 PM" src="https://user-images.githubusercontent.com/466239/143028628-f053823f-1b08-49a0-851a-6241bd6159d4.png">
After:
<img width="268" alt="Screen Shot 2021-11-23 at 1 58 55 PM" src="https://user-images.githubusercontent.com/466239/143028667-f8e89e27-5555-415f-92b9-fec8a8308849.png">


