### PR TITLE
Add the eslint rule jsx/no-leaked-render

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,7 @@ module.exports = {
     // 'react/no-unused-prop-types': 'error',
     'react/no-unused-state': 'error',
     'react/jsx-no-bind': 'error',
+    'react/jsx-no-leaked-render': 'error',
     'flowtype/require-valid-file-annotation': [
       'error',
       'always',

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -75,7 +75,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
             visibleTabs={visibleTabs}
             onSelectTab={this._onSelectTab}
           />
-          {hasSidebar && (
+          {hasSidebar ? (
             <Localized
               id={
                 isSidebarOpen
@@ -100,7 +100,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
                 onClick={this._onClickSidebarButton}
               />
             </Localized>
-          )}
+          ) : null}
         </div>
         <Localized
           id="Details--error-boundary-message"


### PR DESCRIPTION
I noticed this newer useful rule while I was looking at the dependencies upgrade. It seems to align well with our practice.

Here is the documentation for this rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md. I thought about using `{ "validStrategies": ["ternary"] }` but when I tried it it wanted to fix something that seemed OK so I decided to not use it after all. The autofix still use ternaries so I think it's good enough.