### PR TITLE
Show a warning message when search filter doesn't match with any track

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -660,7 +660,7 @@ TrackContextMenu--show-all-tracks-below = Show all tracks below
 # any track.
 # Variables:
 #   $searchFilter (String) - The search filter string that user enters.
-TrackContextMenu--no-track-matching = No track matching “{ $searchFilter }”
+TrackContextMenu--no-results-found = No results found for “<span>{ $searchFilter }</span>”
 
 ## TrackSearchField
 ## The component that is used for the search input in the track context menu.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -656,6 +656,12 @@ TrackContextMenu--show-all-tracks = Show all tracks
 # below it.
 TrackContextMenu--show-all-tracks-below = Show all tracks below
 
+# This is used in the tracks context menu when the search filter doesn't match
+# any track.
+# Variables:
+#   $searchFilter (String) - The search filter string that user enters.
+TrackContextMenu--no-track-matching = No track matching “{ $searchFilter }”
+
 ## TrackSearchField
 ## The component that is used for the search input in the track context menu.
 

--- a/src/components/timeline/TrackContextMenu.css
+++ b/src/components/timeline/TrackContextMenu.css
@@ -27,3 +27,9 @@
   max-height: 43.5vh;
   overflow-y: auto;
 }
+
+.trackContextMenuSearchFilter {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -873,6 +873,12 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       return null;
     });
 
+    // If every global track is null, it means that they are all filtered out.
+    // In that case, we should show a warning explaining this.
+    const isTrackListEmpty = filteredGlobalTracks.every(
+      (track) => track === null
+    );
+
     return (
       <ContextMenuNoHidingOnEnter
         id="TimelineTrackContextMenu"
@@ -894,7 +900,18 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {isolateScreenshot}
         {hideTrack}
         {separator}
-        {filteredGlobalTracks}
+        {isTrackListEmpty ? (
+          <Localized
+            id="TrackContextMenu--no-track-matching"
+            vars={{ searchFilter: searchFilter }}
+          >
+            <MenuItem disabled={true}>
+              No track matching “{searchFilter}”
+            </MenuItem>
+          </Localized>
+        ) : (
+          filteredGlobalTracks
+        )}
       </ContextMenuNoHidingOnEnter>
     );
   }

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -841,6 +841,38 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       searchFilter
     );
 
