### PR TITLE
Upgrade nan to solve a build error in MacOS with node v18

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9808,9 +9808,9 @@ namedtuplemap@^1.0.0:
   integrity sha1-wjF4nFt7R7Szo+czF/A93eHryzQ=
 
 nan@^2.12.1:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
+  integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
 nanoid@^3.3.4:
   version "3.3.4"


### PR DESCRIPTION
Florian reported an issue with node v18 on MacOS:

```
warning Error running install script for optional dependency: "/Users/florian/buildgit/profiler/node_modules/watchpack-chokidar2/node_modules/fsevents: Command failed.
Exit code: 1
Command: node-gyp rebuild
Arguments: 
Directory: /Users/florian/buildgit/profiler/node_modules/watchpack-chokidar2/node_modules/fsevents
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@9.0.0
gyp info using node@18.4.0 | darwin | arm64
gyp info find Python using Python version 3.8.9 found at \"/Applications/Xcode.app/Contents/Developer/usr/bin/python3\"
gyp info spawn /Applications/Xcode.app/Contents/Developer/usr/bin/python3
gyp info spawn args [
gyp info spawn args   '/opt/homebrew/Cellar/node/18.4.0/libexec/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/florian/buildgit/profiler/node_modules/watchpack-chokidar2/node_modules/fsevents/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/opt/homebrew/Cellar/node/18.4.0/libexec/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/florian/Library/Caches/node-gyp/18.4.0/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/Users/florian/Library/Caches/node-gyp/18.4.0',
gyp info spawn args   '-Dnode_gyp_dir=/opt/homebrew/Cellar/node/18.4.0/libexec/lib/node_modules/npm/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/Users/florian/Library/Caches/node-gyp/18.4.0/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/Users/florian/buildgit/profiler/node_modules/watchpack-chokidar2/node_modules/fsevents',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
In file included from ../fsevents.cc:6:
../../../../nan/nan.h:2536:8: warning: 'SetAccessor' is deprecated: Do signature check in accessor [-Wdeprecated-declarations]
  tpl->SetAccessor(
       ^
/Users/florian/Library/Caches/node-gyp/18.4.0/include/node/v8-template.h:837:3: note: 'SetAccessor' has been explicitly marked deprecated here
  V8_DEPRECATED(\"Do signature check in accessor\")
  ^
/Users/florian/Library/Caches/node-gyp/18.4.0/include/node/v8config.h:460:35: note: expanded from macro 'V8_DEPRECATED'
# define V8_DEPRECATED(message) [[deprecated(message)]]
                                  ^
In file included from ../fsevents.cc:6:
In file included from ../../../../nan/nan.h:2884:
../../../../nan/nan_typedarray_contents.h:34:43: error: no member named 'GetContents' in 'v8::ArrayBuffer'
      data   = static_cast<char*>(buffer->GetContents().Data()) + byte_offset;
                                  ~~~~~~~~^
1 warning and 1 error generated.
make: *** [Release/obj.target/fse/fsevents.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/opt/homebrew/Cellar/node/18.4.0/libexec/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (node:events:537:28)
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
gyp ERR! System Darwin 21.4.0
gyp ERR! command \"/opt/homebrew/Cellar/node/18.4.0/bin/node\" \"/opt/homebrew/Cellar/node/18.4.0/libexec/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js\" \"rebuild\"
gyp ERR! cwd /Users/florian/buildgit/profiler/node_modules/watchpack-chokidar2/node_modules/fsevents
```
According to some forums this seems to be fixed with more recent versions of nan, so let's see.