### PR TITLE
When the user sanitizes a fake global track, we need to sanitize its real children tracks

### DIFF
--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -109,18 +109,17 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
       if (!checkedSharingOptions.includeHiddenThreads) {
         for (const globalTrackIndex of hiddenGlobalTracks) {
           const globalTrack = globalTracks[globalTrackIndex];
-          if (
-            globalTrack.type === 'process' &&
-            globalTrack.mainThreadIndex !== null
-          ) {
-            // This is a process thread that has been hidden.
-            shouldRemoveThreads.add(globalTrack.mainThreadIndex);
+          if (globalTrack.type === 'process') {
+            if (globalTrack.mainThreadIndex !== null) {
+              // This is a process thread that has been hidden.
+              shouldRemoveThreads.add(globalTrack.mainThreadIndex);
+            }
+
+            // Also add all of the children threads, as they are hidden as well.
             const localTracks = ensureExists(
               localTracksByPid.get(globalTrack.pid),
               'Expected to be able to get a local track by PID.'
             );
-
-            // Also add all of the children threads, as they are hidden as well.
             for (const localTrack of localTracks) {
               if (localTrack.type === 'thread') {
                 shouldRemoveThreads.add(localTrack.threadIndex);

--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -172,6 +172,36 @@ export function getProfileWithNiceTracks(): Profile {
   return profile;
 }
 
+/*
+ * This produces a profile where no global track will be found. This is simulating
+ * profiles coming from various importers.
+ */
+export function getProfileWithFakeGlobalTrack(): Profile {
+  const { profile } = getProfileFromTextSamples('A', 'B', 'C', 'D');
+
+  const [thread1, thread2, thread3, thread4] = profile.threads;
+
+  // First group of threads
+  thread1.name = 'Thread <0>';
+  thread1.processType = 'default';
+  thread1.pid = 111;
+
+  thread2.name = 'Thread <1>';
+  thread2.processType = 'default';
+  thread2.pid = 111;
+
+  // Second group of threads
+  thread3.name = 'Thread <2>';
+  thread3.processType = 'default';
+  thread3.pid = 222;
+
+  thread4.name = 'Thread <3>';
+  thread4.processType = 'default';
+  thread4.pid = 222;
+
+  return profile;
+}
+
 export function getStoreWithMemoryTrack(pid: number = 222) {
   const { profile } = getProfileFromTextSamples(
     // Create a trivial profile with 10 samples, all of the function "A".

--- a/src/test/store/publish.test.js
+++ b/src/test/store/publish.test.js
@@ -35,6 +35,7 @@ import {
   getHash,
   getTransformStack,
 } from '../../selectors/url-state';
+import { getHasPreferenceMarkers } from '../../selectors/profile';
 import { urlFromState } from '../../app-logic/url-handling';
 import { getHasZipFile } from '../../selectors/zipped-profiles';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
@@ -139,6 +140,24 @@ describe('getCheckedSharingOptions', function () {
         includeHiddenThreads: false,
       });
     });
+  });
+});
+
+describe('getRemoveProfileInformation', function () {
+  it('should bail out early when there is no preference marker in the profile', function () {
+    const { getState, dispatch } = storeWithProfile();
+    // Checking to see that we don't have Preference markers.
+    expect(getHasPreferenceMarkers(getState())).toEqual(false);
+
+    // Setting includePreferenceValues option to false
+    dispatch(toggleCheckedSharingOptions('includePreferenceValues'));
+    expect(
+      getCheckedSharingOptions(getState()).includePreferenceValues
+    ).toEqual(false);
+
+    const removeProfileInformation = getRemoveProfileInformation(getState());
+    // It should return early with null value.
+    expect(removeProfileInformation).toEqual(null);
   });
 });
 

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -12,13 +12,6 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
 import type { RemoveProfileInformation } from 'firefox-profiler/types';
-import { storeWithProfile } from '../fixtures/stores';
-import { getHasPreferenceMarkers } from '../../selectors/profile';
-import {
-  getCheckedSharingOptions,
-  getRemoveProfileInformation,
-} from '../../selectors/publish';
-import { toggleCheckedSharingOptions } from '../../actions/publish';
 import {
   correlateIPCMarkers,
   deriveMarkersFromRawMarkerTable,
@@ -569,23 +562,5 @@ describe('sanitizePII', function () {
     );
 
     expect(sanitizedProfile.threads[0]['eTLD+1']).toBe(eTLDPlus1);
-  });
-});
-
-describe('getRemoveProfileInformation', function () {
-  it('should bail out early when there is no preference marker in the profile', function () {
-    const { getState, dispatch } = storeWithProfile();
-    // Checking to see that we don't have Preference markers.
-    expect(getHasPreferenceMarkers(getState())).toEqual(false);
-
-    // Setting includePreferenceValues option to false
-    dispatch(toggleCheckedSharingOptions('includePreferenceValues'));
-    expect(
-      getCheckedSharingOptions(getState()).includePreferenceValues
-    ).toEqual(false);
-
-    const removeProfileInformation = getRemoveProfileInformation(getState());
-    // It should return early with null value.
-    expect(removeProfileInformation).toEqual(null);
   });
 });

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -301,6 +301,11 @@ export type LocalTrack =
   | {| +type: 'event-delay', +threadIndex: ThreadIndex |};
 
 export type Track = GlobalTrack | LocalTrack;
+
+// A track index doesn't always represent uniquely a track: it's merely an index inside
+// a specific structure:
+// - for global tracks, this is the index in the global tracks array
+// - for local tracks, this is the index in the local tracks array for a specific pid.
 export type TrackIndex = number;
 
 /**

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -285,6 +285,8 @@ export type AccumulatedCounterSamples = {|
 export type StackType = 'js' | 'native' | 'unsymbolicated';
 
 export type GlobalTrack =
+  // mainThreadIndex is null when this is a fake global process added to contain
+  // real threads.
   | {| +type: 'process', +pid: Pid, +mainThreadIndex: ThreadIndex | null |}
   | {| +type: 'screenshots', +id: string, +threadIndex: ThreadIndex |}
   | {| +type: 'visual-progress' |}


### PR DESCRIPTION
Fixes #3787