### PR TITLE
Move tracks context menu button to the left side of the timeline ruler

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -228,8 +228,8 @@ FullTimeline--stack-height = Stack height
 # Variables:
 #   $visibleTrackCount (Number) - Visible track count in the timeline
 #   $totalTrackCount (Number) - Total track count in the timeline
-FullTimeline--tracks-visible =
-    <span>{ $visibleTrackCount }</span> / <span>{ $totalTrackCount }</span> tracks visible
+FullTimeline--tracks-button =
+    <span>{ $visibleTrackCount }</span> / <span>{ $totalTrackCount }</span> tracks
 
 ## Home page
 

--- a/src/components/timeline/FullTimeline.js
+++ b/src/components/timeline/FullTimeline.js
@@ -306,12 +306,14 @@ class FullTimelineImpl extends React.PureComponent<Props, State> {
           )}
         </div>
         <TimelineSelection width={timelineWidth}>
-          <TimelineRuler
-            zeroAt={zeroAt}
-            rangeStart={committedRange.start}
-            rangeEnd={committedRange.end}
-            width={timelineWidth}
-          />
+          <div className="timelineHeader">
+            <TimelineRuler
+              zeroAt={zeroAt}
+              rangeStart={committedRange.start}
+              rangeEnd={committedRange.end}
+              width={timelineWidth}
+            />
+          </div>
           <OverflowEdgeIndicator
             className="timelineOverflowEdgeIndicator"
             panelLayoutGeneration={panelLayoutGeneration}

