### PR TITLE
Change requestSymbolsFromServer return value.

### DIFF
--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -889,8 +889,8 @@ export async function symbolicateProfile(
     buildLibSymbolicationRequestsForAllThreads(symbolicationInfo);
   await symbolStore.getSymbols(
     libSymbolicationRequests,
-    (request, results) => {
-      const { debugName, breakpadId } = request.lib;
+    (lib, results) => {
+      const { debugName, breakpadId } = lib;
       const libKey = `${debugName}/${breakpadId}`;
       finishSymbolicationForLib(
         profile,
@@ -900,7 +900,7 @@ export async function symbolicateProfile(
         symbolicationStepCallback
       );
     },
-    (request, error) => {
+    (_request, error: Error) => {
       if (!(error instanceof SymbolsNotFoundError)) {
         // rethrow JavaScript programming error
         throw error;

--- a/src/test/fixtures/fake-symbol-store.js
+++ b/src/test/fixtures/fake-symbol-store.js
@@ -6,12 +6,14 @@
 
 import { bisectionRight } from 'firefox-profiler/utils/bisect';
 
+import type { RequestedLib } from 'firefox-profiler/types';
 import type {
   LibSymbolicationRequest,
   AddressResult,
+  AbstractSymbolStore,
 } from '../../profile-logic/symbol-store';
 
-export class FakeSymbolStore {
+export class FakeSymbolStore implements AbstractSymbolStore {
   _symbolTables: Map<string, {| addrs: Uint32Array, syms: string[] |}>;
 
   constructor(symbolTables: Map<string, Map<number, string>>) {
@@ -28,7 +30,7 @@ export class FakeSymbolStore {
 
   async getSymbols(
     requests: LibSymbolicationRequest[],
-    successCb: (LibSymbolicationRequest, Map<number, AddressResult>) => void,
+    successCb: (RequestedLib, Map<number, AddressResult>) => void,
     errorCb: (LibSymbolicationRequest, Error) => void
   ): Promise<void> {
     // Make sure that the callbacks are never called synchronously, by enforcing
@@ -47,7 +49,7 @@ export class FakeSymbolStore {
             symbolAddress: symbolTable.addrs[index],
           });
         }
-        successCb(request, results);
+        successCb(lib, results);
       } else {
         errorCb(request, new Error('symbol table not found'));
       }

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -67,29 +67,39 @@ describe('doSymbolicateProfile', function () {
     }
 
     const symbolProvider = {
-      requestSymbolsFromServer: (requests) =>
-        requests.map(async (request) => {
-          if (request.lib.debugName !== 'firefox.pdb') {
-            throw new SymbolsNotFoundError(
-              'Should only have lib called firefox.pdb',
-              request.lib
-            );
+      requestSymbolsFromServer: async (requests) =>
+        requests.map((request) => {
+          const { lib, addresses } = request;
+          if (lib.debugName !== 'firefox.pdb') {
+            return {
+              type: 'ERROR',
+              request,
+              error: new SymbolsNotFoundError(
+                'Should only have lib called firefox.pdb',
+                lib
+              ),
+            };
           }
+
           if (symbolicationProviderMode !== 'from-server') {
-            throw new SymbolsNotFoundError(
-              'Not in from-server mode, try requestSymbolTableFromBrowser.',
-              request.lib
-            );
+            return {
+              type: 'ERROR',
+              request,
+              error: new SymbolsNotFoundError(
+                'Not in from-server mode, try requestSymbolTableFromBrowser.',
+                lib
+              ),
+            };
           }
 
           const map = new Map();
-          for (const address of request.addresses) {
+          for (const address of addresses) {
             const addressResult = symbolTable.getAddressResult(address);
             if (addressResult !== null) {
               map.set(address, addressResult);
             }
           }
-          return map;
+          return { type: 'SUCCESS', lib, results: map };
         }),
 
       requestSymbolTableFromBrowser: async (lib) => {


### PR DESCRIPTION
Rather than returning an array of promises, where each promise indicates
whether a lib was found or not, return just one promise and an array
of objects which either indicate success or failure.

This is a pure refactoring and does not change behavior.

I'm doing this because I want to add another step in the symbolication
sequence: After the Mozilla symbolication API call fails, I want to
fall back to calling the browser's querySymbolicationApi. I'd like this
fallback to make one querySymbolicationApi call per chunk. So I need a
way to await the entire chunk. That's hard to do if there are individual
promises for each library in a chunk. After this refactoring it will be
straightforward.