### PR TITLE
Show categories breakdown in flamegraph tooltip if implementation breakdown not present

### DIFF
--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -2,6 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+:root {
+  --category-color-transparent: #fff;
+  --category-color-purple: var(--purple-70);
+  --category-color-green: var(--green-60);
+  --category-color-orange: var(--orange-60);
+  --category-color-lightblue: var(--blue-40);
+  --category-color-blue: var(--blue-60);
+  --category-color-brown: var(--yellow-70);
+
+  /* it is hard to create a lighter version of the following colors  */
+  --category-color-grey: var(--grey-30);
+  --category-color-yellow: var(--yellow-50);
+  --category-color-red: var(--red-60);
+  --category-color-lightred: var(--red-70);
+  --category-color-darkgray: var(--grey-40);
+}
+
 /**
  * These classes should be used to create a small color swatch to describe a
  * category. They should be used with the class `colored-square` that's defined
@@ -10,49 +27,49 @@
  */
 .category-color-transparent {
   border-color: rgb(0 0 0 / 0.4);
-  background-color: #fff;
+  background-color: var(--category-color-transparent);
 }
 
 .category-color-purple {
-  background-color: var(--purple-70);
+  background-color: var(--category-color-purple);
 }
 
 .category-color-green {
-  background-color: var(--green-60);
+  background-color: var(--category-color-green);
 }
 
 .category-color-orange {
-  background-color: var(--orange-50);
+  background-color: var(--category-color-orange);
 }
 
 .category-color-yellow {
-  background-color: var(--yellow-50);
+  background-color: var(--category-color-yellow);
 }
 
 .category-color-lightblue {
-  background-color: var(--blue-40);
+  background-color: var(--category-color-lightblue);
 }
 
 .category-color-grey {
-  background-color: var(--grey-30);
+  background-color: var(--category-color-grey);
 }
 
 .category-color-blue {
-  background-color: var(--blue-60);
+  background-color: var(--category-color-blue);
 }
 
 .category-color-red {
-  background-color: var(--red-60);
+  background-color: var(--category-color-red);
 }
 
 .category-color-lightred {
-  background-color: var(--red-70);
+  background-color: var(--category-color-lightred);
 }
 
 .category-color-darkgray {
-  background-color: var(--grey-40);
+  background-color: var(--category-color-darkgray);
 }
 
 .category-color-brown {
-  background-color: var(--magenta-60);
+  background-color: var(--category-color-brown);
 }

