### PR TITLE
Add an [X] button on track names in the timeline to quickly hide unin…

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -719,6 +719,13 @@ TrackContextMenu--hide-all-matching-tracks = Hide all matching tracks
 #   $searchFilter (String) - The search filter string that user enters.
 TrackContextMenu--no-results-found = No results found for “<span>{ $searchFilter }</span>”
 
+# This button appears when hovering a track name and is displayed as an X icon.
+TrackNameButton--hide-track =
+    .title = Hide track
+# This button appears when hovering a global track name and is displayed as an X icon.
+TrackNameButton--hide-process =
+    .title = Hide process
+
 ## TrackMemoryGraph
 ## This is used to show the memory graph of that process in the timeline part of
 ## the UI. To learn more about it, visit:

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -5,11 +5,13 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import {
   changeRightClickedTrack,
   changeLocalTrackOrder,
   selectTrackWithModifiers,
+  hideGlobalTrack,
 } from 'firefox-profiler/actions/profile-view';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
 import {
@@ -77,6 +79,7 @@ type DispatchProps = {|
   +changeRightClickedTrack: typeof changeRightClickedTrack,
   +changeLocalTrackOrder: typeof changeLocalTrackOrder,
   +selectTrackWithModifiers: typeof selectTrackWithModifiers,
+  +hideGlobalTrack: typeof hideGlobalTrack,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -96,6 +99,14 @@ class GlobalTrackComponent extends PureComponent<Props> {
   ) => {
     const { selectTrackWithModifiers, trackReference } = this.props;
     selectTrackWithModifiers(trackReference, getTrackSelectionModifiers(event));
+  };
+
+  _hideCurrentTrack = (
+    event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>
+  ) => {
+    const { trackIndex, hideGlobalTrack } = this.props;
+    hideGlobalTrack(trackIndex);
+    event.stopPropagation();
   };
 
   renderTrack() {
@@ -274,6 +285,17 @@ class GlobalTrackComponent extends PureComponent<Props> {
                 </div>
               ) : null}
             </button>
+            <Localized
+              id="TrackNameButton--hide-process"
+              attrs={{ title: true }}
+            >
+              <button
+                type="button"
+                className="timelineTrackCloseButton"
+                title="Hide process"
+                onClick={this._hideCurrentTrack}
+              />
+            </Localized>
           </ContextMenuTrigger>
           <div className="timelineTrackTrack">{this.renderTrack()}</div>
         </div>
@@ -362,6 +384,7 @@ export const TimelineGlobalTrack = explicitConnect<
     changeRightClickedTrack,
     changeLocalTrackOrder,
     selectTrackWithModifiers,
+    hideGlobalTrack,
   },
   component: GlobalTrackComponent,
 });

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -5,10 +5,12 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import {
   changeRightClickedTrack,
   selectTrackWithModifiers,
+  hideLocalTrack,
 } from 'firefox-profiler/actions/profile-view';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
