### PR TITLE
Remove the special handling for Renderer thread during idle thread detection

### DIFF
--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -869,10 +869,6 @@ function _computeThreadDefaultVisibilityScore(
 
 function _isEssentialFirefoxThread(thread: Thread): boolean {
   return (
-    // Don't hide the Renderer thread. This is because Renderer thread is pretty
-    // useful for understanding the painting with WebRender and it's an important
-    // thread for the users.
-    thread.name === 'Renderer' ||
     // Don't hide the main thread of the parent process.
     (thread.name === 'GeckoMain' &&
       thread.processType === 'default' &&

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -212,22 +212,6 @@ describe('actions/receive-profile', function () {
       ]);
     });
 
-    it('will not hide the Renderer thread', function () {
-      const store = blankStore();
-      const { profile, idleThread, workThread } =
-        getProfileWithIdleAndWorkThread();
-      idleThread.name = 'Renderer';
-      idleThread.processType = 'default';
-      workThread.name = 'GeckoMain';
-      workThread.processType = 'default';
-
-      store.dispatch(viewProfile(profile));
-      expect(getHumanReadableTracks(store.getState())).toEqual([
-        'show [thread GeckoMain default] SELECTED',
-        '  - show [thread Renderer]',
-      ]);
-    });
-
     it('will not hide a main thread', function () {
       const store = blankStore();
       const { profile, idleThread, workThread } =
@@ -580,8 +564,6 @@ describe('actions/receive-profile', function () {
       it('will keep certain threads visible even if they have low CPU usage', function () {
         const store = blankStore();
         // A profile with 18 threads, with varying thread scores.
-        // The "Renderer" thread only has a CPU delta sum of 20, but should be
-        // visible anyway, because of its thread name.
 
         const profile = getProfileWithThreadCPUDelta([
           [100, 10, 20, 30, 20, 10, 0, 0, 0, 0, 0, 0, 0],
@@ -622,8 +604,8 @@ describe('actions/receive-profile', function () {
         expect(getHumanReadableTracks(store.getState())).toEqual([
           'show [process]',
           '  - show [thread Thread with 190 CPU] SELECTED',
-          '  - show [thread Renderer]',
-          '  - hide [thread DOM Worker]', // <-- hidden
+          '  - hide [thread Renderer]', // <-- hidden
+          '  - show [thread DOM Worker]',
           '  - show [thread Thread with 270 CPU]',
           '  - show [thread Thread with 330 CPU]',
           '  - show [thread Thread with 180 CPU]',


### PR DESCRIPTION
We had a special handling for Renderer thread because previously we had
screenshot markers in that thread. If people choose to share the profile
with hidden threads removed, then they could also lose the screenshots
coincidentally. We moved the screnshot markers to the main thread in
https://bugzilla.mozilla.org/show_bug.cgi?id=1742722 and it is safe to
remove this handling now.

Fixes #3628.

Example profile: [production](https://profiler.firefox.com/public/nj89s0vzfs795cd263qwphynht2y05dvggt5thg)  / [deploy preview](https://deploy-preview-3921--perf-html.netlify.app/public/nj89s0vzfs795cd263qwphynht2y05dvggt5thg)