### PR TITLE
Remove User-Agent header again.

### DIFF
--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -246,11 +246,6 @@ export function requestSymbols(
     body: JSON.stringify(body),
     method: 'POST',
     mode: 'cors',
-    // Use a profiler-specific user agent, so that the symbolication server knows
-    // what's making this request.
-    headers: new Headers({
-      'User-Agent': `FirefoxProfiler/1.0 (+${location.origin}) ${navigator.userAgent}`,
-    }),
   })
     .then((response) => response.json())
     .then(_ensureIsAPIResultV5);


### PR DESCRIPTION
This reverts the last-minute change I made in #3677.

The addition of the User-Agent header triggers the browser to send an `OPTIONS` request with a CORS preflight request.
`profiler-symbol-server` doesn't currently know how to deal with this, so symbolication with profiler-symbol-server is broken.
This works around it.