### PR TITLE
Add intersection observer to the timeline marker canvases

### DIFF
--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -216,9 +216,15 @@ class TimelineMarkersCanvas extends React.PureComponent<CanvasProps> {
     }
   }
 
-  render() {
+  componentDidMount() {
     this._scheduleDraw();
+  }
 
+  componentDidUpdate() {
+    this._scheduleDraw();
+  }
+
+  render() {
     return (
       <canvas
         className="timelineMarkersCanvas"

--- a/src/components/timeline/Markers.js
+++ b/src/components/timeline/Markers.js
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import memoize from 'memoize-immutable';
+import { InView } from 'react-intersection-observer';
 import {
   overlayFills,
   getMarkerStyle,
@@ -89,6 +90,10 @@ function _drawRoundedRect(
 class TimelineMarkersCanvas extends React.PureComponent<CanvasProps> {
   _canvas: {| current: HTMLCanvasElement | null |} = React.createRef();
   _requestedAnimationFrame: boolean = false;
+  _canvasState: {| renderScheduled: boolean, inView: boolean |} = {
+    renderScheduled: false,
+    inView: false,
+  };
 
   _getMarkerState(marker: Marker): MarkerState {
     const { hoveredMarker, mouseDownMarker, rightClickedMarker } = this.props;
@@ -202,6 +207,16 @@ class TimelineMarkersCanvas extends React.PureComponent<CanvasProps> {
   }
 
   _scheduleDraw() {
+    if (!this._canvasState.inView) {
+      // Canvas is not in the view. Schedule the render for a later intersection
+      // observer callback.
+      this._canvasState.renderScheduled = true;
+      return;
+    }
+
+    // Canvas is in the view. Render the canvas and reset the schedule state.
+    this._canvasState.renderScheduled = false;
+
     if (!this._requestedAnimationFrame) {
       this._requestedAnimationFrame = true;
       window.requestAnimationFrame(() => {
@@ -216,6 +231,16 @@ class TimelineMarkersCanvas extends React.PureComponent<CanvasProps> {
     }
   }
 
+  _observerCallback = (inView: boolean, _entry: IntersectionObserverEntry) => {
+    this._canvasState.inView = inView;
+    if (!this._canvasState.renderScheduled) {
+      // Skip if render is not scheduled.
+      return;
+    }
+
+    this._scheduleDraw();
+  };
+
   componentDidMount() {
     this._scheduleDraw();
   }
@@ -226,14 +251,16 @@ class TimelineMarkersCanvas extends React.PureComponent<CanvasProps> {
 
   render() {
     return (
-      <canvas
-        className="timelineMarkersCanvas"
-        ref={this._canvas}
-        onMouseDown={this.props.onMouseDown}
-        onMouseMove={this.props.onMouseMove}
-        onMouseUp={this.props.onMouseUp}
-        onMouseOut={this.props.onMouseOut}
-      />
+      <InView onChange={this._observerCallback}>
+        <canvas
+          className="timelineMarkersCanvas"
+          ref={this._canvas}
+          onMouseDown={this.props.onMouseDown}
+          onMouseMove={this.props.onMouseMove}
+          onMouseUp={this.props.onMouseUp}
+          onMouseOut={this.props.onMouseOut}
+        />
+      </InView>
     );
   }
 }

--- a/src/test/components/CPUGraph.test.js
+++ b/src/test/components/CPUGraph.test.js
@@ -22,6 +22,7 @@ import {
   getProfileFromTextSamples,
   addCpuUsageValues,
 } from '../fixtures/profiles/processed-profile';
+import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
 
 // Mocking the ActivityGraph and SampleGraph because we don't want to see the
 // content/draw log of it in these tests. It has its own tests.
@@ -41,6 +42,7 @@ const GRAPH_HEIGHT = 10;
 describe('CPUGraph', function () {
   autoMockCanvasContext();
   autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  autoMockIntersectionObserver();
 
   function getSamplesProfile() {
     const profile = getProfileFromTextSamples(`

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -36,10 +36,19 @@ import {
   fireFullContextMenu,
 } from '../fixtures/utils';
 import { mockRaf } from '../fixtures/mocks/request-animation-frame';
-import { autoMockElementSize } from '../fixtures/mocks/element-size';
-import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
+import {
+  autoMockElementSize,
+  setMockedElementSize,
+} from '../fixtures/mocks/element-size';
+import {
+  autoMockIntersectionObserver,
+  triggerIntersectionObservers,
+} from '../fixtures/mocks/intersection-observer';
 
 import type { CssPixels } from 'firefox-profiler/types';
+
+const GRAPH_WIDTH = 200;
+const GRAPH_HEIGHT = 300;
 
 function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
   const flushRafCalls = mockRaf();
@@ -137,13 +146,14 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
     getContextMenu,
     tryToGetMarkerTooltip,
     clickOnMenuItem,
+    flushRafCalls,
     ...renderResult,
   };
 }
 
 describe('TimelineMarkers', function () {
   autoMockCanvasContext();
-  autoMockElementSize({ width: 200, height: 300 });
+  autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
   autoMockIntersectionObserver();
   // We will be hovering over element with a tooltip. It requires root overlay
   // element to be present in DOM.
@@ -299,5 +309,114 @@ describe('TimelineMarkers', function () {
       );
       expect(callsWithHoveredColor).toHaveLength(1);
     });
+  });
+});
+
+describe('TimelineMarkers with intersection observer', function () {
+  autoMockCanvasContext();
+  autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  autoMockIntersectionObserver(false);
+
+  function setup() {
+    const setupResults = setupWithMarkers({ rangeStart: 0, rangeEnd: 15 }, [
+      ['DOMEvent', 0, 10],
+      ['DOMEvent', 0, 10],
+    ]);
+
+    /**
+     * Coordinate the flushing of the requestAnimationFrame and the draw calls.
+     */
+    function getContextDrawCalls() {
+      setupResults.flushRafCalls();
+      return flushDrawLog();
+    }
+
+    return { ...setupResults, getContextDrawCalls };
+  }
+
+  it('will not draw before the intersection observer', () => {
+    const { getContextDrawCalls } = setup();
+    const drawCalls = getContextDrawCalls();
+    // Make sure that marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      false
+    );
+  });
+
+  it('will not draw after the intersection observer if it is not intersecting', () => {
+    const { getContextDrawCalls } = setup();
+    let drawCalls = getContextDrawCalls();
+
+    // Make sure that marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'beginPath')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer and make sure that it still
+    // doesn't draw it.
+    triggerIntersectionObservers({ isIntersecting: false });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      false
+    );
+  });
+
+  it('will draw after the intersection observer if it is intersecting', () => {
+    const { getContextDrawCalls } = setup();
+    let drawCalls = getContextDrawCalls();
+
+    // Make sure that marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer and make sure that it draws it.
+    triggerIntersectionObservers({ isIntersecting: true });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      true
+    );
+  });
+
+  it('will redraw after it becomes visible again', () => {
+    const { getContextDrawCalls } = setup();
+    let drawCalls = getContextDrawCalls();
+
+    // Make sure that marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer and make sure that it draws it.
+    triggerIntersectionObservers({ isIntersecting: true });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      true
+    );
+
+    // Now it goes out of view again. Make sure that we don't redraw.
+    triggerIntersectionObservers({ isIntersecting: false });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      false
+    );
+
+    // Send out the resize with a width change.
+    // By changing the "fake" result of getBoundingClientRect, we ensure that
+    // the pure components rerender because their `width` props change.
+    setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
+    window.dispatchEvent(new Event('resize'));
+    drawCalls = getContextDrawCalls();
+    // It should still be not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer again and make sure that it redraws.
+    triggerIntersectionObservers({ isIntersecting: true });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'fillRect')).toBe(
+      true
+    );
   });
 });

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -37,6 +37,7 @@ import {
 } from '../fixtures/utils';
 import { mockRaf } from '../fixtures/mocks/request-animation-frame';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
 
 import type { CssPixels } from 'firefox-profiler/types';
 
@@ -143,6 +144,7 @@ function setupWithMarkers({ rangeStart, rangeEnd }, ...markersPerThread) {
 describe('TimelineMarkers', function () {
   autoMockCanvasContext();
   autoMockElementSize({ width: 200, height: 300 });
+  autoMockIntersectionObserver();
   // We will be hovering over element with a tooltip. It requires root overlay
   // element to be present in DOM.
   beforeEach(addRootOverlayElement);

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -30,6 +30,7 @@ import {
   getCounterForThread,
 } from '../fixtures/profiles/processed-profile';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
 
 // The following constants determine the size of the drawn graph.
 const SAMPLE_COUNT = 8;
@@ -104,6 +105,7 @@ describe('TrackMemory', function () {
 
   autoMockCanvasContext();
   autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  autoMockIntersectionObserver();
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
 

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -37,6 +37,7 @@ import {
   getProfileWithMarkers,
 } from '../fixtures/profiles/processed-profile';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
 
 // The graph is 400 pixels wide based on the element size mock. Each stack is
 // 100 pixels wide. Use the value 50 to click in the middle of this stack, and
@@ -54,6 +55,7 @@ describe('timeline/TrackThread', function () {
   afterEach(removeRootOverlayElement);
   autoMockCanvasContext();
   autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  autoMockIntersectionObserver();
 
   function getSamplesProfile() {
     return getProfileFromTextSamples(`

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -61,11 +61,13 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
             <div
               class="react-contextmenu-wrapper"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-                height="300"
-                width="200"
-              />
+              <div>
+                <canvas
+                  class="timelineMarkersCanvas"
+                  height="300"
+                  width="200"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -75,11 +77,13 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
             <div
               class="react-contextmenu-wrapper"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-                height="300"
-                width="200"
-              />
+              <div>
+                <canvas
+                  class="timelineMarkersCanvas"
+                  height="300"
+                  width="200"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -162,11 +166,13 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
             <div
               class="react-contextmenu-wrapper"
             >
-              <canvas
-                class="timelineMarkersCanvas"
-                height="300"
-                width="200"
-              />
+              <div>
+                <canvas
+                  class="timelineMarkersCanvas"
+                  height="300"
+                  width="200"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -241,11 +247,13 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="300"
-              width="200"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="300"
+                width="200"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -319,11 +327,13 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="300"
-              width="200"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="300"
+                width="200"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -404,11 +414,13 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
                 <div
                   class="react-contextmenu-wrapper"
                 >
-                  <canvas
-                    class="timelineMarkersCanvas"
-                    height="300"
-                    width="200"
-                  />
+                  <div>
+                    <canvas
+                      class="timelineMarkersCanvas"
+                      height="300"
+                      width="200"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -550,11 +562,13 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                       <div
                         class="react-contextmenu-wrapper"
                       >
-                        <canvas
-                          class="timelineMarkersCanvas"
-                          height="300"
-                          width="200"
-                        />
+                        <div>
+                          <canvas
+                            class="timelineMarkersCanvas"
+                            height="300"
+                            width="200"
+                          />
+                        </div>
                       </div>
                     </div>
                     <div
@@ -564,11 +578,13 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                       <div
                         class="react-contextmenu-wrapper"
                       >
-                        <canvas
-                          class="timelineMarkersCanvas"
-                          height="300"
-                          width="200"
-                        />
+                        <div>
+                          <canvas
+                            class="timelineMarkersCanvas"
+                            height="300"
+                            width="200"
+                          />
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -39,11 +39,13 @@ Process: \\"tab\\" (222)"
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="400"
-              width="400"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="400"
+                width="400"
+              />
+            </div>
           </div>
         </div>
         <div
@@ -53,11 +55,13 @@ Process: \\"tab\\" (222)"
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="400"
-              width="400"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="400"
+                width="400"
+              />
+            </div>
           </div>
         </div>
         <div
@@ -67,11 +71,13 @@ Process: \\"tab\\" (222)"
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="400"
-              width="400"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="400"
+                width="400"
+              />
+            </div>
           </div>
         </div>
         <div
@@ -153,11 +159,13 @@ Process: \\"tab\\" (222)"
               <div
                 class="react-contextmenu-wrapper"
               >
-                <canvas
-                  class="timelineMarkersCanvas"
-                  height="400"
-                  width="400"
-                />
+                <div>
+                  <canvas
+                    class="timelineMarkersCanvas"
+                    height="400"
+                    width="400"
+                  />
+                </div>
               </div>
             </div>
             <div
@@ -237,11 +245,13 @@ Process: \\"tab\\" (222)"
               <div
                 class="react-contextmenu-wrapper"
               >
-                <canvas
-                  class="timelineMarkersCanvas"
-                  height="400"
-                  width="400"
-                />
+                <div>
+                  <canvas
+                    class="timelineMarkersCanvas"
+                    height="400"
+                    width="400"
+                  />
+                </div>
               </div>
             </div>
             <div
@@ -354,11 +364,13 @@ Process: \\"default\\" (5555)"
               <div
                 class="react-contextmenu-wrapper"
               >
-                <canvas
-                  class="timelineMarkersCanvas"
-                  height="400"
-                  width="400"
-                />
+                <div>
+                  <canvas
+                    class="timelineMarkersCanvas"
+                    height="400"
+                    width="400"
+                  />
+                </div>
               </div>
             </div>
             <div

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -32,11 +32,13 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="400"
-              width="400"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="400"
+                width="400"
+              />
+            </div>
           </div>
         </div>
         <div
@@ -159,11 +161,13 @@ Process: \\"tab\\" (222)"
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="400"
-              width="400"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="400"
+                width="400"
+              />
+            </div>
           </div>
         </div>
         <div
@@ -243,11 +247,13 @@ exports[`timeline/LocalTrack with an IPC track matches the snapshot of the IPC t
           <div
             class="react-contextmenu-wrapper"
           >
-            <canvas
-              class="timelineMarkersCanvas"
-              height="400"
-              width="400"
-            />
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="400"
+                width="400"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -10811,11 +10811,13 @@ exports[`ThreadActivityGraph matches the component snapshot 1`] = `
     <div
       class="react-contextmenu-wrapper"
     >
-      <canvas
-        class="timelineMarkersCanvas"
-        height="10"
-        width="80"
-      />
+      <div>
+        <canvas
+          class="timelineMarkersCanvas"
+          height="10"
+          width="80"
+        />
+      </div>
     </div>
   </div>
   <div

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -8,11 +8,13 @@ exports[`TimelineMarkers renders correctly 1`] = `
   <div
     class="react-contextmenu-wrapper"
   >
-    <canvas
-      class="timelineMarkersCanvas"
-      height="300"
-      width="200"
-    />
+    <div>
+      <canvas
+        class="timelineMarkersCanvas"
+        height="300"
+        width="200"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -151,11 +151,13 @@ exports[`TrackMemory matches the component snapshot 1`] = `
     <div
       class="react-contextmenu-wrapper"
     >
-      <canvas
-        class="timelineMarkersCanvas"
-        height="10"
-        width="80"
-      />
+      <div>
+        <canvas
+          class="timelineMarkersCanvas"
+          height="10"
+          width="80"
+        />
+      </div>
     </div>
   </div>
   <div

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -73,11 +73,13 @@ exports[`timeline/TrackThread matches the snapshot for the component 1`] = `
     <div
       class="react-contextmenu-wrapper"
     >
-      <canvas
-        class="timelineMarkersCanvas"
-        height="50"
-        width="400"
-      />
+      <div>
+        <canvas
+          class="timelineMarkersCanvas"
+          height="50"
+          width="400"
+        />
+      </div>
     </div>
   </div>
   <div


### PR DESCRIPTION
This PR adds intersection observer to marker canvases and makes the drawing of them lazy in the timeline. 

Fixes #3821.

[Production](https://share.firefox.dev/3I9iMhZ) / [Deploy preview](https://deploy-preview-3829--perf-html.netlify.app/public/k82sqxse5qw5zq2yk0dvsfxpvy41rga7jz8g320/calltree/?globalTrackOrder=0wxu&localTrackOrderByPid=7589-jk0wi~7731-0~251547-0~8656-0~21932-0~9482-01~383297-0~8917-0~39682-0~18425-0~380689-0~8690-01~244105-0~14942-0~8188-01~8758-01~321994-0~21844-0~379087-0~378989-0~20815-0~339960-0~226091-0~9645-0~8964-0~383211-0~235479-01~9161-0~381172-0~383324-0~8107-0~380798-0~260791-0~35684-0~8562-0~8020-0~22399-01~22136-01~13220-0~9750-0~9361-01~378985-0~378145-0~8973-0~242860-0~8564-0~8762-01~21993-0~255478-0~12906-0~8984-0~9636-0~8207-01~9175-0~22419-0~316120-0~9403-0~375770-0~8760-0~381359-0~9401-0~8279-01~9222-01&thread=0&timelineType=cpu-category&v=6)