### PR TITLE
Add support for fetching source code from the browser, for local Firefox builds

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -37,7 +37,7 @@ AppViewRouter--error-from-url = Could not download the profile.
 # https://profiler.firefox.com/from-url/http%3A%2F%2F127.0.0.1%3A3000%2Fprofile.json/
 AppViewRouter--error-from-localhost-url-safari =
     Due to a <a>specific limitation in Safari</a>, { -profiler-brand-name } is unable
-    to import profiles from the local machine in this browser. Please open 
+    to import profiles from the local machine in this browser. Please open
     this page in { -firefox-brand-name } or Chrome instead.
     .title = Safari cannot import local profiles
 
@@ -728,6 +728,10 @@ TransformNavigator--collapse-function-subtree = Collapse subtree: { $item }
 #   $host (String) - The "host" part of the URL, e.g. hg.mozilla.org
 SourceView--loading-url = Waiting for { $host }…
 
+# Displayed while the source view is waiting for the browser to deliver
+# the source code.
+SourceView--loading-browser-connection = Waiting for { -firefox-brand-name }…
+
 # Displayed whenever the source view was not able to get the source code for
 # a file.
 SourceView--source-not-available-title = Source not available
@@ -752,12 +756,27 @@ SourceView--no-known-cors-url =
 SourceView--network-error-when-obtaining-source =
     There was a network error when fetching the URL { $url }: { $networkErrorMessage }
 
-# Displayed below SourceView--cannot-obtain-source, if querying the API for
-# source code returned in an error.
+# Displayed below SourceView--cannot-obtain-source, if the browser could not
+# be queried for source code using the symbolication API.
+# Variables:
+#   $browserConnectionErrorMessage (String) - The raw internal error message, not localized
+SourceView--browser-connection-error-when-obtaining-source =
+    Could not query the browser’s symbolication API: { $browserConnectionErrorMessage }
+
+# Displayed below SourceView--cannot-obtain-source, if the browser was queried
+# for source code using the symbolication API, and this query returned an error.
 # Variables:
 #   $apiErrorMessage (String) - The raw internal error message from the API, not localized
