### PR TITLE
Show the sum of the power usage in power track's tooltips

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -738,7 +738,7 @@ TrackMemoryGraph--relative-memory-at-this-time = relative memory at this time
 TrackMemoryGraph--memory-range-in-graph = memory range in graph
 TrackMemoryGraph--operations-since-the-previous-sample = operations since the previous sample
 
-## TrackPowerGraph
+## TrackPower
 ## This is used to show the power used by the CPU and other chips in a computer,
 ## graphed over time.
 ## It's not displayed by default in the UI, but an example can be found at
@@ -747,12 +747,14 @@ TrackMemoryGraph--operations-since-the-previous-sample = operations since the pr
 # This is used in the tooltip when the power value uses the Watt unit.
 # Variables:
 #   $value (String) - the power value at this location
-TrackPowerGraph--tooltip-power-watt = Power: <em>{ $value } W</em>
+TrackPower--tooltip-power-watt = { $value } W
+  .label = Power
 
 # This is used in the tooltip when the power value uses the Milliwatt unit.
 # Variables:
 #   $value (String) - the power value at this location
-TrackPowerGraph--tooltip-power-milliwatt = Power: <em>{ $value } mW</em>
+TrackPower--tooltip-power-milliwatt = { $value } mW
+  .label = Power
 
 ## TrackSearchField
 ## The component that is used for the search input in the track context menu.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -744,17 +744,45 @@ TrackMemoryGraph--operations-since-the-previous-sample = operations since the pr
 ## It's not displayed by default in the UI, but an example can be found at
 ## https://share.firefox.dev/3a1fiT7.
 
-# This is used in the tooltip when the power value uses the Watt unit.
+# This is used in the tooltip when the power value uses the watt unit.
 # Variables:
 #   $value (String) - the power value at this location
 TrackPower--tooltip-power-watt = { $value } W
   .label = Power
 
-# This is used in the tooltip when the power value uses the Milliwatt unit.
+# This is used in the tooltip when the instant power value uses the milliwatt unit.
 # Variables:
 #   $value (String) - the power value at this location
 TrackPower--tooltip-power-milliwatt = { $value } mW
   .label = Power
+
+# This is used in the tooltip when the energy used in the current range uses the
+# watt-hour unit.
+# Variables:
+#   $value (String) - the energy value for this range
+TrackPower--tooltip-energy-used-in-range-watthour = { $value } Wh
+  .label = Energy used in the visible range
+
+# This is used in the tooltip when the energy used in the current range uses the
+# milliwatt-hour unit.
+# Variables:
+#   $value (String) - the energy value for this range
+TrackPower--tooltip-energy-used-in-range-milliwatthour = { $value } mWh
+  .label = Energy used in the visible range
+
+# This is used in the tooltip when the energy used in the current preview
+# selection uses the watt-hour unit.
+# Variables:
+#   $value (String) - the energy value for this range
+TrackPower--tooltip-energy-used-in-preview-watthour = { $value } Wh
+  .label = Energy used in the current selection
+
+# This is used in the tooltip when the energy used in the current preview
+# selection uses the milliwatt-hour unit.
+# Variables:
+#   $value (String) - the energy value for this range
+TrackPower--tooltip-energy-used-in-preview-milliwatthour = { $value } mWh
+  .label = Energy used in the current selection
 
 ## TrackSearchField
 ## The component that is used for the search input in the track context menu.

--- a/src/components/timeline/TrackPower.css
+++ b/src/components/timeline/TrackPower.css
@@ -24,14 +24,3 @@
   border-radius: 3px;
   pointer-events: none;
 }
-
-.timelineTrackPowerTooltipLine {
-  white-space: nowrap;
-}
-
-.timelineTrackPowerTooltipNumber {
-  display: inline-block;
-  min-width: 60px;
-  color: var(--grey-60);
-  font-weight: bold;
-}

--- a/src/components/timeline/TrackPowerGraph.js
+++ b/src/components/timeline/TrackPowerGraph.js
@@ -5,10 +5,8 @@
 // @flow
 
 import * as React from 'react';
-import { Localized } from '@fluent/react';
 import { withSize } from 'firefox-profiler/components/shared/WithSize';
 import explicitConnect from 'firefox-profiler/utils/connect';
