### PR TITLE
Tweak tab bar CSS

### DIFF
--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -4,6 +4,7 @@
 
 /* Removing styling from the button */
 .tabBarTabButton {
+  overflow: hidden;
   width: 100%;
   height: 100%;
   padding: 0;
@@ -11,29 +12,29 @@
   margin: 0;
   background: none;
   font: inherit;
+  text-overflow: ellipsis;
 }
 
 .tabBarTabWrapper {
   display: flex;
   min-width: 0; /* This makes the tab container actually shrinkable below min-content */
   flex-flow: row nowrap;
-  padding: 0 0.5px;
-  margin: 0 -1px;
+  padding: 0;
+  margin: 0 -0.5px; /* This combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border */
   list-style: none;
 }
 
 .tabBarTab {
   position: relative;
-  overflow: hidden;
   min-width: 8em;
   padding: 6px 4px;
   border: solid transparent;
   border-width: 0 1px;
+  margin: 0 -0.5px; /* This makes the 1px border between adjacent tabs overlap */
   background-clip: padding-box;
   cursor: default;
   font-size: 12px;
   text-align: center;
-  text-overflow: ellipsis;
   transition: background-color 200ms, border-color 200ms;
   transition-timing-function: var(--animation-timing);
   user-select: none;
@@ -44,8 +45,8 @@
 .tabBarTab::before {
   position: absolute;
   top: 0;
+  right: -1px;
   left: -1px;
-  width: calc(100% + 2px);
   height: 2px;
   background-color: transparent;
   content: '';
@@ -54,9 +55,8 @@
 }
 
 .tabBarTab.selected::before {
-  /* The selected tab is shifted down a bit, so shift this bar back up a bit */
-  top: -1px;
   background-color: var(--blue-50);
+  transition: none; /* Switch the background color instantly when a tab is selected */
 }
 
 .tabBarTab:not(.selected):hover {
@@ -69,10 +69,10 @@
 }
 
 .tabBarTab.selected {
-  /* Cut off the bottom of the border for the tab line. */
-  top: 1px;
-  padding-top: 5px;
+  z-index: 1;
   border-color: var(--grey-30);
+  margin-bottom: -1px; /* Expand 1px towards the bottom to cover the tab bar bottom border. */
   background: #fff;
   color: var(--blue-60);
+  transition: none; /* Switch the background color instantly when a tab is selected */
 }


### PR DESCRIPTION
The 2px blue line on selected tabs is no longer cut off.
The spacing between tabs has been tightened.
The text-overflow now actually works.


[production](https://profiler.firefox.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/marker-chart/?globalTrackOrder=de0wc&hiddenGlobalTracks=1w57wb&hiddenLocalTracksByPid=29495-0w6~5123-0~29556-0~526-0~29603-0~29692-01~5053-01~29650-0~29726-0~4975-0~29481-0~21926-0&localTrackOrderByPid=29495-780w6~5123-0~29556-0~526-0~29603-0~29692-01~5023-0~5053-01~29650-0~29726-0~4975-0~29481-0~21926-10&thread=0&timelineType=cpu-category&v=6)
[deploy preview](https://deploy-preview-4013--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/marker-chart/?globalTrackOrder=de0wc&hiddenGlobalTracks=1w57wb&hiddenLocalTracksByPid=29495-0w6~5123-0~29556-0~526-0~29603-0~29692-01~5053-01~29650-0~29726-0~4975-0~29481-0~21926-0&localTrackOrderByPid=29495-780w6~5123-0~29556-0~526-0~29603-0~29692-01~5023-0~5053-01~29650-0~29726-0~4975-0~29481-0~21926-10&thread=0&timelineType=cpu-category&v=6)

Before:
<img width="971" alt="Screen Shot 2022-04-27 at 11 28 02 AM" src="https://user-images.githubusercontent.com/961291/165556441-dd965717-0fb3-425f-9691-bf04968b17e4.png">

After:
<img width="969" alt="Screen Shot 2022-04-27 at 11 28 11 AM" src="https://user-images.githubusercontent.com/961291/165556452-37f41fd8-2848-4137-9031-647d67df79f2.png">

