### PR TITLE
Do not show the sample graph when the track type is condensed

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -287,19 +287,21 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               maxThreadCPUDelta={maxThreadCPUDelta}
               implementationFilter={implementationFilter}
             />
-            <ThreadSampleGraph
-              className="threadSampleGraph"
-              trackName={trackName}
-              interval={interval}
-              thread={filteredThread}
-              tabFilteredThread={tabFilteredThread}
-              rangeStart={rangeStart}
-              rangeEnd={rangeEnd}
-              callNodeInfo={callNodeInfo}
-              selectedCallNodeIndex={selectedCallNodeIndex}
-              categories={categories}
-              onSampleClick={this._onSampleClick}
-            />
+            {trackType === 'expanded' ? (
+              <ThreadSampleGraph
+                className="threadSampleGraph"
+                trackName={trackName}
+                interval={interval}
+                thread={filteredThread}
+                tabFilteredThread={tabFilteredThread}
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                callNodeInfo={callNodeInfo}
+                selectedCallNodeIndex={selectedCallNodeIndex}
+                categories={categories}
+                onSampleClick={this._onSampleClick}
+              />
+            ) : null}
             {isExperimentalCPUGraphsEnabled &&
             rangeFilteredThread.samples.threadCPUDelta !== undefined ? (
               <ThreadCPUGraph

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -138,25 +138,6 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
           </div>
         </div>
         <div
-          class="threadSampleGraph"
-        >
-          <div>
-            <canvas
-              class="threadSampleGraphCanvas threadSampleGraphCanvas"
-              height="300"
-              width="200"
-            >
-              <h2>
-                Stack Graph for 
-                Page #3
-              </h2>
-              <p>
-                This graph charts the stack height of each sample.
-              </p>
-            </canvas>
-          </div>
-        </div>
-        <div
           class="timelineTrackThreadMarkers"
         >
           <div
@@ -219,25 +200,6 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
         </div>
       </div>
       <div
-        class="threadSampleGraph"
-      >
-        <div>
-          <canvas
-            class="threadSampleGraphCanvas threadSampleGraphCanvas"
-            height="300"
-            width="200"
-          >
-            <h2>
-              Stack Graph for 
-              Merged resource tracks
-            </h2>
-            <p>
-              This graph charts the stack height of each sample.
-            </p>
-          </canvas>
-        </div>
-      </div>
-      <div
         class="timelineTrackThreadMarkers"
       >
         <div
@@ -294,25 +256,6 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
             </h2>
             <p>
               This graph shows a visual chart of thread activity.
-            </p>
-          </canvas>
-        </div>
-      </div>
-      <div
-        class="threadSampleGraph"
-      >
-        <div>
-          <canvas
-            class="threadSampleGraphCanvas threadSampleGraphCanvas"
-            height="300"
-            width="200"
-          >
-            <h2>
-              Stack Graph for 
-              Merged resource tracks
-            </h2>
-            <p>
-              This graph charts the stack height of each sample.
             </p>
           </canvas>
         </div>
@@ -381,25 +324,6 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
                   </h2>
                   <p>
                     This graph shows a visual chart of thread activity.
-                  </p>
-                </canvas>
-              </div>
-            </div>
-            <div
-              class="threadSampleGraph"
-            >
-              <div>
-                <canvas
-                  class="threadSampleGraphCanvas threadSampleGraphCanvas"
-                  height="300"
-                  width="200"
-                >
-                  <h2>
-                    Stack Graph for 
-                    Page #2
-                  </h2>
-                  <p>
-                    This graph charts the stack height of each sample.
                   </p>
                 </canvas>
               </div>


### PR DESCRIPTION
We are only showing activity graph for the "condensed" track type and hiding the markers etc. even if they are present. After adding the sample graph, they were always shown in the active tab view. But problem with them is that the height was was becoming too much and tracks were overflowing. So like markers, it's good to remove the sample graphs when the tracks are "condensed" and show them only when they are "expanded".
There are two condensed places:
1. The merged track where we have resources panel.
2. Resources tracks.

For the merged track, it will be removed directly. But for the resources tracks they will be shown when they are expanded.

Before:
<img width="643" alt="Screen Shot 2022-04-27 at 4 23 42 PM" src="https://user-images.githubusercontent.com/466239/165540927-a0e59319-042f-4d98-94fc-208305ac014d.png">

After:
<img width="610" alt="Screen Shot 2022-04-27 at 4 23 00 PM" src="https://user-images.githubusercontent.com/466239/165540963-59a429c1-a657-4361-9d9f-466a99fc171b.png">

Before:
<img width="595" alt="Screen Shot 2022-04-27 at 4 24 46 PM" src="https://user-images.githubusercontent.com/466239/165541264-75b0b14e-3f66-47ee-9fba-356669cf70e5.png">

After:
<img width="601" alt="Screen Shot 2022-04-27 at 4 25 57 PM" src="https://user-images.githubusercontent.com/466239/165541439-4c966e3c-1d59-459e-96b2-280f11303701.png">

I also want to move the markers to the top of activity graph but will do it in another PR. Right now it's harder to distinguish if it's a marker or a sample graph.

Example profile: [deploy preview](https://deploy-preview-4009--perf-html.netlify.app/public/d3mszd6xzq3np6e86hg8zb35ysb4x2fqbbg97qg/calltree/?implementation=js&thread=yi&timelineType=cpu-category&v=6&view=active-tab) / [production](https://share.firefox.dev/38qBXao)