### PR TITLE
Use the orange color for all current CC markers

### DIFF
--- a/src/profile-logic/marker-styles.js
+++ b/src/profile-logic/marker-styles.js
@@ -27,14 +27,13 @@ const defaultStyle = {
 const gcStyle = {
   ...defaultStyle,
   top: 6,
-  // This color is a yellower ORANGE_50 to help distinguish GC as coming from scripts.
-  // It keeps it within a similar hue as the rest of the memory markers.
-  background: '#ffc600',
+  background: colors.ORANGE_50,
 };
 
 const ccStyle = {
   ...gcStyle,
-  background: colors.ORANGE_50,
+  // This is a paler orange to distinguish CC from GC.
+  background: '#ffc600',
 };
 
 /**
@@ -171,10 +170,18 @@ const markerStyles: { +[styleName: string]: MarkerStyle } = {
   },
   GCSlice: gcStyle,
   GCMinor: gcStyle,
-  CCSlice: gcStyle,
+  'GC Interrupt': gcStyle,
+  CC: {
+    ...ccStyle,
+    squareCorners: true,
+    top: 0,
+  },
+  CCSlice: ccStyle,
+  ForgetSkippable: ccStyle,
+  // Note: these Idle* markers have been removed in Firefox 99 (Bug 1752646),
+  // but they're still here for compatibility for older profiles.
   IdleCCSlice: ccStyle,
   IdleForgetSkippable: ccStyle,
-  ForgetSkippable: ccStyle,
 
   // IO:
   FileIO: {

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -1,6 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TimelineMarkers renders correctly 1`] = `
+exports[`TimelineMarkers renders correctly memory markers 1`] = `
+<div
+  class="timelineMarkers timelineMarkersMemory selected"
+  data-testid="TimelineMarkersMemory"
+>
+  <div
+    class="react-contextmenu-wrapper"
+  >
+    <div>
+      <canvas
+        class="timelineMarkersCanvas"
+        height="300"
+        width="200"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TimelineMarkers renders correctly memory markers 2`] = `
+Array [
+  Array [
+    "clearRect",
+    0,
+    0,
+    200,
+    300,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#ffc600",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    66.66666666666666,
+    6,
+  ],
+  Array [
+    "set fillStyle",
+    "#ff9400",
+  ],
+  Array [
+    "fillRect",
+    67,
+    0,
+    66.66666666666666,
+    6,
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+]
+`;
+
+exports[`TimelineMarkers renders correctly overview markers 1`] = `
 <div
   class="timelineMarkers selected"
   data-testid="TimelineMarkersOverview"
@@ -19,7 +82,7 @@ exports[`TimelineMarkers renders correctly 1`] = `
 </div>
 `;
 
-exports[`TimelineMarkers renders correctly 2`] = `
+exports[`TimelineMarkers renders correctly overview markers 2`] = `
 Array [
   Array [
     "clearRect",


### PR DESCRIPTION
[production](https://profiler.firefox.com/public/09w34r4d14cwyh9cy9f2fq7sxgvxhnv98byg3w8/calltree/?globalTrackOrder=0w3&localTrackOrderByPid=15500-0~21288-0~16880-0~15864-01&range=6035m3431&thread=0&timelineType=cpu-category&v=6)
[deploy preview](https://deploy-preview-3900--perf-html.netlify.app/public/09w34r4d14cwyh9cy9f2fq7sxgvxhnv98byg3w8/calltree/?globalTrackOrder=0w3&localTrackOrderByPid=15500-0~21288-0~16880-0~15864-01&range=6035m3431&thread=0&timelineType=cpu-category&v=6)

Unfortunately newer Firefox versions have a bug where some CC markers are missing in the timeline, see https://bugzilla.mozilla.org/show_bug.cgi?id=1760811

Before:
![image](https://user-images.githubusercontent.com/454175/159668814-2c0d1c49-9438-4bcd-a7f4-258e721c942e.png)

After:
![image](https://user-images.githubusercontent.com/454175/159668871-79694785-ac8f-4f7a-98e1-e69960efdadf.png)

We should probably use the category for these but that's more work than what I want to do now, and I focused on making current use cases work.