### PR TITLE
Change how the test helper to add innerWindowIDs is used

### DIFF
--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1825,51 +1825,34 @@ function getStackIndexForCallNodePath(
  * paths to point to frames using stacks.
  *
  * @param thread The thread to mutate.
- * @param privateInnerWindowID The innerWindowID representing a private browser window.
- * @param nonPrivateInnerWindowID The innerWindowID representing a non private browser window.
- * @param privateCallNodes These call nodes point to frames that will get privateInnerWindowID.
- * @param nonPrivateCallNodes These call nodes point to frames that will get nonPrivateInnerWindowID.
- * @param callNodesToDupe These call nodes point to frames that will be duped to get both privateInnerWindowID and nonPrivateInnerWindowID.
+ * @param listOfOperations A list of pairs { innerWindowID, callNodes }
+ *                         indicating which call nodes this innerWindowID will
+ *                         be assigned to.
+ * @param callNodesToDupe These call nodes point to frames that will be duped to
+ *                        get all passed innerWindowIDs
  */
 export function addInnerWindowIdToStacks(
   thread: Thread,
-  {
-    privateInnerWindowID,
-    nonPrivateInnerWindowID,
-    privateCallNodes,
-    nonPrivateCallNodes,
-    callNodesToDupe,
-  }: {|
-    privateInnerWindowID: number,
-    nonPrivateInnerWindowID: number,
-    privateCallNodes?: CallNodePath[],
-    nonPrivateCallNodes?: CallNodePath[],
-    callNodesToDupe?: CallNodePath[],
-  |}
+  listOfOperations: Array<{ innerWindowID: number, callNodes: CallNodePath[] }>,
+  callNodesToDupe: CallNodePath[]
 ) {
   const { stackTable, frameTable, samples } = thread;
 
-  if (privateCallNodes) {
-    // privateCallNodes contains the call nodes we want to directly change to
-    // "coming from private browsing".
-    for (const callNode of privateCallNodes) {
+  for (const { innerWindowID, callNodes } of listOfOperations) {
+    for (const callNode of callNodes) {
       const stackIndex = getStackIndexForCallNodePath(thread, callNode);
       const foundFrameIndex = stackTable.frame[stackIndex];
-      frameTable.innerWindowID[foundFrameIndex] = privateInnerWindowID;
-    }
-  }
-
-  if (nonPrivateCallNodes) {
-    // nonPrivateCallNodes contains the call nodes we want to directly change to
-    // "coming from non private browsing".
-    for (const callNode of nonPrivateCallNodes) {
-      const stackIndex = getStackIndexForCallNodePath(thread, callNode);
-      const foundFrameIndex = stackTable.frame[stackIndex];
-      frameTable.innerWindowID[foundFrameIndex] = nonPrivateInnerWindowID;
+      frameTable.innerWindowID[foundFrameIndex] = innerWindowID;
     }
   }
 
   if (callNodesToDupe) {
+    if (listOfOperations.length !== 2) {
+      throw new Error(
+        `This tool doesn't support more than 2 innerWindowIDs for duping.`
+      );
+    }
+
     // callNodesToChange contains the call nodes we want to dupe so that the
     // original comes from a non-private browsing window, while the dupe comes
     // from a private browsing window.
@@ -1879,8 +1862,9 @@ export function addInnerWindowIdToStacks(
     for (const callNode of callNodesToDupe) {
       const stackIndex = getStackIndexForCallNodePath(thread, callNode);
       const foundFrameIndex = stackTable.frame[stackIndex];
-      // The found one comes from a non private window
-      frameTable.innerWindowID[foundFrameIndex] = nonPrivateInnerWindowID;
+      // The found one comes from the first tab.
+      frameTable.innerWindowID[foundFrameIndex] =
+        listOfOperations[0].innerWindowID;
 
       // Clone this frame
       const newFrameIndex = frameTable.length++;
@@ -1897,8 +1881,8 @@ export function addInnerWindowIdToStacks(
       frameTable.column.push(frameTable.column[foundFrameIndex]);
       frameTable.optimizations.push(frameTable.optimizations[foundFrameIndex]);
 
-      // And use the passed privateInnerWindowID
-      frameTable.innerWindowID.push(privateInnerWindowID);
+      // And that one comes from the second tab.
+      frameTable.innerWindowID.push(listOfOperations[1].innerWindowID);
 
       // Clone the stack
       const newStackIndex = stackTable.length++;

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -770,13 +770,22 @@ describe('sanitizePII', function () {
         secondTabInnerWindowIDs: nonPrivateTabInnerWindowIDs,
       } = addActiveTabInformationToProfile(originalProfile);
       markTabIdsAsPrivateBrowsing(originalProfile, [privateTabTabID]);
-      addInnerWindowIdToStacks(originalProfile.threads[0], {
-        privateInnerWindowID: privateTabInnerWindowIDs[0],
-        nonPrivateInnerWindowID: nonPrivateTabInnerWindowIDs[0],
-        privateCallNodes: [[A, B, Djs]],
-        nonPrivateCallNodes: [[A, B, Cjs]],
-        callNodesToDupe: [[A, B, Ejs]],
-      });
+      addInnerWindowIdToStacks(
+        originalProfile.threads[0],
+        /* listOfOperations */
+        [
+          {
+            innerWindowID: nonPrivateTabInnerWindowIDs[0],
+            callNodes: [[A, B, Cjs]],
+          },
+          {
+            innerWindowID: privateTabInnerWindowIDs[0],
+            callNodes: [[A, B, Djs]],
+          },
+        ],
+        /* callNodesToDupe */
+        [[A, B, Ejs]]
+      );
 
       const { sanitizedProfile } = setup(
         { shouldRemovePrivateBrowsingData: true },


### PR DESCRIPTION
I realized that it wasn't flexible enough and so I generalized the names to make it easier to use for tests that aren't related to private windows.