### PR TITLE
Add 'align-items: center' to photon-label and remove it from specific…

### DIFF
--- a/res/css/photon/label.css
+++ b/res/css/photon/label.css
@@ -4,6 +4,7 @@
 
 .photon-label {
   display: inline-flex;
+  align-items: center;
   padding: 3px 0;
   color: var(--grey-90);
 }

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -28,7 +28,6 @@
 
 .stackSettingsLabel {
   height: 25px;
-  align-items: center;
   padding: 0;
 }
 

--- a/src/components/timeline/FullTimeline.js
+++ b/src/components/timeline/FullTimeline.js
@@ -131,7 +131,7 @@ class TimelineSettingsGraphType extends React.PureComponent<{|
             />
             <Localized id="FullTimeline--categories">Categories</Localized>
           </label>
-          <label className="photon-label-micro timelineSettingsToggleLabel">
+          <label className="photon-label photon-label-micro timelineSettingsToggleLabel">
             <input
               type="radio"
               name="timelineSettingsToggle"

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -57,8 +57,6 @@
 }
 
 .timelineSettingsToggleLabel {
-  display: flex;
-  align-items: center;
   padding: 0;
 }
 

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -22,7 +22,7 @@ exports[`Timeline renders the header 1`] = `
         Categories
       </label>
       <label
-        class="photon-label-micro timelineSettingsToggleLabel"
+        class="photon-label photon-label-micro timelineSettingsToggleLabel"
       >
         <input
           class="photon-radio photon-radio-micro timelineSettingsToggleInput"


### PR DESCRIPTION
… classes

I realized there was some discrepancy in how we were handling some labels so I made this small patch to streamline this.

[production](https://profiler.firefox.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/) / [deploy preview](https://deploy-preview-3800--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/)


There should be no meaningful differences besides:
* in the publish panel where labels should be better vertically aligned:

before:
![image](https://user-images.githubusercontent.com/454175/148420216-1d466ed8-d520-486e-934e-afa3a5819346.png)

after:
![image](https://user-images.githubusercontent.com/454175/148420471-c486fc45-d4f0-4b3d-b4b6-1b9f60a202ad.png)


* the "stack height" radio button label color:

before:
![image](https://user-images.githubusercontent.com/454175/148421341-41428a4f-e536-443b-905c-474c08e07da4.png)

after:
![image](https://user-images.githubusercontent.com/454175/148421321-992db57a-298e-49e5-8d60-5808eeba3a2d.png)

