### PR TITLE
Use a click handler instead of a mouseup handler for preview selection

### DIFF
--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -59,7 +59,7 @@ type State = {|
 class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
   _handlers: ?{
     mouseMoveHandler: MouseHandler,
-    mouseUpHandler: MouseHandler,
+    mouseClickHandler: MouseHandler,
   };
 
   _container: ?HTMLElement;
@@ -132,7 +132,7 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
       }
     };
 
-    const mouseUpHandler = (event) => {
+    const clickHandler = (event) => {
       if (isRangeSelecting) {
         const mouseMoveTime =
           ((event.pageX - rect.left) / rect.width) *
@@ -154,23 +154,23 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
           selectionEnd,
           isModifying: false,
         });
-        // Stop propagation so that no thread is selected when creating a preview
-        // selection.
+        // Stop propagation so that no thread and no call node is selected when
+        // creating a preview selection.
         event.stopPropagation();
-        this._uninstallMoveAndUpHandlers();
+        this._uninstallMoveAndClickHandlers();
         return;
       }
 
       const { previewSelection } = this.props;
       if (previewSelection.hasSelection) {
-        const mouseUpTime =
+        const clickTime =
           ((event.pageX - rect.left) / rect.width) *
             (committedRange.end - committedRange.start) +
           committedRange.start;
         const { selectionStart, selectionEnd } = previewSelection;
-        if (mouseUpTime < selectionStart || mouseUpTime >= selectionEnd) {
-          // Stop propagation so that no thread is selected when removing the preview
-          // selections.
+        if (clickTime < selectionStart || clickTime >= selectionEnd) {
+          // Stop propagation so that no thread and no call node is selected
+          // when removing the preview selections.
           event.stopPropagation();
 
           // Unset preview selection.
@@ -181,31 +181,31 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
         }
       }
 
-      // Do not stopPropagation(), so that graph gets mouseup event.
-      this._uninstallMoveAndUpHandlers();
+      // Do not stopPropagation(), so that graph gets click event.
+      this._uninstallMoveAndClickHandlers();
     };
 
-    this._installMoveAndUpHandlers(mouseMoveHandler, mouseUpHandler);
+    this._installMoveAndClickHandlers(mouseMoveHandler, clickHandler);
   };
 
-  _installMoveAndUpHandlers(
+  _installMoveAndClickHandlers(
     mouseMoveHandler: MouseHandler,
-    mouseUpHandler: MouseHandler
+    mouseClickHandler: MouseHandler
   ) {
-    // Unregister any leftover old handlers, in case we didn't get a mouseup for the previous
+    // Unregister any leftover old handlers, in case we didn't get a click for the previous
     // drag (e.g. when tab switching during a drag, or when ctrl+clicking on macOS).
-    this._uninstallMoveAndUpHandlers();
+    this._uninstallMoveAndClickHandlers();
 
-    this._handlers = { mouseMoveHandler, mouseUpHandler };
+    this._handlers = { mouseMoveHandler, mouseClickHandler };
     window.addEventListener('mousemove', mouseMoveHandler, true);
-    window.addEventListener('mouseup', mouseUpHandler, true);
+    window.addEventListener('click', mouseClickHandler, true);
   }
 
-  _uninstallMoveAndUpHandlers() {
+  _uninstallMoveAndClickHandlers() {
     if (this._handlers) {
-      const { mouseMoveHandler, mouseUpHandler } = this._handlers;
+      const { mouseMoveHandler, mouseClickHandler } = this._handlers;
       window.removeEventListener('mousemove', mouseMoveHandler, true);
-      window.removeEventListener('mouseup', mouseUpHandler, true);
+      window.removeEventListener('click', mouseClickHandler, true);
       this._handlers = null;
     }
   }

--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -102,9 +102,7 @@ class Screenshots extends PureComponent<Props, State> {
     });
   };
 
-  // This selects a screenshot when clicking on the screenshot strip. Note that
-  // we use the mouseup event so that isMakingPreviewSelection is still
-  // accurate.
+  // This selects a screenshot when clicking on the screenshot strip.
   _selectScreenshotOnClick = (event: SyntheticMouseEvent<HTMLDivElement>) => {
     const { screenshots, updatePreviewSelection, isMakingPreviewSelection } =
       this.props;
@@ -158,7 +156,7 @@ class Screenshots extends PureComponent<Props, State> {
         style={{ height: trackHeight }}
         onMouseLeave={this._handleMouseLeave}
         onMouseMove={this._handleMouseMove}
-        onMouseUp={this._selectScreenshotOnClick}
+        onClick={this._selectScreenshotOnClick}
       >
         <ScreenshotStrip
           thread={thread}

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -115,13 +115,13 @@ describe('timeline/TrackScreenshots', function () {
     // And we should see a small screenshot hover while preview selecting.
     expect(screenShotSize).toEqual({ width: 100, height: 50 });
 
-    // Mouseup should keep this existing selection
+    // click should keep this existing selection
     const previouslySelectedPreviewSelection = getPreviewSelection(getState());
     fireEvent(
       track,
       getMouseEvent('mouseup', { pageX: LEFT + 200, pageY: TOP })
     );
-    fireEvent(track, getMouseEvent('click', { pageX: LEFT + 210, pageY: TOP }));
+    fireEvent(track, getMouseEvent('click', { pageX: LEFT + 200, pageY: TOP }));
 
     expect(getPreviewSelection(getState())).toEqual({
       ...previouslySelectedPreviewSelection,


### PR DESCRIPTION
Fixes #3588

This follows the trend started by Markus in #3452.

[production](https://profiler.firefox.com/public/7syw68a9vsygdk54gtd68k485xafaqwecr10vk0/stack-chart/?globalTrackOrder=0w7&hiddenGlobalTracks=0w57&hiddenLocalTracksByPid=1344-01~31684-02wp&localTrackOrderByPid=18456-120~19232-0~25420-0~15180-0~11368-0~31928-0~1344-01~31684-p0wo&range=2709m1635~3370m188&symbolServer=https%3A%2F%2Fsymbolication.stage.mozaws.net&thread=7&timelineType=cpu-category&v=6) / [deploy preview](https://deploy-preview-3840--perf-html.netlify.app/public/7syw68a9vsygdk54gtd68k485xafaqwecr10vk0/stack-chart/?globalTrackOrder=0w7&hiddenGlobalTracks=0w57&hiddenLocalTracksByPid=1344-01~31684-02wp&localTrackOrderByPid=18456-120~19232-0~25420-0~15180-0~11368-0~31928-0~1344-01~31684-p0wo&range=2709m1635~3370m188&symbolServer=https%3A%2F%2Fsymbolication.stage.mozaws.net&thread=7&timelineType=cpu-category&v=6)

I did some testing on a few profiles and this seemed to work fine, but feel free to do more tests on different profiles!