### PR TITLE
Add a Safari-specific warning for #3446.

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -26,20 +26,20 @@ AppHeader--github-icon =
 ## AppViewRouter
 ## This is used for displaying errors when loading the application.
 
-AppViewRouter--error-message-unpublished =
-    .message = Couldn’t retrieve the profile from { -firefox-brand-name }.
+AppViewRouter--error-unpublished = Couldn’t retrieve the profile from { -firefox-brand-name }.
+AppViewRouter--error-from-file = Couldn’t read the file or parse the profile in it.
+AppViewRouter--error-local = Not implemented yet.
+AppViewRouter--error-public = Could not download the profile.
+AppViewRouter--error-from-url = Could not download the profile.
 
-AppViewRouter--error-message-from-file =
-    .message = Couldn’t read the file or parse the profile in it.
-
-AppViewRouter--error-message-local =
-    .message = Not implemented yet.
-
-AppViewRouter--error-message-public =
-    .message = Could not download the profile.
-
-AppViewRouter--error-message-from-url =
-    .message = Could not download the profile.
+# This error message is displayed when a Safari-specific error state is encountered.
+# Importing profiles from URLs such as http://127.0.0.1:someport/ is not possible in Safari.
+# https://profiler.firefox.com/from-url/http%3A%2F%2F127.0.0.1%3A3000%2Fprofile.json/
+AppViewRouter--error-from-localhost-url-safari =
+    Due to a <a>specific limitation in Safari</a>, { -profiler-brand-name } is unable
+    to import profiles from the local machine in this browser. Please open 
+    this page in { -firefox-brand-name } or Chrome instead.
+    .title = Safari cannot import local profiles
 
 AppViewRouter--route-not-found--home =
     .specialMessage = The URL you tried to reach was not recognized.
@@ -552,26 +552,13 @@ ProfileFilterNavigator--full-range = Full Range
 
 ## Profile Loader Animation
 
