### PR TITLE
Add new fields to the screenshot marker tooltips

### DIFF
--- a/src/components/timeline/TrackScreenshots.js
+++ b/src/components/timeline/TrackScreenshots.js
@@ -18,6 +18,7 @@ import {
 } from 'firefox-profiler/components/shared/WithSize';
 import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
 import { createPortal } from 'react-dom';
+import { computeScreenshotSize } from 'firefox-profiler/profile-logic/marker-data';
 
 import type {
   ScreenshotPayload,
@@ -253,25 +254,16 @@ class HoverPreview extends PureComponent<HoverPreviewProps> {
     if (offsetX === null || pageX === null) {
       return null;
     }
-    const { url, windowWidth, windowHeight } = payload;
-    // Compute the hover image's thumbnail size.
+    const { url } = payload;
 
-    // When making a selection, we'd like that the hover is still displayed,
-    // but much smaller
     const maximumHoverSize = isMakingPreviewSelection
       ? MAXIMUM_HOVER_SIZE_WHEN_SELECTING_RANGE
       : MAXIMUM_HOVER_SIZE;
 
-    // Coefficient should be according to bigger side.
-    const coefficient =
-      windowHeight > windowWidth
-        ? maximumHoverSize / windowHeight
-        : maximumHoverSize / windowWidth;
-    let hoverHeight = windowHeight * coefficient;
-    let hoverWidth = windowWidth * coefficient;
-
-    hoverWidth = Math.round(hoverWidth);
-    hoverHeight = Math.round(hoverHeight);
+    const { width: hoverWidth, height: hoverHeight } = computeScreenshotSize(
+      payload,
+      maximumHoverSize
+    );
 
     // Set the top so it centers around the track.
     let top = containerTop + (trackHeight - hoverHeight) * 0.5;

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -316,7 +316,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
               key="CompositorScreenshot-window size"
             >
               <>
-                {data.windowWidth}px x {data.windowHeight}px
+                {data.windowWidth}px × {data.windowHeight}px
               </>
             </TooltipDetail>,
             <TooltipDetail

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -37,6 +37,7 @@ import {
   formatFromMarkerSchema,
   getSchemaFromMarker,
 } from 'firefox-profiler/profile-logic/marker-schema';
+import { computeScreenshotSize } from 'firefox-profiler/profile-logic/marker-data';
 
 import type {
   CategoryList,
@@ -91,6 +92,9 @@ type StateProps = {|
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, {||}>;
+
+// Maximum image size of a tooltip field.
+const MAXIMUM_IMAGE_SIZE = 350;
 
 /**
  * This component combines Marker Schema, and custom handling to generate tooltips
@@ -195,7 +199,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
    * properties that are difficult to represent with the Schema.
    */
   _renderMarkerDetails(): TooltipDetailComponent[] {
-    const { marker, markerSchemaByName } = this.props;
+    const { marker, markerSchemaByName, thread } = this.props;
     const data = marker.data;
     const details: TooltipDetailComponent[] = [];
 
@@ -287,6 +291,25 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
               key="IPC-Recv Thread Latency"
             >
               {_maybeFormatDuration(data.recvEndTime, data.endTime)}
+            </TooltipDetail>
+          );
+          break;
+        }
+        case 'CompositorScreenshot': {
+          const { width, height } = computeScreenshotSize(
+            data,
+            MAXIMUM_IMAGE_SIZE
+          );
+          details.push(
+            <TooltipDetail label="Image" key="CompositorScreenshot-image">
+              <img
+                className="tooltipScreenshotImg"
+                src={thread.stringTable.getString(data.url)}
+                style={{
+                  width,
+                  height,
+                }}
+              />
             </TooltipDetail>
           );
           break;

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -310,6 +310,21 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
                   height,
                 }}
               />
+            </TooltipDetail>,
+            <TooltipDetail
+              label="Window Size"
+              key="CompositorScreenshot-window size"
+            >
+              <>
+                {data.windowWidth}px x {data.windowHeight}px
+              </>
+            </TooltipDetail>,
+            <TooltipDetail
+              label="Description"
+              key="CompositorScreenshot-description"
+            >
+              This marker spans the time between each composite of a window and
+              shows the window contents during that time.
             </TooltipDetail>
           );
           break;

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -108,6 +108,13 @@
   white-space: nowrap;
 }
 
+.tooltipScreenshotImg {
+  padding: 0.5px;
+  border: 0.5px solid rgb(0 0 0 / 0.2);
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 0.2);
+}
+
 /**
  * Overwrite styles for the sidebar.
  */

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -40,6 +40,7 @@ import type {
   MarkerSchemaByName,
   MarkerDisplayLocation,
   Tid,
+  ScreenshotPayload,
 } from 'firefox-profiler/types';
 
 import type { UniqueStringArray } from '../utils/unique-string-array';
@@ -1352,4 +1353,30 @@ export function filterMarkerByDisplayLocation(
 
     return markerTypes.has(getMarkerSchemaName(markerSchemaByName, marker));
   });
