### PR TITLE
Support to show local tracks using marker data

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -335,6 +335,7 @@ function getInformationFromTrackReference(
             relatedThreadIndex: localTrack.threadIndex,
             relatedTab: 'network-chart',
           };
+        case 'marker':
         case 'ipc':
           return {
             ...commonLocalProperties,

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -46,8 +46,9 @@ export const TRACK_IPC_MARKERS_HEIGHT = 25;
 export const TRACK_IPC_HEIGHT = TRACK_IPC_MARKERS_HEIGHT;
 
 // The following values are the defaults for marker tracks
-export const TRACK_MARKER_MARKERS_DEFAULT_HEIGHT = 25;
-export const TRACK_MARKER_DEFAULT_HEIGHT = TRACK_MARKER_MARKERS_DEFAULT_HEIGHT;
+export const TRACK_MARKER_MARKERS_DEFAULT_HEIGHT = 0;
+export const TRACK_MARKER_DEFAULT_HEIGHT = 'medium';
+export const TRACK_MARKER_HEIGHTS = { small: 12, medium: 25, large: 40 };
 export const TRACK_MARKER_DEFAULT_LINE_WIDTH = 2;
 export const TRACK_MARKER_DEFAULT_LINE_FILL_COLOR = 'transparent';
 export const TRACK_MARKER_DEFAULT_LINE_STROKE_COLOR = ORANGE_50;

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -5,6 +5,7 @@
 // @flow
 
 import type { MarkerPhase } from 'firefox-profiler/types';
+import { ORANGE_50 } from 'photon-colors';
 
 // The current version of the Gecko profile format.
 export const GECKO_PROFILE_VERSION = 26;
@@ -43,6 +44,13 @@ export const TRACK_EVENT_DELAY_LINE_WIDTH = 2;
 // The following values are for IPC track.
 export const TRACK_IPC_MARKERS_HEIGHT = 25;
 export const TRACK_IPC_HEIGHT = TRACK_IPC_MARKERS_HEIGHT;
+
+// The following values are the defaults for marker tracks
+export const TRACK_MARKER_MARKERS_DEFAULT_HEIGHT = 25;
+export const TRACK_MARKER_DEFAULT_HEIGHT = TRACK_MARKER_MARKERS_DEFAULT_HEIGHT;
+export const TRACK_MARKER_DEFAULT_LINE_WIDTH = 2;
+export const TRACK_MARKER_DEFAULT_LINE_FILL_COLOR = 'transparent';
+export const TRACK_MARKER_DEFAULT_LINE_STROKE_COLOR = ORANGE_50;
 
 // Height of the blank area in process track.
 export const TRACK_PROCESS_BLANK_HEIGHT = 30;

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -123,6 +123,7 @@ class LocalTrackComponent extends PureComponent<Props> {
           <TrackCustomMarker
             threadIndex={localTrack.threadIndex}
             markerSchema={localTrack.markerSchema}
+            markerIndex={localTrack.markerIndex}
           />
         );
       default:

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -42,6 +42,7 @@ import type {
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+import { TrackCustomMarker } from './TrackCustomMarker';
 
 type OwnProps = {|
   +pid: Pid,
@@ -117,6 +118,13 @@ class LocalTrackComponent extends PureComponent<Props> {
         return <TrackProcessCPU counterIndex={localTrack.counterIndex} />;
       case 'power':
         return <TrackPower counterIndex={localTrack.counterIndex} />;
+      case 'marker':
+        return (
+          <TrackCustomMarker
+            threadIndex={localTrack.threadIndex}
+            markerSchema={localTrack.markerSchema}
+          />
+        );
       default:
         console.error('Unhandled localTrack type', (localTrack: empty));
         return null;
@@ -216,6 +224,7 @@ export const TimelineLocalTrack = explicitConnect<
         );
         break;
       }
+      case 'marker':
       case 'ipc': {
         const threadIndex = localTrack.threadIndex;
         const selectedTab = getSelectedTab(state);

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -22,6 +22,7 @@ import {
 import explicitConnect from 'firefox-profiler/utils/connect';
 import {
   getLocalTrackName,
+  getLocalTrackTooltip,
   getCounterSelectors,
 } from 'firefox-profiler/selectors/profile';
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
@@ -54,6 +55,7 @@ type OwnProps = {|
 
 type StateProps = {|
   +trackName: string,
+  +trackTooltip: ?string,
   +isSelected: boolean,
   +isHidden: boolean,
   +titleText: string | null,
@@ -123,7 +125,6 @@ class LocalTrackComponent extends PureComponent<Props> {
           <TrackCustomMarker
             threadIndex={localTrack.threadIndex}
             markerSchema={localTrack.markerSchema}
-            markerIndex={localTrack.markerIndex}
           />
         );
       default:
@@ -256,6 +257,7 @@ export const TimelineLocalTrack = explicitConnect<
 
     return {
       trackName: getLocalTrackName(state, pid, trackIndex),
+      trackTooltip: getLocalTrackTooltip(state, pid, trackIndex),
       titleText,
       isSelected,
       isHidden: getHiddenLocalTracks(state, pid).has(trackIndex),

--- a/src/components/timeline/TrackCustomMarker.css
+++ b/src/components/timeline/TrackCustomMarker.css
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.timelineTrackCustomMarkerGraph {
+  position: relative;
+  width: 100%;
+  height: var(--graph-height);
+}
+
+.timelineTrackCustomMarkerCanvas {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.timelineTrackCustomMarkerGraphDot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  margin-left: -3px;
+  background-color: var(--orange-60);
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.timelineTrackCustomMarkerTooltipLine {
+  white-space: nowrap;
+}
+
+.timelineTrackCustomMarkerTooltipNumber {
+  display: inline-block;
+  min-width: 60px;
+  color: var(--grey-60);
+  font-weight: bold;
+}
+
+.timelineMarkersCustomMarker {
+  height: var(--markers-height, 15px);
+  opacity: 1;
+}

--- a/src/components/timeline/TrackCustomMarker.css
+++ b/src/components/timeline/TrackCustomMarker.css
@@ -6,6 +6,7 @@
   position: relative;
   width: 100%;
   height: var(--graph-height);
+  margin-bottom: 2px;
 }
 
 .timelineTrackCustomMarkerCanvas {

--- a/src/components/timeline/TrackCustomMarker.css
+++ b/src/components/timeline/TrackCustomMarker.css
@@ -19,10 +19,10 @@
   position: absolute;
   width: 6px;
   height: 6px;
+  border-radius: 3px;
   margin-top: -3px;
   margin-left: -3px;
   background-color: var(--orange-60);
-  border-radius: 3px;
   pointer-events: none;
 }
 

--- a/src/components/timeline/TrackCustomMarker.js
+++ b/src/components/timeline/TrackCustomMarker.js
@@ -11,7 +11,11 @@ import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
 import { TrackCustomMarkerGraph } from './TrackCustomMarkerGraph';
 import { getMarkerTrackHeight } from 'firefox-profiler/profile-logic/tracks';
 
-import type { ThreadIndex, Milliseconds } from 'firefox-profiler/types';
+import type {
+  ThreadIndex,
+  Milliseconds,
+  MarkerIndex,
+} from 'firefox-profiler/types';
 import type { MarkerSchema } from 'firefox-profiler/types/markers';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -21,6 +25,7 @@ import './TrackMemory.css';
 type OwnProps = {|
   +markerSchema: MarkerSchema,
   +threadIndex: ThreadIndex,
+  +markerIndex: MarkerIndex,
 |};
 
 type StateProps = {|
@@ -39,7 +44,7 @@ type State = {||};
 
 export class TrackCustomMarkerImpl extends React.PureComponent<Props, State> {
   render() {
-    const { markerSchema, threadIndex } = this.props;
+    const { markerSchema, threadIndex, markerIndex } = this.props;
     const trackHeight = getMarkerTrackHeight(markerSchema);
     return (
       <div
@@ -54,6 +59,7 @@ export class TrackCustomMarkerImpl extends React.PureComponent<Props, State> {
           threadIndex={threadIndex}
           markerSchema={markerSchema}
           graphHeight={trackHeight}
+          markerIndex={markerIndex}
         />
       </div>
     );

--- a/src/components/timeline/TrackCustomMarker.js
+++ b/src/components/timeline/TrackCustomMarker.js
@@ -8,12 +8,8 @@ import * as React from 'react';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { getCommittedRange } from 'firefox-profiler/selectors/profile';
 import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
-import {
-  TRACK_MARKER_DEFAULT_HEIGHT,
-  TRACK_MARKER_MARKERS_DEFAULT_HEIGHT,
-} from 'firefox-profiler/app-logic/constants';
 import { TrackCustomMarkerGraph } from './TrackCustomMarkerGraph';
-import { getMarkerTrackConfig } from 'firefox-profiler/profile-logic/tracks';
+import { getMarkerTrackHeight } from 'firefox-profiler/profile-logic/tracks';
 
 import type { ThreadIndex, Milliseconds } from 'firefox-profiler/types';
 import type { MarkerSchema } from 'firefox-profiler/types/markers';
@@ -42,27 +38,16 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 type State = {||};
 
 export class TrackCustomMarkerImpl extends React.PureComponent<Props, State> {
-  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
-    const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
-    updatePreviewSelection({
-      hasSelection: true,
-      isModifying: false,
-      selectionStart: Math.max(rangeStart, start),
-      selectionEnd: Math.min(rangeEnd, end),
-    });
-  };
-
   render() {
-    const { markerSchema, rangeStart, rangeEnd, threadIndex } = this.props;
-    const trackHeight =
-      getMarkerTrackConfig(markerSchema).height || TRACK_MARKER_DEFAULT_HEIGHT;
+    const { markerSchema, threadIndex } = this.props;
+    const trackHeight = getMarkerTrackHeight(markerSchema);
     return (
       <div
         className="timelineTrackMemory"
         style={{
-          height: TRACK_MARKER_MARKERS_DEFAULT_HEIGHT + trackHeight,
+          height: trackHeight,
           '--graph-height': `${trackHeight}px`,
-          '--markers-height': `${TRACK_MARKER_MARKERS_DEFAULT_HEIGHT}px`,
+          '--markers-height': `${0}px`,
         }}
       >
         <TrackCustomMarkerGraph

--- a/src/components/timeline/TrackCustomMarker.js
+++ b/src/components/timeline/TrackCustomMarker.js
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { getCommittedRange } from 'firefox-profiler/selectors/profile';
+import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
+import {
+  TRACK_MARKER_DEFAULT_HEIGHT,
+  TRACK_MARKER_MARKERS_DEFAULT_HEIGHT,
+} from 'firefox-profiler/app-logic/constants';
+import { TrackCustomMarkerGraph } from './TrackCustomMarkerGraph';
+import { getMarkerTrackConfig } from 'firefox-profiler/profile-logic/tracks';
+
+import type { ThreadIndex, Milliseconds } from 'firefox-profiler/types';
+import type { MarkerSchema } from 'firefox-profiler/types/markers';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+import './TrackMemory.css';
+
+type OwnProps = {|
+  +markerSchema: MarkerSchema,
+  +threadIndex: ThreadIndex,
+|};
+
+type StateProps = {|
+  +threadIndex: ThreadIndex,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+|};
+
+type DispatchProps = {|
+  updatePreviewSelection: typeof updatePreviewSelection,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+type State = {||};
+
+export class TrackCustomMarkerImpl extends React.PureComponent<Props, State> {
+  _onMarkerSelect = (start: Milliseconds, end: Milliseconds) => {
+    const { rangeStart, rangeEnd, updatePreviewSelection } = this.props;
+    updatePreviewSelection({
+      hasSelection: true,
+      isModifying: false,
+      selectionStart: Math.max(rangeStart, start),
+      selectionEnd: Math.min(rangeEnd, end),
+    });
+  };
+
+  render() {
+    const { markerSchema, rangeStart, rangeEnd, threadIndex } = this.props;
+    const trackHeight =
+      getMarkerTrackConfig(markerSchema).height || TRACK_MARKER_DEFAULT_HEIGHT;
+    return (
+      <div
+        className="timelineTrackMemory"
+        style={{
+          height: TRACK_MARKER_MARKERS_DEFAULT_HEIGHT + trackHeight,
+          '--graph-height': `${trackHeight}px`,
+          '--markers-height': `${TRACK_MARKER_MARKERS_DEFAULT_HEIGHT}px`,
+        }}
+      >
+        <TrackCustomMarkerGraph
+          threadIndex={threadIndex}
+          markerSchema={markerSchema}
+          graphHeight={trackHeight}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackCustomMarker = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { threadIndex } = ownProps;
+    const { start, end } = getCommittedRange(state);
+    return {
+      threadIndex: threadIndex,
+      rangeStart: start,
+      rangeEnd: end,
+    };
+  },
+  mapDispatchToProps: { updatePreviewSelection },
+  component: TrackCustomMarkerImpl,
+});

--- a/src/components/timeline/TrackCustomMarker.js
+++ b/src/components/timeline/TrackCustomMarker.js
@@ -11,21 +11,16 @@ import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
 import { TrackCustomMarkerGraph } from './TrackCustomMarkerGraph';
 import { getMarkerTrackHeight } from 'firefox-profiler/profile-logic/tracks';
 
-import type {
-  ThreadIndex,
-  Milliseconds,
-  MarkerIndex,
-} from 'firefox-profiler/types';
+import type { ThreadIndex, Milliseconds } from 'firefox-profiler/types';
 import type { MarkerSchema } from 'firefox-profiler/types/markers';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
-import './TrackMemory.css';
+import './TrackCustomMarker.css';
 
 type OwnProps = {|
   +markerSchema: MarkerSchema,
   +threadIndex: ThreadIndex,
-  +markerIndex: MarkerIndex,
 |};
 
 type StateProps = {|
@@ -44,11 +39,11 @@ type State = {||};
 
 export class TrackCustomMarkerImpl extends React.PureComponent<Props, State> {
   render() {
-    const { markerSchema, threadIndex, markerIndex } = this.props;
+    const { markerSchema, threadIndex } = this.props;
     const trackHeight = getMarkerTrackHeight(markerSchema);
     return (
       <div
-        className="timelineTrackMemory"
+        className="timelineTrackCustomMarker"
         style={{
           height: trackHeight,
           '--graph-height': `${trackHeight}px`,
@@ -59,7 +54,6 @@ export class TrackCustomMarkerImpl extends React.PureComponent<Props, State> {
           threadIndex={threadIndex}
           markerSchema={markerSchema}
           graphHeight={trackHeight}
-          markerIndex={markerIndex}
         />
       </div>
     );

--- a/src/components/timeline/TrackCustomMarkerGraph.js
+++ b/src/components/timeline/TrackCustomMarkerGraph.js
@@ -226,6 +226,7 @@ class TrackCustomMarkerCanvas extends React.PureComponent<CanvasProps> {
 
             // The line from 4 to 1 will be implicitly filled in.
             ctx.fill();
+            ctx.closePath();
             break;
           case 'bar':
             for (let i = sampleStart; i < sampleEnd; i++) {

--- a/src/components/timeline/TrackCustomMarkerGraph.js
+++ b/src/components/timeline/TrackCustomMarkerGraph.js
@@ -1,0 +1,506 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import * as React from 'react';
+import { InView } from 'react-intersection-observer';
+import { withSize } from 'firefox-profiler/components/shared/WithSize';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { bisectionRight } from 'firefox-profiler/utils/bisect';
+import {
+  getCommittedRange,
+  getProfileInterval,
+} from 'firefox-profiler/selectors/profile';
+import {
+  getMarkerTrackLineFillColor,
+  getMarkerTrackLineStrokeColor,
+  getMaximumMarkerTrackLineWidth,
+  getMarkerTrackLineWidth,
+} from 'firefox-profiler/profile-logic/tracks';
+import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
+import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
+import { EmptyThreadIndicator } from './EmptyThreadIndicator';
+
+import type {
+  Thread,
+  ThreadIndex,
+  Milliseconds,
+  CssPixels,
+  StartEndRange,
+  IndexIntoSamplesTable,
+  MarkerSchema,
+  CollectedCustomMarkerSamples,
+} from 'firefox-profiler/types';
+
+import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+import './TrackMemory.css';
+
+/**
+ * When adding properties to these props, please consider the comment above the component.
+ */
+type CanvasProps = {|
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +markerSchema: MarkerSchema,
+  +markerSampleRanges: [IndexIntoSamplesTable, IndexIntoSamplesTable],
+  +collectedSamples: CollectedCustomMarkerSamples,
+  +interval: Milliseconds,
+  +width: CssPixels,
+  +height: CssPixels,
+|};
+
+/**
+ * This component controls the rendering of the canvas. Every render call through
+ * React triggers a new canvas render. Because of this, it's important to only pass
+ * in the props that are needed for the canvas draw call.
+ */
+class TrackCustomMarkerCanvas extends React.PureComponent<CanvasProps> {
+  _canvas: null | HTMLCanvasElement = null;
+  _requestedAnimationFrame: boolean = false;
+  _canvasState: {| renderScheduled: boolean, inView: boolean |} = {
+    renderScheduled: false,
+    inView: false,
+  };
+
+  drawCanvas(canvas: HTMLCanvasElement): void {
+    const {
+      rangeStart,
+      rangeEnd,
+      markerSchema,
+      markerSampleRanges,
+      collectedSamples,
+      height,
+      width,
+      interval,
+    } = this.props;
+    if (width === 0) {
+      // This is attempting to draw before the canvas was laid out.
+      return;
+    }
+
+    const { name, trackConfig } = markerSchema;
+
+    const ctx = canvas.getContext('2d');
+    const devicePixelRatio = window.devicePixelRatio;
+    const deviceWidth = width * devicePixelRatio;
+    const deviceHeight = height * devicePixelRatio;
+    const rangeLength = rangeEnd - rangeStart;
+    const millisecondWidth = deviceWidth / rangeLength;
+    const intervalWidth = interval * millisecondWidth;
+
+    // Resize and clear the canvas.
+    canvas.width = Math.round(deviceWidth);
+    canvas.height = Math.round(deviceHeight);
+    ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+
+    if (collectedSamples.numbersPerLine.length === 0) {
+      // This is clearly an error made by the schema creator
+      throw new Error('No lines for marker ' + name);
+    }
+
+    if (trackConfig === undefined) {
+      throw new Error('No track config for marker');
+    }
+
+    const { minNumber, numberRange } = collectedSamples;
+    const [sampleStart, sampleEnd] = markerSampleRanges;
+
+    {
+      for (
+        let lineIndex = 0;
+        lineIndex < trackConfig.lines.length;
+        lineIndex++
+      ) {
+        const samples = collectedSamples[lineIndex];
+        // Draw the chart.
+        //
+        //                 ...--`
+        //  1 ...---```..--      `--. 2
+        //    |_____________________|
+        //  4                        3
+        //
+        // Start by drawing from 1 - 2. This will be the top of all the peaks of the
+        // graph.
+        const deviceLineWidth =
+          getMarkerTrackLineWidth(markerSchema, lineIndex) * devicePixelRatio;
+        const deviceLineHalfWidth = deviceLineWidth * 0.5;
+        const innerDeviceHeight = deviceHeight - deviceLineWidth;
+        ctx.lineWidth = deviceLineWidth;
+        ctx.strokeStyle = getMarkerTrackLineStrokeColor(
+          markerSchema,
+          lineIndex
+        );
+        ctx.fillStyle = getMarkerTrackLineFillColor(markerSchema, lineIndex);
+        ctx.beginPath();
+
+        // The x and y are used after the loop.
+        let x = 0;
+        let y = 0;
+        let firstX = 0;
+        for (let i = sampleStart; i < sampleEnd; i++) {
+          // Create a path for the top of the chart. This is the line that will have
+          // a stroke applied to it.
+          x = (samples.time[i] - rangeStart) * millisecondWidth;
+          // Add on half the stroke's line width so that it won't be cut off the edge
+          // of the graph.
+          const unitGraphCount = (samples[i] - minNumber) / numberRange;
+          y =
+            innerDeviceHeight -
+            innerDeviceHeight * unitGraphCount +
+            deviceLineHalfWidth;
+          if (i === 0) {
+            // This is the first iteration, only move the line, do not draw it. Also
+            // remember this first X, as the bottom of the graph will need to connect
+            // back up to it.
+            firstX = x;
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        // The samples range ends at the time of the last sample, plus the interval.
+        // Draw this last bit.
+        ctx.lineTo(x + intervalWidth, y);
+
+        // Don't do the fill yet, just stroke the top line. This will draw a line from
+        // point 1 to 2 in the diagram above.
+        ctx.stroke();
+
+        // After doing the stroke, continue the path to complete the fill to the bottom
+        // of the canvas. This continues the path to point 3 and then 4.
+
+        // Create a line from 2 to 3.
+        ctx.lineTo(x + intervalWidth, deviceHeight);
+
+        // Create a line from 3 to 4.
+        ctx.lineTo(firstX, deviceHeight);
+
+        // The line from 4 to 1 will be implicitly filled in.
+        ctx.fill();
+      }
+    }
+  }
+
+  _scheduleDraw() {
+    if (!this._canvasState.inView) {
+      // Canvas is not in the view. Schedule the render for a later intersection
+      // observer callback.
+      this._canvasState.renderScheduled = true;
+      return;
+    }
+
+    // Canvas is in the view. Render the canvas and reset the schedule state.
+    this._canvasState.renderScheduled = false;
+
+    if (!this._requestedAnimationFrame) {
+      this._requestedAnimationFrame = true;
+      window.requestAnimationFrame(() => {
+        this._requestedAnimationFrame = false;
+        const canvas = this._canvas;
+        if (canvas) {
+          this.drawCanvas(canvas);
+        }
+      });
+    }
+  }
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  _observerCallback = (inView: boolean, _entry: IntersectionObserverEntry) => {
+    this._canvasState.inView = inView;
+    if (!this._canvasState.renderScheduled) {
+      // Skip if render is not scheduled.
+      return;
+    }
+
+    this._scheduleDraw();
+  };
+
+  componentDidMount() {
+    this._scheduleDraw();
+  }
+
+  componentDidUpdate() {
+    this._scheduleDraw();
+  }
+
+  render() {
+    return (
+      <InView onChange={this._observerCallback}>
+        <canvas
+          className="timelineTrackMemoryCanvas"
+          ref={this._takeCanvasRef}
+        />
+      </InView>
+    );
+  }
+}
+
+type OwnProps = {|
+  +threadIndex: ThreadIndex,
+  +markerSchema: MarkerSchema,
+  +graphHeight: CssPixels,
+|};
+
+type StateProps = {|
+  +threadIndex: ThreadIndex,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +interval: Milliseconds,
+  +filteredThread: Thread,
+  +unfilteredSamplesRange: StartEndRange | null,
+  +markerSchema: MarkerSchema,
+  +markerSampleRanges: [IndexIntoSamplesTable, IndexIntoSamplesTable],
+  +collectedSamples: CollectedCustomMarkerSamples,
+|};
+
+type DispatchProps = {||};
+
+type Props = {|
+  ...SizeProps,
+  ...ConnectedProps<OwnProps, StateProps, DispatchProps>,
+|};
+
+type State = {|
+  hoveredCounter: null | number,
+  mouseX: CssPixels,
+  mouseY: CssPixels,
+|};
+
+/**
+ * The marker track graph takes information from markers, and renders it as a
+ * graph in the timeline.
+ */
+class TrackCustomMarkerGraphImpl extends React.PureComponent<Props, State> {
+  state = {
+    hoveredCounter: null,
+    mouseX: 0,
+    mouseY: 0,
+  };
+
+  _onMouseLeave = () => {
+    // This persistTooltips property is part of the web console API. It helps
+    // in being able to inspect and debug tooltips.
+    if (window.persistTooltips) {
+      return;
+    }
+
+    this.setState({ hoveredCounter: null });
+  };
+
+  _onMouseMove = (event: SyntheticMouseEvent<HTMLDivElement>) => {
+    const { pageX: mouseX, pageY: mouseY } = event;
+    // Get the offset from here, and apply it to the time lookup.
+    const { left } = event.currentTarget.getBoundingClientRect();
+    const {
+      width,
+      rangeStart,
+      rangeEnd,
+      interval,
+      markerSampleRanges,
+      collectedSamples,
+    } = this.props;
+    const rangeLength = rangeEnd - rangeStart;
+    const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
+
+    if (
+      timeAtMouse < collectedSamples.time[0] ||
+      timeAtMouse >
+        collectedSamples.time[collectedSamples.time.length - 1] + interval
+    ) {
+      // We are outside the range of the samples, do not display hover information.
+      this.setState({ hoveredCounter: null });
+    } else {
+      // When the mouse pointer hovers between two points, select the point that's closer.
+      let hoveredCounter;
+      const [sampleStart, sampleEnd] = markerSampleRanges;
+      const bisectionCounter = bisectionRight(
+        collectedSamples.time,
+        timeAtMouse,
+        sampleStart,
+        sampleEnd
+      );
+      if (
+        bisectionCounter > 0 &&
+        bisectionCounter < collectedSamples.time.length
+      ) {
+        const leftDistance =
+          timeAtMouse - collectedSamples.time[bisectionCounter - 1];
+        const rightDistance =
+          collectedSamples.time[bisectionCounter] - timeAtMouse;
+        if (leftDistance < rightDistance) {
+          // Left point is closer
+          hoveredCounter = bisectionCounter - 1;
+        } else {
+          // Right point is closer
+          hoveredCounter = bisectionCounter;
+        }
+      } else {
+        hoveredCounter = bisectionCounter;
+      }
+
+      if (hoveredCounter === collectedSamples.time.length) {
+        // When hovering the last sample, it's possible the mouse is past the time.
+        // In this case, hover over the last sample. This happens because of the
+        // ` + interval` line in the `if` condition above.
+        hoveredCounter = collectedSamples.time.length - 1;
+      }
+
+      this.setState({
+        mouseX,
+        mouseY,
+        hoveredCounter,
+      });
+    }
+  };
+
+  _renderTooltip(counterIndex: number): React.Node {
+    const { collectedSamples, rangeStart, rangeEnd } = this.props;
+    const { mouseX, mouseY } = this.state;
+    if (collectedSamples.length === 0) {
+      throw new Error('No samples for marker ' + marker);
+    }
+
+    const sampleTime = collectedSamples.time[counterIndex];
+    if (sampleTime < rangeStart || sampleTime > rangeEnd) {
+      // Do not draw the tooltip if it will be rendered outside of the timeline.
+      // This could happen when a sample time is outside of the time range.
+      // While range filtering the counters, we add the sample before start and
+      // after end, so charts will not be cut off at the edges.
+      return null;
+    }
+
+    return (
+      <Tooltip mouseX={mouseX} mouseY={mouseY}>
+        <div className="timelineTrackMemoryTooltip">
+          Place description for counter here
+        </div>
+      </Tooltip>
+    );
+  }
+
+  /**
+   * Create a div that is a dot on top of the graph representing the current
+   * height of the graph.
+   */
+  _renderDot(counterIndex: number): React.Node {
+    const {
+      markerSchema,
+      rangeStart,
+      rangeEnd,
+      graphHeight,
+      width,
+      collectedSamples,
+    } = this.props;
+
+    const rangeLength = rangeEnd - rangeStart;
+    const sampleTime = collectedSamples.time[counterIndex];
+
+    if (sampleTime < rangeStart || sampleTime > rangeEnd) {
+      // Do not draw the dot if it will be rendered outside of the timeline.
+      // This could happen when a sample time is outside of the time range.
+      // While range filtering the counters, we add the sample before start and
+      // after end, so charts will not be cut off at the edges.
+      return null;
+    }
+
+    const left = (width * (sampleTime - rangeStart)) / rangeLength;
+
+    const { minNumber, numberRange, numbersPerLine } = collectedSamples;
+    const unitSampleCount =
+      (Math.max(...numbersPerLine.map((l) => l[counterIndex])) - minNumber) /
+      numberRange;
+    const lineWidth = getMaximumMarkerTrackLineWidth(markerSchema);
+    const innerTrackHeight = graphHeight - lineWidth / 2;
+    const top =
+      innerTrackHeight - unitSampleCount * innerTrackHeight + lineWidth / 2;
+
+    return (
+      <div style={{ left, top }} className="timelineTrackMemoryGraphDot" />
+    );
+  }
+
+  render() {
+    const { hoveredCounter } = this.state;
+    const {
+      filteredThread,
+      interval,
+      rangeStart,
+      rangeEnd,
+      unfilteredSamplesRange,
+      markerSchema,
+      markerSampleRanges,
+      graphHeight,
+      width,
+      collectedSamples,
+    } = this.props;
+
+    return (
+      <div
+        className="timelineTrackMemoryGraph"
+        onMouseMove={this._onMouseMove}
+        onMouseLeave={this._onMouseLeave}
+      >
+        <TrackCustomMarkerCanvas
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          markerSchema={markerSchema}
+          markerSampleRanges={markerSampleRanges}
+          height={graphHeight}
+          width={width}
+          interval={interval}
+          collectedSamples={collectedSamples}
+        />
+        {hoveredCounter === null ? null : (
+          <>
+            {this._renderDot(hoveredCounter)}
+            {this._renderTooltip(hoveredCounter)}
+          </>
+        )}
+        <EmptyThreadIndicator
+          thread={filteredThread}
+          interval={interval}
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          unfilteredSamplesRange={unfilteredSamplesRange}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackCustomMarkerGraph = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { threadIndex, markerSchema } = ownProps;
+    const threadSelectors = getThreadSelectors(threadIndex);
+    const markerTrackSelectors = threadSelectors.getMarkerTrackSelectors(
+      markerSchema.name
+    );
+    const { start, end } = getCommittedRange(state);
+    const selectors = getThreadSelectors(threadIndex);
+    return {
+      threadIndex: threadIndex,
+      markerSchema: markerSchema,
+      markerSampleRanges:
+        markerTrackSelectors.getCommittedRangeMarkerSampleRange(state),
+      collectedSamples:
+        markerTrackSelectors.getCollectedCustomMarkerSamples(state),
+      rangeStart: start,
+      rangeEnd: end,
+      interval: getProfileInterval(state),
+      filteredThread: selectors.getFilteredThread(state),
+      unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),
+    };
+  },
+  component: withSize<Props>(TrackCustomMarkerGraphImpl),
+});

--- a/src/components/timeline/TrackCustomMarkerGraph.js
+++ b/src/components/timeline/TrackCustomMarkerGraph.js
@@ -319,7 +319,6 @@ class TrackCustomMarkerCanvas extends React.PureComponent<CanvasProps> {
 type OwnProps = {|
   +threadIndex: ThreadIndex,
   +markerSchema: MarkerSchema,
-  +markerIndex: MarkerIndex,
   +graphHeight: CssPixels,
 |};
 
@@ -334,7 +333,6 @@ type StateProps = {|
   +markerSampleRanges: [IndexIntoSamplesTable, IndexIntoSamplesTable],
   +collectedSamples: CollectedCustomMarkerSamples,
   +getMarker: (MarkerIndex) => Marker,
-  +markerIndex: MarkerIndex,
 |};
 
 type DispatchProps = {||};
@@ -445,13 +443,11 @@ class TrackCustomMarkerGraphImpl extends React.PureComponent<Props, State> {
       markerSchema,
       threadIndex,
       getMarker,
-      markerIndex,
     } = this.props;
     const { mouseX, mouseY } = this.state;
     if (collectedSamples.length === 0) {
       throw new Error('No samples for marker ' + markerSchema.name);
     }
-
     const sampleTime = collectedSamples.time[counterIndex];
     if (sampleTime < rangeStart || sampleTime > rangeEnd) {
       // Do not draw the tooltip if it will be rendered outside of the timeline.
@@ -464,12 +460,11 @@ class TrackCustomMarkerGraphImpl extends React.PureComponent<Props, State> {
     return (
       <Tooltip mouseX={mouseX} mouseY={mouseY}>
         <TooltipMarker
-            className="tooltip"
-            markerIndex={markerIndex}
-            marker={getMarker(collectedSamples.indexes[counterIndex])}
-            threadsKey={threadIndex}
-            restrictHeightWidth={true}
-          />
+          markerIndex={collectedSamples.indexes[counterIndex]}
+          marker={getMarker(collectedSamples.indexes[counterIndex])}
+          threadsKey={threadIndex}
+          restrictHeightWidth={true}
+        />
       </Tooltip>
     );
   }
@@ -526,6 +521,7 @@ class TrackCustomMarkerGraphImpl extends React.PureComponent<Props, State> {
       dots.push(
         <div
           style={{ left, top }}
+          key={lineIndex}
           className="timelineTrackCustomMarkerGraphDot"
         />
       );
@@ -589,7 +585,7 @@ export const TrackCustomMarkerGraph = explicitConnect<
   DispatchProps
 >({
   mapStateToProps: (state, ownProps) => {
-    const { threadIndex, markerSchema, markerIndex } = ownProps;
+    const { threadIndex, markerSchema } = ownProps;
     const { start, end } = getCommittedRange(state);
     const selectors = getThreadSelectors(threadIndex);
     const markerTrackSelectors = selectors.getMarkerTrackSelectors(
@@ -608,7 +604,6 @@ export const TrackCustomMarkerGraph = explicitConnect<
       filteredThread: selectors.getFilteredThread(state),
       unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),
       getMarker: selectors.getMarkerGetter(state),
-      markerIndex,
     };
   },
   component: withSize<Props>(TrackCustomMarkerGraphImpl),

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -240,8 +240,8 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
           // Check for a schema that is looking up and formatting a value from
           // the payload.
           if (schemaData.value === undefined) {
-            const { key, label, format } = schemaData;
-            if (key in data) {
+            const { key, label, format, isHidden } = schemaData;
+            if (key in data && !isHidden) {
               const value = data[key];
 
               // Don't add undefined values, as values are optional.

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -241,11 +241,13 @@ export function parseLabel(
       // Handle:                                      ^^^^^^^^^^^^^^^^
 
       let format = null;
+      let isHidden = false;
       for (const rule of markerSchema.data) {
         // The rule.value === undefined line is odd mainly because Flow was having trouble
         // refining the type.
         if (rule.value === undefined && rule.key === payloadKey) {
           format = rule.format;
+          isHidden = rule.isHidden === true;
           break;
         }
       }
@@ -257,8 +259,9 @@ export function parseLabel(
         }
 
         const value = marker.data[payloadKey];
-        if (value === undefined || value === null) {
+        if (value === undefined || value === null || isHidden) {
           // This would return "undefined" or "null" otherwise.
+          // and also handles the isHidden property
           return '';
         }
         return format

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -24,9 +24,11 @@ import { intersectSets, subtractSets } from '../utils/set';
 import { splitSearchString, stringsToRegExp } from '../utils/string';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 import {
+  TRACK_MARKER_DEFAULT_HEIGHT,
   TRACK_MARKER_DEFAULT_LINE_FILL_COLOR,
   TRACK_MARKER_DEFAULT_LINE_STROKE_COLOR,
   TRACK_MARKER_DEFAULT_LINE_WIDTH,
+  TRACK_MARKER_HEIGHTS,
 } from '../app-logic/constants';
 import {
   GREEN_50,
@@ -55,6 +57,15 @@ export const getMarkerTrackConfig = (schema: MarkerSchema) => {
     throw new Error('No track config for marker ' + schema.name);
   }
   return schema.trackConfig;
+};
+
+export const getMarkerTrackHeight = (schema: MarkerSchema) => {
+  const heightName =
+    getMarkerTrackConfig(schema).height || TRACK_MARKER_DEFAULT_HEIGHT;
+  if (!(heightName in TRACK_MARKER_HEIGHTS)) {
+    throw new Error('Unknown height ' + heightName);
+  }
+  return (TRACK_MARKER_HEIGHTS[heightName]: number);
 };
 
 export const getMarkerTrackLineConfig = (
@@ -87,6 +98,20 @@ export const getMarkerTrackLineFillColor = (
     getMarkerTrackLineConfig(schema, line).fillColor ||
     TRACK_MARKER_DEFAULT_LINE_FILL_COLOR
   );
+};
+
+export const getMarkerTrackConfigLineType = (
+  schema: MarkerSchema,
+  line: number
+) => {
+  return getMarkerTrackLineConfig(schema, line).type || 'line';
+};
+
+export const isMarkerTrackLinePreScaled = (
+  schema: MarkerSchema,
+  line: number
+) => {
+  return getMarkerTrackLineConfig(schema, line).isPreScaled === true;
 };
 
 export const getMarkerTrackLineStrokeColor = (

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -68,6 +68,10 @@ export const getMarkerTrackHeight = (schema: MarkerSchema) => {
   return (TRACK_MARKER_HEIGHTS[heightName]: number);
 };
 
+export const getMarkerTrackTooltip = (schema: MarkerSchema) => {
+  return getMarkerTrackConfig(schema).tooltip;
+};
+
 export const getMarkerTrackLineConfig = (
   schema: MarkerSchema,
   line: number
@@ -350,10 +354,6 @@ export function computeLocalTracksByPid(
         (schema) => schema.trackConfig !== undefined
       )
     : [];
-  const markerNamesToIndex = {};
-  profile.meta.markerSchema.forEach(
-    (schema, index) => (markerNamesToIndex[schema.name] = index)
-  );
 
   for (
     let threadIndex = 0;
@@ -405,7 +405,6 @@ export function computeLocalTracksByPid(
             type: 'marker',
             threadIndex,
             markerSchema: marker,
-            markerIndex: markerNamesToIndex[marker.name],
           });
         }
       }
@@ -992,8 +991,14 @@ export function getLocalTrackName(
   }
 }
 
-// Consider threads whose sample score is less than 5% of the maximum sample score to be idle.
-const IDLE_THRESHOLD_FRACTION = 0.05;
+export function getLocalTrackTooltip(localTrack: LocalTrack): ?string {
+  switch (localTrack.type) {
+    case 'marker':
+      return getMarkerTrackConfig(localTrack.markerSchema).tooltip;
+    default:
+      return undefined;
+  }
+}
 
 // Return a non-empty set of threads that should be shown by default.
 export function computeDefaultVisibleThreads(

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -231,7 +231,11 @@ function _getDefaultLocalTrackOrder(tracks: LocalTrack[], profile: ?Profile) {
 
     // If the tracks are both threads, sort them by thread name, and then by
     // creation time if they have the same name.
-    if (tracks[a].type === 'thread' && tracks[b].type === 'thread' && profile) {
+    if (
+      (tracks[a].type === 'thread' || tracks[a].type === 'marker') &&
+      (tracks[b].type === 'thread' || tracks[b].type === 'marker') &&
+      profile
+    ) {
       const idxA = tracks[a].threadIndex;
       const idxB = tracks[b].threadIndex;
       if (idxA === undefined || idxB === undefined) {

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -350,6 +350,10 @@ export function computeLocalTracksByPid(
         (schema) => schema.trackConfig !== undefined
       )
     : [];
+  const markerNamesToIndex = {};
+  profile.meta.markerSchema.forEach(
+    (schema, index) => (markerNamesToIndex[schema.name] = index)
+  );
 
   for (
     let threadIndex = 0;
@@ -401,6 +405,7 @@ export function computeLocalTracksByPid(
             type: 'marker',
             threadIndex,
             markerSchema: marker,
+            markerIndex: markerNamesToIndex[marker.name],
           });
         }
       }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -68,10 +68,6 @@ export const getMarkerTrackHeight = (schema: MarkerSchema) => {
   return (TRACK_MARKER_HEIGHTS[heightName]: number);
 };
 
-export const isMarkerTrackShownByDefault = (schema: MarkerSchema) => {
-  return getMarkerTrackConfig(schema).showByDefault || false;
-};
-
 export const getMarkerTrackTooltip = (schema: MarkerSchema) => {
   return getMarkerTrackConfig(schema).tooltip;
 };
@@ -847,9 +843,7 @@ function _computeHiddenTracksForVisibleThreads(
     const hiddenLocalTracks = new Set(
       localTrackOrder.filter((localTrackIndex) => {
         const localTrack = localTracks[localTrackIndex];
-        if (localTrack.type === 'marker') {
-          return !isMarkerTrackShownByDefault(localTrack.markerSchema);
-        } else if (localTrack.type !== 'thread') {
+        if (localTrack.type !== 'thread') {
           // Keep non-thread local tracks visible.
           return false;
         }
@@ -1005,6 +999,9 @@ export function getLocalTrackTooltip(localTrack: LocalTrack): ?string {
       return undefined;
   }
 }
+
+// Consider threads whose sample score is less than 5% of the maximum sample score to be idle.
+const IDLE_THRESHOLD_FRACTION = 0.05;
 
 // Return a non-empty set of threads that should be shown by default.
 export function computeDefaultVisibleThreads(

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -86,6 +86,10 @@ export const getMarkerTrackLineWidth = (schema: MarkerSchema, line: number) => {
   );
 };
 
+export const isMarkerTrackPreSelected = (schema: MarkerSchema) => {
+  return getMarkerTrackConfig(schema).isPreSelected === true;
+};
+
 export const getMaximumMarkerTrackLineWidth = (schema: MarkerSchema) => {
   return Math.max(
     ...getMarkerTrackConfig(schema).lines.map(
@@ -843,7 +847,9 @@ function _computeHiddenTracksForVisibleThreads(
     const hiddenLocalTracks = new Set(
       localTrackOrder.filter((localTrackIndex) => {
         const localTrack = localTracks[localTrackIndex];
-        if (localTrack.type !== 'thread') {
+        if (localTrack.type === 'marker') {
+          return !isMarkerTrackPreSelected(localTrack.markerSchema);
+        } else if (localTrack.type !== 'thread') {
           // Keep non-thread local tracks visible.
           return false;
         }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -68,6 +68,10 @@ export const getMarkerTrackHeight = (schema: MarkerSchema) => {
   return (TRACK_MARKER_HEIGHTS[heightName]: number);
 };
 
+export const isMarkerTrackShownByDefault = (schema: MarkerSchema) => {
+  return getMarkerTrackConfig(schema).showByDefault || false;
+};
+
 export const getMarkerTrackTooltip = (schema: MarkerSchema) => {
   return getMarkerTrackConfig(schema).tooltip;
 };
@@ -843,7 +847,9 @@ function _computeHiddenTracksForVisibleThreads(
     const hiddenLocalTracks = new Set(
       localTrackOrder.filter((localTrackIndex) => {
         const localTrack = localTracks[localTrackIndex];
-        if (localTrack.type !== 'thread') {
+        if (localTrack.type === 'marker') {
+          return !isMarkerTrackShownByDefault(localTrack.markerSchema);
+        } else if (localTrack.type !== 'thread') {
           // Keep non-thread local tracks visible.
           return false;
         }

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -18,6 +18,7 @@ import {
   getLocalTracksByPid,
   getActiveTabTimeline,
 } from './profile';
+import { getMarkerTrackConfig } from '../profile-logic/tracks';
 import { getZipFileState } from './zipped-profiles.js';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import {
@@ -26,6 +27,7 @@ import {
   TRACK_NETWORK_HEIGHT,
   TRACK_MEMORY_HEIGHT,
   TRACK_IPC_HEIGHT,
+  TRACK_MARKER_DEFAULT_HEIGHT,
   TRACK_PROCESS_BLANK_HEIGHT,
   TIMELINE_RULER_HEIGHT,
   TRACK_VISUAL_PROGRESS_HEIGHT,
@@ -296,6 +298,11 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                 case 'process-cpu':
                 case 'power':
                   height += TRACK_PROCESS_CPU_HEIGHT + border;
+                  break;
+                case 'marker':
+                  height +=
+                    getMarkerTrackConfig(localTrack.markerSchema).height ||
+                    TRACK_MARKER_DEFAULT_HEIGHT;
                   break;
                 default:
                   throw assertExhaustiveCheck(localTrack);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -299,8 +299,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                   height += TRACK_PROCESS_CPU_HEIGHT + border;
                   break;
                 case 'marker':
-                  height +=
-                    getMarkerTrackHeight(localTrack.markerSchema) + 2;
+                  height += getMarkerTrackHeight(localTrack.markerSchema) + 2;
                   break;
                 default:
                   throw assertExhaustiveCheck(localTrack);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -299,7 +299,8 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                   height += TRACK_PROCESS_CPU_HEIGHT + border;
                   break;
                 case 'marker':
-                  height += getMarkerTrackHeight(localTrack.markerSchema);
+                  height +=
+                    getMarkerTrackHeight(localTrack.markerSchema) + 2;
                   break;
                 default:
                   throw assertExhaustiveCheck(localTrack);

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -18,7 +18,7 @@ import {
   getLocalTracksByPid,
   getActiveTabTimeline,
 } from './profile';
-import { getMarkerTrackConfig } from '../profile-logic/tracks';
+import { getMarkerTrackHeight } from '../profile-logic/tracks';
 import { getZipFileState } from './zipped-profiles.js';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import {
@@ -27,7 +27,6 @@ import {
   TRACK_NETWORK_HEIGHT,
   TRACK_MEMORY_HEIGHT,
   TRACK_IPC_HEIGHT,
-  TRACK_MARKER_DEFAULT_HEIGHT,
   TRACK_PROCESS_BLANK_HEIGHT,
   TIMELINE_RULER_HEIGHT,
   TRACK_VISUAL_PROGRESS_HEIGHT,
@@ -300,9 +299,7 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
                   height += TRACK_PROCESS_CPU_HEIGHT + border;
                   break;
                 case 'marker':
-                  height +=
-                    getMarkerTrackConfig(localTrack.markerSchema).height ||
-                    TRACK_MARKER_DEFAULT_HEIGHT;
+                  height += getMarkerTrackHeight(localTrack.markerSchema);
                   break;
                 default:
                   throw assertExhaustiveCheck(localTrack);

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -32,7 +32,6 @@ import type {
   MarkerSchema,
   MarkerTrackConfig,
   CollectedCustomMarkerSamples,
-  Milliseconds,
   IndexIntoSamplesTable,
 } from 'firefox-profiler/types';
 

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -52,8 +52,9 @@ export function getMarkerSelectorsPerThread(
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
 ) {
-  const _getRawMarkerTable: Selector<RawMarkerTable> = (state) =>
-    threadSelectors.getThread(state).markers;
+  const _getRawMarkerTable: Selector<RawMarkerTable> = (state) => {
+    return threadSelectors.getThread(state).markers;
+  };
 
   /**
    * Similar to thread filtering, the markers can be filtered as well, and it's

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -650,27 +650,19 @@ export function getMarkerSelectorsPerThread(
 
     const getCollectedCustomMarkerSamples: Selector<CollectedCustomMarkerSamples> =
       createSelector(
-        _getRawMarkerTable,
+        getFullMarkerList,
         threadSelectors.getStringTable,
         _getTrackKeys,
-        (rawTable, stringTable, trackKeys) => {
+        (fullMarkerList, stringTable, trackKeys) => {
           const nameIndex = stringTable.indexForString(name);
-          const filteredIndexes = rawTable.name
+          const filteredIndexes = fullMarkerList
             .map((n, i) => [n, i])
-            .filter((t) => t[0] === nameIndex)
+            .filter((t) => t[0].name === name)
             .map((t) => t[1]);
-          const filteredTimes: Milliseconds[] = filteredIndexes.map((i) => {
-            if (rawTable.startTime[i] === null) {
-              throw new Error(
-                'All start times have to be defined for trackable marker ' +
-                  name
-              );
-            }
-            return rawTable.startTime[i];
-          });
+          const markers = filteredIndexes.map((i) => fullMarkerList[i]);
           const numbersPerLine: number[][] = trackKeys.map((key) =>
-            filteredIndexes.map((index) => {
-              const markerPayload = rawTable.data[index];
+            markers.map((marker) => {
+              const markerPayload = marker.data;
               if (
                 !(markerPayload instanceof Object) ||
                 !(key in markerPayload)
@@ -690,7 +682,8 @@ export function getMarkerSelectorsPerThread(
           return {
             minNumber,
             maxNumber,
-            time: filteredTimes,
+            markers,
+            time: markers.map((marker) => marker.start),
             numbersPerLine,
             indexes: filteredIndexes,
             length,
@@ -722,6 +715,7 @@ export function getMarkerSelectorsPerThread(
     getTimelineJankMarkerIndexes,
     getDerivedMarkerInfo,
     getMarkerIndexToRawMarkerIndexes,
+    getFullMarkerList,
     getFullMarkerListIndexes,
     getNetworkMarkerIndexes,
     getSearchFilteredNetworkMarkerIndexes,

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -686,12 +686,10 @@ export function getMarkerSelectorsPerThread(
           const maxNumber = Math.min(
             ...numbersPerLine.map((x) => Math.max(...x))
           );
-          const numberRange = maxNumber - minNumber;
           const length = numbersPerLine.length;
           return {
             minNumber,
             maxNumber,
-            numberRange,
             time: filteredTimes,
             numbersPerLine,
             indexes: filteredIndexes,

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -653,7 +653,6 @@ export function getMarkerSelectorsPerThread(
         threadSelectors.getStringTable,
         _getTrackKeys,
         (fullMarkerList, stringTable, trackKeys) => {
-          const nameIndex = stringTable.indexForString(name);
           const filteredIndexes = fullMarkerList
             .map((n, i) => [n, i])
             .filter((t) => t[0].name === name)
@@ -674,7 +673,7 @@ export function getMarkerSelectorsPerThread(
           const minNumber = Math.min(
             ...numbersPerLine.map((x) => Math.min(...x))
           );
-          const maxNumber = Math.min(
+          const maxNumber = Math.max(
             ...numbersPerLine.map((x) => Math.max(...x))
           );
           const length = numbersPerLine.length;

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -75,12 +75,13 @@ export function getThreadSelectorsPerThread(
    * Either return the raw thread from the profile, or merge several raw threads
    * together.
    */
-  const getThread: Selector<Thread> = (state) =>
-    threadIndexes.size === 1
+  const getThread: Selector<Thread> = (state) => {
+    return threadIndexes.size === 1
       ? ProfileSelectors.getProfile(state).threads[
           ensureExists(getFirstItemFromSet(threadIndexes))
         ]
       : getMergedThread(state);
+  };
   const getStringTable: Selector<UniqueStringArray> = (state) =>
     getThread(state).stringTable;
   const getSamplesTable: Selector<SamplesTable> = (state) =>

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -518,23 +518,16 @@ export const getLocalTrackNamesByPid: Selector<Map<Pid, string[]>> =
   );
 
 export const getLocalTrackTooltipsByPid: Selector<Map<Pid, (?string)[]>> =
-  createSelector(
-    getLocalTracksByPid,
-    getThreads,
-    getCounter,
-    (localTracksByPid, threads, counters) => {
-      const localTrackTooltipsByPid = new Map();
-      for (const [pid, localTracks] of localTracksByPid) {
-        localTrackTooltipsByPid.set(
-          pid,
-          localTracks.map((localTrack) =>
-            Tracks.getLocalTrackTooltip(localTrack)
-          )
-        );
-      }
-      return localTrackTooltipsByPid;
+  createSelector(getLocalTracksByPid, (localTracksByPid) => {
+    const localTrackTooltipsByPid = new Map();
+    for (const [pid, localTracks] of localTracksByPid) {
+      localTrackTooltipsByPid.set(
+        pid,
+        localTracks.map((localTrack) => Tracks.getLocalTrackTooltip(localTrack))
+      );
     }
-  );
+    return localTrackTooltipsByPid;
+  });
 
 export const getLocalTrackName = (
   state: State,

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -517,6 +517,25 @@ export const getLocalTrackNamesByPid: Selector<Map<Pid, string[]>> =
     }
   );
 
+export const getLocalTrackTooltipsByPid: Selector<Map<Pid, (?string)[]>> =
+  createSelector(
+    getLocalTracksByPid,
+    getThreads,
+    getCounter,
+    (localTracksByPid, threads, counters) => {
+      const localTrackTooltipsByPid = new Map();
+      for (const [pid, localTracks] of localTracksByPid) {
+        localTrackTooltipsByPid.set(
+          pid,
+          localTracks.map((localTrack) =>
+            Tracks.getLocalTrackTooltip(localTrack)
+          )
+        );
+      }
+      return localTrackTooltipsByPid;
+    }
+  );
+
 export const getLocalTrackName = (
   state: State,
   pid: Pid,
@@ -524,6 +543,16 @@ export const getLocalTrackName = (
 ): string =>
   ensureExists(
     getLocalTrackNamesByPid(state).get(pid),
+    'Could not find the track names from the given pid'
+  )[trackIndex];
+
+export const getLocalTrackTooltip = (
+  state: State,
+  pid: Pid,
+  trackIndex: TrackIndex
+): ?string =>
+  ensureExists(
+    getLocalTrackTooltipsByPid(state).get(pid),
     'Could not find the track names from the given pid'
   )[trackIndex];
 

--- a/src/test/components/TrackCustomMarker.test.js
+++ b/src/test/components/TrackCustomMarker.test.js
@@ -1,0 +1,309 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// based on the TrackMemory test
+
+// @flow
+
+import type { CssPixels } from 'firefox-profiler/types';
+
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent } from '@testing-library/react';
+
+import { render } from 'firefox-profiler/test/fixtures/testing-library';
+import { TrackCustomMarker } from '../../components/timeline/TrackCustomMarker';
+import { ensureExists } from '../../utils/flow';
+
+import {
+  autoMockCanvasContext,
+  flushDrawLog,
+} from '../fixtures/mocks/canvas-context';
+import { mockRaf } from '../fixtures/mocks/request-animation-frame';
+import { storeWithProfile } from '../fixtures/stores';
+import {
+  addRootOverlayElement,
+  removeRootOverlayElement,
+  getMouseEvent,
+} from '../fixtures/utils';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import {
+  autoMockElementSize,
+  setMockedElementSize,
+} from '../fixtures/mocks/element-size';
+import {
+  autoMockIntersectionObserver,
+  triggerIntersectionObservers,
+} from '../fixtures/mocks/intersection-observer';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
+
+// The following constants determine the size of the drawn graph.
+const SAMPLE_COUNT = 8;
+const PIXELS_PER_SAMPLE = 10;
+const GRAPH_WIDTH = PIXELS_PER_SAMPLE * SAMPLE_COUNT;
+const GRAPH_HEIGHT = 10;
+
+function getMarkerPixelPosition(time: number): CssPixels {
+  // Compute the pixel position related to the given marker time.
+  return (time * GRAPH_WIDTH) / SAMPLE_COUNT;
+}
+
+function setup() {
+  const { profile } = getProfileFromTextSamples(
+    Array(SAMPLE_COUNT).fill('A').join('  ')
+  );
+  const markerStringIndex =
+    profile.threads[0].stringTable.indexForString('Marker');
+  const threadIndex = 0;
+  const thread = profile.threads[threadIndex];
+  profile.meta.markerSchema.push({
+    name: 'Marker',
+    display: ['marker-chart', 'marker-table', 'timeline-memory'],
+    data: [
+      { key: 'first', label: 'first', format: 'integer', searchable: true },
+      { key: 'second', label: 'second', format: 'integer', searchable: true },
+    ],
+    trackConfig: {
+      label: 'JVM CPU Usage',
+      lines: [
+        // multiple lines are supported
+        {
+          key: 'first',
+          type: 'line',
+        },
+        {
+          key: 'second',
+          strokeColor: 'green', // the default color is orange
+          type: 'bar',
+        },
+      ],
+      isPreSelected: true,
+    },
+  });
+  const addMarker = (startTime: number, first: number, second: number) => {
+    // $FlowExpectError - Invalid payload by our type system
+    thread.markers.data.push({ first: first, second: second });
+    thread.markers.name.push(markerStringIndex);
+    thread.markers.startTime.push(startTime);
+    thread.markers.endTime.push(startTime + 1);
+    thread.markers.phase.push(1);
+    thread.markers.category.push(4);
+    thread.markers.length++;
+  };
+  for (let i = 0; i < SAMPLE_COUNT; i++) {
+    addMarker(i, i, i * 2);
+  }
+  const store = storeWithProfile(profile);
+  const { getState, dispatch } = store;
+  const flushRafCalls = mockRaf();
+
+  /**
+   * Coordinate the flushing of the requestAnimationFrame and the draw calls.
+   */
+  function getContextDrawCalls() {
+    flushRafCalls();
+    return flushDrawLog();
+  }
+
+  const renderResult = render(
+    <Provider store={store}>
+      <TrackCustomMarker
+        threadIndex={0}
+        markerSchema={
+          profile.meta.markerSchema[profile.meta.markerSchema.length - 1]
+        }
+      />
+    </Provider>
+  );
+  const { container } = renderResult;
+
+  // WithSize uses requestAnimationFrame
+  flushRafCalls();
+
+  const canvas = ensureExists(
+    container.querySelector('.timelineTrackCustomMarkerCanvas'),
+    `Couldn't find the custom marker canvas, with selector .timelineTrackMarkerCustomCanvas`
+  );
+  const getTooltipContents = () => document.querySelector('.tooltipMarker');
+  const getMarkerDot = () =>
+    container.querySelector('.timelineTrackCustomMarkerGraphDot');
+  const moveMouseAtMarker = (time) =>
+    fireEvent(
+      canvas,
+      getMouseEvent('mousemove', {
+        pageX: getMarkerPixelPosition(time),
+      })
+    );
+  return {
+    ...renderResult,
+    dispatch,
+    getState,
+    profile,
+    thread,
+    store,
+    threadIndex,
+    canvas,
+    getTooltipContents,
+    moveMouseAtMarker,
+    flushRafCalls,
+    getMarkerDot,
+    getContextDrawCalls,
+  };
+}
+
+/**
+ * This test verifies that the custom marker track can draw a bar and a line char.
+ */
+describe('TrackCustomMarker', function () {
+  autoMockCanvasContext();
+  autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  autoMockIntersectionObserver();
+  beforeEach(addRootOverlayElement);
+  afterEach(removeRootOverlayElement);
+
+  it('matches the component snapshot', () => {
+    const { container } = setup();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches the 2d canvas draw snapshot', () => {
+    const { flushRafCalls } = setup();
+    flushRafCalls();
+    expect(flushDrawLog()).toMatchSnapshot();
+  });
+
+  it('can create a tooltip', function () {
+    const { moveMouseAtMarker, getTooltipContents, canvas } = setup();
+    expect(getTooltipContents()).toBeFalsy();
+    moveMouseAtMarker(1);
+    expect(getTooltipContents()).toBeTruthy();
+    fireEvent.mouseLeave(canvas);
+    expect(getTooltipContents()).toBeFalsy();
+  });
+
+  it('has a tooltip that matches the snapshot', function () {
+    const { moveMouseAtMarker, getTooltipContents } = setup();
+    moveMouseAtMarker(5);
+    expect(getTooltipContents()).toMatchSnapshot();
+  });
+
+  it('draws a dot on the graph', function () {
+    const { moveMouseAtMarker, getMarkerDot } = setup();
+    expect(getMarkerDot()).toBeFalsy();
+    moveMouseAtMarker(1);
+    expect(getMarkerDot()).toBeTruthy();
+  });
+
+  it('can draw a dot on both extremes of the graph', function () {
+    const { moveMouseAtMarker, getMarkerDot } = setup();
+    expect(getMarkerDot()).toBeFalsy();
+    moveMouseAtMarker(0);
+    expect(getMarkerDot()).toBeTruthy();
+    moveMouseAtMarker(7);
+    expect(getMarkerDot()).toBeTruthy();
+  });
+
+  it('draws a dot that matches the snapshot', function () {
+    const { moveMouseAtMarker, getMarkerDot } = setup();
+    moveMouseAtMarker(1);
+    expect(getMarkerDot()).toMatchSnapshot();
+  });
+});
+
+describe('TrackCustomMarker with intersection observer', function () {
+  autoMockCanvasContext();
+  autoMockElementSize({ width: GRAPH_WIDTH, height: GRAPH_HEIGHT });
+  // Do not automatically trigger the intersection observers.
+  autoMockIntersectionObserver(false);
+
+  it('will not draw before the intersection observer', () => {
+    const { getContextDrawCalls } = setup();
+    const drawCalls = getContextDrawCalls();
+    // There are other canvases inside the TrackThread too. We want to make sure
+    // that custom marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+  });
+
+  it('will not draw after the intersection observer if it is not intersecting', () => {
+    const { getContextDrawCalls } = setup();
+    let drawCalls = getContextDrawCalls();
+
+    // There are other canvases inside the TrackThread too. We want to make sure
+    // that custom marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer and make sure that it still
+    // doesn't draw it.
+    triggerIntersectionObservers({ isIntersecting: false });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+  });
+
+  it('will draw after the intersection observer if it is intersecting', () => {
+    const { getContextDrawCalls } = setup();
+    let drawCalls = getContextDrawCalls();
+
+    // There are other canvases inside the TrackThread too. We want to make sure
+    // that custom marker graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer and make sure that it draws it.
+    triggerIntersectionObservers({ isIntersecting: true });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      true
+    );
+  });
+
+  it('will redraw after it becomes visible again', () => {
+    const { getContextDrawCalls } = setup();
+    let drawCalls = getContextDrawCalls();
+
+    // There are other canvases inside the TrackThread too. We want to make sure
+    // that activity graph is not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer and make sure that it draws it.
+    triggerIntersectionObservers({ isIntersecting: true });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      true
+    );
+
+    // Now it goes out of view again. Make sure that we don't redraw.
+    triggerIntersectionObservers({ isIntersecting: false });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+
+    // Send out the resize with a width change.
+    // By changing the "fake" result of getBoundingClientRect, we ensure that
+    // the pure components rerender because their `width` props change.
+    setMockedElementSize({ width: GRAPH_WIDTH * 2, height: GRAPH_HEIGHT });
+    triggerResizeObservers();
+    drawCalls = getContextDrawCalls();
+    // It should still be not drawn yet.
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      false
+    );
+
+    // Now let's trigger the intersection observer again and make sure that it redraws.
+    triggerIntersectionObservers({ isIntersecting: true });
+    drawCalls = getContextDrawCalls();
+    expect(drawCalls.some(([operation]) => operation === 'clearRect')).toBe(
+      true
+    );
+  });
+});

--- a/src/test/components/__snapshots__/TrackCustomMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TrackCustomMarker.test.js.snap
@@ -1,0 +1,268 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TrackCustomMarker draws a dot that matches the snapshot 1`] = `
+<div
+  class="timelineTrackCustomMarkerGraphDot"
+  style="left: 10px; top: 23.457142857142856px;"
+/>
+`;
+
+exports[`TrackCustomMarker has a tooltip that matches the snapshot 1`] = `
+<div
+  class="tooltipMarker"
+>
+  <div
+    class="tooltipHeader"
+  >
+    <div
+      class="tooltipOneLine"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Marker
+      </div>
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Thread
+      :
+    </div>
+    Empty
+  </div>
+</div>
+`;
+
+exports[`TrackCustomMarker matches the 2d canvas draw snapshot 1`] = `
+Array [
+  Array [
+    "clearRect",
+    0,
+    0,
+    80,
+    25,
+  ],
+  Array [
+    "set lineWidth",
+    2,
+  ],
+  Array [
+    "set strokeStyle",
+    "#ff9400",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    0,
+    26,
+  ],
+  Array [
+    "lineTo",
+    10,
+    24.392857142857142,
+  ],
+  Array [
+    "lineTo",
+    20,
+    22.785714285714285,
+  ],
+  Array [
+    "lineTo",
+    30,
+    21.17857142857143,
+  ],
+  Array [
+    "lineTo",
+    40,
+    19.571428571428573,
+  ],
+  Array [
+    "lineTo",
+    50,
+    17.964285714285715,
+  ],
+  Array [
+    "lineTo",
+    60,
+    16.357142857142858,
+  ],
+  Array [
+    "lineTo",
+    70,
+    14.75,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "lineTo",
+    80,
+    25,
+  ],
+  Array [
+    "lineTo",
+    0,
+    25,
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "set lineWidth",
+    2,
+  ],
+  Array [
+    "set strokeStyle",
+    "#30e60b",
+  ],
+  Array [
+    "set fillStyle",
+    "transparent",
+  ],
+  Array [
+    "moveTo",
+    0,
+    26,
+  ],
+  Array [
+    "lineTo",
+    0,
+    26,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    10,
+    26,
+  ],
+  Array [
+    "lineTo",
+    10,
+    22.785714285714285,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    20,
+    26,
+  ],
+  Array [
+    "lineTo",
+    20,
+    19.571428571428573,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    30,
+    26,
+  ],
+  Array [
+    "lineTo",
+    30,
+    16.357142857142858,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    40,
+    26,
+  ],
+  Array [
+    "lineTo",
+    40,
+    13.142857142857144,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    50,
+    26,
+  ],
+  Array [
+    "lineTo",
+    50,
+    9.928571428571427,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    60,
+    26,
+  ],
+  Array [
+    "lineTo",
+    60,
+    6.714285714285715,
+  ],
+  Array [
+    "stroke",
+  ],
+  Array [
+    "moveTo",
+    70,
+    26,
+  ],
+  Array [
+    "lineTo",
+    70,
+    3.5,
+  ],
+  Array [
+    "stroke",
+  ],
+]
+`;
+
+exports[`TrackCustomMarker matches the component snapshot 1`] = `
+<div
+  class="timelineTrackCustomMarker"
+  style="height: 25px; --graph-height: 25px; --markers-height: 0px;"
+>
+  <div
+    class="timelineTrackCustomMarkerGraph"
+  >
+    <div>
+      <canvas
+        class="timelineTrackCustomMarkerCanvas"
+        height="25"
+        width="80"
+      />
+    </div>
+    <div
+      class="timelineEmptyThreadIndicator"
+    />
+  </div>
+</div>
+`;

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -143,15 +143,6 @@ export type MarkerSchema = {|
         searchable?: boolean,
         // hidden in the side bar and tooltips?
         isHidden?: boolean,
-        // Show a summary for the passed keys
-        // idea:
-        //           | current | diff to previous |  avg/min/max in selection
-        // pauseTime | 20ms    | 200ms | 100%     | 205ms | 100ms | 300ms
-        //
-        // later: add this to every marker and other tracks like memory
-        // also: add the possibility to enable thin mean/max/min lines (and to zero) it (two buttons beside the normal track remove buttons)
-
-        showInSummaryTable?: boolean,
       |}
     | {|
         // This type is a static bit of text that will be displayed

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -86,6 +86,8 @@ export type MarkerDisplayLocation =
   // TODO - This is not supported yet.
   | 'stack-chart';
 
+export type MarkerTrackConfigLineType = 'bar' | 'line';
+export type MarkerTrackConfigLineHeight = 'small' | 'medium' | 'large';
 export type MarkerTrackConfig = {|
   label: string,
   // height of the track in pixels
@@ -105,9 +107,12 @@ export type MarkerTrackConfig = {|
       | 'grey'
       | string,
     width?: number,
+    type?: MarkerTrackConfigLineType,
+    isPreScaled?: boolean,
   |}>,
 |};
 
+// todo: add format string to marker schema to show only selected keys (e.g. "blub: %key %key2")
 export type MarkerSchema = {|
   // The unique identifier for this marker.
   name: string, // e.g. "CC"
@@ -135,6 +140,9 @@ export type MarkerSchema = {|
         label?: string,
         format: MarkerFormatType,
         searchable?: boolean,
+        // hidden in the side bar and tooltips?
+        hidden?: boolean,
+        showInSummaryTable?: boolean,
       |}
     | {|
         // This type is a static bit of text that will be displayed
@@ -145,6 +153,14 @@ export type MarkerSchema = {|
 
   // if present, give the marker its own local track
   trackConfig?: MarkerTrackConfig,
+  // Show a summary for the passed keys
+  // idea:
+  //           | current | diff to previous |  avg/min/max in selection
+  // pauseTime | 20ms    | 200ms | 100%     | 205ms | 100ms | 300ms
+  //
+  // later: add this to every marker and other tracks like memory
+  // also: add the possibility to enable thin mean/max/min lines (and to zero) it (two buttons beside the normal track remove buttons)
+  showSummaryFor?: string[],
 |};
 
 export type MarkerSchemaByName = ObjectMap<MarkerSchema>;

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -86,6 +86,28 @@ export type MarkerDisplayLocation =
   // TODO - This is not supported yet.
   | 'stack-chart';
 
+export type MarkerTrackConfig = {|
+  label: string,
+  // height of the track in pixels
+  height?: number,
+  lines: Array<{|
+    key: string,
+    fillColor?: string,
+    strokeColor?:
+      | 'magenta'
+      | 'purple'
+      | 'teal'
+      | 'green'
+      | 'yellow'
+      | 'orange'
+      | 'red'
+      | 'transparent'
+      | 'grey'
+      | string,
+    width?: number,
+  |}>,
+|};
+
 export type MarkerSchema = {|
   // The unique identifier for this marker.
   name: string, // e.g. "CC"
@@ -120,6 +142,9 @@ export type MarkerSchema = {|
         value: string,
       |}
   >,
+
+  // if present, give the marker its own local track
+  trackConfig?: MarkerTrackConfig,
 |};
 
 export type MarkerSchemaByName = ObjectMap<MarkerSchema>;

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -93,6 +93,7 @@ export type MarkerTrackConfig = {|
   tooltip?: string,
   // height of the track in pixels
   height?: MarkerTrackConfigLineHeight,
+  showByDefault?: boolean,
   lines: Array<{|
     key: string,
     fillColor?: string,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -112,7 +112,6 @@ export type MarkerTrackConfig = {|
   |}>,
 |};
 
-// todo: add format string to marker schema to show only selected keys (e.g. "blub: %key %key2")
 export type MarkerSchema = {|
   // The unique identifier for this marker.
   name: string, // e.g. "CC"
@@ -141,7 +140,15 @@ export type MarkerSchema = {|
         format: MarkerFormatType,
         searchable?: boolean,
         // hidden in the side bar and tooltips?
-        hidden?: boolean,
+        isHidden?: boolean,
+        // Show a summary for the passed keys
+        // idea:
+        //           | current | diff to previous |  avg/min/max in selection
+        // pauseTime | 20ms    | 200ms | 100%     | 205ms | 100ms | 300ms
+        //
+        // later: add this to every marker and other tracks like memory
+        // also: add the possibility to enable thin mean/max/min lines (and to zero) it (two buttons beside the normal track remove buttons)
+
         showInSummaryTable?: boolean,
       |}
     | {|
@@ -153,14 +160,6 @@ export type MarkerSchema = {|
 
   // if present, give the marker its own local track
   trackConfig?: MarkerTrackConfig,
-  // Show a summary for the passed keys
-  // idea:
-  //           | current | diff to previous |  avg/min/max in selection
-  // pauseTime | 20ms    | 200ms | 100%     | 205ms | 100ms | 300ms
-  //
-  // later: add this to every marker and other tracks like memory
-  // also: add the possibility to enable thin mean/max/min lines (and to zero) it (two buttons beside the normal track remove buttons)
-  showSummaryFor?: string[],
 |};
 
 export type MarkerSchemaByName = ObjectMap<MarkerSchema>;

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -93,7 +93,7 @@ export type MarkerTrackConfig = {|
   tooltip?: string,
   // height of the track in pixels
   height?: MarkerTrackConfigLineHeight,
-  showByDefault?: boolean,
+  isPreSelected?: boolean,
   lines: Array<{|
     key: string,
     fillColor?: string,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -90,8 +90,9 @@ export type MarkerTrackConfigLineType = 'bar' | 'line';
 export type MarkerTrackConfigLineHeight = 'small' | 'medium' | 'large';
 export type MarkerTrackConfig = {|
   label: string,
+  tooltip?: string,
   // height of the track in pixels
-  height?: number,
+  height?: MarkerTrackConfigLineHeight,
   lines: Array<{|
     key: string,
     fillColor?: string,

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -319,11 +319,13 @@ export type CollectedCustomMarkerSamples = {|
   +minNumber: number,
   +maxNumber: number,
   // startTime
-  time: Milliseconds[],
+  markers: Marker[],
+  // needed to make this type more sample table like
+  time: number[],
   // This value holds the number per configured line
   // selection. The array will share the indexes of the range filtered marker samples.
   +numbersPerLine: number[][],
-  +indexes: IndexIntoRawMarkerTable[],
+  +indexes: MarkerIndex[],
   length: number,
 |};
 
@@ -350,7 +352,6 @@ export type LocalTrack =
       +type: 'marker',
       +threadIndex: ThreadIndex,
       +markerSchema: MarkerSchema,
-      +markerIndex: MarkerIndex,
     |};
 
 export type Track = GlobalTrack | LocalTrack;

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -350,6 +350,7 @@ export type LocalTrack =
       +type: 'marker',
       +threadIndex: ThreadIndex,
       +markerSchema: MarkerSchema,
+      +markerIndex: MarkerIndex,
     |};
 
 export type Track = GlobalTrack | LocalTrack;

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -318,7 +318,6 @@ export type AccumulatedCounterSamples = {|
 export type CollectedCustomMarkerSamples = {|
   +minNumber: number,
   +maxNumber: number,
-  +numberRange: number,
   // startTime
   time: Milliseconds[],
   // This value holds the number per configured line

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -4,7 +4,7 @@
 
 // @flow
 import type { Milliseconds, StartEndRange, Address } from './units';
-import type { MarkerPayload } from './markers';
+import type { MarkerPayload, MarkerSchema } from './markers';
 import type {
   IndexIntoFuncTable,
   ThreadIndex,
@@ -312,6 +312,22 @@ export type AccumulatedCounterSamples = {|
   +accumulatedCounts: number[],
 |};
 
+/**
+ * A collection of the data for all configured lines for a given marker
+ */
+export type CollectedCustomMarkerSamples = {|
+  +minNumber: number,
+  +maxNumber: number,
+  +numberRange: number,
+  // startTime
+  time: Milliseconds[],
+  // This value holds the number per configured line
+  // selection. The array will share the indexes of the range filtered marker samples.
+  +numbersPerLine: number[][],
+  +indexes: IndexIntoRawMarkerTable[],
+  length: number,
+|};
+
 export type StackType = 'js' | 'native' | 'unsymbolicated';
 
 export type GlobalTrack =
@@ -330,7 +346,12 @@ export type LocalTrack =
   | {| +type: 'ipc', +threadIndex: ThreadIndex |}
   | {| +type: 'event-delay', +threadIndex: ThreadIndex |}
   | {| +type: 'process-cpu', +counterIndex: CounterIndex |}
-  | {| +type: 'power', +counterIndex: CounterIndex |};
+  | {| +type: 'power', +counterIndex: CounterIndex |}
+  | {|
+      +type: 'marker',
+      +threadIndex: ThreadIndex,
+      +markerSchema: MarkerSchema,
+    |};
 
 export type Track = GlobalTrack | LocalTrack;
 


### PR DESCRIPTION
Support to show local tracks that are specific to a marker. The behavior (and the different lines in the track) can be configured via a `trackConfig` field the MarkerSchema of every markers. This allows the simple creation of addition tracks without altering the profiler UI itself. This is especially important for imported profiles.

An example can be seen in the following (which constitutes a real use case in my application):

![image](https://user-images.githubusercontent.com/490655/185914194-12aa5f86-8a02-47da-9ab8-b09a7c07e984.png)

The "GC Pauses" tracks is based on the "jdk.GarbageCollection" marker payload and configured as follows:

```json
"trackConfig": {
    "label": "GC Pauses",   // label of the track
    "lines": [
        {
            "key": "longestPause",  // key in the payload to use
            "type": "bar"       // bar charts and line charts are supported
        }
    ],
    "isPreSelected": true // select this local track by default
}
```

The "JVM CPU Usage" track is configured in a similar fashion:

```json
"trackConfig": {
    "label": "JVM CPU Usage",
    "lines": [   // multiple lines are supported
        {
            "key": "jvmUser",
            "type": "line"
        },
        {
            "key": "jvmSystem",
            "strokeColor": "green", // the default color is orange
            "type": "line"
        }
    ],
    "isPreSelected": true
}
```

[Sample profile](https://github.com/firefox-devtools/profiler/files/9394118/JVM.Application.on.OpenJDK.64-Bit.Server.VM.OpenJDK.64-Bit.Server.VM.2075-02-18.02.55.profile.json.3.gz)

[Deploy preview](https://deploy-preview-4198--perf-html.netlify.app/public/p4yw5twhpgkfzymjsw6h072a6b8yk2nywgn9f3g/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=57651-1w8&thread=0&v=7)


