### PR TITLE
Add experimental process CPU tracks from process CPU counters

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -15,6 +15,7 @@ import {
   getTrackThreadHeights,
   getIsEventDelayTracksEnabled,
   getIsExperimentalCPUGraphsEnabled,
+  getIsExperimentalProcessCPUTracksEnabled,
 } from 'firefox-profiler/selectors/app';
 import {
   getActiveTabMainTrack,
@@ -33,7 +34,10 @@ import {
   initializeLocalTrackOrderByPid,
 } from 'firefox-profiler/profile-logic/tracks';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
-import { getIsCPUUtilizationProvided } from 'firefox-profiler/selectors/cpu';
+import {
+  getIsCPUUtilizationProvided,
+  getAreThereAnyProcessCPUCounters,
+} from 'firefox-profiler/selectors/cpu';
 
 import type {
   Profile,
@@ -331,6 +335,43 @@ export function enableExperimentalCPUGraphs(): ThunkAction<boolean> {
 
     dispatch({
       type: 'ENABLE_EXPERIMENTAL_CPU_GRAPHS',
+    });
+
+    return true;
+  };
+}
+
+/*
+ * This action enables the process CPU tracks. They are hidden by default because
+ * the front-end work is not done for this data yet.
+ * There is no UI that triggers this action in the profiler interface. Instead,
+ * users have to enable this from the developer console by writing this line:
+ * `experimental.enableExperimentalProcessCPUTracks()`
+ */
+export function enableExperimentalProcessCPUTracks(): ThunkAction<boolean> {
+  return (dispatch, getState) => {
+    if (getIsExperimentalProcessCPUTracksEnabled(getState())) {
+      console.error(
+        'Tried to enable the process CPU tracks, but they are already enabled.'
+      );
+      return false;
+    }
+
+    if (
+      !getIsCPUUtilizationProvided(getState()) &&
+      getAreThereAnyProcessCPUCounters(getState())
+    ) {
+      // Return early if the profile doesn't have threadCPUDelta values or
+      // doesn't have any experimental process CPU counters.
+      console.error(oneLine`
+        Tried to enable the process CPU tracks, but this profile does
+        not have threadCPUDelta values or process CPU threads.
+      `);
+      return false;
+    }
+
+    dispatch({
+      type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
     });
 
     return true;

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -21,6 +21,7 @@ import {
   getActiveTabMainTrack,
   getLocalTracksByPid,
   getThreads,
+  getCounter,
 } from 'firefox-profiler/selectors/profile';
 import { sendAnalytics } from 'firefox-profiler/utils/analytics';
 import {
@@ -32,6 +33,7 @@ import { fatalError } from './errors';
 import {
   addEventDelayTracksForThreads,
   initializeLocalTrackOrderByPid,
+  addProcessCPUTracksForProcess,
 } from 'firefox-profiler/profile-logic/tracks';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import {
@@ -370,8 +372,21 @@ export function enableExperimentalProcessCPUTracks(): ThunkAction<boolean> {
       return false;
     }
 
+    const oldLocalTracks = getLocalTracksByPid(getState());
+    const localTracksByPid = addProcessCPUTracksForProcess(
+      getCounter(getState()),
+      oldLocalTracks
+    );
+    const localTrackOrderByPid = initializeLocalTrackOrderByPid(
+      getLocalTrackOrderByPid(getState()),
+      localTracksByPid,
+      null
+    );
+
     dispatch({
       type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
+      localTracksByPid,
+      localTrackOrderByPid,
     });
 
     return true;

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -353,6 +353,15 @@ export function selectTrack(
             selectedThreadIndex = localTrack.threadIndex;
             break;
           }
+          case 'process-cpu': {
+            const { counterIndex } = localTrack;
+            const counterSelectors = getCounterSelectors(counterIndex);
+            const counter = counterSelectors.getCommittedRangeFilteredCounter(
+              getState()
+            );
+            selectedThreadIndex = counter.mainThreadIndex;
+            break;
+          }
           default:
             throw assertExhaustiveCheck(
               localTrack,

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -52,6 +52,9 @@ export const TRACK_PROCESS_BLANK_HEIGHT = 30;
 // Height of timeline ruler.
 export const TIMELINE_RULER_HEIGHT = 20;
 
+// Height of the process cpu track.
+export const TRACK_PROCESS_CPU_HEIGHT = 25;
+
 // JS Tracer has very high fidelity information, and needs a more fine-grained zoom.
 export const JS_TRACER_MAXIMUM_CHART_ZOOM = 0.001;
 

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -54,6 +54,7 @@ export const TIMELINE_RULER_HEIGHT = 20;
 
 // Height of the process cpu track.
 export const TRACK_PROCESS_CPU_HEIGHT = 25;
+export const TRACK_PROCESS_CPU_LINE_WIDTH = 2;
 
 // JS Tracer has very high fidelity information, and needs a more fine-grained zoom.
 export const JS_TRACER_MAXIMUM_CHART_ZOOM = 0.001;

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -140,6 +140,9 @@ class LocalTrackComponent extends PureComponent<Props> {
         return <TrackIPC threadIndex={localTrack.threadIndex} />;
       case 'event-delay':
         return <TrackEventDelay threadIndex={localTrack.threadIndex} />;
+      case 'process-cpu':
+        // TODO: Add a component later
+        return null;
       default:
         console.error('Unhandled localTrack type', (localTrack: empty));
         return null;
@@ -254,6 +257,12 @@ export const TimelineLocalTrack = explicitConnect<
           selectedTab !== 'event-delay';
         titleText =
           'Event Delay of ' + selectors.getThreadProcessDetails(state);
+        break;
+      }
+      case 'process-cpu': {
+        titleText = getCounterSelectors(localTrack.counterIndex).getDescription(
+          state
+        );
         break;
       }
       default:

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -28,6 +28,7 @@ import { TrackEventDelay } from './TrackEventDelay';
 import { TrackNetwork } from './TrackNetwork';
 import { TrackMemory } from './TrackMemory';
 import { TrackIPC } from './TrackIPC';
+import { TrackProcessCPU } from './TrackProcessCPU';
 import { getTrackSelectionModifier } from 'firefox-profiler/utils';
 import type {
   TrackReference,
@@ -141,8 +142,7 @@ class LocalTrackComponent extends PureComponent<Props> {
       case 'event-delay':
         return <TrackEventDelay threadIndex={localTrack.threadIndex} />;
       case 'process-cpu':
-        // TODO: Add a component later
-        return null;
+        return <TrackProcessCPU counterIndex={localTrack.counterIndex} />;
       default:
         console.error('Unhandled localTrack type', (localTrack: empty));
         return null;

--- a/src/components/timeline/TrackProcessCPU.css
+++ b/src/components/timeline/TrackProcessCPU.css
@@ -20,7 +20,7 @@
   height: 6px;
   margin-top: -3px;
   margin-left: -3px;
-  background-color: var(--orange-60);
+  background-color: var(--grey-50);
   border-radius: 3px;
   pointer-events: none;
 }

--- a/src/components/timeline/TrackProcessCPU.css
+++ b/src/components/timeline/TrackProcessCPU.css
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.timelineTrackProcessCPUGraph {
+  position: relative;
+  width: 100%;
+  height: var(--graph-height);
+}
+
+.timelineTrackProcessCPUCanvas {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.timelineTrackProcessCPUGraphDot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  margin-left: -3px;
+  background-color: var(--orange-60);
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.timelineTrackProcessCPUTooltipLine {
+  white-space: nowrap;
+}
+
+.timelineTrackProcessCPUTooltipNumber {
+  display: inline-block;
+  min-width: 60px;
+  color: var(--grey-60);
+  font-weight: bold;
+}

--- a/src/components/timeline/TrackProcessCPU.js
+++ b/src/components/timeline/TrackProcessCPU.js
@@ -25,7 +25,7 @@ import type {
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
-import './TrackMemory.css';
+import './TrackProcessCPU.css';
 
 type OwnProps = {|
   +counterIndex: CounterIndex,
@@ -50,7 +50,7 @@ export class TracProcessCPUImpl extends React.PureComponent<Props, State> {
     const { counterIndex } = this.props;
     return (
       <div
-        className="timelineTrackMemory"
+        className="timelineTrackProcessCPU"
         style={{
           height: TRACK_PROCESS_CPU_HEIGHT,
           '--graph-height': `${TRACK_PROCESS_CPU_HEIGHT}px`,

--- a/src/components/timeline/TrackProcessCPU.js
+++ b/src/components/timeline/TrackProcessCPU.js
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import {
+  getCommittedRange,
+  getCounterSelectors,
+} from 'firefox-profiler/selectors/profile';
+import { TimelineMarkersMemory } from './Markers';
+import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
+import { TrackMemoryGraph } from './TrackMemoryGraph';
+import {
+  TRACK_MEMORY_GRAPH_HEIGHT,
+  TRACK_MEMORY_MARKERS_HEIGHT,
+  TRACK_MEMORY_LINE_WIDTH,
+} from 'firefox-profiler/app-logic/constants';
+
+import type {
+  CounterIndex,
+  ThreadIndex,
+  Milliseconds,
+} from 'firefox-profiler/types';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+import './TrackMemory.css';
+
+type OwnProps = {|
+  +counterIndex: CounterIndex,
+|};
+
+type StateProps = {|
+  +threadIndex: ThreadIndex,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+|};
+
+type DispatchProps = {|
+  updatePreviewSelection: typeof updatePreviewSelection,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+type State = {||};
+
+export class TrackMemoryImpl extends React.PureComponent<Props, State> {
+  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
+    const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
+    updatePreviewSelection({
+      hasSelection: true,
+      isModifying: false,
+      selectionStart: Math.max(rangeStart, start),
+      selectionEnd: Math.min(rangeEnd, end),
+    });
+  };
+
+  render() {
+    const { counterIndex, rangeStart, rangeEnd, threadIndex } = this.props;
+    return (
+      <div
+        className="timelineTrackMemory"
+        style={{
+          height: TRACK_MEMORY_GRAPH_HEIGHT + TRACK_MEMORY_MARKERS_HEIGHT,
+          '--graph-height': `${TRACK_MEMORY_GRAPH_HEIGHT}px`,
+          '--markers-height': `${TRACK_MEMORY_MARKERS_HEIGHT}px`,
+        }}
+      >
+        <TimelineMarkersMemory
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          threadsKey={threadIndex}
+          onSelect={this._onMarkerSelect}
+        />
+        <TrackMemoryGraph
+          counterIndex={counterIndex}
+          lineWidth={TRACK_MEMORY_LINE_WIDTH}
+          graphHeight={TRACK_MEMORY_GRAPH_HEIGHT}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackMemory = explicitConnect<OwnProps, StateProps, DispatchProps>(
+  {
+    mapStateToProps: (state, ownProps) => {
+      const { counterIndex } = ownProps;
+      const counterSelectors = getCounterSelectors(counterIndex);
+      const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+      const { start, end } = getCommittedRange(state);
+      return {
+        threadIndex: counter.mainThreadIndex,
+        rangeStart: start,
+        rangeEnd: end,
+      };
+    },
+    mapDispatchToProps: { updatePreviewSelection },
+    component: TrackMemoryImpl,
+  }
+);

--- a/src/components/timeline/TrackProcessCPU.js
+++ b/src/components/timeline/TrackProcessCPU.js
@@ -10,13 +10,11 @@ import {
   getCommittedRange,
   getCounterSelectors,
 } from 'firefox-profiler/selectors/profile';
-import { TimelineMarkersMemory } from './Markers';
 import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
-import { TrackMemoryGraph } from './TrackMemoryGraph';
+import { TrackProcessCPUGraph } from './TrackProcessCPUGraph';
 import {
-  TRACK_MEMORY_GRAPH_HEIGHT,
-  TRACK_MEMORY_MARKERS_HEIGHT,
-  TRACK_MEMORY_LINE_WIDTH,
+  TRACK_PROCESS_CPU_HEIGHT,
+  TRACK_PROCESS_CPU_LINE_WIDTH,
 } from 'firefox-profiler/app-logic/constants';
 
 import type {
@@ -47,58 +45,43 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 type State = {||};
 
-export class TrackMemoryImpl extends React.PureComponent<Props, State> {
-  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
-    const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
-    updatePreviewSelection({
-      hasSelection: true,
-      isModifying: false,
-      selectionStart: Math.max(rangeStart, start),
-      selectionEnd: Math.min(rangeEnd, end),
-    });
-  };
-
+export class TracProcessCPUImpl extends React.PureComponent<Props, State> {
   render() {
-    const { counterIndex, rangeStart, rangeEnd, threadIndex } = this.props;
+    const { counterIndex } = this.props;
     return (
       <div
         className="timelineTrackMemory"
         style={{
-          height: TRACK_MEMORY_GRAPH_HEIGHT + TRACK_MEMORY_MARKERS_HEIGHT,
-          '--graph-height': `${TRACK_MEMORY_GRAPH_HEIGHT}px`,
-          '--markers-height': `${TRACK_MEMORY_MARKERS_HEIGHT}px`,
+          height: TRACK_PROCESS_CPU_HEIGHT,
+          '--graph-height': `${TRACK_PROCESS_CPU_HEIGHT}px`,
         }}
       >
-        <TimelineMarkersMemory
-          rangeStart={rangeStart}
-          rangeEnd={rangeEnd}
-          threadsKey={threadIndex}
-          onSelect={this._onMarkerSelect}
-        />
-        <TrackMemoryGraph
+        <TrackProcessCPUGraph
           counterIndex={counterIndex}
-          lineWidth={TRACK_MEMORY_LINE_WIDTH}
-          graphHeight={TRACK_MEMORY_GRAPH_HEIGHT}
+          lineWidth={TRACK_PROCESS_CPU_LINE_WIDTH}
+          graphHeight={TRACK_PROCESS_CPU_HEIGHT}
         />
       </div>
     );
   }
 }
 
-export const TrackMemory = explicitConnect<OwnProps, StateProps, DispatchProps>(
-  {
-    mapStateToProps: (state, ownProps) => {
-      const { counterIndex } = ownProps;
-      const counterSelectors = getCounterSelectors(counterIndex);
-      const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
-      const { start, end } = getCommittedRange(state);
-      return {
-        threadIndex: counter.mainThreadIndex,
-        rangeStart: start,
-        rangeEnd: end,
-      };
-    },
-    mapDispatchToProps: { updatePreviewSelection },
-    component: TrackMemoryImpl,
-  }
-);
+export const TrackProcessCPU = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { counterIndex } = ownProps;
+    const counterSelectors = getCounterSelectors(counterIndex);
+    const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+    const { start, end } = getCommittedRange(state);
+    return {
+      threadIndex: counter.mainThreadIndex,
+      rangeStart: start,
+      rangeEnd: end,
+    };
+  },
+  mapDispatchToProps: { updatePreviewSelection },
+  component: TracProcessCPUImpl,
+});

--- a/src/components/timeline/TrackProcessCPUGraph.js
+++ b/src/components/timeline/TrackProcessCPUGraph.js
@@ -15,7 +15,7 @@ import {
   getProfileInterval,
 } from 'firefox-profiler/selectors/profile';
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
-import { GREY_40 } from 'photon-colors';
+import { GREY_50 } from 'photon-colors';
 import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
 import { EmptyThreadIndicator } from './EmptyThreadIndicator';
 
@@ -116,8 +116,8 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
       // process CPU graph.
 
       ctx.lineWidth = deviceLineWidth;
-      ctx.strokeStyle = GREY_40;
-      ctx.fillStyle = '#b1b1b388'; // Grey 40 with transparency.
+      ctx.strokeStyle = GREY_50;
+      ctx.fillStyle = '#73737388'; // Grey 50 with transparency.
       ctx.beginPath();
 
       // The x and y are used after the loop.

--- a/src/components/timeline/TrackProcessCPUGraph.js
+++ b/src/components/timeline/TrackProcessCPUGraph.js
@@ -32,7 +32,7 @@ import type {
 import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
-import './TrackMemory.css';
+import './TrackProcessCPU.css';
 
 /**
  * When adding properties to these props, please consider the comment above the component.
@@ -188,7 +188,10 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
     this._scheduleDraw();
 
     return (
-      <canvas className="timelineTrackMemoryCanvas" ref={this._takeCanvasRef} />
+      <canvas
+        className="timelineTrackProcessCPUCanvas"
+        ref={this._takeCanvasRef}
+      />
     );
   }
 }
@@ -304,10 +307,10 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
     const cpuUsage = samples.count[counterIndex];
     const cpuRatio = cpuUsage / maxCPU;
     return (
-      <div className="timelineTrackMemoryTooltip">
-        <div className="timelineTrackMemoryTooltipLine">
+      <div className="timelineTrackProcessCPUTooltip">
+        <div className="timelineTrackProcessCPUTooltipLine">
           CPU:{' '}
-          <span className="timelineTrackMemoryTooltipNumber">
+          <span className="timelineTrackProcessCPUTooltipNumber">
             {formatPercent(cpuRatio)}
           </span>
         </div>
@@ -352,7 +355,7 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
       innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;
 
     return (
-      <div style={{ left, top }} className="timelineTrackMemoryGraphDot" />
+      <div style={{ left, top }} className="timelineTrackProcessCPUGraphDot" />
     );
   }
 
@@ -373,7 +376,7 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
 
     return (
       <div
-        className="timelineTrackMemoryGraph"
+        className="timelineTrackProcessCPUGraph"
         onMouseMove={this._onMouseMove}
         onMouseLeave={this._onMouseLeave}
       >

--- a/src/components/timeline/TrackProcessCPUGraph.js
+++ b/src/components/timeline/TrackProcessCPUGraph.js
@@ -1,0 +1,447 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { withSize } from 'firefox-profiler/components/shared/WithSize';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { formatBytes } from 'firefox-profiler/utils/format-numbers';
+import { bisectionRight } from 'firefox-profiler/utils/bisect';
+import {
+  getCommittedRange,
+  getCounterSelectors,
+  getProfileInterval,
+} from 'firefox-profiler/selectors/profile';
+import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
+import { ORANGE_50 } from 'photon-colors';
+import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
+import { EmptyThreadIndicator } from './EmptyThreadIndicator';
+
+import type {
+  CounterIndex,
+  Counter,
+  Thread,
+  ThreadIndex,
+  AccumulatedCounterSamples,
+  Milliseconds,
+  CssPixels,
+  StartEndRange,
+} from 'firefox-profiler/types';
+
+import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+import './TrackMemory.css';
+
+/**
+ * When adding properties to these props, please consider the comment above the component.
+ */
+type CanvasProps = {|
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +counter: Counter,
+  +accumulatedSamples: AccumulatedCounterSamples[],
+  +interval: Milliseconds,
+  +width: CssPixels,
+  +height: CssPixels,
+  +lineWidth: CssPixels,
+|};
+
+/**
+ * This component controls the rendering of the canvas. Every render call through
+ * React triggers a new canvas render. Because of this, it's important to only pass
+ * in the props that are needed for the canvas draw call.
+ */
+class TrackMemoryCanvas extends React.PureComponent<CanvasProps> {
+  _canvas: null | HTMLCanvasElement = null;
+  _requestedAnimationFrame: boolean = false;
+
+  drawCanvas(canvas: HTMLCanvasElement): void {
+    const {
+      rangeStart,
+      rangeEnd,
+      counter,
+      height,
+      width,
+      lineWidth,
+      interval,
+      accumulatedSamples,
+    } = this.props;
+    if (width === 0) {
+      // This is attempting to draw before the canvas was laid out.
+      return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    const devicePixelRatio = window.devicePixelRatio;
+    const deviceWidth = width * devicePixelRatio;
+    const deviceHeight = height * devicePixelRatio;
+    const deviceLineWidth = lineWidth * devicePixelRatio;
+    const deviceLineHalfWidth = deviceLineWidth * 0.5;
+    const innerDeviceHeight = deviceHeight - deviceLineWidth;
+    const rangeLength = rangeEnd - rangeStart;
+    const millisecondWidth = deviceWidth / rangeLength;
+    const intervalWidth = interval * millisecondWidth;
+
+    // Resize and clear the canvas.
+    canvas.width = Math.round(deviceWidth);
+    canvas.height = Math.round(deviceHeight);
+    ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+
+    const sampleGroups = counter.sampleGroups;
+    if (sampleGroups.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and do not draw anything.
+      throw new Error('No sample group found for memory counter');
+    }
+
+    const samples = counter.sampleGroups[0].samples;
+    if (samples.length === 0) {
+      // There's no reason to draw the samples, there are none.
+      return;
+    }
+
+    // Take the sample information, and convert it into chart coordinates. Use a slightly
+    // smaller space than the deviceHeight, so that the stroke will be fully visible
+    // both at the top and bottom of the chart.
+    if (accumulatedSamples.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No accumulated sample found for memory counter');
+    }
+    const { minCount, countRange, accumulatedCounts } = accumulatedSamples[0];
+
+    {
+      // Draw the chart.
+      //
+      //                 ...--`
+      //  1 ...---```..--      `--. 2
+      //    |_____________________|
+      //  4                        3
+      //
+      // Start by drawing from 1 - 2. This will be the top of all the peaks of the
+      // memory graph.
+
+      ctx.lineWidth = deviceLineWidth;
+      ctx.strokeStyle = ORANGE_50;
+      ctx.fillStyle = '#ff940088'; // Orange 50 with transparency.
+      ctx.beginPath();
+
+      // The x and y are used after the loop.
+      let x = 0;
+      let y = 0;
+      let firstX = 0;
+      for (let i = 0; i < samples.length; i++) {
+        // Create a path for the top of the chart. This is the line that will have
+        // a stroke applied to it.
+        x = (samples.time[i] - rangeStart) * millisecondWidth;
+        // Add on half the stroke's line width so that it won't be cut off the edge
+        // of the graph.
+        const unitGraphCount = (accumulatedCounts[i] - minCount) / countRange;
+        y =
+          innerDeviceHeight -
+          innerDeviceHeight * unitGraphCount +
+          deviceLineHalfWidth;
+        if (i === 0) {
+          // This is the first iteration, only move the line, do not draw it. Also
+          // remember this first X, as the bottom of the graph will need to connect
+          // back up to it.
+          firstX = x;
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      }
+      // The samples range ends at the time of the last sample, plus the interval.
+      // Draw this last bit.
+      ctx.lineTo(x + intervalWidth, y);
+
+      // Don't do the fill yet, just stroke the top line. This will draw a line from
+      // point 1 to 2 in the diagram above.
+      ctx.stroke();
+
+      // After doing the stroke, continue the path to complete the fill to the bottom
+      // of the canvas. This continues the path to point 3 and then 4.
+
+      // Create a line from 2 to 3.
+      ctx.lineTo(x + intervalWidth, deviceHeight);
+
+      // Create a line from 3 to 4.
+      ctx.lineTo(firstX, deviceHeight);
+
+      // The line from 4 to 1 will be implicitly filled in.
+      ctx.fill();
+    }
+  }
+
+  _scheduleDraw() {
+    if (!this._requestedAnimationFrame) {
+      this._requestedAnimationFrame = true;
+      window.requestAnimationFrame(() => {
+        this._requestedAnimationFrame = false;
+        const canvas = this._canvas;
+        if (canvas) {
+          this.drawCanvas(canvas);
+        }
+      });
+    }
+  }
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  render() {
+    this._scheduleDraw();
+
+    return (
+      <canvas className="timelineTrackMemoryCanvas" ref={this._takeCanvasRef} />
+    );
+  }
+}
+
+type OwnProps = {|
+  +counterIndex: CounterIndex,
+  +lineWidth: CssPixels,
+  +graphHeight: CssPixels,
+|};
+
+type StateProps = {|
+  +threadIndex: ThreadIndex,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +counter: Counter,
+  +accumulatedSamples: AccumulatedCounterSamples[],
+  +interval: Milliseconds,
+  +filteredThread: Thread,
+  +unfilteredSamplesRange: StartEndRange | null,
+|};
+
+type DispatchProps = {||};
+
+type Props = {|
+  ...SizeProps,
+  ...ConnectedProps<OwnProps, StateProps, DispatchProps>,
+|};
+
+type State = {|
+  hoveredCounter: null | number,
+  mouseX: CssPixels,
+  mouseY: CssPixels,
+|};
+
+/**
+ * The memory track graph takes memory information from counters, and renders it as a
+ * graph in the timeline.
+ */
+class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
+  state = {
+    hoveredCounter: null,
+    mouseX: 0,
+    mouseY: 0,
+  };
+
+  _onMouseLeave = () => {
+    this.setState({ hoveredCounter: null });
+  };
+
+  _onMouseMove = (event: SyntheticMouseEvent<HTMLDivElement>) => {
+    const { pageX: mouseX, pageY: mouseY } = event;
+    // Get the offset from here, and apply it to the time lookup.
+    const { left } = event.currentTarget.getBoundingClientRect();
+    const { width, rangeStart, rangeEnd, counter, interval } = this.props;
+    const rangeLength = rangeEnd - rangeStart;
+    const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
+
+    if (counter.sampleGroups.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No sample group found for memory counter');
+    }
+    const { samples } = counter.sampleGroups[0];
+
+    if (
+      timeAtMouse < samples.time[0] ||
+      timeAtMouse > samples.time[samples.length - 1] + interval
+    ) {
+      // We are outside the range of the samples, do not display hover information.
+      this.setState({ hoveredCounter: null });
+    } else {
+      // When the mouse pointer hovers between two points, select the point that's closer.
+      let hoveredCounter;
+      const bisectionCounter = bisectionRight(samples.time, timeAtMouse);
+      if (bisectionCounter > 0 && bisectionCounter < samples.time.length) {
+        const leftDistance = timeAtMouse - samples.time[bisectionCounter - 1];
+        const rightDistance = samples.time[bisectionCounter] - timeAtMouse;
+        if (leftDistance < rightDistance) {
+          // Left point is closer
+          hoveredCounter = bisectionCounter - 1;
+        } else {
+          // Right point is closer
+          hoveredCounter = bisectionCounter;
+        }
+      } else {
+        hoveredCounter = bisectionCounter;
+      }
+
+      if (hoveredCounter === samples.length) {
+        // When hovering the last sample, it's possible the mouse is past the time.
+        // In this case, hover over the last sample. This happens because of the
+        // ` + interval` line in the `if` condition above.
+        hoveredCounter = samples.time.length - 1;
+      }
+
+      this.setState({
+        mouseX,
+        mouseY,
+        hoveredCounter,
+      });
+    }
+  };
+
+  _renderTooltip(counterIndex: number): React.Node {
+    if (this.props.accumulatedSamples.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No accumulated sample found for memory counter');
+    }
+    const { minCount, countRange, accumulatedCounts } =
+      this.props.accumulatedSamples[0];
+    const bytes = accumulatedCounts[counterIndex] - minCount;
+    return (
+      <div className="timelineTrackMemoryTooltip">
+        <div className="timelineTrackMemoryTooltipLine">
+          <span className="timelineTrackMemoryTooltipNumber">
+            {formatBytes(bytes)}
+          </span>
+          {' relative memory at this time'}
+        </div>
+        <div className="timelineTrackMemoryTooltipLine">
+          <span className="timelineTrackMemoryTooltipNumber">
+            {formatBytes(countRange)}
+          </span>
+          {' memory range in graph'}
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Create a div that is a dot on top of the graph representing the current
+   * height of the graph.
+   */
+  _renderMemoryDot(counterIndex: number): React.Node {
+    const {
+      counter,
+      rangeStart,
+      rangeEnd,
+      graphHeight,
+      width,
+      lineWidth,
+      accumulatedSamples,
+    } = this.props;
+
+    if (counter.sampleGroups.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No sample group found for memory counter');
+    }
+    const { samples } = counter.sampleGroups[0];
+    const rangeLength = rangeEnd - rangeStart;
+    const left =
+      (width * (samples.time[counterIndex] - rangeStart)) / rangeLength;
+
+    if (accumulatedSamples.length === 0) {
+      // Gecko failed to capture samples for some reason and it shouldn't happen for
+      // malloc counter. Print an error and bail out early.
+      throw new Error('No accumulated sample found for memory counter');
+    }
+    const { minCount, countRange, accumulatedCounts } = accumulatedSamples[0];
+    const unitSampleCount =
+      (accumulatedCounts[counterIndex] - minCount) / countRange;
+    const innerTrackHeight = graphHeight - lineWidth / 2;
+    const top =
+      innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;
+
+    return (
+      <div style={{ left, top }} className="timelineTrackMemoryGraphDot" />
+    );
+  }
+
+  render() {
+    const { hoveredCounter, mouseX, mouseY } = this.state;
+    const {
+      filteredThread,
+      interval,
+      rangeStart,
+      rangeEnd,
+      unfilteredSamplesRange,
+      counter,
+      graphHeight,
+      width,
+      lineWidth,
+      accumulatedSamples,
+    } = this.props;
+
+    return (
+      <div
+        className="timelineTrackMemoryGraph"
+        onMouseMove={this._onMouseMove}
+        onMouseLeave={this._onMouseLeave}
+      >
+        <TrackMemoryCanvas
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          counter={counter}
+          height={graphHeight}
+          width={width}
+          lineWidth={lineWidth}
+          interval={interval}
+          accumulatedSamples={accumulatedSamples}
+        />
+        {hoveredCounter === null ? null : (
+          <>
+            {this._renderMemoryDot(hoveredCounter)}
+            <Tooltip mouseX={mouseX} mouseY={mouseY}>
+              {this._renderTooltip(hoveredCounter)}
+            </Tooltip>
+          </>
+        )}
+        <EmptyThreadIndicator
+          thread={filteredThread}
+          interval={interval}
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          unfilteredSamplesRange={unfilteredSamplesRange}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackMemoryGraph = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { counterIndex } = ownProps;
+    const counterSelectors = getCounterSelectors(counterIndex);
+    const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+    const { start, end } = getCommittedRange(state);
+    const selectors = getThreadSelectors(counter.mainThreadIndex);
+    return {
+      counter,
+      threadIndex: counter.mainThreadIndex,
+      accumulatedSamples: counterSelectors.getAccumulateCounterSamples(state),
+      rangeStart: start,
+      rangeEnd: end,
+      interval: getProfileInterval(state),
+      filteredThread: selectors.getFilteredThread(state),
+      unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),
+    };
+  },
+  component: withSize<Props>(TrackMemoryGraphImpl),
+});

--- a/src/components/timeline/TrackProcessCPUGraph.js
+++ b/src/components/timeline/TrackProcessCPUGraph.js
@@ -15,7 +15,7 @@ import {
   getProfileInterval,
 } from 'firefox-profiler/selectors/profile';
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
-import { ORANGE_50 } from 'photon-colors';
+import { GREY_40 } from 'photon-colors';
 import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
 import { EmptyThreadIndicator } from './EmptyThreadIndicator';
 
@@ -116,8 +116,8 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
       // process CPU graph.
 
       ctx.lineWidth = deviceLineWidth;
-      ctx.strokeStyle = ORANGE_50;
-      ctx.fillStyle = '#ff940088'; // Orange 50 with transparency.
+      ctx.strokeStyle = GREY_40;
+      ctx.fillStyle = '#b1b1b388'; // Grey 40 with transparency.
       ctx.beginPath();
 
       // The x and y are used after the loop.

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1475,6 +1475,27 @@ export function accumulateCounterSamples(
 }
 
 /**
+ * The memory counter contains relative offsets of memory. In order to draw an interesting
+ * graph, take the memory counts, and find the minimum and maximum values, by
+ * accumulating them over the entire profile range. Then, map those values to the
+ * accumulatedCounts array.
+ */
+export function computeMaxCounterSampleCounts(
+  samplesArray: Array<CounterSamplesTable>
+): Array<number> {
+  const maxSampleCounts = samplesArray.map((samples) => {
+    let maxCount = 0;
+    for (let i = 0; i < samples.length; i++) {
+      maxCount = Math.max(samples.count[i], maxCount);
+    }
+
+    return maxCount;
+  });
+
+  return maxSampleCounts;
+}
+
+/**
  * Pre-processing of raw eventDelay values.
  *
  * We don't do 16ms event injection for responsiveness values anymore. Instead,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1475,10 +1475,7 @@ export function accumulateCounterSamples(
 }
 
 /**
- * The memory counter contains relative offsets of memory. In order to draw an interesting
- * graph, take the memory counts, and find the minimum and maximum values, by
- * accumulating them over the entire profile range. Then, map those values to the
- * accumulatedCounts array.
+ * Compute the max counter sample counts to determine the range of a counter.
  */
 export function computeMaxCounterSampleCounts(
   samplesArray: Array<CounterSamplesTable>

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -298,11 +298,7 @@ export function addProcessCPUTracksForProcess(
     }
 
     const { pid } = counter;
-    let localTracks = newLocalTracksByPid.get(pid);
-    if (localTracks === undefined) {
-      // It can't be undefined, but let's make sure.
-      localTracks = [];
-    }
+    let localTracks = newLocalTracksByPid.get(pid) ?? [];
 
     // Do not mutate the current state.
     localTracks = [...localTracks, { type: 'process-cpu', counterIndex }];

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -53,6 +53,7 @@ const LOCAL_TRACK_INDEX_ORDER = {
   memory: 2,
   ipc: 3,
   'event-delay': 4,
+  'process-cpu': 5,
 };
 const LOCAL_TRACK_DISPLAY_ORDER = {
   network: 0,
@@ -60,6 +61,7 @@ const LOCAL_TRACK_DISPLAY_ORDER = {
   thread: 2,
   ipc: 3,
   'event-delay': 4,
+  'process-cpu': 5,
 };
 
 const GLOBAL_TRACK_INDEX_ORDER = {
@@ -718,6 +720,8 @@ export function getLocalTrackName(
         getFriendlyThreadName(threads, threads[localTrack.threadIndex]) +
         ' Event Delay'
       );
+    case 'process-cpu':
+      return 'Process CPU';
     default:
       throw assertExhaustiveCheck(localTrack, 'Unhandled LocalTrack type.');
   }
@@ -1100,7 +1104,8 @@ export function getSearchFilteredLocalTracksByPid(
         case 'network':
         case 'memory':
         case 'ipc':
-        case 'event-delay': {
+        case 'event-delay':
+        case 'process-cpu': {
           const { type } = localTrack;
           if (searchRegExp.test(type)) {
             searchFilteredLocalTracks.add(trackIndex);

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -137,6 +137,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'ISOLATE_LOCAL_TRACK':
     case 'TOGGLE_RESOURCES_PANEL':
     case 'ENABLE_EXPERIMENTAL_CPU_GRAPHS':
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
     // Committed range changes: (fallthrough)
     case 'COMMIT_RANGE':
     case 'POP_COMMITTED_RANGES':

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -266,6 +266,20 @@ const cpuGraphs: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+/*
+ * This reducer hold the state for whether the process CPU tracks are enabled.
+ * This feature is still experimental and this will be removed once we have
+ * better handling for this data.
+ */
+const processCPUTracks: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+      return true;
+    default:
+      return state;
+  }
+};
+
 /**
  * This keeps the information about the upload for the current profile, if any.
  * This is retrieved from the IndexedDB for published profiles information in
@@ -296,6 +310,7 @@ const currentProfileUploadedInformation: Reducer<
 const experimental: Reducer<ExperimentalFlags> = combineReducers({
   eventDelayTracks,
   cpuGraphs,
+  processCPUTracks,
 });
 
 const browserConnectionStatus: Reducer<BrowserConnectionStatus> = (

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -98,6 +98,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
       return action.localTracksByPid;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -439,6 +439,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -86,6 +86,9 @@ export const getIsEventDelayTracksEnabled: Selector<boolean> = (state) =>
   getExperimental(state).eventDelayTracks;
 export const getIsExperimentalCPUGraphsEnabled: Selector<boolean> = (state) =>
   getExperimental(state).cpuGraphs;
+export const getIsExperimentalProcessCPUTracksEnabled: Selector<boolean> = (
+  state
+) => getExperimental(state).processCPUTracks;
 
 export const getIsDragAndDropDragging: Selector<boolean> = (state) =>
   getApp(state).isDragAndDropDragging;

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -34,6 +34,7 @@ import {
   TRACK_EVENT_DELAY_HEIGHT,
   TIMELINE_MARGIN_LEFT,
   ACTIVE_TAB_TIMELINE_MARGIN_LEFT,
+  TRACK_PROCESS_CPU_HEIGHT,
 } from '../app-logic/constants';
 
 import type {
@@ -295,6 +296,9 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                   break;
                 case 'ipc':
                   height += TRACK_IPC_HEIGHT + border;
+                  break;
+                case 'process-cpu':
+                  height += TRACK_PROCESS_CPU_HEIGHT + border;
                   break;
                 default:
                   throw assertExhaustiveCheck(localTrack);

--- a/src/selectors/cpu.js
+++ b/src/selectors/cpu.js
@@ -10,6 +10,7 @@ import {
   getProfileInterval,
   getSampleUnits,
   getMeta,
+  getCounter,
 } from './profile';
 import { getThreadSelectors } from './per-thread';
 import { computeMaxThreadCPUDelta } from 'firefox-profiler/profile-logic/cpu';
@@ -32,6 +33,17 @@ export const getIsCPUUtilizationProvided: Selector<boolean> = createSelector(
     );
   }
 );
+
+/**
+ * It will return true if there are experimental process CPU threads in the profile.
+ */
+export const getAreThereAnyProcessCPUCounters: Selector<boolean> =
+  createSelector(
+    getCounter,
+    (counters) =>
+      counters !== null &&
+      counters.some((counter) => counter.category === 'CPU')
+  );
 
 /**
  * This function returns the list of all threads after the CPU values have been

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -11,6 +11,7 @@ import {
   filterCounterToRange,
   accumulateCounterSamples,
   extractProfileFilterPageData,
+  computeMaxCounterSampleCounts,
 } from '../profile-logic/profile-data';
 import {
   IPCMarkerCorrelations,
@@ -284,12 +285,21 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
     )
   );
 
+  const getMaxCounterSampleCounts: Selector<Array<number>> = createSelector(
+    getCounter,
+    (counters) =>
+      computeMaxCounterSampleCounts(
+        counters.sampleGroups.map((group) => group.samples)
+      )
+  );
+
   return {
     getCounter,
     getDescription,
     getPid,
     getCommittedRangeFilteredCounter,
     getAccumulateCounterSamples,
+    getMaxCounterSampleCounts,
   };
 }
 

--- a/src/test/components/TrackProcessCPU.test.js
+++ b/src/test/components/TrackProcessCPU.test.js
@@ -57,12 +57,18 @@ describe('TrackProcessCPU', function () {
     const threadIndex = 0;
     const thread = profile.threads[threadIndex];
     profile.counters = [
-      getCounterForThreadWithSamples(thread, threadIndex, {
-        time: thread.samples.time.slice(),
-        // CPU usage numbers for the per-process CPU.
-        count: [100, 400, 500, 1000, 200, 500, 300, 100],
-        length: SAMPLE_COUNT,
-      }),
+      getCounterForThreadWithSamples(
+        thread,
+        threadIndex,
+        {
+          time: thread.samples.time.slice(),
+          // CPU usage numbers for the per-process CPU.
+          count: [100, 400, 500, 1000, 200, 500, 300, 100],
+          length: SAMPLE_COUNT,
+        },
+        'processCPU',
+        'CPU'
+      ),
     ];
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;

--- a/src/test/components/TrackProcessCPU.test.js
+++ b/src/test/components/TrackProcessCPU.test.js
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type { IndexIntoSamplesTable, CssPixels } from 'firefox-profiler/types';
+
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent } from '@testing-library/react';
+
+import { render } from 'firefox-profiler/test/fixtures/testing-library';
+import { TrackProcessCPU } from '../../components/timeline/TrackProcessCPU';
+import { ensureExists } from '../../utils/flow';
+
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
+import { storeWithProfile } from '../fixtures/stores';
+import {
+  addRootOverlayElement,
+  removeRootOverlayElement,
+  getMouseEvent,
+} from '../fixtures/utils';
+import {
+  getProfileFromTextSamples,
+  getCounterForThreadWithSamples,
+} from '../fixtures/profiles/processed-profile';
+import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
+
+// The following constants determine the size of the drawn graph.
+const SAMPLE_COUNT = 8;
+const PIXELS_PER_SAMPLE = 10;
+const GRAPH_WIDTH = PIXELS_PER_SAMPLE * SAMPLE_COUNT;
+const GRAPH_HEIGHT = 10;
+
+function getSamplesPixelPosition(
+  sampleIndex: IndexIntoSamplesTable,
+  samplePosition
+): CssPixels {
+  // Compute the pixel position of the center of a given sample.
+  return sampleIndex * PIXELS_PER_SAMPLE + PIXELS_PER_SAMPLE * samplePosition;
+}
+
+/**
+ * This test verifies that the process CPU track can draw a graph of the process CPU.
+ */
+describe('TrackProcessCPU', function () {
+  function setup() {
+    const { profile } = getProfileFromTextSamples(
+      Array(SAMPLE_COUNT).fill('A').join('  ')
+    );
+    const threadIndex = 0;
+    const thread = profile.threads[threadIndex];
+    profile.counters = [
+      getCounterForThreadWithSamples(thread, threadIndex, {
+        time: thread.samples.time.slice(),
+        // CPU usage numbers for the per-process CPU.
+        count: [100, 400, 500, 1000, 200, 500, 300, 100],
+        length: SAMPLE_COUNT,
+      }),
+    ];
+    const store = storeWithProfile(profile);
+    const { getState, dispatch } = store;
+    const flushRafCalls = mockRaf();
+
+    const renderResult = render(
+      <Provider store={store}>
+        <TrackProcessCPU counterIndex={0} />
+      </Provider>
+    );
+    const { container } = renderResult;
+
+    // WithSize uses requestAnimationFrame
+    flushRafCalls();
+
+    const canvas = ensureExists(
+      container.querySelector('.timelineTrackProcessCPUCanvas'),
+      `Couldn't find the process CPU canvas, with selector .timelineTrackProcessCPUCanvas`
+    );
+    const getTooltipContents = () =>
+      document.querySelector('.timelineTrackProcessCPUTooltip');
+    const getProcessCPUDot = () =>
+      container.querySelector('.timelineTrackProcessCPUGraphDot');
+    const moveMouseAtCounter = (index, pos) =>
+      fireEvent(
+        canvas,
+        getMouseEvent('mousemove', {
+          pageX: getSamplesPixelPosition(index, pos),
+        })
+      );
+
+    return {
+      ...renderResult,
+      dispatch,
+      getState,
+      profile,
+      thread,
+      store,
+      threadIndex,
+      canvas,
+      getTooltipContents,
+      moveMouseAtCounter,
+      flushRafCalls,
+      getProcessCPUDot,
+    };
+  }
+
+  autoMockCanvasContext();
+  autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  autoMockIntersectionObserver();
+  beforeEach(addRootOverlayElement);
+  afterEach(removeRootOverlayElement);
+
+  it('matches the component snapshot', () => {
+    const { container } = setup();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches the 2d canvas draw snapshot', () => {
+    const { flushRafCalls } = setup();
+    flushRafCalls();
+    expect(flushDrawLog()).toMatchSnapshot();
+  });
+
+  it('can create a tooltip', function () {
+    const { moveMouseAtCounter, getTooltipContents, canvas } = setup();
+    expect(getTooltipContents()).toBeFalsy();
+    moveMouseAtCounter(1, 0.5);
+    expect(getTooltipContents()).toBeTruthy();
+    fireEvent.mouseLeave(canvas);
+    expect(getTooltipContents()).toBeFalsy();
+  });
+
+  it('has a tooltip that matches the snapshot', function () {
+    const { moveMouseAtCounter, getTooltipContents } = setup();
+    // We are hovering exactly between 4th and 5th counter. That's why it should
+    // show the 5th counter.
+    moveMouseAtCounter(4, 0.5);
+    expect(getTooltipContents()).toMatchSnapshot();
+  });
+
+  it('draws a dot on the graph', function () {
+    const { moveMouseAtCounter, getProcessCPUDot } = setup();
+    expect(getProcessCPUDot()).toBeFalsy();
+    moveMouseAtCounter(1, 0.5);
+    expect(getProcessCPUDot()).toBeTruthy();
+  });
+
+  it('can draw a dot on both extremes of the graph', function () {
+    const { moveMouseAtCounter, getProcessCPUDot } = setup();
+    expect(getProcessCPUDot()).toBeFalsy();
+    moveMouseAtCounter(0, 0.25);
+    expect(getProcessCPUDot()).toBeTruthy();
+    moveMouseAtCounter(7, 0);
+    expect(getProcessCPUDot()).toBeTruthy();
+  });
+
+  it('draws a dot that matches the snapshot', function () {
+    const { moveMouseAtCounter, getProcessCPUDot } = setup();
+    moveMouseAtCounter(1, 0.5);
+    expect(getProcessCPUDot()).toMatchSnapshot();
+  });
+});

--- a/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
+++ b/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TrackProcessCPU draws a dot that matches the snapshot 1`] = `
+<div
+  class="timelineTrackProcessCPUGraphDot"
+  style="left: 20px; top: 13px;"
+/>
+`;
+
+exports[`TrackProcessCPU has a tooltip that matches the snapshot 1`] = `
+<div
+  class="timelineTrackProcessCPUTooltip"
+>
+  <div
+    class="timelineTrackProcessCPUTooltipLine"
+  >
+    CPU:
+     
+    <span
+      class="timelineTrackProcessCPUTooltipNumber"
+    >
+      50%
+    </span>
+  </div>
+</div>
+`;
+
+exports[`TrackProcessCPU matches the 2d canvas draw snapshot 1`] = `
+Array [
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    25,
+  ],
+  Array [
+    "set lineWidth",
+    2,
+  ],
+  Array [
+    "set strokeStyle",
+    "#b1b1b3",
+  ],
+  Array [
+    "set fillStyle",
+    "#b1b1b388",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    0,
+    24,
+  ],
+  Array [
+    "lineTo",
+    10,
+    14.799999999999999,
+  ],
+  Array [
+    "lineTo",
+    20,
+    12.5,
+  ],
+  Array [
+    "lineTo",
+    30,
+    1,
+  ],
+  Array [
+    "lineTo",
+    40,
+    19.4,
+  ],
+  Array [
+    "lineTo",
+    50,
+    12.5,
+  ],
+  Array [
+    "lineTo",
+    60,
+    17.1,
+  ],
+  Array [
+    "lineTo",
+    70,
+    21.7,
+  ],
+  Array [
+    "lineTo",
+    80,
+    21.7,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "lineTo",
+    80,
+    25,
+  ],
+  Array [
+    "lineTo",
+    0,
+    25,
+  ],
+  Array [
+    "fill",
+  ],
+]
+`;
+
+exports[`TrackProcessCPU matches the component snapshot 1`] = `
+<div
+  class="timelineTrackProcessCPU"
+  style="height: 25px; --graph-height: 25px;"
+>
+  <div
+    class="timelineTrackProcessCPUGraph"
+  >
+    <canvas
+      class="timelineTrackProcessCPUCanvas"
+      height="25"
+      width="80"
+    />
+    <div
+      class="timelineEmptyThreadIndicator"
+    />
+  </div>
+</div>
+`;

--- a/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
+++ b/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
@@ -40,11 +40,11 @@ Array [
   ],
   Array [
     "set strokeStyle",
-    "#b1b1b3",
+    "#737373",
   ],
   Array [
     "set fillStyle",
-    "#b1b1b388",
+    "#73737388",
   ],
   Array [
     "beginPath",

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1370,8 +1370,8 @@ export function getCounterForThreadWithSamples(
   };
 
   const counter: Counter = {
-    name: name ? name : 'My Counter',
-    category: category ? category : 'My Category',
+    name: name ?? 'My Counter',
+    category: category ?? 'My Category',
     description: 'My Description',
     pid: thread.pid,
     mainThreadIndex,

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1344,6 +1344,48 @@ export function getCounterForThread(
 }
 
 /**
+ * Creates a Counter fixture for a given thread with the given samples.
+ */
+export function getCounterForThreadWithSamples(
+  thread: Thread,
+  mainThreadIndex: ThreadIndex,
+  samples: {
+    time?: number[],
+    number?: number[],
+    count?: number[],
+    length: number,
+  },
+  name?: string,
+  category?: string
+): Counter {
+  const newSamples = {
+    time: samples.time
+      ? samples.time
+      : Array.from({ length: samples.length }, (_, i) => i),
+    number: samples.number ? samples.number : Array(samples.length).fill(0),
+    count: samples.count
+      ? samples.count
+      : Array(samples.length).map((_, i) => Math.sin(i)),
+    length: samples.length,
+  };
+
+  const counter: Counter = {
+    name: name ? name : 'My Counter',
+    category: category ? category : 'My Category',
+    description: 'My Description',
+    pid: thread.pid,
+    mainThreadIndex,
+    sampleGroups: [
+      {
+        id: 0,
+        samples: newSamples,
+      },
+    ],
+  };
+  return counter;
+}
+
+/**
  * Creates a profile that includes a thread with eventDelay values.
  */
 export function getProfileWithEventDelays(

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -106,6 +106,10 @@ export function getHumanReadableTracks(state: State): string[] {
           trackName = profileViewSelectors
             .getCounterSelectors(track.counterIndex)
             .getPid(state);
+        } else if (track.type === 'process-cpu') {
+          trackName = profileViewSelectors
+            .getCounterSelectors(track.counterIndex)
+            .getPid(state);
         } else {
           trackName = threads[track.threadIndex].name;
         }

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -301,6 +301,9 @@ type ProfileAction =
       +type: 'ENABLE_EXPERIMENTAL_CPU_GRAPHS',
     |}
   | {|
+      +type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
+    |}
+  | {|
       +type: 'OPEN_SOURCE_VIEW',
       +file: string,
       +currentTab: TabSlug,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -302,6 +302,8 @@ type ProfileAction =
     |}
   | {|
       +type: 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS',
+      +localTracksByPid: Map<Pid, LocalTrack[]>,
+      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
     |}
   | {|
       +type: 'OPEN_SOURCE_VIEW',

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -298,7 +298,8 @@ export type LocalTrack =
   | {| +type: 'network', +threadIndex: ThreadIndex |}
   | {| +type: 'memory', +counterIndex: CounterIndex |}
   | {| +type: 'ipc', +threadIndex: ThreadIndex |}
-  | {| +type: 'event-delay', +threadIndex: ThreadIndex |};
+  | {| +type: 'event-delay', +threadIndex: ThreadIndex |}
+  | {| +type: 'process-cpu', +counterIndex: CounterIndex |};
 
 export type Track = GlobalTrack | LocalTrack;
 

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -175,6 +175,7 @@ export type UrlSetupPhase = 'initial-load' | 'loading-profile' | 'done';
 export type ExperimentalFlags = {|
   +eventDelayTracks: boolean,
   +cpuGraphs: boolean,
+  +processCPUTracks: boolean,
 |};
 
 export type AppState = {|

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -85,6 +85,19 @@ export function addDataToWindowObject(
         `);
       }
     },
+
+    enableProcessCPUTracks() {
+      const areExperimentalProcessCPUTracksEnabled = dispatch(
+        actions.enableExperimentalProcessCPUTracks()
+      );
+      if (areExperimentalProcessCPUTracksEnabled) {
+        console.log(stripIndent`
+          ✅ The process CPU tracks are now enabled and should be displayed in the timeline.
+          👉 Note that this is an experimental feature that might still have bugs.
+          💡 As an experimental feature their presence isn't persisted as a URL parameter like the other things.
+        `);
+      }
+    },
   };
 
   target.togglePseudoLocalization = function (pseudoStrategy?: string) {


### PR DESCRIPTION
This is an alternative solution to #3751. It uses the counters instead of the fake threads. Similarly, the tracks needs to be enbaleds by `experimental.enableProcessCPUTracks()` I would personally prefer this solution, but this PR is bigger because of the copied components. Currently I directly copy pasted the memory tracks code, that's why it's using a line chart instead of the activity graph. I think it's also not looking so bad. Changing this to use an activity graph would requires a lot more changes since activity graph component excepts a thread and not a counter.

[Example profile](https://deploy-preview-3759--perf-html.netlify.app/public/30bz0xn0qpxb0erbayrf7dqxrk70kwp3wqyvkpg/calltree/?globalTrackOrder=780w6&hiddenGlobalTracks=78&hiddenLocalTracksByPid=21124-0w4~19088-02&localTrackOrderByPid=21124-60w57wb~25496-01~26240-01~8716-01~19088-0w5~37760-01~17004-102&thread=0&timelineType=cpu-category&v=6)

@squelart Hey, what do you think about this?

