### PR TITLE
Compute the activity graph cpu ratio from `maxThreadCPUDeltaPerMs`

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -52,7 +52,7 @@ export type Props = {|
     IndexIntoSamplesTable
   ) => number,
   +enableCPUUsage: boolean,
-  +maxThreadCPUDelta: number,
+  +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
   ...SizeProps,
 |};
@@ -164,7 +164,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
       sampleIndexOffset,
       samplesSelectedStates,
       treeOrderSampleComparator,
-      maxThreadCPUDelta,
+      maxThreadCPUDeltaPerMs,
       enableCPUUsage,
       implementationFilter,
       width,
@@ -196,7 +196,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
           passFillsQuerier={this._setFillsQuerier}
           onClick={this._onClick}
           enableCPUUsage={enableCPUUsage}
-          maxThreadCPUDelta={maxThreadCPUDelta}
+          maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
           width={width}
           height={height}
         />

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -42,7 +42,7 @@ type CanvasProps = {|
   +passFillsQuerier: (ActivityFillGraphQuerier) => void,
   +onClick: (SyntheticMouseEvent<HTMLCanvasElement>) => void,
   +enableCPUUsage: boolean,
-  +maxThreadCPUDelta: number,
+  +maxThreadCPUDeltaPerMs: number,
   ...SizeProps,
 |};
 
@@ -128,7 +128,7 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       treeOrderSampleComparator,
       categories,
       enableCPUUsage,
-      maxThreadCPUDelta,
+      maxThreadCPUDeltaPerMs,
       width,
       height,
     } = this.props;
@@ -150,7 +150,7 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       sampleIndexOffset,
       samplesSelectedStates,
       enableCPUUsage,
-      maxThreadCPUDelta,
+      maxThreadCPUDeltaPerMs,
       xPixelsPerMs: canvasPixelWidth / (rangeEnd - rangeStart),
       treeOrderSampleComparator,
       greyCategoryIndex: categories.findIndex((c) => c.color === 'grey') || 0,

--- a/src/components/shared/thread/CPUGraph.js
+++ b/src/components/shared/thread/CPUGraph.js
@@ -35,7 +35,7 @@ type Props = {|
   // Decide which way the stacks grow up from the floor, or down from the ceiling.
   +stacksGrowFromCeiling?: boolean,
   +trackName: string,
-  +maxThreadCPUDelta: number,
+  +maxThreadCPUDeltaPerMs: number,
 |};
 
 export class ThreadCPUGraph extends PureComponent<Props> {
@@ -43,7 +43,7 @@ export class ThreadCPUGraph extends PureComponent<Props> {
     sampleIndex,
     yPixelsPerHeight,
   }: HeightFunctionParams): number => {
-    const { interval, thread } = this.props;
+    const { thread } = this.props;
     const { samples } = thread;
 
     // Because the cpu value for one sample is about the interval between this
@@ -53,10 +53,9 @@ export class ThreadCPUGraph extends PureComponent<Props> {
       return 0;
     }
     const cpuDelta = ensureExists(samples.threadCPUDelta)[sampleIndex + 1] || 0;
-    const intervalFactor =
-      (samples.time[sampleIndex + 1] - samples.time[sampleIndex]) / interval;
-    const currentCPUPerInterval = cpuDelta / intervalFactor;
-    return currentCPUPerInterval * yPixelsPerHeight;
+    const interval = samples.time[sampleIndex + 1] - samples.time[sampleIndex];
+    const currentCPUPerMs = cpuDelta / interval;
+    return currentCPUPerMs * yPixelsPerHeight;
   };
 
   render() {
@@ -71,7 +70,7 @@ export class ThreadCPUGraph extends PureComponent<Props> {
       selectedCallNodeIndex,
       categories,
       trackName,
-      maxThreadCPUDelta,
+      maxThreadCPUDeltaPerMs,
       onSampleClick,
     } = this.props;
 
@@ -81,7 +80,7 @@ export class ThreadCPUGraph extends PureComponent<Props> {
     return (
       <ThreadHeightGraph
         heightFunc={this._heightFunction}
-        maxValue={maxThreadCPUDelta}
+        maxValue={maxThreadCPUDeltaPerMs}
         className={className}
         trackName={trackName}
         interval={interval}

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -25,7 +25,7 @@ import {
   getTimelineType,
   getInvertCallstack,
   getThreadSelectorsFromThreadsKey,
-  getMaxThreadCPUDelta,
+  getMaxThreadCPUDeltaPerMs,
   getIsExperimentalCPUGraphsEnabled,
   getImplementationFilter,
 } from 'firefox-profiler/selectors';
@@ -99,7 +99,7 @@ type StateProps = {|
   +selectedThreadIndexes: Set<ThreadIndex>,
   +enableCPUUsage: boolean,
   +isExperimentalCPUGraphsEnabled: boolean,
-  +maxThreadCPUDelta: number,
+  +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
 |};
 
@@ -209,7 +209,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       trackType,
       trackName,
       enableCPUUsage,
-      maxThreadCPUDelta,
+      maxThreadCPUDeltaPerMs,
       isExperimentalCPUGraphsEnabled,
       implementationFilter,
     } = this.props;
@@ -277,7 +277,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               samplesSelectedStates={samplesSelectedStates}
               treeOrderSampleComparator={treeOrderSampleComparator}
               enableCPUUsage={enableCPUUsage}
-              maxThreadCPUDelta={maxThreadCPUDelta}
+              maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
               implementationFilter={implementationFilter}
             />
             {trackType === 'expanded' ? (
@@ -309,7 +309,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
                 selectedCallNodeIndex={selectedCallNodeIndex}
                 categories={categories}
                 onSampleClick={this._onSampleClick}
-                maxThreadCPUDelta={maxThreadCPUDelta}
+                maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
               />
             ) : null}
           </>
@@ -395,7 +395,7 @@ export const TimelineTrackThread = explicitConnect<
       selectedThreadIndexes,
       enableCPUUsage,
       isExperimentalCPUGraphsEnabled: getIsExperimentalCPUGraphsEnabled(state),
-      maxThreadCPUDelta: getMaxThreadCPUDelta(state),
+      maxThreadCPUDeltaPerMs: getMaxThreadCPUDeltaPerMs(state),
       implementationFilter: getImplementationFilter(state),
     };
   },

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -36,9 +36,9 @@ export function computeMaxThreadCPUDeltaPerMs(
     // First element of CPU delta is always null because back-end doesn't know
     // the delta since there is no previous sample.
     for (let i = 1; i < samples.length; i++) {
-      const realIntervalInMs =
+      const sampleTimeDeltaInMs =
         i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
-      const cpuDeltaPerMs = (threadCPUDelta[i] || 0) / realIntervalInMs;
+      const cpuDeltaPerMs = (threadCPUDelta[i] || 0) / sampleTimeDeltaInMs;
       maxThreadCPUDeltaPerMs = Math.max(maxThreadCPUDeltaPerMs, cpuDeltaPerMs);
     }
   }

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -15,18 +15,17 @@ import type {
 } from 'firefox-profiler/types';
 
 /**
- * Compute the max CPU delta value for that thread. It computes the max value
- * after the threadCPUDelta processing.
+ * Compute the max CPU delta value per ms for that thread. It computes the
+ * max value after the threadCPUDelta processing.
  */
