### PR TITLE
Add address-timings.js and tests.

### DIFF
--- a/src/profile-logic/address-timings.js
+++ b/src/profile-logic/address-timings.js
@@ -1,0 +1,646 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+/**
+ * In this file, "address" always means "instruction address", expressed as a
+ * byte offset into a given library ("relative address").
+ *
+ * The functions in this file (address-timings.js) behave very similarly to the
+ * ones in line-timings.js.
+ * line-timings.js is for the source view, and address-timings.js is for the
+ * assembly view.
+ *
+ * The assembly view displays the instructions for one "native symbol", i.e. for
+ * a function that the compiler created, and which the compiler didn't inline
+ * away entirely. Every such function has a start address (the symbol address)
+ * and a size in bytes. This defines an address range.
+ *
+ * Since the assembly view only displays the assembly code for a single function
+ * at a time, address-timings.js always computes information only for a single
+ * native symbol. It would also be reasonable to compute information for a
+ * single library; we'll see over time what makes more sense. The computed
+ * result for a single native symbol is small, but needs to be recomputed any
+ * time a different native symbol is selected. The computed result for an entire
+ * library would be quite large (e.g. all address hits for libxul.so), but it
+ * would not need to be recomputed when a different function is selected.
+ */
+
+/**
+ * Quick recap of the relationship between addresses, frames, funcs, and native
+ * symbols for native code:
+ *  - There is one native symbol per "outer" (i.e. non-inlined) function.
+ *  - There is one func per function name + file name pair. Funcs are used for
+ *    both inlined and non-inlined calls.
+ *  - Each frame has at least the following properties:
+ *    address, nativeSymbol, func, inlineDepth
+ *  - As a result, there is a different frame for each sampled instruction address.
+ *  - Multiple frames can share the same func.
+ *  - Multiple frames can share the same native symbol.
+ *
+ * When there's inlining at a given address, then we create a multiple frames
+ * for that address with different func and inlineDepth values, and all these
+ * frames share the same address and native symbol.
+ *
+ * Here's an example "stack" tree.
+ *
+ * Before symbolication:
+ *
+ *  - address:0x123
+ *    - address:0x250
+ *      - address:0x307
+ *    - address:0x427
+ *      - address:0x129
+ *    - address:0x435
+ *
+ * After symbolication:
+ *
+ *  - func:A nativeSymbol:A address:0x123
+ *    - func:B nativeSymbol:B address:0x250
+ *      - func:C nativeSymbol:B address:0x250 (inlineDepth:1)
+ *        - func:D nativeSymbol:B address:0x250 (inlineDepth:2)
+ *          - func:E nativeSymbol:E address:0x307
+ *    - func:F nativeSymbol:F address:0x427
+ *      - func:A nativeSymbol:A address:0x129
+ *        - func:G nativeSymbol:A address:0x129 (inlineDepth:1)
+ *    - func:F nativeSymbol:F address:0x435
+ *      - func:D nativeSymbol:F address:0x435 (inlineDepth:1)
+ */
+
+import type {
+  FrameTable,
+  FuncTable,
+  StackTable,
+  SamplesLikeTable,
+  CallNodeInfo,
+  IndexIntoCallNodeTable,
+  IndexIntoNativeSymbolTable,
+  StackAddressInfo,
+  AddressTimings,
+  Address,
+} from 'firefox-profiler/types';
+
+/**
+ * For each stack in `stackTable`, and one specific native symbol, compute the
+ * sets of addresses for frames belonging to that native symbol that are hit by
+ * the stack.
+ *
+ * For each stack we answer the following question:
+ *  - "Does this stack contribute to address X's self time?"
+ *       Answer: result.selfAddress[stack] === X
+ *  - "Does this stack contribute to address X's total time?"
+ *       Answer: result.stackAddresses[stack].has(X)
+ */
+export function getStackAddressInfo(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  funcTable: FuncTable,
+  nativeSymbol: IndexIntoNativeSymbolTable,
+  isInvertedTree: boolean
+): StackAddressInfo {
+  return isInvertedTree
+    ? getStackAddressInfoInverted(
+        stackTable,
+        frameTable,
+        funcTable,
+        nativeSymbol
+      )
+    : getStackAddressInfoNonInverted(
+        stackTable,
+        frameTable,
+        funcTable,
+        nativeSymbol
+      );
+}
+
+/**
+ * This function handles the non-inverted case of getStackAddressInfo.
+ *
+ * Compute the sets of instruction addresses for the given native symbol that
+ * are hit by each stack.
+ * For each stack in the stack table and each address for the native symbol, we
+ * answer the questions "Does this stack contribute to address X's self time?
+ * Does it contribute to address X's total time?"
+ * Each stack can only contribute to one address's self time: the address of the
+ * stack's own frame.
+ * But each stack can contribute to the total time of multiple addresses for a
+ * single native symbol, if there's recursion and the same native symbol (outer
+ * function) is present in multiple places in the stack.
+ * E.g if function A calls into B which calls into A, the call path [A, B, A]
+ * will contribute to the total time of 2 addresses:
+ *   1. The address in function A which has the call instruction to B,
+ *   2. The address in function A that is being executed at that stack (stack.frame.address).
+ * And if the call to B has been inlined into A, then it'll still just be two
+ * addresses, because the inlined frame has the same address as its parent frame.
+ * But with more complicated recursion you could have more than two addresses
+ * from the same native symbol in the same stack.
+ *
+ * This last address in a stack is the stack's "self address".
+ * If there is recursion, and the same address is present in multiple frames in
+ * the same stack, the address is only counted once - the addresses are stored
+ * in a set.
+ *
+ * The returned StackAddressInfo is computed as follows:
+ *   selfAddress[stack]:
+ *     For stacks whose stack.frame.nativeSymbol is the given native symbol,
+ *     this is stack.frame.address.
+ *     For all other stacks this is null.
+ *   stackAddresses[stack]:
+ *     For stacks whose stack.frame.nativeSymbol is the given native symbol,
+ *     this is the stackAddresses of its prefix stack, plus stack.frame.address
+ *     added to the set.
+ *     For all other stacks this is the same as the stackAddresses set of the
+ *     stack's prefix.
+ */
+export function getStackAddressInfoNonInverted(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  funcTable: FuncTable,
+  nativeSymbol: IndexIntoNativeSymbolTable
+): StackAddressInfo {
+  // "self address" == "the address which a stack's self time is contributed to"
+  const selfAddressForAllStacks = [];
+  // "total addresses" == "the set of addresses whose total time this stack contributes to"
+  const totalAddressesForAllStacks = [];
+
+  // This loop takes advantage of the fact that the stack table is topologically ordered:
+  // Prefix stacks are always visited before their descendants.
+  // Each stack inherits the "total" addresses from its parent stack, and then adds its
+  // self address to that set. If the stack doesn't have a self address in the library, we just
+  // re-use the prefix's set object without copying it.
+  for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
+    const frame = stackTable.frame[stackIndex];
+    const prefixStack = stackTable.prefix[stackIndex];
+    const nativeSymbolOfThisStack = frameTable.nativeSymbol[frame];
+
+    let selfAddress: Address | null = null;
+    let totalAddresses: Set<Address> | null =
+      prefixStack !== null ? totalAddressesForAllStacks[prefixStack] : null;
+
+    if (nativeSymbolOfThisStack === nativeSymbol) {
+      selfAddress = frameTable.address[frame];
+      if (selfAddress !== -1) {
+        // Add this stack's address to this stack's totalAddresses. The rest of this stack's
+        // totalAddresses is the same as for the parent stack.
+        // We avoid creating new Set objects unless the new set is actually
+        // different.
+        if (totalAddresses === null) {
+          // None of the ancestor stack nodes have hit a address in the given library.
+          totalAddresses = new Set([selfAddress]);
+        } else if (!totalAddresses.has(selfAddress)) {
+          totalAddresses = new Set(totalAddresses);
+          totalAddresses.add(selfAddress);
+        }
+      }
+    }
+
+    selfAddressForAllStacks.push(selfAddress);
+    totalAddressesForAllStacks.push(totalAddresses);
+  }
+  return {
+    selfAddress: selfAddressForAllStacks,
+    stackAddresses: totalAddressesForAllStacks,
+  };
+}
+
+/**
+ * This function handles the inverted case of getStackAddressInfo.
+ *
+ * The return value should exactly match what you'd get if you called
+ * `getStackAddressInfo` on the corresponding non-inverted thread.
+ * This function can probably be removed once we handle call tree inversion
+ * differently.
+ *
+ * Reminder about inverted threads: The self time is in the *root* nodes. Example:
+ *
+ * Stack node A, address 0x20
+ *   (called by) Stack node B, address 0x30
+ *
+ * The inverted stack [A, B] contributes to the self time of address 0x20.
+ *
+ * The returned StackAddressInfo is computed as follows:
+ *   selfAddress[stack]:
+ *     For (inverted thread) root stack nodes whose stack.frame.nativeSymbol is
+ *     the given native symbol, this is stack.frame.address.
+ *     For (inverted thread) root stack nodes whose frame is in a different
+ *     native symbol, this is null.
+ *     For (inverted thread) *non-root* stack nodes, this is the same as the
+ *     selfAddress of the stack's prefix. This way, the selfAddress is always
+ *     inherited from the subtree root.
+ *   stackAddresses[stack]:
+ *     For stacks whose stack.frame.nativeSymbol is the given native symbol,
+ *     this is the stackAddresses of its (inverted thread) prefix stack, plus
+ *     stack.frame.address added to the set.
+ *     For all other stacks this is the same as the stackAddresses set of the
+ *     stack's prefix.
+ */
+export function getStackAddressInfoInverted(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  funcTable: FuncTable,
+  nativeSymbol: IndexIntoNativeSymbolTable
+): StackAddressInfo {
+  // "self address" == "the address which a stack's self time is contributed to"
+  const selfAddressForAllStacks = [];
+  // "total addresses" == "the set of addresses whose total time this stack contributes to"
+  const totalAddressesForAllStacks = [];
+
+  // This loop takes advantage of the fact that the stack table is topologically ordered:
+  // Prefix stacks are always visited before their descendants.
+  for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
+    const frame = stackTable.frame[stackIndex];
+    const prefixStack = stackTable.prefix[stackIndex];
+    const nativeSymbolOfThisStack = frameTable.nativeSymbol[frame];
+
+    let selfAddress: Address | null = null;
+    let totalAddresses: Set<Address> | null = null;
+
+    if (prefixStack === null) {
+      // This stack node is a root of the inverted tree. That means that this stack's
+      // frame's address is where the self time is assigned, for the entire subtree of
+      // the inverted stack tree at this root.
+      if (nativeSymbolOfThisStack === nativeSymbol) {
+        selfAddress = frameTable.address[frame];
+        if (selfAddress !== -1) {
+          totalAddresses = new Set([selfAddress]);
+        }
+      }
+    } else {
+      // This stack node has a prefix, which, in inverted mode, means that *this node
+      // calls someone else, and that's where the time is spent*. The prefix is the callee.
+      // So this stack node contributes its time to its root node's address.
+      // We inherit the prefix's self address.
+      selfAddress = selfAddressForAllStacks[prefixStack];
+
+      // Add this stack's address to the totalAddresses set.
+      totalAddresses = totalAddressesForAllStacks[prefixStack];
+      if (nativeSymbolOfThisStack === nativeSymbol) {
+        const thisStackAddress = frameTable.address[frame];
+        if (thisStackAddress !== -1) {
+          if (totalAddresses === null) {
+            totalAddresses = new Set([thisStackAddress]);
+          } else if (!totalAddresses.has(thisStackAddress)) {
+            totalAddresses = new Set(totalAddresses);
+            totalAddresses.add(thisStackAddress);
+          }
+        }
+      }
+    }
+
+    selfAddressForAllStacks.push(selfAddress);
+    totalAddressesForAllStacks.push(totalAddresses);
+  }
+  return {
+    selfAddress: selfAddressForAllStacks,
+    stackAddresses: totalAddressesForAllStacks,
+  };
+}
+
+/**
+ * Gathers the addresses which are hit by a given call node.
+ * This is different from `getStackAddressInfo`: `getStackAddressInfo` counts
+ * address hits anywhere in the stack, and this function only counts hits *in
+ * the given call node*.
+ *
+ * This is useful when opening the assembly view from a call node: We can
+ * directly jump to the place in the assembly where *this particular call node*
+ * spends its time.
+ *
+ * Returns a StackAddressInfo object for the given stackTable and for the library
+ * which contains the call node's func.
+ */
+export function getStackAddressInfoForCallNode(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  callNodeIndex: IndexIntoCallNodeTable,
+  callNodeInfo: CallNodeInfo,
+  nativeSymbol: IndexIntoNativeSymbolTable,
+  isInvertedTree: boolean
+): StackAddressInfo {
+  return isInvertedTree
+    ? getStackAddressInfoForCallNodeInverted(
+        stackTable,
+        frameTable,
+        callNodeIndex,
+        callNodeInfo,
+        nativeSymbol
+      )
+    : getStackAddressInfoForCallNodeNonInverted(
+        stackTable,
+        frameTable,
+        callNodeIndex,
+        callNodeInfo,
+        nativeSymbol
+      );
+}
+
+/**
+ * This function handles the non-inverted case of getStackAddressInfoForCallNode.
+ *
+ * Gathers the addresses which are hit by a given call node in a given native
+ * symbol.
+ *
+ * This is best explained with an example. We first start with a case that does
+ * not have any inlining, because this is already complicated enough.
+ *
+ * Let the call node be the node for the call path [A, B, C].
+ * Let the native symbol be C.
+ * Let every frame have inlineDepth:0.
+ * Let there be a native symbol for every func, with the same name as the func.
+ * Let this be the stack tree:
+ *
+ *  - stack 1, func A
+ *    - stack 2, func B
+ *      - stack 3, func C, address 0x30
+ *      - stack 4, func C, address 0x40
+ *    - stack 5, func B
+ *      - stack 6, func C, address 0x60
+ *      - stack 7, func C, address 0x70
+ *        - stack 8, func D
+ *      - stack 9, func E
+ *    - stack 10, func F
+ *
+ * This maps to the following call tree:
+ *
+ *  - call node 1, func A
+ *    - call node 2, func B
+ *      - call node 3, func C
+ *        - call node 4, func D
+ *      - call node 5, func E
+ *   - call node 6, func F
+ *
+ * The call path [A, B, C] uniquely identifies call node 3.
+ * The following stacks all "collapse into" ("map to") call node 3:
+ * stack 3, 4, 6 and 7.
+ * Stack 8 maps to call node 4, which is a child of call node 3.
+ * Stacks 1, 2, 5, 9 and 10 are outside the call path [A, B, C].
+ *
+ * In this function, we only compute "address hits" that are contributed to
+ * the given call node.
+ * Stacks 3, 4, 6 and 7 all contribute their time both as "self time"
+ * and as "total time" to call node 3, at the addresses 0x30, 0x40, 0x60,
+ * and 0x70, respectively.
+ * Stack 8 also hits call node 3 at address 0x70, but does not contribute to
+ * call node 3's "self time", it only contributes to its "total time".
+ * Stacks 1, 2, 5, 9 and 10 don't contribute to call node 3's self or total time.
+ *
+ * Now here's an example *with* inlining.
+ *
+ * Let the call node be the node for the call path [A, B, C].
+ * Let the native symbol be B.
+ * Let this be the stack tree:
+ *
+ *  - stack 1, func A, nativeSymbol A
+ *    - stack 2, func B, nativeSymbol B, address 0x40
+ *      - stack 3, func C, nativeSymbol B, address 0x40, inlineDepth 1
+ *    - stack 4, func B, nativeSymbol B, address 0x45
+ *      - stack 5, func C, nativeSymbol B, address 0x45, inlineDepth 1
+ *        - stack 6, func D, nativeSymbol D
+ *    - stack 7, func E, nativeSymbol E
+ *  - stack 8, func A, nativeSymbol A, address 0x30
+ *    - stack 9, func B, nativeSymbol A, address 0x30, inlineDepth 1
+ *      - stack 10, func C, nativeSymbol A, address 0x30, inlineDepth 2
+ *
+ * This maps to the following call tree:
+ *
+ *  - call node 1, func A
+ *    - call node 2, func B
+ *      - call node 3, func C
+ *        - call node 4, func D
+ *    - call node 5, func E
+ *
+ * The funky part here is that call node 3 has frames from two different native
+ * symbols: Two from native symbol B, and one from native symbol A. That's
+ * because B is present both as its own native symbol (separate outer function)
+ * and as an inlined call from A. In other words, C has been inlined both into
+ * a standalone B and also into another copy of B which was inlined into A.
+ *
+ * This means that, if the user double clicks call node 3, there are two
+ * different symbols for which we may want to display the assembly code. And
+ * depending on whether the assembly for A or for B is displayed, we want to
+ * call this function for a different native symbol.
+ *
+ * In this example, we call this function for native symbol B.
+ *
+ * The call path [A, B, C] uniquely identifies call node 3.
+ * The following stacks all "collapse into" ("map to") call node 3:
+ * stack 3, 5 and 10. However, only stacks 3 and 5 belong to native symbol B;
+ * stack 10 belongs to native symbol A.
+ * Stack 6 maps to call node 4, which is a child of call node 3.
+ * Stacks 1, 2, 4, 7, 8 and 9 are outside the call path [A, B, C].
+ *
+ * Stacks 3 and 5 both contribute their time both as "self time" and as "total
+ * time" to call node 3 and native symbol B, at the addresses 0x40 and 0x45,
+ * respectively. Stack 10 has the right call node but the wrong native symbol,
+ * so it contributes to neither self nor total time.
+ * Stack 6 also hits call node 3 at address 0x45, but does not contribute to
+ * call node 3's "self time", it only contributes to its "total time".
+ * Stacks 1, 2, 4, 7, 8 and 9 don't contribute to call node 3's self or total time.
+ *
+ * ---
+ *
+ * All stacks can contribute no more than one address in the given call node.
+ * This is different from the getStackAddressInfo function above, where each
+ * stack can hit many addreses in the same library, because all of the ancestor
+ * stacks are taken into account, rather than just one of them. Concretely,
+ * this means that in the returned StackAddressInfo, each stackAddresses[stack]
+ * set will only contain at most one element.
+ *
+ * The returned StackAddressInfo is computed as follows:
+ *   selfAddress[stack]:
+ *     For stacks that map to the given call node and whose nativeSymbol is the
+ *     given native symbol, this is stack.frame.address.
+ *     For all other stacks this is null.
+ *   stackAddresses[stack]:
+ *     For stacks that map to the given call node or one of its descendant
+ *     call nodes, and whose nativeSymbol is the given native symbol, this is a
+ *     set containing one element, which is ancestorStack.frame.address, where
+ *     ancestorStack maps to the given call node.
+ *     For all other stacks, this is null.
+ */
+export function getStackAddressInfoForCallNodeNonInverted(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  callNodeIndex: IndexIntoCallNodeTable,
+  { stackIndexToCallNodeIndex }: CallNodeInfo,
+  nativeSymbol: IndexIntoNativeSymbolTable
+): StackAddressInfo {
+  // "self address" == "the address which a stack's self time is contributed to"
+  const callNodeSelfAddressForAllStacks = [];
+  // "total addresses" == "the set of addresses whose total time this stack contributes to"
+  // Either null or a single-element set.
+  const callNodeTotalAddressesForAllStacks = [];
+
+  // This loop takes advantage of the fact that the stack table is topologically ordered:
+  // Prefix stacks are always visited before their descendants.
+  for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
+    let selfAddress: Address | null = null;
+    let totalAddresses: Set<Address> | null = null;
+    const frame = stackTable.frame[stackIndex];
+
+    if (
+      stackIndexToCallNodeIndex[stackIndex] === callNodeIndex &&
+      frameTable.nativeSymbol[frame] === nativeSymbol
+    ) {
+      // This stack contributes to the call node's self time for the right
+      // native symbol. We needed to check both, because multiple stacks for the
+      // same call node can have different native symbols.
+      selfAddress = frameTable.address[frame];
+      if (selfAddress !== -1) {
+        totalAddresses = new Set([selfAddress]);
+      }
+    } else {
+      // This stack does not map to the given call node or has the wrong native
+      // symbol. So this stack contributes no self time to the call node for the
+      // requested native symbol, and we leave selfAddress at null.
+      // As for totalTime, this stack contributes to the same address's totalTime
+      // as its parent stack: If it is a descendant of a stack X which maps to
+      // the given call node, then it contributes to stack X's address's totalTime,
+      // otherwise it contributes to no address's totalTime.
+      // In the example above, this is how stack 8 contributes to call node 3's
+      // totalTime.
+      const prefixStack = stackTable.prefix[stackIndex];
+      totalAddresses =
+        prefixStack !== null
+          ? callNodeTotalAddressesForAllStacks[prefixStack]
+          : null;
+    }
+
+    callNodeSelfAddressForAllStacks.push(selfAddress);
+    callNodeTotalAddressesForAllStacks.push(totalAddresses);
+  }
+  return {
+    selfAddress: callNodeSelfAddressForAllStacks,
+    stackAddresses: callNodeTotalAddressesForAllStacks,
+  };
+}
+
+/**
+ * This handles the inverted case of getStackAddressInfoForCallNode.
+ *
+ * The returned StackAddressInfo is computed as follows:
+ *   selfAddress[stack]:
+ *     For (inverted thread) root stack nodes that map to the given call node
+ *     and whose stack.frame.nativeSymbol is the given library, this is stack.frame.address.
+ *     For (inverted thread) root stack nodes whose frame is in a different library,
+ *     or which don't map to the given call node, this is null.
+ *     For (inverted thread) *non-root* stack nodes, this is the same as the selfAddress
+ *     of the stack's prefix. This way, the selfAddress is always inherited from the
+ *     subtree root.
+ *   stackAddresses[stack]:
+ *     For stacks that map to the given call node or one of its (inverted tree)
+ *     descendant call nodes, this is a set containing one element, which is
+ *     ancestorStack.frame.address, where ancestorStack maps to the given call
+ *     node.
+ *     For all other stacks, this is null.
+ */
+export function getStackAddressInfoForCallNodeInverted(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  callNodeIndex: IndexIntoCallNodeTable,
+  { stackIndexToCallNodeIndex }: CallNodeInfo,
+  nativeSymbol: IndexIntoNativeSymbolTable
+): StackAddressInfo {
+  // "self address" == "the address which a stack's self time is contributed to"
+  const callNodeSelfAddressForAllStacks = [];
+  // "total addresses" == "the set of addresses whose total time this stack contributes to"
+  // Either null or a single-element set.
+  const callNodeTotalAddressesForAllStacks = [];
+
+  // This loop takes advantage of the fact that the stack table is topologically ordered:
+  // Prefix stacks are always visited before their descendants.
+  for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
+    let selfAddress: Address | null = null;
+    let totalAddresses: Set<Address> | null = null;
+
+    const prefixStack = stackTable.prefix[stackIndex];
+    if (
+      stackIndexToCallNodeIndex[stackIndex] === callNodeIndex &&
+      frameTable.nativeSymbol[stackTable.frame[stackIndex]] === nativeSymbol
+    ) {
+      // This stack contributes to the call node's self time for the right
+      // native symbol. We needed to check both, because multiple stacks for the
+      // same call node can have different native symbols.
+      const frame = stackTable.frame[stackIndex];
+      const address = frameTable.address[frame];
+      if (address !== -1) {
+        totalAddresses = new Set([address]);
+        if (prefixStack === null) {
+          // This is a root of the inverted tree, and it is the given
+          // call node. That means that we have a self address.
+          selfAddress = address;
+        } else {
+          // This is not a root stack node, so no self time is spent
+          // in the given call node for this stack node.
+        }
+      }
+    } else {
+      if (prefixStack === null) {
+        // This is a root of the inverted tree, but it doesn't map
+        // to the given call node. It doesn't contribute to the call node's
+        // self time or total time.
+      } else {
+        // This is not a root stack node. Samples that hit this stack node
+        // spend their time in the root node of our subtree. If that root
+        // maps to the given call node, we may have self time.
+        // Inherit both self and total time contribution from the parent stack.
+        selfAddress = callNodeSelfAddressForAllStacks[prefixStack];
+        totalAddresses = callNodeTotalAddressesForAllStacks[prefixStack];
+      }
+    }
+
+    callNodeSelfAddressForAllStacks.push(selfAddress);
+    callNodeTotalAddressesForAllStacks.push(totalAddresses);
+  }
+  return {
+    selfAddress: callNodeSelfAddressForAllStacks,
+    stackAddresses: callNodeTotalAddressesForAllStacks,
+  };
+}
+
+// An AddressTimings instance without any hits.
+export const emptyAddressTimings: AddressTimings = {
+  totalAddressHits: new Map(),
+  selfAddressHits: new Map(),
+};
+
+// Compute the AddressTimings for the supplied samples with the help of StackAddressInfo.
+// This is fast and can be done whenever the preview selection changes.
+// The slow part was the computation of the StackAddressInfo, which is already done.
+export function getAddressTimings(
+  stackAddressInfo: StackAddressInfo | null,
+  samples: SamplesLikeTable
+): AddressTimings {
+  if (stackAddressInfo === null) {
+    return emptyAddressTimings;
+  }
+  const { selfAddress, stackAddresses } = stackAddressInfo;
+  const totalAddressHits: Map<Address, number> = new Map();
+  const selfAddressHits: Map<Address, number> = new Map();
+
+  // Iterate over all the samples, and aggregate the sample's weight into the
+  // addresses which are hit by the sample's stack.
+  // TODO: Maybe aggregate sample count per stack first, and then visit each stack only once?
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+    const stackIndex = samples.stack[sampleIndex];
+    if (stackIndex === null) {
+      continue;
+    }
+    const weight = samples.weight ? samples.weight[sampleIndex] : 1;
+    const setOfHitAddresses = stackAddresses[stackIndex];
+    if (setOfHitAddresses !== null) {
+      for (const address of setOfHitAddresses) {
+        const oldHitCount = totalAddressHits.get(address) ?? 0;
+        totalAddressHits.set(address, oldHitCount + weight);
+      }
+    }
+    const address = selfAddress[stackIndex];
+    if (address !== null) {
+      const oldHitCount = selfAddressHits.get(address) ?? 0;
+      selfAddressHits.set(address, oldHitCount + weight);
+    }
+  }
+  return { totalAddressHits, selfAddressHits };
+}

