### PR TITLE
Tweak close button CSS some more.

### DIFF
--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -66,15 +66,15 @@
   overflow: hidden;
   width: 15px;
   height: 15px;
-  box-sizing: content-box;
+  flex-shrink: 0;
   padding: 1px;
   border: 0;
-  margin: 0 2px;
   background: url(../../../res/img/svg/close-dark.svg) no-repeat center;
   background-origin: content-box;
   background-size: contain;
   border-radius: 2px;
   color: transparent;
+  margin-inline-end: 2px;
   -moz-user-focus: ignore;
 }
 


### PR DESCRIPTION
[main branch](https://main--perf-html.netlify.app/public/1bstknft8505tjhg519de29q7rawqw8bfz3zw1r/calltree/?globalTrackOrder=0g1wfhwm&localTrackOrderByPid=41346-02w51&thread=6&v=7)
[deploy preview](https://deploy-preview-4179--perf-html.netlify.app/public/1bstknft8505tjhg519de29q7rawqw8bfz3zw1r/calltree/?globalTrackOrder=0g1wfhwm&localTrackOrderByPid=41346-02w51&thread=6&v=7)

Add flex-shrink:0 so that the button is square, and reduce its size
by removing the box-sizing:content-box (17x17 -> 15x15), and also
remove the left margin because the padding in the button is enough.