### PR TITLE
Replace fetchSource thunk action with a <SourceFetcher>.

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -3,62 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { ThunkAction, SourceLoadingError } from 'firefox-profiler/types';
-import {
-  getDownloadRecipeForSourceFile,
-  parseFileNameFromSymbolication,
-} from '../utils/special-paths';
-import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import type { Action, SourceLoadingError } from 'firefox-profiler/types';
 
-export function fetchSourceForFile(file: string): ThunkAction<Promise<void>> {
-  return async (dispatch) => {
-    const errors: SourceLoadingError[] = [];
-    const parsedName = parseFileNameFromSymbolication(file);
-    const downloadRecipe = getDownloadRecipeForSourceFile(parsedName);
+export function beginLoadingSourceFromUrl(file: string, url: string): Action {
+  return { type: 'SOURCE_LOADING_BEGIN', file, url };
+}
 
-    // First, try to fetch just the single file from the web.
-    switch (downloadRecipe.type) {
-      case 'CORS_ENABLED_SINGLE_FILE': {
-        const { url } = downloadRecipe;
-        dispatch({ type: 'SOURCE_LOADING_BEGIN', file, url });
+export function finishLoadingSource(file: string, source: string): Action {
+  return { type: 'SOURCE_LOADING_SUCCESS', file, source };
+}
 
-        try {
-          const response = await fetch(url, { credentials: 'omit' });
-
-          if (response.status !== 200) {
-            throw new Error(
-              `The request to ${url} returned HTTP status ${response.status}`
-            );
-          }
-
-          const source = await response.text();
-          dispatch({ type: 'SOURCE_LOADING_SUCCESS', file, source });
-          return;
-        } catch (e) {
-          errors.push({
-            type: 'NETWORK_ERROR',
-            url,
-            networkErrorMessage: e.toString(),
-          });
-        }
-        break;
-      }
-      case 'CORS_ENABLED_ARCHIVE': {
-        // Not handled yet.
-        errors.push({ type: 'NO_KNOWN_CORS_URL' });
-        break;
-      }
-      case 'NO_KNOWN_CORS_URL': {
-        errors.push({ type: 'NO_KNOWN_CORS_URL' });
-        break;
-      }
-      default:
-        throw assertExhaustiveCheck(downloadRecipe.type);
-    }
-    dispatch({
-      type: 'SOURCE_LOADING_ERROR',
-      file,
-      errors,
-    });
-  };
+export function failLoadingSource(
+  file: string,
+  errors: SourceLoadingError[]
+): Action {
+  return { type: 'SOURCE_LOADING_ERROR', file, errors };
 }

--- a/src/components/app/BottomBox.js
+++ b/src/components/app/BottomBox.js
@@ -18,7 +18,6 @@ import {
 import { closeBottomBox } from 'firefox-profiler/actions/profile-view';
 import { parseFileNameFromSymbolication } from 'firefox-profiler/utils/special-paths';
 import { getSourceViewSource } from 'firefox-profiler/selectors/sources';
-import { fetchSourceForFile } from 'firefox-profiler/actions/sources';
 import { getPreviewSelection } from 'firefox-profiler/selectors/profile';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import explicitConnect from 'firefox-profiler/utils/connect';
@@ -41,7 +40,6 @@ type StateProps = {|
 
 type DispatchProps = {|
   +closeBottomBox: typeof closeBottomBox,
-  +fetchSourceForFile: typeof fetchSourceForFile,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -139,8 +137,6 @@ class BottomBoxImpl extends React.PureComponent<Props> {
   _sourceView = React.createRef<SourceView>();
 
   componentDidMount() {
-    this._triggerSourceLoadingIfNeeded();
-
     if (this._sourceView.current) {
       this._sourceView.current.scrollToHotSpot(
         this.props.selectedCallNodeLineTimings
@@ -149,8 +145,6 @@ class BottomBoxImpl extends React.PureComponent<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    this._triggerSourceLoadingIfNeeded();
-
     if (
       this._sourceView.current &&
       prevProps.sourceViewActivationGeneration <
@@ -159,13 +153,6 @@ class BottomBoxImpl extends React.PureComponent<Props> {
       this._sourceView.current.scrollToHotSpot(
         this.props.selectedCallNodeLineTimings
       );
-    }
-  }
-
-  _triggerSourceLoadingIfNeeded() {
-    const { sourceViewFile, sourceViewSource, fetchSourceForFile } = this.props;
-    if (sourceViewFile && !sourceViewSource) {
-      fetchSourceForFile(sourceViewFile);
     }
   }
 
@@ -238,7 +225,6 @@ export const BottomBox = explicitConnect<{||}, StateProps, DispatchProps>({
   }),
   mapDispatchToProps: {
     closeBottomBox,
-    fetchSourceForFile,
   },
   component: BottomBoxImpl,
 });

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -8,6 +8,7 @@ import React, { PureComponent } from 'react';
 import explicitConnect from 'firefox-profiler/utils/connect';
 
 import { DetailsContainer } from './DetailsContainer';
+import { SourceFetcher } from './SourceFetcher';
 import { BottomBox } from './BottomBox';
 import { ProfileFilterNavigator } from './ProfileFilterNavigator';
 import { MenuButtons } from './MenuButtons';
@@ -156,6 +157,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
           <BeforeUnloadManager />
           <DebugWarning />
           <CurrentProfileUploadedInformationLoader />
+          <SourceFetcher />
         </div>
       </KeyboardShortcut>
     );

--- a/src/components/app/SourceFetcher.js
+++ b/src/components/app/SourceFetcher.js
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React from 'react';
+
+import { getSourceViewFile } from 'firefox-profiler/selectors/url-state';
+import { getSourceViewSource } from 'firefox-profiler/selectors/sources';
+import {
+  beginLoadingSourceFromUrl,
+  finishLoadingSource,
+  failLoadingSource,
+} from 'firefox-profiler/actions/sources';
+import {
+  getDownloadRecipeForSourceFile,
+  parseFileNameFromSymbolication,
+} from 'firefox-profiler/utils/special-paths';
+import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import explicitConnect from 'firefox-profiler/utils/connect';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+import type {
+  FileSourceStatus,
+  SourceLoadingError,
+} from 'firefox-profiler/types';
+
+type StateProps = {|
+  +sourceViewFile: string | null,
+  +sourceViewSource: FileSourceStatus | void,
+|};
+
+type DispatchProps = {|
+  +beginLoadingSourceFromUrl: typeof beginLoadingSourceFromUrl,
+  +finishLoadingSource: typeof finishLoadingSource,
+  +failLoadingSource: typeof failLoadingSource,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+class SourceFetcherImpl extends React.PureComponent<Props> {
+  componentDidMount() {
+    this._triggerSourceLoadingIfNeeded();
+  }
+
+  componentDidUpdate() {
+    this._triggerSourceLoadingIfNeeded();
+  }
+
+  _triggerSourceLoadingIfNeeded() {
+    const { sourceViewFile, sourceViewSource } = this.props;
+    if (sourceViewFile && !sourceViewSource) {
+      this._fetchSourceForFile(sourceViewFile);
+    }
+  }
+
+  async _fetchSourceForFile(file: string) {
+    const {
+      beginLoadingSourceFromUrl,
+      finishLoadingSource,
+      failLoadingSource,
+    } = this.props;
+
+    const errors: SourceLoadingError[] = [];
+    const parsedName = parseFileNameFromSymbolication(file);
+    const downloadRecipe = getDownloadRecipeForSourceFile(parsedName);
+
+    // First, try to fetch just the single file from the web.
+    switch (downloadRecipe.type) {
+      case 'CORS_ENABLED_SINGLE_FILE': {
+        const { url } = downloadRecipe;
+        beginLoadingSourceFromUrl(file, url);
+
+        try {
+          const response = await fetch(url, { credentials: 'omit' });
+
+          if (response.status !== 200) {
+            throw new Error(
+              `The request to ${url} returned HTTP status ${response.status}`
+            );
+          }
+
+          const source = await response.text();
+          finishLoadingSource(file, source);
+          return;
+        } catch (e) {
+          errors.push({
+            type: 'NETWORK_ERROR',
+            url,
+            networkErrorMessage: e.toString(),
+          });
+        }
+        break;
+      }
+      case 'CORS_ENABLED_ARCHIVE': {
+        // Not handled yet.
+        errors.push({ type: 'NO_KNOWN_CORS_URL' });
+        break;
+      }
+      case 'NO_KNOWN_CORS_URL': {
+        errors.push({ type: 'NO_KNOWN_CORS_URL' });
+        break;
+      }
+      default:
+        throw assertExhaustiveCheck(downloadRecipe.type);
+    }
+    failLoadingSource(file, errors);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export const SourceFetcher = explicitConnect<{||}, StateProps, DispatchProps>({
+  mapStateToProps: (state) => ({
+    sourceViewFile: getSourceViewFile(state),
+    sourceViewSource: getSourceViewSource(state),
+  }),
+  mapDispatchToProps: {
+    beginLoadingSourceFromUrl,
+    finishLoadingSource,
+    failLoadingSource,
+  },
+  component: SourceFetcherImpl,
+});


### PR DESCRIPTION
Fixes #3752.

I tried this to see how I feel about it, and it seems fine but doesn't feel like a big difference. So, just like Julien, I also don't have a strong opinion one way or the other.

The biggest trouble was coming up with names for the functions in `actions/sources.js` which create the individual sub-actions objects. If I have a thunk action, the function does some real work, so the function name can describe that work. And the sub-actions are just object literals without extra action creator functions.