-import { formatNumber } from 'firefox-profiler/utils/format-numbers';
 import { bisectionRight } from 'firefox-profiler/utils/bisect';
 import {
   getCommittedRange,
@@ -18,6 +16,7 @@ import {
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import { GREY_50 } from 'photon-colors';
 import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
+import { TooltipTrackPower } from 'firefox-profiler/components/tooltip/TrackPower';
 import { EmptyThreadIndicator } from './EmptyThreadIndicator';
 
 import type {
@@ -35,73 +34,6 @@ import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import './TrackPower.css';
-
-type TooltipOwnProps = {|
-  counter: Counter,
-  counterSampleIndex: number,
-|};
-
-type TooltipStateProps = {|
-  interval: Milliseconds,
-|};
-
-type TooltipProps = ConnectedProps<TooltipOwnProps, TooltipStateProps, {||}>;
-
-class TrackPowerTooltipImpl extends React.PureComponent<TooltipProps> {
-  render() {
-    const { counter, counterSampleIndex, interval } = this.props;
-    const samples = counter.sampleGroups[0].samples;
-
-    const powerUsageInPwh = samples.count[counterSampleIndex]; // picowatt-hour
-    const sampleTimeDeltaInMs =
-      counterSampleIndex === 0
-        ? interval
-        : samples.time[counterSampleIndex] -
-          samples.time[counterSampleIndex - 1];
-    const power =
-      ((powerUsageInPwh * 1e-12) /* pWh->Wh */ / sampleTimeDeltaInMs) *
-      1000 * // ms->s
-      3600; // s->h
-    let value;
-    let l10nId;
-    if (power > 1) {
-      value = formatNumber(power, 3);
-      l10nId = 'TrackPowerGraph--tooltip-power-watt';
-    } else if (power === 0) {
-      value = 0;
-      l10nId = 'TrackPowerGraph--tooltip-power-watt';
-    } else {
-      value = formatNumber(power * 1000);
-      l10nId = 'TrackPowerGraph--tooltip-power-milliwatt';
-    }
-    return (
-      <div className="timelineTrackPowerTooltip">
-        <Localized
-          id={l10nId}
-          vars={{ value }}
-          elems={{
-            em: <span className="timelineTrackPowerTooltipNumber"></span>,
-          }}
-        >
-          <div className="timelineTrackPowerTooltipLine">
-            Power: <em>{value}</em>
-          </div>
-        </Localized>
-      </div>
-    );
-  }
-}
-
-export const TrackPowerTooltip = explicitConnect<
-  TooltipOwnProps,
-  TooltipStateProps,
-  {||}
->({
-  mapStateToProps: (state) => ({
-    interval: getProfileInterval(state),
-  }),
-  component: TrackPowerTooltipImpl,
-});
 
 /**
  * When adding properties to these props, please consider the comment above the component.
@@ -403,7 +335,7 @@ class TrackPowerGraphImpl extends React.PureComponent<Props, State> {
 
     return (
       <Tooltip mouseX={mouseX} mouseY={mouseY}>
-        <TrackPowerTooltip
+        <TooltipTrackPower
           counter={counter}
           counterSampleIndex={counterSampleIndex}
         />

--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { Localized } from '@fluent/react';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { formatNumber } from 'firefox-profiler/utils/format-numbers';
+import { getProfileInterval } from 'firefox-profiler/selectors/profile';
+
+import type { Counter, Milliseconds } from 'firefox-profiler/types';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type OwnProps = {|
+  counter: Counter,
+  counterSampleIndex: number,
+|};
+
+type StateProps = {|
+  interval: Milliseconds,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, {||}>;
+
+class TooltipTrackPowerImpl extends React.PureComponent<Props> {
+  render() {
+    const { counter, counterSampleIndex, interval } = this.props;
+    const samples = counter.sampleGroups[0].samples;
+
+    const powerUsageInPwh = samples.count[counterSampleIndex]; // picowatt-hour
+    const sampleTimeDeltaInMs =
+      counterSampleIndex === 0
+        ? interval
+        : samples.time[counterSampleIndex] -
+          samples.time[counterSampleIndex - 1];
+    const power =
+      ((powerUsageInPwh * 1e-12) /* pWh->Wh */ / sampleTimeDeltaInMs) *
+      1000 * // ms->s
+      3600; // s->h
+    let value;
+    let l10nId;
+    if (power > 1) {
+      value = formatNumber(power, 3);
+      l10nId = 'TrackPowerGraph--tooltip-power-watt';
+    } else if (power === 0) {
+      value = 0;
+      l10nId = 'TrackPowerGraph--tooltip-power-watt';
+    } else {
+      value = formatNumber(power * 1000);
+      l10nId = 'TrackPowerGraph--tooltip-power-milliwatt';
+    }
+    return (
+      <div className="timelineTrackPowerTooltip">
+        <Localized
+          id={l10nId}
+          vars={{ value }}
+          elems={{
+            em: <span className="timelineTrackPowerTooltipNumber"></span>,
+          }}
+        >
+          <div className="timelineTrackPowerTooltipLine">
+            Power: <em>{value}</em>
+          </div>
+        </Localized>
+      </div>
+    );
+  }
+}
+
+export const TooltipTrackPower = explicitConnect<OwnProps, StateProps, {||}>({
+  mapStateToProps: (state) => ({
+    interval: getProfileInterval(state),
+  }),
+  component: TooltipTrackPowerImpl,
+});

