### PR TITLE
Fix the activity graph hit test when there are CPU usage values

### DIFF
--- a/src/test/components/SampleTooltipContents.test.js
+++ b/src/test/components/SampleTooltipContents.test.js
@@ -209,32 +209,32 @@ describe('SampleTooltipContents', function () {
   });
 
   it('renders the sample with µs CPU usage information properly', () => {
-    const profile = getProfileWithCPU([null, 400, 1000, 500], 'µs');
+    const profile = getProfileWithCPU([null, 450, 1000, 500], 'µs');
 
     // Let's check the second threadCPUDelta value
     const hoveredSampleIndex = 1;
     const { getTooltip } = setup(profile, hoveredSampleIndex);
 
     const cpuUsage = ensureExists(screen.getByText(/CPU/).nextElementSibling);
-    expect(cpuUsage).toHaveTextContent('40% (average over 1.0ms)');
+    expect(cpuUsage).toHaveTextContent('45% (average over 1.0ms)');
     expect(getTooltip()).toMatchSnapshot();
   });
 
   it('renders the sample with ns CPU usage information properly', () => {
-    const profile = getProfileWithCPU([null, 600000, 1000000, 500000], 'ns');
+    const profile = getProfileWithCPU([null, 700000, 1000000, 500000], 'ns');
 
     // Let's check the second threadCPUDelta value
     const hoveredSampleIndex = 1;
     const { getTooltip } = setup(profile, hoveredSampleIndex);
 
     const cpuUsage = ensureExists(screen.getByText(/CPU/).nextElementSibling);
-    expect(cpuUsage).toHaveTextContent('60% (average over 1.0ms)');
+    expect(cpuUsage).toHaveTextContent('70% (average over 1.0ms)');
     expect(getTooltip()).toMatchSnapshot();
   });
 
   it('renders the sample with "variable CPU cycles" CPU usage information properly', () => {
     const profile = getProfileWithCPU(
-      [null, 800, 900, 500],
+      [null, 450, 900, 500],
       'variable CPU cycles'
     );
 
@@ -243,12 +243,12 @@ describe('SampleTooltipContents', function () {
     const { getTooltip } = setup(profile, hoveredSampleIndex);
 
     const cpuUsage = ensureExists(screen.getByText(/CPU/).nextElementSibling);
-    expect(cpuUsage).toHaveTextContent('89% (average over 1.0ms)');
+    expect(cpuUsage).toHaveTextContent('50% (average over 1.0ms)');
     expect(getTooltip()).toMatchSnapshot();
   });
 
   it('renders the CPU usage properly for the first part of the sample', () => {
-    const profile = getProfileWithCPU([null, 460, 1000, 500], 'µs');
+    const profile = getProfileWithCPU([null, 450, 1000, 500], 'µs');
 
     // Let's check the second threadCPUDelta value
     const hoveredSampleIndex = 1;
@@ -256,7 +256,7 @@ describe('SampleTooltipContents', function () {
     setup(profile, hoveredSampleIndex, 'before');
 
     const cpuUsage = ensureExists(screen.getByText(/CPU/).nextElementSibling);
-    expect(cpuUsage).toHaveTextContent('46% (average over 1.0ms)');
+    expect(cpuUsage).toHaveTextContent('45% (average over 1.0ms)');
   });
 
   it('renders the CPU usage properly for the second part of the sample', () => {
@@ -274,7 +274,7 @@ describe('SampleTooltipContents', function () {
   it('renders the CPU usage properly for the first part of the sample with irregular sample times', () => {
     // Normally there should be 4 samples in the profile. But second sample
     // takes spaces for 2 samples.
-    const profile = getProfileWithCPU([null, 800, 1000], 'µs');
+    const profile = getProfileWithCPU([null, 860, 1000], 'µs');
     profile.threads[0].samples.time = [0, 2, 3];
     profile.threads[0].samples.length = 3;
 
@@ -284,13 +284,13 @@ describe('SampleTooltipContents', function () {
     setup(profile, hoveredSampleIndex, 'before');
 
     const cpuUsage = ensureExists(screen.getByText(/CPU/).nextElementSibling);
-    expect(cpuUsage).toHaveTextContent('40% (average over 1.0ms)');
+    expect(cpuUsage).toHaveTextContent('43% (average over 1.0ms)');
   });
 
   it('renders the CPU usage properly for the second part of the sample with when there is a missing sample', () => {
     // Normally there should be 4 samples in the profile. But third sample
     // takes spaces for 2 samples.
-    const profile = getProfileWithCPU([null, 1000, 800], 'µs');
+    const profile = getProfileWithCPU([null, 1000, 900], 'µs');
     profile.threads[0].samples.time = [0, 1, 3];
     profile.threads[0].samples.length = 3;
 
@@ -310,6 +310,6 @@ describe('SampleTooltipContents', function () {
     setup(profile, hoveredSampleIndex, 'after');
 
     const cpuUsage = ensureExists(screen.getByText(/CPU/).nextElementSibling);
-    expect(cpuUsage).toHaveTextContent('40% (average over 1.0ms)');
+    expect(cpuUsage).toHaveTextContent('45% (average over 1.0ms)');
   });
 });

--- a/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
@@ -296,7 +296,7 @@ exports[`SampleTooltipContents renders the sample with "variable CPU cycles" CPU
       CPU:
     </div>
     <div>
-      89% (average over 1.0ms)
+      50% (average over 1.0ms)
     </div>
     <div
       class="tooltipDetailSeparator"
@@ -408,7 +408,7 @@ exports[`SampleTooltipContents renders the sample with ns CPU usage information 
       CPU:
     </div>
     <div>
-      60% (average over 1.0ms)
+      70% (average over 1.0ms)
     </div>
     <div
       class="tooltipDetailSeparator"
@@ -520,7 +520,7 @@ exports[`SampleTooltipContents renders the sample with µs CPU usage information
       CPU:
     </div>
     <div>
-      40% (average over 1.0ms)
+      45% (average over 1.0ms)
     </div>
     <div
       class="tooltipDetailSeparator"


### PR DESCRIPTION
Fixes #3717.

Apparently I missed this bug when it's first filed and wasn't aware until there was another comment there. This should be fixed now. Also it might be better to look at the code commit by commit as some of the code has been extracted to a function.

Example profile 1: [Deploy preview](https://deploy-preview-4039--perf-html.netlify.app/public/fdv9a82a0y9ht43c5x27cqm4kjwpk8b9v8kgjh8/calltree/?globalTrackOrder=0&symbolServer=http%3A%2F%2F127.0.0.1%3A3000&thread=0&timelineType=cpu-category&v=6) / [Production](https://share.firefox.dev/3Gee8OG)
Example profile 2: [Deploy preview](https://deploy-preview-4039--perf-html.netlify.app/public/4dtkt64b3pyqyrrj5qpe9sr2yj4kgnks9xgzdd8/calltree/?globalTrackOrder=0wl&hiddenGlobalTracks=1wl&hiddenLocalTracksByPid=20533-0wegwu~20534-0w2~20538-0w2~20547-0w2~20545-0w2~20549-0w3~20551-0w2~20557-01~20550-0w2~20535-0w2~20546-0w2~21024-0w3~20536-0w2~20548-0w2~20845-0w2~20984-0w2~21011-0w2~20607-0w3~20560-0w4~20553-0w2~20537-0w4~20992-0&localTrackOrderByPid=20533-swu0wr~20534-120~20538-120~20547-120~20545-120~20549-2301~20551-120~20557-01~20550-120~20535-120~20546-120~21024-2301~20536-120~20548-120~20845-120~20984-120~21011-120~20607-2301~20560-340w2~20553-120~20537-340w2~20992-120&thread=g&timelineType=cpu-category&v=6) / [Production](https://share.firefox.dev/3kEca1j)
