### PR TITLE
Use the componentDidUpdate instead of resize event listeners in SampleGraph

### DIFF
--- a/src/components/shared/thread/SampleGraph.js
+++ b/src/components/shared/thread/SampleGraph.js
@@ -50,7 +50,6 @@ export class ThreadSampleGraphImpl extends PureComponent<Props> {
   _canvas: null | HTMLCanvasElement = null;
   _takeCanvasRef = (canvas: HTMLCanvasElement | null) =>
     (this._canvas = canvas);
-  _resizeListener = () => this.forceUpdate();
 
   _renderCanvas() {
     const canvas = this._canvas;
@@ -62,12 +61,11 @@ export class ThreadSampleGraphImpl extends PureComponent<Props> {
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this._resizeListener);
-    this.forceUpdate(); // for initial size
+    this._renderCanvas();
   }
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this._resizeListener);
+  componentDidUpdate() {
+    this._renderCanvas();
   }
 
   drawCanvas(canvas: HTMLCanvasElement) {
@@ -223,7 +221,6 @@ export class ThreadSampleGraphImpl extends PureComponent<Props> {
   };
 
   render() {
-    this._renderCanvas();
     const { className, trackName } = this.props;
     return (
       <div className={className}>

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -10071,17 +10071,6 @@ Array [
     1,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "fillRect",
-    32.89473684210527,
-    0,
-    10,
-    10,
-  ],
-  Array [
     "set globalCompositeOperation",
     "lighter",
   ],
@@ -10796,6 +10785,17 @@ Array [
   Array [
     "set fillStyle",
     Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "fillRect",
+    32.89473684210527,
+    0,
+    10,
+    10,
   ],
 ]
 `;

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -1307,1272 +1307,15 @@ Array [
     Object {},
   ],
   Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#d7d7db60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
     "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#d7d7db60",
-          ],
-          Array [
-            0.25,
-            "#d7d7db60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#d7d7db60",
-          ],
-          Array [
-            0.75,
-            "#d7d7db60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
+    "#003eaa",
   ],
   Array [
     "fillRect",
+    -0.4,
     0,
+    0.8,
     0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "transparent",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#6200a460",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#6200a460",
-          ],
-          Array [
-            0.25,
-            "#6200a460",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#6200a460",
-          ],
-          Array [
-            0.75,
-            "#6200a460",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#ffe90060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#ffe90060",
-          ],
-          Array [
-            0.25,
-            "#ffe90060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#ffe90060",
-          ],
-          Array [
-            0.75,
-            "#ffe90060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#ff940060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#ff940060",
-          ],
-          Array [
-            0.25,
-            "#ff940060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#ff940060",
-          ],
-          Array [
-            0.75,
-            "#ff940060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#45a1ff60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#45a1ff60",
-          ],
-          Array [
-            0.25,
-            "#45a1ff60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#45a1ff60",
-          ],
-          Array [
-            0.75,
-            "#45a1ff60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#12bc0060",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#12bc0060",
-          ],
-          Array [
-            0.25,
-            "#12bc0060",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#12bc0060",
-          ],
-          Array [
-            0.75,
-            "#12bc0060",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "scale",
-    1,
-    1,
-  ],
-  Array [
-    "createLinearGradient",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "addColorStop",
-    0,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.25,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    0.5,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "#0060df60",
-  ],
-  Array [
-    "addColorStop",
-    0.75,
-    "transparent",
-  ],
-  Array [
-    "addColorStop",
-    1,
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {
-      "addColorStop": [MockFunction] {
-        "calls": Array [
-          Array [
-            0,
-            "#0060df60",
-          ],
-          Array [
-            0.25,
-            "#0060df60",
-          ],
-          Array [
-            0.25,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "transparent",
-          ],
-          Array [
-            0.5,
-            "#0060df60",
-          ],
-          Array [
-            0.75,
-            "#0060df60",
-          ],
-          Array [
-            0.75,
-            "transparent",
-          ],
-          Array [
-            1,
-            "transparent",
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    4,
-    4,
-  ],
-  Array [
-    "createPattern",
-    <canvas
-      height="4"
-      width="4"
-    />,
-    "repeat",
-  ],
-  Array [
-    "set globalCompositeOperation",
-    "lighter",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db60",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db",
-  ],
-  Array [
-    "set fillStyle",
-    "#d7d7db60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe900",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffe90060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a460",
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a4",
-  ],
-  Array [
-    "set fillStyle",
-    "#6200a460",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#12bc0060",
-  ],
-  Array [
-    "set fillStyle",
-    "#12bc00",
-  ],
-  Array [
-    "set fillStyle",
-    "#12bc0060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#0060df60",
-  ],
-  Array [
-    "set fillStyle",
-    "#0060df",
-  ],
-  Array [
-    "set fillStyle",
-    "#0060df60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#ff940060",
-  ],
-  Array [
-    "set fillStyle",
-    "#ff9400",
-  ],
-  Array [
-    "set fillStyle",
-    "#ff940060",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff60",
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff60",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
-  ],
-  Array [
-    "set fillStyle",
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    "transparent",
-  ],
-  Array [
-    "set fillStyle",
-    Object {},
   ],
   Array [
     "scale",
@@ -3854,15 +2597,1272 @@ Array [
     0,
   ],
   Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
     "set fillStyle",
-    "#003eaa",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
   ],
   Array [
     "fillRect",
-    -0.4,
     0,
-    0.8,
     0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "transparent",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#6200a460",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#6200a460",
+          ],
+          Array [
+            0.25,
+            "#6200a460",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#6200a460",
+          ],
+          Array [
+            0.75,
+            "#6200a460",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#ffe90060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#ffe90060",
+          ],
+          Array [
+            0.25,
+            "#ffe90060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#ffe90060",
+          ],
+          Array [
+            0.75,
+            "#ffe90060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#ff940060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#ff940060",
+          ],
+          Array [
+            0.25,
+            "#ff940060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#ff940060",
+          ],
+          Array [
+            0.75,
+            "#ff940060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#45a1ff60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#45a1ff60",
+          ],
+          Array [
+            0.25,
+            "#45a1ff60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#45a1ff60",
+          ],
+          Array [
+            0.75,
+            "#45a1ff60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe900",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffe90060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a4",
+  ],
+  Array [
+    "set fillStyle",
+    "#6200a460",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "#ff940060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
   ],
   Array [
     "set fillStyle",


### PR DESCRIPTION
This is how we are handling the resizing and rerender in `ActivityGraphCanvas`. And I think this is better since it removes the need of having a resize event listener. This is already a sized component (with `withSize`), so we already rerender when we change the size.

This is also a prerequisite for my work which will make these renderigs lazy (with an intersection observer)

There are no test changes because this is not changing the behavior. It's only refactoring the code to use the componentDidUpdate.

Example profile: [production](https://share.firefox.dev/3n0gh9m) / [deploy preview](https://deploy-preview-3799--perf-html.netlify.app/public/k82sqxse5qw5zq2yk0dvsfxpvy41rga7jz8g320/calltree/?globalTrackOrder=0wxu&hiddenGlobalTracks=1wjlwtvwxjxlwxsxu&hiddenLocalTracksByPid=7589-1wi~7731-0~251547-0~8656-0~21932-0~9482-01~383297-0~8917-0~39682-0~18425-0~380689-0~8690-01~244105-0~14942-0~8758-01~321994-0~21844-0~379087-0~378989-0~339960-0~226091-0~9645-0~8964-0~383211-0~235479-01~9161-0~381172-0~383324-0~380798-0~260791-0~35684-0~8562-0~8020-0~22399-01~22136-01~13220-0~9750-0~9361-01~378985-0~378145-0~8973-0~242860-0~8564-0~8762-01~21993-0~255478-0~12906-0~8984-0~9636-0~9175-0~22419-0~316120-0~9403-0~375770-0~8760-0~381359-0~9401-0~9222-01&localTrackOrderByPid=7589-jk0wi~7731-0~251547-0~8656-0~21932-0~9482-01~383297-0~8917-0~39682-0~18425-0~380689-0~8690-01~244105-0~14942-0~8188-01~8758-01~321994-0~21844-0~379087-0~378989-0~20815-0~339960-0~226091-0~9645-0~8964-0~383211-0~235479-01~9161-0~381172-0~383324-0~8107-0~380798-0~260791-0~35684-0~8562-0~8020-0~22399-01~22136-01~13220-0~9750-0~9361-01~378985-0~378145-0~8973-0~242860-0~8564-0~8762-01~21993-0~255478-0~12906-0~8984-0~9636-0~8207-01~9175-0~22419-0~316120-0~9403-0~375770-0~8760-0~381359-0~9401-0~8279-01~9222-01&thread=0&timelineType=cpu-category&v=6)