### PR TITLE
Hide the experimental process cpu threads and only show them once they are enabled from console

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -32,6 +32,7 @@ import { fatalError } from './errors';
 import {
   addEventDelayTracksForThreads,
   initializeLocalTrackOrderByPid,
+  addExperimentalThreadsForType,
 } from 'firefox-profiler/profile-logic/tracks';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import {
@@ -367,8 +368,22 @@ export function enableExperimentalProcessCPUTracks(): ThunkAction<boolean> {
       return false;
     }
 
+    const oldLocalTracks = getLocalTracksByPid(getState());
+    const localTracksByPid = addExperimentalThreadsForType(
+      getThreads(getState()),
+      'process-cpu',
+      oldLocalTracks
+    );
+    const localTrackOrderByPid = initializeLocalTrackOrderByPid(
+      getLocalTrackOrderByPid(getState()),
+      localTracksByPid,
+      null
+    );
+
     dispatch({
       type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
+      localTracksByPid,
+      localTrackOrderByPid,
     });
 
     return true;

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1069,6 +1069,7 @@ function _processThread(
     unregisterTime: thread.unregisterTime,
     tid: thread.tid,
     pid: thread.pid,
+    experimental: thread.experimental,
     libs,
     pausedRanges: pausedRanges || [],
     frameTable,

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -265,6 +265,20 @@ const cpuGraphs: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+/*
+ * This reducer hold the state for whether the process CPU tracks are enabled.
+ * This feature is still experimental and this will be removed once we have
+ * better handling for this data.
+ */
+const processCPUTracks: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+      return true;
+    default:
+      return state;
+  }
+};
+
 /**
  * This keeps the information about the upload for the current profile, if any.
  * This is retrieved from the IndexedDB for published profiles information in
@@ -295,6 +309,7 @@ const currentProfileUploadedInformation: Reducer<
 const experimental: Reducer<ExperimentalFlags> = combineReducers({
   eventDelayTracks,
   cpuGraphs,
+  processCPUTracks,
 });
 
 const appStateReducer: Reducer<AppState> = combineReducers({

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -136,6 +136,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'ISOLATE_LOCAL_TRACK':
     case 'TOGGLE_RESOURCES_PANEL':
     case 'ENABLE_EXPERIMENTAL_CPU_GRAPHS':
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
     // Committed range changes: (fallthrough)
     case 'COMMIT_RANGE':
     case 'POP_COMMITTED_RANGES':

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -98,6 +98,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
       return action.localTracksByPid;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -439,6 +439,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -75,6 +75,9 @@ export const getIsEventDelayTracksEnabled: Selector<boolean> = (state) =>
   getExperimental(state).eventDelayTracks;
 export const getIsExperimentalCPUGraphsEnabled: Selector<boolean> = (state) =>
   getExperimental(state).cpuGraphs;
+export const getIsExperimentalProcessCPUTracksEnabled: Selector<boolean> = (
+  state
+) => getExperimental(state).processCPUTracks;
 
 export const getIsDragAndDropDragging: Selector<boolean> = (state) =>
   getApp(state).isDragAndDropDragging;

--- a/src/selectors/cpu.js
+++ b/src/selectors/cpu.js
@@ -43,6 +43,14 @@ export const getIsCPUUtilizationProvided: Selector<boolean> = createSelector(
 );
 
 /**
+ * It will return true if there are experimental process CPU threads in the profile.
+ */
+export const getAreThereAnyProcessCPUThreads: Selector<boolean> =
+  createSelector(getThreads, (threads) =>
+    threads.some((thread) => thread.experimental === 'process-cpu')
+  );
+
+/**
  * This function returns the list of all threads after the CPU values have been
  * processed. This uses a selector from the per-thread selectors. Because we'll
  * use this selector for every thread, and also need the full state for this call,

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -56,6 +56,7 @@ Object {
   "threads": Array [
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -436,6 +437,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -654,6 +656,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -872,6 +875,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -1401,6 +1405,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -1653,6 +1658,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2006,6 +2012,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2192,6 +2199,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2408,6 +2416,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2628,6 +2637,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -2844,6 +2854,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -3120,6 +3131,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -4110,6 +4122,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -5100,6 +5113,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -6094,6 +6108,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,
@@ -7088,6 +7103,7 @@ Object {
     },
     Object {
       "eTLD+1": undefined,
+      "experimental": undefined,
       "frameTable": Object {
         "address": Array [
           -1,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -300,6 +300,8 @@ type ProfileAction =
     |}
   | {|
       +type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
+      +localTracksByPid: Map<Pid, LocalTrack[]>,
+      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
     |}
   | {|
       +type: 'OPEN_SOURCE_VIEW',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -299,6 +299,9 @@ type ProfileAction =
       +type: 'ENABLE_EXPERIMENTAL_CPU_GRAPHS',
     |}
   | {|
+      +type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
+    |}
+  | {|
       +type: 'OPEN_SOURCE_VIEW',
       +file: string,
       +currentTab: TabSlug,

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -15,6 +15,7 @@ import type {
   VisualMetrics,
   ProfilerConfiguration,
   SampleUnits,
+  ExperimentalThreadType,
 } from './profile';
 import type { MarkerPayload_Gecko, MarkerSchema } from './markers';
 import type { Milliseconds, Nanoseconds } from './units';
@@ -241,6 +242,10 @@ export type GeckoThread = {|
   unregisterTime: number | null,
   tid: number,
   pid: number,
+  // Experimental flag. If it's present in a thread, it means that the thread is
+  // experimental and therefore should be hidden. The value represents the
+  // experiment type, so they can be enabled by type when needed.
+  experimental?: ExperimentalThreadType,
   markers: GeckoMarkers,
   samples: GeckoSamples,
   frameTable: GeckoFrameTable,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -604,6 +604,11 @@ export type ProfilerOverhead = {|
 |};
 
 /**
+ * Type for experimental threads that annotate the experiment type.
+ */
+export type ExperimentalThreadType = 'process-cpu' | string;
+
+/**
  * Gecko has one or more processes. There can be multiple threads per processes. Each
  * thread has a unique set of tables for its data.
  */
