### PR TITLE
Better perf script format detection

### DIFF
--- a/src/test/unit/profile-conversion.test.js
+++ b/src/test/unit/profile-conversion.test.js
@@ -4,6 +4,7 @@
 // @flow
 
 import { unserializeProfileOfArbitraryFormat } from '../../profile-logic/process-profile';
+import { isPerfScriptFormat } from '../../profile-logic/import/linux-perf';
 import { GECKO_PROFILE_VERSION } from '../../app-logic/constants';
 import type {
   TracingEventUnion,
@@ -54,6 +55,12 @@ describe('converting Linux perf profile', function () {
     }
     return profile;
   }
+
+  it('should not detect a JSON profile as perf script', function () {
+    expect(
+      isPerfScriptFormat('{"meta": {"product": "Cool stuff 123 456:"}}')
+    ).toBe(false);
+  });
 
   it('should import a perf profile', async function () {
     const profile = await loadProfile(


### PR DESCRIPTION
The `perf script` format is a text format that doesn't contain a
distinctive header. Our detection was too general and was incorrectly
detecting JSON profiles as perf script profiles.

Now we bail out if the file starts with an opening brace.

I've also simplified how we treat perf script profiles with header.
Rather than skipping the header and detecting the first sample, we just
detect the header.