### PR TITLE
Improve the CSS of the Treeview shared component

### DIFF
--- a/src/components/calltree/CallTree.css
+++ b/src/components/calltree/CallTree.css
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.treeViewHeaderColumn.total,
+.treeViewHeaderColumn.self {
+  text-align: right;
+}
+
+.treeViewFixedColumn.total {
+  left: 0;
+  width: 70px;
+}
+
+.treeViewFixedColumn.totalPercent {
+  left: 70px;
+  width: 50px;
+  border-right: none;
+}
+
+.treeViewFixedColumn.self {
+  left: 120px;
+  width: 70px;
+}
+
+.treeViewHeaderColumn.total {
+  width: 120px;
+}
+
+.treeViewFixedColumn.icon {
+  left: 190px;
+  display: flex;
+  width: 19px;
+  flex-flow: column nowrap;
+  align-items: center;
+}
+
+.treeViewRowColumn.total,
+.treeViewRowColumn.totalPercent,
+.treeViewRowColumn.self,
+.treeViewRowColumn.timestamp {
+  padding-right: 5px;
+  text-align: right;
+}
+
+.treeBadge.inlined,
+.treeBadge.divergent-inlining {
+  background: url(../../../res/img/svg/inlined-icon.svg);
+}

--- a/src/components/calltree/CallTree.css
+++ b/src/components/calltree/CallTree.css
@@ -8,27 +8,29 @@
 }
 
 .treeViewFixedColumn.total {
-  left: 0;
   width: 70px;
 }
 
-.treeViewFixedColumn.totalPercent {
-  left: 70px;
-  width: 50px;
-  border-right: none;
-}
-
-.treeViewFixedColumn.self {
-  left: 120px;
-  width: 70px;
-}
-
+/* The header for the total column spans both totalPercent and total columns */
 .treeViewHeaderColumn.total {
   width: 120px;
 }
 
+.treeViewFixedColumn.totalPercent {
+  width: 50px;
+  border-right: none;
+}
+
+/* The header for the totalPercent column is not visible */
+.treeViewHeaderColumn.totalPercent {
+  display: none;
+}
+
+.treeViewFixedColumn.self {
+  width: 70px;
+}
+
 .treeViewFixedColumn.icon {
-  left: 190px;
   display: flex;
   width: 19px;
   flex-flow: column nowrap;

--- a/src/components/calltree/CallTree.css
+++ b/src/components/calltree/CallTree.css
@@ -41,7 +41,6 @@
 .treeViewRowColumn.totalPercent,
 .treeViewRowColumn.self,
 .treeViewRowColumn.timestamp {
-  padding-right: 5px;
   text-align: right;
 }
 

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -46,6 +46,8 @@ import type { CallTree as CallTreeType } from 'firefox-profiler/profile-logic/ca
 import type { Column } from 'firefox-profiler/components/shared/TreeView';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
+import './CallTree.css';
+
 type StateProps = {|
   +threadsKey: ThreadsKey,
   +scrollToSelectionGeneration: number,

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -30,6 +30,11 @@
   width: 80px;
 }
 
+.treeViewRowColumn.type {
+  padding-left: 5px;
+  text-align: left;
+}
+
 .treeViewMainColumn.name {
   left: 255px;
 }

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -11,30 +11,27 @@
 }
 
 .treeViewFixedColumn.start {
-  left: 0;
   width: 80px;
   padding-right: 5px;
   text-align: right;
 }
 
 .treeViewFixedColumn.duration {
-  left: 80px;
   width: 80px;
   padding-right: 5px;
   border-right: none;
   text-align: right;
 }
 
+.treeViewHeaderColumn.name {
+  padding-left: 20px;
+}
+
 .treeViewFixedColumn.type {
-  left: 160px;
   width: 80px;
 }
 
 .treeViewRowColumn.type {
   padding-left: 5px;
   text-align: left;
-}
-
-.treeViewMainColumn.name {
-  left: 255px;
 }

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -25,7 +25,7 @@
 }
 
 .treeViewFixedColumn.type {
-  width: 80px;
+  width: 100px;
 }
 
 .treeViewRowColumn.type {

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -12,18 +12,16 @@
 
 .treeViewFixedColumn.start {
   width: 80px;
-  padding-right: 5px;
   text-align: right;
 }
 
 .treeViewFixedColumn.duration {
   width: 80px;
-  padding-right: 5px;
   text-align: right;
 }
 
 .treeViewHeaderColumn.name {
-  padding-left: 20px;
+  padding: 0 20px;
 }
 
 .treeViewFixedColumn.type {
@@ -31,6 +29,5 @@
 }
 
 .treeViewRowColumn.type {
-  padding-left: 5px;
   text-align: left;
 }

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -19,7 +19,6 @@
 .treeViewFixedColumn.duration {
   width: 80px;
   padding-right: 5px;
-  border-right: none;
   text-align: right;
 }
 

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -85,6 +85,7 @@
 
 .treeViewFixedColumn {
   overflow: hidden;
+  padding: 0 5px;
   text-overflow: ellipsis;
 }
 

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -11,9 +11,20 @@
   user-select: none;
 }
 