--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -9,11 +9,20 @@ import { Localized } from '@fluent/react';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { formatNumber } from 'firefox-profiler/utils/format-numbers';
-import { getProfileInterval } from 'firefox-profiler/selectors/profile';
+import {
+  getCommittedRange,
+  getPreviewSelection,
+  getProfileInterval,
+} from 'firefox-profiler/selectors/profile';
 
 import { TooltipDetails, TooltipDetail } from './TooltipDetails';
 
-import type { Counter, Milliseconds } from 'firefox-profiler/types';
+import type {
+  Counter,
+  Milliseconds,
+  PreviewSelection,
+  StartEndRange,
+} from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
@@ -24,6 +33,8 @@ type OwnProps = {|
 
 type StateProps = {|
   interval: Milliseconds,
+  committedRange: StartEndRange,
+  previewSelection: PreviewSelection,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, {||}>;
@@ -81,6 +92,8 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
 export const TooltipTrackPower = explicitConnect<OwnProps, StateProps, {||}>({
   mapStateToProps: (state) => ({
     interval: getProfileInterval(state),
+    committedRange: getCommittedRange(state),
+    previewSelection: getPreviewSelection(state),
   }),
   component: TooltipTrackPowerImpl,
 });

--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -6,9 +6,12 @@
 
 import * as React from 'react';
 import { Localized } from '@fluent/react';
+
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { formatNumber } from 'firefox-profiler/utils/format-numbers';
 import { getProfileInterval } from 'firefox-profiler/selectors/profile';
+
+import { TooltipDetails, TooltipDetail } from './TooltipDetails';
 
 import type { Counter, Milliseconds } from 'firefox-profiler/types';
 
@@ -44,27 +47,21 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
     let l10nId;
     if (power > 1) {
       value = formatNumber(power, 3);
-      l10nId = 'TrackPowerGraph--tooltip-power-watt';
+      l10nId = 'TrackPower--tooltip-power-watt';
     } else if (power === 0) {
       value = 0;
-      l10nId = 'TrackPowerGraph--tooltip-power-watt';
+      l10nId = 'TrackPower--tooltip-power-watt';
     } else {
       value = formatNumber(power * 1000);
-      l10nId = 'TrackPowerGraph--tooltip-power-milliwatt';
+      l10nId = 'TrackPower--tooltip-power-milliwatt';
     }
     return (
       <div className="timelineTrackPowerTooltip">
-        <Localized
-          id={l10nId}
-          vars={{ value }}
-          elems={{
-            em: <span className="timelineTrackPowerTooltipNumber"></span>,
-          }}
-        >
-          <div className="timelineTrackPowerTooltipLine">
-            Power: <em>{value}</em>
-          </div>
-        </Localized>
+        <TooltipDetails>
+          <Localized id={l10nId} vars={{ value }} attrs={{ label: true }}>
+            <TooltipDetail label="Power">{value}</TooltipDetail>
+          </Localized>
+        </TooltipDetails>
       </div>
     );
   }

--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -29,6 +29,26 @@ type StateProps = {|
 type Props = ConnectedProps<OwnProps, StateProps, {||}>;
 
 class TooltipTrackPowerImpl extends React.PureComponent<Props> {
+  _formatPowerValue(power: number, l10nIdUnit, l10nIdMilliUnit): Localized {
+    let value, l10nId;
+    if (power > 1) {
+      value = formatNumber(power, 3);
+      l10nId = l10nIdUnit;
+    } else if (power === 0) {
+      value = 0;
+      l10nId = l10nIdUnit;
+    } else {
+      value = formatNumber(power * 1000);
+      l10nId = l10nIdMilliUnit;
+    }
+
+    return (
+      <Localized id={l10nId} vars={{ value }} attrs={{ label: true }}>
+        <TooltipDetail label="">{value}</TooltipDetail>
+      </Localized>
+    );
+  }
+
   render() {
     const { counter, counterSampleIndex, interval } = this.props;
     const samples = counter.sampleGroups[0].samples;
@@ -43,24 +63,15 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
       ((powerUsageInPwh * 1e-12) /* pWh->Wh */ / sampleTimeDeltaInMs) *
       1000 * // ms->s
       3600; // s->h
-    let value;
-    let l10nId;
-    if (power > 1) {
-      value = formatNumber(power, 3);
-      l10nId = 'TrackPower--tooltip-power-watt';
-    } else if (power === 0) {
-      value = 0;
-      l10nId = 'TrackPower--tooltip-power-watt';
-    } else {
-      value = formatNumber(power * 1000);
-      l10nId = 'TrackPower--tooltip-power-milliwatt';
-    }
+
     return (
       <div className="timelineTrackPowerTooltip">
         <TooltipDetails>
-          <Localized id={l10nId} vars={{ value }} attrs={{ label: true }}>
-            <TooltipDetail label="Power">{value}</TooltipDetail>
-          </Localized>
+          {this._formatPowerValue(
+            power,
+            'TrackPower--tooltip-power-watt',
+            'TrackPower--tooltip-power-milliwatt'
+          )}
         </TooltipDetails>
       </div>
     );

--- a/src/test/components/TrackPower.test.js
+++ b/src/test/components/TrackPower.test.js
@@ -179,6 +179,8 @@ describe('TrackPower', function () {
     moveMouseAtCounter(3, 0);
     // 1000pWh spent over 1ms is 3.6mW
     // Note: Fluent adds isolation characters \u2068 and \u2069 around variables.
-    expect(screen.getByText(/Power:/)).toHaveTextContent('3.6\u2069 mW');
+    expect(screen.getByText(/Power:/).nextSibling).toHaveTextContent(
+      '3.6\u2069 mW'
+    );
   });
 });

--- a/src/test/components/TrackPower.test.js
+++ b/src/test/components/TrackPower.test.js
@@ -11,6 +11,8 @@ import { Provider } from 'react-redux';
 import { fireEvent } from '@testing-library/react';
 
 import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
+
+import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
 import { TrackPower } from '../../components/timeline/TrackPower';
 import { ensureExists } from '../../utils/flow';
 
@@ -64,8 +66,8 @@ describe('TrackPower', function () {
         threadIndex,
         {
           time: thread.samples.time.slice(),
-          // Power usage numbers.
-          count: [100, 400, 500, 1000, 200, 500, 300, 100],
+          // Power usage numbers. They are pWh so they are pretty big.
+          count: [10000, 40000, 50000, 100000, 2000000, 5000000, 30000, 10000],
           length: SAMPLE_COUNT,
         },
         'SystemPower',
@@ -148,6 +150,11 @@ describe('TrackPower', function () {
     const { moveMouseAtCounter, getTooltipContents } = setup();
     // We are hovering exactly between 4th and 5th counter. That's why it should
     // show the 5th counter.
+    // Here are the values we'll get in the tooltip:
+    // 5th counter value is 5000000 pWh, that is 5 µWh. Over 1ms, this means
+    // 18W (5 * 1000 * 3600 / 1000^2).
+    // Over the full range, we get 7.240 µWh, therefore we'll see in the tooltip
+    // 0.007 mWh.
     moveMouseAtCounter(4, 0.5);
     expect(getTooltipContents()).toMatchSnapshot();
   });
@@ -175,12 +182,29 @@ describe('TrackPower', function () {
   });
 
   it('shows a tooltip with a Power: line and a power unit', function () {
-    const { moveMouseAtCounter } = setup();
+    const { dispatch, moveMouseAtCounter } = setup();
+    dispatch(
+      updatePreviewSelection({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 5,
+        selectionEnd: 6,
+      })
+    );
     moveMouseAtCounter(3, 0);
-    // 1000pWh spent over 1ms is 3.6mW
+    // 100000pWh spent over 1ms is 360mW
     // Note: Fluent adds isolation characters \u2068 and \u2069 around variables.
     expect(screen.getByText(/Power:/).nextSibling).toHaveTextContent(
-      '3.6\u2069 mW'
+      '360\u2069 mW'
     );
+    // Over the full range, we get 7.240 µWh, therefore we'll see in the tooltip
+    // 0.007 mWh.
+    expect(screen.getByText(/visible range:/).nextSibling).toHaveTextContent(
+      '0.007\u2069 mWh'
+    );
+    // Over the preview selection, we get 5 µWh which shows up as 0.005 mWh.
+    expect(
+      screen.getByText(/current selection:/).nextSibling
+    ).toHaveTextContent('0.005\u2069 mWh');
   });
 });

--- a/src/test/components/__snapshots__/TrackPower.test.js.snap
+++ b/src/test/components/__snapshots__/TrackPower.test.js.snap
@@ -21,6 +21,13 @@ exports[`TrackPower has a tooltip that matches the snapshot 1`] = `
       :
     </div>
     ⁨1.8⁩ mW
+    <div
+      class="tooltipLabel"
+    >
+      Power used in range
+      :
+    </div>
+    ⁨0.000⁩ mWh
   </div>
 </div>
 `;

--- a/src/test/components/__snapshots__/TrackPower.test.js.snap
+++ b/src/test/components/__snapshots__/TrackPower.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TrackPower draws a dot that matches the snapshot 1`] = `
 <div
   class="timelineTrackPowerGraphDot"
-  style="left: 15px; top: 18.6px;"
+  style="left: 15px; top: 24.872px;"
 />
 `;
 
@@ -20,14 +20,14 @@ exports[`TrackPower has a tooltip that matches the snapshot 1`] = `
       Power
       :
     </div>
-    ⁨1.8⁩ mW
+    ⁨18.0⁩ W
     <div
       class="tooltipLabel"
     >
-      Power used in range
+      Energy used in the visible range
       :
     </div>
-    ⁨0.000⁩ mWh
+    ⁨0.007⁩ mWh
   </div>
 </div>
 `;
@@ -64,42 +64,42 @@ Array [
   Array [
     "lineTo",
     15,
-    17.866666666666667,
+    23.877333333333333,
   ],
   Array [
     "lineTo",
     20,
-    1,
+    23.54,
   ],
   Array [
     "lineTo",
     30,
-    1,
+    23.54,
   ],
   Array [
     "lineTo",
     40,
-    19.4,
+    14.799999999999999,
   ],
   Array [
     "lineTo",
     50,
-    12.5,
+    1,
   ],
   Array [
     "lineTo",
     60,
-    17.1,
+    23.862,
   ],
   Array [
     "lineTo",
     70,
-    21.7,
+    23.954,
   ],
   Array [
     "lineTo",
     80,
-    21.7,
+    23.954,
   ],
   Array [
     "stroke",

--- a/src/test/components/__snapshots__/TrackPower.test.js.snap
+++ b/src/test/components/__snapshots__/TrackPower.test.js.snap
@@ -12,14 +12,15 @@ exports[`TrackPower has a tooltip that matches the snapshot 1`] = `
   class="timelineTrackPowerTooltip"
 >
   <div
-    class="timelineTrackPowerTooltipLine"
+    class="tooltipDetails"
   >
-    Power: 
-    <span
-      class="timelineTrackPowerTooltipNumber"
+    <div
+      class="tooltipLabel"
     >
-      ⁨1.8⁩ mW
-    </span>
+      Power
+      :
+    </div>
+    ⁨1.8⁩ mW
   </div>
 </div>
 `;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/454175/182862039-ef29716f-ef8c-461e-b231-ee8bdcc645c4.png)

[deploy preview](https://deploy-preview-4172--perf-html.netlify.app/public/sd5xpa4ptd2z9zxrha9d9wkk89hvk8z3g5d5380/marker-chart/?globalTrackOrder=x10v1wux0&hiddenGlobalTracks=2wt&hiddenLocalTracksByPid=4212-0w3~15036-0~18344-0~6592-0~18832-0~5316-0~12952-01~1908-01~18924-01~15624-01~18536-01~8424-01~6164-01~4872-01~19428-01~18448-0~18624-01~18280-01~7100-01~4900-01~3908-0~8760-0~12468-01~11012-01~7300-01~19040-01~696-01~7976-01~888-0w2~17296-023&localTrackOrderByPid=4212-450w3687~4220-01~15036-0~18344-0~6592-0~18832-0~5316-0~12952-01~1908-01~18924-01~15624-01~18536-01~8424-01~6164-01~4872-01~19428-01~18448-0~18624-01~18280-01~7100-01~4900-01~3908-0~8760-0~12468-01~11012-01~7300-01~19040-01~696-01~7976-01~888-120~19200-01~17296-40231~10508-01&thread=0&v=7)

I won't be able to change it more before my holidays but I believe it's fairly ready now. Please change the labels if needed and then merge when approved :-)

Please look at the individual commits. The first commits are "technical" in that they're extracting the tooltip rendering into its own component and file, so that we won't rerender the graph for each new preview selection.

Fixes #4154 