-ProfileLoaderAnimation--loading-message-unpublished =
-    .message = Importing the profile directly from { -firefox-brand-name }…
-
-ProfileLoaderAnimation--loading-message-from-file =
-    .message = Reading the file and processing the profile…
-
-ProfileLoaderAnimation--loading-message-local =
-    .message = Not implemented yet.
-
-ProfileLoaderAnimation--loading-message-public =
-    .message = Downloading and processing the profile…
-
-ProfileLoaderAnimation--loading-message-from-url =
-    .message = Downloading and processing the profile…
-
-ProfileLoaderAnimation--loading-message-compare =
-    .message = Reading and processing profiles…
-
-ProfileLoaderAnimation--loading-message-view-not-found =
-    .message = View not found
+ProfileLoaderAnimation--loading-unpublished = Importing the profile directly from { -firefox-brand-name }…
+ProfileLoaderAnimation--loading-from-file = Reading the file and processing the profile…
+ProfileLoaderAnimation--loading-local = Not implemented yet.
+ProfileLoaderAnimation--loading-public = Downloading and processing the profile…
+ProfileLoaderAnimation--loading-from-url = Downloading and processing the profile…
+ProfileLoaderAnimation--loading-compare = Reading and processing profiles…
+ProfileLoaderAnimation--loading-view-not-found = View not found
 
 ## ProfileRootMessage
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1056,6 +1056,29 @@ function _wait(delayMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
+function _loadProbablyFailedDueToSafariLocalhostHTTPRestriction(
+  url: string,
+  error: Error
+): boolean {
+  if (!navigator.userAgent.match(/Safari\/\d+\.\d+/)) {
+    return false;
+  }
+  // Check if Safari considers this mixed content.
+  const parsedUrl = new URL(url);
+  return (
+    error.name === 'TypeError' &&
+    parsedUrl.protocol === 'http:' &&
+    (parsedUrl.hostname === 'localhost' ||
+      parsedUrl.hostname === '127.0.0.1' ||
+      parsedUrl.hostname === '::1') &&
+    location.protocol === 'https:'
+  );
+}
+
+class SafariLocalhostHTTPLoadError extends Error {
+  name = 'SafariLocalhostHTTPLoadError';
+}
+
 type FetchProfileArgs = {
   url: string,
   onTemporaryError: (TemporaryError) => void,
@@ -1085,21 +1108,31 @@ export async function _fetchProfile(
   const reportError = args.reportError || console.error;
 
   while (true) {
-    const response = await fetch(url);
-    // Case 1: successful answer.
+    let response;
+    try {
+      response = await fetch(url);
+    } catch (e) {
+      // Case 1: Exception.
+      if (_loadProbablyFailedDueToSafariLocalhostHTTPRestriction(url, e)) {
+        throw new SafariLocalhostHTTPLoadError();
+      }
+      throw e;
+    }
+
+    // Case 2: successful answer.
     if (response.ok) {
       return _extractProfileOrZipFromResponse(url, response, reportError);
     }
 
-    // case 2: unrecoverable error.
+    // case 3: unrecoverable error.
     if (response.status !== 403) {
       throw new Error(oneLine`
-        Could not fetch the profile on remote server.
-        Response was: ${response.status} ${response.statusText}.
-      `);
+          Could not fetch the profile on remote server.
+          Response was: ${response.status} ${response.statusText}.
+        `);
     }
 
-    // case 3: 403 errors can be transient while a profile is uploaded.
+    // case 4: 403 errors can be transient while a profile is uploaded.
 
     if (i++ === MAX_WAIT_SECONDS) {
       // In the last iteration we don't send a temporary error because we'll

--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -28,13 +28,13 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import { Localized } from '@fluent/react';
 
 const ERROR_MESSAGES_L10N_ID: { [string]: string } = Object.freeze({
-  'from-browser': 'AppViewRouter--error-message-unpublished',
-  unpublished: 'AppViewRouter--error-message-unpublished',
-  'from-file': 'AppViewRouter--error-message-from-file',
-  local: 'AppViewRouter--error-message-local',
-  public: 'AppViewRouter--error-message-public',
-  'from-url': 'AppViewRouter--error-message-from-url',
-  compare: 'AppViewRouter--error-message-compare',
+  'from-browser': 'AppViewRouter--error-unpublished',
+  unpublished: 'AppViewRouter--error-unpublished',
+  'from-file': 'AppViewRouter--error-from-file',
+  local: 'AppViewRouter--error-local',
+  public: 'AppViewRouter--error-public',
+  'from-url': 'AppViewRouter--error-from-url',
+  compare: 'AppViewRouter--error-compare',
 });
 
 type AppViewRouterStateProps = {|
@@ -81,24 +81,43 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
       case 'DATA_RELOAD':
         return <ProfileLoaderAnimation />;
       case 'FATAL_ERROR': {
-        const message =
-          ERROR_MESSAGES_L10N_ID[dataSource] ||
-          'AppViewRouter--error-message-public';
+        let message =
+          ERROR_MESSAGES_L10N_ID[dataSource] || 'AppViewRouter--error-public';
         let additionalMessage = null;
         if (view.error) {
-          console.error(view.error);
-          additionalMessage =
-            `${view.error.toString()}\n` +
-            'The full stack has been written to the Web Console.';
+          if (view.error.name === 'SafariLocalhostHTTPLoadError') {
+            message = 'AppViewRouter--error-from-localhost-url-safari';
+          } else {
+            console.error(view.error);
+            additionalMessage = (
+              <>
+                <p>{view.error.toString()}</p>
+                <p>The full stack has been written to the Web Console.</p>
+              </>
+            );
+          }
         }
 
         return (
-          <Localized id={message} attrs={{ message: true }}>
+          <Localized
+            id={message}
+            attrs={{ title: true }}
+            elems={{
+              // WebKit bug link, only used for AppViewRouter--message-from-localhost-url-safari
+              a: (
+                <a
+                  href="https://bugs.webkit.org/show_bug.cgi?id=171934"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+            }}
+          >
             <ProfileRootMessage
-              message={message}
               additionalMessage={additionalMessage}
               showLoader={false}
-            />
+              showBackHomeLink={true}
+            >{`missing translation for ${message}`}</ProfileRootMessage>
           </Localized>
         );
       }

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent } from 'react';
+import * as React from 'react';
+import { PureComponent } from 'react';
 import { Localized } from '@fluent/react';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
@@ -18,13 +19,13 @@ import type { AppViewState, State, DataSource } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 const LOADING_MESSAGES_L10N_ID: { [string]: string } = Object.freeze({
-  'from-browser': 'ProfileLoaderAnimation--loading-message-unpublished',
-  unpublished: 'ProfileLoaderAnimation--loading-message-unpublished',
-  'from-file': 'ProfileLoaderAnimation--loading-message-from-file',
-  local: 'ProfileLoaderAnimation--loading-message-local',
-  public: 'ProfileLoaderAnimation--loading-message-public',
-  'from-url': 'ProfileLoaderAnimation--loading-message-from-url',
-  compare: 'ProfileLoaderAnimation--loading-message-compare',
+  'from-browser': 'ProfileLoaderAnimation--loading-unpublished',
+  unpublished: 'ProfileLoaderAnimation--loading-unpublished',
+  'from-file': 'ProfileLoaderAnimation--loading-from-file',
+  local: 'ProfileLoaderAnimation--loading-local',
+  public: 'ProfileLoaderAnimation--loading-public',
+  'from-url': 'ProfileLoaderAnimation--loading-from-url',
+  compare: 'ProfileLoaderAnimation--loading-compare',
 });
 
 // TODO Switch to a proper i18n library
@@ -56,31 +57,37 @@ class ProfileLoaderAnimationImpl extends PureComponent<ProfileLoaderAnimationPro
     const loadingMessage = LOADING_MESSAGES_L10N_ID[dataSource];
     const message = loadingMessage
       ? loadingMessage
-      : 'ProfileLoaderAnimation--loading-message-view-not-found';
+      : 'ProfileLoaderAnimation--loading-view-not-found';
     const showLoader = Boolean(loadingMessage);
-
-    let additionalMessage = '';
-    if (view.additionalData) {
-      if (view.additionalData.message) {
-        additionalMessage = view.additionalData.message;
-      }
-
-      if (view.additionalData.attempt) {
-        const attempt = view.additionalData.attempt;
-        additionalMessage += `\nTried ${fewTimes(attempt.count)} out of ${
-          attempt.total
-        }.`;
-      }
-    }
+    const showBackHomeLink = Boolean(
+      view.additionalData && view.additionalData.message
+    );
 
     return (
-      <Localized id={message} attrs={{ message: true }}>
+      <Localized id={message} attrs={{ title: true }} elems={{ a: <span /> }}>
         <ProfileRootMessage
-          message={message}
-          additionalMessage={additionalMessage}
+          additionalMessage={this._renderAdditionalMessage()}
           showLoader={showLoader}
-        />
+          showBackHomeLink={showBackHomeLink}
+        >{`Untranslated ${message}`}</ProfileRootMessage>
       </Localized>
+    );
+  }
+
+  _renderAdditionalMessage(): React.Node {
+    const { view } = this.props;
+    if (!view.additionalData) {
+      return null;
+    }
+
+    const { message, attempt } = view.additionalData;
+    return (
+      <>
+        {message ? <p>{message}</p> : null}
+        {attempt ? (
+          <p>{`Tried ${fewTimes(attempt.count)} out of ${attempt.total}.`}</p>
+        ) : null}
+      </>
     );
   }
 }

--- a/src/components/app/ProfileRootMessage.css
+++ b/src/components/app/ProfileRootMessage.css
@@ -23,7 +23,8 @@
 }
 
 .rootMessageText,
-.rootMessageAdditional {
+.rootMessageAdditional,
+.rootBackHomeLink {
   line-height: 1.5;
 }
 

--- a/src/components/app/ProfileRootMessage.js
+++ b/src/components/app/ProfileRootMessage.js
@@ -10,30 +10,32 @@ import * as React from 'react';
 import './ProfileRootMessage.css';
 
 type Props = {|
-  +message: string,
-  +additionalMessage: string | null,
+  +title?: string,
+  +additionalMessage: React.Node,
   +showLoader: boolean,
+  +showBackHomeLink: boolean,
+  +children: React.Node,
 |};
 
 export class ProfileRootMessage extends React.PureComponent<Props> {
-  toParagraphs(str: string): Array<React.Element<'p'>> {
-    return str.split('\n').map((s, i) => {
-      return <p key={i}>{s}</p>;
-    });
-  }
-
   render() {
-    const { message, additionalMessage, showLoader } = this.props;
+    const { children, additionalMessage, showLoader, showBackHomeLink, title } =
+      this.props;
     return (
       <div className="rootMessageContainer">
         <div className="rootMessage">
           <Localized id="ProfileRootMessage--title">
             <h1 className="rootMessageTitle">Firefox Profiler</h1>
           </Localized>
-          <div className="rootMessageText">{message}</div>
+          {title ? <h2>{title}</h2> : null}
+          <div className="rootMessageText">
+            <p>{children}</p>
+          </div>
           {additionalMessage ? (
-            <div className="rootMessageAdditional">
-              {this.toParagraphs(additionalMessage)}
+            <div className="rootMessageAdditional">{additionalMessage}</div>
+          ) : null}
+          {showBackHomeLink ? (
+            <div className="rootBackHomeLink">
               <a href="/">
                 <Localized id="ProfileRootMessage--additional">
                   Back to home

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -17,7 +17,9 @@ exports[`app/AppViewRouter renders an home when the user pressed back after an e
     <div
       class="rootMessageText"
     >
-      Could not download the profile.
+      <p>
+        Could not download the profile.
+      </p>
     </div>
     <div
       class="rootMessageAdditional"
@@ -28,6 +30,10 @@ exports[`app/AppViewRouter renders an home when the user pressed back after an e
       <p>
         The full stack has been written to the Web Console.
       </p>
+    </div>
+    <div
+      class="rootBackHomeLink"
+    >
       <a
         href="/"
       >
@@ -57,7 +63,9 @@ exports[`app/AppViewRouter renders temporary errors 1`] = `
     <div
       class="rootMessageText"
     >
-      Downloading and processing the profile…
+      <p>
+        Downloading and processing the profile…
+      </p>
     </div>
     <div
       class="rootMessageAdditional"
@@ -68,6 +76,10 @@ exports[`app/AppViewRouter renders temporary errors 1`] = `
       <p>
         Tried 3 times out of 10.
       </p>
+    </div>
+    <div
+      class="rootBackHomeLink"
+    >
       <a
         href="/"
       >
@@ -127,7 +139,9 @@ exports[`app/AppViewRouter renders the addon loading page, and the profile view 
     <div
       class="rootMessageText"
     >
-      Importing the profile directly from ⁨Firefox⁩…
+      <p>
+        Importing the profile directly from ⁨Firefox⁩…
+      </p>
     </div>
     <div
       class="loading"
@@ -184,7 +198,9 @@ exports[`app/AppViewRouter renders the profile view 1`] = `
     <div
       class="rootMessageText"
     >
-      Downloading and processing the profile…
+      <p>
+        Downloading and processing the profile…
+      </p>
     </div>
     <div
       class="loading"


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-3673--perf-html.netlify.app/from-url/http%3A%2F%2F127.0.0.1%3A3000%2Fprofile.json/?symbolServer=http%3A%2F%2F127.0.0.1%3A3000)

Adds a warning for #3446.

This warning is displayed when the profile load fails, if we're requesting an HTTP localhost URL from an HTTPS URL.
Safari is the only browser that considers this mixed content.

<img width="907" alt="Screen Shot 2021-11-26 at 6 25 32 PM" src="https://user-images.githubusercontent.com/961291/143661412-c392c464-d09c-43fb-b81a-47cc7daf8202.png">