+.treeViewRow,
 .treeViewHeader {
-  position: relative;
-  height: 16px;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  white-space: nowrap;
+}
+
+.treeViewRowScrolledColumns {
+  align-items: center;
+}
+
+.treeViewHeader {
+  height: 17px;
   padding: 1px 0;
   border-bottom: 1px solid var(--grey-30);
   background: white;
@@ -64,22 +75,17 @@
   background: white;
 }
 
-.treeViewRow {
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  justify-content: flex-start;
-  white-space: nowrap;
-}
-
 .treeViewHeaderColumn {
-  position: absolute;
-  top: 0;
-  bottom: 0;
+  position: relative;
   box-sizing: border-box;
   padding: 1px 5px;
   line-height: 15px;
   white-space: nowrap;
+}
+
+.treeViewFixedColumn {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .treeViewHeaderColumn.treeViewFixedColumn::after {
@@ -93,10 +99,8 @@
 }
 
 .treeViewRowColumn.treeViewFixedColumn {
-  overflow: hidden;
   box-sizing: border-box;
   border-right: 1px solid var(--grey-30);
-  text-overflow: ellipsis;
 }
 
 .treeBadge {

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -24,8 +24,8 @@
 }
 
 .treeViewHeader {
-  height: 17px;
-  padding: 1px 0;
+  height: 15px;
+  padding: 4px 0;
   border-bottom: 1px solid var(--grey-30);
   background: white;
 }
@@ -78,7 +78,7 @@
 .treeViewHeaderColumn {
   position: relative;
   box-sizing: border-box;
-  padding: 1px 5px;
+  padding: 0 5px;
   line-height: 15px;
   white-space: nowrap;
 }
@@ -88,14 +88,8 @@
   text-overflow: ellipsis;
 }
 
-.treeViewHeaderColumn.treeViewFixedColumn::after {
-  position: absolute;
-  top: 3px;
-  right: 0;
-  bottom: 3px;
-  width: 1px;
-  background: #e5e5e5;
-  content: '';
+.treeViewHeaderColumn.treeViewFixedColumn {
+  border-right: 1px solid #e2e2e2;
 }
 
 .treeViewRowColumn.treeViewFixedColumn {

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -90,6 +90,10 @@
 }
 
 .treeViewHeaderColumn.treeViewFixedColumn {
+  /* The fixed columns in the row don't shrink because they're positioning using
+   * position: sticky, therefore we prevent shrinking for the columns in the
+   * header too. */
+  flex: none;
   border-right: 1px solid #e2e2e2;
 }
 

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -92,57 +92,11 @@
   content: '';
 }
 
-.treeViewHeaderColumn.total,
-.treeViewHeaderColumn.self {
-  text-align: right;
-}
-
 .treeViewRowColumn.treeViewFixedColumn {
   overflow: hidden;
   box-sizing: border-box;
   border-right: 1px solid var(--grey-30);
   text-overflow: ellipsis;
-}
-
-.treeViewFixedColumn.total {
-  left: 0;
-  width: 70px;
-}
-
-.treeViewFixedColumn.totalPercent {
-  left: 70px;
-  width: 50px;
-  border-right: none;
-}
-
-.treeViewFixedColumn.self {
-  left: 120px;
-  width: 70px;
-}
-
-.treeViewHeaderColumn.total {
-  width: 120px;
-}
-
-.treeViewFixedColumn.icon {
-  left: 190px;
-  display: flex;
-  width: 19px;
-  flex-flow: column nowrap;
-  align-items: center;
-}
-
-.treeViewRowColumn.total,
-.treeViewRowColumn.totalPercent,
-.treeViewRowColumn.self,
-.treeViewRowColumn.timestamp {
-  padding-right: 5px;
-  text-align: right;
-}
-
-.treeViewRowColumn.type {
-  padding-left: 5px;
-  text-align: left;
 }
 
 .treeBadge {
@@ -153,11 +107,6 @@
   margin-right: 2px;
   color: transparent;
   vertical-align: -2px;
-}
-
-.treeBadge.inlined,
-.treeBadge.divergent-inlining {
-  background: url(../../../res/img/svg/inlined-icon.svg);
 }
 
 .treeRowIndentSpacer {


### PR DESCRIPTION
There are 5 commits here:
1. This moves some component-specific CSS (for either the call tree or the marker table) to separate CSS files. This doesn't make any change to the content.
2. This makes the header `display: flex` and fixes a few issues related to that change.
3. This changes how the border is implemented -- as a result it's also less blurry when zooming the page (because the browser rounds non-integer border widths, but not non-integer node widths), and also now the duration column in the marker table has a column.
4. This makes the padding RTL friendly.
5. This increases the width of the marker table's duration column.

Other than that there should be no visible change.

You'll want to look at this commit by commit, especially that some of my inline comments don't appear in the merged view because of the first commit.

[Deploy preview](https://deploy-preview-4225--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/?globalTrackOrder=de0wc&hiddenGlobalTracks=12&hiddenLocalTracksByPid=29495-1w6~5123-0~29556-0~21926-0&thread=0&v=7)