### PR TITLE
Add `profilingLog` and `profileGatheringLog` to processed profile format

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1503,6 +1503,21 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
     []
   );
 
+  // Profiling log is not present by default. But it may be present if backend
+  // has recorded it.
+  let profilingLog = { ...(geckoProfile.profilingLog || {}) };
+
+  for (const subprocessProfile of geckoProfile.processes) {
+    profilingLog = {
+      ...profilingLog,
+      ...(subprocessProfile.profilingLog || {}),
+    };
+  }
+
+  // Only parent process has this log, therefore we don't need to check the
+  // sub-processes.
+  const profileGatheringLog = { ...(geckoProfile.profileGatheringLog || {}) };
+
   // Convert JS tracer information into their own threads. This mutates
   // the threads array.
   for (const thread of threads.slice()) {
@@ -1532,6 +1547,8 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
     counters,
     profilerOverhead,
     threads,
+    profilingLog,
+    profileGatheringLog,
   };
   return result;
 }

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -53,7 +53,9 @@ Object {
     "visualMetrics": undefined,
   },
   "pages": Array [],
+  "profileGatheringLog": Object {},
   "profilerOverhead": Array [],
+  "profilingLog": Object {},
   "threads": Array [
     Object {
       "eTLD+1": undefined,

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -426,6 +426,24 @@ export type LibMapping = {|
   codeId?: string, // e.g. "6132B96B70fd000"
 |};
 
+/**
+ * Log object that holds the profiling-related logging information for a
+ * single process only. This is optional and older profiles don't have it.
+ * This type might also change in the future without warning.
+ */
+export type ProcessProfilingLog = {
+  [log: string]: mixed,
+};
+
+/**
+ * Log object that holds the profiling-related logging information.
+ * This is optional and older profiles don't have it.
+ * This type might also change in the future without warning.
+ */
+export type ProfilingLog = {
+  [pid: number]: ProcessProfilingLog,
+};
+
 export type GeckoProfileWithMeta<Meta> = {|
   counters?: GeckoCounter[],
   // Optional because older Firefox versions may not have that data and
@@ -438,6 +456,9 @@ export type GeckoProfileWithMeta<Meta> = {|
   pausedRanges: PausedRange[],
   processes: GeckoSubprocessProfile[],
   jsTracerDictionary?: string[],
+  // Logs are optional because older Firefox versions may not have that data.
+  profilingLog?: ProfilingLog,
+  profileGatheringLog?: ProfilingLog,
 |};
 
 export type GeckoSubprocessProfile =

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -7,7 +7,7 @@
 import type { Milliseconds, Address, Microseconds, Bytes } from './units';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 import type { MarkerPayload, MarkerSchema } from './markers';
-import type { MarkerPhase } from './gecko-profile';
+import type { MarkerPhase, ProfilingLog } from './gecko-profile';
 
 export type IndexIntoStackTable = number;
 export type IndexIntoSamplesTable = number;
@@ -872,6 +872,8 @@ export type Profile = {|
   // This is list because there is a profiler overhead per process.
   profilerOverhead?: ProfilerOverhead[],
   threads: Thread[],
+  profilingLog?: ProfilingLog,
+  profileGatheringLog?: ProfilingLog,
 |};
 
 type SerializableThread = {|


### PR DESCRIPTION
This is the front-end changes for [Bug 1676271](https://bugzilla.mozilla.org/show_bug.cgi?id=1676271). This PR only adds these objects to processed format. We don't have any user visible changes and probably we don't need something like that in the future too, since this is mostly for debugging related information for the profiler.

cc @squelart 