### PR TITLE
Remove a warning when running tests

### DIFF
--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -747,7 +747,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       <div className="treeView">
         <TreeViewHeader fixedColumns={fixedColumns} mainColumn={mainColumn} />
         <ContextMenuTrigger
-          id={contextMenuId}
+          id={contextMenuId ?? 'unknown'}
           disable={!contextMenuId}
           attributes={{ className: 'treeViewContextMenu' }}
         >


### PR DESCRIPTION
I noticed this error in the console when running the tests for `ZipFIleTree`:
```
    console.error
      Warning: Failed prop type: The prop `id` is marked as required in `ContextMenuTrigger`, but its value is `undefined`.
          at ContextMenuTrigger (/home/julien/travail/git/perf.html/node_modules/@firefox-devtools/react-contextmenu/modules/ContextMenuTrigger.js:62:5)
          at ContextMenuTrigger (/home/julien/travail/git/perf.html/src/components/shared/ContextMenuTrigger.js:10:8)
          at div
          at TreeView (/home/julien/travail/git/perf.html/src/components/shared/TreeView.js:400:3)
          at div
          at section
          at ZipFileViewerImpl (/home/julien/travail/git/perf.html/src/components/app/ZipFileViewer.js:128:5)
          at ConnectFunction (/home/julien/travail/git/perf.html/node_modules/react-redux/lib/components/connectAdvanced.js:235:41)
          at Provider (/home/julien/travail/git/perf.html/node_modules/react-redux/lib/components/Provider.js:21:20)
          at LocalizationProvider (/home/julien/travail/git/perf.html/node_modules/@fluent/react/index.js:108:75)
```
This is a fallout of #3863.