### PR TITLE
Add nativeSymbols functionSize column.

### DIFF
--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -10,7 +10,7 @@ import type { MarkerPhase } from 'firefox-profiler/types';
 export const GECKO_PROFILE_VERSION = 25;
 
 // The current version of the "processed" profile format.
-export const PROCESSED_PROFILE_VERSION = 41;
+export const PROCESSED_PROFILE_VERSION = 42;
 
 // The following are the margin sizes for the left and right of the timeline. Independent
 // components need to share these values.

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -172,6 +172,7 @@ export function shallowCloneNativeSymbolTable(
     libIndex: nativeSymbols.libIndex.slice(),
     address: nativeSymbols.address.slice(),
     name: nativeSymbols.name.slice(),
+    functionSize: nativeSymbols.functionSize.slice(),
     length: nativeSymbols.length,
   };
 }
@@ -199,6 +200,7 @@ export function getEmptyNativeSymbolTable(): NativeSymbolTable {
     libIndex: [],
     address: [],
     name: [],
+    functionSize: [],
     length: 0,
   };
 }

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -561,6 +561,7 @@ function combineNativeSymbolTables(
       const nameIndex = nativeSymbols.name[i];
       const newName = stringTable.getString(nameIndex);
       const address = nativeSymbols.address[i];
+      const functionSize = nativeSymbols.functionSize[i];
 
       // Duplicate search.
       const nativeSymbolKey = [newName, address].join('#');
@@ -577,6 +578,7 @@ function combineNativeSymbolTables(
       newNativeSymbols.libIndex.push(libIndex);
       newNativeSymbols.name.push(newStringTable.indexForString(newName));
       newNativeSymbols.address.push(address);
+      newNativeSymbols.functionSize.push(functionSize);
 
       newNativeSymbols.length++;
     }

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2130,5 +2130,13 @@ const _upgraders = {
     }
     profile.libs = libs;
   },
