### PR TITLE
Add a language switcher - second possibility

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -214,7 +214,9 @@ FooterLinks--Privacy = Privacy
 FooterLinks--Cookies = Cookies
 FooterLinks--languageSwitcher--select =
     .title = Change language
-
+FooterLinks--hide-button =
+    .title = Hide footer links
+    .aria-label = Hide footer links
 
 ## FullTimeline
 ## The timeline component of the full view in the analysis UI at the top of the

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -212,6 +212,9 @@ Details--error-boundary-message =
 FooterLinks--legal = Legal
 FooterLinks--Privacy = Privacy
 FooterLinks--Cookies = Cookies
+FooterLinks--languageSwitcher--select =
+    .title = Change language
+
 
 ## FullTimeline
 ## The timeline component of the full view in the analysis UI at the top of the

--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -10,28 +10,41 @@ import {
   PSEUDO_STRATEGIES_DIRECTION,
 } from 'firefox-profiler/utils/l10n-pseudo';
 
-// This contains the locales we support in the production. Don't forget to update
-// the array RTL_LOCALES when adding a RTL locale, if necessary.
-// AVAILABLE_STAGING_LOCALES is replaced, using webpack's DefinePlugin, by all
-// available locales, when running with L10N=1, using the "l10n" versions of the
-// yarn scripts. Especially this is done when building and deploying the l10n
-// branch in netlify.
-export const AVAILABLE_LOCALES: Array<string> = AVAILABLE_STAGING_LOCALES || [
-  'de',
-  'el',
-  'en-GB',
-  'en-US',
-  'es-CL',
-  'fr',
-  'ia',
-  'it',
-  'nl',
-  'pt-BR',
-  'sv-SE',
-  'uk',
-  'zh-CN',
-  'zh-TW',
-];
+// This object contains the locales that are at least 90% complete and
+// that we enable by default. Don't forget to update the array RTL_LOCALES when
+// adding a RTL locale, if necessary.
+// The localized names are copied from the curated list that can be found at
+// https://mozilla-l10n.github.io/firefox-languages/.
+// We use the language names in their own language.
+// Also note that the order specified here is the order they'll be displayed in the
+// language switcher, so it's important to keep the alphabetical order.
+export const AVAILABLE_LOCALES_TO_LOCALIZED_NAMES = {
+  de: 'Deutsch',
+  el: 'Ελληνικά',
+  'en-GB': 'English (GB)',
+  'en-US': 'English (US)',
+  'es-CL': 'Español', // Use "Español (CL)" once we have more spanish versions
+  fr: 'Français',
+  ia: 'Interlingua',
+  it: 'Italiano',
+  nl: 'Nederlands',
+  'pt-BR': 'Português (BR)',
+  'sv-SE': 'Svenska',
+  uk: 'Українська',
+  'zh-CN': '简体中文',
+  'zh-TW': '正體中文',
+};
+
+// This constant contains all locales available to our application. The default
+// is to use the keys of the previous object.
+// However when running the yarn scripts with the environment variable L10N=1,
+// webpack replaces AVAILABLE_STAGING_LOCALES with all locales that have an FTL
+// file in the repository, and this becomes the value for this constant. This
+// is used in our l10n branch when deployed on netlify.
+export const AVAILABLE_LOCALES: Array<string> =
+  AVAILABLE_STAGING_LOCALES ||
+  Object.keys(AVAILABLE_LOCALES_TO_LOCALIZED_NAMES);
+
 export const DEFAULT_LOCALE = 'en-US';
 
 // This array contains only the locales that are RTL (Right-To-Left).

--- a/src/components/app/FooterLinks.css
+++ b/src/components/app/FooterLinks.css
@@ -16,7 +16,7 @@
 .appFooterLinksLink,
 .appFooterLinksClose {
   display: inline-block;
-  padding: 3px 5px;
+  margin: 2px 4px;
   color: var(--blue-60);
   text-decoration: none;
 }
@@ -32,6 +32,12 @@
 .appFooterLinksLink:hover,
 .appFooterLinksClose:hover {
   text-decoration: underline;
+}
+
+.appFooterLinksLanguageSwitcher {
+  margin: 2px 5px;
+  color: inherit;
+  font: inherit;
 }
 
 @media (max-width: 767px) {

--- a/src/components/app/FooterLinks.js
+++ b/src/components/app/FooterLinks.js
@@ -5,6 +5,8 @@
 
 import { Localized } from '@fluent/react';
 import React, { PureComponent } from 'react';
+import { LanguageSwitcher } from './LanguageSwitcher';
+
 import './FooterLinks.css';
 
 type State = {| hide: boolean |};
@@ -57,6 +59,7 @@ export class FooterLinks extends PureComponent<{||}, State> {
         >
           <Localized id="FooterLinks--Cookies">Cookies</Localized>
         </a>
+        <LanguageSwitcher />
       </div>
     );
   }