-export function computeMaxThreadCPUDelta(
+export function computeMaxThreadCPUDeltaPerMs(
   threads: Thread[],
-  interval: Milliseconds
+  profileInterval: Milliseconds
 ): number {
-  let maxThreadCPUDelta = 0;
-
+  let maxThreadCPUDeltaPerMs = 0;
   for (let threadIndex = 0; threadIndex < threads.length; threadIndex++) {
     const { samples } = threads[threadIndex];
-    const { time, threadCPUDelta } = samples;
+    const { threadCPUDelta } = samples;
 
     if (!threadCPUDelta) {
       // The thread have any ThreadCPUDelta values. Older profiles don't have
@@ -37,15 +36,14 @@ export function computeMaxThreadCPUDelta(
     // First element of CPU delta is always null because back-end doesn't know
     // the delta since there is no previous sample.
     for (let i = 1; i < samples.length; i++) {
-      const cpuDelta = threadCPUDelta[i] || 0;
-      // Interval is not always steady depending on the overhead.
-      const intervalFactor = (time[i] - time[i - 1]) / interval;
-      const currentCPUPerInterval = cpuDelta / intervalFactor;
-      maxThreadCPUDelta = Math.max(maxThreadCPUDelta, currentCPUPerInterval);
+      const realIntervalInMs =
+        i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
+      const cpuDeltaPerMs = (threadCPUDelta[i] || 0) / realIntervalInMs;
+      maxThreadCPUDeltaPerMs = Math.max(maxThreadCPUDeltaPerMs, cpuDeltaPerMs);
     }
   }
 
-  return maxThreadCPUDelta;
+  return maxThreadCPUDeltaPerMs;
 }
 
 /**
@@ -83,8 +81,13 @@ export function computeMaxCPUDeltaPerInterval(profile: Profile): number | null {
         getCpuDeltaTimeUnitMultiplier(threadCPUDeltaUnit);
       return cpuDeltaTimeUnitMultiplier * interval;
     }
-    case 'variable CPU cycles':
-      return computeMaxThreadCPUDelta(profile.threads, interval);
+    case 'variable CPU cycles': {
+      const maxThreadCPUDeltaPerMs = computeMaxThreadCPUDeltaPerMs(
+        profile.threads,
+        interval
+      );
+      return maxThreadCPUDeltaPerMs * interval;
+    }
     default:
       throw assertExhaustiveCheck(
         threadCPUDeltaUnit,

--- a/src/selectors/cpu.js
+++ b/src/selectors/cpu.js
@@ -13,7 +13,7 @@ import {
   getCounter,
 } from './profile';
 import { getThreadSelectors } from './per-thread';
-import { computeMaxThreadCPUDelta } from 'firefox-profiler/profile-logic/cpu';
+import { computeMaxThreadCPUDeltaPerMs } from 'firefox-profiler/profile-logic/cpu';
 
 import type { Selector, State, Thread } from 'firefox-profiler/types';
 
@@ -68,8 +68,8 @@ function getCPUProcessedThreads(state: State): Thread[] {
   return _cpuProcessedThreads;
 }
 
-export const getMaxThreadCPUDelta: Selector<number> = createSelector(
+export const getMaxThreadCPUDeltaPerMs: Selector<number> = createSelector(
   getCPUProcessedThreads,
   getProfileInterval,
-  computeMaxThreadCPUDelta
+  computeMaxThreadCPUDeltaPerMs
 );


### PR DESCRIPTION
This was reminded to me by @mstange in one of the previous PRs here: https://github.com/firefox-devtools/profiler/pull/4039#discussion_r869634882

We unnecessarily had the interval in various calculations before. This was not needed when we preprocess the cpu values properly and convert them to cpu delta values per millisecond. This PR fixes that and removes those calculations.
While working on this, I was also reminded by the issue #3716. I will also work on this issue but wanted to land them separately.

This PR doesn't change any tests because we are actually covered by the tests here: https://github.com/firefox-devtools/profiler/blob/ecba3796f746534a4e740b70f79ffeaeedcef928/src/test/components/ThreadActivityGraph.test.js#L146-L149
Since we don't have any user facing changes in the behavior, the activity graph rendering values don't change. (and they actually helped me catching a but while I was working on this!)


Example profile from Windows: [production](https://share.firefox.dev/3x4dLDl) / [deploy preview](https://deploy-preview-4067--perf-html.netlify.app/public/3wj9kvegnbtxhmv4tkh6kq3cwd3e3n0hnh200mg/calltree/?globalTrackOrder=70w6&hiddenGlobalTracks=1w47&localTrackOrderByPid=3588-j0wi~20072-10&range=9120m613~9174m238&thread=0&timelineType=cpu-category&v=6)
Example profile from Linux: [production](https://share.firefox.dev/3Mb5nHN) / [deploy preview](https://deploy-preview-4067--perf-html.netlify.app/public/d3mszd6xzq3np6e86hg8zb35ysb4x2fqbbg97qg/calltree/?globalTrackOrder=xu0wxt&hiddenGlobalTracks=1wxs&hiddenLocalTracksByPid=3590-0w5~121817-01~121827-0~121753-0~121675-0~121627-0~121848-0~121679-0~121925-0~121422-01~121453-01~121131-01~24720-0~3826-0~122334-01~118928-0~95728-0~122176-01~110346-0~99924-0~91597-0~4354-0~25231-0~108968-0~3688-0~96103-0~122178-01~7667-0~122182-01~122201-01~121790-01~122073-01~122024-01~107501-0~3928-0~16267-0~51435-0~122115-01~96064-0~3882-0~23335-0~121156-0~3950-0~7604-0~23921-01~3806-01~3874-0~16423-0~102169-0~24570-01~12188-0~110943-0~100058-0~3910-0~122153-01~108151-01~5288-01~108621-01~3891-0w3~83272-0w3~3878-0w3&localTrackOrderByPid=3590-670w5~121817-01~121827-0~121753-0~121675-0~121627-0~121848-0~121679-0~121925-0~121422-10~121453-10~121131-10~24720-0~3826-0~122334-01~118928-0~95728-0~122176-01~110346-0~99924-0~91597-0~4354-0~25231-0~108968-0~3688-0~96103-0~122178-01~7667-0~122182-01~122201-01~121790-10~122073-01~122024-01~107501-0~3928-0~16267-0~51435-0~122115-01~96064-0~3882-0~23335-0~121156-0~3950-0~7604-0~23921-01~3806-01~3874-0~16423-0~102169-0~24570-01~12188-0~110943-0~100058-0~3910-0~122153-10~108151-10~5288-10~108621-10~3891-2301~83272-30w2~3878-2301~121351-01&range=7285m3350&thread=0&timelineType=cpu-category&v=6)
Example profile from macOS: [production](https://share.firefox.dev/3t7Cs0w) / [deploy preview](https://deploy-preview-4067--perf-html.netlify.app/public/d44gqy8a1zcxt5ghk7b7tt39x0r1a749m2mpmqr/calltree/?globalTrackOrder=0wi&hiddenGlobalTracks=1wg&hiddenLocalTracksByPid=89846-1w6~89868-0~89847-0~89877-0~89871-0~89858-01~89849-0~89852-01~89866-01~89870-0~89856-0~89851-01~89857-01~89863-01~89864-01~89867-01~89862-01&localTrackOrderByPid=89846-70w689~89868-0~89847-0~89877-0~89871-0~89858-01~89849-0~89852-01~89866-01~89870-0~89856-0~89851-01~89857-01~89863-01~89864-01~89867-01~89862-01~89848-01~89850-01&range=1026m5006~3956m788&thread=p&timelineType=cpu-category&v=6)