--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.tooltipCallNodeImplementation {
+.tooltipCallNodeImplementation,
+.tooltipCallNodeCategory {
   display: grid;
   padding-bottom: 10px;
   border-bottom: 1px solid var(--grey-30);
@@ -10,7 +11,7 @@
   grid-template-columns: repeat(4, min-content);
 }
 
-.tooltipCallNodeImplementationHeader {
+.tooltipCallNodeHeader {
   padding: 0 5px;
   border-right: 1px solid var(--grey-30);
   margin-top: 5px;
@@ -18,42 +19,48 @@
   white-space: nowrap;
 }
 
-.tooltipCallNodeImplementationName {
+.tooltipCallNodeName {
   white-space: nowrap;
 }
 
-.tooltipCallNodeImplementationGraph {
+.tooltipCallNodeGraph {
   position: relative;
   width: var(--graph-width);
   height: var(--graph-height);
   border-radius: 2px;
-  margin-top: 2px;
+  margin-top: 3px;
   background-color: var(--grey-30);
 }
 
-.tooltipCallNodeImplementationGraphRunning {
-  height: var(--graph-height);
+.tooltipCallNodeGraphRunning {
+  height: calc(var(--graph-height) / 2 - 1px);
   border-radius: 2px;
   background-color: var(--blue-40);
 }
 
-.tooltipCallNodeImplementationGraphSelf {
+.tooltipCallNodeGraphSelf {
   position: absolute;
   top: 0;
   left: 0;
-  height: var(--graph-height);
+  height: calc(var(--graph-height) / 2 - 1px);
   border-radius: 2px;
+  margin-top: calc(var(--graph-height) / 2);
   background-color: var(--blue-60);
 }
 
-.tooltipCallNodeImplementationTiming {
+.tooltipCallNodeCategory .tooltipCategoryRowHeader {
+  margin-top: 8px;
+  font-weight: bold;
+}
+
+.tooltipCallNodeTiming {
   padding: 0 5px;
   text-align: right;
   white-space: nowrap;
 }
 
-.tooltipCallNodeImplementationHeaderSwatchRunning,
-.tooltipCallNodeImplementationHeaderSwatchSelf {
+.tooltipCallNodeHeaderSwatchRunning,
+.tooltipCallNodeHeaderSwatchSelf {
   display: inline-block;
   width: 9px;
   height: 9px;
@@ -62,16 +69,30 @@
   margin-right: 3px;
 }
 
-.tooltipCallNodeImplementationHeaderSwatchRunning {
+.tooltipCallNodeHeaderSwatchRunning {
   background-color: var(--blue-40);
 }
 
-.tooltipCallNodeImplementationHeaderSwatchSelf {
+.tooltipCallNodeHeaderSwatchSelf {
   background-color: var(--blue-60);
+}
+
+.tooltipCallNodeCategory .tooltipCallNodeHeaderSwatchSelf,
+.tooltipCallNodeCategory .tooltipCallNodeHeaderSwatchRunning {
+  display: none;
 }
 
 .tooltipCallNodeDetailsLeft {
   min-width: 150px;
   padding: 10px;
   padding-bottom: 5px;
+}
+
+.tooltipCategoryRowHeader.tooltipCallNodeGraph {
+  /* we have to add 3px to the 8px of category row to realign the callnode graph propertly */
+  margin-top: 11px;
+}
+
+.tooltipCategoryRowHeader.tooltipCategoryName {
+  padding-right: 4px;
 }

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -97,14 +97,14 @@ export class TooltipCallNode extends React.PureComponent<Props> {
             className="tooltipCallNodeGraphRunning"
             style={{
               width: (GRAPH_WIDTH * totalTime) / overallTotalTime,
-              'background-color': `var(--category-color-${color})`,
+              backgroundColor: `var(--category-color-${color})`,
             }}
           />
           <div
             className="tooltipCallNodeGraphSelf"
             style={{
               width: (GRAPH_WIDTH * selfTime) / overallTotalTime,
-              'background-color': `var(--category-color-${color})`,
+              backgroundColor: `var(--category-color-${color})`,
             }}
           />
         </div>
@@ -134,18 +134,18 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     );
   }
 
-  _renderOneCategoryLine(
+  _maybeRenderOneCategoryGroup(
     { selfTime, totalTime }: ItemTimings,
     category: IndexIntoCategoryList,
     isHighPrecision: boolean
-  ): Array<React.Node> {
+  ): React.Node {
     if (totalTime.breakdownByCategory === null) {
-      return [];
+      return null;
     }
     const { entireCategoryValue, subcategoryBreakdown }: OneCategoryBreakdown =
       totalTime.breakdownByCategory[category];
     if (entireCategoryValue === 0) {
-      return [];
+      return null;
     }
     const { categories } = this.props;
     const selfTimeValue = selfTime.breakdownByCategory
@@ -179,12 +179,12 @@ export class TooltipCallNode extends React.PureComponent<Props> {
       this._renderOneSubCategoryLine(
         categoryName,
         category,
-        -1,
+        -1 /* Any number different from a subcategory index */,
         selfTimeValue,
         entireCategoryValue,
         entireCategoryValue,
         isHighPrecision,
-        true
+        true /* isCategoryHeader */
       )
     );
 
@@ -209,7 +209,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           subCategoryValue,
           entireCategoryValue,
           isHighPrecision,
-          false
+          false /* isCategoryHeader */
         )
       );
     };
@@ -244,17 +244,6 @@ export class TooltipCallNode extends React.PureComponent<Props> {
 
     // JS Tracer threads have data relevant to the microsecond level.
     const isHighPrecision: boolean = Boolean(thread.isJsTracer);
-
-    const rows: Array<React.Node> = [];
-    totalBreakdownByCategory.forEach((_, category) => {
-      rows.push(
-        ...this._renderOneCategoryLine(
-          { totalTime, selfTime },
-          category,
-          isHighPrecision
-        )
-      );
-    });
 
     return (
       <div className="tooltipCallNodeCategory">
@@ -303,7 +292,13 @@ export class TooltipCallNode extends React.PureComponent<Props> {
                 selfTime.value
               )}
         </div>
-        {rows}
+        {totalBreakdownByCategory.map((_, categoryIndex) =>
+          this._maybeRenderOneCategoryGroup(
+            { totalTime, selfTime },
+            categoryIndex,
+            isHighPrecision
+          )
+        )}
       </div>
     );
   }

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -350,13 +350,13 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         <div className="tooltipLabel">Overall</div>
         <div className="tooltipCallNodeGraph">
           <div
-            className="tooltipCallNodeImplementationGraphRunning"
+            className="tooltipCallNodeGraphRunning"
             style={{
               width: GRAPH_WIDTH,
             }}
           />
           <div
-            className="tooltipCallNodeImplementationGraphSelf"
+            className="tooltipCallNodeGraphSelf"
             style={{
               width: (GRAPH_WIDTH * selfTime.value) / totalTime.value,
             }}

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -386,7 +386,7 @@ export type OneCategoryBreakdown = {|
   subcategoryBreakdown: Milliseconds[], // { [IndexIntoSubcategoryList]: Milliseconds }
 |};
 export type BreakdownByCategory = OneCategoryBreakdown[]; // { [IndexIntoCategoryList]: OneCategoryBreakdown }
-type ItemTimings = {|
+export type ItemTimings = {|
   selfTime: {|
     // time spent excluding children
     value: Milliseconds,
@@ -2593,6 +2593,7 @@ export function shouldDisplaySubcategoryInfoForCategory(
   return category.subcategories.length > 1;
 }
 
+/** Interprets sub category 0 as the category itself */
 export function getCategoryPairLabel(
   categories: CategoryList,
   categoryIndex: number,

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -79,11 +79,11 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph"
         >
           <div
-            class="tooltipCallNodeImplementationGraphRunning"
+            class="tooltipCallNodeGraphRunning"
             style="width: 150px;"
           />
           <div
-            class="tooltipCallNodeImplementationGraphSelf"
+            class="tooltipCallNodeGraphSelf"
             style="width: 0px;"
           />
         </div>
@@ -225,11 +225,11 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph"
         >
           <div
-            class="tooltipCallNodeImplementationGraphRunning"
+            class="tooltipCallNodeGraphRunning"
             style="width: 150px;"
           />
           <div
-            class="tooltipCallNodeImplementationGraphSelf"
+            class="tooltipCallNodeGraphSelf"
             style="width: 0px;"
           />
         </div>
@@ -901,11 +901,11 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           class="tooltipCallNodeGraph"
         >
           <div
-            class="tooltipCallNodeImplementationGraphRunning"
+            class="tooltipCallNodeGraphRunning"
             style="width: 150px;"
           />
           <div
-            class="tooltipCallNodeImplementationGraphSelf"
+            class="tooltipCallNodeGraphSelf"
             style="width: 150px;"
           />
         </div>
@@ -1053,11 +1053,11 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           class="tooltipCallNodeGraph"
         >
           <div
-            class="tooltipCallNodeImplementationGraphRunning"
+            class="tooltipCallNodeGraphRunning"
             style="width: 150px;"
           />
           <div
-            class="tooltipCallNodeImplementationGraphSelf"
+            class="tooltipCallNodeGraphSelf"
             style="width: 150px;"
           />
         </div>

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -17,7 +17,7 @@ exports[`FlameGraph EmptyReasons matches the snapshot when a profile has no samp
 </div>
 `;
 
-exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
+exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
@@ -52,21 +52,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
       >
         <div />
         <div
-          class="tooltipCallNodeImplementationHeader"
+          class="tooltipCallNodeHeader"
         />
         <div
-          class="tooltipCallNodeImplementationHeader"
+          class="tooltipCallNodeHeader"
         >
           <span
-            class="tooltipCallNodeImplementationHeaderSwatchRunning"
+            class="tooltipCallNodeHeaderSwatchRunning"
           />
           Running
         </div>
         <div
-          class="tooltipCallNodeImplementationHeader"
+          class="tooltipCallNodeHeader"
         >
           <span
-            class="tooltipCallNodeImplementationHeaderSwatchSelf"
+            class="tooltipCallNodeHeaderSwatchSelf"
           />
           Self
         </div>
@@ -76,7 +76,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
           Overall
         </div>
         <div
-          class="tooltipCallNodeImplementationGraph"
+          class="tooltipCallNodeGraph"
         >
           <div
             class="tooltipCallNodeImplementationGraphRunning"
@@ -88,22 +88,141 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
           />
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
         >
           3 samples
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
         >
           —
         </div>
         <div
-          class="tooltipCallNodeImplementationName tooltipLabel"
+          class="tooltipCallNodeName tooltipLabel"
         >
           Native code
         </div>
         <div
-          class="tooltipCallNodeImplementationGraph"
+          class="tooltipCallNodeGraph"
+        >
+          <div
+            class="tooltipCallNodeGraphRunning"
+            style="width: 150px;"
+          />
+          <div
+            class="tooltipCallNodeGraphSelf"
+            style="width: 0px;"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
+        >
+          3 samples
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
+        >
+          —
+        </div>
+      </div>
+      <div
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          Native
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-blue"
+          />
+          DOM
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          File:
+        </div>
+        <div
+          class="tooltipDetailsUrl"
+        >
+          path/to/file:10:100
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FlameGraph has a tooltip that matches the snapshot with implementation 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 14px; top: 306px;"
+>
+  <div
+    class="tooltipCallNode"
+    style="--graph-width: 150px; --graph-height: 10px;"
+  >
+    <div
+      class="tooltipOneLine tooltipHeader"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        3.0ms (100%)
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        A
+      </div>
+      <div
+        class="tooltipIcon"
+      />
+    </div>
+    <div
+      class="tooltipCallNodeDetails"
+    >
+      <div
+        class="tooltipCallNodeImplementation"
+      >
+        <div />
+        <div
+          class="tooltipCallNodeHeader"
+        />
+        <div
+          class="tooltipCallNodeHeader"
+        >
+          <span
+            class="tooltipCallNodeHeaderSwatchRunning"
+          />
+          Running
+        </div>
+        <div
+          class="tooltipCallNodeHeader"
+        >
+          <span
+            class="tooltipCallNodeHeaderSwatchSelf"
+          />
+          Self
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Overall
+        </div>
+        <div
+          class="tooltipCallNodeGraph"
         >
           <div
             class="tooltipCallNodeImplementationGraphRunning"
@@ -115,12 +234,39 @@ exports[`FlameGraph has a tooltip that matches the snapshot 1`] = `
           />
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
         >
           3 samples
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
+        >
+          —
+        </div>
+        <div
+          class="tooltipCallNodeName tooltipLabel"
+        >
+          Native code
+        </div>
+        <div
+          class="tooltipCallNodeGraph"
+        >
+          <div
+            class="tooltipCallNodeGraphRunning"
+            style="width: 150px;"
+          />
+          <div
+            class="tooltipCallNodeGraphSelf"
+            style="width: 0px;"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
+        >
+          3 samples
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
         >
           —
         </div>
@@ -693,7 +839,7 @@ Array [
 ]
 `;
 
-exports[`FlameGraph shows a tooltip with the resource information 1`] = `
+exports[`FlameGraph shows a tooltip with the resource information with categories 1`] = `
 <div
   class="tooltip"
   data-testid="tooltip"
@@ -728,21 +874,21 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
       >
         <div />
         <div
-          class="tooltipCallNodeImplementationHeader"
+          class="tooltipCallNodeHeader"
         />
         <div
-          class="tooltipCallNodeImplementationHeader"
+          class="tooltipCallNodeHeader"
         >
           <span
-            class="tooltipCallNodeImplementationHeaderSwatchRunning"
+            class="tooltipCallNodeHeaderSwatchRunning"
           />
           Running
         </div>
         <div
-          class="tooltipCallNodeImplementationHeader"
+          class="tooltipCallNodeHeader"
         >
           <span
-            class="tooltipCallNodeImplementationHeaderSwatchSelf"
+            class="tooltipCallNodeHeaderSwatchSelf"
           />
           Self
         </div>
@@ -752,7 +898,7 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
           Overall
         </div>
         <div
-          class="tooltipCallNodeImplementationGraph"
+          class="tooltipCallNodeGraph"
         >
           <div
             class="tooltipCallNodeImplementationGraphRunning"
@@ -764,22 +910,147 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
           />
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeImplementationName tooltipLabel"
+          class="tooltipCallNodeName tooltipLabel"
         >
           Native code
         </div>
         <div
-          class="tooltipCallNodeImplementationGraph"
+          class="tooltipCallNodeGraph"
+        >
+          <div
+            class="tooltipCallNodeGraphRunning"
+            style="width: 150px;"
+          />
+          <div
+            class="tooltipCallNodeGraphSelf"
+            style="width: 150px;"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
+        >
+          1 sample
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
+        >
+          1 sample
+        </div>
+      </div>
+      <div
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          Native
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-green"
+          />
+          Graphics
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          File:
+        </div>
+        <div
+          class="tooltipDetailsUrl"
+        >
+          widget/cocoa/nsAppShell.mm:17:107
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Resource:
+        </div>
+        libxul.so
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FlameGraph shows a tooltip with the resource information with implementation 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 80.66666666666666px; top: 226px;"
+>
+  <div
+    class="tooltipCallNode"
+    style="--graph-width: 150px; --graph-height: 10px;"
+  >
+    <div
+      class="tooltipOneLine tooltipHeader"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1.0ms (33%)
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        J
+      </div>
+      <div
+        class="tooltipIcon"
+      />
+    </div>
+    <div
+      class="tooltipCallNodeDetails"
+    >
+      <div
+        class="tooltipCallNodeImplementation"
+      >
+        <div />
+        <div
+          class="tooltipCallNodeHeader"
+        />
+        <div
+          class="tooltipCallNodeHeader"
+        >
+          <span
+            class="tooltipCallNodeHeaderSwatchRunning"
+          />
+          Running
+        </div>
+        <div
+          class="tooltipCallNodeHeader"
+        >
+          <span
+            class="tooltipCallNodeHeaderSwatchSelf"
+          />
+          Self
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Overall
+        </div>
+        <div
+          class="tooltipCallNodeGraph"
         >
           <div
             class="tooltipCallNodeImplementationGraphRunning"
@@ -791,12 +1062,39 @@ exports[`FlameGraph shows a tooltip with the resource information 1`] = `
           />
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeImplementationTiming"
+          class="tooltipCallNodeTiming"
+        >
+          1 sample
+        </div>
+        <div
+          class="tooltipCallNodeName tooltipLabel"
+        >
+          Native code
+        </div>
+        <div
+          class="tooltipCallNodeGraph"
+        >
+          <div
+            class="tooltipCallNodeGraphRunning"
+            style="width: 150px;"
+          />
+          <div
+            class="tooltipCallNodeGraphSelf"
+            style="width: 150px;"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
+        >
+          1 sample
+        </div>
+        <div
+          class="tooltipCallNodeTiming"
         >
           1 sample
         </div>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -110,3 +110,13 @@ export function getTrackSelectionModifiers(
     shift: event.shiftKey && !event.altKey,
   };
 }
+
+export function countPositiveValues(arr: Array<number>): number {
+  let count = 0;
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i] > 0) {
+      count++;
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
Adds a breakdown based on categories to the tooltips if the implementation breakdown cannot be shown (no implementation data present). Showing both at the same time would clutter the UI too much. Useful especially for imported profiles where the implementation data is missing.

Related to #4189 which added an option to omit the implementation data.

[Sample profile](https://github.com/firefox-devtools/profiler/files/9381008/JVM.Application.on.OpenJDK.64-Bit.Server.VM.OpenJDK.64-Bit.Server.VM.2075-03-22.11.25.profile.json.gz)

[Current production](https://share.firefox.dev/3pAjiOw)
[Deploy preview](https://deploy-preview-4193--perf-html.netlify.app/public/dxqevjfbjq2exh02vj8rfq3a453aa9026f9ghtg/flame-graph/?globalTrackOrder=0&hiddenLocalTracksByPid=29468-1&thread=0&v=7)
[Deploy preview 2](https://deploy-preview-4193--perf-html.netlify.app/public/9hrc8kecbef6rdaad6nj82gqbxq13g69wvq48g0/flame-graph/?globalTrackOrder=0&thread=2&v=7)