### PR TITLE
Support inline callstack symbolication for local Firefox builds

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -878,8 +878,16 @@ function getSymbolStore(
       }
       try {
         return await MozillaSymbolicationAPI.requestSymbols(
+          'symbol server',
           requests,
-          symbolServerUrl
+          async (path, json) => {
+            const response = await fetch(symbolServerUrl + path, {
+              body: json,
+              method: 'POST',
+              mode: 'cors',
+            });
+            return response.json();
+          }
         );
       } finally {
         for (const { lib } of requests) {

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -885,6 +885,10 @@ function getSymbolStore(
         requests,
         callback
       );
+    } catch (e) {
+      throw new Error(
+        `There was a problem with the symbolication API request to the ${symbolSupplierName}: ${e.message}`
+      );
     } finally {
       for (const { lib } of requests) {
         dispatch(receivedSymbolTableReply(lib));

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -87,6 +87,7 @@ import type {
   BrowserConnection,
   BrowserConnectionStatus,
 } from '../app-logic/browser-connection';
+import type { LibSymbolicationRequest } from '../profile-logic/symbol-store';
 
 /**
  * This file collects all the actions that are used for receiving the profile in the
@@ -869,32 +870,61 @@ function getSymbolStore(
     // return a symbol store in this case.
     return null;
   }
+
+  async function requestSymbolsWithCallback(
+    symbolSupplierName: string,
+    requests: LibSymbolicationRequest[],
+    callback: (path: string, requestJson: string) => Promise<MixedObject>
+  ) {
+    for (const { lib } of requests) {
+      dispatch(requestingSymbolTable(lib));
+    }
+    try {
+      return await MozillaSymbolicationAPI.requestSymbols(
+        symbolSupplierName,
+        requests,
+        callback
+      );
+    } finally {
+      for (const { lib } of requests) {
+        dispatch(receivedSymbolTableReply(lib));
+      }
+    }
+  }
+
   // Note, the database name still references the old project name, "perf.html". It was
   // left the same as to not invalidate user's information.
   const symbolStore = new SymbolStore('perf-html-async-storage', {
-    requestSymbolsFromServer: async (requests) => {
-      for (const { lib } of requests) {
-        dispatch(requestingSymbolTable(lib));
-      }
-      try {
-        return await MozillaSymbolicationAPI.requestSymbols(
-          'symbol server',
-          requests,
-          async (path, json) => {
-            const response = await fetch(symbolServerUrl + path, {
-              body: json,
-              method: 'POST',
-              mode: 'cors',
-            });
-            return response.json();
-          }
-        );
-      } finally {
-        for (const { lib } of requests) {
-          dispatch(receivedSymbolTableReply(lib));
+    requestSymbolsFromServer: (requests) =>
+      requestSymbolsWithCallback(
+        'symbol server',
+        requests,
+        async (path, json) => {
+          const response = await fetch(symbolServerUrl + path, {
+            body: json,
+            method: 'POST',
+            mode: 'cors',
+          });
+          return response.json();
         }
+      ),
+
+    requestSymbolsFromBrowser: async (requests) => {
+      if (browserConnection === null) {
+        throw new Error(
+          'No connection to the browser, cannot run querySymbolicationApi'
+        );
       }
+
+      const bc = browserConnection;
+      return requestSymbolsWithCallback(
+        'browser',
+        requests,
+        async (path, json) =>
+          JSON.parse(await bc.querySymbolicationApi(path, json))
+      );
     },
+
     requestSymbolTableFromBrowser: async (lib) => {
       if (browserConnection === null) {
         throw new Error(

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -13,9 +13,16 @@ import type {
 // on https://tecken.readthedocs.io/en/latest/symbolication.html .
 // Specifically, it uses version 5 of the API, which was implemented in
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1377479 .
-// The actual request happens via a callback. The current callback sends the
-// request to the Mozilla Symbolication Server, or to an alternative symbol server
-// which was configured with a ?symbolServer URL parameter.
+//
+// The actual request happens via a callback. We use two different callbacks:
+//
+//  - When requesting symbols via HTTP, we use a callback which calls fetch.
+//    This is used to request symbols from the Mozilla Symbolication Server,
+//    or from an alternative symbol server which was configured with a
+//    ?symbolServer URL parameter.
+//  - When requesting symbols from the browser, we use a callback which sends a
+//    WebChannel message. The WebChannel has a querySymbolicationApi entry point
+//    which uses the same API as the server.
 
 // The type for the callback, see comment above.
 export type QuerySymbolicationApiCallback = (

--- a/src/profile-logic/mozilla-symbolication-api.js
+++ b/src/profile-logic/mozilla-symbolication-api.js
@@ -8,7 +8,6 @@ import type {
   LibSymbolicationRequest,
   LibSymbolicationResponse,
 } from './symbol-store';
-import { SymbolsNotFoundError } from './errors';
 
 // This file handles requesting symbolication information from the Mozilla
 // symbol server using the API described on
@@ -152,17 +151,15 @@ function getV5ResultForLibRequest(
   const { debugName, breakpadId } = lib;
 
   if (!json.found_modules[`${debugName}/${breakpadId}`]) {
-    throw new SymbolsNotFoundError(
-      `The symbol server does not have symbols for ${debugName}/${breakpadId}.`,
-      lib
+    throw new Error(
+      `The symbol server does not have symbols for ${debugName}/${breakpadId}.`
     );
   }
 
   const addressInfo = json.stacks[0];
   if (addressInfo.length !== addressArray.length) {
-    throw new SymbolsNotFoundError(
-      'The result from the symbol server has an unexpected length.',
-      lib
+    throw new Error(
+      'The result from the symbol server has an unexpected length.'
     );
   }
 

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -63,6 +63,12 @@ interface SymbolProvider {
   ): Promise<LibSymbolicationResponse[]>;
 
   // Expensive, should be called if requestSymbolsFromServer was unsuccessful.
+  requestSymbolsFromBrowser(
+    requests: LibSymbolicationRequest[]
+  ): Promise<LibSymbolicationResponse[]>;
+
+  // Expensive, should be called if the other two options were unsuccessful.
+  // Does not carry file + line + inlines information.
   requestSymbolTableFromBrowser(lib: RequestedLib): Promise<SymbolTableAsTuple>;
 }
 

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -265,7 +265,8 @@ export class SymbolStore {
     // it. We try all options in order, advancing to the next option on failure.
     // Option 1: Symbol tables cached in the database, this._db.
     // Option 2: Obtain symbols from the symbol server.
-    // Option 3: Obtain symbol tables from the browser.
+    // Option 3: Obtain symbols from the browser, using the symbolication API.
+    // Option 4: Obtain symbols from the browser, via individual symbol tables.
 
     // Check requests for validity first.
     requests = requests.filter((request) => {
@@ -335,7 +336,7 @@ export class SymbolStore {
 
     // Kick off the requests to the symbolication API, and create a list of
     // promises, one promise per chunk.
-    const chunkResponsePromises: Array<
+    const symbolicationApiRequestsAndResponsesPerChunk: Array<
       [LibSymbolicationRequest[], Promise<LibSymbolicationResponse[]>]
     > = chunks.map((requests) => [
       requests,
@@ -361,82 +362,125 @@ export class SymbolStore {
     // Process the results from the symbolication API request, as they arrive.
     // For unsuccessful requests, fall back to _getSymbolsFromBrowser.
     await Promise.all(
-      chunkResponsePromises.map(async ([requests, chunkResponsePromise]) => {
-        try {
-          // Await the response for this chunk.
-          const responses: LibSymbolicationResponse[] =
-            await chunkResponsePromise;
+      symbolicationApiRequestsAndResponsesPerChunk.map(
+        async ([option2Requests, option2ResponsePromise]) => {
+          // Store any errors encountered along the way in this map.
+          // We will report them if all avenues fail.
+          const errorMap: Map<LibSymbolicationRequest, Error[]> = new Map(
+            requests.map((r) => [r, []])
+          );
 
-          const requestsWithErrors = [];
-          for (const response of responses) {
-            if (response.type === 'SUCCESS') {
-              // We've found symbols for this library! Option 2 was successful.
-              const { lib, results } = response;
-              successCb(lib, results);
-            } else {
-              // Collect unsuccessful requests in requestsWithErrors.
-              // We keep the error around so that we can report it if all avenues fail.
-              const { request, error } = response;
-              requestsWithErrors.push({ request, error });
-            }
-          }
-
-          if (requestsWithErrors.length > 0) {
-            // Fall back to getting symbols from the browser for these.
-            await this._getSymbolsFromBrowser(
-              requestsWithErrors,
-              demangleCallback,
-              successCb,
-              errorCb
+          // Process the results of option 2: The response from the Mozilla symbolication APi.
+          const option3Requests =
+            await this._processSuccessfulResponsesAndReturnRemaining(
+              option2Requests,
+              option2ResponsePromise,
+              errorMap,
+              successCb
             );
+
+          if (option3Requests.length === 0) {
+            // Done!
+            return;
           }
-        } catch (error) {
-          // There was a problem for the entire chunk of requests, for example there
-          // might have been a problem parsing the response JSON.
-          // Map all requests to the same error, and then try to get symbols from the browser.
-          const requestsWithErrors = requests.map((request) => ({
-            request,
-            error: new SymbolsNotFoundError(
-              'There was a problem with the JSON returned by the symbolication API.',
-              request.lib,
-              error
-            ),
-          }));
-          await this._getSymbolsFromBrowser(
-            requestsWithErrors,
+
+          // Some libraries are still remaining, try option 3 for them.
+          // Option 3 is symbolProvider.requestSymbolsFromBrowser.
+          const option3ResponsePromise =
+            this._symbolProvider.requestSymbolsFromBrowser(option3Requests);
+          const option4Requests =
+            await this._processSuccessfulResponsesAndReturnRemaining(
+              option3Requests,
+              option3ResponsePromise,
+              errorMap,
+              successCb
+            );
+
+          if (option4Requests.length === 0) {
+            // Done!
+            return;
+          }
+
+          // Some libraries are still remaining, try option 4 for them.
+          // Option 4 is symbolProvider.requestSymbolTableFromBrowser.
+          await this._getSymbolTablesFromBrowser(
+            option4Requests,
+            errorMap,
             demangleCallback,
             successCb,
             errorCb
           );
         }
-      })
+      )
     );
   }
 
-  // Try to get symbols from the browser for any libraries which couldn't be
-  // symbolicated with the symbolication API.
-  async _getSymbolsFromBrowser(
-    requestsWithErrors: Array<{|
-      // A symbolication request for one library.
-      request: LibSymbolicationRequest,
-      // The error which was encountered when trying to obtain symbols for
-      // this library using the symbolication API.
-      // This gets reported in the final error if all avenues fail.
-      error: Error,
-    |}>,
+  // This method awaits `responsesPromise`. All successful responses are forwarded
+  // to successCb.
+  // Returns any requests which were not successful.
+  // Mutates errorMap by adding the error that was encountered for a failed request.
+  async _processSuccessfulResponsesAndReturnRemaining(
+    requests: LibSymbolicationRequest[],
+    responsesPromise: Promise<LibSymbolicationResponse[]>,
+    errorMap: Map<LibSymbolicationRequest, Error[]>,
+    successCb: (RequestedLib, Map<number, AddressResult>) => void
+  ): Promise<LibSymbolicationRequest[]> {
+    try {
+      const responses: LibSymbolicationResponse[] = await responsesPromise;
+
+      const failedRequests = [];
+      for (let i = 0; i < responses.length; i++) {
+        const response = responses[i];
+        if (response.type === 'SUCCESS') {
+          // We've found symbols for this library!
+          const { lib, results } = response;
+          successCb(lib, results);
+        } else {
+          // No symbols for this library, it'll need to try the next option.
+          const { request, error } = response;
+          failedRequests.push(request);
+          // Put the error into the errorMap.
+          // errorMap has been initialized for all requests, this .get() never returns undefined.
+          (errorMap.get(request) ?? []).push(error);
+        }
+      }
+      return failedRequests;
+    } catch (error) {
+      // There was a problem for the entire chunk of requests, for example there
+      // might have been a problem parsing the response JSON.
+      // Add this error for all requests.
+      for (const request of requests) {
+        // errorMap has been initialized for all requests, this .get() never returns undefined.
+        (errorMap.get(request) ?? []).push(error);
+      }
+      return requests;
+    }
+  }
+
+  // Try to get individual symbol tables from the browser, for any libraries
+  // which couldn't be symbolicated with the symbolication API.
+  // This is needed for two cases:
+  //  1. Firefox 95 and earlier, which didn't have a querySymbolicationApi
+  //     WebChannel access point, and only supports symbol tables.
+  //  2. Android system libraries, even in modern versions of Firefox. We don't
+  //     support querySymbolicationApi for them yet, see
+  //     https://bugzilla.mozilla.org/show_bug.cgi?id=1735897
+  async _getSymbolTablesFromBrowser(
+    requests: LibSymbolicationRequest[],
+    errorMap: Map<LibSymbolicationRequest, Error[]>,
     demangleCallback: DemangleFunction,
     successCb: (RequestedLib, Map<number, AddressResult>) => void,
     errorCb: (LibSymbolicationRequest, Error) => void
   ): Promise<void> {
-    for (const { request, error } of requestsWithErrors) {
+    for (const request of requests) {
       const { lib, addresses } = request;
       try {
-        // Option 3: Request a symbol table from the browser.
+        // Option 4: Request a symbol table from the browser.
         // This call will throw if the browser cannot obtain the symbol table.
         const symbolTable =
           await this._symbolProvider.requestSymbolTableFromBrowser(lib);
 
-        // Did not throw, option 3 was successful!
+        // Did not throw, option 4 was successful!
         successCb(
           lib,
           readSymbolsFromSymbolTable(addresses, symbolTable, demangleCallback)
@@ -446,13 +490,13 @@ export class SymbolStore {
         await this._storeSymbolTableInDB(lib, symbolTable);
       } catch (lastError) {
         // None of the symbolication methods were successful.
-        // Call the error callback.
+        // Call the error callback with all accumulated errors.
         errorCb(
           request,
           new SymbolsNotFoundError(
             `Could not obtain symbols for ${lib.debugName}/${lib.breakpadId}.`,
             lib,
-            error,
+            ...(errorMap.get(request) ?? []),
             lastError
           )
         );

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -699,11 +699,8 @@ describe('actions/receive-profile', function () {
         expect(error.errors).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              errors: expect.arrayContaining([
-                expect.objectContaining({
-                  message: 'No symbolication API in place',
-                }),
-              ]),
+              message:
+                'There was a problem with the symbolication API request to the symbol server: No symbolication API in place',
             }),
             expect.objectContaining({ message: 'No symbol tables available' }),
           ])
@@ -910,8 +907,8 @@ describe('actions/receive-profile', function () {
         expect.objectContaining({
           message:
             'Could not obtain symbols for libxul/SOMETHING_FAKE.\n' +
-            ' - SymbolsNotFoundError: There was a problem with the JSON returned by the symbolication API.\n' +
-            ' - Error: Expected an object with property `results`\n' +
+            ' - Error: There was a problem with the symbolication API request to the symbol server: Expected an object with property `results`\n' +
+            ' - Error: No connection to the browser, cannot run querySymbolicationApi\n' +
             ' - Error: No connection to the browser, cannot obtain symbol tables',
         })
       );

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -102,6 +102,10 @@ describe('doSymbolicateProfile', function () {
           return { type: 'SUCCESS', lib, results: map };
         }),
 
+      requestSymbolsFromBrowser: async (_path, _requestJson) => {
+        throw new Error('requestSymbolsFromBrowser unsupported in this test');
+      },
+
       requestSymbolTableFromBrowser: async (lib) => {
         if (lib.debugName !== 'firefox.pdb') {
           throw new SymbolsNotFoundError(

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -61,6 +61,9 @@ describe('SymbolStore', function () {
           })
         )
       ),
+      requestSymbolsFromBrowser: async (_path, _requestJson) => {
+        throw new Error('requestSymbolsFromBrowser unsupported in this test');
+      },
       requestSymbolTableFromBrowser: jest.fn(() =>
         Promise.resolve(completeSymbolTableAsTuple)
       ),
@@ -152,6 +155,11 @@ describe('SymbolStore', function () {
           }))
         )
       ),
+      requestSymbolsFromBrowser: jest.fn((_path, _requestJson) =>
+        Promise.reject(
+          new Error('requestSymbolsFromBrowser unsupported in this test')
+        )
+      ),
       requestSymbolTableFromBrowser: jest.fn(() =>
         Promise.resolve(completeSymbolTableAsTuple)
       ),
@@ -223,6 +231,11 @@ describe('SymbolStore', function () {
         }
         return responses;
       }),
+      requestSymbolsFromBrowser: jest.fn((_path, _requestJson) =>
+        Promise.reject(
+          new Error('requestSymbolsFromBrowser unsupported in this test')
+        )
+      ),
       requestSymbolTableFromBrowser: jest
         .fn()
         .mockResolvedValue(completeSymbolTableAsTuple),
@@ -379,6 +392,11 @@ describe('SymbolStore', function () {
         }
         return responses;
       },
+      requestSymbolsFromBrowser: jest.fn((_path, _requestJson) =>
+        Promise.reject(
+          new Error('requestSymbolsFromBrowser unsupported in this test')
+        )
+      ),
       requestSymbolTableFromBrowser: async ({ debugName, breakpadId }) => {
         expect(debugName).not.toEqual('');
         expect(breakpadId).not.toEqual('');

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -456,6 +456,7 @@ describe('SymbolStore', function () {
       new SymbolsNotFoundError(
         'Could not obtain symbols for available-from-neither/dont-care.\n' +
           ' - Error: symbol table not found\n' +
+          ' - Error: requestSymbolsFromBrowser unsupported in this test\n' +
           ' - Error: The browser does not have symbols for this library.',
         {
           debugName: 'available-from-neither',


### PR DESCRIPTION
This PR makes it so that we will get inline callstacks when profiling local Firefox builds. It hooks up symbolication to the new `querySymbolicationApi` entry point from the WebChannel.

Example profile: https://share.firefox.dev/31CAqLf

Fixes #1516.