--- a/src/components/app/FooterLinks.js
+++ b/src/components/app/FooterLinks.js
@@ -26,15 +26,18 @@ export class FooterLinks extends PureComponent<{||}, State> {
     }
     return (
       <div className="appFooterLinks">
-        <button
-          aria-label="Hide links to legal information"
-          title="Hide links to legal information"
-          className="appFooterLinksClose"
-          type="button"
-          onClick={this._onClick}
+        <Localized
+          id="FooterLinks--hide-button"
+          attrs={{ title: true, 'aria-label': true }}
         >
-          ✕
-        </button>
+          <button
+            className="appFooterLinksClose"
+            type="button"
+            onClick={this._onClick}
+          >
+            ✕
+          </button>
+        </Localized>
         <a
           className="appFooterLinksLink"
           href="https://www.mozilla.org/about/legal/terms/mozilla"

--- a/src/components/app/LanguageSwitcher.js
+++ b/src/components/app/LanguageSwitcher.js
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+
+import { Localized } from '@fluent/react';
+
+import { requestL10n } from 'firefox-profiler/actions/l10n';
+import { getPrimaryLocale } from 'firefox-profiler/selectors/l10n';
+import {
+  AVAILABLE_LOCALES_TO_LOCALIZED_NAMES,
+  AVAILABLE_LOCALES,
+} from 'firefox-profiler/app-logic/l10n';
+import explicitConnect from 'firefox-profiler/utils/connect';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type OwnProps = {||};
+type StateProps = {|
+  +primaryLocale: string | null,
+|};
+type DispatchProps = {|
+  requestL10n: typeof requestL10n,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+class LanguageSwitcherImpl extends React.PureComponent<Props> {
+  _onLocaleChange = (event: SyntheticEvent<HTMLSelectElement>) => {
+    this.props.requestL10n([event.currentTarget.value]);
+  };
+
+  render() {
+    const { primaryLocale } = this.props;
+    if (!primaryLocale) {
+      // We're actually guaranteed primaryLocale is not null, because
+      // AppLocalizationProvider doesn't render when it is. This check is mostly
+      // so that Flow doesn't warn later.
+      return null;
+    }
+    return (
+      <Localized
+        id="FooterLinks--languageSwitcher--select"
+        attrs={{ title: true }}
+      >
+        <select
+          className="appFooterLinksLanguageSwitcher"
+          onChange={this._onLocaleChange}
+          value={primaryLocale}
+        >
+          {AVAILABLE_LOCALES.map((locale) => (
+            <option value={locale} key={locale}>
+              {AVAILABLE_LOCALES_TO_LOCALIZED_NAMES[locale] ?? locale}
+            </option>
+          ))}
+        </select>
+      </Localized>
+    );
+  }
+}
+
+export const LanguageSwitcher = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  component: LanguageSwitcherImpl,
+  mapStateToProps: (state) => ({
+    primaryLocale: getPrimaryLocale(state),
+  }),
+  mapDispatchToProps: { requestL10n },
+});

--- a/src/components/app/MenuButtons/index.css
+++ b/src/components/app/MenuButtons/index.css
@@ -52,6 +52,13 @@
   content: '';
 }
 
+/* position: relative so that we can use position: absolute for the generated
+ * element below. */
+.menuButtonsButton-hasRightBorder,
+.menuButtonsButton-hasLeftBorder {
+  position: relative;
+}
+
 /* These classes define respectively a right or a left border. We use ::after for
  * both of them, so one element won't be able to have both a right and a left
  * borders with this technique.

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -27,9 +27,9 @@ import {
 /* Note: the order of import is important, from most general to most specific,
  * so that the CSS rules are in the correct order. */
 import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
