### PR TITLE
Fix the experimental process cpu graph values

### DIFF
--- a/src/components/timeline/TrackProcessCPUGraph.js
+++ b/src/components/timeline/TrackProcessCPUGraph.js
@@ -128,12 +128,12 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
         // Create a path for the top of the chart. This is the line that will have
         // a stroke applied to it.
         x = (samples.time[i] - rangeStart) * millisecondWidth;
-        // Add on half the stroke's line width so that it won't be cut off the edge
-        // of the graph.
         const sampleTimeDeltaInMs =
           i === 0 ? interval : samples.time[i] - samples.time[i - 1];
         const unitGraphCount =
           samples.count[i] / sampleTimeDeltaInMs / countRangePerMs;
+        // Add on half the stroke's line width so that it won't be cut off the edge
+        // of the graph.
         y =
           innerDeviceHeight -
           innerDeviceHeight * unitGraphCount +

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1475,15 +1475,21 @@ export function accumulateCounterSamples(
 }
 
 /**
- * Compute the max counter sample counts to determine the range of a counter.
+ * Compute the max counter sample counts per milliseconds to determine the range
+ * of a counter.
  */
-export function computeMaxCounterSampleCounts(
-  samplesArray: Array<CounterSamplesTable>
+export function computeMaxCounterSampleCountsPerMs(
+  samplesArray: Array<CounterSamplesTable>,
+  profileInterval: Milliseconds
 ): Array<number> {
   const maxSampleCounts = samplesArray.map((samples) => {
     let maxCount = 0;
     for (let i = 0; i < samples.length; i++) {
-      maxCount = Math.max(samples.count[i], maxCount);
+      const count = samples.count[i];
+      const sampleTimeDeltaInMs =
+        i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
+      const countPerMs = count / sampleTimeDeltaInMs;
+      maxCount = Math.max(countPerMs, maxCount);
     }
 
     return maxCount;

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -11,7 +11,7 @@ import {
   filterCounterToRange,
   accumulateCounterSamples,
   extractProfileFilterPageData,
-  computeMaxCounterSampleCounts,
+  computeMaxCounterSampleCountsPerMs,
 } from '../profile-logic/profile-data';
 import {
   IPCMarkerCorrelations,
@@ -287,13 +287,16 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
     )
   );
 
-  const getMaxCounterSampleCounts: Selector<Array<number>> = createSelector(
-    getCounter,
-    (counters) =>
-      computeMaxCounterSampleCounts(
-        counters.sampleGroups.map((group) => group.samples)
-      )
-  );
+  const getMaxCounterSampleCountsPerMs: Selector<Array<number>> =
+    createSelector(
+      getCounter,
+      getProfileInterval,
+      (counters, profileInterval) =>
+        computeMaxCounterSampleCountsPerMs(
+          counters.sampleGroups.map((group) => group.samples),
+          profileInterval
+        )
+    );
 
   return {
     getCounter,
@@ -301,7 +304,7 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
     getPid,
     getCommittedRangeFilteredCounter,
     getAccumulateCounterSamples,
-    getMaxCounterSampleCounts,
+    getMaxCounterSampleCountsPerMs,
   };
 }
 

--- a/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
+++ b/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TrackProcessCPU draws a dot that matches the snapshot 1`] = `
 <div
   class="timelineTrackProcessCPUGraphDot"
-  style="left: 20px; top: 13px;"
+  style="left: 15px; top: 18.6px;"
 />
 `;
 
@@ -56,13 +56,13 @@ Array [
   ],
   Array [
     "lineTo",
-    10,
-    14.799999999999999,
+    15,
+    17.866666666666667,
   ],
   Array [
     "lineTo",
     20,
-    12.5,
+    1,
   ],
   Array [
     "lineTo",


### PR DESCRIPTION
Fixes #4059 

Previously we weren't accounting the sample times and naively just printing the values without diving the intervals. Now, we are properly dividing the numbers to the intervals and computing the max value per millisecond. This is exactly the same calculation we are doing in the activity graph now.

[Production](https://share.firefox.dev/3MuwQnV) / [Deploy preview](https://deploy-preview-4076--perf-html.netlify.app/public/24w7nnvf9qe7sr9y123kzdrrcrfzq703keps660/marker-chart/?globalTrackOrder=80w7&hiddenGlobalTracks=1w4&hiddenLocalTracksByPid=26408-0wy8yawyj~14532-0wa~9584-0wi~27504-0wi~26512-0wi~25868-0wp~26136-0ws~23092-0wxb&localTrackOrderByPid=26408-ykwyt0wyj~14532-890a1w7~9584-fg0h1w6i7we~27504-fg0h1w6i7we~26512-fg0h1w6i7we~25868-qr0st1wp~26136-twv0x0wx31ws~23092-xcxd0xewxg1wxb&thread=0&timelineType=cpu-category&v=6)
[Production](https://share.firefox.dev/3GCH4S5) / [Deploy preview](https://deploy-preview-4076--perf-html.netlify.app/public/h6v301jd6g24v452b6yd4zyff2mnkj4j4bc3t58/calltree/?globalTrackOrder=0wg&hiddenGlobalTracks=1wadwf&hiddenLocalTracksByPid=456844-0w5~224516-0~391928-01~291388-0~289924-0~433716-0~268984-0~58072-0~632308-02wa&localTrackOrderByPid=456844-60w5~224516-0~391928-01~291388-0~289924-10~433716-0~178320-0~268984-10~58072-0~632308-0wa&range=48723m7189~53708m1725&thread=0&timelineType=cpu-category&v=6)