### PR TITLE
Fix the requestAnimationFrame loop in case of losing focus in the Viewport component

### DIFF
--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -625,6 +625,10 @@ export const withChartViewport: WithChartViewport<*, *> =
         this._keysDown.delete(BARE_KEYMAP[event.nativeEvent.code]);
       };
 
+      _onBlur = () => {
+        this._keysDown.clear();
+      };
+
       _keyboardNavigation = (timestamp) => {
         if (this._keysDown.size === 0) {
           // No keys are down, nothing to do.  Don't request a new
@@ -839,6 +843,7 @@ export const withChartViewport: WithChartViewport<*, *> =
             onMouseDown={this._mouseDownListener}
             onKeyDown={this._keyDownListener}
             onKeyUp={this._keyUpListener}
+            onBlur={this._onBlur}
             ref={this._takeContainerRef}
             tabIndex={0}
           >


### PR DESCRIPTION
STR:
1. open a profile such as [this one](https://profiler.firefox.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/stack-chart/?globalTrackOrder=de0wc&hiddenGlobalTracks=1w57wb&hiddenLocalTracksByPid=29495-1w6~5123-0~29556-0~526-0~29603-0~29692-01~5053-01~29650-0~29726-0~4975-0~29481-0~21926-0&localTrackOrderByPid=29495-780w6~5123-0~29556-0~526-0~29603-0~29692-01~5023-0~5053-01~29650-0~29726-0~4975-0~29481-0~21926-10&thread=0&timelineType=cpu-category&v=6)
2. focus the chart
3. press one of the button that's being used such as qsdawe,
4. before unpressing it, press tab, or focus an another window

When this happens, the `keyup` event isn't caught by the `Viewport` component, and as a result we call `requestAnimationFrame` continuously. The user impact is mostly just CPU usage.

In this PR I also included a fix for the requestAnimationFrame mock we use in tests, for a bug I found while testing the new test on the main branch. Indeed in recent node versions, the logged error doesn't show the `message` but the `stack` property... which includes the `message` in normal operations. But in our mocks we were replacing the stack of an error with a proper message with the stack of an error without any message, and as a result we properly got an error in the test, but without any useful message.

cc @fqueze 