### PR TITLE
Prevent enter key to close the track context menu

### DIFF
--- a/src/components/shared/ContextMenuNoHidingOnEnter.js
+++ b/src/components/shared/ContextMenuNoHidingOnEnter.js
@@ -6,13 +6,13 @@
 import { ContextMenu, hideMenu as hideContextMenu } from 'react-contextmenu';
 
 /**
- * This is the track context menu component that is used mainly in the timeline.
+ * This is a context menu component with adjusted hide menu behavior.
  * This implementation changes the behavior of the extended ContextMenu component
- * slightly by overriding the hideMenu method. For track context menu, we don't
+ * slightly by overriding the hideMenu method. For some context menus, we don't
  * want enter key to close the context menu completely because we would like to
  * select multiple items in a row without closing the context menu with it.
  */
-export class TrackContextMenu extends ContextMenu {
+export class ContextMenuNoHidingOnEnter extends ContextMenu {
   /**
    * This hideMenu method is the overriden version of the ContextMenu component.
    * See the original function here:

--- a/src/components/shared/TrackContextMenu.js
+++ b/src/components/shared/TrackContextMenu.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { ContextMenu, hideMenu as hideContextMenu } from 'react-contextmenu';
+
+/**
+ * This is the track context menu component that is used mainly in the timeline.
+ * This implementation changes the behavior of the extended ContextMenu component
+ * slightly by overriding the hideMenu method. For track context menu, we don't
+ * want enter key to close the context menu completely because we would like to
+ * select multiple items in a row without closing the context menu with it.
+ */
+export class TrackContextMenu extends ContextMenu {
+  /**
+   * This hideMenu method is the overriden version of the ContextMenu component.
+   * See the original function here:
+   * https://github.com/vkbansal/react-contextmenu/blob/d9018dbfbd6e21423cb2b753b3762adf5a6d77b0/src/ContextMenu.js#L156-L160
+   */
+  hideMenu = (e: KeyboardEvent) => {
+    // Differently, we are only checking for the ESC key instead of both ESC and enter.
+    if (e.keyCode === 27) {
+      hideContextMenu();
+    }
+  };
+}

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -42,7 +42,7 @@ import {
   getSearchFilteredGlobalTracks,
   getSearchFilteredLocalTracksByPid,
 } from 'firefox-profiler/profile-logic/tracks';
-import { TrackContextMenu } from 'firefox-profiler/components/shared/TrackContextMenu';
+import { ContextMenuNoHidingOnEnter } from 'firefox-profiler/components/shared/ContextMenuNoHidingOnEnter';
 import classNames from 'classnames';
 
 import type {
@@ -842,7 +842,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     );
 
     return (
-      <TrackContextMenu
+      <ContextMenuNoHidingOnEnter
         id="TimelineTrackContextMenu"
         className="timelineTrackContextMenu"
         onShow={this._onShow}
@@ -905,7 +905,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
           }
           return null;
         })}
-      </TrackContextMenu>
+      </ContextMenuNoHidingOnEnter>
     );
   }
 }

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -4,7 +4,7 @@
 
 // @flow
 import React, { PureComponent } from 'react';
-import { ContextMenu, MenuItem } from 'react-contextmenu';
+import { MenuItem } from 'react-contextmenu';
 import { Localized } from '@fluent/react';
 
 import './TrackContextMenu.css';
@@ -42,6 +42,7 @@ import {
   getSearchFilteredGlobalTracks,
   getSearchFilteredLocalTracksByPid,
 } from 'firefox-profiler/profile-logic/tracks';
+import { TrackContextMenu } from 'firefox-profiler/components/shared/TrackContextMenu';
 import classNames from 'classnames';
 
 import type {
@@ -841,7 +842,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     );
 
     return (
-      <ContextMenu
+      <TrackContextMenu
         id="TimelineTrackContextMenu"
         className="timelineTrackContextMenu"
         onShow={this._onShow}
@@ -904,7 +905,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
           }
           return null;
         })}
-      </ContextMenu>
+      </TrackContextMenu>
     );
   }
 }

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -723,5 +723,20 @@ describe('timeline/TrackContextMenu', function () {
       // Make sure that the context menu is still visible.
       expect(isContextMenuVisible()).toBeTruthy();
     });
+
+    it('escape key closes the context menu', () => {
+      const { showContextMenu, isContextMenuVisible } = setup();
+      showContextMenu();
+      // Make sure that the context menu is open.
+      expect(isContextMenuVisible()).toBeTruthy();
+
+      // Now press escape to test this behavior.
+      fireFullKeyPress(screen.getByPlaceholderText('Enter filter terms'), {
+        key: 'Escape',
+      });
+
+      // Make sure that the context menu is closed now.
+      expect(isContextMenuVisible()).toBeFalsy();
+    });
   });
 });

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -7,6 +7,7 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import { fireEvent } from '@testing-library/react';
+import { showMenu } from 'react-contextmenu';
 
 import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
 import { ensureExists } from '../../utils/flow';
@@ -30,7 +31,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 
 import { storeWithProfile } from '../fixtures/stores';
-import { fireFullClick } from '../fixtures/utils';
+import { fireFullClick, fireFullKeyPress } from '../fixtures/utils';
 
 describe('timeline/TrackContextMenu', function () {
   beforeEach(() => {
@@ -63,6 +64,22 @@ describe('timeline/TrackContextMenu', function () {
       jest.runAllTimers();
     };
 
+    const isContextMenuVisible = (): boolean => {
+      const contextMenu = ensureExists(
+        document.querySelector('.react-contextmenu'),
+        `Couldn't find the context menu.`
+      );
+      return contextMenu.classList.contains('react-contextmenu--visible');
+    };
+
+    const showContextMenu = () => {
+      showMenu({
+        data: null,
+        id: 'TimelineTrackContextMenu',
+        position: { x: 0, y: 0 },
+      });
+    };
+
     return {
       ...renderResult,
       dispatch,
@@ -70,6 +87,8 @@ describe('timeline/TrackContextMenu', function () {
       profile,
       store,
       changeSearchFilter,
+      isContextMenuVisible,
+      showContextMenu,
     };
   }
 
@@ -686,6 +705,23 @@ describe('timeline/TrackContextMenu', function () {
       expect(screen.queryByText('GeckoMain')).not.toBeInTheDocument();
       expect(screen.getByText('Content Process')).toBeInTheDocument();
       expect(screen.getByText('Style')).toBeInTheDocument();
+    });
+  });
+
+  describe('keyboard controls', function () {
+    it('enter key would not close the context menu', () => {
+      const { showContextMenu, isContextMenuVisible } = setup();
+      showContextMenu();
+      // Make sure that the context menu is open.
+      expect(isContextMenuVisible()).toBeTruthy();
+
+      // Now press enter to test this behavior.
+      fireFullKeyPress(screen.getByPlaceholderText('Enter filter terms'), {
+        key: 'Enter',
+      });
+
+      // Make sure that the context menu is still visible.
+      expect(isContextMenuVisible()).toBeTruthy();
     });
   });
 });

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -370,6 +370,7 @@ export function fireFullKeyPress(
   const optionsConfigured = {
     code: codes[options.key.toLowerCase()],
     charCode: codes[options.key.toLowerCase()],
+    keyCode: codes[options.key.toLowerCase()],
     ...options,
   };
 


### PR DESCRIPTION
This is a follow-up of #3634.

With this, enter key will not close the context menu when pressed while entering a search filter item.

[Main branch](https://main--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-1wr&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6)
[Deploy preview](https://deploy-preview-3667--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-1wr&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6)