### PR TITLE
Implement the shift click gesture to select several adjacent threads in the timeline

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -280,6 +280,8 @@ type TrackInformation = {|
   // This is the tab that should be selected from this track. `null` if this
   // track doesn't have a prefered tab.
   relatedTab: null | TabSlug,
+  // This is the initial track reference
+  trackReference: TrackReference,
 |};
 
 /**
@@ -306,6 +308,7 @@ function getInformationFromTrackReference(
           }
 
           return {
+            trackReference,
             threadIndex: mainThreadIndex,
             relatedThreadIndex: mainThreadIndex,
             relatedTab:
@@ -335,6 +338,7 @@ function getInformationFromTrackReference(
       switch (localTrack.type) {
         case 'thread':
           return {
+            trackReference,
             threadIndex: localTrack.threadIndex,
             relatedThreadIndex: localTrack.threadIndex,
             // Move to a relevant thread-based tab when the previous tab was
@@ -346,18 +350,21 @@ function getInformationFromTrackReference(
           };
         case 'network':
           return {
+            trackReference,
             threadIndex: null,
             relatedThreadIndex: localTrack.threadIndex,
             relatedTab: 'network-chart',
           };
         case 'ipc':
           return {
+            trackReference,
             threadIndex: null,
             relatedThreadIndex: localTrack.threadIndex,
             relatedTab: 'marker-chart',
           };
         case 'event-delay':
           return {
+            trackReference,
             threadIndex: null,
             relatedThreadIndex: localTrack.threadIndex,
             relatedTab: null,
@@ -368,6 +375,7 @@ function getInformationFromTrackReference(
           const counterSelectors = getCounterSelectors(localTrack.counterIndex);
           const counter = counterSelectors.getCounter(state);
           return {
+            trackReference,
             threadIndex: null,
             relatedThreadIndex: counter.mainThreadIndex,
             relatedTab: null,
@@ -393,10 +401,15 @@ function setOneTrackSelection(
   trackInformation: TrackInformation,
   selectedTab: TabSlug
 ): Action {
+  const selectedThreadIndexes = new Set([trackInformation.relatedThreadIndex]);
   return {
     type: 'SELECT_TRACK',
-    selectedThreadIndexes: new Set([trackInformation.relatedThreadIndex]),
+    selectedThreadIndexes,
     selectedTab,
+    lastNonShiftClickInformation: {
+      clickedTrack: trackInformation.trackReference,
+      selection: selectedThreadIndexes,
+    },
   };
 }
 
@@ -424,6 +437,10 @@ function toggleOneTrack(
       type: 'SELECT_TRACK',
       selectedThreadIndexes,
       selectedTab,
+      lastNonShiftClickInformation: {
+        clickedTrack: trackInformation.trackReference,
+        selection: selectedThreadIndexes,
+      },
     });
   };
 }
@@ -614,6 +631,7 @@ export function selectActiveTabTrack(
       type: 'SELECT_TRACK',
       selectedThreadIndexes,
       selectedTab,
+      lastNonShiftClickInformation: null,
     });
   };
 }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -42,10 +42,16 @@ import {
   getSampleCategories,
   findBestAncestorCallNode,
 } from 'firefox-profiler/profile-logic/profile-data';
-import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import {
+  assertExhaustiveCheck,
+  getFirstItemFromSet,
+} from 'firefox-profiler/utils/flow';
 import { sendAnalytics } from 'firefox-profiler/utils/analytics';
 import { objectShallowEquals } from 'firefox-profiler/utils/index';
-import { getTrackReferenceFromTid } from 'firefox-profiler/profile-logic/tracks';
+import {
+  getTrackReferenceFromTid,
+  getTrackReferenceFromThreadIndex,
+} from 'firefox-profiler/profile-logic/tracks';
 
 import type {
   PreviewSelection,
@@ -609,10 +615,18 @@ function selectRangeOfTracks(
   return (dispatch, getState) => {
     const lastNonShiftClickInformation = getLastNonShiftClick(getState());
 
-    const lastClickedTrack =
+    let lastClickedTrack =
       lastNonShiftClickInformation && lastNonShiftClickInformation.clickedTrack;
     if (!lastClickedTrack) {
-      // TODO get the track reference from the selected thread
+      const selectedThreadIndexes = getSelectedThreadIndexes(getState());
+      const threadIndex = getFirstItemFromSet(selectedThreadIndexes);
+      if (threadIndex !== undefined) {
+        lastClickedTrack = getTrackReferenceFromThreadIndex(
+          threadIndex,
+          getGlobalTracks(getState()),
+          getLocalTracksByPid(getState())
+        );
+      }
     }
 
     if (lastClickedTrack) {

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -77,6 +77,7 @@ import type {
   Milliseconds,
   Tid,
   GlobalTrack,
+  KeyboardModifiers,
 } from 'firefox-profiler/types';
 import { funcHasRecursiveCall } from '../profile-logic/transforms';
 import { changeStoredProfileNameInDb } from 'firefox-profiler/app-logic/uploaded-profiles-db';
@@ -289,12 +290,14 @@ type TrackInformation = {|
   globalTrackIndex: TrackIndex,
   // This is the PID for the process that this track belongs to.
   pid: Pid,
-  // This is the track index of the local track in its process group.
+  // This is the track index of the local track in its process group. This is
+  // null for global tracks.
   localTrackIndex: null | TrackIndex,
   // This is the tab that should be selected from this track. `null` if this
   // track doesn't have a prefered tab.
   relatedTab: null | TabSlug,
-  // This is the initial track reference
+  // This is the track reference that was passed to
+  // getInformationFromTrackReference to generate this structure.
   trackReference: TrackReference,
 |};
 
@@ -611,7 +614,7 @@ function findThreadsBetweenTracks(
 function selectRangeOfTracks(
   clickedTrackInformation: TrackInformation,
   selectedTab: TabSlug
-) {
+): ThunkAction<void> {
   return (dispatch, getState) => {
     const lastNonShiftClickInformation = getLastNonShiftClick(getState());
 
@@ -675,7 +678,7 @@ function selectRangeOfTracks(
  */
 export function selectTrackWithModifiers(
   trackReference: TrackReference,
-  modifiers: $Shape<{ ctrlOrMeta: boolean, shift: boolean }> = {}
+  modifiers: $Shape<KeyboardModifiers> = {}
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     // These get assigned based on the track type.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -949,6 +949,7 @@ export function hideGlobalTrack(trackIndex: TrackIndex): ThunkAction<void> {
     dispatch({
       type: 'HIDE_GLOBAL_TRACK',
       trackIndex,
+      pid: globalTrackToHide.type === 'process' ? globalTrackToHide.pid : null,
       selectedThreadIndexes: newSelectedThreadIndexes,
     });
   };

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import {
   changeRightClickedTrack,
   changeLocalTrackOrder,
-  selectTrack,
+  selectTrackWithModifiers,
 } from 'firefox-profiler/actions/profile-view';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
 import {
@@ -36,7 +36,7 @@ import { TimelineLocalTrack } from './LocalTrack';
 import { TrackVisualProgress } from './TrackVisualProgress';
 import { Reorderable } from 'firefox-profiler/components/shared/Reorderable';
 import { TRACK_PROCESS_BLANK_HEIGHT } from 'firefox-profiler/app-logic/constants';
-import { getTrackSelectionModifier } from 'firefox-profiler/utils';
+import { getTrackSelectionModifiers } from 'firefox-profiler/utils';
 
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type {
@@ -76,7 +76,7 @@ type StateProps = {|
 type DispatchProps = {|
   +changeRightClickedTrack: typeof changeRightClickedTrack,
   +changeLocalTrackOrder: typeof changeLocalTrackOrder,
-  +selectTrack: typeof selectTrack,
+  +selectTrackWithModifiers: typeof selectTrackWithModifiers,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -94,8 +94,8 @@ class GlobalTrackComponent extends PureComponent<Props> {
   _selectCurrentTrack = (
     event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>
   ) => {
-    const { selectTrack, trackReference } = this.props;
-    selectTrack(trackReference, getTrackSelectionModifier(event));
+    const { selectTrackWithModifiers, trackReference } = this.props;
+    selectTrackWithModifiers(trackReference, getTrackSelectionModifiers(event));
   };
 
   renderTrack() {
@@ -361,7 +361,7 @@ export const TimelineGlobalTrack = explicitConnect<
   mapDispatchToProps: {
     changeRightClickedTrack,
     changeLocalTrackOrder,
-    selectTrack,
+    selectTrackWithModifiers,
   },
   component: GlobalTrackComponent,
 });

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import {
   changeRightClickedTrack,
-  selectTrack,
+  selectTrackWithModifiers,
 } from 'firefox-profiler/actions/profile-view';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
@@ -30,7 +30,7 @@ import { TrackMemory } from './TrackMemory';
 import { TrackIPC } from './TrackIPC';
 import { TrackProcessCPU } from './TrackProcessCPU';
 import { TrackPower } from './TrackPower';
-import { getTrackSelectionModifier } from 'firefox-profiler/utils';
+import { getTrackSelectionModifiers } from 'firefox-profiler/utils';
 import type {
   TrackReference,
   Pid,
@@ -58,7 +58,7 @@ type StateProps = {|
 
 type DispatchProps = {|
   +changeRightClickedTrack: typeof changeRightClickedTrack,
-  +selectTrack: typeof selectTrack,
+  +selectTrackWithModifiers: typeof selectTrackWithModifiers,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -72,9 +72,9 @@ class LocalTrackComponent extends PureComponent<Props> {
   _selectCurrentTrack = (
     event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>
   ) => {
-    this.props.selectTrack(
+    this.props.selectTrackWithModifiers(
       this._getTrackReference(),
-      getTrackSelectionModifier(event)
+      getTrackSelectionModifiers(event)
     );
   };
 
@@ -234,7 +234,7 @@ export const TimelineLocalTrack = explicitConnect<
   },
   mapDispatchToProps: {
     changeRightClickedTrack,
-    selectTrack,
+    selectTrackWithModifiers,
   },
   component: LocalTrackComponent,
 });

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -45,8 +45,7 @@ import {
 import { reportTrackThreadHeight } from 'firefox-profiler/actions/app';
 import { hasThreadKeys } from 'firefox-profiler/profile-logic/profile-data';
 import { EmptyThreadIndicator } from './EmptyThreadIndicator';
-import { getTrackSelectionModifier } from 'firefox-profiler/utils';
-import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import { getTrackSelectionModifiers } from 'firefox-profiler/utils';
 import './TrackThread.css';
 
 import type {
@@ -125,45 +124,39 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
     event: SyntheticMouseEvent<>,
     sampleIndex: IndexIntoSamplesTable
   ) => {
-    const modifier = getTrackSelectionModifier(event);
-    switch (modifier) {
-      case 'none': {
-        const {
-          threadsKey,
-          selectLeafCallNode,
-          selectRootCallNode,
-          focusCallTree,
-          invertCallstack,
-          selectedThreadIndexes,
-        } = this.props;
+    const modifiers = getTrackSelectionModifiers(event);
+    if (modifiers.ctrlOrMeta || modifiers.shift) {
+      // Do nothing, the track selection logic will kick in.
+      return;
+    }
 
-        // Sample clicking only works for one thread. See issue #2709
-        if (selectedThreadIndexes.size === 1) {
-          if (invertCallstack) {
-            // When we're displaying the inverted call stack, the "leaf" call node we're
-            // interested in is actually displayed as the "root" of the tree.
-            selectRootCallNode(threadsKey, sampleIndex);
-          } else {
-            selectLeafCallNode(threadsKey, sampleIndex);
-          }
-          focusCallTree();
-        }
-        if (
-          typeof threadsKey === 'number' &&
-          selectedThreadIndexes.has(threadsKey)
-        ) {
-          // We could have multiple threads selected here, and we wouldn't want
-          // to de-select one when interacting with it.
-          event.stopPropagation();
-        }
-        break;
+    const {
+      threadsKey,
+      selectLeafCallNode,
+      selectRootCallNode,
+      focusCallTree,
+      invertCallstack,
+      selectedThreadIndexes,
+    } = this.props;
+
+    // Sample clicking only works for one thread. See issue #2709
+    if (selectedThreadIndexes.size === 1) {
+      if (invertCallstack) {
+        // When we're displaying the inverted call stack, the "leaf" call node we're
+        // interested in is actually displayed as the "root" of the tree.
+        selectRootCallNode(threadsKey, sampleIndex);
+      } else {
+        selectLeafCallNode(threadsKey, sampleIndex);
       }
-      case 'ctrl':
-        // Do nothing, the track selection logic will kick in.
-        break;
-      default:
-        assertExhaustiveCheck(modifier, 'Unhandled modifier case.');
-        break;
+      focusCallTree();
+    }
+    if (
+      typeof threadsKey === 'number' &&
+      selectedThreadIndexes.has(threadsKey)
+    ) {
+      // We could have multiple threads selected here, and we wouldn't want
+      // to de-select one when interacting with it.
+      event.stopPropagation();
     }
   };
 

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -1272,3 +1272,50 @@ export function getTrackReferenceFromTid(
   // Failed to find the thread from tid.
   return null;
 }
+
+/**
+ * Returns the track reference from a threadIndex
+ * Returns null if the given threadIndex is not found.
+ */
+export function getTrackReferenceFromThreadIndex(
+  threadIndex: ThreadIndex,
+  globalTracks: GlobalTrack[],
+  localTracksByPid: Map<Pid, LocalTrack[]>
+): TrackReference | null {
+  // First, check if it's a global track.
+  for (
+    let globalTrackIndex = 0;
+    globalTrackIndex < globalTracks.length;
+    globalTrackIndex++
+  ) {
+    const globalTrack = globalTracks[globalTrackIndex];
+
+    if (
+      globalTrack.type === 'process' &&
+      globalTrack.mainThreadIndex === threadIndex
+    ) {
+      return { type: 'global', trackIndex: globalTrackIndex };
+    }
+  }
+
+  // Then, check if it's a local track
+  for (const [pid, localTracks] of localTracksByPid) {
+    for (
+      let localTrackIndex = 0;
+      localTrackIndex < localTracks.length;
+      localTrackIndex++
+    ) {
+      const localTrack = localTracks[localTrackIndex];
+
+      if (
+        localTrack.type === 'thread' &&
+        localTrack.threadIndex === threadIndex
+      ) {
+        return { type: 'local', pid: pid, trackIndex: localTrackIndex };
+      }
+    }
+  }
+
+  // Failed to find the thread from its thread index.
+  return null;
+}

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -494,6 +494,41 @@ const lastNonShiftClick: Reducer<LastNonShiftClickInformation | null> = (
   switch (action.type) {
     case 'SELECT_TRACK':
       return action.lastNonShiftClickInformation;
+
+    // Reset the state if the user hides the previously clicked track.
+    case 'HIDE_GLOBAL_TRACK': {
+      if (!state) {
+        return null;
+      }
+      const { clickedTrack } = state;
+      if (
+        clickedTrack.type === 'global' &&
+        clickedTrack.trackIndex === action.trackIndex
+      ) {
+        // This global track is hidden.
+        return null;
+      }
+      if (clickedTrack.type === 'local' && clickedTrack.pid === action.pid) {
+        // The global track where this local track belongs is hidden.
+        return null;
+      }
+      return state;
+    }
+    case 'HIDE_LOCAL_TRACK': {
+      if (!state) {
+        return null;
+      }
+      const { clickedTrack } = state;
+      if (
+        clickedTrack.type === 'local' &&
+        clickedTrack.pid === action.pid &&
+        clickedTrack.trackIndex === action.trackIndex
+      ) {
+        // This local track is hidden.
+        return null;
+      }
+      return state;
+    }
     default:
       return state;
   }

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -13,6 +13,7 @@ import type {
   Pid,
   LocalTrack,
   GlobalTrack,
+  LastNonShiftClickInformation,
   OriginsTimeline,
   StartEndRange,
   PreviewSelection,
@@ -486,6 +487,18 @@ const rootRange: Reducer<StartEndRange> = (
   }
 };
 
+const lastNonShiftClick: Reducer<LastNonShiftClickInformation | null> = (
+  state = null,
+  action
+) => {
+  switch (action.type) {
+    case 'SELECT_TRACK':
+      return action.lastNonShiftClickInformation;
+    default:
+      return state;
+  }
+};
+
 const rightClickedTrack: Reducer<TrackReference | null> = (
   state = null,
   action
@@ -661,6 +674,7 @@ const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
       scrollToSelectionGeneration,
       focusCallTreeGeneration,
       rootRange,
+      lastNonShiftClick,
       rightClickedTrack,
       rightClickedCallNode,
       rightClickedMarker,

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -53,6 +53,7 @@ import type {
   GlobalTrackReference,
   LocalTrackReference,
   TrackReference,
+  LastNonShiftClickInformation,
   PreviewSelection,
   HiddenTrackCount,
   ActiveTabGlobalTrackReference,
@@ -161,6 +162,9 @@ export const getThreads: Selector<Thread[]> = (state) =>
   getProfile(state).threads;
 export const getThreadNames: Selector<string[]> = (state) =>
   getProfile(state).threads.map((t) => t.name);
+export const getLastNonShiftClick: Selector<
+  LastNonShiftClickInformation | null
+> = (state) => getProfileViewOptions(state).lastNonShiftClick;
 export const getRightClickedTrack: Selector<TrackReference | null> = (state) =>
   getProfileViewOptions(state).rightClickedTrack;
 export const getCounter: Selector<Counter[] | null> = (state) =>

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -17,7 +17,7 @@ import {
   changeMarkersSearchString,
   hideGlobalTrack,
   hideLocalTrack,
-  selectTrack,
+  selectTrackWithModifiers,
 } from '../../actions/profile-view';
 import { ensureExists } from '../../utils/flow';
 import { getEmptyThread } from 'firefox-profiler/profile-logic/data-structures';
@@ -348,7 +348,7 @@ describe('MarkerTable', function () {
 
     it('can switch to a local track', function () {
       const { getState, dispatch } = setupWithTracksAndIPCMarker();
-      dispatch(selectTrack(parentTrackReference, 'none'));
+      dispatch(selectTrackWithModifiers(parentTrackReference));
       // Make sure that we are in the parent process thread.
       expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
         new Set([parentThreadIndex])
@@ -365,7 +365,7 @@ describe('MarkerTable', function () {
 
     it('can switch to a hidden local track', function () {
       const { getState, dispatch } = setupWithTracksAndIPCMarker();
-      dispatch(selectTrack(parentTrackReference, 'none'));
+      dispatch(selectTrackWithModifiers(parentTrackReference));
       // Make sure that we are in the parent process thread.
       expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
         new Set([parentThreadIndex])
@@ -406,7 +406,7 @@ describe('MarkerTable', function () {
 
     it('does not render when the other thread is not profiled', function () {
       const { getState, dispatch } = setupWithTracksAndIPCMarker();
-      dispatch(selectTrack(styleTrackReference, 'none'));
+      dispatch(selectTrackWithModifiers(styleTrackReference));
       // Make sure that we are in the Style thread.
       expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
         new Set([styleThreadIndex])

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -826,6 +826,203 @@ describe('Timeline multiple thread selection', function () {
     ]);
   });
 
+  it('forgets a local clicked track whose process is hidden later', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on on a local track
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#2' }));
+
+    // Then hides its global track
+    fireFullContextMenu(screen.getByRole('button', { name: /PID: 1000/ }));
+    fireFullClick(screen.getByText(/Hide/));
+
+    // Then shift-click another track
+    fireFullClick(screen.getByRole('button', { name: 'AudioPool#2' }), {
+      shiftKey: true,
+    });
+
+    // The selected tracks are between the track that's been selected after the
+    // hiding operation and the newly clicked track.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'hide [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1] SELECTED',
+      '  - show [thread AudioPool#2] SELECTED',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
+  it('forgets a global clicked track whose process is hidden later', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on a global track
+    fireFullClick(screen.getByRole('button', { name: /PID: 1002/ }));
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Then hide this global track
+    fireFullContextMenu(screen.getByRole('button', { name: /PID: 1002/ }));
+    fireFullClick(screen.getByText(/Hide/));
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'hide [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Then shift-click another track
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#3' }), {
+      shiftKey: true,
+    });
+
+    // The selected tracks are between the track that's been selected after the
+    // hiding operation and the newly clicked track.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'hide [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
+  it('forgets a local clicked track that is hidden later', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on a local track
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#2' }));
+
+    // Then hides its global track
+    fireFullContextMenu(screen.getByRole('button', { name: /PID: 1000/ }));
+    fireFullClick(screen.getByRole('menuitem', { name: 'ThreadPool#2' }));
+
+    // Another thread has been selected because the currently selected one has
+    // been hidden.
+    // Note because the newly selected thread is a local track, this also tests
+    // the path of finding the local track from a thread index.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - hide [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Then shift-click another track
+    fireFullClick(screen.getByRole('button', { name: 'AudioPool#2' }), {
+      shiftKey: true,
+    });
+
+    // The selected tracks are between the track that's been selected after the
+    // hiding operation and the newly clicked track.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - hide [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1] SELECTED',
+      '  - show [thread AudioPool#2] SELECTED',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
   it('selects also the related thread when a related track is first clicked', function () {
     const profile = getProfileWithMoreNiceTracks();
 

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -606,6 +606,92 @@ describe('Timeline multiple thread selection', function () {
     ]);
   });
 
+  it('can select a range of tracks with shift clicking in the reverse order too', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on on a local track
+    // Then shift-click on another local track above
+    fireFullClick(screen.getByRole('button', { name: 'AudioPool#2' }));
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#2' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1] SELECTED',
+      '  - show [thread AudioPool#2] SELECTED',
+      '  - show [thread Renderer]',
+    ]);
+
+    // We can also select tracks where start and end are in the same global process.
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#5' }));
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#1' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // This also works if the start track is the global track.
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#5' }));
+    fireFullClick(screen.getByRole('button', { name: /PID: 1000/ }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
   it('is possible to mix both ctrl and shift modifiers', function () {
     const { getState } = setup(getProfileWithMoreNiceTracks());
     expect(getHumanReadableTracks(getState())).toEqual([
@@ -677,8 +763,6 @@ describe('Timeline multiple thread selection', function () {
       '  - show [thread Renderer]',
     ]);
 
-    /* NOTE: this comment will be removed in a commit later, because this needs
-     * another commit to work properly.
     // Shift-clicking again above the initial track should unselect the ones
     // that were selected before and select the new ones. Indeed everything
     // happens as if the previous selection was canceled.
@@ -699,7 +783,7 @@ describe('Timeline multiple thread selection', function () {
       '  - show [thread AudioPool#1]',
       '  - show [thread AudioPool#2]',
       '  - show [thread Renderer]',
-    ]);*/
+    ]);
   });
 
   it('selects also the related thread when a related track is first clicked', function () {

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -8,8 +8,17 @@ import { Provider } from 'react-redux';
 
 import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
 import { Timeline } from '../../components/timeline';
+import {
+  selectedThreadSelectors,
+  getRightClickedTrack,
+} from 'firefox-profiler/selectors';
+import { ensureExists } from '../../utils/flow';
+
 import { storeWithProfile } from '../fixtures/stores';
-import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import {
+  getProfileFromTextSamples,
+  addIPCMarkerPairToThreads,
+} from '../fixtures/profiles/processed-profile';
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
 import { autoMockDomRect } from 'firefox-profiler/test/fixtures/mocks/domrect.js';
 import { mockRaf } from '../fixtures/mocks/request-animation-frame';
@@ -24,14 +33,9 @@ import {
 } from '../fixtures/utils';
 import ReactDOM from 'react-dom';
 import {
-  selectedThreadSelectors,
-  getRightClickedTrack,
-} from 'firefox-profiler/selectors';
-import {
   getProfileWithNiceTracks,
   getHumanReadableTracks,
 } from '../fixtures/profiles/tracks';
-import { ensureExists } from '../../utils/flow';
 import { autoMockIntersectionObserver } from '../fixtures/mocks/intersection-observer';
 
 import type { Profile } from 'firefox-profiler/types';
@@ -433,6 +437,455 @@ describe('Timeline multiple thread selection', function () {
       '  - show [thread ThreadPool#5]',
       'show [thread GeckoMain tab] SELECTED',
       '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
+  it('can select a range of tracks with shift clicking', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on on a local track
+    // Then shift-click on another local track below
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#2' }));
+    fireFullClick(screen.getByRole('button', { name: 'AudioPool#2' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1] SELECTED',
+      '  - show [thread AudioPool#2] SELECTED',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Shift-clicking on another local track will still use the first clicked
+    // track as the start.
+    fireFullClick(screen.getByRole('button', { name: 'Style' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // We can also select tracks where start and end are in the same global process.
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#1' }));
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#5' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // This also works if the start track is the global track.
+    fireFullClick(screen.getByRole('button', { name: /PID: 1000/ }));
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#5' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1] SELECTED',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
+  it('skips over hidden tracks', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+
+    // Hide the "middle" global track
+    fireFullContextMenu(screen.getByRole('button', { name: /PID: 1001/ }));
+    fireFullClick(screen.getByText(/Hide/));
+
+    // And hide a local track in the first process
+    fireFullContextMenu(screen.getByRole('button', { name: /PID: 1000/ }));
+    fireFullClick(screen.getByRole('menuitem', { name: 'ThreadPool#1' }));
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - hide [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'hide [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Click a track in the first process, then shift click another track in the
+    // last process
+    fireFullClick(screen.getByRole('button', { name: /PID: 1000/ }));
+    fireFullClick(screen.getByRole('button', { name: /PID: 1002/ }), {
+      shiftKey: true,
+    });
+
+    // Notice that the tracks in the hidden process aren't selected, nor the
+    // hidden local track in the first process.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - hide [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5] SELECTED',
+      'hide [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
+  it('is possible to mix both ctrl and shift modifiers', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on on a track
+    // Then ctrl-click on another track.
+    // Finally shift-ctrl-click on a third track.
+    fireFullClick(screen.getByRole('button', { name: /PID: 1000/ }));
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#2' }), {
+      ctrlKey: true,
+    });
+    fireFullClick(screen.getByRole('button', { name: 'ThreadPool#4' }), {
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // This is also additive when the ctrlKey is pressed only at the first click
+    // but not the second click.
+    fireFullClick(screen.getByRole('button', { name: /PID: 1002/ }), {
+      ctrlKey: true,
+    });
+    fireFullClick(screen.getByRole('button', { name: 'AudioPool#2' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1] SELECTED',
+      '  - show [thread AudioPool#2] SELECTED',
+      '  - show [thread Renderer]',
+    ]);
+
+    /* NOTE: this comment will be removed in a commit later, because this needs
+     * another commit to work properly.
+    // Shift-clicking again above the initial track should unselect the ones
+    // that were selected before and select the new ones. Indeed everything
+    // happens as if the previous selection was canceled.
+    fireFullClick(screen.getByRole('button', { name: /PID: 1001/ }), {
+      shiftKey: true,
+    });
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process] SELECTED',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2] SELECTED',
+      '  - show [thread ThreadPool#3] SELECTED',
+      '  - show [thread ThreadPool#4] SELECTED',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);*/
+  });
+
+  it('selects also the related thread when a related track is first clicked', function () {
+    const profile = getProfileWithMoreNiceTracks();
+
+    // Change the profile to have some local tracks that aren't threads
+    addIPCMarkerPairToThreads(
+      {
+        startTime: 1,
+        endTime: 10,
+        messageSeqno: 1,
+      },
+      profile.threads[0], // Parent process
+      profile.threads[6] // tab process
+    );
+
+    addIPCMarkerPairToThreads(
+      {
+        startTime: 11,
+        endTime: 20,
+        messageSeqno: 2,
+      },
+      profile.threads[0], // Parent process
+      profile.threads[7] // DOM Worker
+    );
+
+    const { getState } = setup(profile);
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [ipc GeckoMain] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [ipc DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on the first ipc track in the tab process.
+    fireFullClick(
+      screen.getByRole('button', { name: 'IPC — Content Process (1/2)' })
+    );
+
+    // No change is expected because this track was already selected.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [ipc GeckoMain] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [ipc DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Then shift click on the second ipc track in the same process
+    fireFullClick(screen.getByRole('button', { name: 'IPC — DOM Worker' }), {
+      shiftKey: true,
+    });
+
+    // The DOM Worker thread is selected, but also the main thread in this
+    // process, despite that it was outside of the range.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [ipc GeckoMain] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [ipc DOM Worker] SELECTED',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
+  // This test is similar to the previous one, except that the "related track"
+  // is selected last.
+  it('selects also the related thread when a related track is last clicked', function () {
+    const profile = getProfileWithMoreNiceTracks();
+
+    // Change the profile to have some local tracks that aren't threads
+    addIPCMarkerPairToThreads(
+      {
+        startTime: 1,
+        endTime: 10,
+        messageSeqno: 1,
+      },
+      profile.threads[0], // Parent process
+      profile.threads[6] // tab process
+    );
+
+    addIPCMarkerPairToThreads(
+      {
+        startTime: 11,
+        endTime: 20,
+        messageSeqno: 2,
+      },
+      profile.threads[0], // Parent process
+      profile.threads[7] // DOM Worker
+    );
+
+    const { getState } = setup(profile);
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [ipc GeckoMain] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [ipc DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // First click on the second ipc track in the tab process.
+    fireFullClick(screen.getByRole('button', { name: 'IPC — DOM Worker' }));
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [ipc DOM Worker] SELECTED',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Then shift click on the first ipc track in the same process
+    fireFullClick(
+      screen.getByRole('button', { name: 'IPC — Content Process (1/2)' }),
+      { shiftKey: true }
+    );
+
+    // The DOM Worker thread is selected, but also the main thread in this
+    // process, despite that it was outside of the range.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [ipc GeckoMain]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [ipc GeckoMain] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [ipc DOM Worker] SELECTED',
       '  - show [thread Style]',
       'show [thread GeckoMain tab]',
       '  - show [thread AudioPool#1]',

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -606,6 +606,46 @@ describe('Timeline multiple thread selection', function () {
     ]);
   });
 
+  it('can select a range of tracks with shift clicking starting at the selected track', function () {
+    const { getState } = setup(getProfileWithMoreNiceTracks());
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+      'show [thread GeckoMain tab]',
+      '  - show [thread AudioPool#1]',
+      '  - show [thread AudioPool#2]',
+      '  - show [thread Renderer]',
+    ]);
+
+    // Just shift-click on another local track below the selected track
+    fireFullClick(screen.getByRole('button', { name: 'AudioPool#2' }), {
+      shiftKey: true,
+    });
+
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain process]',
+      '  - show [thread ThreadPool#1]',
+      '  - show [thread ThreadPool#2]',
+      '  - show [thread ThreadPool#3]',
+      '  - show [thread ThreadPool#4]',
+      '  - show [thread ThreadPool#5]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker] SELECTED',
+      '  - show [thread Style] SELECTED',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread AudioPool#1] SELECTED',
+      '  - show [thread AudioPool#2] SELECTED',
+      '  - show [thread Renderer]',
+    ]);
+  });
+
   it('can select a range of tracks with shift clicking in the reverse order too', function () {
     const { getState } = setup(getProfileWithMoreNiceTracks());
     expect(getHumanReadableTracks(getState())).toEqual([

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -389,7 +389,7 @@ describe('actions/ProfileView', function () {
 
       it('can switch to another global track', function () {
         const { getState, dispatch, parentTrack } = setup();
-        dispatch(ProfileView.selectTrack(parentTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(parentTrackReference));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([parentTrack.mainThreadIndex])
         );
@@ -397,7 +397,7 @@ describe('actions/ProfileView', function () {
 
       it('can switch to a local track', function () {
         const { getState, dispatch, workerTrack } = setup();
-        dispatch(ProfileView.selectTrack(workerTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(workerTrackReference));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([workerTrack.threadIndex])
         );
@@ -430,7 +430,7 @@ describe('actions/ProfileView', function () {
       it('can switch to the network track, which selects the network chart tab', function () {
         const profile = getNetworkTrackProfile();
         const { dispatch, getState } = storeWithProfile(profile);
-        dispatch(ProfileView.selectTrack(networkTrack, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(networkTrack));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([0])
         );
@@ -449,14 +449,14 @@ describe('actions/ProfileView', function () {
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'marker-table'
         );
-        dispatch(ProfileView.selectTrack(networkTrack, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(networkTrack));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([0])
         );
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'network-chart'
         );
-        dispatch(ProfileView.selectTrack(threadTrack, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(threadTrack));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([0])
         );
@@ -509,7 +509,7 @@ describe('actions/ProfileView', function () {
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([1])
         );
-        dispatch(ProfileView.selectTrack(memoryTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(memoryTrackReference));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([0])
         );
@@ -526,7 +526,7 @@ describe('actions/ProfileView', function () {
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'marker-table'
         );
-        dispatch(ProfileView.selectTrack(memoryTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(memoryTrackReference));
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'marker-table'
         );
@@ -554,7 +554,7 @@ describe('actions/ProfileView', function () {
           'flame-graph'
         );
 
-        dispatch(ProfileView.selectTrack(diffingTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(diffingTrackReference));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([2])
         );
@@ -608,7 +608,7 @@ describe('actions/ProfileView', function () {
         const { dispatch, getState } = storeWithProfile(profile);
 
         // Setup the test to view native allocations.
-        dispatch(ProfileView.selectTrack(nativeAllocationsThread, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(nativeAllocationsThread));
         dispatch(
           ProfileView.changeCallTreeSummaryStrategy('native-allocations')
         );
@@ -617,7 +617,7 @@ describe('actions/ProfileView', function () {
         ).toEqual('native-allocations');
 
         // Switch to a thread without native allocations.
-        dispatch(ProfileView.selectTrack(timingOnlyThread, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(timingOnlyThread));
 
         // Expect that it switches the summary strategy to one it supports.
         expect(
@@ -630,14 +630,14 @@ describe('actions/ProfileView', function () {
         const { dispatch, getState } = storeWithProfile(profile);
 
         // Setup the test to view js allocations.
-        dispatch(ProfileView.selectTrack(jsAllocationsThread, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(jsAllocationsThread));
         dispatch(ProfileView.changeCallTreeSummaryStrategy('js-allocations'));
         expect(
           selectedThreadSelectors.getCallTreeSummaryStrategy(getState())
         ).toEqual('js-allocations');
 
         // Switch to a thread without js allocations.
-        dispatch(ProfileView.selectTrack(timingOnlyThread, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(timingOnlyThread));
 
         // Expect that it switches the summary strategy to one it supports.
         expect(
@@ -652,7 +652,7 @@ describe('actions/ProfileView', function () {
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'marker-chart'
         );
-        dispatch(ProfileView.selectTrack(parentTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(parentTrackReference));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([parentTrack.mainThreadIndex])
         );
@@ -666,7 +666,7 @@ describe('actions/ProfileView', function () {
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
           'network-chart'
         );
-        dispatch(ProfileView.selectTrack(parentTrackReference, 'none'));
+        dispatch(ProfileView.selectTrackWithModifiers(parentTrackReference));
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([parentTrack.mainThreadIndex])
         );

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -65,6 +65,7 @@ describe('getUsefulTabs', function () {
       type: 'SELECT_TRACK',
       selectedThreadIndexes: new Set([2]),
       selectedTab: 'calltree',
+      lastNonShiftClickInformation: null,
     });
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -232,6 +232,7 @@ type ProfileAction =
   | {|
       +type: 'HIDE_GLOBAL_TRACK',
       +trackIndex: TrackIndex,
+      +pid: Pid | null,
       +selectedThreadIndexes: Set<ThreadIndex>,
     |}
   | {|

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -159,6 +159,10 @@ export type CheckedSharingOptions = {|
 
 export type Localization = ReactLocalization;
 
+// This type is used when selecting tracks in the timeline. Ctrl and Meta are
+// stored in the same property to accommodate all OSes.
+export type KeyboardModifiers = {| ctrlOrMeta: boolean, shift: boolean |};
+
 type ProfileAction =
   | {|
       +type: 'ROUTE_NOT_FOUND',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -106,6 +106,11 @@ export type LocalTrackReference = {|
 
 export type TrackReference = GlobalTrackReference | LocalTrackReference;
 
+export type LastNonShiftClickInformation = {|
+  clickedTrack: TrackReference,
+  selection: Set<ThreadIndex>,
+|};
+
 /**
  * Active tab track references
  * A TrackReference uniquely identifies a track.
@@ -409,6 +414,7 @@ type UrlStateAction =
     |}
   | {|
       +type: 'SELECT_TRACK',
+      +lastNonShiftClickInformation: LastNonShiftClickInformation | null,
       +selectedThreadIndexes: Set<ThreadIndex>,
       +selectedTab: TabSlug,
     |}

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -15,6 +15,7 @@ import type {
   TimelineType,
   CheckedSharingOptions,
   Localization,
+  LastNonShiftClickInformation,
 } from './actions';
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type { StartEndRange, CssPixels, Milliseconds } from './units';
@@ -101,6 +102,7 @@ export type ProfileViewState = {
     scrollToSelectionGeneration: number,
     focusCallTreeGeneration: number,
     rootRange: StartEndRange,
+    lastNonShiftClick: LastNonShiftClickInformation | null,
     rightClickedTrack: TrackReference | null,
     rightClickedCallNode: RightClickedCallNode | null,
     rightClickedMarker: MarkerReference | null,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,9 +4,10 @@
 // @flow
 
 import type {
-  StartEndRange,
+  KeyboardModifiers,
   Marker,
   Milliseconds,
+  StartEndRange,
 } from 'firefox-profiler/types';
 
 /**
@@ -103,7 +104,7 @@ export function getTrackSelectionModifiers(
     | KeyboardEvent
     | SyntheticMouseEvent<>
     | SyntheticKeyboardEvent<>
-): {| ctrlOrMeta: boolean, shift: boolean |} {
+): KeyboardModifiers {
   return {
     ctrlOrMeta: (event.ctrlKey || event.metaKey) && !event.altKey,
     shift: event.shiftKey && !event.altKey,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -96,22 +96,16 @@ export function getStartEndRangeForMarker(
 /**
  * This logic is shared between multiple components, but it is used to determine how a
  * track gets selected, based on the modifiers used.
- *
- * See issue #2710 about adding "shift" behavior.
  */
-export function getTrackSelectionModifier(
+export function getTrackSelectionModifiers(
   event:
     | MouseEvent
     | KeyboardEvent
     | SyntheticMouseEvent<>
     | SyntheticKeyboardEvent<>
-): 'ctrl' | 'none' {
-  if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey) {
-    return 'ctrl';
-  }
-  // Uncomment the following lines to implement issue #2710:
-  // if (event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
-  //   return 'shift';
-  // }
-  return 'none';
+): {| ctrlOrMeta: boolean, shift: boolean |} {
+  return {
+    ctrlOrMeta: (event.ctrlKey || event.metaKey) && !event.altKey,
+    shift: event.shiftKey && !event.altKey,
+  };
 }


### PR DESCRIPTION
Gestures that work:
* click some track, shift click some other track => threads in-between are selected. This works in both directions.
* click some track, ctrl click some other track, shift + click a third track => the range is added to the initial selection
* at load time, when there's just one selected track, it's possible to shift + click another track, the existing selected track will be used as the start of the range
* for all of these gestures, after a shift-click, we can shift-click elsewhere, which should cancel the previous shift-click and select again.

Here is a [deploy preview](https://deploy-preview-4138--perf-html.netlify.app/public/gq17n8ck41vfq9vwcbbazd1449dpxr0j6csrtt0/calltree/?globalTrackOrder=0wx8&hiddenGlobalTracks=1wtx0wx6&hiddenLocalTracksByPid=1577709-0wxe~2262903-0w3~1856658-0w3~1577784-0w2~2263414-0w3~1577891-0w5~1642896-0w3~2263332-0w3~1846040-0w3~1776010-0w3~2263283-0w3~2261091-0w3~2262511-0w3~1642608-0w3~2016853-0w3~2024524-0w3~1578256-0wg~2262841-0w3~2020425-0w3~2263091-0w5~2020544-0w3~1579421-0w3~1642983-0w3~1577934-0w5~2262966-0w3~1845149-0w3~1772789-0w3~1577897-0w3~1763983-0w3~1799316-0w5~1578275-0w7~1577831-01~1577849-0w5~1577894-0w6~1577918-0w5~1577956-0w5~1577908-0w8~1578749-0w7~1773756-0w7~1864629-0w278~2263032-0w2568awd&thread=0&timelineType=cpu-category&v=6)

Fixes #2710


https://user-images.githubusercontent.com/454175/180269712-b1c10d66-eee6-44a7-b228-e5caf216f63c.mp4
