### PR TITLE
Fix the incorrect first counters on the graphs when zoomed in

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -349,9 +349,7 @@ export function selectTrack(
           case 'memory': {
             const { counterIndex } = localTrack;
             const counterSelectors = getCounterSelectors(counterIndex);
-            const counter = counterSelectors.getCommittedRangeFilteredCounter(
-              getState()
-            );
+            const counter = counterSelectors.getCounter(getState());
             selectedThreadIndex = counter.mainThreadIndex;
             break;
           }
@@ -363,9 +361,7 @@ export function selectTrack(
           case 'power': {
             const { counterIndex } = localTrack;
             const counterSelectors = getCounterSelectors(counterIndex);
-            const counter = counterSelectors.getCommittedRangeFilteredCounter(
-              getState()
-            );
+            const counter = counterSelectors.getCounter(getState());
             selectedThreadIndex = counter.mainThreadIndex;
             break;
           }

--- a/src/components/timeline/TrackMemory.js
+++ b/src/components/timeline/TrackMemory.js
@@ -90,7 +90,7 @@ export const TrackMemory = explicitConnect<OwnProps, StateProps, DispatchProps>(
     mapStateToProps: (state, ownProps) => {
       const { counterIndex } = ownProps;
       const counterSelectors = getCounterSelectors(counterIndex);
-      const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+      const counter = counterSelectors.getCounter(state);
       const { start, end } = getCommittedRange(state);
       return {
         threadIndex: counter.mainThreadIndex,

--- a/src/components/timeline/TrackPower.js
+++ b/src/components/timeline/TrackPower.js
@@ -70,7 +70,7 @@ export const TrackPower = explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: (state, ownProps) => {
     const { counterIndex } = ownProps;
     const counterSelectors = getCounterSelectors(counterIndex);
-    const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+    const counter = counterSelectors.getCounter(state);
     const { start, end } = getCommittedRange(state);
     return {
       threadIndex: counter.mainThreadIndex,

--- a/src/components/timeline/TrackProcessCPU.js
+++ b/src/components/timeline/TrackProcessCPU.js
@@ -74,7 +74,7 @@ export const TrackProcessCPU = explicitConnect<
   mapStateToProps: (state, ownProps) => {
     const { counterIndex } = ownProps;
     const counterSelectors = getCounterSelectors(counterIndex);
-    const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+    const counter = counterSelectors.getCounter(state);
     const { start, end } = getCommittedRange(state);
     return {
       threadIndex: counter.mainThreadIndex,

--- a/src/components/timeline/TrackProcessCPU.js
+++ b/src/components/timeline/TrackProcessCPU.js
@@ -45,7 +45,7 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 type State = {||};
 
-export class TracProcessCPUImpl extends React.PureComponent<Props, State> {
+export class TrackProcessCPUImpl extends React.PureComponent<Props, State> {
   render() {
     const { counterIndex } = this.props;
     return (
@@ -83,5 +83,5 @@ export const TrackProcessCPU = explicitConnect<
     };
   },
   mapDispatchToProps: { updatePreviewSelection },
-  component: TracProcessCPUImpl,
+  component: TrackProcessCPUImpl,
 });

--- a/src/components/timeline/TrackProcessCPUGraph.js
+++ b/src/components/timeline/TrackProcessCPUGraph.js
@@ -27,6 +27,7 @@ import type {
   Milliseconds,
   CssPixels,
   StartEndRange,
+  IndexIntoSamplesTable,
 } from 'firefox-profiler/types';
 
 import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
@@ -41,6 +42,7 @@ type CanvasProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +counter: Counter,
+  +counterSampleRanges: Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>,
   +maxCounterSampleCountsPerMs: number[],
   +interval: Milliseconds,
   +width: CssPixels,
@@ -67,6 +69,7 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
       lineWidth,
       interval,
       maxCounterSampleCountsPerMs,
+      counterSampleRanges,
     } = this.props;
     if (width === 0) {
       // This is attempting to draw before the canvas was laid out.
@@ -90,7 +93,7 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
     ctx.clearRect(0, 0, deviceWidth, deviceHeight);
 
     const sampleGroups = counter.sampleGroups;
-    if (sampleGroups.length === 0) {
+    if (sampleGroups.length === 0 || counterSampleRanges.length === 0) {
       // Gecko failed to capture samples for some reason and it shouldn't happen for
       // malloc counter. Print an error and do not draw anything.
       throw new Error('No sample group found for process CPU counter');
@@ -102,6 +105,7 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
       return;
     }
 
+    const [sampleStart, sampleEnd] = counterSampleRanges[0];
     const countRangePerMs = maxCounterSampleCountsPerMs[0];
 
     {
@@ -124,7 +128,7 @@ class TrackProcessCPUCanvas extends React.PureComponent<CanvasProps> {
       let x = 0;
       let y = 0;
       let firstX = 0;
-      for (let i = 0; i < samples.length; i++) {
+      for (let i = sampleStart; i < sampleEnd; i++) {
         // Create a path for the top of the chart. This is the line that will have
         // a stroke applied to it.
         x = (samples.time[i] - rangeStart) * millisecondWidth;
@@ -210,6 +214,7 @@ type StateProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +counter: Counter,
+  +counterSampleRanges: Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>,
   +maxCounterSampleCountsPerMs: number[],
   +interval: Milliseconds,
   +filteredThread: Thread,
@@ -248,7 +253,14 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
     const { pageX: mouseX, pageY: mouseY } = event;
     // Get the offset from here, and apply it to the time lookup.
     const { left } = event.currentTarget.getBoundingClientRect();
-    const { width, rangeStart, rangeEnd, counter, interval } = this.props;
+    const {
+      width,
+      rangeStart,
+      rangeEnd,
+      counter,
+      interval,
+      counterSampleRanges,
+    } = this.props;
     const rangeLength = rangeEnd - rangeStart;
     const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
 
@@ -268,7 +280,13 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
     } else {
       // When the mouse pointer hovers between two points, select the point that's closer.
       let hoveredCounter;
-      const bisectionCounter = bisectionRight(samples.time, timeAtMouse);
+      const [sampleStart, sampleEnd] = counterSampleRanges[0];
+      const bisectionCounter = bisectionRight(
+        samples.time,
+        timeAtMouse,
+        sampleStart,
+        sampleEnd
+      );
       if (bisectionCounter > 0 && bisectionCounter < samples.time.length) {
         const leftDistance = timeAtMouse - samples.time[bisectionCounter - 1];
         const rightDistance = samples.time[bisectionCounter] - timeAtMouse;
@@ -409,6 +427,7 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
       rangeEnd,
       unfilteredSamplesRange,
       counter,
+      counterSampleRanges,
       graphHeight,
       width,
       lineWidth,
@@ -425,6 +444,7 @@ class TrackProcessCPUGraphImpl extends React.PureComponent<Props, State> {
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
           counter={counter}
+          counterSampleRanges={counterSampleRanges}
           height={graphHeight}
           width={width}
           lineWidth={lineWidth}
@@ -457,8 +477,10 @@ export const TrackProcessCPUGraph = explicitConnect<
   mapStateToProps: (state, ownProps) => {
     const { counterIndex } = ownProps;
     const counterSelectors = getCounterSelectors(counterIndex);
-    const counter = counterSelectors.getCommittedRangeFilteredCounter(state);
+    const counter = counterSelectors.getCounter(state);
     const { start, end } = getCommittedRange(state);
+    const counterSampleRanges =
+      counterSelectors.getCommittedRangeCounterSampleRanges(state);
     const selectors = getThreadSelectors(counter.mainThreadIndex);
     return {
       counter,
@@ -467,6 +489,7 @@ export const TrackProcessCPUGraph = explicitConnect<
         counterSelectors.getMaxCounterSampleCountsPerMs(state),
       rangeStart: start,
       rangeEnd: end,
+      counterSampleRanges,
       interval: getProfileInterval(state),
       filteredThread: selectors.getFilteredThread(state),
       unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1457,36 +1457,6 @@ export function processCounter(counter: Counter): Counter {
   };
 }
 
-export function filterCounterToRange(
-  counter: Counter,
-  rangeStart: number,
-  rangeEnd: number
-): Counter {
-  const filteredGroups = counter.sampleGroups.map((sampleGroup) => {
-    const samples = sampleGroup.samples;
-    const [sBegin, sEnd] = getInclusiveSampleIndexRangeForSelection(
-      samples,
-      rangeStart,
-      rangeEnd
-    );
-
-    return {
-      ...sampleGroup,
-      samples: {
-        time: samples.time.slice(sBegin, sEnd),
-        number: samples.number.slice(sBegin, sEnd),
-        count: samples.count.slice(sBegin, sEnd),
-        length: sEnd - sBegin,
-      },
-    };
-  });
-
-  return {
-    ...counter,
-    sampleGroups: filteredGroups,
-  };
-}
-
 /**
  * The memory counter contains relative offsets of memory. In order to draw an interesting
  * graph, take the memory counts, and find the minimum and maximum values, by

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1494,14 +1494,24 @@ export function filterCounterToRange(
  * accumulatedCounts array.
  */
 export function accumulateCounterSamples(
-  samplesArray: Array<CounterSamplesTable>
+  samplesArray: Array<CounterSamplesTable>,
+  sampleRanges?: Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>
 ): Array<AccumulatedCounterSamples> {
-  const accumulatedSamples = samplesArray.map((samples) => {
+  const accumulatedSamples = samplesArray.map((samples, index) => {
     let minCount = 0;
     let maxCount = 0;
     let accumulated = 0;
-    const accumulatedCounts = [];
-    for (let i = 0; i < samples.length; i++) {
+    const accumulatedCounts = Array(samples.length).fill(0);
+    // If a range is provided, use it instead. This will also include the
+    // samples right before and after the range.
+    const startSampleIndex =
+      sampleRanges && sampleRanges[index] ? sampleRanges[index][0] : 0;
+    const endSampleIndex =
+      sampleRanges && sampleRanges[index]
+        ? sampleRanges[index][1]
+        : samples.length;
+
+    for (let i = startSampleIndex; i < endSampleIndex; i++) {
       accumulated += samples.count[i];
       minCount = Math.min(accumulated, minCount);
       maxCount = Math.max(accumulated, maxCount);

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -285,12 +285,28 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
     (counters, range) => filterCounterToRange(counters, range.start, range.end)
   );
 
+  const getCommittedRangeCounterSampleRanges: Selector<
+    Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>
+  > = createSelector(getCounter, getCommittedRange, (counter, range) =>
+    counter.sampleGroups.map((group) =>
+      getInclusiveSampleIndexRangeForSelection(
+        group.samples,
+        range.start,
+        range.end
+      )
+    )
+  );
+
   const getAccumulateCounterSamples: Selector<
     Array<AccumulatedCounterSamples>
-  > = createSelector(getCommittedRangeFilteredCounter, (counters) =>
-    accumulateCounterSamples(
-      counters.sampleGroups.map((group) => group.samples)
-    )
+  > = createSelector(
+    getCounter,
+    getCommittedRangeCounterSampleRanges,
+    (counters, sampleRanges) =>
+      accumulateCounterSamples(
+        counters.sampleGroups.map((group) => group.samples),
+        sampleRanges
+      )
   );
 
   const getMaxCounterSampleCountsPerMs: Selector<Array<number>> =
@@ -303,18 +319,6 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
           profileInterval
         )
     );
-
-  const getCommittedRangeCounterSampleRanges: Selector<
-    Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>
-  > = createSelector(getCounter, getCommittedRange, (counter, range) =>
-    counter.sampleGroups.map((group) =>
-      getInclusiveSampleIndexRangeForSelection(
-        group.samples,
-        range.start,
-        range.end
-      )
-    )
-  );
 
   const getMaxRangeCounterSampleCountsPerMs: Selector<Array<number>> =
     createSelector(

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -13,6 +13,7 @@ import {
   extractProfileFilterPageData,
   computeMaxCounterSampleCountsPerMs,
   getFriendlyThreadName,
+  processCounter,
 } from '../profile-logic/profile-data';
 import {
   IPCMarkerCorrelations,
@@ -264,10 +265,12 @@ export const getCounterSelectors = (index: CounterIndex): CounterSelectors => {
  */
 function _createCounterSelectors(counterIndex: CounterIndex) {
   const getCounter: Selector<Counter> = (state) =>
-    ensureExists(
-      getProfile(state).counters,
-      'Attempting to get a counter by index, but no counters exist.'
-    )[counterIndex];
+    processCounter(
+      ensureExists(
+        getProfile(state).counters,
+        'Attempting to get a counter by index, but no counters exist.'
+      )[counterIndex]
+    );
 
   const getDescription: Selector<string> = (state) =>
     getCounter(state).description;

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -8,7 +8,6 @@ import * as Tracks from '../profile-logic/tracks';
 import * as UrlState from './url-state';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 import {
-  filterCounterToRange,
   accumulateCounterSamples,
   extractProfileFilterPageData,
   computeMaxCounterSampleCountsPerMs,
@@ -279,12 +278,6 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
 
   const getPid: Selector<Pid> = (state) => getCounter(state).pid;
 
-  const getCommittedRangeFilteredCounter: Selector<Counter> = createSelector(
-    getCounter,
-    getCommittedRange,
-    (counters, range) => filterCounterToRange(counters, range.start, range.end)
-  );
-
   const getCommittedRangeCounterSampleRanges: Selector<
     Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>
   > = createSelector(getCounter, getCommittedRange, (counter, range) =>
@@ -337,7 +330,6 @@ function _createCounterSelectors(counterIndex: CounterIndex) {
     getCounter,
     getDescription,
     getPid,
-    getCommittedRangeFilteredCounter,
     getAccumulateCounterSamples,
     getMaxCounterSampleCountsPerMs,
     getMaxRangeCounterSampleCountsPerMs,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3151,22 +3151,6 @@ describe('counter selectors', function () {
     expect(getCounterSelectors(0).getPid(getState())).toBe(0);
   });
 
-  it('can get the commited range filtered counters', function () {
-    const { getState, dispatch } = setup();
-    // The range includes the sample just before and the sample just after the selection
-    // range.
-    dispatch(ProfileView.commitRange(3.5, 5.5));
-    const originalCounter = getCounterSelectors(0).getCounter(getState());
-    expect(originalCounter.sampleGroups[0].samples.time).toEqual([
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-    ]);
-
-    const filteredCounter = getCounterSelectors(
-      0
-    ).getCommittedRangeFilteredCounter(getState());
-    expect(filteredCounter.sampleGroups[0].samples.time).toEqual([3, 4, 5, 6]);
-  });
-
   it('can accumulate samples', function () {
     const { getState, counterA } = setup();
     counterA.sampleGroups[0].samples.count = [

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -48,6 +48,7 @@ import {
 import { ensureExists } from '../../utils/flow';
 import {
   getCallNodeIndexFromPath,
+  processCounter,
   type BreakdownByCategory,
 } from '../../profile-logic/profile-data';
 
@@ -3117,13 +3118,25 @@ describe('counter selectors', function () {
     const counterB = getCounterForThread(thread, threadIndex);
     profile.counters = [counterA, counterB];
     const { getState, dispatch } = storeWithProfile(profile);
-    return { getState, dispatch, counterA, counterB };
+    const processedCounterA = processCounter(counterA);
+    const processedCounterB = processCounter(counterB);
+    return {
+      getState,
+      dispatch,
+      counterA,
+      processedCounterA,
+      processedCounterB,
+    };
   }
 
   it('can get the counters', function () {
-    const { counterA, counterB, getState } = setup();
-    expect(getCounterSelectors(0).getCounter(getState())).toBe(counterA);
-    expect(getCounterSelectors(1).getCounter(getState())).toBe(counterB);
+    const { processedCounterA, processedCounterB, getState } = setup();
+    expect(getCounterSelectors(0).getCounter(getState())).toStrictEqual(
+      processedCounterA
+    );
+    expect(getCounterSelectors(1).getCounter(getState())).toStrictEqual(
+      processedCounterB
+    );
   });
 
   it('can get the counter description', function () {


### PR DESCRIPTION
This PR converts the graphs that use `counters` (memory/process-cpu/power) to take the whole samples table and not only the range filtered ones.  While passing the whole counter samples, we are also adding a samples range and only computing the samples between that range. Performance of the graphs should be nearly identical. Might be even better for some cases since we don't compute the range filtered samples table on every range change.

(I've started this PR for power graph only and changed it to fix other graphs as well) memory and per process cpu should be identical right now compared to the previous code. But see the power track that was incorrect before (due to incorrect first value calculation). Let me know what you think!

Exaple profile for memory and power graphs:
[Main branch](https://main--perf-html.netlify.app/public/gfcqt0z9tkzzc5s0kzb1d0m8zthta46j7yajzp0/calltree/?globalTrackOrder=80w7&hiddenGlobalTracks=1w5&hiddenLocalTracksByPid=7496-0w2~8116-01~8796-01~8908-01~8920-01~8204-01~8060-0w2~7468-0&localTrackOrderByPid=7496-3w501627wb~8116-01~8796-01~8908-01~8920-01~8204-01~8060-340512~7468-1w304&range=8332m1664&thread=0&timelineType=cpu-category&v=6) / [Deploy preview](https://deploy-preview-4114--perf-html.netlify.app/public/gfcqt0z9tkzzc5s0kzb1d0m8zthta46j7yajzp0/calltree/?globalTrackOrder=80w7&hiddenGlobalTracks=1w5&hiddenLocalTracksByPid=7496-0w2~8116-01~8796-01~8908-01~8920-01~8204-01~8060-0w2~7468-0&localTrackOrderByPid=7496-3w501627wb~8116-01~8796-01~8908-01~8920-01~8204-01~8060-340512~7468-1w304&range=8332m1664&thread=0&timelineType=cpu-category&v=6)

Example profile for per process cpu graph:
[Production](https://share.firefox.dev/3yqmqka) / [Deploy preview](https://deploy-preview-4114--perf-html.netlify.app/public/24w7nnvf9qe7sr9y123kzdrrcrfzq703keps660/marker-chart/?globalTrackOrder=80w7&hiddenGlobalTracks=1w4&hiddenLocalTracksByPid=26408-0wy8yawyj~14532-0wa~9584-0wi~27504-0wi~26512-0wi~25868-0wp~26136-0ws~23092-0wxb&localTrackOrderByPid=26408-ykwytxexfxd6xihxhy6a87yayf0ncxlxoxty3y4y7xbxnx9ox3x4xpxqy2y5ygyh1k593xgxkxrxsy8pxcxjx1xaxuyiyb4xvy0ycwyebqwx0x5xmx8x6x7edfg2x2y9yjy1jlmi~14532-8924610a735~9584-fg56d31a90hi4bc827e~27504-fg56a31b90hi4cd827e~26512-fg56d31a90hi4bc827e~25868-qwt5p23140lh6gfknimjo7w9baecd~26136-twx356a41fc903de82ghpwsmwoikjl7b~23092-xcwxg56p31eb904cdxb82fhqwsx0twvx1wx3x5x4x6wxaiwo7ga&thread=0&timelineType=cpu-category&v=6)