### PR TITLE
Change localization initialization process

### DIFF
--- a/src/actions/l10n.js
+++ b/src/actions/l10n.js
@@ -4,23 +4,19 @@
 
 // @flow
 
-import { negotiateLanguages } from '@fluent/langneg';
-import { ReactLocalization } from '@fluent/react';
-import type { Action, ThunkAction, Localization } from 'firefox-profiler/types';
-import {
-  AVAILABLE_LOCALES,
-  DEFAULT_LOCALE,
-  fetchMessages,
-  lazilyParsedBundles,
-  getLocaleDirection,
-} from 'firefox-profiler/app-logic/l10n';
+import type {
+  Action,
+  Localization,
+  PseudoStrategy,
+} from 'firefox-profiler/types';
 
 /**
  * Notify that translations for the UI are being fetched.
  */
-export function requestL10n(): Action {
+export function requestL10n(locales: Array<string>): Action {
   return {
     type: 'REQUEST_L10N',
+    locales,
   };
 }
 
@@ -40,45 +36,9 @@ export function receiveL10n(
   };
 }
 
-/**
- * This function is called when the AppLocalizationProvider is mounted.
- * It takes the locales available and generates l10n bundles for those locales.
- * Initially it dispatches the info that translations are now fetching and
- * later it dispatches the translations and updates the state
- */
-export function setupLocalization(
-  locales: Array<string>,
-  pseudoStrategy?: 'accented' | 'bidi'
-): ThunkAction<Promise<void>> {
-  return async (dispatch) => {
-    dispatch(requestL10n());
-
-    // Setting defaultLocale to `en-US` means that it will always be the
-    // last fallback locale, thus making sure the UI is always working.
-    const languages = negotiateLanguages(locales, AVAILABLE_LOCALES, {
-      defaultLocale: DEFAULT_LOCALE,
-    });
-
-    // It's important to note that `languages` is the result of the negotiation,
-    // and can be different than `locales`.
-    // languages may contain the requested locale as well as some fallback
-    // locales. Also `negotiateLanguages` always adds the default locale if it's
-    // not present.
-    // Some examples:
-    // * navigator.locales == ['fr', 'en-US', 'en'] => languages == ['fr-FR', 'en-US', 'en-GB']
-    // * navigator.locales == ['fr'] => languages == ['fr-FR', 'en-US']
-    // Because our primary locale is en-US it's not useful to go past it and
-    // fetch more locales than necessary, so let's slice to that entry.
-    const indexOfDefaultLocale = languages.indexOf(DEFAULT_LOCALE); // Guaranteed to be positive
-    const localesToFetch = languages.slice(0, indexOfDefaultLocale + 1);
-    const fetchedMessages = await Promise.all(
-      localesToFetch.map(fetchMessages)
-    );
-    const bundles = lazilyParsedBundles(fetchedMessages, pseudoStrategy);
-    const localization = new ReactLocalization(bundles);
-
-    const primaryLocale = languages[0];
-    const direction = getLocaleDirection(primaryLocale, pseudoStrategy);
-    dispatch(receiveL10n(localization, primaryLocale, direction));
+export function togglePseudoStrategy(pseudoStrategy: PseudoStrategy): Action {
+  return {
+    type: 'TOGGLE_PSEUDO_STRATEGY',
+    pseudoStrategy,
   };
 }

--- a/src/actions/l10n.js
+++ b/src/actions/l10n.js
@@ -44,7 +44,7 @@ export function receiveL10n(
  * This function is called when the AppLocalizationProvider is mounted.
  * It takes the locales available and generates l10n bundles for those locales.
  * Initially it dispatches the info that translations are now fetching and
- * later it dispacthes the translations and updates the state
+ * later it dispatches the translations and updates the state
  */
 export function setupLocalization(
   locales: Array<string>,

--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -56,7 +56,7 @@ export async function fetchMessages(locale: string): Promise<[string, string]> {
  */
 export function* lazilyParsedBundles(
   fetchedMessages: Array<[string, string]>,
-  pseudoStrategy?: 'accented' | 'bidi'
+  pseudoStrategy?: 'accented' | 'bidi' | null
 ): Generator<FluentBundle, void, void> {
   const transform = pseudoStrategy
     ? PSEUDO_STRATEGIES[pseudoStrategy]
@@ -77,7 +77,7 @@ export function* lazilyParsedBundles(
  */
 export function getLocaleDirection(
   language: string,
-  pseudoStrategy?: 'accented' | 'bidi'
+  pseudoStrategy?: 'accented' | 'bidi' | null
 ): 'ltr' | 'rtl' {
   if (pseudoStrategy && pseudoStrategy in PSEUDO_STRATEGIES_DIRECTION) {
     return PSEUDO_STRATEGIES_DIRECTION[pseudoStrategy];

--- a/src/reducers/l10n.js
+++ b/src/reducers/l10n.js
@@ -3,27 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type {
-  Reducer,
-  L10nState,
-  L10nFetchingPhase,
-} from 'firefox-profiler/types';
+import type { Reducer, L10nState } from 'firefox-profiler/types';
 import { ReactLocalization } from '@fluent/react';
 import { combineReducers } from 'redux';
-
-const l10nFetchingPhase: Reducer<L10nFetchingPhase> = (
-  state = 'not-fetching',
-  action
-) => {
-  switch (action.type) {
-    case 'REQUEST_L10N':
-      return 'fetching-ftl';
-    case 'RECEIVE_L10N':
-      return 'done-fetching';
-    default:
-      return state;
-  }
-};
 
 const localization: Reducer<ReactLocalization> = (
   state = new ReactLocalization([]),
@@ -56,7 +38,6 @@ const direction: Reducer<'ltr' | 'rtl'> = (state = 'ltr', action) => {
 };
 
 const l10nReducer: Reducer<L10nState> = combineReducers({
-  l10nFetchingPhase,
   localization,
   primaryLocale,
   direction,

--- a/src/reducers/l10n.js
+++ b/src/reducers/l10n.js
@@ -3,9 +3,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Reducer, L10nState } from 'firefox-profiler/types';
+import type {
+  Reducer,
+  L10nState,
+  PseudoStrategy,
+} from 'firefox-profiler/types';
 import { ReactLocalization } from '@fluent/react';
 import { combineReducers } from 'redux';
+
+const requestedLocales: Reducer<string[] | null> = (state = null, action) => {
+  switch (action.type) {
+    case 'REQUEST_L10N':
+      return action.locales;
+    default:
+      return state;
+  }
+};
+
+const pseudoStrategy: Reducer<PseudoStrategy> = (state = null, action) => {
+  switch (action.type) {
+    case 'TOGGLE_PSEUDO_STRATEGY':
+      return action.pseudoStrategy;
+    default:
+      return state;
+  }
+};
 
 const localization: Reducer<ReactLocalization> = (
   state = new ReactLocalization([]),
@@ -41,6 +63,8 @@ const l10nReducer: Reducer<L10nState> = combineReducers({
   localization,
   primaryLocale,
   direction,
+  requestedLocales,
+  pseudoStrategy,
 });
 
 export default l10nReducer;

--- a/src/selectors/l10n.js
+++ b/src/selectors/l10n.js
@@ -4,16 +4,9 @@
 
 // @flow
 
-import type {
-  Selector,
-  L10nState,
-  Localization,
-  L10nFetchingPhase,
-} from 'firefox-profiler/types';
+import type { Selector, L10nState, Localization } from 'firefox-profiler/types';
 
 export const getL10nState: Selector<L10nState> = (state) => state.l10n;
-export const getL10nFetchingPhase: Selector<L10nFetchingPhase> = (state) =>
-  getL10nState(state).l10nFetchingPhase;
 export const getLocalization: Selector<Localization> = (state) =>
   getL10nState(state).localization;
 export const getPrimaryLocale: Selector<string | null> = (state) =>

--- a/src/selectors/l10n.js
+++ b/src/selectors/l10n.js
@@ -4,7 +4,12 @@
 
 // @flow
 
-import type { Selector, L10nState, Localization } from 'firefox-profiler/types';
+import type {
+  Selector,
+  L10nState,
+  Localization,
+  PseudoStrategy,
+} from 'firefox-profiler/types';
 
 export const getL10nState: Selector<L10nState> = (state) => state.l10n;
 export const getLocalization: Selector<Localization> = (state) =>
@@ -13,3 +18,7 @@ export const getPrimaryLocale: Selector<string | null> = (state) =>
   getL10nState(state).primaryLocale;
 export const getDirection: Selector<'ltr' | 'rtl'> = (state) =>
   getL10nState(state).direction;
+export const getRequestedLocales: Selector<string[] | null> = (state) =>
+  getL10nState(state).requestedLocales;
+export const getPseudoStrategy: Selector<PseudoStrategy> = (state) =>
+  getL10nState(state).pseudoStrategy;

--- a/src/test/components/AppLocalizationProvider.test.js
+++ b/src/test/components/AppLocalizationProvider.test.js
@@ -11,7 +11,6 @@ import { render, screen } from '@testing-library/react';
 import { lazilyParsedBundles } from 'firefox-profiler/app-logic/l10n';
 import { AppLocalizationProvider } from 'firefox-profiler/components/app/AppLocalizationProvider';
 import {
-  getL10nFetchingPhase,
   getLocalization,
   getPrimaryLocale,
   getDirection,
@@ -79,10 +78,8 @@ describe('AppLocalizationProvider', () => {
 
   it('changes the state accordingly when the actions are dispatched', () => {
     const { dispatch, getState } = setup();
-    expect(getL10nFetchingPhase(getState())).toBe('not-fetching');
     expect(getLocalization(getState())).toEqual(new ReactLocalization([]));
     dispatch(requestL10n());
-    expect(getL10nFetchingPhase(getState())).toBe('fetching-ftl');
     const resource = [
       'locale',
       'data-testid = content-test-ApplocalizationProvider',
@@ -90,7 +87,6 @@ describe('AppLocalizationProvider', () => {
     const bundles = lazilyParsedBundles([resource]);
     const testLocalization = new ReactLocalization(bundles);
     dispatch(receiveL10n(testLocalization, 'en-US', 'ltr'));
-    expect(getL10nFetchingPhase(getState())).toBe('done-fetching');
     expect(getLocalization(getState())).toEqual(testLocalization);
     expect(getPrimaryLocale(getState())).toEqual('en-US');
     expect(getDirection(getState())).toEqual('ltr');

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -24,6 +24,7 @@ import type { Transform, TransformStacksPerThread } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type {
+  PseudoStrategy,
   UrlState,
   UploadState,
   State,
@@ -545,12 +546,19 @@ type CurrentProfileUploadedInformationAction = {|
 |};
 
 type L10nAction =
-  | {| +type: 'REQUEST_L10N' |}
+  | {|
+      +type: 'REQUEST_L10N',
+      +locales: string[],
+    |}
   | {|
       +type: 'RECEIVE_L10N',
       +localization: Localization,
       +primaryLocale: string,
       +direction: 'ltr' | 'rtl',
+    |}
+  | {|
+      +type: 'TOGGLE_PSEUDO_STRATEGY',
+      +pseudoStrategy: PseudoStrategy,
     |};
 
 type SourcesAction =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -339,13 +339,7 @@ export type UrlState = {|
 /**
  * Localization State
  */
-export type L10nFetchingPhase =
-  | 'not-fetching'
-  | 'fetching-ftl'
-  | 'done-fetching';
-
 export type L10nState = {|
-  +l10nFetchingPhase: L10nFetchingPhase,
   +localization: Localization,
   +primaryLocale: string | null,
   +direction: 'ltr' | 'rtl',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -339,7 +339,10 @@ export type UrlState = {|
 /**
  * Localization State
  */
+export type PseudoStrategy = null | 'bidi' | 'accented';
 export type L10nState = {|
+  +requestedLocales: string[] | null,
+  +pseudoStrategy: PseudoStrategy,
   +localization: Localization,
   +primaryLocale: string | null,
   +direction: 'ltr' | 'rtl',

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -114,7 +114,7 @@ export function addDataToWindowObject(
       return;
     }
 
-    dispatch(actions.setupLocalization(navigator.languages, pseudoStrategy));
+    dispatch(actions.togglePseudoStrategy(pseudoStrategy ?? null));
     if (pseudoStrategy) {
       console.log(stripIndent`
         ✅ The pseudo strategy "${pseudoStrategy}" is now enabled for the localization.


### PR DESCRIPTION
The goals for this patch are:
* make it easy to switch the language
* uncouple the requested language from the pseudo strategy. Indeed the thunk action makes these 2 options too tangled.

There should be no visible change with this patch for a normal user.

Here are the changes though:
* we can change separately the language and the pseudo locale
* as a result, when toggling the pseudo locale, the new implementation will keep the current language
* just as well, we can keep the current pseudo locale strategy when switching the locale

You can try this in the console with command lines such as:
```js
dispatch(actions.requestL10n(["de"]));
togglePseudoLocalization("accented");
dispatch(actions.requestL10n(["es"]));
```

[deploy preview for the homepage](https://deploy-preview-3882--perf-html.netlify.app/)
[deploy preview for a profile](https://deploy-preview-3882--perf-html.netlify.app/public/n8np5p5b78df15c2kq3dtc3aa5vedvw19e4decr/)

You can review the 2 commits separately. The first commit is removing some unused state, probably a left over from a previous refactoring.