### PR TITLE
Implement Method Table view

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -712,6 +712,7 @@ StackSettings--panel-search =
 ## Tab Bar for the bottom half of the analysis UI.
 
 TabBar--calltree-tab = Call Tree
+TabBar--function-table-tab = Function Table
 TabBar--flame-graph-tab = Flame Graph
 TabBar--stack-chart-tab = Stack Chart
 TabBar--marker-chart-tab = Marker Chart

--- a/res/css/style.css
+++ b/res/css/style.css
@@ -44,7 +44,8 @@ body {
   flex-shrink: 1;
 }
 
-.treeAndSidebarWrapper {
+.treeAndSidebarWrapper,
+.functionTableAndSidebarWrapper {
   display: flex;
   flex: 1;
   flex-flow: column nowrap;

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -122,6 +122,24 @@ export function changeSelectedCallNode(
 }
 
 /**
+ * Select a call node for a given thread for the method table.
+ *
+ * Uses the last function index in selectedCallNodePath as the selected function.
+ * Ignores the third argument (it's just for compatibility with changeSelectedCallNode)
+ */
+export function changeSelectedFunctionTableCallNode(
+  threadsKey: ThreadsKey,
+  selectedCallNodePath: CallNodePath,
+  _?: CallNodePath
+): Action {
+  return {
+    type: 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,',
+    selectedFunction: selectedCallNodePath[selectedCallNodePath.length - 1],
+    threadsKey,
+  };
+}
+
+/**
  * This action is used when the user right clicks on a call node (in panels such
  * as the call tree, the flame chart, or the stack chart). It's especially used
  * to display the context menu.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -133,7 +133,7 @@ export function changeSelectedFunctionTableCallNode(
   _?: CallNodePath
 ): Action {
   return {
-    type: 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,',
+    type: 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE',
     selectedFunction: selectedCallNodePath[selectedCallNodePath.length - 1],
     threadsKey,
   };

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -11,6 +11,7 @@
  */
 export const tabsWithTitleL10nId = {
   calltree: 'TabBar--calltree-tab',
+  'function-table': 'TabBar--function-table-tab',
   'flame-graph': 'TabBar--flame-graph-tab',
   'stack-chart': 'TabBar--stack-chart-tab',
   'marker-chart': 'TabBar--marker-chart-tab',
@@ -43,6 +44,7 @@ export const tabsWithTitleL10nIdArray: $ReadOnlyArray<TabsWithTitleL10nId> =
 
 export const tabsShowingSampleData: $ReadOnlyArray<TabSlug> = [
   'calltree',
+  'function-table',
   'flame-graph',
   'stack-chart',
 ];

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -379,6 +379,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
   switch (selectedTab) {
     case 'stack-chart':
     case 'flame-graph':
+    case 'function-table':
     case 'calltree': {
       if (selectedTab === 'stack-chart') {
         // Stack chart uses all of the CallTree's query strings but also has an

--- a/src/components/app/BottomBox.js
+++ b/src/components/app/BottomBox.js
@@ -10,10 +10,12 @@ import { SourceView } from '../shared/SourceView';
 import {
   getSourceViewFile,
   getSourceViewActivationGeneration,
+  getSelectedTab,
 } from 'firefox-profiler/selectors/url-state';
 import {
   selectedThreadSelectors,
   selectedNodeSelectors,
+  selectedFunctionTableNodeSelectors,
 } from 'firefox-profiler/selectors/per-thread';
 import { closeBottomBox } from 'firefox-profiler/actions/profile-view';
 import { parseFileNameFromSymbolication } from 'firefox-profiler/utils/special-paths';
@@ -274,7 +276,9 @@ export const BottomBox = explicitConnect<{||}, StateProps, DispatchProps>({
     sourceViewSource: getSourceViewSource(state),
     globalLineTimings: selectedThreadSelectors.getSourceViewLineTimings(state),
     selectedCallNodeLineTimings:
-      selectedNodeSelectors.getSourceViewLineTimings(state),
+      getSelectedTab(state) === 'function-table'
+        ? selectedFunctionTableNodeSelectors.getSourceViewLineTimings(state)
+        : selectedNodeSelectors.getSourceViewLineTimings(state),
     sourceViewActivationGeneration: getSourceViewActivationGeneration(state),
     disableOverscan: getPreviewSelection(state).isModifying,
   }),

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -12,6 +12,7 @@ import explicitConnect from 'firefox-profiler/utils/connect';
 import { TabBar } from './TabBar';
 import { ErrorBoundary } from './ErrorBoundary';
 import { ProfileCallTreeView } from 'firefox-profiler/components/calltree/ProfileCallTreeView';
+import { ProfileFunctionTableView } from 'firefox-profiler/components/calltree/ProfileFunctionTableView';
 import { MarkerTable } from 'firefox-profiler/components/marker-table';
 import { StackChart } from 'firefox-profiler/components/stack-chart/';
 import { MarkerChart } from 'firefox-profiler/components/marker-chart/';
@@ -113,6 +114,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
             {
               {
                 calltree: <ProfileCallTreeView />,
+                'function-table': <ProfileFunctionTableView />,
                 'flame-graph': <FlameGraph />,
                 'stack-chart': <StackChart />,
                 'marker-chart': <MarkerChart />,

--- a/src/components/calltree/ProfileFunctionTableView.js
+++ b/src/components/calltree/ProfileFunctionTableView.js
@@ -14,9 +14,8 @@ import type { CallTree as CallTreeType } from 'firefox-profiler/profile-logic/ca
 import { CallTree } from './CallTree';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import {
+  changeSelectedFunctionTableCallNode,
   changeSelectedCallNode,
-  changeRightClickedCallNode,
-  changeExpandedCallNodes,
 } from 'firefox-profiler/actions/profile-view';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 
@@ -32,22 +31,19 @@ type StateProps = {|
 
 type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
-  +changeRightClickedCallNode: typeof changeRightClickedCallNode,
-  +changeExpandedCallNodes: typeof changeExpandedCallNodes,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
-class ProfileCallTreeViewImpl extends PureComponent<Props> {
+class ProfileFunctionTableViewImpl extends PureComponent<Props> {
   render() {
     return (
       <div
-        className="treeAndSidebarWrapper"
-        id="calltree-tab"
+        className="functionTableAndSidebarWrapper"
         role="tabpanel"
-        aria-labelledby="calltree-tab-button"
+        aria-labelledby="function-table-tab-button"
       >
-        <StackSettings />
+        <StackSettings hideInvertCallstack={true} />
         <TransformNavigator />
         <CallTree {...this.props} />
       </div>
@@ -55,31 +51,30 @@ class ProfileCallTreeViewImpl extends PureComponent<Props> {
   }
 }
 
-export const ProfileCallTreeView = explicitConnect<
+const _emptyExpandedCallNodexIndexes = [];
+
+export const ProfileFunctionTableView = explicitConnect<
   {||},
   StateProps,
   DispatchProps
 >({
   mapStateToProps: (state) => ({
-    tabslug: 'calltree',
-    tree: selectedThreadSelectors.getCallTree(state),
-    callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+    tabslug: 'function-table',
+    tree: selectedThreadSelectors.getFunctionTableCallTree(state),
+    callNodeInfo:
+      selectedThreadSelectors.getFunctionTableCallNodeInfoWithFuncMapping(state)
+        .callNodeInfo,
     selectedCallNodeIndex:
-      selectedThreadSelectors.getSelectedCallNodeIndex(state),
-    rightClickedCallNodeIndex:
-      selectedThreadSelectors.getRightClickedCallNodeIndex(state),
-    expandedCallNodeIndexes:
-      selectedThreadSelectors.getExpandedCallNodeIndexes(state),
-    // Use the filtered call node max depth, rather than the preview filtered call node
-    // max depth so that the width of the TreeView component is stable across preview
-    // selections.
-    callNodeMaxDepth:
-      selectedThreadSelectors.getFilteredCallNodeMaxDepth(state),
+      selectedThreadSelectors.getSelectedFunctionTableCallNodeIndex(state),
+    // right clicking is not supported for now
+    // as most of the transformations do not make sense in this context
+    rightClickedCallNodeIndex: null,
+    // we cannot expand any call nodes
+    expandedCallNodeIndexes: _emptyExpandedCallNodexIndexes,
+    callNodeMaxDepth: 0,
   }),
   mapDispatchToProps: {
-    changeSelectedCallNode,
-    changeRightClickedCallNode,
-    changeExpandedCallNodes,
+    changeSelectedCallNode: changeSelectedFunctionTableCallNode,
   },
-  component: ProfileCallTreeViewImpl,
+  component: ProfileFunctionTableViewImpl,
 });

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -13,6 +13,7 @@ import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
 import {
   selectedThreadSelectors,
   selectedNodeSelectors,
+  selectedFunctionTableNodeSelectors,
 } from 'firefox-profiler/selectors/per-thread';
 import { getSelectedThreadsKey } from 'firefox-profiler/selectors/url-state';
 import { toggleOpenCategoryInSidebar } from 'firefox-profiler/actions/app';
@@ -507,6 +508,28 @@ export const CallTreeSidebar = explicitConnect<{||}, StateProps, {||}>({
     name: getFunctionName(selectedNodeSelectors.getName(state)),
     lib: selectedNodeSelectors.getLib(state),
     timings: selectedNodeSelectors.getTimingsForSidebar(state),
+    categoryList: getCategories(state),
+    weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),
+    tracedTiming: selectedThreadSelectors.getTracedTiming(state),
+  }),
+  component: CallTreeSidebarImpl,
+});
+
+export const FunctionTableCallTreeSidebar = explicitConnect<
+  {||},
+  StateProps,
+  {||}
+>({
+  mapStateToProps: (state) => ({
+    selectedNodeIndex:
+      selectedThreadSelectors.getSelectedFunctionTableCallNodeIndex(state),
+    callNodeTable:
+      selectedThreadSelectors.getFunctionTableCallNodeInfoWithFuncMapping(state)
+        .callNodeInfo.callNodeTable,
+    selectedThreadsKey: getSelectedThreadsKey(state),
+    name: getFunctionName(selectedFunctionTableNodeSelectors.getName(state)),
+    lib: selectedFunctionTableNodeSelectors.getLib(state),
+    timings: selectedFunctionTableNodeSelectors.getTimingsForSidebar(state),
     categoryList: getCategories(state),
     weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),
     tracedTiming: selectedThreadSelectors.getTracedTiming(state),

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -5,7 +5,10 @@
 
 import * as React from 'react';
 
-import { CallTreeSidebar } from './CallTreeSidebar';
+import {
+  CallTreeSidebar,
+  FunctionTableCallTreeSidebar,
+} from './CallTreeSidebar';
 import { MarkerSidebar } from './MarkerSidebar';
 
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
@@ -17,6 +20,7 @@ export function selectSidebar(
 ): React.ComponentType<{||}> | null {
   return {
     calltree: CallTreeSidebar,
+    'function-table': FunctionTableCallTreeSidebar,
     'flame-graph': CallTreeSidebar,
     'stack-chart': null,
     'marker-chart': null,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -895,7 +895,7 @@ export function computeFunctionTableCallTreeCountsAndSummary(
   // Compute the following variables:
   const callNodeTotalSummary = callNodeTotal;
   const callNodeChildCount = new Uint32Array(callNodeTable.length).fill(0);
-  const rootTotalSummary = samples.length;
+  const rootTotalSummary = endIndex - startIndex;
   const rootCount = callNodeTable.length;
 
   return {

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -467,7 +467,7 @@ function _getStackSelf(
  * This computes all of the count and timing information displayed in the calltree.
  * It takes into account both the normal tree, and the inverted tree.
  *
- * Note: The "timionmgs" could have a number of different meanings based on the
+ * Note: The "timings" could have a number of different meanings based on the
  * what type of weight is in the SamplesLikeTable. For instance, it could be
  * milliseconds, sample counts, or bytes.
  */
@@ -628,7 +628,7 @@ type SummarySpecificFuncs<T> = {|
  * The whole sample range is split into slices of equal size.
  * We store for every slice the function list information.
  * The slices are further split recursively into smaller, non overlapping,
- * slides until the slices contain at mosty MAX_SAMPLE_SLICE_NUMBER samples.
+ * slices until the slices contain at mostly MAX_SAMPLE_SLICE_NUMBER samples.
  *
  * Now when we want to get the function list information for a specific range,
  * we combine the information from all tree nodes on the root level
@@ -639,6 +639,8 @@ type SummarySpecificFuncs<T> = {|
  *
  * The information in the tree nodes themselfes is only computed when needed,
  * and then cached.
+ *
+ * It usually contains indexes into the samples of the filtered thread.
  *
  * @param T The type of the information that is stored in the tree nodes,
  *          e.g. the function list information (_SummaryPerFunction).
@@ -868,7 +870,7 @@ const _createSummaryCacheTreeMemoized = memoize(_createSummaryCacheTree, {
  * It does only use the stackTable and the frameTable from the thread, and not the samples table.
  * The samples should include all samples of the whole range of the thread.
  *
- * Note: The "timionmgs" could have a number of different meanings based on the
+ * Note: The "timings" could have a number of different meanings based on the
  * what type of weight is in the SamplesLikeTable. For instance, it could be
  * milliseconds, sample counts, or bytes.
  */

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -140,6 +140,7 @@ const symbolicationStatus: Reducer<SymbolicationStatus> = (
 export const defaultThreadViewOptions = {
   selectedCallNodePath: [],
   expandedCallNodePaths: new PathSet(),
+  selectedFunctionTableFunction: null,
   selectedMarker: null,
   selectedNetworkMarker: null,
 };
@@ -260,6 +261,24 @@ const viewOptionsPerThread: Reducer<ThreadViewOptionsPerThreads> = (
       return _updateThreadViewOptions(state, threadsKey, {
         selectedCallNodePath,
         expandedCallNodePaths,
+      });
+    }
+    case 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,': {
+      const { selectedFunction, threadsKey } = action;
+
+      const threadState = _getThreadViewOptions(state, threadsKey);
+
+      const previousSelectedFunction =
+        threadState.selectedFunctionTableFunction;
+
+      // If the selected function doesn't actually change, let's return the previous
+      // state to avoid rerenders.
+      if (selectedFunction === previousSelectedFunction) {
+        return state;
+      }
+
+      return _updateThreadViewOptions(state, threadsKey, {
+        selectedFunctionTableFunction: selectedFunction,
       });
     }
     case 'CHANGE_INVERT_CALLSTACK': {
@@ -450,6 +469,7 @@ const scrollToSelectionGeneration: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
     case 'CHANGE_SELECTED_CALL_NODE':
+    case 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,':
     case 'CHANGE_SELECTED_THREAD':
     case 'SELECT_TRACK':
     case 'HIDE_GLOBAL_TRACK':

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -263,7 +263,7 @@ const viewOptionsPerThread: Reducer<ThreadViewOptionsPerThreads> = (
         expandedCallNodePaths,
       });
     }
-    case 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,': {
+    case 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE': {
       const { selectedFunction, threadsKey } = action;
 
       const threadState = _getThreadViewOptions(state, threadsKey);
@@ -469,7 +469,7 @@ const scrollToSelectionGeneration: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
     case 'CHANGE_SELECTED_CALL_NODE':
-    case 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,':
+    case 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE':
     case 'CHANGE_SELECTED_THREAD':
     case 'SELECT_TRACK':
     case 'HIDE_GLOBAL_TRACK':

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -303,3 +303,107 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
     getSourceViewLineTimings,
   };
 })();
+
+export const selectedFunctionTableNodeSelectors: NodeSelectors = (() => {
+  const getName: Selector<string> = createSelector(
+    selectedThreadSelectors.getSelectedFunctionTableFunction,
+    selectedThreadSelectors.getFilteredThread,
+    (selectedFunction, { stringTable, funcTable }) => {
+      if (selectedFunction === null) {
+        return '';
+      }
+
+      return stringTable.getString(funcTable.name[selectedFunction]);
+    }
+  );
+
+  const getIsJS: Selector<boolean> = createSelector(
+    selectedThreadSelectors.getSelectedFunctionTableFunction,
+    selectedThreadSelectors.getFilteredThread,
+    (selectedFunction, { funcTable }) => {
+      return selectedFunction !== null && funcTable.isJS[selectedFunction];
+    }
+  );
+
+  const getLib: Selector<string> = createSelector(
+    selectedThreadSelectors.getSelectedFunctionTableFunction,
+    selectedThreadSelectors.getFilteredThread,
+    (selectedFunction, { stringTable, funcTable, resourceTable }) => {
+      if (selectedFunction === null) {
+        return '';
+      }
+
+      return ProfileData.getOriginAnnotationForFunc(
+        selectedFunction,
+        funcTable,
+        resourceTable,
+        stringTable
+      );
+    }
+  );
+
+  const getTimingsForSidebar: Selector<TimingsForPath> = createSelector(
+    selectedThreadSelectors.getSelectedFunctionTableFunction,
+    selectedThreadSelectors.getFunctionTableCallNodeInfoWithFuncMapping,
+    ProfileSelectors.getProfileInterval,
+    selectedThreadSelectors.getPreviewFilteredThread,
+    selectedThreadSelectors.getThread,
+    selectedThreadSelectors.getSampleIndexOffsetFromPreviewRange,
+    ProfileSelectors.getCategories,
+    selectedThreadSelectors.getPreviewFilteredSamplesForCallTree,
+    selectedThreadSelectors.getUnfilteredSamplesForCallTree,
+    ProfileSelectors.getProfileUsesFrameImplementation,
+    ProfileData.getTimingsForFunction
+  );
+
+  const getSourceViewStackLineInfo: Selector<StackLineInfo | null> =
+    createSelector(
+      selectedThreadSelectors.getFilteredThread,
+      UrlState.getSourceViewFile,
+      selectedThreadSelectors.getCallNodeInfo,
+      selectedThreadSelectors.getSelectedCallNodeIndex,
+      UrlState.getInvertCallstack,
+      (
+        { stackTable, frameTable, funcTable, stringTable }: Thread,
+        sourceViewFile,
+        callNodeInfo,
+        selectedCallNodeIndex,
+        invertCallStack
+      ): StackLineInfo | null => {
+        if (sourceViewFile === null || selectedCallNodeIndex === null) {
+          return null;
+        }
+        const selectedFunc =
+          callNodeInfo.callNodeTable.func[selectedCallNodeIndex];
+        const selectedFuncFile = funcTable.fileName[selectedFunc];
+        if (
+          selectedFuncFile === null ||
+          stringTable.getString(selectedFuncFile) !== sourceViewFile
+        ) {
+          return null;
+        }
+        return getStackLineInfoForCallNode(
+          stackTable,
+          frameTable,
+          selectedCallNodeIndex,
+          callNodeInfo,
+          invertCallStack
+        );
+      }
+    );
+
+  const getSourceViewLineTimings: Selector<LineTimings> = createSelector(
+    getSourceViewStackLineInfo,
+    selectedThreadSelectors.getPreviewFilteredSamplesForCallTree,
+    getLineTimings
+  );
+
+  return {
+    getName,
+    getIsJS,
+    getLib,
+    getTimingsForSidebar,
+    getSourceViewStackLineInfo,
+    getSourceViewLineTimings,
+  };
+})();

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -316,7 +316,6 @@ export function getStackAndSampleSelectorsPerThread(
 
   const getFunctionTableCallTreeCountsAndSummary: Selector<CallTree.CallTreeCountsAndSummary> =
     createSelector(
-      //threadSelectors.getPreviewFilteredThread,
       threadSelectors.getFilteredThread,
       ProfileSelectors.getPreviewSelection,
       threadSelectors.getFilteredSamplesForCallTree,

--- a/src/test/components/Details.test.js
+++ b/src/test/components/Details.test.js
@@ -22,6 +22,9 @@ import type { TabSlug } from '../../app-logic/tabs-handling';
 jest.mock('../../components/calltree/ProfileCallTreeView', () => ({
   ProfileCallTreeView: 'call-tree',
 }));
+jest.mock('../../components/calltree/ProfileFunctionTableView', () => ({
+  ProfileFunctionTableView: 'function-table',
+}));
 jest.mock('../../components/flame-graph', () => ({
   FlameGraph: 'flame-graph',
 }));
@@ -71,7 +74,12 @@ describe('app/Details', function () {
       const { container, store } = setup();
       store.dispatch(changeSelectedTab(tabSlug));
       // The call tree has a special handling, see the comment above for more information.
-      const expectedCustomName = tabSlug === 'calltree' ? 'call-tree' : tabSlug;
+      const table = {
+        calltree: 'call-tree',
+        'function-table': 'function-table',
+      };
+      const expectedCustomName =
+        tabSlug in table ? table[(tabSlug: string)] : tabSlug;
       expect(container.querySelector(expectedCustomName)).toBeTruthy();
     });
   });

--- a/src/test/components/DetailsContainer.test.js
+++ b/src/test/components/DetailsContainer.test.js
@@ -39,6 +39,7 @@ describe('app/DetailsContainer', function () {
 
   const expectedSidebar: { [TabSlug]: boolean } = {
     calltree: true,
+    'function-table': true,
     'flame-graph': true,
     'stack-chart': false,
     'marker-chart': false,

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -146,9 +146,9 @@ describe('TooltipCallNode', function () {
         iframeUrl,
       });
 
+      expect(container).toMatchSnapshot();
       expect(getByText(iframeUrl)).toBeInTheDocument();
       expect(getByText(pageUrl)).toBeInTheDocument();
-      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('displays the private browsing information', () => {

--- a/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
@@ -73,69 +73,71 @@ exports[`TooltipCallNode handles native allocations 1`] = `
 `;
 
 exports[`TooltipCallNode with page information displays Page URL for iframe pages 1`] = `
-<div
-  class="tooltipCallNode"
-  style="--graph-width: 150px; --graph-height: 10px;"
->
+<div>
   <div
-    class="tooltipOneLine tooltipHeader"
+    class="tooltipCallNode"
+    style="--graph-width: 150px; --graph-height: 10px;"
   >
     <div
-      class="tooltipTiming"
+      class="tooltipOneLine tooltipHeader"
     >
-      Fake Duration Text
+      <div
+        class="tooltipTiming"
+      >
+        Fake Duration Text
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        Cjs
+      </div>
+      <div
+        class="tooltipIcon"
+      />
     </div>
     <div
-      class="tooltipTitle"
-    >
-      Cjs
-    </div>
-    <div
-      class="tooltipIcon"
-    />
-  </div>
-  <div
-    class="tooltipCallNodeDetails"
-  >
-    <div
-      class="tooltipDetails tooltipCallNodeDetailsLeft"
+      class="tooltipCallNodeDetails"
     >
       <div
-        class="tooltipLabel"
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
       >
-        Stack Type:
-      </div>
-      <div>
-        JavaScript
-      </div>
-      <div
-        class="tooltipLabel"
-      >
-        Category:
-      </div>
-      <div>
-        <span
-          class="colored-square category-color-yellow"
-        />
-        JavaScript
-      </div>
-      <div
-        class="tooltipLabel"
-      >
-        iframe URL:
-      </div>
-      <div
-        class="tooltipDetailsUrl"
-      >
-        https://iframe.example.com/
-      </div>
-      <div
-        class="tooltipLabel"
-      >
-        Page URL:
-      </div>
-      <div>
-        https://developer.mozilla.org/en-US/
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          JavaScript
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-yellow"
+          />
+          JavaScript
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          iframe URL:
+        </div>
+        <div
+          class="tooltipDetailsUrl"
+        >
+          https://iframe.example.com/
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Page URL:
+        </div>
+        <div>
+          https://developer.mozilla.org/en-US/
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -4565,6 +4565,7 @@ Object {
     0,
     1,
   ],
+  "selectedFunctionTableFunction": null,
   "selectedMarker": 1,
   "selectedNetworkMarker": null,
 }

--- a/src/test/store/useful-tabs.test.js
+++ b/src/test/store/useful-tabs.test.js
@@ -23,6 +23,7 @@ describe('getUsefulTabs', function () {
     const { getState } = storeWithProfile(profile);
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',
+      'function-table',
       'flame-graph',
       'stack-chart',
       'marker-chart',
@@ -55,6 +56,7 @@ describe('getUsefulTabs', function () {
     const { getState, dispatch } = storeWithProfile(profile);
     expect(selectedThreadSelectors.getUsefulTabs(getState())).toEqual([
       'calltree',
+      'function-table',
       'flame-graph',
       'stack-chart',
       'marker-chart',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -188,7 +188,7 @@ type ProfileAction =
       +optionalExpandedToCallNodePath: ?CallNodePath,
     |}
   | {|
-      +type: 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,',
+      +type: 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE',
       +threadsKey: ThreadsKey,
       +selectedFunction: IndexIntoFuncTable,
     |}

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -40,6 +40,7 @@ import type {
 } from './state';
 import type { CssPixels, StartEndRange, Milliseconds } from './units';
 import type { BrowserConnectionStatus } from '../app-logic/browser-connection';
+import type { IndexIntoFuncTable } from '../types';
 
 export type DataSource =
   | 'none'
@@ -185,6 +186,11 @@ type ProfileAction =
       +threadsKey: ThreadsKey,
       +selectedCallNodePath: CallNodePath,
       +optionalExpandedToCallNodePath: ?CallNodePath,
+    |}
+  | {|
+      +type: 'CHANGE_SELECTED_FUNCTIONTABLE_CALL_NODE,',
+      +threadsKey: ThreadsKey,
+      +selectedFunction: IndexIntoFuncTable,
     |}
   | {|
       +type: 'UPDATE_TRACK_THREAD_HEIGHT',

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -38,6 +38,7 @@ import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { PathSet } from '../utils/path.js';
 import type { UploadedProfileInformation as ImportedUploadedProfileInformation } from 'firefox-profiler/app-logic/uploaded-profiles-db';
 import type { BrowserConnectionStatus } from 'firefox-profiler/app-logic/browser-connection';
+import type { IndexIntoFuncTable } from 'firefox-profiler/types';
 
 export type Reducer<T> = (T | void, Action) => T;
 
@@ -50,6 +51,7 @@ export type UploadedProfileInformation = ImportedUploadedProfileInformation;
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {|
   +selectedCallNodePath: CallNodePath,
+  +selectedFunctionTableFunction: IndexIntoFuncTable | null,
   +expandedCallNodePaths: PathSet,
   +selectedMarker: MarkerIndex | null,
   +selectedNetworkMarker: MarkerIndex | null,

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -43,6 +43,7 @@ export function toValidTabSlug(tabSlug: any): TabSlug | null {
   const coercedTabSlug = (tabSlug: TabSlug);
   switch (coercedTabSlug) {
     case 'calltree':
+    case 'function-table':
     case 'stack-chart':
     case 'marker-chart':
     case 'network-chart':


### PR DESCRIPTION
This PR implements a CallTree based view that presents all methods with their total and self times:

![image](https://user-images.githubusercontent.com/490655/189304075-7d6b4183-e878-4695-a7bd-5ccb4021f5e8.png)

It implements a simplified version of the view first suggested in #15 (Add a "top functions" call tree view) and reiterated in #4205.

It supports all the amenities of the CallTree view like the side bar or highlighting the samples in the timeline.

[Sample profile](https://github.com/firefox-devtools/profiler/files/9533691/Firefox.2022-09-09.10.02.profile.json.gz)

[Deployment preview](https://deploy-preview-4227--perf-html.netlify.app/public/thbxdz0kz120624rgx13hdeg0kw9tekp8ekxsj0/methodtable/?globalTrackOrder=0&thread=0&v=7)

_As in other PRs: This PR has not yet any tests, but it is manually tested and I'll add the tests after I'm sure what the final implementation is. The tests should be really similar to the tests for the CallTree view itself, as it is essentially the same view just with a different source of data._

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-576)
