### PR TITLE
Add the missing ftl string in the AppViewRouter component

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -31,6 +31,7 @@ AppViewRouter--error-from-file = Couldn’t read the file or parse the profile i
 AppViewRouter--error-local = Not implemented yet.
 AppViewRouter--error-public = Could not download the profile.
 AppViewRouter--error-from-url = Could not download the profile.
+AppViewRouter--error-compare = Could not retrieve the profiles.
 
 # This error message is displayed when a Safari-specific error state is encountered.
 # Importing profiles from URLs such as http://127.0.0.1:someport/ is not possible in Safari.


### PR DESCRIPTION
This was brought up in #4035.

This was the original error message before the i18n implementation: 
https://github.com/firefox-devtools/profiler/blob/474b465be639b0b9c37a9fcc1d2b2576262aae89/src/components/app/AppViewRouter.js#L36

But it looks like while we were working on the i18n, we somehow missed to add this ftl string to our default locale. This fixes it. Only difference is that I've decided to make the "profile" plural since we have two here. 

Current code we use this ftl string:
https://github.com/firefox-devtools/profiler/blob/2cd6f9a4c17da2622f373ee62098091d318d371a/src/components/app/AppViewRouter.js#L37
