### PR TITLE
Tweak the call node tooltip.

### DIFF
--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -224,6 +224,7 @@ function setupFlameGraph() {
   const {
     profile,
     funcNamesPerThread: [funcNames],
+    funcNamesDictPerThread: [funcNamesDict],
   } = getProfileFromTextSamples(`
     A[cat:DOM]       A[cat:DOM]       A[cat:DOM]
     B[cat:DOM]       B[cat:DOM]       B[cat:DOM]
@@ -241,6 +242,9 @@ function setupFlameGraph() {
     funcTable.columnNumber[funcIndex] = funcIndex + 100;
     funcTable.fileName[funcIndex] = stringTable.indexForString('path/to/file');
   }
+  funcTable.fileName[funcNamesDict.J] = stringTable.indexForString(
+    'hg:hg.mozilla.org/mozilla-central:widget/cocoa/nsAppShell.mm:997f00815e6bc28806b75448c8829f0259d2cb28'
+  );
 
   const store = storeWithProfile(profile);
 

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -150,7 +150,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
         <div
           class="tooltipLabel"
         >
-          Script URL:
+          File:
         </div>
         <div
           class="tooltipDetailsUrl"
@@ -827,12 +827,12 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
         <div
           class="tooltipLabel"
         >
-          Script URL:
+          File:
         </div>
         <div
           class="tooltipDetailsUrl"
         >
-          path/to/file:17:107
+          widget/cocoa/nsAppShell.mm:17:107
         </div>
         <div
           class="tooltipLabel"


### PR DESCRIPTION
In the past, only JS functions would have fileName information, so the fileName was always a URL.
More recently, symbolication can now add filenames on native functions, and those filenames can have special path syntax that isn't pretty to look at.
So this commit renames 'Script URL' to 'File' and strips away the special path syntax, so that the path is nicer to look at.

Fixes #3714.
Fixes #3652.