### PR TITLE
Use `controlling` event instead of `activated` for workbox service worker.

### DIFF
--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -126,20 +126,20 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
       });
     });
 
-    wb.addEventListener('activated', () => {
+    wb.addEventListener('controlling', () => {
       // The update could have been triggered by this tab or another tab.
       // We distinguish these cases by looking at this.state.installStatus.
       console.log(
-        '[ServiceWorker] The new version of the application has been enabled.'
+        '[ServiceWorker] The new version of the application has started handling the fetch requests.'
       );
 
       if (this.state.installStatus === 'activating') {
-        // In this page the user clicked on the "reload" button.
+        // In this page the user clicked on the "Apply and reload" button.
         this.reloadPage();
         return;
       }
 
-      // In another page, the user clicked on the "reload" button.
+      // In another page, the user clicked on the "Apply and reload" button.
 
       const ready =
         !this._hasDataSourceProfile() || this._isProfileLoadedAndReady();

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -29,7 +29,7 @@ type StateProps = {|
 |};
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 
-type InstallStatus = 'pending' | 'activating' | 'activated' | 'idle';
+type InstallStatus = 'pending' | 'activating' | 'controlling' | 'idle';
 type State = {|
   installStatus: InstallStatus,
   isNoticeDisplayed: boolean,
@@ -145,7 +145,7 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
         !this._hasDataSourceProfile() || this._isProfileLoadedAndReady();
 
       this.setState({
-        installStatus: 'activated',
+        installStatus: 'controlling',
         // But if we weren't quite ready, we should write it in the notice.
         updatedWhileNotReady: !ready,
       });
@@ -306,7 +306,7 @@ class ServiceWorkerManagerImpl extends PureComponent<Props, State> {
             </button>
           </Localized>
         );
-      case 'activated':
+      case 'controlling':
         // Another tab applied the new service worker.
         return (
           <Localized id="ServiceWorkerManager--installed-button">

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -174,7 +174,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(container.firstChild).toMatchSnapshot();
 
       // Some other tab applied the update before we had the chance.
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(getReloadButton()).toHaveTextContent('Reload the application');
       expect(container.firstChild).toMatchSnapshot();
 
@@ -199,7 +199,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(reloadButton).toHaveTextContent('Applying…');
 
       // And we should now reload automatically when the SW is fully updated.
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(window.location.reload).toHaveBeenCalledTimes(1);
     });
   });
@@ -282,7 +282,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(container).toBeEmptyDOMElement();
 
       // Some other tabs updated the SW.
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(
         ensureExists(container.querySelector('.photon-message-bar')).className
       ).toMatch(/\bphoton-message-bar-warning\b/);
@@ -319,7 +319,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(container).toBeEmptyDOMElement();
 
       // And we still don't if it was updated elsewhere.
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(instance.messageSkipWaiting).not.toHaveBeenCalled();
       expect(container).toBeEmptyDOMElement();
     });
@@ -346,7 +346,7 @@ describe('app/ServiceWorkerManager', () => {
       expect(container).toBeEmptyDOMElement();
 
       // But we do if it's updated from another tab.
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(instance.messageSkipWaiting).not.toHaveBeenCalled();
       expect(
         ensureExists(container.querySelector('.photon-message-bar')).className
@@ -389,7 +389,7 @@ describe('app/ServiceWorkerManager', () => {
       dispatch(fatalError(new Error('Error while loading profile')));
       expect(window.location.reload).not.toHaveBeenCalled();
       // Dispatch the event that an update has been activated in another tab.
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(window.location.reload).toHaveBeenCalled();
     });
 
@@ -399,7 +399,7 @@ describe('app/ServiceWorkerManager', () => {
       const { dispatch, getWorkboxInstance } = setup();
       const instance = getWorkboxInstance();
 
-      instance.dispatchEvent('activated');
+      instance.dispatchEvent('controlling');
       expect(window.location.reload).not.toHaveBeenCalled();
       dispatch(fatalError(new Error('Error while loading profile')));
       expect(window.location.reload).toHaveBeenCalled();


### PR DESCRIPTION
So it turned out `activated` is not being called after a refresh and we should use `controlling` to handle the refresh instead.
See:
- https://developer.chrome.com/docs/workbox/handling-service-worker-updates/
- https://github.com/GoogleChrome/workbox/blob/v6/packages/workbox-window/src/Workbox.ts#L564-L571


That's why we've decided to use `controlling` instead. This PR changes this. There are a few cases to test:
1. Directly loading the website after an update and clicking "apply and reload" button (which is the most straightforward one).
2. After an update, load the website and refresh the page. Then click "apply and reload" (this wasn't working before).
3. Open two tabs of the website, click "apply and reload" button on one of them and make sure that the other tab has changed to "Reload the application" and make sure that it refreshes it properly (this was also working before).
4. Open two tabs of the website, **and reload both of them.** Click "apply and reload" button on one of them and make sure that the other tab has changed to "Reload the application" and make sure that it refreshes it properly (This wasn't working before either).