### PR TITLE
Add a "Copy page URL" marker context menu item 

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -341,6 +341,7 @@ MarkerContextMenu--end-selection-at-marker-end =
 MarkerContextMenu--copy-description = Copy description
 MarkerContextMenu--copy-call-stack = Copy call stack
 MarkerContextMenu--copy-url = Copy URL
+MarkerContextMenu--copy-page-url = Copy page URL
 MarkerContextMenu--copy-as-json = Copy as JSON
 
 # This string is used on the marker context menu item when right clicked on an

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -23,7 +23,6 @@ import MixedTupleMap from 'mixedtuplemap';
 import type {
   Thread,
   CategoryList,
-  PageList,
   CssPixels,
   Milliseconds,
   CallNodeInfo,
@@ -32,6 +31,8 @@ import type {
   WeightType,
   SamplesLikeTable,
   TracedTiming,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type {
@@ -46,7 +47,7 @@ import type { Viewport } from 'firefox-profiler/components/shared/chart/Viewport
 export type OwnProps = {|
   +thread: Thread,
   +weightType: WeightType,
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +unfilteredThread: Thread,
   +sampleIndexOffset: number,
   +maxStackDepth: number,
@@ -281,7 +282,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       interval,
       isInverted,
       callTreeSummaryStrategy,
-      pages,
+      innerWindowIDToPageMap,
       weightType,
       samples,
       unfilteredSamples,
@@ -322,7 +323,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       <TooltipCallNode
         thread={thread}
         weightType={weightType}
-        pages={pages}
+        innerWindowIDToPageMap={innerWindowIDToPageMap}
         interval={interval}
         callNodeIndex={callNodeIndex}
         callNodeInfo={callNodeInfo}

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -14,7 +14,7 @@ import {
   getPreviewSelection,
   getScrollToSelectionGeneration,
   getProfileInterval,
-  getPageList,
+  getInnerWindowIDToPageMap,
 } from 'firefox-profiler/selectors/profile';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import {
@@ -33,7 +33,6 @@ import {
 import type {
   Thread,
   CategoryList,
-  PageList,
   Milliseconds,
   StartEndRange,
   WeightType,
@@ -44,6 +43,8 @@ import type {
   IndexIntoCallNodeTable,
   TracedTiming,
   ThreadsKey,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type { FlameGraphTiming } from 'firefox-profiler/profile-logic/flame-graph';
@@ -66,7 +67,7 @@ const SELECTABLE_THRESHOLD = 0.001;
 type StateProps = {|
   +thread: Thread,
   +weightType: WeightType,
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +unfilteredThread: Thread,
   +sampleIndexOffset: number,
   +maxStackDepth: number,
@@ -315,7 +316,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
       categories,
       interval,
       isInverted,
-      pages,
+      innerWindowIDToPageMap,
       weightType,
       samples,
       unfilteredSamples,
@@ -350,7 +351,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
             // FlameGraphCanvas props
             chartProps={{
               thread,
-              pages,
+              innerWindowIDToPageMap,
               weightType,
               unfilteredThread,
               sampleIndexOffset,
@@ -415,7 +416,7 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
     isInverted: getInvertCallstack(state),
     callTreeSummaryStrategy:
       selectedThreadSelectors.getCallTreeSummaryStrategy(state),
-    pages: getPageList(state),
+    innerWindowIDToPageMap: getInnerWindowIDToPageMap(state),
     samples:
       selectedThreadSelectors.getPreviewFilteredSamplesForCallTree(state),
     unfilteredSamples:

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -23,7 +23,6 @@ import { TooltipMarker } from '../tooltip/Marker';
 import type {
   Thread,
   CategoryList,
-  PageList,
   ThreadsKey,
   UserTimingMarkerPayload,
   WeightType,
@@ -36,6 +35,8 @@ import type {
   UnitIntervalOfProfileRange,
   MarkerIndex,
   Marker,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type {
@@ -47,7 +48,7 @@ import type { WrapFunctionInDispatch } from '../../utils/connect';
 
 type OwnProps = {|
   +thread: Thread,
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +threadsKey: ThreadsKey,
   +interval: Milliseconds,
   +weightType: WeightType,
@@ -418,7 +419,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       getMarker,
       shouldDisplayTooltips,
       interval,
-      pages,
+      innerWindowIDToPageMap,
     } = this.props;
 
     if (!shouldDisplayTooltips()) {
@@ -448,7 +449,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       <TooltipCallNode
         thread={thread}
         weightType={weightType}
-        pages={pages}
+        innerWindowIDToPageMap={innerWindowIDToPageMap}
         interval={interval}
         callNodeIndex={callNodeIndex}
         callNodeInfo={callNodeInfo}

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -16,7 +16,7 @@ import {
   getPreviewSelection,
   getScrollToSelectionGeneration,
   getCategories,
-  getPageList,
+  getInnerWindowIDToPageMap,
 } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 import {
@@ -40,7 +40,6 @@ import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import type {
   Thread,
   CategoryList,
-  PageList,
   CallNodeInfo,
   IndexIntoCallNodeTable,
   CombinedTimingRows,
@@ -53,6 +52,8 @@ import type {
   WeightType,
   ThreadsKey,
   CssPixels,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -64,7 +65,7 @@ const STACK_FRAME_HEIGHT = 16;
 type StateProps = {|
   +thread: Thread,
   +weightType: WeightType,
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +maxStackDepth: number,
   +combinedTimingRows: CombinedTimingRows,
   +timeRange: StartEndRange,
@@ -173,7 +174,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       categories,
       selectedCallNodeIndex,
       scrollToSelectionGeneration,
-      pages,
+      innerWindowIDToPageMap,
       getMarker,
       userTimings,
       weightType,
@@ -217,7 +218,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   interval,
                   thread,
                   weightType,
-                  pages,
+                  innerWindowIDToPageMap,
                   threadsKey,
                   combinedTimingRows,
                   getMarker,
@@ -269,7 +270,7 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       rightClickedCallNodeIndex:
         selectedThreadSelectors.getRightClickedCallNodeIndex(state),
       scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
-      pages: getPageList(state),
+      innerWindowIDToPageMap: getInnerWindowIDToPageMap(state),
       getMarker: selectedThreadSelectors.getMarkerGetter(state),
       userTimings: selectedThreadSelectors.getUserTimingMarkerIndexes(state),
       timelineMarginLeft: getTimelineMarginLeft(state),

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -15,7 +15,7 @@ import { VerticalIndicators } from './VerticalIndicators';
 import {
   getCommittedRange,
   getZeroAt,
-  getPageList,
+  getInnerWindowIDToPageMap,
   getPreviewSelection,
 } from 'firefox-profiler/selectors/profile';
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
@@ -36,11 +36,12 @@ import { bisectionRight } from 'firefox-profiler/utils/bisect';
 import type {
   CssPixels,
   ThreadIndex,
-  PageList,
   Marker,
   MarkerIndex,
   MarkerTiming,
   Milliseconds,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
@@ -249,7 +250,7 @@ type OwnProps = {|
 |};
 
 type StateProps = {|
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +isModifyingSelection: boolean,
@@ -334,7 +335,7 @@ class Network extends PureComponent<Props, State> {
 
   render() {
     const {
-      pages,
+      innerWindowIDToPageMap,
       rangeStart,
       rangeEnd,
       getMarker,
@@ -389,7 +390,7 @@ class Network extends PureComponent<Props, State> {
           <VerticalIndicators
             verticalMarkerIndexes={verticalMarkerIndexes}
             getMarker={getMarker}
-            pages={pages}
+            innerWindowIDToPageMap={innerWindowIDToPageMap}
             rangeStart={rangeStart}
             rangeEnd={rangeEnd}
             zeroAt={zeroAt}
@@ -426,7 +427,7 @@ export const TrackNetwork = explicitConnect<
     const networkTiming = selectors.getNetworkTrackTiming(state);
     return {
       getMarker: selectors.getMarkerGetter(state),
-      pages: getPageList(state),
+      innerWindowIDToPageMap: getInnerWindowIDToPageMap(state),
       networkTiming: networkTiming,
       rangeStart: start,
       rangeEnd: end,

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -9,11 +9,12 @@ import { displayNiceUrl } from 'firefox-profiler/utils';
 import { formatSeconds } from 'firefox-profiler/utils/format-numbers';
 
 import type {
-  PageList,
   Marker,
   MarkerIndex,
   Milliseconds,
   CssPixels,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import './VerticalIndicators.css';
@@ -21,7 +22,7 @@ import './VerticalIndicators.css';
 type Props = {|
   +getMarker: (MarkerIndex) => Marker,
   +verticalMarkerIndexes: MarkerIndex[],
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +zeroAt: Milliseconds,
@@ -48,7 +49,7 @@ export class VerticalIndicators extends React.PureComponent<Props> {
     const {
       getMarker,
       verticalMarkerIndexes,
-      pages,
+      innerWindowIDToPageMap,
       rangeStart,
       rangeEnd,
       zeroAt,
@@ -84,16 +85,14 @@ export class VerticalIndicators extends React.PureComponent<Props> {
       let url = null;
       const { data } = marker;
       if (
-        pages &&
+        innerWindowIDToPageMap &&
         data &&
         data.type === 'tracing' &&
         data.category === 'Navigation'
       ) {
         const innerWindowID = data.innerWindowID;
         if (innerWindowID) {
-          const page = pages.find(
-            (page) => page.innerWindowID === innerWindowID
-          );
+          const page = innerWindowIDToPageMap.get(innerWindowID);
           if (page) {
             url = (
               <div className="timelineVerticalIndicatorsUrl">

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -18,13 +18,14 @@ import type { CallTree } from 'firefox-profiler/profile-logic/call-tree';
 import type {
   Thread,
   CategoryList,
-  PageList,
   IndexIntoCallNodeTable,
   CallNodeDisplayData,
   CallNodeInfo,
   WeightType,
   Milliseconds,
   CallTreeSummaryStrategy,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type { TimingsForPath } from 'firefox-profiler/profile-logic/profile-data';
@@ -37,7 +38,7 @@ const GRAPH_HEIGHT = 10;
 type Props = {|
   +thread: Thread,
   +weightType: WeightType,
-  +pages: PageList | null,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +callNodeIndex: IndexIntoCallNodeTable,
   +callNodeInfo: CallNodeInfo,
   +categories: CategoryList,
@@ -172,7 +173,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
       callTree,
       timings,
       callTreeSummaryStrategy,
-      pages,
+      innerWindowIDToPageMap,
       callNodeInfo: { callNodeTable },
     } = this.props;
     const categoryIndex = callNodeTable.category[callNodeIndex];
@@ -240,8 +241,8 @@ export class TooltipCallNode extends React.PureComponent<Props> {
 
     // Finding current frame and parent frame URL(if there is).
     let pageAndParentPageURL;
-    if (pages) {
-      const page = pages.find((p) => p.innerWindowID === innerWindowID);
+    if (innerWindowIDToPageMap) {
+      const page = innerWindowIDToPageMap.get(innerWindowID);
       if (page) {
         if (page.embedderInnerWindowID !== 0) {
           // This is an iframe since it has an embedder.
@@ -255,8 +256,8 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           ];
 
           // Getting the embedder URL now.
-          const parentPage = pages.find(
-            (p) => p.innerWindowID === page.embedderInnerWindowID
+          const parentPage = innerWindowIDToPageMap.get(
+            page.embedderInnerWindowID
           );
           // Ideally it should find a page.
           if (parentPage) {

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -614,6 +614,27 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
 );
 
 /**
+ * Returns an InnerWindowID -> Page map, so we can look up the page from inner
+ * window id quickly. Returns null if there are no pages in the profile.
+ */
+export const getInnerWindowIDToPageMap: Selector<Map<
+  InnerWindowID,
+  Page
+> | null> = createSelector(getPageList, (pages) => {
+  if (!pages) {
+    // Return null if there are no pages.
+    return null;
+  }
+
+  const innerWindowIDToPageMap: Map<InnerWindowID, Page> = new Map();
+  for (const page of pages) {
+    innerWindowIDToPageMap.set(page.innerWindowID, page);
+  }
+
+  return innerWindowIDToPageMap;
+});
+
+/**
  * Get the pages array and construct a Map of pages that we can use to get the
  * relationships of tabs. The constructed map is `Map<TabID,Page[]>`.
  * The TabID we use in that map is the TabID of the topmost frame. That corresponds
@@ -622,22 +643,18 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
  */
 export const getPagesMap: Selector<Map<TabID, Page[]> | null> = createSelector(
   getPageList,
-  (pageList) => {
-    if (pageList === null || pageList.length === 0) {
+  getInnerWindowIDToPageMap,
+  (pageList, innerWindowIDToPageMap) => {
+    if (
+      pageList === null ||
+      innerWindowIDToPageMap === null ||
+      pageList.length === 0
+    ) {
       // There is no data, return null
       return null;
     }
 
-    // Constructing this map first so we won't have to walk through the page list
-    // all the time.
-    const innerWindowIDToPageMap: Map<InnerWindowID, Page> = new Map();
-
-    for (const page of pageList) {
-      innerWindowIDToPageMap.set(page.innerWindowID, page);
-    }
-
-    // Now we have a way to fastly traverse back with the previous Map.
-    // We can do construction of TabID to Page array map.
+    // Construction of TabID to Page array map.
     const pageMap: Map<TabID, Page[]> = new Map();
     const appendPageMap = (tabID, page) => {
       const tabEntry = pageMap.get(tabID);

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -28,6 +28,7 @@ import {
   getMarkerTableProfile,
   addMarkersToThreadWithCorrespondingSamples,
   addIPCMarkerPairToThreads,
+  getNetworkTrackProfile,
 } from '../fixtures/profiles/processed-profile';
 import { fireFullClick, fireFullContextMenu } from '../fixtures/utils';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
@@ -195,6 +196,30 @@ describe('MarkerTable', function () {
       D [libxul.so]
       E [libxul.so]
     `);
+  });
+
+  it("can copy a marker's page url using the context menu", () => {
+    // A simple profile that contains markers with page information.
+    // We will be using `DOMContentLoaded` that has a page url.
+    const profile = getNetworkTrackProfile();
+    setup(profile);
+
+    // Make sure that a marker without an innerWindowID doesn't have this
+    // context menu item. `Navigation::Start` doesn't have one.
+    //
+    // We are using `getAllByText` here because marker table puts the same text
+    // to both `type` and `name` columns. But right clicking on either of them
+    // results in the same menu item.
+    fireFullContextMenu(screen.getAllByText('Navigation::Start')[0]);
+    expect(screen.queryByText('Copy page URL')).not.toBeInTheDocument();
+
+    // Make sure that a marker with innerWindowID has this context menu item and
+    // can copy its page url successfully.
+    fireFullContextMenu(screen.getByText('DOMContentLoaded'));
+    fireFullClick(screen.getByText('Copy page URL'));
+    expect(copy).toHaveBeenLastCalledWith(
+      'https://developer.mozilla.org/en-US/'
+    );
   });
 
   describe('EmptyReasons', () => {

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -33,7 +33,9 @@ describe('TooltipCallNode', function () {
           <TooltipCallNode
             thread={selectedThreadSelectors.getThread(getState())}
             weightType="samples"
-            pages={ProfileSelectors.getPageList(getState())}
+            innerWindowIDToPageMap={ProfileSelectors.getInnerWindowIDToPageMap(
+              getState()
+            )}
             callNodeIndex={ensureExists(
               selectedThreadSelectors.getSelectedCallNodeIndex(getState()),
               'Unable to find a selected call node index.'


### PR DESCRIPTION
Fixes #3965.

With this PR, it should be possible to copy the marker page urls from the context menu directly.
<img width="734" alt="Screen Shot 2022-04-07 at 12 23 15 PM" src="https://user-images.githubusercontent.com/466239/162178518-b3776dd0-8eeb-4871-ae85-239f1ec762b1.png">

My first commit is a bit of a refactoring to make this lookup faster with a Map.

[Deploy preview](https://deploy-preview-3981--perf-html.netlify.app/public/8rrd9r40x0v7837n46vx7qkf6ct2wy6cp3760j0/marker-chart/?globalTrackOrder=ab0w9&hiddenGlobalTracks=1w689&hiddenLocalTracksByPid=2942-0w9~3051-0~3088-0~3154-0~3241-0~3444-0~3910-01~3970-0~3124-0w2&localTrackOrderByPid=2942-ab0w9~3051-0~3088-0~3154-0~3241-0~3444-0~3910-10~3311-01~3970-0~3124-201&thread=i&timelineType=cpu-category&v=6) / [Production](https://share.firefox.dev/3NyIv76)