+    const filteredGlobalTracks = globalTrackOrder.map((globalTrackIndex) => {
+      const globalTrack = globalTracks[globalTrackIndex];
+      if (rightClickedTrack === null) {
+        return this.renderGlobalTrack(
+          globalTrackIndex,
+          searchFilteredGlobalTracks,
+          searchFilteredLocalTracksByPid
+        );
+      } else if (
+        rightClickedTrack.type === 'global' &&
+        rightClickedTrack.trackIndex === globalTrackIndex
+      ) {
+        return this.renderGlobalTrack(
+          globalTrackIndex,
+          searchFilteredGlobalTracks,
+          searchFilteredLocalTracksByPid
+        );
+      } else if (
+        rightClickedTrack.type === 'local' &&
+        globalTrack.type === 'process'
+      ) {
+        if (rightClickedTrack.pid === globalTrack.pid) {
+          return this.renderGlobalTrack(
+            globalTrackIndex,
+            searchFilteredGlobalTracks,
+            searchFilteredLocalTracksByPid
+          );
+        }
+      }
+      return null;
+    });
+
     return (
       <ContextMenuNoHidingOnEnter
         id="TimelineTrackContextMenu"
@@ -862,37 +894,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {isolateScreenshot}
         {hideTrack}
         {separator}
-        {globalTrackOrder.map((globalTrackIndex) => {
-          const globalTrack = globalTracks[globalTrackIndex];
-          if (rightClickedTrack === null) {
-            return this.renderGlobalTrack(
-              globalTrackIndex,
-              searchFilteredGlobalTracks,
-              searchFilteredLocalTracksByPid
-            );
-          } else if (
-            rightClickedTrack.type === 'global' &&
-            rightClickedTrack.trackIndex === globalTrackIndex
-          ) {
-            return this.renderGlobalTrack(
-              globalTrackIndex,
-              searchFilteredGlobalTracks,
-              searchFilteredLocalTracksByPid
-            );
-          } else if (
-            rightClickedTrack.type === 'local' &&
-            globalTrack.type === 'process'
-          ) {
-            if (rightClickedTrack.pid === globalTrack.pid) {
-              return this.renderGlobalTrack(
-                globalTrackIndex,
-                searchFilteredGlobalTracks,
-                searchFilteredLocalTracksByPid
-              );
-            }
-          }
-          return null;
-        })}
+        {filteredGlobalTracks}
       </ContextMenuNoHidingOnEnter>
     );
   }

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -346,7 +346,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     }
 
     return (
-      <React.Fragment>
+      <React.Fragment key={trackIndex}>
         <MenuItem
           key={trackIndex}
           preventClose={true}
@@ -865,41 +865,29 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {globalTrackOrder.map((globalTrackIndex) => {
           const globalTrack = globalTracks[globalTrackIndex];
           if (rightClickedTrack === null) {
-            return (
-              <div key={globalTrackIndex}>
-                {this.renderGlobalTrack(
-                  globalTrackIndex,
-                  searchFilteredGlobalTracks,
-                  searchFilteredLocalTracksByPid
-                )}
-              </div>
+            return this.renderGlobalTrack(
+              globalTrackIndex,
+              searchFilteredGlobalTracks,
+              searchFilteredLocalTracksByPid
             );
           } else if (
             rightClickedTrack.type === 'global' &&
             rightClickedTrack.trackIndex === globalTrackIndex
           ) {
-            return (
-              <div key={globalTrackIndex}>
-                {this.renderGlobalTrack(
-                  globalTrackIndex,
-                  searchFilteredGlobalTracks,
-                  searchFilteredLocalTracksByPid
-                )}
-              </div>
+            return this.renderGlobalTrack(
+              globalTrackIndex,
+              searchFilteredGlobalTracks,
+              searchFilteredLocalTracksByPid
             );
           } else if (
             rightClickedTrack.type === 'local' &&
             globalTrack.type === 'process'
           ) {
             if (rightClickedTrack.pid === globalTrack.pid) {
-              return (
-                <div key={globalTrackIndex}>
-                  {this.renderGlobalTrack(
-                    globalTrackIndex,
-                    searchFilteredGlobalTracks,
-                    searchFilteredLocalTracksByPid
-                  )}
-                </div>
+              return this.renderGlobalTrack(
+                globalTrackIndex,
+                searchFilteredGlobalTracks,
+                searchFilteredLocalTracksByPid
               );
             }
           }

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -348,7 +348,6 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     return (
       <React.Fragment key={trackIndex}>
         <MenuItem
-          key={trackIndex}
           preventClose={true}
           data={{ trackIndex }}
           onClick={this._toggleGlobalTrackVisibility}
@@ -902,11 +901,18 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {separator}
         {isTrackListEmpty ? (
           <Localized
-            id="TrackContextMenu--no-track-matching"
+            id="TrackContextMenu--no-results-found"
             vars={{ searchFilter: searchFilter }}
+            elems={{
+              span: <span className="trackContextMenuSearchFilter" />,
+            }}
           >
             <MenuItem disabled={true}>
-              No track matching “{searchFilter}”
+              No results found for “
+              <span className="trackContextMenuSearchFilter">
+                {searchFilter}
+              </span>
+              ”
             </MenuItem>
           </Localized>
         ) : (

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -706,6 +706,32 @@ describe('timeline/TrackContextMenu', function () {
       expect(screen.getByText('Content Process')).toBeInTheDocument();
       expect(screen.getByText('Style')).toBeInTheDocument();
     });
+
+    it('shows a message when search filter does not match any track', () => {
+      const { changeSearchFilter } = setup();
+      const searchText = 'search term';
+
+      // Check if all the tracks are visible at first.
+      expect(screen.getByText('GeckoMain')).toBeInTheDocument();
+      expect(screen.getByText('Content Process')).toBeInTheDocument();
+      expect(screen.getByText('Style')).toBeInTheDocument();
+
+      // Change the search filter with something that doesn't match any track.
+      changeSearchFilter(searchText);
+
+      jest.runAllTimers();
+
+      // There shouldn't be any tracks visible now.
+      expect(screen.queryByText('GeckoMain')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content Process')).not.toBeInTheDocument();
+      expect(screen.queryByText('Style')).not.toBeInTheDocument();
+
+      // Also there should be a text explaining that there is no track matching that text.
+      // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
+      expect(
+        screen.getByText(/No track matching “\u2068search term\u2069”/)
+      ).toBeInTheDocument();
+    });
   });
 
   describe('keyboard controls', function () {

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -726,11 +726,9 @@ describe('timeline/TrackContextMenu', function () {
       expect(screen.queryByText('Content Process')).not.toBeInTheDocument();
       expect(screen.queryByText('Style')).not.toBeInTheDocument();
 
-      // Also there should be a text explaining that there is no track matching that text.
-      // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
-      expect(
-        screen.getByText(/No track matching “\u2068search term\u2069”/)
-      ).toBeInTheDocument();
+      // Also there should be a text explaining that there is no results found
+      // for that text.
+      expect(screen.getByText(/No results found for/)).toBeInTheDocument();
     });
   });
 

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -26,21 +26,19 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
   <div
     class="react-contextmenu-separator"
   />
-  <div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
-      role="menuitem"
-      tabindex="-1"
-      title="Screenshots"
-    >
-      <span>
-        Screenshots
-      </span>
-      <span
-        class="timelineTrackContextMenuSpacer"
-      />
-    </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
+    role="menuitem"
+    tabindex="-1"
+    title="Screenshots"
+  >
+    <span>
+      Screenshots
+    </span>
+    <span
+      class="timelineTrackContextMenuSpacer"
+    />
   </div>
 </nav>
 `;
@@ -79,44 +77,42 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
   <div
     class="react-contextmenu-separator"
   />
-  <div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
-      role="menuitem"
-      tabindex="-1"
-      title="Content Process (Process ID: 222)"
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
+    role="menuitem"
+    tabindex="-1"
+    title="Content Process (Process ID: 222)"
+  >
+    <span>
+      Content Process
+    </span>
+    <span
+      class="timelineTrackContextMenuSpacer"
+    />
+    <span
+      class="timelineTrackContextMenuPid"
     >
-      <span>
-        Content Process
-      </span>
-      <span
-        class="timelineTrackContextMenuSpacer"
-      />
-      <span
-        class="timelineTrackContextMenuPid"
-      >
-        (
-        222
-        )
-      </span>
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      DOM Worker
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Style
-    </div>
+      (
+      222
+      )
+    </span>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item checkable indented checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    DOM Worker
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item checkable indented checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Style
   </div>
 </nav>
 `;
@@ -136,44 +132,42 @@ exports[`timeline/TrackContextMenu selected global track network track will be d
   >
     Hide “⁨Process 0⁩”
   </div>
-  <div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
-      role="menuitem"
-      tabindex="-1"
-      title="Process 0 (Process ID: 0)"
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
+    role="menuitem"
+    tabindex="-1"
+    title="Process 0 (Process ID: 0)"
+  >
+    <span>
+      Process 0
+    </span>
+    <span
+      class="timelineTrackContextMenuSpacer"
+    />
+    <span
+      class="timelineTrackContextMenuPid"
     >
-      <span>
-        Process 0
-      </span>
-      <span
-        class="timelineTrackContextMenuSpacer"
-      />
-      <span
-        class="timelineTrackContextMenuPid"
-      >
-        (
-        0
-        )
-      </span>
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Network
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Empty
-    </div>
+      (
+      0
+      )
+    </span>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item checkable indented checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Network
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item checkable indented checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Empty
   </div>
 </nav>
 `;
@@ -204,44 +198,42 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
   <div
     class="react-contextmenu-separator"
   />
-  <div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
-      role="menuitem"
-      tabindex="-1"
-      title="Content Process (Process ID: 222)"
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
+    role="menuitem"
+    tabindex="-1"
+    title="Content Process (Process ID: 222)"
+  >
+    <span>
+      Content Process
+    </span>
+    <span
+      class="timelineTrackContextMenuSpacer"
+    />
+    <span
+      class="timelineTrackContextMenuPid"
     >
-      <span>
-        Content Process
-      </span>
-      <span
-        class="timelineTrackContextMenuSpacer"
-      />
-      <span
-        class="timelineTrackContextMenuPid"
-      >
-        (
-        222
-        )
-      </span>
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      DOM Worker
-    </div>
-    <div
-      aria-disabled="false"
-      class="react-contextmenu-item checkable indented checked"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Style
-    </div>
+      (
+      222
+      )
+    </span>
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item checkable indented checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    DOM Worker
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item checkable indented checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Style
   </div>
 </nav>
 `;


### PR DESCRIPTION
This is a follow-up for the initial track context menu PR. Previously, when a search filter doesn't match anything, it was not showing anything, which was a bit confusing. Now it properly shows a warning message that no track found matching the given search filter.

Before:
![Screenshot from 2021-11-24 13-45-36](https://user-images.githubusercontent.com/466239/143241018-5945fe97-fa46-4a24-8d92-199f94219fe2.png)
After:
![Screenshot from 2021-11-24 13-45-30](https://user-images.githubusercontent.com/466239/143241057-4869406f-4af8-4ab0-a3f5-f544d2395101.png)

Example profile:
[Before](https://main--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-1w9bwrt&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6)
[After](https://deploy-preview-3670--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-1w9bwrt&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6)