### PR TITLE
Do not animate the keyboard shortcuts panel if user prefers reduced motion

### DIFF
--- a/src/components/app/KeyboardShortcut.css
+++ b/src/components/app/KeyboardShortcut.css
@@ -118,3 +118,11 @@
     background: #000a;
   }
 }
+
+/* Do not animate the panel or the background if user prefers reduced motion */
+@media (prefers-reduced-motion) {
+  .appKeyboardShortcuts,
+  .appKeyboardShortcutsBox {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Fixes #3894.

STR:
1. Set your OS to prefer reduced motion.
2. Open the deploy preview 
3. Press `?` key to open the shortcuts panel.
4. See that the appearing animation is gone now.

Example profile: [production](https://share.firefox.dev/3BxgvuS) / [deploy preview](https://deploy-preview-3895--perf-html.netlify.app/public/8gj6d7vamdwdh6xwaqjj5vh47tb0k50dhahwdm8/calltree/?ctSummary=native-retained-allocations&globalTrackOrder=x10wx0&hiddenGlobalTracks=1wv&hiddenLocalTracksByPid=169055-1wg~192517-0~169132-0~169369-0~169194-0~1300387-01~1286775-01~191935-0~1300252-0~169809-0~169462-0~1301183-0~169373-0~192005-0~1300460-0~1672761-0~1300318-01~1675551-0~1300463-0~1300408-01~1301186-0~1300531-0~1672801-0~1300313-01~192077-0w2~1672868-0~1300210-01~169249-0&localTrackOrderByPid=169055-hi0wg~192517-0~169132-0~169369-0~169194-0~1300387-01~1286775-01~191935-0~1300252-0~169809-0~169462-0~1301183-0~169373-0~192005-0~1300460-0~1672761-0~1300318-01~1675551-0~1300463-0~1300408-01~1301186-0~1300531-0~1672801-0~1300313-01~192077-120~1672868-0~1300210-01~169249-0~1675555-0&thread=xi&timelineType=cpu-category&v=6)