### PR TITLE
Remove animations from various places for users with `prefer-reduced-motion`

### DIFF
--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -165,15 +165,18 @@
   position: relative;
 }
 
-.homeTransition-enter {
-  opacity: 0.1;
-  transform: translateX(100px);
-}
+/* Only show the home transition when reduced motion is not preferred */
+@media (prefers-reduced-motion: no-preference) {
+  .homeTransition-enter {
+    opacity: 0.1;
+    transform: translateX(100px);
+  }
 
-.homeTransition-enter.homeTransition-enter-active {
-  opacity: 1;
-  transform: translateX(0);
-  transition: opacity 300ms ease-out, transform 300ms ease-out;
+  .homeTransition-enter.homeTransition-enter-active {
+    opacity: 1;
+    transform: translateX(0);
+    transition: opacity 300ms ease-out, transform 300ms ease-out;
+  }
 }
 
 .homeSectionUploadFromFileInput {

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -175,3 +175,10 @@
 .menuButtonsPublishError {
   margin: 10px 0;
 }
+
+/* Do not animate the publish animation for stripes at the top loading bar. */
+@media (prefers-reduced-motion) {
+  .menuButtonsPublishUploadBarInner {
+    animation: none;
+  }
+}

--- a/src/components/app/ProfileRootMessage.css
+++ b/src/components/app/ProfileRootMessage.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .rootMessageContainer {
   position: absolute;
   top: 0;
@@ -163,5 +167,14 @@
   100% {
     opacity: 0;
     transform: translateX(-100px);
+  }
+}
+
+/* Do not animate the loading animation when user prefers reduced motion. The
+ * other alternative was to remove these boxes completely, but it's still nice
+ * to keep the boxes as a nice visualization. */
+@media (prefers-reduced-motion) {
+  .loading-div {
+    animation: none;
   }
 }

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 @keyframes profileViewerFadeIn {
   0% {
     opacity: 0;
@@ -113,4 +117,14 @@
 
 .profileViewerSpacer {
   flex: 1;
+}
+
+/* Do no animate the whole profile viewer during loading and publishing if user
+ * prefers reduced motion. */
+@media (prefers-reduced-motion) {
+  .profileViewer,
+  .profileViewerFadeOut,
+  .profileViewerFadeInSanitized {
+    animation: none;
+  }
 }

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -160,3 +160,11 @@
   opacity: 0;
   transform: translateX(50%);
 }
+
+/* Do not animate the filter navigator bar items when user prefers reduced motion */
+@media (prefers-reduced-motion) {
+  .filterNavigatorBarItem {
+    animation: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
Fixes #3969 and some more animations we have.
This PR removes the animation from a few places for users with `prefer-reduced-motion`:

1. Home view slide-in animation for texts and images during page load.
2. Stripes animation of the top loading bar while publishing a profile.
3. Loading animation with the colorful boxes (while either fetching a profile from Firefox or while downloading an profile)
4. Profile viewer animation that happens while loading a profile or publishing a profile.
5. Filter navigator bar item animations while adding or removing a new item.

[Deploy preview](https://deploy-preview-3972--perf-html.netlify.app/public/d44gqy8a1zcxt5ghk7b7tt39x0r1a749m2mpmqr/calltree/?globalTrackOrder=0wi&hiddenGlobalTracks=1wg&hiddenLocalTracksByPid=89846-1w6~89868-0~89847-0~89877-0~89871-0~89858-01~89849-0~89852-01~89866-01~89870-0~89856-0~89851-01~89857-01~89863-01~89864-01~89867-01~89862-01&localTrackOrderByPid=89846-70w689~89868-0~89847-0~89877-0~89871-0~89858-01~89849-0~89852-01~89866-01~89870-0~89856-0~89851-01~89857-01~89863-01~89864-01~89867-01~89862-01~89848-01~89850-01&thread=0&timelineType=cpu-category&v=6) / [Production](https://share.firefox.dev/3K9Ss8G)
You can activate the `prefer-reduced-motion` by following the steps here: https://github.com/firefox-devtools/profiler/issues/3969#issuecomment-1086391997