### PR TITLE
Move the call to createBrowserConnection into UrlManager.

### DIFF
--- a/src/components/app/ProfileLoader.js
+++ b/src/components/app/ProfileLoader.js
@@ -13,6 +13,7 @@ import {
   retrieveProfileOrZipFromUrl,
   retrieveProfilesToCompare,
 } from 'firefox-profiler/actions/receive-profile';
+import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import {
   getDataSource,
   getHash,
@@ -41,7 +42,7 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class ProfileLoaderImpl extends PureComponent<Props> {
-  _retrieveProfileFromDataSource = () => {
+  _retrieveProfileFromDataSource = async () => {
     const {
       dataSource,
       hash,
@@ -53,9 +54,13 @@ class ProfileLoaderImpl extends PureComponent<Props> {
       retrieveProfilesToCompare,
     } = this.props;
     switch (dataSource) {
-      case 'from-browser':
-        retrieveProfileFromBrowser();
+      case 'from-browser': {
+        const browserConnectionStatus = await createBrowserConnection(
+          'Firefox/123.0'
+        );
+        retrieveProfileFromBrowser(browserConnectionStatus);
         break;
+      }
       case 'from-file':
         // retrieveProfileFromFile should already have been called
         break;

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -19,6 +19,7 @@ import {
   stateFromLocation,
   getIsHistoryReplaceState,
 } from 'firefox-profiler/app-logic/url-handling';
+import { createBrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import {
   retrieveProfileForRawUrl,
   typeof retrieveProfileForRawUrl as RetrieveProfileForRawUrl,
@@ -93,6 +94,16 @@ class UrlManagerImpl extends React.PureComponent<Props> {
     // Notify the UI that we are starting to fetch profiles.
     startFetchingProfiles();
 
+    // Establish a connection to the browser, for certain URLs. This isn't the best
+    // place to do it, but hopefully this code will be cleaned up soon;
+    // in the future, this will have a normal (non-overridden) UserAgent check and
+    // will be done for all URLs.
+    let browserConnectionStatus;
+    const route = window.location.pathname.split('/').filter((s) => s)[0];
+    if (['from-browser', 'from-addon', 'from-file'].includes(route)) {
+      browserConnectionStatus = await createBrowserConnection('Firefox/123.0');
+    }
+
     try {
       // Process the raw url and fetch the profile.
       // We try to fetch the profile before setting the url state, because we
@@ -106,9 +117,16 @@ class UrlManagerImpl extends React.PureComponent<Props> {
       //
       // To handle the latter case properly, we won't `pushState` if we're in
       // a FATAL_ERROR state.
-      const { profile, browserConnection } = await retrieveProfileForRawUrl(
-        window.location
+
+      const profile = await retrieveProfileForRawUrl(
+        window.location,
+        browserConnectionStatus
       );
+      const browserConnection =
+        browserConnectionStatus !== undefined &&
+        browserConnectionStatus.status === 'ESTABLISHED'
+          ? browserConnectionStatus.browserConnection
+          : null;
       setupInitialUrlState(window.location, profile, browserConnection);
     } catch (error) {
       // Complete the URL setup, as values can come from the user, so we should

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -80,7 +80,8 @@ describe('app/AppViewRouter', function () {
     navigateToFromBrowserProfileLoadingPage();
     dispatch(waitingForProfileFromBrowser());
     expect(container.firstChild).toMatchSnapshot();
-    expect(retrieveProfileFromBrowser).toBeCalled();
+    // We do not check that retrieveProfileFromBrowser gets called, because the call
+    // happens asynchronously.
 
     const { profile } = getProfileFromTextSamples(`A`);
     dispatch(viewProfile(profile));


### PR DESCRIPTION
This means we don't need to awkwardly propagate the browserConnection
back out of retrieveProfileFromBrowser and retrieveProfileForRawUrl.

It does mean that we will call createBrowserConnection from more places.
I'm aiming to reduce the number of callsites of createBrowserConnection
in the future, but the path to get there is somewhat unclear at the moment.