@@ -640,6 +645,10 @@ export type Thread = {|
   isJsTracer?: boolean,
   pid: Pid,
   tid: Tid | void,
+  // Experimental flag. If it's present in a thread, it means that the thread is
+  // experimental and therefore should be hidden. The value represents the
+  // experiment type, so they can be enabled by type when needed.
+  experimental?: ExperimentalThreadType,
   samples: SamplesTable,
   jsAllocations?: JsAllocationsTable,
   nativeAllocations?: NativeAllocationsTable,

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -174,6 +174,7 @@ export type UrlSetupPhase = 'initial-load' | 'loading-profile' | 'done';
 export type ExperimentalFlags = {|
   +eventDelayTracks: boolean,
   +cpuGraphs: boolean,
+  +processCPUTracks: boolean,
 |};
 
 export type AppState = {|

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -85,6 +85,19 @@ export function addDataToWindowObject(
         `);
       }
     },
+
+    enableProcessCPUTracks() {
+      const areExperimentalProcessCPUTracksEnabled = dispatch(
+        actions.enableExperimentalProcessCPUTracks()
+      );
+      if (areExperimentalProcessCPUTracksEnabled) {
+        console.log(stripIndent`
+          ✅ The process CPU tracks are now enabled and should be displayed in the timeline.
+          👉 Note that this is an experimental feature that might still have bugs.
+          💡 As an experimental feature their presence isn't persisted as a URL parameter like the other things.
+        `);
+      }
+    },
   };
 
   target.togglePseudoLocalization = function (pseudoStrategy?: string) {


### PR DESCRIPTION
This is a PR that hides the experimental threads from [Bug 1744670](https://bugzilla.mozilla.org/show_bug.cgi?id=1744670). I wasn't sure how this would look in the PR, so I wanted to write this PR to test it. I can't say that I like this solution that much. I think it could be better to change the back-end to the counters and land it right in the first time. To enable the experimental tracks, you need to enter `experimental.enableProcessCPUTracks()` in the console. 

@squelart what do you think?

