### PR TITLE
Limit default visible threads to 15.

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -36,7 +36,6 @@ import {
   getIsCPUUtilizationProvided,
   getSymbolServerUrl,
   getActiveTabID,
-  getIdleThreadsByCPU,
 } from 'firefox-profiler/selectors';
 import {
   withHistoryReplaceStateAsync,
@@ -327,11 +326,7 @@ export function finalizeFullProfileView(
       // This is the case for the initial profile load.
       // We also get here if the URL info was ignored, for example if
       // respecting it would have caused all threads to become hidden.
-      hiddenTracks = computeDefaultHiddenTracks(
-        tracksWithOrder,
-        profile,
-        getIdleThreadsByCPU(getState())
-      );
+      hiddenTracks = computeDefaultHiddenTracks(tracksWithOrder, profile);
     }
 
     const selectedThreadIndexes = initializeSelectedThreadIndex(

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import { isContentThreadWithNoPaint } from './profile-data';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 
 import type {
@@ -12,7 +11,7 @@ import type {
   Milliseconds,
   SampleUnits,
   ThreadCPUDeltaUnit,
-  ThreadIndex,
+  Profile,
 } from 'firefox-profiler/types';
 
 /**
@@ -47,6 +46,51 @@ export function computeMaxThreadCPUDelta(
   }
 
   return maxThreadCPUDelta;
+}
+
+/**
+ * Returns the expected cpu delta per sample if cpu is at 100% and
+ * sampling happens at the declared interval.
+ *
+ * Returns null if the profile does not use cpu deltas.
+ * Otherwise, returns a ratio that can be used to compare activity
+ * between threads with cpu deltas and threads without cpu deltas.
+ *
+ * Examples:
+ *  - interval: 2 (ms), sampleUnits: undefined
+ *    Returns null.
+ *  - interval: 5 (ms), sampleUnits.threadCPUDelta: "µs"
+ *    Returns 5000, i.e. "5000µs cpu delta per sample if each sample ticks at
+ *    the declared 5ms interval and the CPU usage is at 100%".
+ *  - interval: 3 (ms), sampleUnits.threadCPUDelta: "variable CPU cycles",
+ *    max_{sample}(sample.cpuDelta / sample.timeDelta) == 1234567 cycles per ms
+ *    Returns 1234567 * 3, i.e. "3703701 cycles per sample if each sample ticks at
+ *    the declared 3ms interval and the CPU usage is at the observed maximum".
+ */
+export function computeMaxCPUDeltaPerInterval(profile: Profile): number | null {
+  const sampleUnits = profile.meta.sampleUnits;
+  if (!sampleUnits) {
+    return null;
+  }
+
+  const interval = profile.meta.interval;
+  const threadCPUDeltaUnit = sampleUnits.threadCPUDelta;
+
+  switch (threadCPUDeltaUnit) {
+    case 'µs':
+    case 'ns': {
+      const cpuDeltaTimeUnitMultiplier =
+        getCpuDeltaTimeUnitMultiplier(threadCPUDeltaUnit);
+      return cpuDeltaTimeUnitMultiplier * interval;
+    }
+    case 'variable CPU cycles':
+      return computeMaxThreadCPUDelta(profile.threads, interval);
+    default:
+      throw assertExhaustiveCheck(
+        threadCPUDeltaUnit,
+        'Unhandled threadCPUDelta unit in computeMaxCPUDeltaPerInterval.'
+      );
+  }
 }
 
 /**
@@ -190,125 +234,4 @@ function findClosestNonNullValueToIdx(
   }
 
   return findClosestNonNullValueToIdx(array, idx, ++distance);
-}
-
-// Threshold to be used for checking if a single threadCPUDelta value is above
-// the maxThreadCPUDelta. If the sample CPU value is using more than 10% of CPU,
-// it's safe to assume that this sample is active and non-idle.
-const CPU_IDLENESS_PERCENTAGE = 0.1;
-
-/**
- * Compute the activity percentages for each threads by looking at their CPU usage
- * per thread. This will be used to determine the idle threads and also to
- * visualize the activity of threads in the UI.
- * A sample is considered active if its CPU value is above
- * `maxThreadCPUDelta * CPU_IDLENESS_PERCENTAGE`.
- */
-export function computeThreadActivityPercentages(
-  threads: Thread[],
-  sampleUnits: SampleUnits | void,
-  profileInterval: Milliseconds,
-  maxThreadCPUDelta: number
-): Map<ThreadIndex, number> {
-  const activityPercentages = new Map();
-
-  if (!sampleUnits) {
-    // There is no CPU value in this thread, return empty map.
-    return activityPercentages;
-  }
-
-  const cpuThresholdPerInterval = maxThreadCPUDelta * CPU_IDLENESS_PERCENTAGE;
-  for (let threadIndex = 0; threadIndex < threads.length; threadIndex++) {
-    const thread = threads[threadIndex];
-    const { samples } = thread;
-    const { threadCPUDelta } = samples;
-
-    if (!threadCPUDelta) {
-      // This should not happen because this is checked before. But continue
-      // early just in case.
-      activityPercentages.set(threadIndex, 0);
-      continue;
-    }
-
-    let activeStackCount = 0;
-    // Skipping zero because we know for sure that the first index will be null.
-    for (let sampleIndex = 1; sampleIndex < samples.length; sampleIndex++) {
-      const currentThreadCPUDelta = threadCPUDelta[sampleIndex] || 0;
-      // Interval is not always steady depending on the overhead.
-      const intervalFactor =
-        (samples.time[sampleIndex] - samples.time[sampleIndex - 1]) /
-        profileInterval;
-      const currentCPUPerInterval = currentThreadCPUDelta / intervalFactor;
-
-      // Check if the sample's CPUDelta value is above the threshold.
-      if (
-        currentCPUPerInterval !== null &&
-        currentCPUPerInterval >= cpuThresholdPerInterval
-      ) {
-        activeStackCount++;
-      }
-    }
-
-    // Compute the activity percentage of the thread and add it to the map.
-    const threadActivityPercentage = activeStackCount / samples.length;
-    activityPercentages.set(threadIndex, threadActivityPercentage);
-  }
-
-  return activityPercentages;
-}
-
-// Threshold to be used for checking a thread's CPU activity percentage vs the
-// most active thread CPU activity percentage. Currently, we assume a thread
-// idle if it's activity below 10% compared to the most active thread.
-const ACTIVE_SAMPLE_PERCENTAGE = 0.1;
-// Threshold for only content processes with no paint markers. If there's no
-// paint marker, it's safe to assume that the content process is not interesting
-// for the user. So it should be marked as idle, even if it has slightly more CPU
-// usage. It will be marked as non-idle if it has more than 20% of CPU activity.
-const ACTIVE_SAMPLE_PERCENTAGE_CONTENT_PROCESS_NO_PAINT = 0.2;
-
-/**
- * Get the activity percentages for all threads, and find out the idle threads
- * by looking at the relative CPU usage for each thread. It's relative to the
- * most active thread in the whole profile.
- */
-export function computeIdleThreadsByCPU(
-  threads: Thread[],
-  threadActivityPercentages: Map<ThreadIndex, number>
-): Set<ThreadIndex> {
-  const idleThreads = new Set();
-  // Find the max percentage value across profile. This will be used to compute
-  // the idleness sample percentage threshold.
-  let maxActivityPercentage = 0;
-  threadActivityPercentages.forEach((activenessPercentage) => {
-    maxActivityPercentage = Math.max(
-      maxActivityPercentage,
-      activenessPercentage
-    );
-  });
-
-  // We have two thresholds for activeness. The first one is used most of the time.
-  // But if there are any content process main threads with no paint markers,
-  // then the second threshold will be used, which is higher. This means that
-  // we're more agressively hiding content processes with no paint markers.
-  const defaultThreshold = maxActivityPercentage * ACTIVE_SAMPLE_PERCENTAGE;
-  const thresholdForContentProcessWithNoPaint =
-    maxActivityPercentage * ACTIVE_SAMPLE_PERCENTAGE_CONTENT_PROCESS_NO_PAINT;
-
-  for (const [
-    threadIndex,
-    activityPercentage,
-  ] of threadActivityPercentages.entries()) {
-    // Threshold changes for each thread. If it's a content process main thread
-    // with no paint markers, the threshold will be higher.
-    const thresholdForThread = isContentThreadWithNoPaint(threads[threadIndex])
-      ? thresholdForContentProcessWithNoPaint
-      : defaultThreshold;
-
-    if (activityPercentage < thresholdForThread) {
-      idleThreads.add(threadIndex);
-    }
-  }
-
-  return idleThreads;
 }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -3320,37 +3320,3 @@ export function nudgeReturnAddresses(thread: Thread): Thread {
     mapForBacktraceSelfStacks
   );
 }
-
-/**
- * Returns true if the thread doesn't include any RefreshDriverTick. This
- * indicates they were not painted to, and most likely idle. This is just
- * a heuristic to help users.
- */
-export function isThreadWithNoPaint({ markers, stringTable }: Thread): boolean {
-  let paintMarkerFound = false;
-  if (stringTable.hasString('RefreshDriverTick')) {
-    const paintStringIndex = stringTable.indexForString('RefreshDriverTick');
-
-    for (let markerIndex = 0; markerIndex < markers.length; markerIndex++) {
-      if (paintStringIndex === markers.name[markerIndex]) {
-        paintMarkerFound = true;
-        break;
-      }
-    }
-  }
-  if (!paintMarkerFound) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Returns true if a thread is a content process main thread with no paint markers.
- */
-export function isContentThreadWithNoPaint(thread: Thread): boolean {
-  if (thread.name === 'GeckoMain' && thread.processType === 'tab') {
-    return isThreadWithNoPaint(thread);
-  }
-
-  return false;
-}

--- a/src/selectors/cpu.js
+++ b/src/selectors/cpu.js
@@ -12,18 +12,9 @@ import {
   getMeta,
 } from './profile';
 import { getThreadSelectors } from './per-thread';
-import {
-  computeMaxThreadCPUDelta,
-  computeThreadActivityPercentages,
-  computeIdleThreadsByCPU,
-} from 'firefox-profiler/profile-logic/cpu';
+import { computeMaxThreadCPUDelta } from 'firefox-profiler/profile-logic/cpu';
 
-import type {
-  Selector,
-  State,
-  Thread,
-  ThreadIndex,
-} from 'firefox-profiler/types';
+import type { Selector, State, Thread } from 'firefox-profiler/types';
 
 export const getIsCPUUtilizationProvided: Selector<boolean> = createSelector(
   getSampleUnits,
@@ -69,26 +60,4 @@ export const getMaxThreadCPUDelta: Selector<number> = createSelector(
   getCPUProcessedThreads,
   getProfileInterval,
   computeMaxThreadCPUDelta
-);
-
-/**
- * Get the map of thread index -> activity percentage for each thread if the CPU
- * usage values are provided in the profile.
- */
-export const getThreadActivityPercentages: Selector<Map<ThreadIndex, number>> =
-  createSelector(
-    getThreads,
-    getSampleUnits,
-    getProfileInterval,
-    getMaxThreadCPUDelta,
-    computeThreadActivityPercentages
-  );
-
-/**
- * Get the idle threads by looking at their CPU activity.
- */
-export const getIdleThreadsByCPU: Selector<Set<ThreadIndex>> = createSelector(
-  getThreads,
-  getThreadActivityPercentages,
-  computeIdleThreadsByCPU
 );


### PR DESCRIPTION
Fixes #3703.

This is a bit of a rewrite of the thread idleness detection.
Instead of showing all non-idle threads, we compute a score for all threads so that we can compare non-idle threads and only show the most important ones.

Why 15 and not 20?
By limiting the "threads" to 15, we can end up with 15-60 "tracks": Each thread might be a background thread from a different process, so by showing it we may also show its process's main thread. In addition, we may show a memory track and a network track for each process.
First I tried just picking 10 threads, and it felt fine, until I tested [this audio profile](https://profiler.firefox.com/public/c1d0b127624cfa840947ff5a7502f978ecb7d0e2) where 10 threads wasn't enough to show all the audio threads. So I increased it by 5 and that seemed to work fine.

Why am I removing the "paint" marker check?
For simplicity, and because it didn't seem necessary. All the example profiles still work fine. We can re-add the check if we find profiles where it makes a positive difference.

I've made a list of all profiles that were referenced in previous changes to idleness detection, and this PR works well for all of them.

 - [production](https://profiler.firefox.com/public/9123fab7068c9fa242d79396f257b614bcd67bce), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/9123fab7068c9fa242d79396f257b614bcd67bce) (from https://github.com/firefox-devtools/profiler/pull/1218)
     - should show three or two threads (all main)
 - [production](https://profiler.firefox.com/public/a4db2dc3143ae68a18d529af08160a6a22dcccea), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/a4db2dc3143ae68a18d529af08160a6a22dcccea) (from https://github.com/firefox-devtools/profiler/issues/1651)
     - should show parent + content 2/2 (which main branch currently hides), and maybe webextensions
 - no profile (from https://github.com/firefox-devtools/profiler/issues/1436)
     - should show the content process without paint whose main thread is running 100% CPU GC
 - [production](https://profiler.firefox.com/public/91bdb2248d08174f07d9186aabbe1025e5ff9bf1), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/91bdb2248d08174f07d9186aabbe1025e5ff9bf1) (from https://github.com/firefox-devtools/profiler/pull/1312)
     - should show parent + content 4/4, not the other content processes even though they have some CC activity (except maybe 2/4)
 - [production](https://profiler.firefox.com/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr) (from https://github.com/firefox-devtools/profiler/pull/3611)
     - should only show parent main + renderer, but not various idle WR threads
 - [production](https://profiler.firefox.com/public/k82sqxse5qw5zq2yk0dvsfxpvy41rga7jz8g320), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/k82sqxse5qw5zq2yk0dvsfxpvy41rga7jz8g320) (from https://github.com/firefox-devtools/profiler/pull/3611))
     - should show parent main + render and various content main threads, but no SwComposite threads
 - [production](https://profiler.firefox.com/public/yypb94qpr72dc7dve5fsaxte7885zerqwfthmkg), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/yypb94qpr72dc7dve5fsaxte7885zerqwfthmkg) (from https://github.com/firefox-devtools/profiler/pull/3611))
     - really idle, should show a weird assortment of totally idle threads
 - [production](https://profiler.firefox.com/public/a3b9yfe8bm7bxrgc0k0ptxzzcdxz3rk6wcm307r), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/a3b9yfe8bm7bxrgc0k0ptxzzcdxz3rk6wcm307r) (from https://github.com/firefox-devtools/profiler/pull/3611#issuecomment-951043836)
     - should show AndroidUI and not much else, ideally. main currently fails this
 - [production](https://profiler.firefox.com/public/5e32d56b5a4eb9b13882eac3be8879b05d259376), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/5e32d56b5a4eb9b13882eac3be8879b05d259376)/ (from https://github.com/firefox-devtools/profiler/issues/1235)
     - should not hide the Renderer thread (fixed in https://github.com/firefox-devtools/profiler/pull/1236)
 - [production](https://profiler.firefox.com/public/c1d0b127624cfa840947ff5a7502f978ecb7d0e2), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/c1d0b127624cfa840947ff5a7502f978ecb7d0e2) (from https://github.com/firefox-devtools/profiler/pull/2495)
     - should show basically all audio threads, because they were profiled and something's doing audio
 - [production](https://profiler.firefox.com/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr), [deploy preview](https://deploy-preview-3743--perf-html.netlify.app/public/vyr06p688xrqrf06tgjeyrthkc5hcfye0044yvr) (from https://github.com/firefox-devtools/profiler/pull/3627)
     - should make the renderer thread visible, and parent process main thread, but not much else