### PR TITLE
Remove the extraneous persistTooltips console message

### DIFF
--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -50,13 +50,6 @@ type Props = {|
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
 |};
 
-// For debugging purposes, allow tooltips to persist. This aids in inspecting
-// the DOM structure.
-window.persistTooltips = false;
-if (process.env.NODE_ENV === 'development') {
-  console.log('To debug tooltips, set window.persistTooltips to true.');
-}
-
 /**
  * This class collects the tooltip rendering for anything that cares about call nodes.
  * This includes the Flame Graph and Stack Chart.


### PR DESCRIPTION
This is a small PR that removes the window.persistTooltips and its message that we already have in the window-console.js file here:
https://github.com/firefox-devtools/profiler/blob/75a70f2c3502d6ced1b958b62f31bd1ed02bc07c/src/utils/window-console.js#L235-L237
The declaration of this `persistTooltips` property also is here:
https://github.com/firefox-devtools/profiler/blob/75a70f2c3502d6ced1b958b62f31bd1ed02bc07c/src/utils/window-console.js#L135-L137
(It's not possible to link the deploy preview since this is development environment only)
