### PR TITLE
Reword some ftl strings to clarify them

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -341,7 +341,7 @@ MarkerContextMenu--end-selection-at-marker-end =
 MarkerContextMenu--copy-description = Copy description
 MarkerContextMenu--copy-call-stack = Copy call stack
 MarkerContextMenu--copy-url = Copy URL
-MarkerContextMenu--copy-full-payload = Copy full payload
+MarkerContextMenu--copy-as-json = Copy as JSON
 
 ## MarkerSettings
 ## This is used in all panels related to markers.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -633,7 +633,7 @@ TabBar--js-tracer-tab = JS Tracer
 ## This is used as a context menu for timeline to organize the tracks in the
 ## analysis UI.
 
-TrackContextMenu--only-show-this-process-group = Only show this process group
+TrackContextMenu--only-show-this-process = Only show this process
 
 # This is used as the context menu item to show only the given track.
 # Variables:

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -360,8 +360,8 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
         ) : null}
         <MenuItem onClick={this.copyMarkerJSON}>
           <span className="react-contextmenu-icon markerContextMenuIconCopyPayload" />
-          <Localized id="MarkerContextMenu--copy-full-payload">
-            Copy full payload
+          <Localized id="MarkerContextMenu--copy-as-json">
+            Copy as JSON
           </Localized>
         </MenuItem>
       </ContextMenu>

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -522,8 +522,8 @@ class TimelineTrackContextMenuImpl extends PureComponent<
 
     return (
       <MenuItem onClick={this._isolateProcess} disabled={isDisabled}>
-        <Localized id="TrackContextMenu--only-show-this-process-group">
-          Only show this process group
+        <Localized id="TrackContextMenu--only-show-this-process">
+          Only show this process
         </Localized>
       </MenuItem>
     );

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -153,7 +153,7 @@ exports[`MarkerChart context menus displays when right clicking on a marker 1`] 
     <span
       class="react-contextmenu-icon markerContextMenuIconCopyPayload"
     />
-    Copy full payload
+    Copy as JSON
   </div>
 </nav>
 `;

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -64,7 +64,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     role="menuitem"
     tabindex="-1"
   >
-    Only show this process group
+    Only show this process
   </div>
   <div
     aria-disabled="false"


### PR DESCRIPTION
This PR changes two strings:
1. "Only show this process group" -> "Only show this process".
This is changed because it looks like some translations (e.g. French) are not 100% accurate with this one. They usually get confused around the "process group" thinking that there are multiple processes involved. Removing the "group" doesn't change the meaning for English and hope it makes the translation easier.
2. "Copy full payload" -> "Copy as JSON". 
This was also not accurate for every translations (e.g. French again). And it's also not really accurate actually. "payload" is only a part of the marker, but we are copying the whole marker. This change makes both English and translations' wording correct.

cc @fqueze 