### PR TITLE
Hide the user interface components showing stacks for tracks that don't have stack samples

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -380,14 +380,13 @@ export function selectTrack(
         );
     }
 
-    const doesNextTrackHaveSelectedTab = getThreadSelectors(selectedThreadIndex)
-      .getUsefulTabs(getState())
-      .includes(selectedTab);
-
-    if (!doesNextTrackHaveSelectedTab) {
+    const visibleTabs = getThreadSelectors(selectedThreadIndex).getUsefulTabs(
+      getState()
+    );
+    if (!visibleTabs.includes(selectedTab)) {
       // If the user switches to another track that doesn't have the current
-      // selectedTab then switch to the calltree.
-      selectedTab = 'calltree';
+      // selectedTab then switch to the first tab.
+      selectedTab = visibleTabs[0];
     }
 
     let selectedThreadIndexes = new Set(getSelectedThreadIndexes(getState()));
@@ -546,16 +545,13 @@ export function selectActiveTabTrack(
         );
     }
 
-    const doesNextTrackHaveSelectedTab = getThreadSelectors(
-      selectedThreadIndexes
-    )
-      .getUsefulTabs(getState())
-      .includes(selectedTab);
-
-    if (!doesNextTrackHaveSelectedTab) {
+    const visibleTabs = getThreadSelectors(selectedThreadIndexes).getUsefulTabs(
+      getState()
+    );
+    if (!visibleTabs.includes(selectedTab)) {
       // If the user switches to another track that doesn't have the current
-      // selectedTab then switch to the calltree.
-      selectedTab = 'calltree';
+      // selectedTab then switch to the first tab.
+      selectedTab = visibleTabs[0];
     }
 
     if (

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -40,3 +40,9 @@ export const tabsWithTitleL10nIdArray: $ReadOnlyArray<TabsWithTitleL10nId> =
     name: tabSlug,
     title: tabsWithTitleL10nId[tabSlug],
   }));
+
+export const tabsShowingSampleData: $ReadOnlyArray<TabSlug> = [
+  'calltree',
+  'flame-graph',
+  'stack-chart',
+];

--- a/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
@@ -298,10 +298,10 @@ exports[`SampleTooltipContents renders the sample with "variable CPU cycles" CPU
     <div>
       50% (average over 1.0ms)
     </div>
-    <div
-      class="tooltipDetailSeparator"
-    />
   </div>
+  <div
+    class="tooltipDetailSeparator"
+  />
   <div
     class="tooltipDetails"
   >
@@ -410,10 +410,10 @@ exports[`SampleTooltipContents renders the sample with ns CPU usage information 
     <div>
       70% (average over 1.0ms)
     </div>
-    <div
-      class="tooltipDetailSeparator"
-    />
   </div>
+  <div
+    class="tooltipDetailSeparator"
+  />
   <div
     class="tooltipDetails"
   >
@@ -522,10 +522,10 @@ exports[`SampleTooltipContents renders the sample with µs CPU usage information
     <div>
       45% (average over 1.0ms)
     </div>
-    <div
-      class="tooltipDetailSeparator"
-    />
   </div>
+  <div
+    class="tooltipDetailSeparator"
+  />
   <div
     class="tooltipDetails"
   >

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -441,12 +441,12 @@ describe('actions/ProfileView', function () {
       it('can switch back to the thread, which remembers the last viewed panel', function () {
         const profile = getNetworkTrackProfile();
         const { dispatch, getState } = storeWithProfile(profile);
-        dispatch(App.changeSelectedTab('flame-graph'));
+        dispatch(App.changeSelectedTab('marker-table'));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([0])
         );
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'flame-graph'
+          'marker-table'
         );
         dispatch(ProfileView.selectTrack(networkTrack, 'none'));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
@@ -460,7 +460,7 @@ describe('actions/ProfileView', function () {
           new Set([0])
         );
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'flame-graph'
+          'marker-table'
         );
       });
     });
@@ -519,9 +519,15 @@ describe('actions/ProfileView', function () {
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'calltree'
         );
+        // The thread with the memory track doesn't have samples, so switch to
+        // a tab that exists even for tables without samples.
+        dispatch(App.changeSelectedTab('marker-table'));
+        expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
+          'marker-table'
+        );
         dispatch(ProfileView.selectTrack(memoryTrackReference, 'none'));
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
+          'marker-table'
         );
       });
     });

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -7,6 +7,7 @@ import { selectedThreadSelectors } from '../../selectors/per-thread';
 
 import { storeWithProfile } from '../fixtures/stores';
 import {
+  getMarkerTableProfile,
   getProfileFromTextSamples,
   getProfileWithMarkers,
   getNetworkMarkers,
@@ -33,9 +34,6 @@ describe('getUsefulTabs', function () {
     const profile = getProfileWithMarkers(getNetworkMarkers());
     const { getState } = storeWithProfile(profile);
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
-      'calltree',
-      'flame-graph',
-      'stack-chart',
       'marker-chart',
       'marker-table',
       'network-chart',
@@ -46,9 +44,6 @@ describe('getUsefulTabs', function () {
     const profile = getProfileWithJsTracerEvents([['A', 0, 10]]);
     const { getState } = storeWithProfile(profile);
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
-      'calltree',
-      'flame-graph',
-      'stack-chart',
       'marker-chart',
       'marker-table',
       'js-tracer',
@@ -97,12 +92,27 @@ describe('getUsefulTabs', function () {
 
     // Check the tabs and make sure that the network chart is there.
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
-      'calltree',
-      'flame-graph',
-      'stack-chart',
       'marker-chart',
       'marker-table',
       'network-chart',
+    ]);
+  });
+
+  it('hides sample related tabs when there is no sample data in the profile', function () {
+    const profile = getMarkerTableProfile();
+    const { getState } = storeWithProfile(profile);
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'marker-chart',
+      'marker-table',
+    ]);
+  });
+
+  it('hides sample related tabs when samples contain only the (root) frame', function () {
+    const { profile } = getProfileFromTextSamples('(root)');
+    const { getState } = storeWithProfile(profile);
+    expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
+      'marker-chart',
+      'marker-table',
     ]);
   });
 });


### PR DESCRIPTION
This is to help with profiles where either the `nostacksampling` or the `markersallthreads`.

When `nostacksampling` is used, we have samples that only contain a '(root)' frame. When `markersallthreads` is used, we have some tracks that have no samples at all. In both cases, the Call Tree, Flame Graph and Stack Chart panels are useless, and having the Marker Chart selected by default would be a lot more useful.

Additionally, when we didn't sample the stack but still sampled the CPU, hovering the timeline in areas where some CPU was used shows a tooltip with the CPU percentage (good!) but also a broken empty stack with the unknown category and a single "(root)" frame. I think it's better to hide this stack to avoid distracting the user from the CPU use information that actually exists.

Example profiles:
- nostacksampling: https://share.firefox.dev/3OPXOsj
- markersallthreads: https://share.firefox.dev/3OTwU2u