### PR TITLE
Fix an issue when loading active tab view

### DIFF
--- a/src/profile-logic/active-tab.js
+++ b/src/profile-logic/active-tab.js
@@ -197,9 +197,12 @@ function _getActiveTabResourceName(
 ): string {
   if (isMainThread(thread)) {
     // This is a sub-frame.
-    // Get the first innerWindowID inside the thread.
+    // Get the first innerWindowID inside the thread that's also present of innerWindowIDToPageMap.
     let firstInnerWindowID = ensureExists(thread.frameTable.innerWindowID).find(
-      (innerWindowID) => innerWindowID && innerWindowID !== 0
+      (innerWindowID) =>
+        innerWindowID &&
+        innerWindowID !== 0 &&
+        innerWindowIDToPageMap.has(innerWindowID)
     );
     if (firstInnerWindowID === undefined || firstInnerWindowID === null) {
       const markerData = thread.markers.data.find((data) => {

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1696,14 +1696,14 @@ export function addActiveTabInformationToProfile(
     },
     // An iframe page inside the previous page
     {
-      tabID: 2,
+      tabID: firstTabTabID,
       innerWindowID: iframeInnerWindowIDsWithChild,
       url: 'Page #2',
       embedderInnerWindowID: parentInnerWindowIDsWithChildren,
     },
     // Another iframe page inside the previous iframe
     {
-      tabID: 3,
+      tabID: firstTabTabID,
       innerWindowID: firstTabInnerWindowIDs[2],
       url: 'Page #3',
       embedderInnerWindowID: iframeInnerWindowIDsWithChild,
@@ -1834,7 +1834,7 @@ function getStackIndexForCallNodePath(
 export function addInnerWindowIdToStacks(
   thread: Thread,
   listOfOperations: Array<{ innerWindowID: number, callNodes: CallNodePath[] }>,
-  callNodesToDupe: CallNodePath[]
+  callNodesToDupe?: CallNodePath[]
 ) {
   const { stackTable, frameTable, samples } = thread;
 


### PR DESCRIPTION
I found this issue when testing my patch about sanitizing active tab views.

The problem is when the first sample with an innerWindowID for a thread that's not a top most thread isn't part of the current tab.

For example:
* active tab is the tab with CNN
* another profiled tab is a tab with Le Monde.
* both profiled tab have an iframe to eg outbrain.com. By bad luck, the first sample with an innerwindowid in the thread for this website is part of the second tab.

It may be that fission makes it more present, by grouping iframes from the same domain in the same thread.

Example with a real-life profile:
[production](https://profiler.firefox.com/public/8sepzr5240d2jjv06p4ggh7200mwmgs2jyv125g/marker-chart/?view=active-tab)
[deploy preview](https://deploy-preview-3855--perf-html.netlify.app/public/8sepzr5240d2jjv06p4ggh7200mwmgs2jyv125g/marker-chart/?view=active-tab)

Please look at the 2nd commit only, as the 1st commit is #3854.