### PR TITLE
Update Yarn install docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ We're friendly and we're on the [Mozilla Matrix instance](https://chat.mozilla.o
 
 You will need a recent enough version of [Yarn 1 (Classic)](https://classic.yarnpkg.com/),
 version 1.10 is known to work correctly.
-You can install it using `npm install -g yarn`.
+You can install it using `npm install -g yarn`. Please refer to [its documentation](https://classic.yarnpkg.com/en/docs/install) for other possible install procedures.
 
 To get started clone the repo and get the web application started.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,16 +31,9 @@ We're friendly and we're on the [Mozilla Matrix instance](https://chat.mozilla.o
 
 [profiler.firefox.com](https://profiler.firefox.com) is a web application that loads in performance profiles for analysis. The profiles are loaded in from a variety of sources including directly imported from Firefox, online storage, and from local files.
 
-You will need a recent enough version of [Yarn](http://yarnpkg.com/),
-version 1.0.1 is known to work correctly.
-You can install it into your home directory on Linux and probably OS X with:
-
-```bash
-cd /tmp
-wget https://yarnpkg.com/install.sh
-chmod a+x install.sh
-./install.sh
-```
+You will need a recent enough version of [Yarn 1 (Classic)](https://classic.yarnpkg.com/),
+version 1.10 is known to work correctly.
+You can install it using `npm install -g yarn`.
 
 To get started clone the repo and get the web application started.
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,9 @@ If you would like to help us test on other assistive technologies or improve the
 
 ### Development
 
-You will need a recent enough version of [Yarn](http://yarnpkg.com/),
+You will need a recent enough version of [Yarn 1 (Classic)](https://classic.yarnpkg.com/),
 version 1.10 is known to work correctly.
-You can install it into your home directory on Linux and probably OS X with:
-
-```bash
-cd /tmp
-wget https://yarnpkg.com/install.sh
-chmod a+x install.sh
-./install.sh
-```
+You can install it using `npm install -g yarn`.
 
 To download and build the Firefox Profiler web app run:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you would like to help us test on other assistive technologies or improve the
 
 You will need a recent enough version of [Yarn 1 (Classic)](https://classic.yarnpkg.com/),
 version 1.10 is known to work correctly.
-You can install it using `npm install -g yarn`.
+You can install it using `npm install -g yarn`. Please refer to [its documentation](https://classic.yarnpkg.com/en/docs/install) for other possible install procedures.
 
 To download and build the Firefox Profiler web app run:
 


### PR DESCRIPTION
After finding out that Yarn 3.2.3 modifies the yarn lockfile on `yarn install`, this pr highlights that Yarn 1 should be used instead for development, and also states the [recommended installation procedure](https://classic.yarnpkg.com/en/docs/install).