### PR TITLE
Move the IPC tracks right below their threads during the initial load

### DIFF
--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -295,10 +295,10 @@ describe('MarkerTable', function () {
         'hide [thread GeckoMain process]',
         '  - show [ipc GeckoMain]',
         'show [thread GeckoMain tab] SELECTED',
-        '  - show [thread DOM Worker]',
-        '  - show [thread Style]',
         '  - show [ipc GeckoMain] SELECTED',
+        '  - show [thread DOM Worker]',
         '  - show [ipc DOM Worker]',
+        '  - show [thread Style]',
         '  - show [ipc Style]',
       ]);
 
@@ -313,10 +313,10 @@ describe('MarkerTable', function () {
         'show [thread GeckoMain process] SELECTED',
         '  - show [ipc GeckoMain] SELECTED',
         'show [thread GeckoMain tab]',
-        '  - show [thread DOM Worker]',
-        '  - show [thread Style]',
         '  - show [ipc GeckoMain]',
+        '  - show [thread DOM Worker]',
         '  - show [ipc DOM Worker]',
+        '  - show [thread Style]',
         '  - show [ipc Style]',
       ]);
     });
@@ -353,10 +353,10 @@ describe('MarkerTable', function () {
         'show [thread GeckoMain process] SELECTED',
         '  - show [ipc GeckoMain] SELECTED',
         'hide [thread GeckoMain tab]',
-        '  - hide [thread DOM Worker]',
-        '  - show [thread Style]',
         '  - show [ipc GeckoMain]',
+        '  - hide [thread DOM Worker]',
         '  - show [ipc DOM Worker]',
+        '  - show [thread Style]',
         '  - show [ipc Style]',
       ]);
 
@@ -371,10 +371,10 @@ describe('MarkerTable', function () {
         'show [thread GeckoMain process]',
         '  - show [ipc GeckoMain]',
         'show [thread GeckoMain tab]',
-        '  - show [thread DOM Worker] SELECTED',
-        '  - show [thread Style]',
         '  - show [ipc GeckoMain]',
+        '  - show [thread DOM Worker] SELECTED',
         '  - show [ipc DOM Worker] SELECTED',
+        '  - show [thread Style]',
         '  - show [ipc Style]',
       ]);
     });

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -351,7 +351,7 @@ describe('ordering and hiding', function () {
         );
       });
 
-      it('creates a separate user-facing ordering that is different from the internal sortiong', function () {
+      it('creates a separate user-facing ordering that is different from the internal sorting', function () {
         const { globalTracks, globalTrackOrder } = setup();
         expect(
           globalTrackOrder.map((trackIndex) => globalTracks[trackIndex].type)
@@ -623,7 +623,7 @@ describe('ordering and hiding', function () {
         );
       });
 
-      it('creates a separate user-facing ordering that is different from the internal sortiong', function () {
+      it('creates a separate user-facing ordering that is different from the internal sorting', function () {
         const { localTracks, localTrackOrder } = setup();
         expect(
           localTrackOrder.map((trackIndex) => localTracks[trackIndex].type)


### PR DESCRIPTION
Fixes #3890.

Previously the IPC tracks were always appearing at the end of the local tracks. But that's not a great user experience when our users need to look at the IPC markers. There are two IPC track cases:
1. If an IPC track belongs to a global track, we would like to show those tracks right after network and memory tracks and before other threads.
2. If an IPC track belongs to a local track, we would like to show those tracks right after those local thread tracks.

With this PR fixes those two items.

Some example profiles:
1. [Deploy preview](https://deploy-preview-3968--perf-html.netlify.app/public/d44gqy8a1zcxt5ghk7b7tt39x0r1a749m2mpmqr) / [Production](https://profiler.firefox.com/public/d44gqy8a1zcxt5ghk7b7tt39x0r1a749m2mpmqr/)
2. [Deploy preview](https://deploy-preview-3968--perf-html.netlify.app/public/vbfaj98f620zvkc9mthankp2d7c8x5mz5e1j19g/) / [Production](https://profiler.firefox.com/public/vbfaj98f620zvkc9mthankp2d7c8x5mz5e1j19g/)
3. [Deploy preview](https://deploy-preview-3968--perf-html.netlify.app/public/s22a03dhzmvhp8rrkmzajm2e49bzx9bm9nynd7g/) / [Production](https://profiler.firefox.com/public/s22a03dhzmvhp8rrkmzajm2e49bzx9bm9nynd7g/)

Note that some of the IPC tracks may be visible even though their threads are not. This is because we always show the IPC tracks right now but it will be fixed one #3908 lands.