### PR TITLE
Update root README screenshot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The [Firefox Profiler] visualizes performance data recorded from web browsers. I
 
 [Mozilla] develops this tool to help make [Firefox] silky smooth and fast for millions of its users, and to help make sites and apps faster across the web.
 
-![Screenshot of the Firefox Profiler](./docs-user/images/screenshot-2021-10-21.png?raw=true)
+![Screenshot of the Firefox Profiler](./docs-user/images/screenshot-2022-04-25.png?raw=true)
 
 ### Usage
 


### PR DESCRIPTION
I saw #3998, but shouldn't the screenshot link for the root README be updated as well? It is pretty bright when GitHub is in dark mode 👓 