### PR TITLE
Add a "Hide all matching tracks" track context menu item 

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -683,8 +683,12 @@ TrackContextMenu--hide-track = Hide “{ $trackName }”
 TrackContextMenu--show-all-tracks = Show all tracks
 
 # This is used in the tracks context menu as a button to show all the tracks
-# below it.
+# that match the search filter.
 TrackContextMenu--show-all-matching-tracks = Show all matching tracks
+
+# This is used in the tracks context menu as a button to hide all the tracks
+# that match the search filter.
+TrackContextMenu--hide-all-matching-tracks = Hide all matching tracks
 
 # This is used in the tracks context menu when the search filter doesn't match
 # any track.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -684,7 +684,7 @@ TrackContextMenu--show-all-tracks = Show all tracks
 
 # This is used in the tracks context menu as a button to show all the tracks
 # below it.
-TrackContextMenu--show-all-tracks-below = Show all tracks below
+TrackContextMenu--show-all-matching-tracks = Show all matching tracks
 
 # This is used in the tracks context menu when the search filter doesn't match
 # any track.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1069,13 +1069,15 @@ export function changeLocalTrackOrder(
  * that both hide that global tracks, and local tracks. When hiding a global track,
  * then it will not have a local track to ignore. When hiding local track, it will
  * need to ignore the local track index that's being hidden, AND the global track
- * that it's attached to, as it's already been checked.
+ * that it's attached to, as it's already been checked. When hiding multiple
+ * tracks that might include global and local tracks, it will need to ignore
+ * both global and local tracks.
  */
 function _findOtherVisibleThread(
   getState: () => State,
-  // Either this global track is already hidden, or it has been taken into account.
+  // Either these global tracks are already hidden, or they have been taken into account.
   globalTrackIndexesToIgnore?: Set<TrackIndex>,
-  // This is helpful when hiding a new local track index, it won't be selected.
+  // This is helpful when hiding new local track indexes, they won't be selected.
   localTrackIndexesToIgnoreByPid?: Map<Pid, Set<TrackIndex>>
 ): ThreadIndex | null {
   const globalTracks = getGlobalTracks(getState());

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -786,6 +786,7 @@ export function hideProvidedTracks(
       newHiddenGlobalTrackCount < globalTracks.length;
     if (!visibleGlobalTracksLeftAfterHiding) {
       // Bail if there isn't any other visible global track left after hiding.
+      console.warn('No other visible global track left after hiding');
       return;
     }
 
@@ -815,8 +816,8 @@ export function hideProvidedTracks(
     }
 
     if (newSelectedThreadIndexes.size === 0) {
-      // Hiding this process would make it so that there is no selected thread.
-      // Bail out.
+      // Hiding this process would make it so that there is no selected thread
+      // since no more visible threads exist, bail out.
       return;
     }
 

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -203,6 +203,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       searchFilteredLocalTracksByPid === null
     ) {
       // This shouldn't happen!
+      console.warn('Unexpected null search filtered tracks');
       return;
     }
 
@@ -830,7 +831,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       newHiddenGlobalTrackCount < globalTracks.length;
 
     // 2.1. Check if there are any global tracks to hide.
-    const globalTracksToHide = [...searchFilteredGlobalTracks].filter(
+    const hasGlobalTracksToHide = [...searchFilteredGlobalTracks].some(
       (trackIndex) => !hiddenGlobalTracks.has(trackIndex)
     );
 
@@ -857,10 +858,9 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       }
 
       const hiddenLocalTracks = ensureExists(hiddenLocalTracksByPid.get(pid));
-      hasLocalTrackToHide =
-        [...searchFilteredLocalTracks].filter(
-          (trackIndex) => !hiddenLocalTracks.has(trackIndex)
-        ).length > 0;
+      hasLocalTrackToHide = [...searchFilteredLocalTracks].some(
+        (trackIndex) => !hiddenLocalTracks.has(trackIndex)
+      );
       if (hasLocalTrackToHide) {
         // There is at least one local track to hide. Skip the other global track checks.
         break;
@@ -869,7 +869,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
 
     const isDisabled =
       visibleGlobalTracksLeftAfterHiding === false ||
-      (globalTracksToHide.length === 0 && hasLocalTrackToHide === false);
+      (!hasGlobalTracksToHide && hasLocalTrackToHide === false);
 
     return (
       <MenuItem onClick={this._hideMatchedTracks} disabled={isDisabled}>

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -730,14 +730,11 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       hiddenLocalTracksCount + this.props.hiddenGlobalTracks.size === 0;
 
     return (
-      <React.Fragment>
-        <MenuItem onClick={this._showAllTracks} disabled={isDisabled}>
-          <Localized id="TrackContextMenu--show-all-tracks">
-            Show all tracks
-          </Localized>
-        </MenuItem>
-        <div className="react-contextmenu-separator" />
-      </React.Fragment>
+      <MenuItem onClick={this._showAllTracks} disabled={isDisabled}>
+        <Localized id="TrackContextMenu--show-all-tracks">
+          Show all tracks
+        </Localized>
+      </MenuItem>
     );
   }
 
@@ -748,14 +745,11 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     }
 
     return (
-      <React.Fragment>
-        <MenuItem onClick={this._showMatchingTracks}>
-          <Localized id="TrackContextMenu--show-all-matching-tracks">
-            Show all matching tracks
-          </Localized>
-        </MenuItem>
-        <div className="react-contextmenu-separator" />
-      </React.Fragment>
+      <MenuItem onClick={this._showMatchingTracks}>
+        <Localized id="TrackContextMenu--show-all-matching-tracks">
+          Show all matching tracks
+        </Localized>
+      </MenuItem>
     );
   }
 
