### PR TITLE
WIP: Share resourceTable between threads

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -32,6 +32,7 @@ import type {
   WeightType,
   SamplesLikeTable,
   TracedTiming,
+  Resource,
 } from 'firefox-profiler/types';
 
 import type {
@@ -62,6 +63,7 @@ export type OwnProps = {|
   +shouldDisplayTooltips: () => boolean,
   +scrollToSelectionGeneration: number,
   +categories: CategoryList,
+  +resources: Resource[],
   +interval: Milliseconds,
   +isInverted: boolean,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
@@ -278,6 +280,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       callNodeInfo,
       shouldDisplayTooltips,
       categories,
+      resources,
       interval,
       isInverted,
       callTreeSummaryStrategy,
@@ -323,6 +326,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
         thread={thread}
         weightType={weightType}
         pages={pages}
+        resources={resources}
         interval={interval}
         callNodeIndex={callNodeIndex}
         callNodeInfo={callNodeInfo}

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -10,6 +10,7 @@ import { FlameGraphCanvas } from './Canvas';
 
 import {
   getCategories,
+  getResources,
   getCommittedRange,
   getPreviewSelection,
   getScrollToSelectionGeneration,
@@ -33,6 +34,7 @@ import {
 import type {
   Thread,
   CategoryList,
+  Resource,
   PageList,
   Milliseconds,
   StartEndRange,
@@ -80,6 +82,7 @@ type StateProps = {|
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +scrollToSelectionGeneration: number,
   +categories: CategoryList,
+  +resources: Resource[],
   +interval: Milliseconds,
   +isInverted: boolean,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
@@ -313,6 +316,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
       scrollToSelectionGeneration,
       callTreeSummaryStrategy,
       categories,
+      resources,
       interval,
       isInverted,
       pages,
@@ -359,6 +363,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
               callTree,
               callNodeInfo,
               categories,
+              resources,
               selectedCallNodeIndex,
               rightClickedCallNodeIndex,
               scrollToSelectionGeneration,
@@ -405,6 +410,7 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
     previewSelection: getPreviewSelection(state),
     callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
     categories: getCategories(state),
+    resources: getResources(state),
     threadsKey: getSelectedThreadsKey(state),
     selectedCallNodeIndex:
       selectedThreadSelectors.getSelectedCallNodeIndex(state),

--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -17,6 +17,7 @@ import type {
   Thread,
   IndexIntoStackTable,
   ImplementationFilter,
+  Resource,
 } from 'firefox-profiler/types';
 
 import './Backtrace.css';
@@ -29,11 +30,18 @@ type Props = {|
   +stackIndex: IndexIntoStackTable,
   +implementationFilter: ImplementationFilter,
   +categories: CategoryList,
+  +resources: Resource[],
 |};
 
 export function Backtrace(props: Props) {
-  const { stackIndex, thread, implementationFilter, maxStacks, categories } =
-    props;
+  const {
+    stackIndex,
+    thread,
+    implementationFilter,
+    maxStacks,
+    categories,
+    resources,
+  } = props;
   const callNodePath = filterCallNodeAndCategoryPathByImplementation(
     thread,
     implementationFilter,
@@ -41,7 +49,8 @@ export function Backtrace(props: Props) {
   );
   const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(
     callNodePath,
-    thread
+    thread,
+    resources
   ).reverse();
 
   if (funcNamesAndOrigins.length) {

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -25,6 +25,7 @@ import {
 } from 'firefox-profiler/selectors/url-state';
 import { getRightClickedCallNodeInfo } from 'firefox-profiler/selectors/right-clicked-call-node';
 import { getThreadSelectorsFromThreadsKey } from 'firefox-profiler/selectors/per-thread';
+import { getProfile } from 'firefox-profiler/selectors';
 import { oneLine } from 'common-tags';
 
 import {
@@ -38,6 +39,7 @@ import type {
   IndexIntoCallNodeTable,
   CallNodeInfo,
   CallNodePath,
+  Profile,
   Thread,
   ThreadsKey,
 } from 'firefox-profiler/types';
@@ -46,6 +48,7 @@ import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 type StateProps = {|
+  +profile: Profile | null,
   +thread: Thread | null,
   +threadsKey: ThreadsKey | null,
   +callNodeInfo: CallNodeInfo | null,
@@ -331,7 +334,8 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
 
     const {
       callNodePath,
-      thread: { funcTable, stringTable, resourceTable },
+      profile,
+      thread: { funcTable, stringTable },
     } = rightClickedCallNodeInfo;
 
     const funcIndex = callNodePath[callNodePath.length - 1];
@@ -350,8 +354,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
     if (resourceIndex === -1) {
       return null;
     }
-    const resNameStringIndex = resourceTable.name[resourceIndex];
-    return stringTable.getString(resNameStringIndex);
+    return profile.resources[resourceIndex].name;
   }
 
   /**
@@ -385,6 +388,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
   }
 
   getRightClickedCallNodeInfo(): null | {|
+    +profile: Profile,
     +thread: Thread,
     +threadsKey: ThreadsKey,
     +callNodeInfo: CallNodeInfo,
@@ -392,6 +396,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
     +callNodeIndex: IndexIntoCallNodeTable,
   |} {
     const {
+      profile,
       thread,
       threadsKey,
       callNodeInfo,
@@ -400,6 +405,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
     } = this.props;
 
     if (
+      profile &&
       thread &&
       threadsKey !== null &&
       callNodeInfo &&
@@ -407,6 +413,7 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
       typeof rightClickedCallNodeIndex === 'number'
     ) {
       return {
+        profile,
         thread,
         threadsKey,
         callNodeInfo,
@@ -658,6 +665,7 @@ export const CallNodeContextMenu = explicitConnect<
   mapStateToProps: (state) => {
     const rightClickedCallNodeInfo = getRightClickedCallNodeInfo(state);
 
+    let profile = null;
     let thread = null;
     let threadsKey = null;
     let callNodeInfo = null;
@@ -669,6 +677,7 @@ export const CallNodeContextMenu = explicitConnect<
         rightClickedCallNodeInfo.threadsKey
       );
 
+      profile = getProfile(state);
       thread = selectors.getThread(state);
       threadsKey = rightClickedCallNodeInfo.threadsKey;
       callNodeInfo = selectors.getCallNodeInfo(state);
@@ -677,6 +686,7 @@ export const CallNodeContextMenu = explicitConnect<
     }
 
     return {
+      profile,
       thread,
       threadsKey,
       callNodeInfo,

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -30,10 +30,12 @@ import type {
   IndexIntoStackTable,
   Thread,
   MarkerReference,
+  Resource,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import { getImplementationFilter } from 'firefox-profiler/selectors/url-state';
+import { getResources } from 'firefox-profiler/selectors';
 
 import { filterCallNodeAndCategoryPathByImplementation } from 'firefox-profiler/profile-logic/transforms';
 import {
@@ -55,6 +57,7 @@ type StateProps = {|
   +committedRange: StartEndRange,
   +thread: Thread | null,
   +implementationFilter: ImplementationFilter,
+  +resources: Resource[],
   +getMarkerLabelToCopy: (MarkerIndex) => string,
 |};
 
@@ -145,7 +148,7 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
   }
 
   _convertStackToString(stack: IndexIntoStackTable): string {
-    const { thread, implementationFilter } = this.props;
+    const { thread, implementationFilter, resources } = this.props;
 
     if (thread === null) {
       return '';
@@ -157,7 +160,11 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
       convertStackToCallNodeAndCategoryPath(thread, stack)
     );
 
-    const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(path, thread);
+    const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(
+      path,
+      thread,
+      resources
+    );
     return funcNamesAndOrigins
       .map(({ funcName, origin }) => `${funcName} [${origin}]`)
       .join('\n');
@@ -382,6 +389,7 @@ const MarkerContextMenu = explicitConnect<OwnProps, StateProps, DispatchProps>({
       previewSelection: getPreviewSelection(state),
       committedRange: getCommittedRange(state),
       implementationFilter: getImplementationFilter(state),
+      resources: getResources(state),
       thread: selectors.getThread(state),
       getMarkerLabelToCopy: selectors.getMarkerLabelToCopyGetter(state),
     };

--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -17,6 +17,7 @@ import type {
   ImplementationFilter,
   IndexIntoSamplesTable,
   CategoryList,
+  Resource,
   Thread,
 } from 'firefox-profiler/types';
 import type { CpuRatioInTimeRange } from './thread/ActivityGraphFills';
@@ -26,6 +27,7 @@ type CPUProps = CpuRatioInTimeRange;
 type RestProps = {|
   +sampleIndex: IndexIntoSamplesTable,
   +categories: CategoryList,
+  +resources: Resource[],
   +rangeFilteredThread: Thread,
   +implementationFilter: ImplementationFilter,
 |};
@@ -67,6 +69,7 @@ class SampleTooltipRestContents extends React.PureComponent<RestProps> {
       sampleIndex,
       rangeFilteredThread,
       categories,
+      resources,
       implementationFilter,
     } = this.props;
     const { samples, stackTable } = rangeFilteredThread;
@@ -97,6 +100,7 @@ class SampleTooltipRestContents extends React.PureComponent<RestProps> {
           stackIndex={stackIndex}
           thread={rangeFilteredThread}
           implementationFilter={implementationFilter}
+          resources={resources}
           categories={categories}
         />
       </>
@@ -116,6 +120,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
       rangeFilteredThread,
       categories,
       implementationFilter,
+      resources,
     } = this.props;
     return (
       <>
@@ -130,6 +135,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
           rangeFilteredThread={rangeFilteredThread}
           categories={categories}
           implementationFilter={implementationFilter}
+          resources={resources}
         />
       </>
     );

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -26,6 +26,7 @@ import type {
   SelectedState,
   Milliseconds,
   CssPixels,
+  Resource,
 } from 'firefox-profiler/types';
 import type {
   ActivityFillGraphQuerier,
@@ -46,6 +47,7 @@ export type Props = {|
     sampleIndex: IndexIntoSamplesTable
   ) => void,
   +categories: CategoryList,
+  +resources: Resource[],
   +samplesSelectedStates: null | SelectedState[],
   +treeOrderSampleComparator: (
     IndexIntoSamplesTable,
@@ -157,6 +159,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
       fullThread,
       rangeFilteredThread,
       categories,
+      resources,
       trackName,
       interval,
       rangeStart,
@@ -208,6 +211,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
               rangeFilteredThread={rangeFilteredThread}
               categories={categories}
               implementationFilter={implementationFilter}
+              resources={resources}
             />
           </Tooltip>
         )}

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -36,6 +36,7 @@ import type {
   UnitIntervalOfProfileRange,
   MarkerIndex,
   Marker,
+  Resource,
 } from 'firefox-profiler/types';
 
 import type {
@@ -60,6 +61,7 @@ type OwnProps = {|
   >,
   +getMarker: (MarkerIndex) => Marker,
   +categories: CategoryList,
+  +resources: Resource[],
   +callNodeInfo: CallNodeInfo,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +onSelectionChange: (IndexIntoCallNodeTable | null) => void,
@@ -414,6 +416,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       threadsKey,
       combinedTimingRows,
       categories,
+      resources,
       callNodeInfo,
       getMarker,
       shouldDisplayTooltips,
@@ -453,6 +456,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
         callNodeIndex={callNodeIndex}
         callNodeInfo={callNodeInfo}
         categories={categories}
+        resources={resources}
         // The stack chart doesn't support other call tree summary types.
         callTreeSummaryStrategy="timing"
         durationText={formatMilliseconds(duration)}

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -17,6 +17,7 @@ import {
   getScrollToSelectionGeneration,
   getCategories,
   getPageList,
+  getResources,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import {
@@ -53,6 +54,7 @@ import type {
   WeightType,
   ThreadsKey,
   CssPixels,
+  Resource,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -73,6 +75,7 @@ type StateProps = {|
   +threadsKey: ThreadsKey,
   +callNodeInfo: CallNodeInfo,
   +categories: CategoryList,
+  +resources: Resource[],
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +scrollToSelectionGeneration: number,
@@ -171,6 +174,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       updatePreviewSelection,
       callNodeInfo,
       categories,
+      resources,
       selectedCallNodeIndex,
       scrollToSelectionGeneration,
       pages,
@@ -228,6 +232,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   stackFrameHeight: STACK_FRAME_HEIGHT,
                   callNodeInfo,
                   categories,
+                  resources,
                   selectedCallNodeIndex,
                   onSelectionChange: this._onSelectedCallNodeChange,
                   // TODO: support right clicking user timing markers #2354.
@@ -264,6 +269,7 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       threadsKey: getSelectedThreadsKey(state),
       callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
       categories: getCategories(state),
+      resources: getResources(state),
       selectedCallNodeIndex:
         selectedThreadSelectors.getSelectedCallNodeIndex(state),
       rightClickedCallNodeIndex:

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -24,6 +24,7 @@ import {
   getSelectedThreadIndexes,
   getTimelineType,
   getInvertCallstack,
+  getResources,
   getTimelineTrackOrganization,
   getThreadSelectorsFromThreadsKey,
   getMaxThreadCPUDelta,
@@ -66,6 +67,7 @@ import type {
   State,
   TimelineTrackOrganization,
   ThreadsKey,
+  Resource,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -90,6 +92,7 @@ type StateProps = {|
   +rangeEnd: Milliseconds,
   +sampleIndexOffset: number,
   +categories: CategoryList,
+  +resources: Resource[],
   +timelineType: TimelineType,
   +hasFileIoMarkers: boolean,
   +samplesSelectedStates: null | SelectedState[],
@@ -204,6 +207,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       selectedCallNodeIndex,
       unfilteredSamplesRange,
       categories,
+      resources,
       timelineType,
       hasFileIoMarkers,
       showMemoryMarkers,
@@ -281,6 +285,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               sampleIndexOffset={sampleIndexOffset}
               onSampleClick={this._onSampleClick}
               categories={categories}
+              resources={resources}
               samplesSelectedStates={samplesSelectedStates}
               treeOrderSampleComparator={treeOrderSampleComparator}
               enableCPUUsage={enableCPUUsage}
@@ -426,6 +431,7 @@ export const TimelineTrackThread = explicitConnect<
       sampleIndexOffset:
         selectors.getSampleIndexOffsetFromCommittedRange(state),
       categories: getCategories(state),
+      resources: getResources(state),
       timelineType,
       hasFileIoMarkers:
         selectors.getTimelineFileIoMarkerIndexes(state).length !== 0,

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -18,6 +18,7 @@ import type { CallTree } from 'firefox-profiler/profile-logic/call-tree';
 import type {
   Thread,
   CategoryList,
+  Resource,
   PageList,
   IndexIntoCallNodeTable,
   CallNodeDisplayData,
@@ -40,6 +41,7 @@ type Props = {|
   +pages: PageList | null,
   +callNodeIndex: IndexIntoCallNodeTable,
   +callNodeInfo: CallNodeInfo,
+  +resources: Resource[],
   +categories: CategoryList,
   +interval: Milliseconds,
   // Since this tooltip can be used in different context, provide some kind of duration
@@ -175,6 +177,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
       callNodeIndex,
       thread,
       durationText,
+      resources,
       categories,
       callTree,
       timings,
@@ -233,7 +236,6 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     const resourceIndex = thread.funcTable.resource[funcIndex];
 
     if (resourceIndex !== -1) {
-      const resourceNameIndex = thread.resourceTable.name[resourceIndex];
       // Because of our use of Grid Layout, all our elements need to be direct
       // children of the grid parent. That's why we use arrays here, to add
       // the elements as direct children.
@@ -241,7 +243,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         <div className="tooltipLabel" key="resource">
           Resource:
         </div>,
-        thread.stringTable.getString(resourceNameIndex),
+        resources[resourceIndex].name,
       ];
     }
 

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -19,6 +19,7 @@ import {
   getZeroAt,
   getThreadIdToNameMap,
   getThreadSelectorsFromThreadsKey,
+  getResources,
 } from 'firefox-profiler/selectors';
 
 import {
@@ -48,6 +49,7 @@ import type {
   PageList,
   MarkerSchemaByName,
   MarkerIndex,
+  Resource,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -87,6 +89,7 @@ type StateProps = {|
   +threadIdToNameMap: Map<number, string>,
   +markerSchemaByName: MarkerSchemaByName,
   +getMarkerLabel: (MarkerIndex) => string,
+  +resources: Resource[],
   +categories: CategoryList,
 |};
 
@@ -319,6 +322,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
       thread,
       implementationFilter,
       restrictHeightWidth,
+      resources,
       categories,
     } = this.props;
     const { data, start } = marker;
@@ -349,6 +353,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
               stackIndex={cause.stack}
               thread={thread}
               implementationFilter={implementationFilter}
+              resources={resources}
               categories={categories}
             />
           </div>
@@ -430,6 +435,7 @@ export const TooltipMarker = explicitConnect<OwnProps, StateProps, {||}>({
       threadIdToNameMap: getThreadIdToNameMap(state),
       markerSchemaByName: getMarkerSchemaByName(state),
       getMarkerLabel: selectors.getMarkerTooltipLabelGetter(state),
+      resources: getResources(state),
       categories: getCategories(state),
     };
   },

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -19,7 +19,6 @@ import type {
   JsAllocationsTable,
   UnbalancedNativeAllocationsTable,
   BalancedNativeAllocationsTable,
-  ResourceTable,
   NativeSymbolTable,
   Profile,
   ExtensionTable,
@@ -176,20 +175,6 @@ export function shallowCloneNativeSymbolTable(
   };
 }
 
-export function getEmptyResourceTable(): ResourceTable {
-  return {
-    // Important!
-    // If modifying this structure, please update all callers of this function to ensure
-    // that they are pushing on correctly to the data structure. These pushes may not
-    // be caught by the type system.
-    lib: [],
-    name: [],
-    host: [],
-    type: [],
-    length: 0,
-  };
-}
-
 export function getEmptyNativeSymbolTable(): NativeSymbolTable {
   return {
     // Important!
@@ -293,24 +278,6 @@ export function shallowCloneRawMarkerTable(
   };
 }
 
-export function getResourceTypes() {
-  return {
-    unknown: 0,
-    library: 1,
-    addon: 2,
-    webhost: 3,
-    otherhost: 4,
-    url: 5,
-  };
-}
-
-/**
- * Export a read-only copy of the resource types.
- */
-export const resourceTypes = (getResourceTypes(): $Exact<
-  $ReadOnly<$Call<typeof getResourceTypes>>
->);
-
 export function getEmptyExtensions(): ExtensionTable {
   return {
     // Important!
@@ -372,7 +339,6 @@ export function getEmptyThread(overrides?: $Shape<Thread>): Thread {
     frameTable: getEmptyFrameTable(),
     stringTable: new UniqueStringArray(),
     funcTable: getEmptyFuncTable(),
-    resourceTable: getEmptyResourceTable(),
     nativeSymbols: getEmptyNativeSymbolTable(),
   };
 
@@ -407,6 +373,7 @@ export function getEmptyProfile(): Profile {
       markerSchema: [],
     },
     libs: [],
+    resources: [],
     pages: [],
     threads: [],
   };

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -16,7 +16,6 @@ import {
 } from './process-profile';
 import {
   getEmptyProfile,
-  getEmptyResourceTable,
   getEmptyNativeSymbolTable,
   getEmptyFrameTable,
   getEmptyFuncTable,
@@ -44,7 +43,7 @@ import type {
   CategoryList,
   IndexIntoFrameTable,
   IndexIntoFuncTable,
-  IndexIntoResourceTable,
+  IndexIntoResources,
   IndexIntoLibs,
   IndexIntoNativeSymbolTable,
   IndexIntoStackTable,
@@ -53,7 +52,6 @@ import type {
   FrameTable,
   Lib,
   NativeSymbolTable,
-  ResourceTable,
   StackTable,
   SamplesTable,
   UrlState,
@@ -294,8 +292,8 @@ type TranslationMapForCategories = Map<
 >;
 type TranslationMapForFuncs = Map<IndexIntoFuncTable, IndexIntoFuncTable>;
 type TranslationMapForResources = Map<
-  IndexIntoResourceTable,
-  IndexIntoResourceTable
+  IndexIntoResources,
+  IndexIntoResources
 >;
 type TranslationMapForNativeSymbols = Map<
   IndexIntoNativeSymbolTable,
@@ -491,7 +489,7 @@ function combineResourceTables(
   resourceTable: ResourceTable,
   translationMaps: TranslationMapForResources[],
 } {
-  const mapOfInsertedResources: Map<string, IndexIntoResourceTable> = new Map();
+  const mapOfInsertedResources: Map<string, IndexIntoResources> = new Map();
   const translationMaps = [];
   const newResourceTable = getEmptyResourceTable();
 

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -13,7 +13,6 @@
  */
 
 import { sortDataTable } from '../utils/data-table-utils';
-import { resourceTypes } from './data-structures';
 import { UniqueStringArray } from '../utils/unique-string-array';
 import { timeCode } from '../utils/time-code';
 import { PROCESSED_PROFILE_VERSION } from '../app-logic/constants';
@@ -320,6 +319,14 @@ const _upgraders = {
         icon: [],
         addonId: [],
         host: [],
+      };
+      const resourceTypes = {
+        unknown: 0,
+        library: 1,
+        addon: 2,
+        webhost: 3,
+        otherhost: 4,
+        url: 5,
       };
       function addLibResource(name, lib) {
         const index = newResourceTable.length++;
@@ -1754,6 +1761,7 @@ const _upgraders = {
     // The frame table has a new field: nativeSymbol.
     // The function table loses one field: address. (This field moves to the nativeSymbols table.)
     // The NativeSymbolsTable has the fields libIndex, address, and name.
+    const RESOURCE_TYPE_LIBRARY = 1;
     for (const thread of profile.threads) {
       const nativeSymbols = {
         libIndex: [],
@@ -1772,7 +1780,7 @@ const _upgraders = {
           continue;
         }
         const resourceType = resourceTable.type[resourceIndex];
-        if (resourceType !== resourceTypes.library) {
+        if (resourceType !== RESOURCE_TYPE_LIBRARY) {
           continue;
         }
         const libIndex = resourceTable.lib[resourceIndex];
@@ -2107,5 +2115,6 @@ const _upgraders = {
     }
     profile.libs = libs;
   },
+  // TODO: Upgrader for shared resources
 };
 /* eslint-enable no-useless-computed-key */

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -444,8 +444,7 @@ function sanitizeThreadPII(
     // be split in 2.
     const funcIndexesToBeKept = new Set();
 
-    const { frameTable, funcTable, resourceTable, stackTable, samples } =
-      newThread;
+    const { frameTable, funcTable, stackTable, samples } = newThread;
     for (let frameIndex = 0; frameIndex < frameTable.length; frameIndex++) {
       const innerWindowID = frameTable.innerWindowID[frameIndex];
       const funcIndex = frameTable.func[frameIndex];

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -223,7 +223,8 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
   const getLib: Selector<string> = createSelector(
     selectedThreadSelectors.getSelectedCallNodePath,
     selectedThreadSelectors.getFilteredThread,
-    (selectedPath, { stringTable, funcTable, resourceTable }) => {
+    ProfileSelectors.getResources,
+    (selectedPath, { stringTable, funcTable }, resources) => {
       if (!selectedPath.length) {
         return '';
       }
@@ -231,7 +232,7 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
       return ProfileData.getOriginAnnotationForFunc(
         ProfileData.getLeafFuncIndex(selectedPath),
         funcTable,
-        resourceTable,
+        resources,
         stringTable
       );
     }

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -236,6 +236,7 @@ export function getStackAndSampleSelectorsPerThread(
     ProfileSelectors.getProfileInterval,
     getCallNodeInfo,
     ProfileSelectors.getCategories,
+    ProfileSelectors.getResources,
     UrlState.getImplementationFilter,
     getCallTreeCountsAndSummary,
     getWeightTypeForCallTree,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -183,12 +183,18 @@ export function getThreadSelectorsPerThread(
   const getRangeAndTransformFilteredThread: Selector<Thread> = createSelector(
     getRangeFilteredThread,
     getTransformStack,
+    ProfileSelectors.getResources,
     ProfileSelectors.getDefaultCategory,
-    (startingThread, transforms, defaultCategory) =>
+    (startingThread, transforms, resources, defaultCategory) =>
       transforms.reduce(
         // Apply the reducer using an arrow function to ensure correct memoization.
         (thread, transform) =>
-          _applyTransformMemoized(thread, transform, defaultCategory),
+          _applyTransformMemoized(
+            thread,
+            resources,
+            transform,
+            defaultCategory
+          ),
         startingThread
       )
   );
@@ -203,9 +209,14 @@ export function getThreadSelectorsPerThread(
   const _getImplementationAndSearchFilteredThread: Selector<Thread> =
     createSelector(
       _getImplementationFilteredThread,
+      ProfileSelectors.getResources,
       UrlState.getSearchStrings,
-      (thread, searchStrings) => {
-        return ProfileData.filterThreadToSearchStrings(thread, searchStrings);
+      (thread, resources, searchStrings) => {
+        return ProfileData.filterThreadToSearchStrings(
+          thread,
+          resources,
+          searchStrings
+        );
       }
     );
 
@@ -363,6 +374,7 @@ export function getThreadSelectorsPerThread(
     createSelector(
       getRangeAndTransformFilteredThread,
       getFriendlyThreadName,
+      ProfileSelectors.getResources,
       getTransformStack,
       Transforms.getTransformLabelL10nIds
     );

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -69,6 +69,7 @@ import type {
   MarkerSchema,
   MarkerSchemaByName,
   SampleUnits,
+  Resource,
 } from 'firefox-profiler/types';
 
 export const getProfileView: Selector<ProfileViewState> = (state) =>
@@ -151,6 +152,8 @@ export const getProfileInterval: Selector<Milliseconds> = (state) =>
   getProfile(state).meta.interval;
 export const getPageList = (state: State): PageList | null =>
   getProfile(state).pages || null;
+export const getResources: Selector<Resource[]> = (state) =>
+  getProfile(state).resources;
 export const getDefaultCategory: Selector<IndexIntoCategoryList> = (state) =>
   getCategories(state).findIndex((c) => c.color === 'grey');
 export const getThreads: Selector<Thread[]> = (state) =>

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -39,6 +39,7 @@ describe('TooltipCallNode', function () {
               'Unable to find a selected call node index.'
             )}
             callNodeInfo={selectedThreadSelectors.getCallNodeInfo(getState())}
+            resources={ProfileSelectors.getResources(getState())}
             categories={ProfileSelectors.getCategories(getState())}
             interval={ProfileSelectors.getProfileInterval(getState())}
             durationText="Fake Duration Text"

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -24,7 +24,7 @@ import type {
   Transform,
   CallNodePath,
   IndexIntoFuncTable,
-  IndexIntoResourceTable,
+  IndexIntoResources,
 } from 'firefox-profiler/types';
 
 type KeyPressOptions = { key: string, ... };
@@ -35,7 +35,7 @@ type TestSetup = {|
   expectedCallNodePath: CallNodePath,
   // This should be expectedCallNodePath[expectedCallNodePath.length - 1], but this simplifies tests a bit.
   expectedFuncIndex: IndexIntoFuncTable,
-  expectedResourceIndex: IndexIntoResourceTable,
+  expectedResourceIndex: IndexIntoResources,
 |};
 
 function testTransformKeyboardShortcuts(setup: () => TestSetup) {

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -7,7 +7,6 @@ import {
   getEmptyProfile,
   getEmptyThread,
   getEmptyJsTracerTable,
-  resourceTypes,
   getEmptyJsAllocationsTable,
   getEmptyUnbalancedNativeAllocationsTable,
   getEmptyBalancedNativeAllocationsTable,
@@ -809,14 +808,7 @@ function _buildThreadFromTextOnlyStacks(
 ): Thread {
   const thread = getEmptyThread();
 
-  const {
-    funcTable,
-    stringTable,
-    frameTable,
-    stackTable,
-    samples,
-    resourceTable,
-  } = thread;
+  const { funcTable, stringTable, frameTable, stackTable, samples } = thread;
 
   // Create the FuncTable.
   funcNames.forEach((funcName) => {
@@ -861,13 +853,7 @@ function _buildThreadFromTextOnlyStacks(
             breakpadId: 'SOMETHING_FAKE',
             codeId: null,
           });
-
-          resourceTable.lib.push(libIndex);
-          resourceTable.name.push(stringTable.indexForString(libraryName));
-          resourceTable.type.push(resourceTypes.library);
-          resourceTable.host.push(null);
-          resourceIndex = resourceTable.length++;
-
+          resourceIndex = globalDataCollector.indexForLibResource(libIndex);
           resourceIndexCache[libraryName] = resourceIndex;
         }
       }

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -131,6 +131,7 @@ export function callTreeFromProfile(
     interval,
     callNodeInfo,
     categories,
+    profile.resources,
     'combined',
     callTreeCountsAndSummary,
     'samples'

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -12,7 +12,6 @@ import type { ExampleSymbolTable } from '../fixtures/example-symbol-table';
 import { SymbolStore } from '../../profile-logic/symbol-store.js';
 import * as ProfileViewSelectors from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { resourceTypes } from '../../profile-logic/data-structures';
 import { doSymbolicateProfile } from '../../actions/receive-profile';
 import {
   changeSelectedCallNode,
@@ -533,13 +532,13 @@ function _createUnsymbolicatedProfile() {
     codeId: null,
   };
 
-  thread.resourceTable = {
-    length: 1,
-    lib: [libIndex],
-    name: [thread.stringTable.indexForString('example lib')],
-    host: [thread.stringTable.indexForString('example host')],
-    type: [resourceTypes.library],
-  };
+  profile.resources = [
+    {
+      type: 'LIBRARY',
+      name: 'example lib',
+      libIndex,
+    },
+  ];
   for (let i = 0; i < thread.funcTable.length; i++) {
     thread.funcTable.resource[i] = 0;
   }

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -648,9 +648,8 @@ describe('"collapse-resource" transform', function () {
     const collapsedFuncNames = [...funcNames, 'firefox'];
     const threadIndex = 0;
     const thread = profile.threads[threadIndex];
-    const firefoxNameIndex = thread.stringTable.indexForString('firefox');
-    const firefoxResourceIndex = thread.resourceTable.name.findIndex(
-      (stringIndex) => stringIndex === firefoxNameIndex
+    const firefoxResourceIndex = profile.resources.findIndex(
+      (res) => res.name === 'firefox'
     );
     if (firefoxResourceIndex === -1) {
       throw new Error('Unable to find the firefox resource');
@@ -750,9 +749,8 @@ describe('"collapse-resource" transform', function () {
     const collapsedFuncNames = [...funcNames, 'firefox'];
     const threadIndex = 0;
     const thread = profile.threads[threadIndex];
-    const firefoxNameIndex = thread.stringTable.indexForString('firefox');
-    const firefoxResourceIndex = thread.resourceTable.name.findIndex(
-      (stringIndex) => stringIndex === firefoxNameIndex
+    const firefoxResourceIndex = profile.resources.findIndex(
+      (res) => res.name === 'firefox'
     );
     if (firefoxResourceIndex === -1) {
       throw new Error('Unable to find the firefox resource');

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -91,17 +91,19 @@ describe('extract functions and resource from location strings', function () {
     length: 2,
   };
   const globalDataCollector = new GlobalDataCollector();
+  globalDataCollector.addResourcesForExtensions(extensions);
 
   it('extracts the information for all different types of locations', function () {
-    const { funcTable, resourceTable, frameFuncs } =
+    const { funcTable, frameFuncs } =
       extractFuncsAndResourcesFromFrameLocations(
         locationIndexes,
         locationIndexes.map(() => false),
         stringTable,
         libs,
-        extensions,
         globalDataCollector
       );
+
+    const { resources } = globalDataCollector.finish();
 
     expect(
       frameFuncs.map((funcIndex, locationIndex) => {
@@ -119,25 +121,18 @@ describe('extract functions and resource from location strings', function () {
 
         let libIndex, resourceName, host, resourceType;
         if (resourceIndex === -1) {
+          libIndex = null;
           resourceName = null;
           host = null;
           resourceType = null;
         } else {
-          const hostStringIndex = resourceTable.host[resourceIndex];
-          libIndex = resourceTable.lib[resourceIndex];
-          resourceName = stringTable.getString(
-            resourceTable.name[resourceIndex]
-          );
-          host =
-            hostStringIndex === undefined || hostStringIndex === null
-              ? null
-              : stringTable.getString(hostStringIndex);
-          resourceType = resourceTable.type[resourceIndex];
+          const resource = resources[resourceIndex];
+          libIndex = resource.type === 'LIBRARY' ? resource.libIndex : null;
+          resourceName = resource.name;
+          host = resource.type === 'WEBHOST' ? resource.host : null;
+          resourceType = resource.type;
         }
-        const lib =
-          libIndex === undefined || libIndex === null || libIndex === -1
-            ? undefined
-            : libs[libIndex];
+        const lib = libIndex === null ? undefined : libs[libIndex];
 
         return [
           locationName,

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -24,7 +24,6 @@ import {
   extractProfileFilterPageData,
   findAddressProofForFile,
 } from '../../profile-logic/profile-data';
-import { resourceTypes } from '../../profile-logic/data-structures';
 import {
   createGeckoProfile,
   createGeckoProfileWithJsTimings,
@@ -287,17 +286,16 @@ describe('process-profile', function () {
     });
 
     it('should create one resource per used library', function () {
-      const thread = profile.threads[0];
-      expect(thread.resourceTable.length).toEqual(3);
-      expect(thread.resourceTable.type[0]).toEqual(resourceTypes.addon);
-      expect(thread.resourceTable.type[1]).toEqual(resourceTypes.library);
-      expect(thread.resourceTable.type[2]).toEqual(resourceTypes.url);
-      const [name0, name1, name2] = thread.resourceTable.name;
-      expect(thread.stringTable.getString(name0)).toEqual(
+      const resources = profile.resources;
+      expect(resources.length).toEqual(3);
+      expect(resources[0].type).toEqual('ADDON');
+      expect(resources[1].type).toEqual('LIBRARY');
+      expect(resources[2].type).toEqual('URL');
+      expect(resources[0].name).toEqual(
         'Extension "Form Autofill" (ID: formautofill@mozilla.org)'
       );
-      expect(thread.stringTable.getString(name1)).toEqual('firefox');
-      expect(thread.stringTable.getString(name2)).toEqual('chrome://blargh');
+      expect(resources[1].name).toEqual('firefox');
+      expect(resources[2].name).toEqual('chrome://blargh');
     });
   });
 

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -16,7 +16,7 @@
  * This combination of information will provide a stable reference to a call node for a
  * given view into a call tree.
  */
-import type { IndexIntoFuncTable, IndexIntoResourceTable } from './profile';
+import type { IndexIntoFuncTable, IndexIntoResources } from './profile';
 import type { CallNodePath, ThreadsKey } from './profile-derived';
 import type { ImplementationFilter } from './actions';
 
@@ -229,7 +229,7 @@ export type TransformDefinitions = {
    */
   'collapse-resource': {|
     +type: 'collapse-resource',
-    +resourceIndex: IndexIntoResourceTable,
+    +resourceIndex: IndexIntoResources,
     // This is the index of the newly created function that represents the collapsed stack.
     +collapsedFuncIndex: IndexIntoFuncTable,
     +implementation: ImplementationFilter,


### PR DESCRIPTION
This isn't fully finished yet, but I wanted to put it up for discussion.

This makes two changes:

 1. It modifies the shape of the resourceTable to be array-of-structs instead of struct-of-arrays, and renames it to `resources`. Each resource is now typed as a tagged union and contains regular strings. That's because the number of resources is usually quite low, and there's not a lot of GC pressure from the individual resource objects.
 2. It moves the resource to the profile's root object, out of the thread. Resources are now shared between threads.

The more interesting aspect of this patch is the ripple effect it has on the rest of the profiler: Lots of places that were passing the `thread` around now need to pass around the `thread` and the `resources`, in separate function arguments or separate component props.
As we share more and more stuff, we'll need to pass more and more stuff in addition to the thread. This is going to get unwieldy.
I noticed that many places where I had to add an extra `resources` argument (or prop) also pass `pages` or `categories` (or even both).
I think it would make sense to group shared data into a `profile.shared` object. Then we can just pass the pair `shared, thread` in all these places, and we won't need to add more arguments as we move more things from `thread` to `shared`.
For example, in the beginning, we could have:

```js
type Profile = {|
  meta: ProfileMeta,
  shared: ProfileSharedData,
  threads: Thread[],
|};

type ProfileSharedData = {|
  categories: CategoryList,
  extensions?: ExtensionTable,
  pages?: PageList,
  libs: Lib[],
  counters?: Counter[],
  resources: Resource[],
|}
```

Thoughts? @julienw, @canova

I haven't really thought about what happens once we have a shared stackTable and need to apply per-thread transforms or search filtering. Would the return value of `getFilteredThread` be a `{ thread, shared }` object? I'm not sure.