### PR TITLE
Remove the prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "namedtuplemap": "^1.0.0",
     "offline-plugin": "^5.0.7",
     "photon-colors": "^3.3.2",
-    "prop-types": "^15.7.2",
     "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
This was removed in https://github.com/firefox-devtools/profiler/pull/788 but got reintroduced by mistake shortly after, probably as the resolution of a merge conflict. Let's remove it again!

`yarn.lock` isn't updated probably because some of our dependencies dedend on it still.