@@ -893,6 +887,9 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {searchFilter
           ? this.renderShowProvidedTracks()
           : this.renderShowAllTracks()}
+        {rightClickedTrack === null ? (
+          <div className="react-contextmenu-separator" />
+        ) : null}
         {isolateProcessMainThread}
         {isolateProcess}
         {isolateLocalTrack}

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -816,7 +816,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     // 2. Are there any global (2.1) or local tracks (2.2) to hide for this
     // search filter?
     // Also, all these checks (1, 2.1, 2.2) are extracted into arrow functions,
-    // so we don't have to do all these checks if they are not needed anymore.
+    // so we don't have to do all these checks if they are not needed.
 
     // 1. First we need to check if there are going to be visible tracks left
     // after hiding the matching ones.
@@ -825,7 +825,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     // the hidden tracks.
 
     // New global tracks counts after this menu item is clicked.
-    const visibleGlobalTracksLeftAfterHiding = () => {
+    const hasVisibleGlobalTracksLeftAfterHiding = () => {
       const newHiddenGlobalTrackCount =
         hiddenGlobalTracks.size +
         searchFilteredGlobalTracks.size -
@@ -834,7 +834,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     };
 
     // 2.1. Check if there are any global tracks to hide.
-    const hasGlobalTracksToHide = () =>
+    const hasGlobalTrackToHide = () =>
       [...searchFilteredGlobalTracks].some(
         (trackIndex) => !hiddenGlobalTracks.has(trackIndex)
       );
@@ -842,8 +842,8 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     // 2.2. Check if there are any local tracks to hide. It's a bit more
     // complicated than checking the global tracks because of the nested Map/Sets.
 
-    // Create a hidden global track pids set for faster checks.
     const hasLocalTrackToHide = () => {
+      // Create a hidden global track pids set for faster checks.
       const hiddenGlobalTrackPids = new Set<Pid>();
       for (const trackIndex of hiddenGlobalTracks) {
         const globalTrack = globalTracks[trackIndex];
@@ -876,8 +876,8 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     };
 
     const isDisabled =
-      visibleGlobalTracksLeftAfterHiding() === false ||
-      (hasGlobalTracksToHide() === false && hasLocalTrackToHide() === false);
+      !hasVisibleGlobalTracksLeftAfterHiding() ||
+      (!hasGlobalTrackToHide() && !hasLocalTrackToHide());
 
     return (
       <MenuItem onClick={this._hideMatchedTracks} disabled={isDisabled}>

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -108,7 +108,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     showAllTracks();
   };
 
-  _showProvidedTracks = (): void => {
+  _showMatchingTracks = (): void => {
     const {
       showProvidedTracks,
       globalTracks,
@@ -749,9 +749,9 @@ class TimelineTrackContextMenuImpl extends PureComponent<
 
     return (
       <React.Fragment>
-        <MenuItem onClick={this._showProvidedTracks}>
-          <Localized id="TrackContextMenu--show-all-tracks-below">
-            Show all tracks below
+        <MenuItem onClick={this._showMatchingTracks}>
+          <Localized id="TrackContextMenu--show-all-matching-tracks">
+            Show all matching tracks
           </Localized>
         </MenuItem>
         <div className="react-contextmenu-separator" />

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -19,6 +19,7 @@ import {
   hideLocalTrack,
   showLocalTrack,
   showProvidedTracks,
+  hideProvidedTracks,
 } from 'firefox-profiler/actions/profile-view';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { ensureExists } from 'firefox-profiler/utils/flow';
@@ -44,6 +45,7 @@ import {
 } from 'firefox-profiler/profile-logic/tracks';
 import { ContextMenuNoHidingOnEnter } from 'firefox-profiler/components/shared/ContextMenuNoHidingOnEnter';
 import classNames from 'classnames';
+import { intersectSets } from 'firefox-profiler/utils/set';
 
 import type {
   Thread,
@@ -83,6 +85,7 @@ type DispatchProps = {|
   +isolateProcessMainThread: typeof isolateProcessMainThread,
   +isolateScreenshot: typeof isolateScreenshot,
   +showProvidedTracks: typeof showProvidedTracks,
+  +hideProvidedTracks: typeof hideProvidedTracks,
 |};
 
 type TimelineTrackContextMenuProps = ConnectedProps<
@@ -170,6 +173,43 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     }
 
     showProvidedTracks(searchFilteredGlobalTracks, localTracksByPidToShow);
+  };
+
+  _hideMatchedTracks = (): void => {
+    const {
+      globalTracks,
+      globalTrackNames,
+      localTracksByPid,
+      localTrackNamesByPid,
+      threads,
+      hideProvidedTracks,
+    } = this.props;
+    const { searchFilter } = this.state;
+    const searchFilteredGlobalTracks = getSearchFilteredGlobalTracks(
+      globalTracks,
+      globalTrackNames,
+      threads,
+      searchFilter
+    );
+    const searchFilteredLocalTracksByPid = getSearchFilteredLocalTracksByPid(
+      localTracksByPid,
+      localTrackNamesByPid,
+      threads,
+      searchFilter
+    );
+
+    if (
+      searchFilteredGlobalTracks === null ||
+      searchFilteredLocalTracksByPid === null
+    ) {
+      // This shouldn't happen!
+      return;
+    }
+
+    hideProvidedTracks(
+      searchFilteredGlobalTracks,
+      searchFilteredLocalTracksByPid
+    );
   };
 
   _toggleGlobalTrackVisibility = (
@@ -753,6 +793,93 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     );
   }
 
+  renderHideMatchingTracks(
+    searchFilteredGlobalTracks: Set<TrackIndex>,
+    searchFilteredLocalTracksByPid: Map<Pid, Set<TrackIndex>>
+  ) {
+    const {
+      rightClickedTrack,
+      hiddenGlobalTracks,
+      globalTracks,
+      hiddenLocalTracksByPid,
+    } = this.props;
+    if (rightClickedTrack !== null) {
+      // This option should only be visible in the top context menu and not when
+      // user right clicks on a track.
+      return null;
+    }
+
+    // We need to do a few checks here to determine if this menu item should be
+    // enabled or not. Two things we need to check:
+    // 1. Are there any global tracks left to show after hiding the matched tracks?
+    // 2. Are there any global (2.1) or local tracks (2.2) to hide for this
+    // search filter?
+
+    // 1. First we need to check if there are going to be visible tracks left
+    // after hiding the matching ones.
+    // Check `subtractSets(visible tracks, search filtered tracks)`. Since we
+    // don't have the computed visible tracks, let's check the same thing with
+    // the hidden tracks.
+
+    // New global tracks counts after this menu item is clicked.
+    const newHiddenGlobalTrackCount =
+      hiddenGlobalTracks.size +
+      searchFilteredGlobalTracks.size -
+      intersectSets(hiddenGlobalTracks, searchFilteredGlobalTracks).size;
+    const visibleGlobalTracksLeftAfterHiding =
+      newHiddenGlobalTrackCount < globalTracks.length;
+
+    // 2.1. Check if there are any global tracks to hide.
+    const globalTracksToHide = [...searchFilteredGlobalTracks].filter(
+      (trackIndex) => !hiddenGlobalTracks.has(trackIndex)
+    );
+
+    // 2.2. Check if there are any local tracks to hide. It's a bit more
+    // complicated than checking the global tracks because of the nested Map/Sets.
+
+    // Create a hidden global track pids set for faster checks.
+    const hiddenGlobalTrackPids = new Set<Pid>();
+    for (const trackIndex of hiddenGlobalTracks) {
+      const globalTrack = globalTracks[trackIndex];
+      if (globalTrack.type === 'process') {
+        hiddenGlobalTrackPids.add(globalTrack.pid);
+      }
+    }
+
+    let hasLocalTrackToHide = false;
+    for (const [
+      pid,
+      searchFilteredLocalTracks,
+    ] of searchFilteredLocalTracksByPid) {
+      if (hiddenGlobalTrackPids.has(pid)) {
+        // The global track is already hidden. Do not check the local tracks of it.
+        continue;
+      }
+
+      const hiddenLocalTracks = ensureExists(hiddenLocalTracksByPid.get(pid));
+      hasLocalTrackToHide =
+        [...searchFilteredLocalTracks].filter(
+          (trackIndex) => !hiddenLocalTracks.has(trackIndex)
+        ).length > 0;
+      if (hasLocalTrackToHide) {
+        // There is at least one local track to hide. Skip the other global track checks.
+        break;
+      }
+    }
+
+    const isDisabled =
+      visibleGlobalTracksLeftAfterHiding === false ||
+      (globalTracksToHide.length === 0 && hasLocalTrackToHide === false);
+
+    return (
+      <MenuItem onClick={this._hideMatchedTracks} disabled={isDisabled}>
+        <Localized id="TrackContextMenu--hide-all-matching-tracks">
+          Hide all matching tracks
+        </Localized>
+      </MenuItem>
+    );
+  }
+
   renderTrackSearchField() {
     const { rightClickedTrack } = this.props;
     const { searchFilter } = this.state;
@@ -887,6 +1014,14 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {searchFilter
           ? this.renderShowProvidedTracks()
           : this.renderShowAllTracks()}
+        {searchFilter &&
+        searchFilteredGlobalTracks &&
+        searchFilteredLocalTracksByPid
+          ? this.renderHideMatchingTracks(
+              searchFilteredGlobalTracks,
+              searchFilteredLocalTracksByPid
+            )
+          : null}
         {rightClickedTrack === null ? (
           <div className="react-contextmenu-separator" />
         ) : null}
@@ -949,6 +1084,7 @@ export const TimelineTrackContextMenu = explicitConnect<
     hideLocalTrack,
     showLocalTrack,
     showProvidedTracks,
+    hideProvidedTracks,
   },
   component: TimelineTrackContextMenuImpl,
 });

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -129,6 +129,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'HIDE_GLOBAL_TRACK':
     case 'SHOW_ALL_TRACKS':
     case 'SHOW_PROVIDED_TRACKS':
+    case 'HIDE_PROVIDED_TRACKS':
     case 'SHOW_GLOBAL_TRACK':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -450,6 +450,7 @@ const scrollToSelectionGeneration: Reducer<number> = (state = 0, action) => {
     case 'SELECT_TRACK':
     case 'HIDE_GLOBAL_TRACK':
     case 'HIDE_LOCAL_TRACK':
+    case 'HIDE_PROVIDED_TRACKS':
     case 'CHANGE_SELECTED_MARKER':
     case 'CHANGE_SELECTED_NETWORK_MARKER':
       return state + 1;

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -97,7 +97,7 @@ describe('timeline/TrackContextMenu', function () {
       const results = setup();
       const selectAllTracksItem = () => screen.getByText('Show all tracks');
 
-      const hideAllTracks = () => {
+      const clickAllTracks = () => {
         // To hide the tracks before testing 'Show all tracks'
         fireFullClick(screen.getByText('GeckoMain'));
         fireFullClick(screen.getByText('DOM Worker'));
@@ -107,12 +107,13 @@ describe('timeline/TrackContextMenu', function () {
       return {
         ...results,
         selectAllTracksItem,
-        hideAllTracks,
+        clickAllTracks,
       };
     }
 
     it('selects all tracks', () => {
-      const { getState, selectAllTracksItem, hideAllTracks } = setupAllTracks();
+      const { getState, selectAllTracksItem, clickAllTracks } =
+        setupAllTracks();
       // Test behavior when all tracks are already shown
       fireFullClick(selectAllTracksItem());
       expect(getHumanReadableTracks(getState())).toEqual([
@@ -123,7 +124,7 @@ describe('timeline/TrackContextMenu', function () {
       ]);
 
       // Hide all tracks to test behavior
-      hideAllTracks();
+      clickAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden
         'hide [thread GeckoMain process]',
@@ -149,14 +150,14 @@ describe('timeline/TrackContextMenu', function () {
       const selectShowAllMatchingTracksItem = () =>
         screen.getByText('Show all matching tracks');
 
-      const hideAllTracks = () => {
+      const clickAllTracks = () => {
         // To hide the tracks before testing 'Show all tracks'
         fireFullClick(screen.getByText('GeckoMain'));
         fireFullClick(screen.getByText('DOM Worker'));
         fireFullClick(screen.getByText('Style'));
       };
 
-      const hideAllTracksExceptMain = () => {
+      const clickAllTracksExceptMain = () => {
         fireFullClick(screen.getByText('DOM Worker'));
         fireFullClick(screen.getByText('Style'));
         fireFullClick(screen.getByText('Content Process'));
@@ -165,8 +166,8 @@ describe('timeline/TrackContextMenu', function () {
       return {
         ...results,
         selectShowAllMatchingTracksItem,
-        hideAllTracks,
-        hideAllTracksExceptMain,
+        clickAllTracks,
+        clickAllTracksExceptMain,
       };
     }
 
@@ -174,11 +175,11 @@ describe('timeline/TrackContextMenu', function () {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        hideAllTracks,
+        clickAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      hideAllTracks();
+      clickAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain process]',
@@ -206,11 +207,11 @@ describe('timeline/TrackContextMenu', function () {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        hideAllTracks,
+        clickAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      hideAllTracks();
+      clickAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain process]',
@@ -238,11 +239,11 @@ describe('timeline/TrackContextMenu', function () {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        hideAllTracks,
+        clickAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      hideAllTracks();
+      clickAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain process]',
@@ -270,11 +271,11 @@ describe('timeline/TrackContextMenu', function () {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        hideAllTracks,
+        clickAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      hideAllTracks();
+      clickAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain process]',
@@ -302,11 +303,11 @@ describe('timeline/TrackContextMenu', function () {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        hideAllTracksExceptMain,
+        clickAllTracksExceptMain,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide the local tracks and tehe global track with children for this behavior.
-      hideAllTracksExceptMain();
+      clickAllTracksExceptMain();
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain process] SELECTED',
         // These tracks must be hidden at the start.
@@ -336,7 +337,7 @@ describe('timeline/TrackContextMenu', function () {
       const selectHideAllMatchingTracksItem = () =>
         screen.getByText('Hide all matching tracks');
 
-      const hideAllTracksExceptMain = () => {
+      const clickAllTracksExceptMain = () => {
         fireFullClick(screen.getByText('DOM Worker'));
         fireFullClick(screen.getByText('Style'));
         fireFullClick(screen.getByText('Content Process'));
@@ -345,7 +346,7 @@ describe('timeline/TrackContextMenu', function () {
       return {
         ...setupResults,
         selectHideAllMatchingTracksItem,
-        hideAllTracksExceptMain,
+        clickAllTracksExceptMain,
       };
     }
 
@@ -428,11 +429,11 @@ describe('timeline/TrackContextMenu', function () {
       const {
         getState,
         selectHideAllMatchingTracksItem,
-        hideAllTracksExceptMain,
+        clickAllTracksExceptMain,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks except the main to test the behavior.
-      hideAllTracksExceptMain();
+      clickAllTracksExceptMain();
       expect(getHumanReadableTracks(getState())).toEqual([
         // This must be the only visible track.
         'show [thread GeckoMain process] SELECTED',

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -143,11 +143,11 @@ describe('timeline/TrackContextMenu', function () {
     });
   });
 
-  describe('show all tracks below', function () {
+  describe('show all matching tracks', function () {
     function setupAllTracks() {
       const results = setup();
-      const selectAllTracksBelowItem = () =>
-        screen.getByText('Show all tracks below');
+      const selectShowAllMatchingTracksItem = () =>
+        screen.getByText('Show all matching tracks');
 
       const hideAllTracks = () => {
         // To hide the tracks before testing 'Show all tracks'
@@ -164,7 +164,7 @@ describe('timeline/TrackContextMenu', function () {
 
       return {
         ...results,
-        selectAllTracksBelowItem,
+        selectShowAllMatchingTracksItem,
         hideAllTracks,
         hideAllTracksExceptMain,
       };
@@ -173,7 +173,7 @@ describe('timeline/TrackContextMenu', function () {
     it('shows a single track', () => {
       const {
         getState,
-        selectAllTracksBelowItem,
+        selectShowAllMatchingTracksItem,
         hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
@@ -191,7 +191,7 @@ describe('timeline/TrackContextMenu', function () {
       // Search something to filter the tracks.
       changeSearchFilter('GeckoMain');
       // Click the button.
-      fireFullClick(selectAllTracksBelowItem());
+      fireFullClick(selectShowAllMatchingTracksItem());
 
       // GeckoMain should be visible now.
       expect(getHumanReadableTracks(getState())).toEqual([
@@ -205,7 +205,7 @@ describe('timeline/TrackContextMenu', function () {
     it('shows children of a global track', () => {
       const {
         getState,
-        selectAllTracksBelowItem,
+        selectShowAllMatchingTracksItem,
         hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
@@ -223,7 +223,7 @@ describe('timeline/TrackContextMenu', function () {
       // Search something to filter the tracks.
       changeSearchFilter('Content Process');
       // Click the button.
-      fireFullClick(selectAllTracksBelowItem());
+      fireFullClick(selectShowAllMatchingTracksItem());
 
       // Children of Content Process should be visible now.
       expect(getHumanReadableTracks(getState())).toEqual([
@@ -237,7 +237,7 @@ describe('timeline/TrackContextMenu', function () {
     it('shows a local track', () => {
       const {
         getState,
-        selectAllTracksBelowItem,
+        selectShowAllMatchingTracksItem,
         hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
@@ -255,7 +255,7 @@ describe('timeline/TrackContextMenu', function () {
       // Search something to filter the tracks.
       changeSearchFilter('DOM Worker');
       // Click the button.
-      fireFullClick(selectAllTracksBelowItem());
+      fireFullClick(selectShowAllMatchingTracksItem());
 
       // DOM Worker track should be visible now.
       expect(getHumanReadableTracks(getState())).toEqual([
@@ -269,7 +269,7 @@ describe('timeline/TrackContextMenu', function () {
     it('does not show anything if the list is empty', () => {
       const {
         getState,
-        selectAllTracksBelowItem,
+        selectShowAllMatchingTracksItem,
         hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
@@ -287,7 +287,7 @@ describe('timeline/TrackContextMenu', function () {
       // Search something to filter the tracks. This time it's something random.
       changeSearchFilter('this should not be in the tracks list');
       // Click the button.
-      fireFullClick(selectAllTracksBelowItem());
+      fireFullClick(selectShowAllMatchingTracksItem());
 
       // No new track should be visible.
       expect(getHumanReadableTracks(getState())).toEqual([
@@ -301,7 +301,7 @@ describe('timeline/TrackContextMenu', function () {
     it("shows local track's global track even if it wasn't visible before", () => {
       const {
         getState,
-        selectAllTracksBelowItem,
+        selectShowAllMatchingTracksItem,
         hideAllTracksExceptMain,
         changeSearchFilter,
       } = setupAllTracks();
@@ -318,7 +318,7 @@ describe('timeline/TrackContextMenu', function () {
       // Search a local track.
       changeSearchFilter('DOM Worker');
       // Click the button.
-      fireFullClick(selectAllTracksBelowItem());
+      fireFullClick(selectShowAllMatchingTracksItem());
 
       // DOM Worker and its global process should be visible now.
       expect(getHumanReadableTracks(getState())).toEqual([

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -238,6 +238,12 @@ type ProfileAction =
       +localTracksByPidToShow: Map<Pid, Set<TrackIndex>>,
     |}
   | {|
+      +type: 'HIDE_PROVIDED_TRACKS',
+      +globalTracksToHide: Set<TrackIndex>,
+      +localTracksByPidToHide: Map<Pid, Set<TrackIndex>>,
+      +selectedThreadIndexes: Set<ThreadIndex>,
+    |}
+  | {|
       +type: 'SHOW_GLOBAL_TRACK',
       +trackIndex: TrackIndex,
     |}


### PR DESCRIPTION
Fixes #3771.
This PR also changes the name of the "Show all tracks below" to something more consistent with this one. I didn't want to use "Hide all tracks below" because that wasn't really correct. For example when we search "network" we also show the global tracks of network tracks to give the user an idea. But we are not actually hiding them since they are not matched. (also it would make hiding a  lot harder since searching for network would hide all global tracks, and we won't have any global track left in the timeline)

I also did some checks to decide if this item should be enabled or not. I make it disabled if the there is nothing to hide, or if there won't be any global track left after this operation. Right now, we don't have the same check for "show all matching" item, but I intend to do the same thing for that as well.


It would be better to review it commit by commit.

[Deploy preview](https://deploy-preview-3955--perf-html.netlify.app/public/d44gqy8a1zcxt5ghk7b7tt39x0r1a749m2mpmqr/calltree/?globalTrackOrder=0wi&hiddenGlobalTracks=1wg&hiddenLocalTracksByPid=89846-1w6~89868-0~89847-0~89877-0~89871-0~89858-01~89849-0~89852-01~89866-01~89870-0~89856-0~89851-01~89857-01~89863-01~89864-01~89867-01~89862-01&localTrackOrderByPid=89846-70w689~89868-0~89847-0~89877-0~89871-0~89858-01~89849-0~89852-01~89866-01~89870-0~89856-0~89851-01~89857-01~89863-01~89864-01~89867-01~89862-01~89848-01~89850-01&thread=o&timelineType=cpu-category&v=6) / [Production](https://share.firefox.dev/3tI5Efo)
