### PR TITLE
Update symbolication API URL

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -107,7 +107,7 @@ export const PROFILER_SERVER_ORIGIN = 'https://api.profiler.firefox.com';
 // [1] https://github.com/mstange/profiler-symbol-server/
 
 // This is the default server.
-export const SYMBOL_SERVER_URL = 'https://symbols.mozilla.org';
+export const SYMBOL_SERVER_URL = 'https://symbolication.services.mozilla.com';
 
 // See the MarkerPhase type for more information.
 export const INSTANT: MarkerPhase = 0;

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -198,6 +198,11 @@ export function requestSymbols(
     body: JSON.stringify(body),
     method: 'POST',
     mode: 'cors',
+    // Use a profiler-specific user agent, so that the symbolication server knows
+    // what's making this request.
+    headers: new Headers({
+      'User-Agent': `FirefoxProfiler/1.0 (+${location.origin}) ${navigator.userAgent}`,
+    }),
   })
     .then((response) => response.json())
     .then(_ensureIsAPIResultV5);

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -318,6 +318,7 @@ function _shouldAllowSymbolServerUrl(symbolServerUrl) {
     // For non-localhost hosts, we require HTTPS.
     const otherAllowedHostnames = [
       'symbols.mozilla.org',
+      'symbolication.services.mozilla.com',
       'symbolication.stage.mozaws.net',
     ];
     if (!otherAllowedHostnames.includes(url.hostname)) {

--- a/src/test/__snapshots__/url-handling.test.js.snap
+++ b/src/test/__snapshots__/url-handling.test.js.snap
@@ -7,7 +7,7 @@ exports[`symbolServerUrl will allow an allowed https host 1`] = `Array []`;
 exports[`symbolServerUrl will error when switching to an allowed but non-https host 1`] = `
 Array [
   Array [
-    "HTTPS is required for non-localhost symbol servers. Rejecting http://symbols.mozilla.org/ and defaulting to https://symbols.mozilla.org.",
+    "HTTPS is required for non-localhost symbol servers. Rejecting http://symbolication.services.mozilla.com/ and defaulting to https://symbolication.services.mozilla.com.",
   ],
 ]
 `;
@@ -15,7 +15,7 @@ Array [
 exports[`symbolServerUrl will error when switching to an invalid host 1`] = `
 Array [
   Array [
-    "The symbol server URL was not valid. Rejecting invalid and defaulting to https://symbols.mozilla.org.",
+    "The symbol server URL was not valid. Rejecting invalid and defaulting to https://symbolication.services.mozilla.com.",
     [TypeError: Invalid URL: invalid],
   ],
 ]
@@ -24,7 +24,7 @@ Array [
 exports[`symbolServerUrl will error when switching to an unknown host 1`] = `
 Array [
   Array [
-    "The symbol server URL was not in the list of allowed domains. Rejecting https://symbols.mozilla.org.example.com/symbols and defaulting to https://symbols.mozilla.org.",
+    "The symbol server URL was not in the list of allowed domains. Rejecting https://symbolication.services.mozilla.com.example.com/symbols and defaulting to https://symbolication.services.mozilla.com.",
   ],
 ]
 `;

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -794,7 +794,7 @@ describe('actions/receive-profile', function () {
       );
 
       expect(window.fetch).toHaveBeenCalledWith(
-        'https://symbols.mozilla.org/symbolicate/v5',
+        'https://symbolication.services.mozilla.com/symbolicate/v5',
         expect.objectContaining({
           body: expect.stringMatching(/memoryMap.*firefox/),
         })
@@ -807,7 +807,7 @@ describe('actions/receive-profile', function () {
       await dispatch(retrieveProfileFromBrowser());
 
       expect(window.fetch).toHaveBeenCalledWith(
-        'https://symbols.mozilla.org/symbolicate/v5',
+        'https://symbolication.services.mozilla.com/symbolicate/v5',
         expect.objectContaining({
           body: expect.stringMatching(/memoryMap.*firefox/),
         })
@@ -890,7 +890,7 @@ describe('actions/receive-profile', function () {
       await store.dispatch(retrieveProfileFromStore('FAKEHASH'));
 
       expect(window.fetch).toHaveBeenLastCalledWith(
-        'https://symbols.mozilla.org/symbolicate/v5',
+        'https://symbolication.services.mozilla.com/symbolicate/v5',
         expect.objectContaining({
           body: expect.stringMatching(/memoryMap.*libxul/),
         })
@@ -1446,7 +1446,7 @@ describe('actions/receive-profile', function () {
       });
 
       expect(window.fetch).toHaveBeenCalledWith(
-        'https://symbols.mozilla.org/symbolicate/v5',
+        'https://symbolication.services.mozilla.com/symbolicate/v5',
         expect.objectContaining({
           body: expect.stringMatching(/memoryMap.*firefox/),
         })

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -1697,11 +1697,11 @@ describe('symbolServerUrl', function () {
 
   it('will error when switching to an unknown host', function () {
     const { symbolServerUrl, queryString } = setup(
-      '?symbolServer=https://symbols.mozilla.org.example.com/symbols'
+      '?symbolServer=https://symbolication.services.mozilla.com.example.com/symbols'
     );
     expect(symbolServerUrl).toEqual(SYMBOL_SERVER_URL);
     expect(queryString).toContain(
-      'symbolServer=https%3A%2F%2Fsymbols.mozilla.org.example.com%2Fsymbols'
+      'symbolServer=https%3A%2F%2Fsymbolication.services.mozilla.com.example.com%2Fsymbols'
     );
     expect(console.error.mock.calls).toMatchSnapshot();
   });
@@ -1715,11 +1715,11 @@ describe('symbolServerUrl', function () {
 
   it('will error when switching to an allowed but non-https host', function () {
     const { symbolServerUrl, queryString } = setup(
-      '?symbolServer=http://symbols.mozilla.org/'
+      '?symbolServer=http://symbolication.services.mozilla.com/'
     );
     expect(symbolServerUrl).toEqual(SYMBOL_SERVER_URL);
     expect(queryString).toContain(
-      'symbolServer=http%3A%2F%2Fsymbols.mozilla.org%2F'
+      'symbolServer=http%3A%2F%2Fsymbolication.services.mozilla.com%2F'
     );
     expect(console.error.mock.calls).toMatchSnapshot();
   });


### PR DESCRIPTION
As requested in https://groups.google.com/a/mozilla.com/g/crash-reporting-wg/c/ZK_H54qblMc/m/jCv1rDamAQAJ

The symbols.mozilla.org URL still works, but it proxies everything over to the new URL already.