+  [42]: (profile) => {
+    // The nativeSymbols table now has a new column: functionSize.
+    // Its values can be null.
+    for (const thread of profile.threads) {
+      const { nativeSymbols } = thread;
+      nativeSymbols.functionSize = Array(nativeSymbols.length).fill(null);
+    }
+  },
 };
 /* eslint-enable no-useless-computed-key */

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -946,6 +946,7 @@ function _buildThreadFromTextOnlyStacks(
           nativeSymbols.libIndex.push(libIndex);
           nativeSymbols.address.push(0); // todo
           nativeSymbols.name.push(nativeSymbolNameStringIndex);
+          nativeSymbols.functionSize.push(null);
         } else {
           throw new Error(
             `[sym:] has to be used together with [lib:] - missing lib in "${funcNameWithModifier}"`

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -402,7 +402,7 @@ Object {
     "oscpu": "",
     "physicalCPUs": 0,
     "platform": "",
-    "preprocessedProfileVersion": 41,
+    "preprocessedProfileVersion": 42,
     "processType": 0,
     "product": "Firefox",
     "sourceURL": "",
@@ -638,6 +638,7 @@ Object {
       "name": "Thread with samples",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -1048,6 +1049,7 @@ Object {
       "name": "Thread with markers",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -1328,6 +1330,7 @@ Array [
     "name": "Thread with samples",
     "nativeSymbols": Object {
       "address": Array [],
+      "functionSize": Array [],
       "length": 0,
       "libIndex": Array [],
       "name": Array [],
@@ -1738,6 +1741,7 @@ Array [
     "name": "Thread with markers",
     "nativeSymbols": Object {
       "address": Array [],
+      "functionSize": Array [],
       "length": 0,
       "libIndex": Array [],
       "name": Array [],
@@ -2579,6 +2583,7 @@ CallTree {
   "_jsOnly": false,
   "_nativeSymbols": Object {
     "address": Array [],
+    "functionSize": Array [],
     "length": 0,
     "libIndex": Array [],
     "name": Array [],
@@ -2838,6 +2843,7 @@ Object {
   "name": "Thread with samples",
   "nativeSymbols": Object {
     "address": Array [],
+    "functionSize": Array [],
     "length": 0,
     "libIndex": Array [],
     "name": Array [],
@@ -3248,6 +3254,7 @@ Object {
   "name": "Thread with samples",
   "nativeSymbols": Object {
     "address": Array [],
+    "functionSize": Array [],
     "length": 0,
     "libIndex": Array [],
     "name": Array [],
@@ -3572,6 +3579,7 @@ Object {
   "name": "Thread with samples",
   "nativeSymbols": Object {
     "address": Array [],
+    "functionSize": Array [],
     "length": 0,
     "libIndex": Array [],
     "name": Array [],
@@ -3902,6 +3910,7 @@ Object {
   "name": "Thread with samples",
   "nativeSymbols": Object {
     "address": Array [],
+    "functionSize": Array [],
     "length": 0,
     "libIndex": Array [],
     "name": Array [],
@@ -4236,6 +4245,7 @@ Object {
   "name": "Thread with samples",
   "nativeSymbols": Object {
     "address": Array [],
+    "functionSize": Array [],
     "length": 0,
     "libIndex": Array [],
     "name": Array [],

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -39,7 +39,7 @@ Object {
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,
-    "preprocessedProfileVersion": 41,
+    "preprocessedProfileVersion": 42,
     "processType": 0,
     "product": "Firefox",
     "sampleUnits": undefined,
@@ -257,6 +257,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -546,6 +547,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -763,6 +765,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -1178,6 +1181,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -1526,6 +1530,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -1831,6 +1836,7 @@ Object {
       "name": "gdbus",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -2093,6 +2099,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -2296,6 +2303,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -2511,6 +2519,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -2730,6 +2739,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -2963,6 +2973,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -3742,6 +3753,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -4731,6 +4743,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -5720,6 +5733,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -6713,6 +6727,7 @@ Object {
       "name": "firefox",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -7490,6 +7505,7 @@ Object {
       "name": "FS Broker 5906",
       "nativeSymbols": Object {
         "address": Array [],
+        "functionSize": Array [],
         "length": 0,
         "libIndex": Array [],
         "name": Array [],
@@ -11126,7 +11142,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 41,
+    "preprocessedProfileVersion": 42,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -11393,6 +11409,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -11801,6 +11821,10 @@ Object {
           3972,
           6725,
         ],
+        "functionSize": Array [
+          null,
+          null,
+        ],
         "length": 2,
         "libIndex": Array [
           0,
@@ -12207,6 +12231,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -12773,7 +12801,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 41,
+    "preprocessedProfileVersion": 42,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -13064,6 +13092,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -13474,6 +13506,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -13942,6 +13978,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -14570,7 +14610,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 41,
+    "preprocessedProfileVersion": 42,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -14899,6 +14939,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -15312,6 +15356,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [
@@ -15782,6 +15830,10 @@ Object {
         "address": Array [
           3972,
           6725,
+        ],
+        "functionSize": Array [
+          null,
+          null,
         ],
         "length": 2,
         "libIndex": Array [

--- a/src/test/unit/merge-compare.test.js
+++ b/src/test/unit/merge-compare.test.js
@@ -190,6 +190,7 @@ describe('mergeProfilesForDiffing function', function () {
       ],
       address: [0x20, 0x50],
       libIndex: [0, 0],
+      functionSize: [null, null],
     };
 
     threadB.nativeSymbols = {
@@ -200,6 +201,7 @@ describe('mergeProfilesForDiffing function', function () {
       ],
       address: [0x25, 0x45],
       libIndex: [0, 0],
+      functionSize: [null, null],
     };
 
     const profileState = stateFromLocation({

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -90,10 +90,12 @@ describe('SymbolStore', function () {
     expect(secondAndThirdSymbol.get(0xf01)).toEqual({
       name: 'second symbol',
       symbolAddress: 0xf00,
+      functionSize: 0xb00,
     });
     expect(secondAndThirdSymbol.get(0x1a50)).toEqual({
       name: 'third symbol',
       symbolAddress: 0x1a00,
+      functionSize: 0x600,
     });
 
     const lib2 = { debugName: 'firefox2', breakpadId: 'dont-care2' };
@@ -113,6 +115,7 @@ describe('SymbolStore', function () {
     expect(firstAndLastSymbol.get(0x33)).toEqual({
       name: 'first symbol',
       symbolAddress: 0,
+      functionSize: 0xf00,
     });
     expect(firstAndLastSymbol.get(0x2000)).toEqual({
       name: 'last symbol',
@@ -289,6 +292,7 @@ describe('SymbolStore', function () {
     expect(lib2Symbols.get(0x33)).toEqual({
       name: 'first symbol',
       symbolAddress: 0,
+      functionSize: 0xf00,
     });
     expect(lib2Symbols.get(0x2000)).toEqual({
       name: 'last symbol',

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -399,10 +399,8 @@ export type NativeSymbolTable = {|
   address: Array<Address>,
   // The symbol name, demangled.
   name: Array<IndexIntoStringTable>,
-
-  // This would be a good spot for a "size" field. But the symbolication API does
-  // not give us information about the size of a function.
-  // https://github.com/mstange/profiler-get-symbols/issues/17
+  // The size of the function's machine code (if known), in bytes.
+  functionSize: Array<Bytes | null>,
 
   length: number,
 |};


### PR DESCRIPTION
In order to know how much assembly code to display for a native symbol in the assembly view, we need to know how large the function is, i.e. how many bytes of machine code in contains.

In the assembly view we want to display the entire function, not just the assembly code up until the highest instruction address that we've seen for that function.

The symbolication API now gives us this information, as of https://github.com/mstange/profiler-get-symbols/commit/e8649bf0cf571cfc4844a9ae7f29e61f79afbe65 . So we can have this information for local builds and when using samply. The Mozilla symbolication API does not return this information yet, so we need to support "null" values with some kind of fallback.

This commit gets the information from the symbolication result, if present, and forwards it into the nativeSymbols table. We also bump the processed profile version and add an upgrader.