-SourceView--api-error-when-obtaining-source =
-    The symbolication API returned an error: { $apiErrorMessage }
+SourceView--browser-api-error-when-obtaining-source =
+    The browser’s symbolication API returned an error: { $apiErrorMessage }
+
+# Displayed below SourceView--cannot-obtain-source, if a symbol server which is
+# running locally was queried for source code using the symbolication API, and
+# this query returned an error.
+# Variables:
+#   $apiErrorMessage (String) - The raw internal error message from the API, not localized
+SourceView--local-symbol-server-api-error-when-obtaining-source =
+    The local symbol server’s symbolication API returned an error: { $apiErrorMessage }
 
 # Displayed below SourceView--cannot-obtain-source, if a file could not be found in
 # an archive file (.tar.gz) which was downloaded from crates.io.

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -6,7 +6,11 @@
 import type { Action, SourceLoadingError } from 'firefox-profiler/types';
 
 export function beginLoadingSourceFromUrl(file: string, url: string): Action {
-  return { type: 'SOURCE_LOADING_BEGIN', file, url };
+  return { type: 'SOURCE_LOADING_BEGIN_URL', file, url };
+}
+
+export function beginLoadingSourceFromBrowserConnection(file: string): Action {
+  return { type: 'SOURCE_LOADING_BEGIN_BROWSER_CONNECTION', file };
 }
 
 export function finishLoadingSource(file: string, source: string): Action {

--- a/src/components/app/BottomBox.js
+++ b/src/components/app/BottomBox.js
@@ -51,20 +51,36 @@ function SourceStatusOverlay({ status }: SourceStatusOverlayProps) {
     case 'AVAILABLE':
       return null; // No overlay if we have source code.
     case 'LOADING': {
-      const { url } = status;
-      let host;
-      try {
-        host = new URL(url).host;
-      } catch (e) {
-        host = url;
+      const { source } = status;
+      switch (source.type) {
+        case 'URL': {
+          const { url } = source;
+          let host;
+          try {
+            host = new URL(url).host;
+          } catch (e) {
+            host = url;
+          }
+          return (
+            <Localized id="SourceView--loading-url" vars={{ host }}>
+              <div className="sourceStatusOverlay loading">
+                {`Waiting for ${host}…`}
+              </div>
+            </Localized>
+          );
+        }
+        case 'BROWSER_CONNECTION': {
+          return (
+            <Localized id="SourceView--loading-browser-connection">
+              <div className="sourceStatusOverlay loading">
+                Waiting for browser…
+              </div>
+            </Localized>
+          );
+        }
+        default:
+          throw assertExhaustiveCheck(source.type);
       }
-      return (
-        <Localized id="SourceView--loading-url" vars={{ host }}>
-          <div className="sourceStatusOverlay loading">
-            {`Waiting for ${host}…`}
-          </div>
-        </Localized>
-      );
     }
     case 'ERROR': {
       return (
@@ -119,14 +135,37 @@ function SourceStatusOverlay({ status }: SourceStatusOverlayProps) {
                       </Localized>
                     );
                   }
+                  case 'BROWSER_CONNECTION_ERROR': {
+                    const { browserConnectionErrorMessage } = error;
+                    return (
+                      <Localized
+                        key={key}
+                        id="SourceView--browser-connection-error-when-obtaining-source"
+                        vars={{ browserConnectionErrorMessage }}
+                      >
+                        <li>{`Could not query the browser’s symbolication API: ${browserConnectionErrorMessage}`}</li>
+                      </Localized>
+                    );
+                  }
+                  case 'BROWSER_API_ERROR': {
+                    const { apiErrorMessage } = error;
+                    return (
+                      <Localized
+                        id="SourceView--browser-api-error-when-obtaining-source"
+                        vars={{ apiErrorMessage }}
+                      >
+                        <li>{`The browser’s symbolication API returned an error: ${apiErrorMessage}`}</li>
+                      </Localized>
+                    );
+                  }
                   case 'SYMBOL_SERVER_API_ERROR': {
                     const { apiErrorMessage } = error;
                     return (
                       <Localized
-                        id="SourceView--api-error-when-obtaining-source"
+                        id="SourceView--local-symbol-server-api-error-when-obtaining-source"
                         vars={{ apiErrorMessage }}
                       >
-                        <li>{`The symbolication API returned an error: ${apiErrorMessage}`}</li>
+                        <li>{`The local symbol server’s symbolication API returned an error: ${apiErrorMessage}`}</li>
                       </Localized>
                     );
                   }

--- a/src/components/app/SourceFetcher.js
+++ b/src/components/app/SourceFetcher.js
@@ -10,14 +10,17 @@ import {
   getSymbolServerUrl,
 } from 'firefox-profiler/selectors/url-state';
 import { getSourceViewSource } from 'firefox-profiler/selectors/sources';
+import { getBrowserConnection } from 'firefox-profiler/selectors/app';
 import { getProfileOrNull } from 'firefox-profiler/selectors';
 import {
   beginLoadingSourceFromUrl,
+  beginLoadingSourceFromBrowserConnection,
   finishLoadingSource,
   failLoadingSource,
 } from 'firefox-profiler/actions/sources';
 import { fetchSource } from 'firefox-profiler/utils/fetch-source';
 import { findAddressProofForFile } from 'firefox-profiler/profile-logic/profile-data';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import explicitConnect from 'firefox-profiler/utils/connect';
 
@@ -29,10 +32,12 @@ type StateProps = {|
   +sourceViewSource: FileSourceStatus | void,
   +symbolServerUrl: string,
   +profile: Profile | null,
+  +browserConnection: BrowserConnection | null,
 |};
 
 type DispatchProps = {|
   +beginLoadingSourceFromUrl: typeof beginLoadingSourceFromUrl,
+  +beginLoadingSourceFromBrowserConnection: typeof beginLoadingSourceFromBrowserConnection,
   +finishLoadingSource: typeof finishLoadingSource,
   +failLoadingSource: typeof failLoadingSource,
 |};
@@ -60,10 +65,12 @@ class SourceFetcherImpl extends React.PureComponent<Props> {
   async _fetchSourceForFile(file: string) {
     const {
       beginLoadingSourceFromUrl,
+      beginLoadingSourceFromBrowserConnection,
       finishLoadingSource,
       failLoadingSource,
       symbolServerUrl,
       profile,
+      browserConnection,
     } = this.props;
 
     const addressProof =
@@ -95,6 +102,16 @@ class SourceFetcherImpl extends React.PureComponent<Props> {
           }
           return response;
         },
+        queryBrowserSymbolicationApi: async (
+          path: string,
+          requestJson: string
+        ) => {
+          if (browserConnection === null) {
+            throw new Error('No connection to the browser.');
+          }
+          beginLoadingSourceFromBrowserConnection(file);
+          return browserConnection.querySymbolicationApi(path, requestJson);
+        },
       }
     );
 
@@ -121,9 +138,11 @@ export const SourceFetcher = explicitConnect<{||}, StateProps, DispatchProps>({
     sourceViewSource: getSourceViewSource(state),
     symbolServerUrl: getSymbolServerUrl(state),
     profile: getProfileOrNull(state),
+    browserConnection: getBrowserConnection(state),
   }),
   mapDispatchToProps: {
     beginLoadingSourceFromUrl,
+    beginLoadingSourceFromBrowserConnection,
     finishLoadingSource,
     failLoadingSource,
   },

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -10,10 +10,19 @@ const sources: Reducer<Map<string, FileSourceStatus>> = (
   action
 ) => {
   switch (action.type) {
-    case 'SOURCE_LOADING_BEGIN': {
+    case 'SOURCE_LOADING_BEGIN_URL': {
       const { file, url } = action;
       const newState = new Map(state);
-      newState.set(file, { type: 'LOADING', url });
+      newState.set(file, { type: 'LOADING', source: { type: 'URL', url } });
+      return newState;
+    }
+    case 'SOURCE_LOADING_BEGIN_BROWSER_CONNECTION': {
+      const { file } = action;
+      const newState = new Map(state);
+      newState.set(file, {
+        type: 'LOADING',
+        source: { type: 'BROWSER_CONNECTION' },
+      });
       return newState;
     }
     case 'SOURCE_LOADING_SUCCESS': {

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -548,7 +548,8 @@ type L10nAction =
     |};
 
 type SourcesAction =
-  | {| +type: 'SOURCE_LOADING_BEGIN', file: string, url: string |}
+  | {| +type: 'SOURCE_LOADING_BEGIN_URL', file: string, url: string |}
+  | {| +type: 'SOURCE_LOADING_BEGIN_BROWSER_CONNECTION', file: string |}
   | {| +type: 'SOURCE_LOADING_SUCCESS', file: string, source: string |}
   | {|
       +type: 'SOURCE_LOADING_ERROR',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -233,9 +233,13 @@ export type SourceViewState = {|
 |};
 
 export type FileSourceStatus =
-  | {| type: 'LOADING', url: string |}
+  | {| type: 'LOADING', source: FileSourceLoadingSource |}
   | {| type: 'ERROR', errors: SourceLoadingError[] |}
   | {| type: 'AVAILABLE', source: string |};
+
+export type FileSourceLoadingSource =
+  | {| type: 'URL', url: string |}
+  | {| type: 'BROWSER_CONNECTION' |};
 
 export type SourceLoadingError =
   | {| type: 'NO_KNOWN_CORS_URL' |}
@@ -256,6 +260,14 @@ export type SourceLoadingError =
     |}
   | {|
       type: 'SYMBOL_SERVER_API_ERROR',
+      apiErrorMessage: string,
+    |}
+  | {|
+      type: 'BROWSER_CONNECTION_ERROR',
+      browserConnectionErrorMessage: string,
+    |}
+  | {|
+      type: 'BROWSER_API_ERROR',
       apiErrorMessage: string,
     |};
 


### PR DESCRIPTION
Fixes #3755.

This PR is based on #3781 and #3778.

To test:

 1. Build Firefox locally.
 2. Run it and change `devtools.performance.recording.ui-base-url` to `https://deploy-preview-3786--perf-html.netlify.app`.
 3. Capture a profile.
 4. In the call tree, double-click a C++ or Rust function with a local file path.