### PR TITLE
Make the IPC tracks hidden by default during the first profile load

### DIFF
--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -18,6 +18,7 @@ import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import {
   changeSelectedThreads,
   hideLocalTrack,
+  showLocalTrack,
 } from '../../actions/profile-view';
 import { TimelineLocalTrack } from '../../components/timeline/LocalTrack';
 import {
@@ -130,13 +131,37 @@ describe('timeline/LocalTrack', function () {
   });
 
   describe('with an IPC track', function () {
+    it('appears hidden by default', function () {
+      const { container } = setupWithIPC();
+      expect(container.querySelector('.timelineTrackHidden')).toBeTruthy();
+      expect(container.querySelector('.timelineTrack')).toBeFalsy();
+    });
+
+    it('can be shown', function () {
+      const { dispatch, pid, trackReference, container } = setupWithIPC();
+
+      // First check that the IPC track is hidden by default.
+      expect(container.querySelector('.timelineTrackHidden')).toBeTruthy();
+      expect(container.querySelector('.timelineTrack')).toBeFalsy();
+
+      // Now make it visible and check it.
+      dispatch(showLocalTrack(pid, trackReference.trackIndex));
+      expect(container.querySelector('.timelineTrackHidden')).toBeFalsy();
+      expect(container.querySelector('.timelineTrack')).toBeTruthy();
+    });
+
     it('correctly renders the IPC label', function () {
-      const { getLocalTrackLabel } = setupWithIPC();
+      const { dispatch, pid, trackReference, getLocalTrackLabel } =
+        setupWithIPC();
+      dispatch(showLocalTrack(pid, trackReference.trackIndex));
       expect(getLocalTrackLabel()).toHaveTextContent('IPC — Empty');
     });
 
     it('matches the snapshot of the IPC track', () => {
-      const { container } = setupWithIPC();
+      const { pid, dispatch, trackReference, container, flushRafCalls } =
+        setupWithIPC();
+      dispatch(showLocalTrack(pid, trackReference.trackIndex));
+      flushRafCalls();
       expect(container.firstChild).toMatchSnapshot();
     });
   });
@@ -191,6 +216,7 @@ function setup(
     pid: PID,
     getLocalTrackLabel,
     getLocalTrackRow,
+    flushRafCalls,
   };
 }
 

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -334,13 +334,13 @@ describe('MarkerTable', function () {
       // Make sure that it's hidden.
       expect(getHumanReadableTracks(getState())).toEqual([
         'hide [thread GeckoMain default]',
-        '  - show [ipc GeckoMain]',
+        '  - hide [ipc GeckoMain]',
         'show [thread GeckoMain tab] SELECTED',
-        '  - show [ipc GeckoMain] SELECTED',
+        '  - hide [ipc GeckoMain] SELECTED',
         '  - show [thread DOM Worker]',
-        '  - show [ipc DOM Worker]',
+        '  - hide [ipc DOM Worker]',
         '  - show [thread Style]',
-        '  - show [ipc Style]',
+        '  - hide [ipc Style]',
       ]);
 
       // Check the actual behavior now.
@@ -352,13 +352,13 @@ describe('MarkerTable', function () {
       // Make sure that it's not hidden anymore.
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default] SELECTED',
-        '  - show [ipc GeckoMain] SELECTED',
+        '  - hide [ipc GeckoMain] SELECTED',
         'show [thread GeckoMain tab]',
-        '  - show [ipc GeckoMain]',
+        '  - hide [ipc GeckoMain]',
         '  - show [thread DOM Worker]',
-        '  - show [ipc DOM Worker]',
+        '  - hide [ipc DOM Worker]',
         '  - show [thread Style]',
-        '  - show [ipc Style]',
+        '  - hide [ipc Style]',
       ]);
     });
 
@@ -392,13 +392,13 @@ describe('MarkerTable', function () {
       // Make sure that they are hidden.
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default] SELECTED',
-        '  - show [ipc GeckoMain] SELECTED',
+        '  - hide [ipc GeckoMain] SELECTED',
         'hide [thread GeckoMain tab]',
-        '  - show [ipc GeckoMain]',
+        '  - hide [ipc GeckoMain]',
         '  - hide [thread DOM Worker]',
-        '  - show [ipc DOM Worker]',
+        '  - hide [ipc DOM Worker]',
         '  - show [thread Style]',
-        '  - show [ipc Style]',
+        '  - hide [ipc Style]',
       ]);
 
       // Check the actual behavior now.
@@ -410,13 +410,13 @@ describe('MarkerTable', function () {
       // Make sure that they are not hidden anymore.
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default]',
-        '  - show [ipc GeckoMain]',
+        '  - hide [ipc GeckoMain]',
         'show [thread GeckoMain tab]',
-        '  - show [ipc GeckoMain]',
+        '  - hide [ipc GeckoMain]',
         '  - show [thread DOM Worker] SELECTED',
-        '  - show [ipc DOM Worker] SELECTED',
+        '  - hide [ipc DOM Worker] SELECTED',
         '  - show [thread Style]',
-        '  - show [ipc Style]',
+        '  - hide [ipc Style]',
       ]);
     });
 

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -671,10 +671,10 @@ describe('ordering and hiding', function () {
         'show [thread GeckoMain default]',
         'show [thread GeckoMain tab] SELECTED',
         // Belongs to the global tab track.
-        '  - show [ipc GeckoMain] SELECTED',
+        '  - hide [ipc GeckoMain] SELECTED',
         '  - show [thread DOM Worker]',
         // Belongs to the DOM Worker local track.
-        '  - show [ipc DOM Worker]',
+        '  - hide [ipc DOM Worker]',
         '  - show [thread Style]',
       ]);
     });


### PR DESCRIPTION
Fixes #3888.

Let's not make them visible by default, so they wouldn't take up a lot of space in the timeline. People still can always make them visible by using the tracks context menu if they are interested in them.

Example profile: [production](https://profiler.firefox.com/public/3cv7e4mtrp963rcb6nbws7rzgj4mwy6ggs4md0r/) / [deploy preview](https://deploy-preview-3908--perf-html.netlify.app/public/3cv7e4mtrp963rcb6nbws7rzgj4mwy6ggs4md0r/)