-import { MetaInfoPanel } from 'firefox-profiler/components/app/MenuButtons/MetaInfo';
-import { MenuButtonsPublish } from 'firefox-profiler/components/app/MenuButtons/Publish';
-import { MenuButtonsPermalink } from 'firefox-profiler/components/app/MenuButtons/Permalink';
+import { MetaInfoPanel } from './MetaInfo';
+import { MenuButtonsPublish } from './Publish';
+import { MenuButtonsPermalink } from './Permalink';
 import {
   ProfileDeletePanel,
   ProfileDeleteSuccess,

--- a/src/test/components/FooterLinks.test.js
+++ b/src/test/components/FooterLinks.test.js
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import fs from 'fs';
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { FooterLinks } from 'firefox-profiler/components/app/FooterLinks';
+import { AppLocalizationProvider } from 'firefox-profiler/components/app/AppLocalizationProvider';
+
+import { blankStore } from 'firefox-profiler/test/fixtures/stores';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { coerceMatchingShape } from 'firefox-profiler/utils/flow';
+
+beforeEach(() => {
+  // Implement the fetch operation for local language files, so that we can test
+  // switching languages.
+  const fetchUrlRe = /^\/locales\/(?<language>[^/]+)\/app.ftl$/;
+  (window: any).fetch = jest.fn().mockImplementation((fetchUrl: string) => {
+    const matchUrlResult = fetchUrlRe.exec(fetchUrl);
+    if (matchUrlResult) {
+      // $FlowExpectError Our Flow doesn't know about named groups.
+      const { language } = matchUrlResult.groups;
+      const path = `locales/${language}/app.ftl`;
+      if (fs.existsSync(path)) {
+        const response = (({
+          ok: true,
+          status: 200,
+          headers: {
+            get: () => 'text/plain',
+          },
+          text: () => Promise.resolve(fs.readFileSync(path)),
+        }: any): Response);
+        return Promise.resolve(response);
+      }
+    }
+    return Promise.reject(
+      coerceMatchingShape<Response>({
+        ok: false,
+        status: 404,
+        statusText: 'Not found',
+      })
+    );
+  });
+});
+
+afterEach(function () {
+  delete window.fetch;
+});
+
+async function setup() {
+  const store = blankStore();
+  render(
+    <Provider store={store}>
+      <AppLocalizationProvider>
+        <FooterLinks />
+      </AppLocalizationProvider>
+    </Provider>
+  );
+  await screen.findByText(/Legal/);
+}
+
+it('correctly renders the FooterLinks component', async () => {
+  await setup();
+  expect(document.body).toMatchSnapshot();
+});
+
+it('can hide the footer links', async () => {
+  await setup();
+  expect(screen.getByText(/Privacy/)).toBeInTheDocument();
+  const closeButton = screen.getByRole('button', {
+    name: 'Hide footer links',
+  });
+  fireEvent.click(closeButton);
+  expect(screen.queryByText(/Privacy/)).not.toBeInTheDocument();
+});
+
+it('makes it possible to switch the language', async () => {
+  await setup();
+
+  // Select the german language
+  const select = screen.getByRole('combobox', { name: 'Change language' });
+  const option: HTMLOptionElement = (screen.getByRole('option', {
+    name: 'Deutsch',
+  }): any);
+  option.selected = true;
+  fireEvent.change(select);
+  expect(await screen.findByText('Rechtliches')).toBeInTheDocument();
+});

--- a/src/test/components/__snapshots__/FooterLinks.test.js.snap
+++ b/src/test/components/__snapshots__/FooterLinks.test.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correctly renders the FooterLinks component 1`] = `
+<body>
+  <div>
+    <div
+      class="appFooterLinks"
+    >
+      <button
+        aria-label="Hide footer links"
+        class="appFooterLinksClose"
+        title="Hide footer links"
+        type="button"
+      >
+        ✕
+      </button>
+      <a
+        class="appFooterLinksLink"
+        href="https://www.mozilla.org/about/legal/terms/mozilla"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Legal
+      </a>
+      <a
+        class="appFooterLinksLink"
+        href="https://www.mozilla.org/privacy/websites"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Privacy
+      </a>
+      <a
+        class="appFooterLinksLink"
+        href="https://www.mozilla.org/privacy/websites/#cookies"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Cookies
+      </a>
+      <select
+        class="appFooterLinksLanguageSwitcher"
+        title="Change language"
+      >
+        <option
+          value="de"
+        >
+          Deutsch
+        </option>
+        <option
+          value="el"
+        >
+          Ελληνικά
+        </option>
+        <option
+          value="en-GB"
+        >
+          English (GB)
+        </option>
+        <option
+          value="en-US"
+        >
+          English (US)
+        </option>
+        <option
+          value="es-CL"
+        >
+          Español
+        </option>
+        <option
+          value="fr"
+        >
+          Français
+        </option>
+        <option
+          value="ia"
+        >
+          Interlingua
+        </option>
+        <option
+          value="it"
+        >
+          Italiano
+        </option>
+        <option
+          value="nl"
+        >
+          Nederlands
+        </option>
+        <option
+          value="pt-BR"
+        >
+          Português (BR)
+        </option>
+        <option
+          value="sv-SE"
+        >
+          Svenska
+        </option>
+        <option
+          value="uk"
+        >
+          Українська
+        </option>
+        <option
+          value="zh-CN"
+        >
+          简体中文
+        </option>
+        <option
+          value="zh-TW"
+        >
+          正體中文
+        </option>
+      </select>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
![language-switching webm](https://user-images.githubusercontent.com/454175/155342371-6cca4502-ddb1-4f5e-941d-6ef0a4a62a77.gif)


See the [deploy preview](https://deploy-preview-3905--perf-html.netlify.app/public/n8np5p5b78df15c2kq3dtc3aa5vedvw19e4decr/)

This also localizes the `x` button as well as adding a few tests for the `FooterLinks` component. So it may be easier to look at the 3 commits separately.

In a next patch I intend to persist the chosen language.