@@ -59,6 +61,7 @@ type StateProps = {|
 type DispatchProps = {|
   +changeRightClickedTrack: typeof changeRightClickedTrack,
   +selectTrackWithModifiers: typeof selectTrackWithModifiers,
+  +hideLocalTrack: typeof hideLocalTrack,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -82,6 +85,14 @@ class LocalTrackComponent extends PureComponent<Props> {
     const { pid, trackIndex } = this.props;
     return { type: 'local', pid, trackIndex };
   }
+
+  _hideCurrentTrack = (
+    event: SyntheticMouseEvent<> | SyntheticKeyboardEvent<>
+  ) => {
+    const { pid, trackIndex, hideLocalTrack } = this.props;
+    hideLocalTrack(pid, trackIndex);
+    event.stopPropagation();
+  };
 
   renderTrack() {
     const { localTrack, trackName } = this.props;
@@ -150,6 +161,14 @@ class LocalTrackComponent extends PureComponent<Props> {
             <button type="button" className="timelineTrackNameButton">
               {trackName}
             </button>
+            <Localized id="TrackNameButton--hide-track" attrs={{ title: true }}>
+              <button
+                type="button"
+                className="timelineTrackCloseButton"
+                title="Hide track"
+                onClick={this._hideCurrentTrack}
+              />
+            </Localized>
           </ContextMenuTrigger>
           <div className="timelineTrackTrack">{this.renderTrack()}</div>
         </div>
@@ -235,6 +254,7 @@ export const TimelineLocalTrack = explicitConnect<
   mapDispatchToProps: {
     changeRightClickedTrack,
     selectTrackWithModifiers,
+    hideLocalTrack,
   },
   component: LocalTrackComponent,
 });

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -50,7 +50,6 @@
   height: calc(100% - 8px);
   padding: 0 0 0 10px;
   border: none;
-  margin: auto;
   background: none;
   font: inherit;
   text-align: left;
@@ -61,6 +60,26 @@
 .timelineTrackNameButtonAdditionalDetails {
   color: var(--grey-90-a60);
   font-size: 10px;
+}
+
+.timelineTrackCloseButton {
+  position: relative;
+  right: 5px;
+  overflow: hidden;
+  width: 11px;
+  height: 11px;
+  padding: 0;
+  border: 0;
+  background: url(../../../res/img/svg/searchfield-cancel.svg) top left
+    no-repeat;
+  background-size: contain;
+  color: transparent;
+  margin-inline-start: 8px;
+  -moz-user-focus: ignore;
+}
+
+.timelineTrackLabel:not(:hover) > .timelineTrackCloseButton {
+  display: none;
 }
 
 .timelineTrackTrack {

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -25,6 +25,11 @@ Process: \\"tab\\" (222)"
           222
         </div>
       </button>
+      <button
+        class="timelineTrackCloseButton"
+        title="Hide process"
+        type="button"
+      />
     </div>
     <div
       class="timelineTrackTrack"
@@ -145,6 +150,11 @@ Process: \\"tab\\" (222)"
           >
             DOM Worker
           </button>
+          <button
+            class="timelineTrackCloseButton"
+            title="Hide track"
+            type="button"
+          />
         </div>
         <div
           class="timelineTrackTrack"
@@ -231,6 +241,11 @@ Process: \\"tab\\" (222)"
           >
             Style
           </button>
+          <button
+            class="timelineTrackCloseButton"
+            title="Hide track"
+            type="button"
+          />
         </div>
         <div
           class="timelineTrackTrack"
@@ -319,6 +334,11 @@ exports[`timeline/GlobalTrack matches the snapshot of a global process track wit
       >
         Process 5555
       </button>
+      <button
+        class="timelineTrackCloseButton"
+        title="Hide process"
+        type="button"
+      />
     </div>
     <div
       class="timelineTrackTrack"
@@ -350,6 +370,11 @@ Process: \\"default\\" (5555)"
           >
             NoMain
           </button>
+          <button
+            class="timelineTrackCloseButton"
+            title="Hide track"
+            type="button"
+          />
         </div>
         <div
           class="timelineTrackTrack"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -17,6 +17,11 @@ exports[`timeline/LocalTrack with a memory track matches the snapshot of the mem
       >
         Memory
       </button>
+      <button
+        class="timelineTrackCloseButton"
+        title="Hide track"
+        type="button"
+      />
     </div>
     <div
       class="timelineTrackTrack"
@@ -77,6 +82,11 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
       >
         Network
       </button>
+      <button
+        class="timelineTrackCloseButton"
+        title="Hide track"
+        type="button"
+      />
     </div>
     <div
       class="timelineTrackTrack"
@@ -149,6 +159,11 @@ Process: \\"tab\\" (222)"
       >
         DOM Worker
       </button>
+      <button
+        class="timelineTrackCloseButton"
+        title="Hide track"
+        type="button"
+      />
     </div>
     <div
       class="timelineTrackTrack"
@@ -235,6 +250,11 @@ exports[`timeline/LocalTrack with an IPC track matches the snapshot of the IPC t
       >
         IPC — Empty
       </button>
+      <button
+        class="timelineTrackCloseButton"
+        title="Hide track"
+        type="button"
+      />
     </div>
     <div
       class="timelineTrackTrack"


### PR DESCRIPTION
…teresting tracks or processes.
<img width="204" alt="Capture d’écran 2022-08-03 à 20 15 33" src="https://user-images.githubusercontent.com/2633774/182679948-b2b826b6-ede8-4d53-bb28-59020c353fff.png">
<img width="222" alt="Capture d’écran 2022-08-03 à 20 15 44" src="https://user-images.githubusercontent.com/2633774/182679956-2daed4f3-2cba-43a9-8a82-55a21812deb1.png">

[deploy preview](https://deploy-preview-4170--perf-html.netlify.app/public/y78ha305v0820gkcqmd37wh23g6yyx53mz0zd1r/marker-table/?globalTrackOrder=a0w9&hiddenGlobalTracks=1w4&hiddenLocalTracksByPid=20172-0w35w8hikwy3y5wy8~20175-0wa~20223-0wf~20222-0wf~20229-0wf~20181-0wenwr~20176-0wdmwx1~20178-0wjswx0~20180-0wjstx0~20182-0wjswx2&localTrackOrderByPid=20180-uv524d9803abs71tgefhwr6cx0x1~20172-y4wy84h56v8xjxtxuxnxpxvxbxcx1y2037y1xhxixkxoxsy0x2xdx3xmj2y3xqxrx5wx7xawx89wcedf1x4xlixgxexfkmrnltpqosux0gy9&range=30327m9093&thread=b&v=7)
