### PR TITLE
Stop using :hover selector for context menu and use ..--selected class instead

### DIFF
--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -505,7 +505,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
         {nameForResource
           ? this.renderTransformMenuItem({
               l10nId: 'CallNodeContextMenu--transform-collapse-resource',
-              additionalLocalizedProps: {
+              l10nProps: {
                 vars: { nameForResource: nameForResource },
                 elems: { strong: <strong /> },
               },
@@ -586,7 +586,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
 
   renderTransformMenuItem(props: {|
     +l10nId: string,
-    +additionalLocalizedProps?: mixed,
+    +l10nProps?: mixed,
     +content: React.Node,
     +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
     +transform: string,
@@ -602,7 +602,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
         <Localized
           id={props.l10nId}
           attrs={{ title: true }}
-          {...props.additionalLocalizedProps}
+          {...props.l10nProps}
         >
           <DivWithTitle
             className="react-contextmenu-item-content"
@@ -699,7 +699,7 @@ export const CallNodeContextMenu = explicitConnect<
 });
 
 function DivWithTitle(props: {|
-  +className: string,
+  +className?: string,
   +children: React.Node,
   +title: string,
 |}) {

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -446,137 +446,100 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
 
     return (
       <>
-        <Localized
-          id="CallNodeContextMenu--transform-merge-function"
-          attrs={{ title: true }}
-        >
-          <TransformMenuItem
-            shortcut="m"
-            icon="Merge"
-            onClick={this._handleClick}
-            transform="merge-function"
-            title=""
-          >
-            Merge function
-          </TransformMenuItem>
-        </Localized>
+        {this.renderTransformMenuItem({
+          l10nId: 'CallNodeContextMenu--transform-merge-function',
+          shortcut: 'm',
+          icon: 'Merge',
+          onClick: this._handleClick,
+          transform: 'merge-function',
+          title: '',
+          content: 'Merge function',
+        })}
 
-        {inverted ? null : (
-          <Localized
-            id="CallNodeContextMenu--transform-merge-call-node"
-            attrs={{ title: true }}
-          >
-            <TransformMenuItem
-              shortcut="M"
-              icon="Merge"
-              onClick={this._handleClick}
-              transform="merge-call-node"
-              title=""
-            >
-              Merge node only
-            </TransformMenuItem>
-          </Localized>
-        )}
+        {inverted
+          ? null
+          : this.renderTransformMenuItem({
+              l10nId: 'CallNodeContextMenu--transform-merge-call-node',
+              shortcut: 'M',
+              icon: 'Merge',
+              onClick: this._handleClick,
+              transform: 'merge-call-node',
+              title: '',
+              content: 'Merge node only',
+            })}
 
-        <Localized
-          id={
-            inverted
-              ? 'CallNodeContextMenu--transform-focus-function-inverted'
-              : 'CallNodeContextMenu--transform-focus-function'
-          }
-          attrs={{ title: true }}
-        >
-          <TransformMenuItem
-            shortcut="f"
-            icon="Focus"
-            onClick={this._handleClick}
-            transform="focus-function"
-            title=""
-          >
-            {inverted ? 'Focus on function (inverted)' : 'Focus on function'}
-          </TransformMenuItem>
-        </Localized>
+        {this.renderTransformMenuItem({
+          l10nId: inverted
+            ? 'CallNodeContextMenu--transform-focus-function-inverted'
+            : 'CallNodeContextMenu--transform-focus-function',
+          shortcut: 'f',
+          icon: 'Focus',
+          onClick: this._handleClick,
+          transform: 'focus-function',
+          title: '',
+          content: inverted
+            ? 'Focus on function (inverted)'
+            : 'Focus on function',
+        })}
 
-        <Localized
-          id="CallNodeContextMenu--transform-focus-subtree"
-          attrs={{ title: true }}
-        >
-          <TransformMenuItem
-            shortcut="F"
-            icon="Focus"
-            onClick={this._handleClick}
-            transform="focus-subtree"
-            title=""
-          >
-            Focus on subtree only
-          </TransformMenuItem>
-        </Localized>
+        {this.renderTransformMenuItem({
+          l10nId: 'CallNodeContextMenu--transform-focus-subtree',
+          shortcut: 'F',
+          icon: 'Focus',
+          onClick: this._handleClick,
+          transform: 'focus-subtree',
+          title: '',
+          content: 'Focus on subtree only',
+        })}
 
-        <Localized
-          id="CallNodeContextMenu--transform-collapse-function-subtree"
-          attrs={{ title: true }}
-        >
-          <TransformMenuItem
-            shortcut="c"
-            icon="Collapse"
-            onClick={this._handleClick}
-            transform="collapse-function-subtree"
-            title=""
-          >
-            Collapse function
-          </TransformMenuItem>
-        </Localized>
+        {this.renderTransformMenuItem({
+          l10nId: 'CallNodeContextMenu--transform-collapse-function-subtree',
+          shortcut: 'c',
+          icon: 'Collapse',
+          onClick: this._handleClick,
+          transform: 'collapse-function-subtree',
+          title: '',
+          content: 'Collapse function',
+        })}
 
-        {nameForResource ? (
-          <Localized
-            id="CallNodeContextMenu--transform-collapse-resource"
-            attrs={{ title: true }}
-            vars={{ nameForResource: nameForResource }}
-            elems={{ strong: <strong /> }}
-          >
-            <TransformMenuItem
-              shortcut="C"
-              icon="Collapse"
-              onClick={this._handleClick}
-              transform="collapse-resource"
-              title=""
-            >
-              Collapse <strong>{nameForResource}</strong>
-            </TransformMenuItem>
-          </Localized>
-        ) : null}
+        {nameForResource
+          ? this.renderTransformMenuItem({
+              l10nId: 'CallNodeContextMenu--transform-collapse-resource',
+              additionalLocalizedProps: {
+                vars: { nameForResource: nameForResource },
+                elems: { strong: <strong /> },
+              },
+              shortcut: 'C',
+              icon: 'Collapse',
+              onClick: this._handleClick,
+              transform: 'collapse-resource',
+              title: '',
+              content: `Collapse <strong>${nameForResource}</strong>`,
+            })
+          : null}
 
-        {this.isRecursiveCall() ? (
-          <Localized
-            id="CallNodeContextMenu--transform-collapse-direct-recursion"
-            attrs={{ title: true }}
-          >
-            <TransformMenuItem
-              shortcut="r"
-              icon="Collapse"
-              onClick={this._handleClick}
-              transform="collapse-direct-recursion"
-              title=""
-            >
-              Collapse direct recursion
-            </TransformMenuItem>
-          </Localized>
-        ) : null}
+        {this.isRecursiveCall()
+          ? this.renderTransformMenuItem({
+              l10nId:
+                'CallNodeContextMenu--transform-collapse-direct-recursion',
+              shortcut: 'r',
+              icon: 'Collapse',
+              onClick: this._handleClick,
+              transform: 'collapse-direct-recursion',
+              title: '',
+              content: 'Collapse direct recursion',
+            })
+          : null}
 
-        <Localized
-          id="CallNodeContextMenu--transform-drop-function"
-          attrs={{ title: true }}
-        >
-          <TransformMenuItem
-            shortcut="d"
-            icon="Drop"
-            onClick={this._handleClick}
-            transform="drop-function"
-            title=""
-          >
-            Drop samples with this function
-          </TransformMenuItem>
-        </Localized>
+        {this.renderTransformMenuItem({
+          l10nId: 'CallNodeContextMenu--transform-drop-function',
+          shortcut: 'd',
+          icon: 'Drop',
+          onClick: this._handleClick,
+          transform: 'drop-function',
+          title: '',
+          content: 'Drop samples with this function',
+        })}
 
         <div className="react-contextmenu-separator" />
 
@@ -620,6 +583,38 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
           </MenuItem>
         </Localized>
       </>
+    );
+  }
+
+  renderTransformMenuItem(props: {|
+    +l10nId: string,
+    +additionalLocalizedProps?: mixed,
+    +content: React.Node,
+    +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
+    +transform: string,
+    +shortcut: string,
+    +icon: string,
+    +title: string,
+  |}) {
+    return (
+      <MenuItem onClick={props.onClick} data={{ type: props.transform }}>
+        <span
+          className={`react-contextmenu-icon callNodeContextMenuIcon${props.icon}`}
+        />
+        <Localized
+          id={props.l10nId}
+          attrs={{ title: true }}
+          {...props.additionalLocalizedProps}
+        >
+          <DivWithTitle
+            className="react-contextmenu-item-content"
+            title={props.title}
+          >
+            {props.content}
+          </DivWithTitle>
+        </Localized>
+        <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
+      </MenuItem>
     );
   }
 
@@ -688,29 +683,6 @@ export const CallNodeContextMenu = explicitConnect<
   component: CallNodeContextMenuImpl,
 });
 
-function TransformMenuItem(props: {|
-  +children: React.Node,
-  +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
-  +transform: string,
-  +shortcut: string,
-  +icon: string,
-  +title: string,
-|}) {
-  return (
-    <MenuItem
-      onClick={props.onClick}
-      data={{ type: props.transform }}
-      attributes={{ title: oneLine`${props.title}` }}
-    >
-      <span
-        className={`react-contextmenu-icon callNodeContextMenuIcon${props.icon}`}
-      />
-      <div className="react-contextmenu-item-content">{props.children}</div>
-      <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
-    </MenuItem>
-  );
-}
-
 function MenuItemWithShortcut(props: {|
   +children: React.Node,
   +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
@@ -722,5 +694,17 @@ function MenuItemWithShortcut(props: {|
       <div className="react-contextmenu-item-content">{props.children}</div>
       <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
     </MenuItem>
+  );
+}
+
+function DivWithTitle(props: {|
+  +className: string,
+  +children: React.Node,
+  +title: string,
+|}) {
+  return (
+    <div className={props.className} title={oneLine`${props.title}`}>
+      {props.children}
+    </div>
   );
 }

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -545,15 +545,13 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
 
         {showExpandAll ? (
           <>
-            <Localized id="CallNodeContextMenu--expand-all">
-              <MenuItemWithShortcut
-                onClick={this._handleClick}
-                data={{ type: 'expand-all' }}
-                shortcut="*"
-              >
-                Expand all
-              </MenuItemWithShortcut>
-            </Localized>
+            {this.renderMenuItemWithShortcut({
+              l10nId: 'CallNodeContextMenu--expand-all',
+              onClick: this._handleClick,
+              data: { type: 'expand-all' },
+              shortcut: '*',
+              content: 'Expand all',
+            })}
             <div className="react-contextmenu-separator" />
           </>
         ) : null}
@@ -612,6 +610,23 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
           >
             {props.content}
           </DivWithTitle>
+        </Localized>
+        <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
+      </MenuItem>
+    );
+  }
+
+  renderMenuItemWithShortcut(props: {|
+    +l10nId: string,
+    +content: React.Node,
+    +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
+    +shortcut: string,
+    +data: { type: string },
+  |}) {
+    return (
+      <MenuItem onClick={props.onClick} data={{ type: props.data.type }}>
+        <Localized id={props.l10nId}>
+          <div className="react-contextmenu-item-content">{props.content}</div>
         </Localized>
         <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
       </MenuItem>
@@ -682,20 +697,6 @@ export const CallNodeContextMenu = explicitConnect<
   },
   component: CallNodeContextMenuImpl,
 });
-
-function MenuItemWithShortcut(props: {|
-  +children: React.Node,
-  +onClick: (event: SyntheticEvent<>, data: { type: string }) => void,
-  +shortcut: string,
-  +data: { type: string },
-|}) {
-  return (
-    <MenuItem onClick={props.onClick} data={{ type: props.data.type }}>
-      <div className="react-contextmenu-item-content">{props.children}</div>
-      <kbd className="callNodeContextMenuShortcut">{props.shortcut}</kbd>
-    </MenuItem>
-  );
-}
 
 function DivWithTitle(props: {|
   +className: string,

--- a/src/components/shared/ContextMenu.css
+++ b/src/components/shared/ContextMenu.css
@@ -41,7 +41,6 @@
 }
 
 .react-contextmenu-item.react-contextmenu-item--active,
-.react-contextmenu-item:hover,
 .react-contextmenu-item--selected {
   border-color: var(--blue-60);
   background-color: var(--blue-60);
@@ -105,7 +104,7 @@
 }
 
 .react-contextmenu-item.react-contextmenu-item--active.checked,
-.react-contextmenu-item.checked:hover {
+.react-contextmenu-item--selected.checked {
   border-color: #fff;
 }
 
@@ -113,8 +112,7 @@
   background-color: var(--blue-50-a30);
 }
 
-.react-contextmenu-item--selected.checked:not(.react-contextmenu-item--disabled)::before,
-.react-contextmenu-item:hover.checked:not(.react-contextmenu-item--disabled)::before {
+.react-contextmenu-item--selected.checked:not(.react-contextmenu-item--disabled)::before {
   /* Invert the colors of the checkmark when selected */
   border-color: #fff;
 }
@@ -143,7 +141,6 @@
   color: #38383d;
 }
 
-.react-contextmenu-item--selected > strong,
-.react-contextmenu-item:hover > strong {
+.react-contextmenu-item--selected > strong {
   color: #fff;
 }

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -12,13 +12,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Merging a function removes it from the profile, and assigns its time to the function that called it. This happens anywhere the function was called in the tree."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconMerge"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Merging a function removes it from the profile, and assigns its time to the function that called it. This happens anywhere the function was called in the tree."
     >
       Merge function
     </div>
@@ -33,13 +33,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Merging a node removes it from the profile, and assigns its time to the function’s node that called it. It only removes the function from that specific part of the tree. Any other places the function was called from will remain in the profile."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconMerge"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Merging a node removes it from the profile, and assigns its time to the function’s node that called it. It only removes the function from that specific part of the tree. Any other places the function was called from will remain in the profile."
     >
       Merge node only
     </div>
@@ -54,13 +54,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Focusing on a function will remove any sample that does not include that function. In addition, it re-roots the call tree so that the function is the only root of the tree. This can combine multiple function call sites across a profile into one call node."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconFocus"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Focusing on a function will remove any sample that does not include that function. In addition, it re-roots the call tree so that the function is the only root of the tree. This can combine multiple function call sites across a profile into one call node."
     >
       Focus on function
     </div>
@@ -75,13 +75,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Focusing on a subtree will remove any sample that does not include that specific part of the call tree. It pulls out a branch of the call tree, however it only does it for that single call node. All other calls of the function are ignored."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconFocus"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Focusing on a subtree will remove any sample that does not include that specific part of the call tree. It pulls out a branch of the call tree, however it only does it for that single call node. All other calls of the function are ignored."
     >
       Focus on subtree only
     </div>
@@ -96,13 +96,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Collapsing a function will remove everything it called, and assign all of the time to the function. This can help simplify a profile that calls into code that does not need to be analyzed."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconCollapse"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Collapsing a function will remove everything it called, and assign all of the time to the function. This can help simplify a profile that calls into code that does not need to be analyzed."
     >
       Collapse function
     </div>
@@ -117,13 +117,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Collapsing a resource will flatten out all the calls to that resource into a single collapsed call node."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconCollapse"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Collapsing a resource will flatten out all the calls to that resource into a single collapsed call node."
     >
       Collapse 
       <strong>
@@ -141,13 +141,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Collapsing direct recursion removes calls that repeatedly recurse into the same function."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconCollapse"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Collapsing direct recursion removes calls that repeatedly recurse into the same function."
     >
       Collapse direct recursion
     </div>
@@ -162,13 +162,13 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
-    title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not relevant for the analysis."
   >
     <span
       class="react-contextmenu-icon callNodeContextMenuIconDrop"
     />
     <div
       class="react-contextmenu-item-content"
+      title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not relevant for the analysis."
     >
       Drop samples with this function
     </div>


### PR DESCRIPTION
In context menu components, `.react-contextmenu-item:hover` and `.react-contextmenu-item--selected` are nearly the same things. `.react-contextmenu-item--selected` one is added by the context menu component library, and it's actually better for styling because it both handles the keyboard arrow and mouse hover cases. In addition to this, having `:hover` actually make things worse in this case, where we don't want to highlight the hovered item:

STR:
1. Open the track context menu (example profile: [production](https://share.firefox.dev/3IfQZNv) / [deploy preview](https://deploy-preview-3690--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-4679adfgst&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6))
2. Hover an item in the context menu, and don't move the mouse.
3. Press the down arrow to go to the item below.

Expected result:
There should be only one highlighted item and the item below should be selected.

Actual result:
There are two highlighted items now, the hovered one and the "real" selected one below. 

Here's a screenshot of the actual result:
<img width="328" alt="Screen Shot 2021-12-02 at 10 37 08 PM" src="https://user-images.githubusercontent.com/466239/144507192-6d038bcc-6f27-4d2d-881a-f317d562aab7.png">

Note that there are two hover selectors left in this file, but they appear to be necessary (one for disabled items and one for submenus).

