### PR TITLE
Fix the padding in multi-lines message bars

### DIFF
--- a/res/css/photon/message-bar.css
+++ b/res/css/photon/message-bar.css
@@ -48,6 +48,17 @@
 .photon-message-bar-inner-text {
   display: flex;
   align-items: center;
+
+  /* This padding is carefully computed so that multi-line message bars have the
+   * same top padding than single-line message bars. Having this property
+   * shouldn't change anything for single-line message bars.
+   * It's computed like this:
+   * height of single-line message bars is 32px
+   * padding of the message-bar div is 4px
+   * height of the inner text is line-height * font-size = 1.4 * 13px = 18.2px
+   * => (32 - 4 - 18.2) / 2 = 2.9px
+   */
+  padding: 2.9px 0;
 }
 
 .photon-message-bar-error {

--- a/res/photon/index.html
+++ b/res/photon/index.html
@@ -179,6 +179,30 @@
   &lt;div class="photon-message-bar-inner-text"&gt;
     This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
   &lt;/div&gt;
+&lt;/div&gt;
+        </pre>
+        <div class="photon-message-bar photon-message-bar-inner-content">
+          <div class="photon-message-bar-inner-text">
+            This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+          </div>
+        </div>
+        <div class="photon-message-bar photon-message-bar-inner-content sized-to-content">
+          <div class="photon-message-bar-inner-text">
+            This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+          </div>
+        </div>
+        <div class="photon-message-bar photon-message-bar-inner-content sized-constrained">
+          <div class="photon-message-bar-inner-text">
+            This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <pre>
+&lt;div class="photon-message-bar photon-message-bar-inner-content"&gt;
+  &lt;div class="photon-message-bar-inner-text"&gt;
+    This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+  &lt;/div&gt;
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
@@ -319,6 +343,30 @@
   &lt;div class="photon-message-bar-inner-text"&gt;
     This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
   &lt;/div&gt;
+&lt;/div&gt;
+        </pre>
+        <div class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">
+          <div class="photon-message-bar-inner-text">
+            This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+          </div>
+        </div>
+        <div class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content sized-to-content">
+          <div class="photon-message-bar-inner-text">
+            This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+          </div>
+        </div>
+        <div class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content sized-constrained">
+          <div class="photon-message-bar-inner-text">
+            This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <pre>
+&lt;div class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content"&gt;
+  &lt;div class="photon-message-bar-inner-text"&gt;
+    This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+  &lt;/div&gt;
   &lt;button class="photon-button photon-button-micro photon-message-bar-action-button" type="button"&gt;
     Call to action
   &lt;/button&gt;
@@ -451,8 +499,32 @@
       </div>
     </div>
   </div>
-      
+
   <h3 class='photon-title-20'>Photon Message Bar Warning</h3>
+    <div class="row">
+      <pre>
+&lt;div class="photon-message-bar photon-message-bar-warning photon-message-bar-inner-content"&gt;
+  &lt;div class="photon-message-bar-inner-text"&gt;
+    This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+  &lt;/div&gt;
+&lt;/div&gt;
+      </pre>
+      <div class="photon-message-bar photon-message-bar-warning photon-message-bar-inner-content">
+        <div class="photon-message-bar-inner-text">
+          This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+        </div>
+      </div>
+      <div class="photon-message-bar photon-message-bar-warning photon-message-bar-inner-content sized-to-content">
+        <div class="photon-message-bar-inner-text">
+          This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+        </div>
+      </div>
+      <div class="photon-message-bar photon-message-bar-warning photon-message-bar-inner-content sized-constrained">
+        <div class="photon-message-bar-inner-text">
+          This is a non-dismissable message bar. This add-on is not compatible with your version of Firefox.
+        </div>
+      </div>
+    </div>
     <div class="row">
       <pre>
 &lt;div class="photon-message-bar photon-message-bar-warning photon-message-bar-inner-content"&gt;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/454175/148403352-37812e53-bff8-4a31-9189-f054d942baba.png)

After:
![image](https://user-images.githubusercontent.com/454175/148403459-537ed07a-9834-4864-a9f4-273a45a4e96e.png)

Look closely at the top of the multiline message, the new version is more balanced. The other messages are unchanged.

There's no easy way to add such a padding to the bottom of the button so I decided to keep it like this. I discussed this a bit with some friends who know better than me about CSS, they said we need a something like a resize observer, and I'm not ready for this :-)

I also added these simpler examples to the photon page:
![image](https://user-images.githubusercontent.com/454175/148403984-8e7d3ded-74ba-4f79-b69b-add2f2773d65.png)

(without the padding change, they looked like this:
![image](https://user-images.githubusercontent.com/454175/148404237-5e8c45d3-cdfa-4863-9a5a-c77c87298e06.png)
)

If you want to try this out locally, you'll need to cherry-pick #3797 as well, so that you can actually start the webpack server for photon.