### PR TITLE
Add the operation count to the memory graph tooltip

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -657,6 +657,15 @@ TrackContextMenu--show-all-tracks-below = Show all tracks below
 #   $searchFilter (String) - The search filter string that user enters.
 TrackContextMenu--no-results-found = No results found for “<span>{ $searchFilter }</span>”
 
+## TrackMemoryGraph
+## This is used to show the memory graph of that process in the timeline part of
+## the UI. To learn more about it, visit:
+## https://profiler.firefox.com/docs/#/./memory-allocations?id=memory-track
+
+TrackMemoryGraph--relative-memory-at-this-time = relative memory at this time
+TrackMemoryGraph--memory-range-in-graph = memory range in graph
+TrackMemoryGraph--operations-since-the-previous-sample = operations since the previous sample
+
 ## TrackSearchField
 ## The component that is used for the search input in the track context menu.
 

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -6,6 +6,7 @@
 
 import * as React from 'react';
 import { InView } from 'react-intersection-observer';
+import { Localized } from '@fluent/react';
 import { withSize } from 'firefox-profiler/components/shared/WithSize';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import {
@@ -363,19 +364,27 @@ class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
           <span className="timelineTrackMemoryTooltipNumber">
             {formatBytes(bytes)}
           </span>
-          {' relative memory at this time'}
+          <Localized id="TrackMemoryGraph--relative-memory-at-this-time">
+            relative memory at this time
+          </Localized>
         </div>
+
         <div className="timelineTrackMemoryTooltipLine">
           <span className="timelineTrackMemoryTooltipNumber">
             {formatBytes(countRange)}
           </span>
-          {' memory range in graph'}
+          <Localized id="TrackMemoryGraph--memory-range-in-graph">
+            memory range in graph
+          </Localized>
         </div>
+
         <div className="timelineTrackMemoryTooltipLine">
           <span className="timelineTrackMemoryTooltipNumber">
             {formatNumber(allocations, 2, 0)}
           </span>
-          {' operations since the previous sample'}
+          <Localized id="TrackMemoryGraph--operations-since-the-previous-sample">
+            operations since the previous sample
+          </Localized>
         </div>
       </div>
     );

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -283,6 +283,12 @@ class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
   };
 
   _onMouseLeave = () => {
+    // This persistTooltips property is part of the web console API. It helps
+    // in being able to inspect and debug tooltips.
+    if (window.persistTooltips) {
+      return;
+    }
+
     this.setState({ hoveredCounter: null });
   };
 

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -8,7 +8,10 @@ import * as React from 'react';
 import { InView } from 'react-intersection-observer';
 import { withSize } from 'firefox-profiler/components/shared/WithSize';
 import explicitConnect from 'firefox-profiler/utils/connect';
