### PR TITLE
Upgrade the nativeSymbols table libIndexes along with resourceTable libs

### DIFF
--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -12208,8 +12208,8 @@ Object {
         ],
         "length": 2,
         "libIndex": Array [
-          0,
-          0,
+          1,
+          1,
         ],
         "name": Array [
           1,
@@ -13943,8 +13943,8 @@ Object {
         ],
         "length": 2,
         "libIndex": Array [
-          0,
-          0,
+          1,
+          1,
         ],
         "name": Array [
           1,
@@ -15783,8 +15783,8 @@ Object {
         ],
         "length": 2,
         "libIndex": Array [
-          0,
-          0,
+          1,
+          1,
         ],
         "name": Array [
           1,


### PR DESCRIPTION
Fixes #4035.

It looks like after merging the `libs` and making them profile-wide instead of per-thread, we forgot to update the `nativeSymbols` table `libIndex` fields while upgrading. #4035 is not exactly the bug description of this but it's more like a symptom of this issue. They both should be fixed with this. 

[Deploy peview](https://deploy-preview-4041--perf-html.netlify.app/compare/calltree/?profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2Fhbdfgae1spn06r27s5q1gcdxdme1j75twcdvf8g%2Fcalltree%2F%3FglobalTrackOrder%3D70w6%26hiddenGlobalTracks%3D1w7%26hiddenLocalTracksByPid%3D1038-0wd~1039-0~1052-0~1051-0~1050-0~1047-0~1041-0%26localTrackOrderByPid%3D1038-70w68wd~1039-0~1052-0~1051-0~1050-0~1047-0~1041-1023%26profileName%3DFirefox%252098%2520%25E2%2580%2593%2520macOS%252010.15.7%2520-%252010.14%2520SDK%26range%3Dm2990%26thread%3D0%26timelineType%3Dcpu-category%26v%3D6&profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2F95vp7avfcbpdpx6n7n1trem4k2emtyd559y5mf8%2Fcalltree%2F%3FglobalTrackOrder%3D90w8%26hiddenGlobalTracks%3D1w9%26hiddenLocalTracksByPid%3D1240-0wb~1249-0~1252-0~1241-0~1250-0~1251-0~1244-01~1245-0~1242-0%26localTrackOrderByPid%3D1240-60w57wb~1249-0~1252-0~1241-0~1250-0~1251-0~1244-01~1245-0~1242-1023%26profileName%3DFirefox%252098%2520%25E2%2580%2593%2520macOS%252010.15.7%2520-%252011%2520SDK%26range%3Dm2993%26thread%3D0%26timelineType%3Dcpu-category%26v%3D6&v=6) / [production](https://profiler.firefox.com/compare/calltree/?profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2Fhbdfgae1spn06r27s5q1gcdxdme1j75twcdvf8g%2Fcalltree%2F%3FglobalTrackOrder%3D70w6%26hiddenGlobalTracks%3D1w7%26hiddenLocalTracksByPid%3D1038-0wd~1039-0~1052-0~1051-0~1050-0~1047-0~1041-0%26localTrackOrderByPid%3D1038-70w68wd~1039-0~1052-0~1051-0~1050-0~1047-0~1041-1023%26profileName%3DFirefox%252098%2520%25E2%2580%2593%2520macOS%252010.15.7%2520-%252010.14%2520SDK%26range%3Dm2990%26thread%3D0%26timelineType%3Dcpu-category%26v%3D6&profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2F95vp7avfcbpdpx6n7n1trem4k2emtyd559y5mf8%2Fcalltree%2F%3FglobalTrackOrder%3D90w8%26hiddenGlobalTracks%3D1w9%26hiddenLocalTracksByPid%3D1240-0wb~1249-0~1252-0~1241-0~1250-0~1251-0~1244-01~1245-0~1242-0%26localTrackOrderByPid%3D1240-60w57wb~1249-0~1252-0~1241-0~1250-0~1251-0~1244-01~1245-0~1242-1023%26profileName%3DFirefox%252098%2520%25E2%2580%2593%2520macOS%252010.15.7%2520-%252011%2520SDK%26range%3Dm2993%26thread%3D0%26timelineType%3Dcpu-category%26v%3D6&v=6)