### PR TITLE
Use the correct thread information for the call node context menu

### DIFF
--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -669,7 +669,7 @@ export const CallNodeContextMenu = explicitConnect<
         rightClickedCallNodeInfo.threadsKey
       );
 
-      thread = selectors.getThread(state);
+      thread = selectors.getFilteredThread(state);
       threadsKey = rightClickedCallNodeInfo.threadsKey;
       callNodeInfo = selectors.getCallNodeInfo(state);
       rightClickedCallNodePath = rightClickedCallNodeInfo.callNodePath;


### PR DESCRIPTION
Fixes #4031

STR:
1. Open [this profile](https://profiler.firefox.com/public/dss4w1ezqaacmneaar26h980xqwap22eskcd3j0/flame-graph/?globalTrackOrder=021&localTrackOrderByPid=2981406-120~3012339-01&search=sdk&thread=2&timelineType=cpu-category&transforms=cr-combined-48-4744&v=6)
2. Right click on one of the "sdk.privacy-center.org" entry

=> This crashes!

[deploy preview](deploy-preview-4032--perf-html.netlify.app/public/dss4w1ezqaacmneaar26h980xqwap22eskcd3j0/flame-graph/?globalTrackOrder=021&localTrackOrderByPid=2981406-120~3012339-01&search=sdk&thread=2&timelineType=cpu-category&transforms=cr-combined-48-4744&v=6)

I believe this happens especially with this transform `collapse-resource` because this adds a new entry to the func table, so this needs the updated func table. Other transforms remove entries, and as a result this doesn't result with a crash.

I didn't add a test because I thought it would be fragile and testing only one specific case and I thought this wasn't worth it.