### PR TITLE
Move the active tab markers to the top of activity graph

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -24,7 +24,6 @@ import {
   getSelectedThreadIndexes,
   getTimelineType,
   getInvertCallstack,
-  getTimelineTrackOrganization,
   getThreadSelectorsFromThreadsKey,
   getMaxThreadCPUDelta,
   getIsExperimentalCPUGraphsEnabled,
@@ -64,7 +63,6 @@ import type {
   IndexIntoCallNodeTable,
   SelectedState,
   State,
-  TimelineTrackOrganization,
   ThreadsKey,
 } from 'firefox-profiler/types';
 
@@ -98,7 +96,6 @@ type StateProps = {|
     IndexIntoSamplesTable,
     IndexIntoSamplesTable
   ) => number,
-  +timelineTrackOrganization: TimelineTrackOrganization,
   +selectedThreadIndexes: Set<ThreadIndex>,
   +enableCPUUsage: boolean,
   +isExperimentalCPUGraphsEnabled: boolean,
@@ -210,7 +207,6 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       samplesSelectedStates,
       treeOrderSampleComparator,
       trackType,
-      timelineTrackOrganization,
       trackName,
       enableCPUUsage,
       maxThreadCPUDelta,
@@ -231,42 +227,39 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
 
     return (
       <div className={classNames('timelineTrackThread', trackType)}>
-        {timelineTrackOrganization.type !== 'active-tab' ? (
-          <>
-            {showMemoryMarkers ? (
-              <TimelineMarkersMemory
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-            {hasFileIoMarkers ? (
-              <TimelineMarkersFileIo
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-            {displayJank ? (
-              <TimelineMarkersJank
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-            {displayMarkers ? (
-              <TimelineMarkersOverview
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-          </>
+        {trackType === 'expanded' && showMemoryMarkers ? (
+          <TimelineMarkersMemory
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            threadsKey={threadsKey}
+            onSelect={this._onMarkerSelect}
+          />
         ) : null}
+        {trackType === 'expanded' && hasFileIoMarkers ? (
+          <TimelineMarkersFileIo
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            threadsKey={threadsKey}
+            onSelect={this._onMarkerSelect}
+          />
+        ) : null}
+        {displayJank ? (
+          <TimelineMarkersJank
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            threadsKey={threadsKey}
+            onSelect={this._onMarkerSelect}
+          />
+        ) : null}
+        {trackType === 'expanded' && displayMarkers ? (
+          <TimelineMarkersOverview
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            threadsKey={threadsKey}
+            onSelect={this._onMarkerSelect}
+          />
+        ) : null}
+
         {(timelineType === 'category' || timelineType === 'cpu-category') &&
         !filteredThread.isJsTracer ? (
           <>
@@ -335,42 +328,6 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
             onSampleClick={this._onSampleClick}
           />
         )}
-        {timelineTrackOrganization.type === 'active-tab' ? (
-          <div className="timelineTrackThreadMarkers">
-            {trackType === 'expanded' && showMemoryMarkers ? (
-              <TimelineMarkersMemory
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-            {trackType === 'expanded' && hasFileIoMarkers ? (
-              <TimelineMarkersFileIo
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-            {displayJank ? (
-              <TimelineMarkersJank
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-            {trackType === 'expanded' && displayMarkers ? (
-              <TimelineMarkersOverview
-                rangeStart={rangeStart}
-                rangeEnd={rangeEnd}
-                threadsKey={threadsKey}
-                onSelect={this._onMarkerSelect}
-              />
-            ) : null}
-          </div>
-        ) : null}
         <EmptyThreadIndicator
           thread={filteredThread}
           interval={interval}
@@ -435,7 +392,6 @@ export const TimelineTrackThread = explicitConnect<
         selectors.getSamplesSelectedStatesInFilteredThread(state),
       treeOrderSampleComparator:
         selectors.getTreeOrderComparatorInFilteredThread(state),
-      timelineTrackOrganization: getTimelineTrackOrganization(state),
       selectedThreadIndexes,
       enableCPUUsage,
       isExperimentalCPUGraphsEnabled: getIsExperimentalCPUGraphsEnabled(state),

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -14,6 +14,38 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
         class="timelineTrackThread expanded"
       >
         <div
+          class="timelineMarkers"
+          data-testid="TimelineMarkersJank"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="300"
+                width="200"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="timelineMarkers timelineMarkersGeckoMain"
+          data-testid="TimelineMarkersOverview"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="300"
+                width="200"
+              />
+            </div>
+          </div>
+        </div>
+        <div
           class="threadActivityGraph"
         >
           <div>
@@ -52,42 +84,6 @@ exports[`ActiveTabTimeline ActiveTabGlobalTrack matches the snapshot of a global
           </div>
         </div>
         <div
-          class="timelineTrackThreadMarkers"
-        >
-          <div
-            class="timelineMarkers"
-            data-testid="TimelineMarkersJank"
-          >
-            <div
-              class="react-contextmenu-wrapper"
-            >
-              <div>
-                <canvas
-                  class="timelineMarkersCanvas"
-                  height="300"
-                  width="200"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="timelineMarkers timelineMarkersGeckoMain"
-            data-testid="TimelineMarkersOverview"
-          >
-            <div
-              class="react-contextmenu-wrapper"
-            >
-              <div>
-                <canvas
-                  class="timelineMarkersCanvas"
-                  height="300"
-                  width="200"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
           class="timelineEmptyThreadIndicator"
         />
       </div>
@@ -119,6 +115,22 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
         class="timelineTrackThread condensed"
       >
         <div
+          class="timelineMarkers"
+          data-testid="TimelineMarkersJank"
+        >
+          <div
+            class="react-contextmenu-wrapper"
+          >
+            <div>
+              <canvas
+                class="timelineMarkersCanvas"
+                height="300"
+                width="200"
+              />
+            </div>
+          </div>
+        </div>
+        <div
           class="threadActivityGraph"
         >
           <div>
@@ -135,26 +147,6 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
                 This graph shows a visual chart of thread activity.
               </p>
             </canvas>
-          </div>
-        </div>
-        <div
-          class="timelineTrackThreadMarkers"
-        >
-          <div
-            class="timelineMarkers"
-            data-testid="TimelineMarkersJank"
-          >
-            <div
-              class="react-contextmenu-wrapper"
-            >
-              <div>
-                <canvas
-                  class="timelineMarkersCanvas"
-                  height="300"
-                  width="200"
-                />
-              </div>
-            </div>
           </div>
         </div>
         <div
@@ -181,6 +173,22 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
       class="timelineTrackThread condensed"
     >
       <div
+        class="timelineMarkers"
+        data-testid="TimelineMarkersJank"
+      >
+        <div
+          class="react-contextmenu-wrapper"
+        >
+          <div>
+            <canvas
+              class="timelineMarkersCanvas"
+              height="300"
+              width="200"
+            />
+          </div>
+        </div>
+      </div>
+      <div
         class="threadActivityGraph"
       >
         <div>
@@ -197,26 +205,6 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
               This graph shows a visual chart of thread activity.
             </p>
           </canvas>
-        </div>
-      </div>
-      <div
-        class="timelineTrackThreadMarkers"
-      >
-        <div
-          class="timelineMarkers"
-          data-testid="TimelineMarkersJank"
-        >
-          <div
-            class="react-contextmenu-wrapper"
-          >
-            <div>
-              <canvas
-                class="timelineMarkersCanvas"
-                height="300"
-                width="200"
-              />
-            </div>
-          </div>
         </div>
       </div>
       <div
@@ -242,6 +230,22 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
       class="timelineTrackThread condensed"
     >
       <div
+        class="timelineMarkers"
+        data-testid="TimelineMarkersJank"
+      >
+        <div
+          class="react-contextmenu-wrapper"
+        >
+          <div>
+            <canvas
+              class="timelineMarkersCanvas"
+              height="300"
+              width="200"
+            />
+          </div>
+        </div>
+      </div>
+      <div
         class="threadActivityGraph"
       >
         <div>
@@ -258,26 +262,6 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
               This graph shows a visual chart of thread activity.
             </p>
           </canvas>
-        </div>
-      </div>
-      <div
-        class="timelineTrackThreadMarkers"
-      >
-        <div
-          class="timelineMarkers"
-          data-testid="TimelineMarkersJank"
-        >
-          <div
-            class="react-contextmenu-wrapper"
-          >
-            <div>
-              <canvas
-                class="timelineMarkersCanvas"
-                height="300"
-                width="200"
-              />
-            </div>
-          </div>
         </div>
       </div>
       <div
@@ -310,6 +294,22 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
             class="timelineTrackThread condensed"
           >
             <div
+              class="timelineMarkers"
+              data-testid="TimelineMarkersJank"
+            >
+              <div
+                class="react-contextmenu-wrapper"
+              >
+                <div>
+                  <canvas
+                    class="timelineMarkersCanvas"
+                    height="300"
+                    width="200"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
               class="threadActivityGraph"
             >
               <div>
@@ -326,26 +326,6 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
                     This graph shows a visual chart of thread activity.
                   </p>
                 </canvas>
-              </div>
-            </div>
-            <div
-              class="timelineTrackThreadMarkers"
-            >
-              <div
-                class="timelineMarkers"
-                data-testid="TimelineMarkersJank"
-              >
-                <div
-                  class="react-contextmenu-wrapper"
-                >
-                  <div>
-                    <canvas
-                      class="timelineMarkersCanvas"
-                      height="300"
-                      width="200"
-                    />
-                  </div>
-                </div>
               </div>
             </div>
             <div
@@ -439,6 +419,38 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                   class="timelineTrackThread expanded"
                 >
                   <div
+                    class="timelineMarkers selected"
+                    data-testid="TimelineMarkersJank"
+                  >
+                    <div
+                      class="react-contextmenu-wrapper"
+                    >
+                      <div>
+                        <canvas
+                          class="timelineMarkersCanvas"
+                          height="300"
+                          width="200"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="timelineMarkers timelineMarkersGeckoMain selected"
+                    data-testid="TimelineMarkersOverview"
+                  >
+                    <div
+                      class="react-contextmenu-wrapper"
+                    >
+                      <div>
+                        <canvas
+                          class="timelineMarkersCanvas"
+                          height="300"
+                          width="200"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
                     class="threadActivityGraph"
                   >
                     <div>
@@ -474,42 +486,6 @@ exports[`ActiveTabTimeline should be rendered properly from the Timeline compone
                           This graph charts the stack height of each sample.
                         </p>
                       </canvas>
-                    </div>
-                  </div>
-                  <div
-                    class="timelineTrackThreadMarkers"
-                  >
-                    <div
-                      class="timelineMarkers selected"
-                      data-testid="TimelineMarkersJank"
-                    >
-                      <div
-                        class="react-contextmenu-wrapper"
-                      >
-                        <div>
-                          <canvas
-                            class="timelineMarkersCanvas"
-                            height="300"
-                            width="200"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="timelineMarkers timelineMarkersGeckoMain selected"
-                      data-testid="TimelineMarkersOverview"
-                    >
-                      <div
-                        class="react-contextmenu-wrapper"
-                      >
-                        <div>
-                          <canvas
-                            class="timelineMarkersCanvas"
-                            height="300"
-                            width="200"
-                          />
-                        </div>
-                      </div>
                     </div>
                   </div>
                   <div


### PR DESCRIPTION
These markers were at the bottom while we were designing the active tab view. But it doesn't really make sense anymore to put the at the bottom especially since we have sample graph there too now. It was really hard to distinguish between them before. Now markers will at the top of activity graph and sample graph will be at the bottom. This will make it easier to understand.

Before:
<img width="990" alt="Screen Shot 2022-04-28 at 2 42 56 PM" src="https://user-images.githubusercontent.com/466239/165754537-b17f2dd9-948a-4bbe-b7a0-d5ad301e867a.png">

After:
<img width="990" alt="Screen Shot 2022-04-28 at 2 42 21 PM" src="https://user-images.githubusercontent.com/466239/165754569-2d2ad152-a7e9-4bfd-bca5-98a07420f0d4.png">

Example profile: [deploy preview](https://deploy-preview-4017--perf-html.netlify.app/public/d3mszd6xzq3np6e86hg8zb35ysb4x2fqbbg97qg/calltree/?implementation=js&thread=yi&timelineType=cpu-category&v=6&view=active-tab) / [production](https://share.firefox.dev/38qBXao)