+}
+
+/**
+ * Compute the Screenshot image's thumbnail size.
+ */
+export function computeScreenshotSize(
+  payload: ScreenshotPayload,
+  maximumSize: number
+): {| +width: number, +height: number |} {
+  const { windowWidth, windowHeight } = payload;
+
+  // Coefficient should be according to bigger side.
+  const coefficient =
+    windowHeight > windowWidth
+      ? maximumSize / windowHeight
+      : maximumSize / windowWidth;
+  let width = windowWidth * coefficient;
+  let height = windowHeight * coefficient;
+
+  width = Math.round(width);
+  height = Math.round(height);
+
+  return {
+    width,
+    height,
+  };
 }

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -1233,6 +1233,14 @@ function mergeMarkers(
             stack: newStack,
           },
         });
+      } else if (oldData && oldData.type === 'CompositorScreenshot') {
+        const oldUrlIndex = oldData.url;
+        const urlString = stringTable.getString(oldUrlIndex);
+
+        newMarkerTable.data.push({
+          ...oldData,
+          url: newStringTable.indexForString(urlString),
+        });
       } else {
         newMarkerTable.data.push(oldData);
       }

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -916,4 +916,43 @@ describe('TooltipMarker', function () {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('shows image of CompositorScreenshot markers', function () {
+    const { profile } = getProfileFromTextSamples(`A`);
+    const thread = profile.threads[0];
+
+    const screenshotUrl = 'Screenshot Url';
+    const screenshotUrlIndex = thread.stringTable.indexForString(screenshotUrl);
+    addMarkersToThreadWithCorrespondingSamples(thread, [
+      [
+        'CompositorScreenshot',
+        1,
+        2,
+        {
+          type: 'CompositorScreenshot',
+          url: screenshotUrlIndex,
+          windowID: 'XXX',
+          windowWidth: 600,
+          windowHeight: 300,
+        },
+      ],
+    ]);
+
+    const store = storeWithProfile(profile);
+    const { getState } = store;
+    const getMarker = selectedThreadSelectors.getMarkerGetter(getState());
+
+    const { container } = render(
+      <Provider store={store}>
+        <TooltipMarker
+          markerIndex={0}
+          marker={getMarker(0)}
+          threadsKey={0}
+          restrictHeightWidth={true}
+        />
+      </Provider>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -4680,3 +4680,67 @@ exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
   </div>
 </div>
 `;
+
+exports[`TooltipMarker shows image of CompositorScreenshot markers 1`] = `
+<div
+  class="tooltipMarker"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        2ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        CompositorScreenshot
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Image
+      :
+    </div>
+    <img
+      class="tooltipScreenshotImg"
+      src="Screenshot Url"
+      style="width: 350px; height: 175px;"
+    />
+    <div
+      class="tooltipLabel"
+    >
+      Window Size
+      :
+    </div>
+    600
+    px x 
+    300
+    px
+    <div
+      class="tooltipLabel"
+    >
+      Description
+      :
+    </div>
+    This marker spans the time between each composite of a window and shows the window contents during that time.
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+</div>
+`;

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -4724,7 +4724,7 @@ exports[`TooltipMarker shows image of CompositorScreenshot markers 1`] = `
       :
     </div>
     600
-    px x 
+    px × 
     300
     px
     <div


### PR DESCRIPTION
Fixes #3036.

This PR does a few things:
1. Adds screenshot images to the tooltips.
2. Adds 2 additional fields to the screenshot tooltips: "window size" and "description".
3. Fixes the problem in merge thread algorithm where we don't properly update the string table index.


It would be better to look at it commit by commit.

The tooltip looks like this now:
<img width="644" alt="Screen Shot 2022-03-29 at 11 03 40 AM" src="https://user-images.githubusercontent.com/466239/160575752-d51cecb7-e57e-4aa9-8556-7225b46dba50.png">
(since the description is a bit too long, it's making the tooltip wider than the image)

[Deploy preview](https://deploy-preview-3957--perf-html.netlify.app/public/x2ps56jhxw2vxdkqmcgw4x316efcqv5hnjanag0/marker-chart/?globalTrackOrder=80w7&hiddenGlobalTracks=1w6&hiddenLocalTracksByPid=9683-014w7~9696-0w3&localTrackOrderByPid=9683-40w35w8~9684-102~10555-102~9692-1023~9691-1023~10527-1023~9693-1023~9696-1023&markerSearch=key%2Capz%2Ccomposit%2Cvsync%2Crefresh&range=2281m1429~3201m138&thread=3&v=6) / [production](https://share.firefox.dev/3Di1YnP)

To test the merge threads code:
[Deploy preview](https://deploy-preview-3957--perf-html.netlify.app/public/x2ps56jhxw2vxdkqmcgw4x316efcqv5hnjanag0/marker-chart/?globalTrackOrder=80w7&hiddenGlobalTracks=1w6&hiddenLocalTracksByPid=9683-014w7~9696-0w3&localTrackOrderByPid=9683-40w35w8~9684-102~10555-102~9692-1023~9691-1023~10527-1023~9693-1023~9696-1023&markerSearch=key%2Capz%2Ccomposit%2Cvsync%2Crefresh&range=2281m1429~3201m138&thread=034h&v=6) / [Production](https://share.firefox.dev/32fiQtO)