### PR TITLE
Allow consecutive samples with the same timestamp

### DIFF
--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -900,11 +900,11 @@ function _accumulateInBuffer(
   // A number between 0 and 1 for sample ratio. It changes depending on
   // the CPU usage per ms if it's given. If not, it uses 1 directly.
   const beforeSampleCpuRatio =
-    cpuDeltaBeforeSample === null
+    cpuDeltaBeforeSample === null || sampleTimeDeltaBefore === 0
       ? 1
       : cpuDeltaBeforeSample / sampleTimeDeltaBefore / maxThreadCPUDeltaPerMs;
   const afterSampleCpuRatio =
-    cpuDeltaAfterSample === null
+    cpuDeltaAfterSample === null || sampleTimeDeltaAfter === 0
       ? 1
       : cpuDeltaAfterSample / sampleTimeDeltaAfter / maxThreadCPUDeltaPerMs;
 

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -38,8 +38,13 @@ export function computeMaxThreadCPUDeltaPerMs(
     for (let i = 1; i < samples.length; i++) {
       const sampleTimeDeltaInMs =
         i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
-      const cpuDeltaPerMs = (threadCPUDelta[i] || 0) / sampleTimeDeltaInMs;
-      maxThreadCPUDeltaPerMs = Math.max(maxThreadCPUDeltaPerMs, cpuDeltaPerMs);
+      if (sampleTimeDeltaInMs !== 0) {
+        const cpuDeltaPerMs = (threadCPUDelta[i] || 0) / sampleTimeDeltaInMs;
+        maxThreadCPUDeltaPerMs = Math.max(
+          maxThreadCPUDeltaPerMs,
+          cpuDeltaPerMs
+        );
+      }
     }
   }
 


### PR DESCRIPTION
[Production](https://share.firefox.dev/3Q1u1hh) (empty activity graph)
[Deploy preview](https://deploy-preview-4068--perf-html.netlify.app/public/et3gbnrhbgkwc36z68s5js4jyf6rebhzy9v2ap8/calltree/?globalTrackOrder=0wc&hiddenGlobalTracks=1wc&hiddenLocalTracksByPid=3082-0wxkxmwAp~100051-0ws~100093-0wr~100136-0wr~100140-0wr~100208-0wr&localTrackOrderByPid=3082-0wAp~100051-0ws~100093-0wr~100136-0wr~100140-0wr~100208-0wr&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F3b8a7bmf2gn6xjj9h2js33hz0biv4k9xrnphhgc&thread=xl&timelineType=cpu-category&v=6) (normal activity graph)

My generator sometimes outputs two consecutive samples with the same timestamp. This happens if there is an off-cpu-sample for the entire "thread sleep duration" immediately followed by an on-cpu-sample with the wake up timestamp.
These samples were breaking activity graph drawing.

The time delta is zero, so we were dividing by zero and creating NaN values.
And then the smoothing blurred the NaN over the entire length of the canvas.
And then we couldn't draw a graph because everything was NaN.