### PR TITLE
Change 'symbol tables' to 'symbols' in the overlay.

### DIFF
--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -51,7 +51,7 @@ class SymbolicationStatusOverlayImpl extends PureComponent<Props> {
         return (
           <div className="symbolicationStatusOverlay">
             <span className="symbolicationStatusOverlayThrobber" />
-            {`Waiting for symbol tables for ${englishSgPlLibrary(
+            {`Waiting for symbols for ${englishSgPlLibrary(
               libNames.length
             )} ${englishListJoin(libNames)}...`}
           </div>


### PR DESCRIPTION
The overlay currently says "Waiting for symbol tables for XUL..." even when we're only getting individual symbols for a handful of addresses from the symbolication API.

This PR changes it to "Waiting for symbols for XUL..." instead.

I wrote this string in the very beginning, when all symbols only came from the browser. This was before the profiler knew how to get symbols from the symbolication API. So back than it was only full symbol tables.