--- a/src/components/timeline/FullTimeline.js
+++ b/src/components/timeline/FullTimeline.js
@@ -167,7 +167,7 @@ class TimelineSettingsHiddenTracks extends React.PureComponent<{|
 
     return (
       <Localized
-        id="FullTimeline--tracks-visible"
+        id="FullTimeline--tracks-button"
         elems={{
           span: <span className="timelineSettingsHiddenTracksNumber" />,
         }}
@@ -188,7 +188,7 @@ class TimelineSettingsHiddenTracks extends React.PureComponent<{|
           <span className="timelineSettingsHiddenTracksNumber">
             {hiddenTrackCount.total}{' '}
           </span>
-          tracks visible
+          tracks
         </button>
       </Localized>
     );
@@ -288,10 +288,6 @@ class FullTimelineImpl extends React.PureComponent<Props, State> {
             changeTimelineType={changeTimelineType}
             isCPUUtilizationProvided={isCPUUtilizationProvided}
           />
-          <TimelineSettingsHiddenTracks
-            hiddenTrackCount={hiddenTrackCount}
-            changeRightClickedTrack={changeRightClickedTrack}
-          />
           {/*
             Removing the active tab view checkbox for now.
             TODO: Bring it back once we are done with the new active tab UI implementation.
@@ -307,6 +303,10 @@ class FullTimelineImpl extends React.PureComponent<Props, State> {
         </div>
         <TimelineSelection width={timelineWidth}>
           <div className="timelineHeader">
+            <TimelineSettingsHiddenTracks
+              hiddenTrackCount={hiddenTrackCount}
+              changeRightClickedTrack={changeRightClickedTrack}
+            />
             <TimelineRuler
               zeroAt={zeroAt}
               rangeStart={committedRange.start}

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -68,21 +68,14 @@
 
   /* 1px is allocated for the vertical separator line. */
   width: calc(var(--thread-label-column-width) - 1px);
-  height: 20px;
 
   /* 8px is intentional to align this text with the text above. */
   padding: 0 20px 0 8px;
   border: 0;
-  margin: 0;
   background: none;
   color: inherit;
-
-  /* Specific for links. */
-  cursor: default;
   font: inherit;
-  line-height: 20px;
   text-align: left;
-  text-decoration: none;
 }
 
 .timelineSettingsHiddenTracks:hover {

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -102,3 +102,8 @@
 .timelineSettingsHiddenTracksNumber {
   font-weight: bold;
 }
+
+.timelineHeader {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -65,30 +65,39 @@
 .timelineSettingsHiddenTracks {
   /* Make sure and override all rules that have to do with button defaults. */
   position: relative;
-  height: 17px;
-  padding: 0 7px 0 20px;
+
+  /* 1px is allocated for the vertical separator line. */
+  width: calc(var(--thread-label-column-width) - 1px);
+  height: 20px;
+
+  /* 8px is intentional to align this text with the text above. */
+  padding: 0 20px 0 8px;
   border: 0;
-  margin: 4px 5px 0;
-  background-color: var(--blue-60);
-  border-radius: 12px;
-  color: #fff;
+  margin: 0;
+  background: none;
+  color: inherit;
+
+  /* Specific for links. */
+  cursor: default;
   font: inherit;
-  line-height: 17px;
+  line-height: 20px;
+  text-align: left;
+  text-decoration: none;
 }
 
 .timelineSettingsHiddenTracks:hover {
-  background-color: var(--blue-70);
+  background-color: rgb(0 0 0 / 0.1);
 }
 
-.timelineSettingsHiddenTracks:active {
-  background-color: var(--blue-80);
+.timelineSettingsHiddenTracks:hover:active {
+  background-color: rgb(0 0 0 / 0.2);
 }
 
 /* This is the dropdown arrow on the left of the button. */
 .timelineSettingsHiddenTracks::before {
   position: absolute;
-  top: 1px;
-  left: 2px;
+  top: 2px;
+  right: 2px;
   border-top: 6px solid;
   border-right: 4px solid transparent;
   border-bottom: 0 solid transparent;
@@ -96,6 +105,7 @@
   margin-top: 5px;
   margin-right: 5px;
   margin-left: 5px;
+  color: var(--grey-60);
   content: '';
 }
 
@@ -105,5 +115,7 @@
 
 .timelineHeader {
   display: flex;
+  height: 20px;
   flex-direction: row;
+  margin-left: calc(var(--thread-label-column-width) * -1);
 }

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -488,6 +488,8 @@ describe('Timeline', function () {
   });
 
   describe('TimelineSettingsHiddenTracks', () => {
+    autoMockDomRect();
+
     it('resets "rightClickedTrack" state when clicked', () => {
       const profile = _getProfileWithDroppedSamples();
 
@@ -506,7 +508,7 @@ describe('Timeline', function () {
         type: 'global',
       });
 
-      fireFullClick(screen.getByText('/ tracks visible'));
+      fireFullClick(screen.getByText('/ tracks'));
       expect(getRightClickedTrack(store.getState())).toEqual(null);
     });
   });

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -33,23 +33,6 @@ exports[`Timeline renders the header 1`] = `
       </label>
     </div>
   </form>
-  <button
-    class="timelineSettingsHiddenTracks"
-    type="button"
-  >
-    <span
-      class="timelineSettingsHiddenTracksNumber"
-    >
-      ⁨4⁩
-    </span>
-     / 
-    <span
-      class="timelineSettingsHiddenTracksNumber"
-    >
-      ⁨4⁩
-    </span>
-     tracks visible
-  </button>
 </div>
 `;
 


### PR DESCRIPTION
This PR moves the tracks context menu button to the left side of the timeline ruler. The text is shortened to make it fit into a smaller space.

New button location:
<img width="552" alt="Screen Shot 2021-12-09 at 3 46 34 PM" src="https://user-images.githubusercontent.com/466239/145417970-434e5726-a408-4507-b596-a8a0e23f58ab.png">

[Deploy preview](https://deploy-preview-3730--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=33845-g&localTrackOrderByPid=33845-st0wr&thread=0&timelineType=cpu-category&v=6)

Note that I didn't change the code in this PR to add an `active` state to the button. It requires some changes, so I would like to do it in a follow-up. I think it will be easier to review that way.