### PR TITLE
Fix an issue where a local track wasn't unselected when its global track is hidden

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -689,7 +689,6 @@ function _removeSelectedThreadIndexesForGlobalTrack(
       )) {
         if (localTrack.type === 'thread') {
           selectedThreadIndexes.delete(localTrack.threadIndex);
-          break;
         }
       }
     }


### PR DESCRIPTION
I noticed this issue when working on #4138.

STR is:
1. select a local track that's not the first one in a process
2. hide the full process (with right click + hide this process)

=> the old track is still selected

[production](https://profiler.firefox.com/public/gq17n8ck41vfq9vwcbbazd1449dpxr0j6csrtt0/calltree/?globalTrackOrder=0wx8&localTrackOrderByPid=1578275-9168a27340b5c&thread=0&v=7) / [deploy preview](https://deploy-preview-4158--perf-html.netlify.app/public/gq17n8ck41vfq9vwcbbazd1449dpxr0j6csrtt0/calltree/?globalTrackOrder=0wx8&localTrackOrderByPid=1578275-9168a27340b5c&thread=0&v=7)