-import { formatBytes } from 'firefox-profiler/utils/format-numbers';
+import {
+  formatBytes,
+  formatNumber,
+} from 'firefox-profiler/utils/format-numbers';
 import { bisectionRight } from 'firefox-profiler/utils/bisect';
 import {
   getCommittedRange,
@@ -338,14 +341,16 @@ class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
   };
 
   _renderTooltip(counterIndex: number): React.Node {
-    if (this.props.accumulatedSamples.length === 0) {
+    const { accumulatedSamples, counter } = this.props;
+    if (accumulatedSamples.length === 0) {
       // Gecko failed to capture samples for some reason and it shouldn't happen for
       // malloc counter. Print an error and bail out early.
       throw new Error('No accumulated sample found for memory counter');
     }
-    const { minCount, countRange, accumulatedCounts } =
-      this.props.accumulatedSamples[0];
+    const { minCount, countRange, accumulatedCounts } = accumulatedSamples[0];
     const bytes = accumulatedCounts[counterIndex] - minCount;
+    const { number } = counter.sampleGroups[0].samples;
+    const allocations = number[counterIndex];
     return (
       <div className="timelineTrackMemoryTooltip">
         <div className="timelineTrackMemoryTooltipLine">
@@ -359,6 +364,12 @@ class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
             {formatBytes(countRange)}
           </span>
           {' memory range in graph'}
+        </div>
+        <div className="timelineTrackMemoryTooltipLine">
+          <span className="timelineTrackMemoryTooltipNumber">
+            {formatNumber(allocations, 2, 0)}
+          </span>
+          {' operations since the previous sample'}
         </div>
       </div>
     );

--- a/src/components/timeline/TrackMemoryGraph.js
+++ b/src/components/timeline/TrackMemoryGraph.js
@@ -356,10 +356,19 @@ class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
     }
     const { minCount, countRange, accumulatedCounts } = accumulatedSamples[0];
     const bytes = accumulatedCounts[counterIndex] - minCount;
-    const { number } = counter.sampleGroups[0].samples;
-    const allocations = number[counterIndex];
+    const operationsCounters = counter.sampleGroups[0].samples.number;
+    const operations = operationsCounters[counterIndex];
     return (
       <div className="timelineTrackMemoryTooltip">
+        <div className="timelineTrackMemoryTooltipLine">
+          <span className="timelineTrackMemoryTooltipNumber">
+            {formatNumber(operations, 2, 0)}
+          </span>
+          <Localized id="TrackMemoryGraph--operations-since-the-previous-sample">
+            operations since the previous sample
+          </Localized>
+        </div>
+
         <div className="timelineTrackMemoryTooltipLine">
           <span className="timelineTrackMemoryTooltipNumber">
             {formatBytes(bytes)}
@@ -375,15 +384,6 @@ class TrackMemoryGraphImpl extends React.PureComponent<Props, State> {
           </span>
           <Localized id="TrackMemoryGraph--memory-range-in-graph">
             memory range in graph
-          </Localized>
-        </div>
-
-        <div className="timelineTrackMemoryTooltipLine">
-          <span className="timelineTrackMemoryTooltipNumber">
-            {formatNumber(allocations, 2, 0)}
-          </span>
-          <Localized id="TrackMemoryGraph--operations-since-the-previous-sample">
-            operations since the previous sample
           </Localized>
         </div>
       </div>

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -17,6 +17,16 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
     <span
       class="timelineTrackMemoryTooltipNumber"
     >
+      36
+    </span>
+    operations since the previous sample
+  </div>
+  <div
+    class="timelineTrackMemoryTooltipLine"
+  >
+    <span
+      class="timelineTrackMemoryTooltipNumber"
+    >
       0.000B
     </span>
     relative memory at this time
@@ -30,16 +40,6 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
       2B
     </span>
     memory range in graph
-  </div>
-  <div
-    class="timelineTrackMemoryTooltipLine"
-  >
-    <span
-      class="timelineTrackMemoryTooltipNumber"
-    >
-      36
-    </span>
-    operations since the previous sample
   </div>
 </div>
 `;

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -31,6 +31,16 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
     </span>
      memory range in graph
   </div>
+  <div
+    class="timelineTrackMemoryTooltipLine"
+  >
+    <span
+      class="timelineTrackMemoryTooltipNumber"
+    >
+      36
+    </span>
+     operations since the previous sample
+  </div>
 </div>
 `;
 

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -19,7 +19,7 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
     >
       0.000B
     </span>
-     relative memory at this time
+    relative memory at this time
   </div>
   <div
     class="timelineTrackMemoryTooltipLine"
@@ -29,7 +29,7 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
     >
       2B
     </span>
-     memory range in graph
+    memory range in graph
   </div>
   <div
     class="timelineTrackMemoryTooltipLine"
@@ -39,7 +39,7 @@ exports[`TrackMemory has a tooltip that matches the snapshot 1`] = `
     >
       36
     </span>
-     operations since the previous sample
+    operations since the previous sample
   </div>
 </div>
 `;


### PR DESCRIPTION
It would be easier to look at it commit by commit. 
This PR does two things:
1. Adds the operation count to the memory graph.
2. Makes the memory graph tooltip localizable.

WIth this additional field, tooltip looks like this:
<img width="359" alt="Screen Shot 2022-03-03 at 2 51 57 PM" src="https://user-images.githubusercontent.com/466239/156578504-116d1a03-4dee-4c3f-8a7e-196d99bc2588.png">

This is how it looks with the pseudo localization:
<img width="458" alt="Screen Shot 2022-03-03 at 2 54 13 PM" src="https://user-images.githubusercontent.com/466239/156578530-9b98ba8c-53c5-4bcb-bb92-87cea5bb606a.png">

Example profile: [production](https://share.firefox.dev/3Mk1e5p) /[ deploy preview](https://deploy-preview-3915--perf-html.netlify.app/public/nj89s0vzfs795cd263qwphynht2y05dvggt5thg/marker-chart/?globalTrackOrder=80w7&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=18380-0w68wa~18405-01~18381-01~18391-01~18390-01~18397-01~18385-01&localTrackOrderByPid=18380-670w58wa~18405-01~18381-01~18391-01~18390-01~18397-01~18385-01~18388-0w2&thread=0&timelineType=cpu-category&v=6)