### PR TITLE
Make the global track visible when its local track is becoming visible with "Show all tracks below" button 

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -676,9 +676,8 @@ export function showProvidedTracks(
     // visible too. Let's iterate over the global tracks and include them if
     // their children are going to be made visible.
     const globalTracks = getGlobalTracks(getState());
+    const pidsToShow = new Set(localTracksByPidToShow.keys());
     for (const [globalTrackIndex, globalTrack] of globalTracks.entries()) {
-      const pidsToShow = new Set(localTracksByPidToShow.keys());
-
       if (globalTrack.pid && pidsToShow.has(globalTrack.pid)) {
         globalTracksToShow.add(globalTrackIndex);
       }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -664,12 +664,25 @@ export function showProvidedTracks(
   globalTracksToShow: Set<TrackIndex>,
   localTracksByPidToShow: Map<Pid, Set<TrackIndex>>
 ): ThunkAction<void> {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     sendAnalytics({
       hitType: 'event',
       eventCategory: 'timeline',
       eventAction: 'show provided tracks',
     });
+
+    // We got the global and local tracks, but if a local track's global track
+    // is not visible, we should still make it visible so the local one can be
+    // visible too. Let's iterate over the global tracks and include them if
+    // their children are going to be made visible.
+    const globalTracks = getGlobalTracks(getState());
+    for (const [globalTrackIndex, globalTrack] of globalTracks.entries()) {
+      const pidsToShow = new Set(localTracksByPidToShow.keys());
+
+      if (globalTrack.pid && pidsToShow.has(globalTrack.pid)) {
+        globalTracksToShow.add(globalTrackIndex);
+      }
+    }
 
     dispatch({
       type: 'SHOW_PROVIDED_TRACKS',

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -1151,7 +1151,10 @@ export function getSearchFilteredLocalTracksByPid(
       }
     }
 
-    searchFilteredLocalTracksByPid.set(pid, searchFilteredLocalTracks);
+    if (searchFilteredLocalTracks.size > 0) {
+      // Only add the global track when the are some search filtered local tracks.
+      searchFilteredLocalTracksByPid.set(pid, searchFilteredLocalTracks);
+    }
   }
 
   return searchFilteredLocalTracksByPid;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -401,11 +401,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
         pid,
         localTracksToMakeVisible,
       ] of action.localTracksByPidToShow.entries()) {
-        const hiddenLocalTracks = state.get(pid);
-        if (!hiddenLocalTracks) {
-          throw new Error('Failed to find the local tracks');
-        }
-
+        const hiddenLocalTracks = state.get(pid) ?? new Set();
         const newHiddenLocalTracks = new Set(hiddenLocalTracks);
         localTracksToMakeVisible.forEach(
           Set.prototype.delete,

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -395,20 +395,25 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
       return hiddenLocalTracksByPid;
     }
     case 'SHOW_PROVIDED_TRACKS': {
-      const hiddenLocalTracksByPid = new Map();
-      // Go through the local tracks and make the provided ones visible.
-      for (const [pid, hiddenLocalTracks] of state.entries()) {
-        const newHiddenLocalTracks = new Set(hiddenLocalTracks);
-        // Remove all provided local tracks.
-        const localTracks = action.localTracksByPidToShow.get(pid);
-
-        if (!localTracks) {
+      const hiddenLocalTracksByPid = new Map(state);
+      // Go through the filtered local tracks to make them visible.
+      for (const [
+        pid,
+        localTracksToMakeVisible,
+      ] of action.localTracksByPidToShow.entries()) {
+        const hiddenLocalTracks = state.get(pid);
+        if (!hiddenLocalTracks) {
           throw new Error('Failed to find the local tracks');
         }
 
-        localTracks.forEach(Set.prototype.delete, newHiddenLocalTracks);
+        const newHiddenLocalTracks = new Set(hiddenLocalTracks);
+        localTracksToMakeVisible.forEach(
+          Set.prototype.delete,
+          newHiddenLocalTracks
+        );
         hiddenLocalTracksByPid.set(pid, newHiddenLocalTracks);
       }
+
       return hiddenLocalTracksByPid;
     }
     case 'SHOW_LOCAL_TRACK': {

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -156,10 +156,17 @@ describe('timeline/TrackContextMenu', function () {
         fireFullClick(screen.getByText('Style'));
       };
 
+      const hideAllTracksExceptMain = () => {
+        fireFullClick(screen.getByText('DOM Worker'));
+        fireFullClick(screen.getByText('Style'));
+        fireFullClick(screen.getByText('Content Process'));
+      };
+
       return {
         ...results,
         selectAllTracksBelowItem,
         hideAllTracks,
+        hideAllTracksExceptMain,
       };
     }
 
@@ -287,6 +294,37 @@ describe('timeline/TrackContextMenu', function () {
         'hide [thread GeckoMain process]',
         'show [thread GeckoMain tab] SELECTED',
         '  - hide [thread DOM Worker]',
+        '  - hide [thread Style]',
+      ]);
+    });
+
+    it("shows local track's global track even if it wasn't visible before", () => {
+      const {
+        getState,
+        selectAllTracksBelowItem,
+        hideAllTracksExceptMain,
+        changeSearchFilter,
+      } = setupAllTracks();
+      // Hide the local tracks and tehe global track with children for this behavior.
+      hideAllTracksExceptMain();
+      expect(getHumanReadableTracks(getState())).toEqual([
+        'show [thread GeckoMain process] SELECTED',
+        // These tracks must be hidden at the start.
+        'hide [thread GeckoMain tab]',
+        '  - hide [thread DOM Worker]',
+        '  - hide [thread Style]',
+      ]);
+
+      // Search a local track.
+      changeSearchFilter('DOM Worker');
+      // Click the button.
+      fireFullClick(selectAllTracksBelowItem());
+
+      // DOM Worker and its global process should be visible now.
+      expect(getHumanReadableTracks(getState())).toEqual([
+        'show [thread GeckoMain process] SELECTED',
+        'show [thread GeckoMain tab]',
+        '  - show [thread DOM Worker]',
         '  - hide [thread Style]',
       ]);
     });


### PR DESCRIPTION
Fixes #3853.

Additionally, there is one thing to keep in mind:
If the hidden global track includes some other local tracks that were visible before, they will also be visible because we don't want to reset the shown local tracks for that global track completely. Otherwise, it would be annoying for the user since they would lose their previous visible local tracks.

[Production](https://share.firefox.dev/3GrWKpb) / [Deploy preview](https://deploy-preview-3861--perf-html.netlify.app/public/k6803sjwa5y1eqvett67vx37j81fan7tm05zx00/calltree/?globalTrackOrder=b0wa&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=81237-0wnpwze~81245-0wh~81251-0wh~81250-0wx3~81259-0wf~81258-0wf~81238-0w8~81257-0wf~81249-0wt~81248-0wx3~81239-0wxa&localTrackOrderByPid=81237-zf0wzezgwzr~81245-0wh~81251-0wh~81250-u0wtvwx3~81259-0wf~81258-0wf~81238-0w8~81257-0wf~81249-0wt~81248-0wx3~81239-x30wx2x4wxa&thread=0&timelineType=cpu-category&v=6)