### PR TITLE
Add intersection observer to memory graph

### DIFF
--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -193,9 +193,15 @@ class TrackMemoryCanvas extends React.PureComponent<CanvasProps> {
     this._canvas = canvas;
   };
 
-  render() {
+  componentDidMount() {
     this._scheduleDraw();
+  }
 
+  componentDidUpdate() {
+    this._scheduleDraw();
+  }
+
+  render() {
     return (
       <canvas className="timelineTrackMemoryCanvas" ref={this._takeCanvasRef} />
     );

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -5,6 +5,7 @@
 // @flow
 
 import * as React from 'react';
+import { InView } from 'react-intersection-observer';
 import { withSize } from 'firefox-profiler/components/shared/WithSize';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { formatBytes } from 'firefox-profiler/utils/format-numbers';
@@ -57,6 +58,10 @@ type CanvasProps = {|
 class TrackMemoryCanvas extends React.PureComponent<CanvasProps> {
   _canvas: null | HTMLCanvasElement = null;
   _requestedAnimationFrame: boolean = false;
+  _canvasState: {| renderScheduled: boolean, inView: boolean |} = {
+    renderScheduled: false,
+    inView: false,
+  };
 
   drawCanvas(canvas: HTMLCanvasElement): void {
     const {
@@ -177,6 +182,16 @@ class TrackMemoryCanvas extends React.PureComponent<CanvasProps> {
   }
 
   _scheduleDraw() {
+    if (!this._canvasState.inView) {
+      // Canvas is not in the view. Schedule the render for a later intersection
+      // observer callback.
+      this._canvasState.renderScheduled = true;
+      return;
+    }
+
+    // Canvas is in the view. Render the canvas and reset the schedule state.
+    this._canvasState.renderScheduled = false;
+
     if (!this._requestedAnimationFrame) {
       this._requestedAnimationFrame = true;
       window.requestAnimationFrame(() => {
@@ -193,6 +208,16 @@ class TrackMemoryCanvas extends React.PureComponent<CanvasProps> {
     this._canvas = canvas;
   };
 
+  _observerCallback = (inView: boolean, _entry: IntersectionObserverEntry) => {
+    this._canvasState.inView = inView;
+    if (!this._canvasState.renderScheduled) {
+      // Skip if render is not scheduled.
+      return;
+    }
+
+    this._scheduleDraw();
+  };
+
   componentDidMount() {
     this._scheduleDraw();
   }
@@ -203,7 +228,12 @@ class TrackMemoryCanvas extends React.PureComponent<CanvasProps> {
 
   render() {
     return (
-      <canvas className="timelineTrackMemoryCanvas" ref={this._takeCanvasRef} />
+      <InView onChange={this._observerCallback}>
+        <canvas
+          className="timelineTrackMemoryCanvas"
+          ref={this._takeCanvasRef}
+        />
+      </InView>
     );
   }
 }

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -44,11 +44,13 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
         <div
           class="timelineTrackMemoryGraph"
         >
-          <canvas
-            class="timelineTrackMemoryCanvas"
-            height="25"
-            width="400"
-          />
+          <div>
+            <canvas
+              class="timelineTrackMemoryCanvas"
+              height="25"
+              width="400"
+            />
+          </div>
           <div
             class="timelineEmptyThreadIndicator"
           />

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -163,11 +163,13 @@ exports[`TrackMemory matches the component snapshot 1`] = `
   <div
     class="timelineTrackMemoryGraph"
   >
-    <canvas
-      class="timelineTrackMemoryCanvas"
-      height="25"
-      width="80"
-    />
+    <div>
+      <canvas
+        class="timelineTrackMemoryCanvas"
+        height="25"
+        width="80"
+      />
+    </div>
     <div
       class="timelineEmptyThreadIndicator"
     />


### PR DESCRIPTION
Fixes #3822.

This PR adds intersection observer to memory graphs and makes the drawing of them lazy in the timeline.

[Production](https://share.firefox.dev/3u58Jqk) / [Deploy preview](https://deploy-preview-3842--perf-html.netlify.app/public/k82sqxse5qw5zq2yk0dvsfxpvy41rga7jz8g320/calltree/?globalTrackOrder=0wxu&hiddenLocalTracksByPid=7589-0wj~8690-0&localTrackOrderByPid=7589-jk0wi~7731-0~251547-0~8656-0~21932-0~9482-01~383297-0~8917-0~39682-0~18425-0~380689-0~8690-01~244105-0~14942-0~8188-01~8758-01~321994-0~21844-0~379087-0~378989-0~20815-0~339960-0~226091-0~9645-0~8964-0~383211-0~235479-01~9161-0~381172-0~383324-0~8107-0~380798-0~260791-0~35684-0~8562-0~8020-0~22399-01~22136-01~13220-0~9750-0~9361-01~378985-0~378145-0~8973-0~242860-0~8564-0~8762-01~21993-0~255478-0~12906-0~8984-0~9636-0~8207-01~9175-0~22419-0~316120-0~9403-0~375770-0~8760-0~381359-0~9401-0~8279-01~9222-01&thread=0&timelineType=cpu-category&v=6)