### PR TITLE
Use the current implementation filter in the activity graph's tooltip

### DIFF
--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -14,6 +14,7 @@ import {
 } from 'firefox-profiler/utils/format-numbers';
 
 import type {
+  ImplementationFilter,
   IndexIntoSamplesTable,
   CategoryList,
   Thread,
@@ -26,6 +27,7 @@ type RestProps = {|
   +sampleIndex: IndexIntoSamplesTable,
   +categories: CategoryList,
   +rangeFilteredThread: Thread,
+  +implementationFilter: ImplementationFilter,
 |};
 
 type Props = {|
@@ -61,7 +63,12 @@ class SampleTooltipCPUContents extends React.PureComponent<CPUProps> {
  */
 class SampleTooltipRestContents extends React.PureComponent<RestProps> {
   render() {
-    const { sampleIndex, rangeFilteredThread, categories } = this.props;
+    const {
+      sampleIndex,
+      rangeFilteredThread,
+      categories,
+      implementationFilter,
+    } = this.props;
     const { samples, stackTable } = rangeFilteredThread;
     const stackIndex = samples.stack[sampleIndex];
     if (stackIndex === null) {
@@ -89,7 +96,7 @@ class SampleTooltipRestContents extends React.PureComponent<RestProps> {
           maxStacks={20}
           stackIndex={stackIndex}
           thread={rangeFilteredThread}
-          implementationFilter="combined"
+          implementationFilter={implementationFilter}
           categories={categories}
         />
       </>
@@ -108,6 +115,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
       sampleIndex,
       rangeFilteredThread,
       categories,
+      implementationFilter,
     } = this.props;
     return (
       <>
@@ -121,6 +129,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
           sampleIndex={sampleIndex}
           rangeFilteredThread={rangeFilteredThread}
           categories={categories}
+          implementationFilter={implementationFilter}
         />
       </>
     );

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -21,6 +21,7 @@ import './ActivityGraph.css';
 import type {
   Thread,
   CategoryList,
+  ImplementationFilter,
   IndexIntoSamplesTable,
   SelectedState,
   Milliseconds,
@@ -52,6 +53,7 @@ export type Props = {|
   ) => number,
   +enableCPUUsage: boolean,
   +maxThreadCPUDelta: number,
+  +implementationFilter: ImplementationFilter,
   ...SizeProps,
 |};
 
@@ -164,6 +166,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
       treeOrderSampleComparator,
       maxThreadCPUDelta,
       enableCPUUsage,
+      implementationFilter,
       width,
       height,
     } = this.props;
@@ -204,6 +207,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
               cpuRatioInTimeRange={hoveredPixelState.cpuRatioInTimeRange}
               rangeFilteredThread={rangeFilteredThread}
               categories={categories}
+              implementationFilter={implementationFilter}
             />
           </Tooltip>
         )}

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -28,6 +28,7 @@ import {
   getThreadSelectorsFromThreadsKey,
   getMaxThreadCPUDelta,
   getIsExperimentalCPUGraphsEnabled,
+  getImplementationFilter,
 } from 'firefox-profiler/selectors';
 import {
   TimelineMarkersJank,
@@ -59,6 +60,7 @@ import type {
   Milliseconds,
   StartEndRange,
   CallNodeInfo,
+  ImplementationFilter,
   IndexIntoCallNodeTable,
   SelectedState,
   State,
@@ -101,6 +103,7 @@ type StateProps = {|
   +enableCPUUsage: boolean,
   +isExperimentalCPUGraphsEnabled: boolean,
   +maxThreadCPUDelta: number,
+  +implementationFilter: ImplementationFilter,
 |};
 
 type DispatchProps = {|
@@ -212,6 +215,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       enableCPUUsage,
       maxThreadCPUDelta,
       isExperimentalCPUGraphsEnabled,
+      implementationFilter,
     } = this.props;
 
     const processType = filteredThread.processType;
@@ -281,6 +285,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               treeOrderSampleComparator={treeOrderSampleComparator}
               enableCPUUsage={enableCPUUsage}
               maxThreadCPUDelta={maxThreadCPUDelta}
+              implementationFilter={implementationFilter}
             />
             <ThreadSampleGraph
               className="threadSampleGraph"
@@ -433,6 +438,7 @@ export const TimelineTrackThread = explicitConnect<
       enableCPUUsage,
       isExperimentalCPUGraphsEnabled: getIsExperimentalCPUGraphsEnabled(state),
       maxThreadCPUDelta: getMaxThreadCPUDelta(state),
+      implementationFilter: getImplementationFilter(state),
     };
   },
   mapDispatchToProps: {

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -816,7 +816,7 @@ function _buildThreadFromTextOnlyStacks(
   funcNames.forEach((funcName) => {
     funcTable.name.push(stringTable.indexForString(funcName));
     funcTable.fileName.push(null);
-    funcTable.relevantForJS.push(funcName.endsWith('js-relevant'));
+    funcTable.relevantForJS.push(funcName.endsWith('-relevantForJS'));
     funcTable.isJS.push(_isJsFunctionName(funcName));
     funcTable.lineNumber.push(null);
     funcTable.columnNumber.push(null);


### PR DESCRIPTION
Fixes #3732

[production](https://profiler.firefox.com/public/7x55avf4gs5gz0pbxe4a3r5dna15r7nkczny17r/calltree/?globalTrackOrder=s0wr&hiddenGlobalTracks=1wq&hiddenLocalTracksByPid=169055-13we~169132-0~192517-0~191935-0~169373-0~169462-0~169809-0~169249-0~192005-0~169194-0~192077-01&implementation=js&localTrackOrderByPid=169055-fg102we~169132-0~192517-0~191935-0~169373-0~169462-0~169809-0~169249-0~192005-0~169194-0~192077-10~169369-01&thread=xb&timelineType=cpu-category&v=6) / [deploy preview](https://deploy-preview-3848--perf-html.netlify.app/public/7x55avf4gs5gz0pbxe4a3r5dna15r7nkczny17r/calltree/?globalTrackOrder=s0wr&hiddenGlobalTracks=1wq&hiddenLocalTracksByPid=169055-13we~169132-0~192517-0~191935-0~169373-0~169462-0~169809-0~169249-0~192005-0~169194-0~192077-01&implementation=js&localTrackOrderByPid=169055-fg102we~169132-0~192517-0~191935-0~169373-0~169462-0~169809-0~169249-0~192005-0~169194-0~192077-10~169369-01&thread=xb&timelineType=cpu-category&v=6)

STR is hovering on the activity graph on non-javascript samples.