--- a/src/profile-logic/line-timings.js
+++ b/src/profile-logic/line-timings.js
@@ -289,7 +289,7 @@ export function getStackLineInfoForCallNode(
  * The following stacks all "collapse into" ("map to") call node 3:
  * stack 3, 4, 6 and 7.
  * Stack 8 maps to call node 4, which is a child of call node 3.
- * All other stacks are outside the call path [A, B, C].
+ * Stacks 1, 2, 5, 9 and 10 are outside the call path [A, B, C].
  *
  * In this function, we only compute "line hits" that are contributed to
  * the given call node.
@@ -298,7 +298,7 @@ export function getStackLineInfoForCallNode(
  * and 70, respectively.
  * Stack 8 also hits call node 3 at line 70, but does not contribute to
  * call node 3's "self time", it only contributes to its "total time".
- * All other stacks don't contribute to call node 3's self or total time.
+ * Stacks 1, 2, 5, 9 and 10 don't contribute to call node 3's self or total time.
  *
  * All stacks can contribute no more than one line in the given call node.
  * This is different from the getStackLineInfo function above, where each

--- a/src/test/unit/address-timings.test.js
+++ b/src/test/unit/address-timings.test.js
@@ -1,0 +1,425 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import {
+  getStackAddressInfo,
+  getStackAddressInfoForCallNode,
+  getAddressTimings,
+} from 'firefox-profiler/profile-logic/address-timings';
+import {
+  invertCallstack,
+  getCallNodeInfo,
+  getCallNodeIndexFromPath,
+} from '../../profile-logic/profile-data';
+import { ensureExists } from 'firefox-profiler/utils/flow';
+import type {
+  CallNodePath,
+  Thread,
+  IndexIntoCategoryList,
+  IndexIntoNativeSymbolTable,
+} from 'firefox-profiler/types';
+
+describe('getStackAddressInfo', function () {
+  it('computes results for all stacks', function () {
+    const { profile, nativeSymbolsDictPerThread } = getProfileFromTextSamples(`
+      A[lib:one][address:0x20][sym:Asym]  A[lib:one][address:0x21][sym:Asym]  A[lib:one][address:0x20][sym:Asym]
+      B[lib:one][address:0x30][sym:Bsym]  B[lib:one][address:0x30][sym:Bsym]  B[lib:one][address:0x30][sym:Bsym]
+      C[lib:two][address:0x10][sym:Csym]  C[lib:two][address:0x11][sym:Csym]  D[lib:two][address:0x40][sym:Dsym]
+      B[lib:one][address:0x30][sym:Bsym]                                      D[lib:two][address:0x40][sym:Dsym]
+    `);
+    const [thread] = profile.threads;
+    const [{ Asym }] = nativeSymbolsDictPerThread;
+    const { stackTable, frameTable, funcTable } = thread;
+
+    const stackLineInfoOne = getStackAddressInfo(
+      stackTable,
+      frameTable,
+      funcTable,
+      Asym,
+      false
+    );
+
+    // Expect the returned arrays to have the same length as the stackTable.
+    expect(stackTable.length).toBe(9);
+    expect(stackLineInfoOne.selfAddress.length).toBe(9);
+    expect(stackLineInfoOne.stackAddresses.length).toBe(9);
+  });
+});
+
+describe('getAddressTimings for getStackAddressInfo', function () {
+  function getTimings(
+    thread: Thread,
+    sym: IndexIntoNativeSymbolTable,
+    isInverted: boolean
+  ) {
+    const { stackTable, frameTable, funcTable, samples } = thread;
+    const stackLineInfo = getStackAddressInfo(
+      stackTable,
+      frameTable,
+      funcTable,
+      sym,
+      isInverted
+    );
+    return getAddressTimings(stackLineInfo, samples);
+  }
+
+  it('passes a basic test', function () {
+    // In this example, there's one self address hit at address 0x30.
+    // Both address 0x20 and address 0x30 have one total time hit.
+    const { profile, nativeSymbolsDictPerThread } = getProfileFromTextSamples(`
+      A[lib:file][address:0x20][sym:Asym]
+      A[lib:file][address:0x30][sym:Asym]
+    `);
+    const [thread] = profile.threads;
+    const [{ Asym }] = nativeSymbolsDictPerThread;
+    const addressTimings = getTimings(thread, Asym, false);
+    expect(addressTimings.totalAddressHits.get(0x20)).toBe(1);
+    expect(addressTimings.totalAddressHits.get(0x30)).toBe(1);
+    expect(addressTimings.totalAddressHits.size).toBe(2); // no other hits
+    expect(addressTimings.selfAddressHits.get(0x20)).toBe(undefined);
+    expect(addressTimings.selfAddressHits.get(0x30)).toBe(1);
+    expect(addressTimings.selfAddressHits.size).toBe(1); // no other hits
+  });
+
+  it('passes a test with inlining', function () {
+    // In this example, there's one self address hit at address 0x30.
+    // Both address 0x20 and address 0x30 have one total time hit.
+    const { profile, nativeSymbolsDictPerThread } = getProfileFromTextSamples(`
+      A[lib:file][address:0x20][sym:Asym]
+      B[lib:file][address:0x20][sym:Asym][inl:1]
+      C[lib:file][address:0x20][sym:Asym][inl:2]
+      A[lib:file][address:0x30][sym:Asym]
+    `);
+    const [thread] = profile.threads;
+    const [{ Asym }] = nativeSymbolsDictPerThread;
+    const addressTimings = getTimings(thread, Asym, false);
+    expect(addressTimings.totalAddressHits.get(0x20)).toBe(1);
+    expect(addressTimings.totalAddressHits.get(0x30)).toBe(1);
+    expect(addressTimings.totalAddressHits.size).toBe(2); // no other hits
+    expect(addressTimings.selfAddressHits.get(0x20)).toBe(undefined);
+    expect(addressTimings.selfAddressHits.get(0x30)).toBe(1);
+    expect(addressTimings.selfAddressHits.size).toBe(1); // no other hits
+  });
+
+  it('passes a test with two files and recursion', function () {
+    const { profile, nativeSymbolsDictPerThread } = getProfileFromTextSamples(`
+      A[lib:one][address:0x20][sym:Asym]  A[lib:one][address:0x21][sym:Asym]  A[lib:one][address:0x20][sym:Asym]
+      B[lib:one][address:0x30][sym:Bsym]  B[lib:one][address:0x30][sym:Bsym]  B[lib:one][address:0x30][sym:Bsym]
+      C[lib:two][address:0x10][sym:Csym]  C[lib:two][address:0x11][sym:Csym]  D[lib:two][address:0x40][sym:Dsym]
+      B[lib:one][address:0x30][sym:Bsym]                                      D[lib:two][address:0x40][sym:Dsym]
+    `);
+    const [thread] = profile.threads;
+    const [{ Asym, Bsym, Csym, Dsym }] = nativeSymbolsDictPerThread;
+
+    const addressTimingsA = getTimings(thread, Asym, false);
+    expect(addressTimingsA.totalAddressHits.get(0x20)).toBe(2);
+    expect(addressTimingsA.totalAddressHits.get(0x21)).toBe(1);
+    // 0x30 is in the righ lib (one) but in the wrong native symbol (B instead
+    // of A), so we should not see any hits on it.
+    expect(addressTimingsA.totalAddressHits.get(0x30)).toBe(undefined);
+    expect(addressTimingsA.totalAddressHits.size).toBe(2); // no other hits
+    // There is no self address hit for Asym.
+    expect(addressTimingsA.selfAddressHits.get(0x20)).toBe(undefined);
+    expect(addressTimingsA.selfAddressHits.get(0x21)).toBe(undefined);
+    expect(addressTimingsA.selfAddressHits.get(0x30)).toBe(undefined);
+    expect(addressTimingsA.selfAddressHits.size).toBe(0); // no other hits
+
+    const addressTimingsB = getTimings(thread, Bsym, false);
+    // Address 0x30 was hit in every sample, twice in the first sample
+    // (due to recursion) but that still only counts as one sample
+    expect(addressTimingsB.totalAddressHits.get(0x30)).toBe(3);
+    expect(addressTimingsB.totalAddressHits.size).toBe(1); // no other hits
+    // There is only one self address hit for Bsym: 0x30 in the first sample.
+    expect(addressTimingsB.selfAddressHits.get(0x20)).toBe(undefined);
+    expect(addressTimingsB.selfAddressHits.get(0x21)).toBe(undefined);
+    expect(addressTimingsB.selfAddressHits.get(0x30)).toBe(1);
+    expect(addressTimingsB.selfAddressHits.size).toBe(1); // no other hits
+
+    const addressTimingsC = getTimings(thread, Csym, false);
+    expect(addressTimingsC.totalAddressHits.get(0x10)).toBe(1);
+    expect(addressTimingsC.totalAddressHits.get(0x11)).toBe(1);
+    expect(addressTimingsC.totalAddressHits.size).toBe(2); // no other hits
+    expect(addressTimingsC.selfAddressHits.get(0x10)).toBe(undefined);
+    expect(addressTimingsC.selfAddressHits.get(0x11)).toBe(1);
+    expect(addressTimingsC.selfAddressHits.size).toBe(1); // no other hits
+
+    const addressTimingsD = getTimings(thread, Dsym, false);
+    expect(addressTimingsD.totalAddressHits.get(0x40)).toBe(1);
+    expect(addressTimingsD.totalAddressHits.size).toBe(1); // no other hits
+    // Dsym's address 0x40 recursed but should only be counted as 1 sample
+    expect(addressTimingsD.selfAddressHits.get(0x40)).toBe(1);
+    expect(addressTimingsD.selfAddressHits.size).toBe(1); // no other hits
+  });
+
+  it('computes the same values on an inverted thread', function () {
+    const { profile, nativeSymbolsDictPerThread } = getProfileFromTextSamples(`
+    A[lib:one][address:0x20][sym:Asym]  A[lib:one][address:0x21][sym:Asym]  A[lib:one][address:0x20][sym:Asym]
+    B[lib:one][address:0x30][sym:Bsym]  B[lib:one][address:0x30][sym:Bsym]  B[lib:one][address:0x30][sym:Bsym]
+    C[lib:two][address:0x10][sym:Csym]  C[lib:two][address:0x11][sym:Csym]  D[lib:two][address:0x40][sym:Dsym]
+    B[lib:one][address:0x30][sym:Bsym]                                      D[lib:two][address:0x40][sym:Dsym]
+    `);
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
+
+    const [thread] = profile.threads;
+    const [{ Asym, Bsym, Csym, Dsym }] = nativeSymbolsDictPerThread;
+    const defaultCategory = categories.findIndex((c) => c.color === 'grey');
+    const invertedThread = invertCallstack(thread, defaultCategory);
+
+    const addressTimingsA = getTimings(thread, Asym, false);
+    const addressTimingsInvertedA = getTimings(invertedThread, Asym, true);
+    expect(addressTimingsInvertedA).toEqual(addressTimingsA);
+
+    const addressTimingsB = getTimings(thread, Bsym, false);
+    const addressTimingsInvertedB = getTimings(invertedThread, Bsym, true);
+    expect(addressTimingsInvertedB).toEqual(addressTimingsB);
+
+    const addressTimingsC = getTimings(thread, Csym, false);
+    const addressTimingsInvertedC = getTimings(invertedThread, Csym, true);
+    expect(addressTimingsInvertedC).toEqual(addressTimingsC);
+
+    const addressTimingsD = getTimings(thread, Dsym, false);
+    const addressTimingsInvertedD = getTimings(invertedThread, Dsym, true);
+    expect(addressTimingsInvertedD).toEqual(addressTimingsD);
+  });
+});
+
+describe('getAddressTimings for getStackAddressInfoForCallNode', function () {
+  function getTimings(
+    thread: Thread,
+    callNodePath: CallNodePath,
+    defaultCat: IndexIntoCategoryList,
+    nativeSymbol: IndexIntoNativeSymbolTable,
+    isInverted: boolean
+  ) {
+    const { stackTable, frameTable, funcTable, samples } = thread;
+    const callNodeInfo = getCallNodeInfo(
+      stackTable,
+      frameTable,
+      funcTable,
+      defaultCat
+    );
+    const callNodeIndex = ensureExists(
+      getCallNodeIndexFromPath(callNodePath, callNodeInfo.callNodeTable),
+      'invalid call node path'
+    );
+    const stackLineInfo = getStackAddressInfoForCallNode(
+      stackTable,
+      frameTable,
+      callNodeIndex,
+      callNodeInfo,
+      nativeSymbol,
+      isInverted
+    );
+    return getAddressTimings(stackLineInfo, samples);
+  }
+
+  it('passes a basic test', function () {
+    const { profile, funcNamesDictPerThread, nativeSymbolsDictPerThread } =
+      getProfileFromTextSamples(`
+      A[lib:file][address:0x20][sym:Asym]
+      B[lib:file][address:0x30][sym:Bsym]
+    `);
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
+    const defaultCat = categories.findIndex((c) => c.color === 'grey');
+
+    const [{ A, B }] = funcNamesDictPerThread;
+    const [{ Asym, Bsym }] = nativeSymbolsDictPerThread;
+    const [thread] = profile.threads;
+
+    // Compute the address timings for the root call node.
+    // No self address hit, one total address hit at address 0x20.
+    const addressTimingsRoot = getTimings(thread, [A], defaultCat, Asym, false);
+    expect(addressTimingsRoot.totalAddressHits.get(0x20)).toBe(1);
+    expect(addressTimingsRoot.totalAddressHits.size).toBe(1); // no other hits
+    expect(addressTimingsRoot.selfAddressHits.size).toBe(0); // no self hits
+
+    // Compute the address timings for the child call node.
+    // One self address hit at address 0x30, which is also the only total address hit.
+    const addressTimingsChild = getTimings(
+      thread,
+      [A, B],
+      defaultCat,
+      Bsym,
+      false
+    );
+    expect(addressTimingsChild.totalAddressHits.get(0x30)).toBe(1);
+    expect(addressTimingsChild.totalAddressHits.size).toBe(1); // no other hits
+    expect(addressTimingsChild.selfAddressHits.get(0x30)).toBe(1);
+    expect(addressTimingsChild.selfAddressHits.size).toBe(1); // no other hits
+  });
+
+  it('passes a basic test with recursion', function () {
+    const { profile, funcNamesDictPerThread, nativeSymbolsDictPerThread } =
+      getProfileFromTextSamples(`
+      A[lib:file][address:0x20][sym:Asym]
+      B[lib:file][address:0x30][sym:Bsym]
+      A[lib:file][address:0x21][sym:Asym]
+    `);
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
+    const defaultCat = categories.findIndex((c) => c.color === 'grey');
+
+    const [{ A, B }] = funcNamesDictPerThread;
+    const [{ Asym }] = nativeSymbolsDictPerThread;
+    const [thread] = profile.threads;
+
+    // Compute the address timings for the root call node.
+    // No self address hit, one total address hit at address 0x20.
+    const addressTimingsRoot = getTimings(thread, [A], defaultCat, Asym, false);
+    expect(addressTimingsRoot.totalAddressHits.get(0x20)).toBe(1);
+    expect(addressTimingsRoot.totalAddressHits.size).toBe(1); // no other hits
+    expect(addressTimingsRoot.selfAddressHits.size).toBe(0); // no self hits
+
+    // Compute the address timings for the leaf call node.
+    // One self address hit at address 0x21, which is also the only total address hit.
+    // In particular, we shouldn't record a hit for line 20, even though
+    // the hit at line 20 is also in A. But it's in the wrong call node.
+    const addressTimingsChild = getTimings(
+      thread,
+      [A, B, A],
+      defaultCat,
+      Asym,
+      false
+    );
+    expect(addressTimingsChild.totalAddressHits.get(0x21)).toBe(1);
+    expect(addressTimingsChild.totalAddressHits.size).toBe(1); // no other hits
+    expect(addressTimingsChild.selfAddressHits.get(0x21)).toBe(1);
+    expect(addressTimingsChild.selfAddressHits.size).toBe(1); // no other hits
+  });
+
+  it('passes a test where the same function is called via different call paths', function () {
+    const { profile, funcNamesDictPerThread, nativeSymbolsDictPerThread } =
+      getProfileFromTextSamples(`
+      A[lib:one][address:0x20][sym:Asym]  A[lib:one][address:0x21][sym:Asym]  A[lib:one][address:0x20][sym:Asym]
+      B[lib:one][address:0x30][sym:Bsym]  D[lib:one][address:0x50][sym:Dsym]  B[lib:one][address:0x31][sym:Bsym]
+      C[lib:two][address:0x10][sym:Csym]  C[lib:two][address:0x11][sym:Csym]  C[lib:two][address:0x12][sym:Csym]
+                                                                              D[lib:one][address:0x51][sym:Dsym]
+    `);
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
+    const defaultCat = categories.findIndex((c) => c.color === 'grey');
+
+    const [{ A, B, C }] = funcNamesDictPerThread;
+    const [{ Csym }] = nativeSymbolsDictPerThread;
+    const [thread] = profile.threads;
+
+    const addressTimingsABC = getTimings(
+      thread,
+      [A, B, C],
+      defaultCat,
+      Csym,
+      false
+    );
+    expect(addressTimingsABC.totalAddressHits.get(0x10)).toBe(1);
+    expect(addressTimingsABC.totalAddressHits.get(0x12)).toBe(1);
+    expect(addressTimingsABC.totalAddressHits.size).toBe(2); // no other hits
+    expect(addressTimingsABC.selfAddressHits.get(0x10)).toBe(1);
+    expect(addressTimingsABC.selfAddressHits.size).toBe(1); // no other hits
+  });
+
+  it('passes a test with an inverted thread', function () {
+    const { profile, funcNamesDictPerThread, nativeSymbolsDictPerThread } =
+      getProfileFromTextSamples(`
+      A[lib:one][address:0x20][sym:Asym]  A[lib:one][address:0x21][sym:Asym]  A[lib:one][address:0x20][sym:Asym]
+      B[lib:one][address:0x30][sym:Bsym]  D[lib:one][address:0x50][sym:Dsym]  B[lib:one][address:0x31][sym:Bsym]
+      D[lib:one][address:0x51][sym:Dsym]  D[lib:one][address:0x52][sym:Dsym]  C[lib:two][address:0x12][sym:Csym]
+                                                                              D[lib:one][address:0x51][sym:Dsym]
+    `);
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
+    const defaultCat = categories.findIndex((c) => c.color === 'grey');
+
+    const [{ C, D }] = funcNamesDictPerThread;
+    const [{ Csym, Dsym }] = nativeSymbolsDictPerThread;
+    const [thread] = profile.threads;
+    const invertedThread = invertCallstack(thread, defaultCat);
+
+    // For the root D of the inverted tree, we have 3 self address hits.
+    const addressTimingsD = getTimings(
+      invertedThread,
+      [D],
+      defaultCat,
+      Dsym,
+      true
+    );
+    expect(addressTimingsD.totalAddressHits.get(0x51)).toBe(2);
+    expect(addressTimingsD.totalAddressHits.get(0x52)).toBe(1);
+    expect(addressTimingsD.totalAddressHits.size).toBe(2); // no other hits
+    expect(addressTimingsD.selfAddressHits.get(0x51)).toBe(2);
+    expect(addressTimingsD.selfAddressHits.get(0x52)).toBe(1);
+    expect(addressTimingsD.selfAddressHits.size).toBe(2); // no other hits
+
+    // For the C call node which is a child (direct caller) of D, we have
+    // no self address hit and one hit at address 0x12.
+    const addressTimingsDC = getTimings(
+      invertedThread,
+      [D, C],
+      defaultCat,
+      Csym,
+      true
+    );
+    expect(addressTimingsDC.totalAddressHits.get(0x12)).toBe(1);
+    expect(addressTimingsDC.totalAddressHits.size).toBe(1); // no other hits
+    expect(addressTimingsDC.selfAddressHits.size).toBe(0); // no self address hits
+  });
+
+  it('passes a test where a function is present in two different native symbols', function () {
+    // The funky part here is that the targeted call node has frames from two different native
+    // symbols: Two from native symbol Bsym, and one from native symbol Asym. That's
+    // because B is present both as its own native symbol (separate outer function)
+    // and as an inlined call from A. In other words, C has been inlined both into
+    // a standalone B and also into another copy of B which was inlined into A.
+    //
+    // This means that, if the user double clicks call node [A, B, C], there are two
+    // different symbols for which we may want to display the assembly code. And
+    // depending on whether the assembly for Asym or for Bsym is displayed, we want to
+    // call this function for a different native symbol.
+    //
+    // In this test, we compute the timings for native symbol Bsym.
+    const { profile, funcNamesDictPerThread, nativeSymbolsDictPerThread } =
+      getProfileFromTextSamples(`
+      A[lib:one][address:0x20][sym:Asym]         A[lib:one][address:0x30][sym:Asym]         A[lib:one][address:0x20][sym:Asym]  A[lib:one][address:0x20][sym:Asym]
+      B[lib:one][address:0x40][sym:Bsym]         B[lib:one][address:0x30][sym:Asym][inl:1]  B[lib:one][address:0x45][sym:Bsym]  E[lib:one][address:0x31][sym:Esym]
+      C[lib:one][address:0x40][sym:Bsym][inl:1]  C[lib:one][address:0x30][sym:Asym][inl:2]  C[lib:one][address:0x45][sym:Bsym]
+                                                                                            D[lib:one][address:0x51][sym:Dsym]
+    `);
+    const categories = ensureExists(
+      profile.meta.categories,
+      'Expected to find categories'
+    );
+    const defaultCat = categories.findIndex((c) => c.color === 'grey');
+
+    const [{ A, B, C }] = funcNamesDictPerThread;
+    const [{ Bsym }] = nativeSymbolsDictPerThread;
+    const [thread] = profile.threads;
+
+    const addressTimingsABCForBsym = getTimings(
+      thread,
+      [A, B, C],
+      defaultCat,
+      Bsym,
+      false
+    );
+    expect(addressTimingsABCForBsym.totalAddressHits.get(0x40)).toBe(1);
+    expect(addressTimingsABCForBsym.totalAddressHits.get(0x45)).toBe(1);
+    expect(addressTimingsABCForBsym.totalAddressHits.size).toBe(2); // no other hits
+    expect(addressTimingsABCForBsym.selfAddressHits.get(0x40)).toBe(1);
+    expect(addressTimingsABCForBsym.selfAddressHits.size).toBe(1); // no other hits
+  });
+});

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -99,6 +99,31 @@ export type LineTimings = {|
   selfLineHits: Map<LineNumber, number>,
 |};
 
+// Stores, for all stacks of a thread and for one specific file, the addresses
+// in that file that are hit by each stack.
+// This can be computed once for a filtered thread, and then queried cheaply
+// as the preview selection changes.
+// The order of these arrays is the same as the order of thread.stackTable;
+// the array index is a stackIndex.
+export type StackAddressInfo = {|
+  // An array that contains, for each stack, the address that this stack
+  // spends its self time in, in this library, or null if the self time of the
+  // stack is in a different library or if the address is not known.
+  selfAddress: Array<Address | null>,
+  // An array that contains, for each stack, all the addresses that the frames
+  // in this stack hit in this library, or null if this stack does not hit any
+  // address in the given library.
+  stackAddresses: Array<Set<Address> | null>,
+|};
+
+// Stores, for all addresses of one specific library, how many times each
+// address is hit by samples in a thread. The maps only contain non-zero values.
+// So map.get(address) === undefined should be treated as zero.
+export type AddressTimings = {|
+  totalAddressHits: Map<Address, number>,
+  selfAddressHits: Map<Address, number>,
+|};
+
 // Stores the information that's needed to prove to the symbolication API that
 // we are authorized to request the source code for a specific file.
 // This "address proof" makes it easy for the browser (or local symbol server)


### PR DESCRIPTION
This is a first step on the path to an assembly view.
It adds the ability to compute, per native symbol, the instructions
addresses that we encountered during profiling, along with their total
and self times.
These sample counts will be shown in the assembly view gutter, similarly
to the source view gutter.