### PR TITLE
Switch tabs on mousedown

### DIFF
--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -26,7 +26,8 @@ export class TabBar extends React.PureComponent<Props> {
     this.props.onSelectTab(e.currentTarget.dataset.name);
   };
 
-  _onMouseDown = (e: SyntheticMouseEvent<>) => {
+  _onMouseDown = (e: SyntheticMouseEvent<HTMLElement>) => {
+    this.props.onSelectTab(e.currentTarget.dataset.name);
     // Prevent focusing the tab so that actual content like the
     // calltree can perform its own focusing.
     e.preventDefault();


### PR DESCRIPTION
This was the original behavior; we switched to click when we added the `<button>` elements for accessibility.
Let's just handle both mousedown and click. All tab bars in the entire world switch tabs on mousedown rather than mouseup.