### PR TITLE
Do not show the top border of the first timeline track

### DIFF
--- a/src/components/timeline/ActiveTabTimeline.js
+++ b/src/components/timeline/ActiveTabTimeline.js
@@ -97,7 +97,7 @@ class ActiveTabTimelineImpl extends React.PureComponent<Props, State> {
             width={width}
           />
           <OverflowEdgeIndicator
-            className="timelineOverflowEdgeIndicator"
+            className="tracksContainer timelineOverflowEdgeIndicator"
             panelLayoutGeneration={panelLayoutGeneration}
             initialSelected={this.state.initialSelected}
             forceLayoutGeneration={this.state.forceLayoutGeneration}

--- a/src/components/timeline/FullTimeline.js
+++ b/src/components/timeline/FullTimeline.js
@@ -315,7 +315,7 @@ class FullTimelineImpl extends React.PureComponent<Props, State> {
             />
           </div>
           <OverflowEdgeIndicator
-            className="timelineOverflowEdgeIndicator"
+            className="tracksContainer timelineOverflowEdgeIndicator"
             panelLayoutGeneration={panelLayoutGeneration}
             initialSelected={this.state.initialSelected}
           >

--- a/src/components/timeline/OriginsTimeline.js
+++ b/src/components/timeline/OriginsTimeline.js
@@ -157,7 +157,7 @@ class OriginsTimelineView extends React.PureComponent<Props, State> {
             width={width}
           />
           <OverflowEdgeIndicator
-            className="timelineOverflowEdgeIndicator"
+            className="tracksContainer timelineOverflowEdgeIndicator"
             panelLayoutGeneration={panelLayoutGeneration}
             initialSelected={this.state.initialSelected}
           >

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -13,12 +13,6 @@
   box-shadow: 0 1px var(--grey-30);
 }
 
-.timelineThreadList > .timelineTrack:first-child {
-  /* Remove the top border of the first timeline track because we already have
-   * a border bottom in the timeline header. */
-  border: none;
-}
-
 .timelineTrackLocal {
   margin-left: 15px;
 }

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -106,6 +106,9 @@
 }
 
 .timelineHeader {
+  /* This should be on top of the overflow edge indicator that wraps the thread
+   list, so border bottom will always be visible. */
+  z-index: 1;
   display: flex;
   height: 20px;
   flex-direction: row;
@@ -118,4 +121,13 @@
   border-bottom: 1px solid var(--grey-30);
   margin-right: calc(var(--vertical-scrollbar-reserved-width) * -1);
   margin-left: calc(var(--thread-label-column-width) * -1);
+}
+
+.tracksContainer {
+  /* This should be below the timeline header. */
+  z-index: 0;
+
+  /* Moving the timeline 1 pixel below the timeline header. This way, the first 
+   * visible track's top border will be hidden as expected. */
+  margin-top: -1px;
 }

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -121,6 +121,9 @@
   border-bottom: 1px solid var(--grey-30);
   margin-right: calc(var(--vertical-scrollbar-reserved-width) * -1);
   margin-left: calc(var(--thread-label-column-width) * -1);
+
+  /* This div needs to be apaque so that it can properly hide the hidden tracks
+   * container border below */
   background: white;
 }
 

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -121,13 +121,15 @@
   border-bottom: 1px solid var(--grey-30);
   margin-right: calc(var(--vertical-scrollbar-reserved-width) * -1);
   margin-left: calc(var(--thread-label-column-width) * -1);
+  background: white;
 }
 
 .tracksContainer {
   /* This should be below the timeline header. */
   z-index: 0;
 
-  /* Moving the timeline 1 pixel below the timeline header. This way, the first 
+  /* Moving the timeline 1 pixel below the timeline header. This way, the first
    * visible track's top border will be hidden as expected. */
   margin-top: -1px;
+  margin-bottom: -1px;
 }

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -447,7 +447,7 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
     </ol>
   </div>
   <div
-    class="overflowEdgeIndicator timelineOverflowEdgeIndicator"
+    class="overflowEdgeIndicator tracksContainer timelineOverflowEdgeIndicator"
   >
     <div
       class="overflowEdgeIndicatorEdge topEdge"
@@ -462,7 +462,7 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
       class="overflowEdgeIndicatorEdge leftEdge"
     />
     <div
-      class="overflowEdgeIndicatorScrollbox timelineOverflowEdgeIndicatorScrollbox"
+      class="overflowEdgeIndicatorScrollbox tracksContainer timelineOverflowEdgeIndicatorScrollbox"
     >
       <div
         class="overflowEdgeIndicatorContentsWrapper"


### PR DESCRIPTION
Fixes #3802.

Example profile: [production](https://share.firefox.dev/34urrgq) / [deploy preview](https://deploy-preview-3803--perf-html.netlify.app/public/3xh1xp8ka89k61keapnkmma3ehpg6bs2c6b05e8/marker-chart/?globalTrackOrder=0wn&hiddenGlobalTracks=0w79wn&hiddenLocalTracksByPid=94066-1wjmwr~94212-0~94079-0~94071-0~98017-0~99745-0~94085-0~99654-0~97817-0~94070-0~94082-0~98057-0~94214-0~94093-01~99558-0~94081-0~94087-01~94089-0~94206-01~94092-01~94080-0w2~94114-0w3~94110-0w7&localTrackOrderByPid=94066-st0wr~94212-0~94079-0~94071-0~98017-0~99745-0~94085-10~99654-0~97817-0~94070-0~94086-01~94082-120~98057-0~94214-0~94093-01~99558-0~94081-0~94087-10~94089-0~94206-10~94092-10~94080-201~94114-30w2~94110-70w6&markerSearch=domevent%2Crequestanimationframe&thread=x5&timelineType=cpu-category&v=6)