### PR TITLE
Support another tab id active tab view

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -581,6 +581,8 @@ export function finalizeActiveTabProfileView(
   tabID: TabID | null
 ): ThunkAction<void> {
   return (dispatch, getState) => {
+    // First, dispatch the new tab ids so that the states can be computed.
+    dispatch({ type: 'CHANGE_ACTIVE_TAB', tabID });
     const hasUrlInfo = selectedThreadIndexes !== null;
     const relevantPages = getRelevantPagesForActiveTab(getState());
 

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -163,7 +163,7 @@ type FullProfileSpecificBaseQuery = {|
 // Base query that only applies to active tab profile view.
 type ActiveTabProfileSpecificBaseQuery = {|
   resources: null | void,
-  ctxId: TabID | void,
+  tabID: TabID | void,
 |};
 
 // Base query that only applies to origins profile view.
@@ -288,7 +288,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
   const selectedThreadsKey =
     selectedThreads !== null ? getThreadsKey(selectedThreads) : null;
 
-  let ctxId;
+  let tabID;
   let view;
   const { timelineTrackOrganization } = urlState;
   switch (timelineTrackOrganization.type) {
@@ -297,7 +297,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       break;
     case 'active-tab':
       view = timelineTrackOrganization.type;
-      ctxId = timelineTrackOrganization.tabID;
+      tabID = timelineTrackOrganization.tabID;
       break;
     case 'origins':
       view = timelineTrackOrganization.type;
@@ -338,7 +338,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
         .isResourcesPanelOpen
         ? null
         : undefined;
-      baseQuery.ctxId = ctxId || undefined;
+      baseQuery.tabID = tabID || undefined;
       break;
     }
     case 'origins':
@@ -582,8 +582,8 @@ export function stateFromLocation(
   }
 
   let tabID = null;
-  if (query.ctxId && Number.isInteger(Number(query.ctxId))) {
-    tabID = Number(query.ctxId);
+  if (query.tabID && Number.isInteger(Number(query.tabID))) {
+    tabID = Number(query.tabID);
   }
 
   const selectedTab =

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -1347,7 +1347,7 @@ function validateTimelineTrackOrganization(
  * provided or something else is provided for some reason.
  */
 function validateTimelineType(type: ?string): TimelineType {
-  // Pretend this is a TimelineTrackOrganization so that we can exhaustively
+  // Pretend this is a TimelineType so that we can exhaustively
   // go through each option.
   const timelineType: TimelineType = (type: any);
   switch (timelineType) {

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.profileFilterNavigator--tabID-select {
+  width: 15em;
+}

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -82,6 +82,7 @@ import type {
   BottomBoxInfo,
   Bytes,
   ThreadWithReservedFunctions,
+  TabID,
 } from 'firefox-profiler/types';
 import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
 
@@ -2858,75 +2859,79 @@ export function filterToRetainedAllocations(
 }
 
 /**
- * Extract the hostname and favicon from the last page if we are in single tab
- * view. We assume that the user wants to know about the last loaded page in
- * this tab.
- * Returns null if profiler is not in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page for all tab ids. we
+ * assume that the user wants to know about the last loaded page in this tab.
+ * returns null if we don't have information about pages (in older profiles).
  */
 export function extractProfileFilterPageData(
-  pages: PageList | null,
-  relevantPages: Set<InnerWindowID>
-): ProfileFilterPageData | null {
-  if (relevantPages.size === 0 || pages === null) {
-    // Either we are not in single tab view, or we don't have pages array(which
-    // is the case for older profiles). Return early.
-    return null;
+  pagesMapByTabID: Map<TabID, PageList> | null
+): Map<TabID, ProfileFilterPageData> {
+  if (pagesMapByTabID === null) {
+    // We don't have pages array (which is the case for older profiles). Return early.
+    return new Map();
   }
 
-  // Getting the pages that are relevant and a top-most frame.
-  let filteredPages = pages.filter(
-    (page) =>
-      // It's the top-most frame if `embedderInnerWindowID` is zero.
-      page.embedderInnerWindowID === 0 && relevantPages.has(page.innerWindowID)
-  );
-
-  if (filteredPages.length > 1) {
-    // If there are more than one top-most page, it's also good to filter out the
-    // `about:` pages so user can see their url they are actually profiling.
-    filteredPages = filteredPages.filter(
-      (page) => !page.url.startsWith('about:')
+  const pageDataByTabID = new Map();
+  for (const [tabID, pages] of pagesMapByTabID) {
+    let filteredPages = pages.filter(
+      (page) =>
+        // It's the top-most frame if `embedderInnerWindowID` is zero.
+        page.embedderInnerWindowID === 0
     );
-  }
 
-  if (filteredPages.length === 0) {
-    // There should be at least one relevant page.
-    console.error(`Expected a relevant page but couldn't find it.`);
-    return null;
-  }
-
-  const pageUrl = filteredPages[filteredPages.length - 1].url;
-
-  if (pageUrl.startsWith('about:')) {
-    // If we only have an `about:*` page, we should return early with a friendly
-    // origin and hostname. Otherwise the try block will fail.
-    return {
-      origin: pageUrl,
-      hostname: pageUrl,
-      favicon: null,
-    };
-  }
-
-  try {
-    const page = new URL(pageUrl);
-    // FIXME(Bug 1620546): This is not ideal and we should get the favicon
-    // either during profile capture or profile pre-process.
-    const favicon = new URL('/favicon.ico', page.origin);
-    if (favicon.protocol === 'http:') {
-      // Upgrade http requests.
-      favicon.protocol = 'https:';
+    if (filteredPages.length > 1) {
+      // If there are more than one top-most page, it's also good to filter out the
+      // `about:` pages so user can see their url they are actually profiling.
+      filteredPages = filteredPages.filter(
+        (page) => !page.url.startsWith('about:')
+      );
     }
-    return {
-      origin: page.origin,
-      hostname: page.hostname,
-      favicon: favicon.href,
-    };
-  } catch (e) {
-    console.error(
-      'Error while extracing the hostname and favicon from the page url',
-      pageUrl
-    );
-    return null;
+
+    if (filteredPages.length === 0) {
+      // There should be at least one relevant page.
+      console.error(
+        `Expected a relevant page for tabID ${tabID} but couldn't find it.`
+      );
+      continue;
+    }
+
+    // The last page is the one we care about.
+    const pageUrl = filteredPages[filteredPages.length - 1].url;
+
+    if (pageUrl.startsWith('about:')) {
+      // If we only have an `about:*` page, we should return early with a friendly
+      // origin and hostname. Otherwise the try block will fail.
+      pageDataByTabID.set(tabID, {
+        origin: pageUrl,
+        hostname: pageUrl,
+        favicon: null,
+      });
+      continue;
+    }
+
+    try {
+      const page = new URL(pageUrl);
+      // FIXME(Bug 1620546): This is not ideal and we should get the favicon
+      // either during profile capture or profile pre-process.
+      const favicon = new URL('/favicon.ico', page.origin);
+      if (favicon.protocol === 'http:') {
+        // Upgrade http requests.
+        favicon.protocol = 'https:';
+      }
+      pageDataByTabID.set(tabID, {
+        origin: page.origin,
+        hostname: page.hostname,
+        favicon: favicon.href,
+      });
+    } catch (e) {
+      console.error(
+        'Error while extracing the hostname and favicon from the page url',
+        pageUrl
+      );
+      continue;
+    }
   }
+  return pageDataByTabID;
 }
 
 // Returns the resource index for a "url" or "webhost" resource which is created

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2858,11 +2858,10 @@ export function filterToRetainedAllocations(
 }
 
 /**
- * Extract the hostname and favicon from the first page if we are in single tab
- * view. Currently we assume that we don't change the origin of webpages while
- * profiling in web developer preset. That's why we are simply getting the first
- * page we find that belongs to the active tab. Returns null if profiler is not
- * in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page if we are in single tab
+ * view. We assume that the user wants to know about the last loaded page in
+ * this tab.
+ * Returns null if profiler is not in the single tab view at the moment.
  */
 export function extractProfileFilterPageData(
   pages: PageList | null,
@@ -2895,7 +2894,7 @@ export function extractProfileFilterPageData(
     return null;
   }
 
-  const pageUrl = filteredPages[0].url;
+  const pageUrl = filteredPages[filteredPages.length - 1].url;
 
   if (pageUrl.startsWith('about:')) {
     // If we only have an `about:*` page, we should return early with a friendly

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -548,6 +548,11 @@ const timelineTrackOrganization: Reducer<TimelineTrackOrganization> = (
         type: 'active-tab',
         tabID: action.tabID,
       };
+    case 'CHANGE_ACTIVE_TAB':
+      return {
+        type: 'active-tab',
+        tabID: action.tabID,
+      };
     case 'VIEW_ORIGINS_PROFILE':
       return { type: 'origins' };
     default:

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -849,11 +849,10 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
 );
 
 /**
- * Extracts the data of the first page on the tab filtered profile.
- * Currently we assume that we don't change the origin of webpages while
- * profiling in web developer preset. That's why we are simply getting the
- * first page we find that belongs to the active tab. Returns null if profiler
- * is not in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page if we are in single tab
+ * view. We assume that the user wants to know about the last loaded page in
+ * this tab.
+ * Returns null if profiler is not in the single tab view at the moment.
  */
 export const getProfileFilterPageData: Selector<ProfileFilterPageData | null> =
   createSelector(

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -264,6 +264,7 @@ export const getActiveTabID: Selector<TabID | null> = (state) => {
   }
 
   if (
+    timelineTrackOrganization.type === 'active-tab' &&
     configuration &&
     configuration.activeTabID &&
     configuration.activeTabID !== 0

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -822,8 +822,8 @@ export const getRelevantInnerWindowIDsForActiveTab: Selector<
 
 /**
  * A simple wrapper for getRelevantInnerWindowIDsForActiveTab.
- * It returns an empty Set if ctxId is null, and returns the real Set if
- * ctxId is assigned already. We should usually use this instead of the
+ * It returns an empty Set if tabID is null, and returns the real Set if
+ * tabID is assigned already. We should usually use this instead of the
  * wrapped function. But the wrapped function is helpful to calculate the hidden
  * tracks by active tab view during the first page load(inside viewProfile function).
  */

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -251,6 +251,18 @@ export const getMarkerSchemaByName: Selector<MarkerSchemaByName> =
 
 export const getActiveTabID: Selector<TabID | null> = (state) => {
   const configuration = getProfilerConfiguration(state);
+  const pagesMap = getPagesMap(state);
+  const timelineTrackOrganization =
+    UrlState.getTimelineTrackOrganization(state);
+  if (
+    pagesMap &&
+    timelineTrackOrganization.type === 'active-tab' &&
+    timelineTrackOrganization.tabID &&
+    pagesMap.has(timelineTrackOrganization.tabID)
+  ) {
+    return timelineTrackOrganization.tabID;
+  }
+
   if (
     configuration &&
     configuration.activeTabID &&

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -744,7 +744,7 @@ describe('timeline/TrackContextMenu', function () {
     // TODO - We should wait until we have some real tracks without a thread index.
     it.todo('can present a disabled isolate item on non-process tracks');
 
-    it('network track will be displayed when a number is not set for ctxId', () => {
+    it('network track will be displayed when a number is not set for tabID', () => {
       const { container } = setupGlobalTrack(getNetworkTrackProfile(), 0);
       // We can't use getHumanReadableTracks here because that function doesn't
       // use the functions used by context menu directly and gives us wrong results.

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -92,14 +92,18 @@ exports[`app/ProfileFilterNavigator renders the site hostname as its first eleme
       <div
         class="nodeIcon "
       />
-      <span
-        title="https://developer.mozilla.org"
+      <select
+        class="profileFilterNavigator--tabID-select"
       >
-        developer.mozilla.org
-         (
-        51ms
-        )
-      </span>
+        <option
+          value="123123"
+        >
+          developer.mozilla.org
+        </option>
+      </select>
+      (
+      51ms
+      )
     </span>
   </li>
 </ol>

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -132,7 +132,7 @@ exports[`timeline/TrackContextMenu when a global track is right clicked matches 
 </nav>
 `;
 
-exports[`timeline/TrackContextMenu when a global track is right clicked network track will be displayed when a number is not set for ctxId 1`] = `
+exports[`timeline/TrackContextMenu when a global track is right clicked network track will be displayed when a number is not set for tabID 1`] = `
 <nav
   class="react-contextmenu timelineTrackContextMenu"
   role="menu"

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -328,7 +328,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function () {
   const tabID = 123123;
   const innerWindowID = 2;
 
-  function setup(ctxId, markers: ?Array<any>) {
+  function setup(withTabID, markers: ?Array<any>) {
     const profile = getProfileWithMarkers(
       markers || [
         [
@@ -381,7 +381,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function () {
     };
     const { getState, dispatch } = storeWithProfile(profile);
 
-    if (ctxId) {
+    if (withTabID) {
       dispatch(
         changeTimelineTrackOrganization({
           type: 'active-tab',

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -524,8 +524,8 @@ describe('profileName', function () {
   });
 });
 
-describe('ctxId', function () {
-  it('serializes the ctxId in the URL', function () {
+describe('tabID', function () {
+  it('serializes the tabID in the URL', function () {
     const { profile } = addActiveTabInformationToProfile(
       getProfileWithNiceTracks()
     );
@@ -534,7 +534,7 @@ describe('ctxId', function () {
 
     dispatch(changeTimelineTrackOrganization({ type: 'active-tab', tabID }));
     const queryString = getQueryStringFromState(getState());
-    expect(queryString).toContain(`ctxId=${tabID}`);
+    expect(queryString).toContain(`tabID=${tabID}`);
   });
 
   it('reflects in the state from URL', function () {
@@ -543,7 +543,7 @@ describe('ctxId', function () {
     );
     const { getState } = _getStoreWithURL(
       {
-        search: '?ctxId=123&view=active-tab',
+        search: '?tabID=123&view=active-tab',
       },
       profile
     );
@@ -553,7 +553,7 @@ describe('ctxId', function () {
     });
   });
 
-  it('returns the full view when ctxId is not specified', function () {
+  it('returns the full view when tabID is not specified', function () {
     const { profile } = addActiveTabInformationToProfile(
       getProfileWithNiceTracks()
     );
@@ -575,7 +575,7 @@ describe('ctxId', function () {
       iframeInnerWindowIDsWithChild;
     const { getState } = _getStoreWithURL(
       {
-        search: '?view=active-tab&ctxId=123',
+        search: '?view=active-tab&tabID=123',
       },
       profile
     );
@@ -606,7 +606,7 @@ describe('ctxId', function () {
     const { getState } = _getStoreWithURL(
       {
         search:
-          '?ctxId=123&view=active-tab&globalTrackOrder=3w0&hiddenGlobalTracks=45&hiddenLocalTracksByPid=111-1&thread=0',
+          '?tabID=123&view=active-tab&globalTrackOrder=3w0&hiddenGlobalTracks=45&hiddenLocalTracksByPid=111-1&thread=0',
       },
       profile
     );
@@ -617,7 +617,7 @@ describe('ctxId', function () {
     );
     // The url states that are relevant to full view should be stripped out.
     expect(newUrl.search).toEqual(
-      `?ctxId=123&thread=0&v=${CURRENT_URL_VERSION}&view=active-tab`
+      `?tabID=123&thread=0&v=${CURRENT_URL_VERSION}&view=active-tab`
     );
   });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -426,6 +426,10 @@ type ReceiveProfileAction =
       +timelineType: TimelineType | null,
     |}
   | {|
+      +type: 'CHANGE_ACTIVE_TAB',
+      +tabID: TabID | null,
+    |}
+  | {|
       +type: 'DATA_RELOAD',
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}


### PR DESCRIPTION
[deploy preview](https://deploy-preview-3852--perf-html.netlify.app/public/1wvnq04arqq4ca02yr001r1qe7xm6cxd0jehq9g/calltree/?view=active-tab)

Look at the select at the top, and select the last `localhost` or `cnn` (others don't have a lot of samples, if any).

Remaining tasks (non exhaustive):
* [ ] Styling
* [ ] Order available tab by activity (I believe we have some similar code already)
* [ ] Look closer at how the various selectors merge into each other, as it's not clear to me when exactly they return null etc. It might be good to move code around to make it simpler.
* [ ] (possibly in another PR) make it possible to switch back and forth between this view and the full view
* [ ] Remove the "origins" unfinished view, because I believe this replaces it

Fixes #3215

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-512)
