### PR TITLE
Support loading sources from localhost and sending post requests to servers on double click

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ const localConfigExists = fs.existsSync(
 );
 
 const serverConfig = {
-  allowedHosts: ['localhost', '.gitpod.io'],
+  allowedHosts: ['localhost', '.gitpod.io', 'github.com'],
   host,
   port,
   // We disable hot reloading because this takes lot of CPU and memory in the

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1924,10 +1924,15 @@ export function changeMouseTimePosition(
   };
 }
 
-export function openSourceView(file: string, currentTab: TabSlug): Action {
+export function openSourceView(
+  file: string,
+  name: string | null,
+  currentTab: TabSlug
+): Action {
   return {
     type: 'OPEN_SOURCE_VIEW',
     file,
+    name,
     currentTab,
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -577,6 +577,7 @@ export function stateFromLocation(
   const sourceView: SourceViewState = {
     activationGeneration: 0,
     file: null,
+    name: null,
   };
   const isBottomBoxOpenPerPanel = {};
   tabSlugs.forEach((tabSlug) => (isBottomBoxOpenPerPanel[tabSlug] = false));

--- a/src/components/app/BottomBox.js
+++ b/src/components/app/BottomBox.js
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import { SourceView } from '../shared/SourceView';
 import {
   getSourceViewFile,
+  getSourceViewFileName,
   getSourceViewActivationGeneration,
 } from 'firefox-profiler/selectors/url-state';
 import {
@@ -31,6 +32,7 @@ import './BottomBox.css';
 
 type StateProps = {|
   +sourceViewFile: string | null,
+  +sourceViewFileName: string | null,
   +sourceViewSource: FileSourceStatus | void,
   +globalLineTimings: LineTimings,
   +selectedCallNodeLineTimings: LineTimings,
@@ -215,6 +217,7 @@ class BottomBoxImpl extends React.PureComponent<Props> {
   render() {
     const {
       sourceViewFile,
+      sourceViewFileName,
       sourceViewSource,
       globalLineTimings,
       disableOverscan,
@@ -228,7 +231,7 @@ class BottomBoxImpl extends React.PureComponent<Props> {
     const path =
       sourceViewFile !== null
         ? parseFileNameFromSymbolication(sourceViewFile).path
-        : null;
+        : sourceViewFileName;
     return (
       <div className="bottom-box">
         <div className="bottom-box-bar">
@@ -271,6 +274,7 @@ class BottomBoxImpl extends React.PureComponent<Props> {
 export const BottomBox = explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: (state) => ({
     sourceViewFile: getSourceViewFile(state),
+    sourceViewFileName: getSourceViewFileName(state),
     sourceViewSource: getSourceViewSource(state),
     globalLineTimings: selectedThreadSelectors.getSourceViewLineTimings(state),
     selectedCallNodeLineTimings:

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -87,7 +87,6 @@ class CallTreeImpl extends PureComponent<Props> {
   };
   _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
-  _isShiftKeyPressed: boolean = false;
 
   /**
    * Call Trees can have different types of "weights" for the data. Choose the
@@ -211,11 +210,6 @@ class CallTreeImpl extends PureComponent<Props> {
       threadsKey,
     } = this.props;
 
-    this._isShiftKeyPressed = false;
-    if (event.key === 'Shift') {
-      this._isShiftKeyPressed = true;
-    }
-
     const nodeIndex =
       rightClickedCallNodeIndex !== null
         ? rightClickedCallNodeIndex
@@ -226,16 +220,24 @@ class CallTreeImpl extends PureComponent<Props> {
     handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
   };
 
-  _onKeyUp = (_) => {
-    this._isShiftKeyPressed = false;
-  };
-
-  _onEnterOrDoubleClick = (nodeId: IndexIntoCallNodeTable) => {
+  _onEnter = (nodeId: IndexIntoCallNodeTable) => {
     const { tree, openSourceView } = this.props;
     tree.handleOpenSourceView(
       nodeId,
       (file) => openSourceView(file, 'calltree'),
-      this._isShiftKeyPressed
+      false
+    );
+  };
+
+  _onDoubleClick = (
+    nodeId: IndexIntoCallNodeTable,
+    event: SyntheticMouseEvent<>
+  ) => {
+    const { tree, openSourceView } = this.props;
+    tree.handleOpenSourceView(
+      nodeId,
+      (file) => openSourceView(file, 'calltree'),
+      event.shiftKey
     );
   };
 
@@ -305,9 +307,8 @@ class CallTreeImpl extends PureComponent<Props> {
         rowHeight={16}
         indentWidth={10}
         onKeyDown={this._onKeyDown}
-        onKeyUp={this._onKeyUp}
-        onEnterKey={this._onEnterOrDoubleClick}
-        onDoubleClick={this._onEnterOrDoubleClick}
+        onEnterKey={this._onEnter}
+        onDoubleClick={this._onDoubleClick}
       />
     );
   }

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -87,6 +87,7 @@ class CallTreeImpl extends PureComponent<Props> {
   };
   _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
+  _isShiftKeyPressed: boolean = false;
 
   /**
    * Call Trees can have different types of "weights" for the data. Choose the
@@ -209,6 +210,12 @@ class CallTreeImpl extends PureComponent<Props> {
       handleCallNodeTransformShortcut,
       threadsKey,
     } = this.props;
+
+    this._isShiftKeyPressed = false;
+    if (event.key === 'Shift') {
+      this._isShiftKeyPressed = true;
+    }
+
     const nodeIndex =
       rightClickedCallNodeIndex !== null
         ? rightClickedCallNodeIndex
@@ -219,13 +226,17 @@ class CallTreeImpl extends PureComponent<Props> {
     handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
   };
 
+  _onKeyUp = (_) => {
+    this._isShiftKeyPressed = false;
+  };
+
   _onEnterOrDoubleClick = (nodeId: IndexIntoCallNodeTable) => {
     const { tree, openSourceView } = this.props;
-    const file = tree.getRawFileNameForCallNode(nodeId);
-    if (file === null) {
-      return;
-    }
-    openSourceView(file, 'calltree');
+    tree.handleOpenSourceView(
+      nodeId,
+      (file) => openSourceView(file, 'calltree'),
+      this._isShiftKeyPressed
+    );
   };
 
   procureInterestingInitialSelection() {
@@ -294,6 +305,7 @@ class CallTreeImpl extends PureComponent<Props> {
         rowHeight={16}
         indentWidth={10}
         onKeyDown={this._onKeyDown}
+        onKeyUp={this._onKeyUp}
         onEnterKey={this._onEnterOrDoubleClick}
         onDoubleClick={this._onEnterOrDoubleClick}
       />

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -224,7 +224,7 @@ class CallTreeImpl extends PureComponent<Props> {
     const { tree, openSourceView } = this.props;
     tree.handleOpenSourceView(
       nodeId,
-      (file) => openSourceView(file, 'calltree'),
+      (file, name) => openSourceView(file, name, 'calltree'),
       false
     );
   };
@@ -236,7 +236,7 @@ class CallTreeImpl extends PureComponent<Props> {
     const { tree, openSourceView } = this.props;
     tree.handleOpenSourceView(
       nodeId,
-      (file) => openSourceView(file, 'calltree'),
+      (file, name) => openSourceView(file, name, 'calltree'),
       event.shiftKey
     );
   };

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -58,8 +58,11 @@ export type OwnProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +rightClickedCallNodeIndex: IndexIntoCallNodeTable | null,
   +onSelectionChange: (IndexIntoCallNodeTable | null) => void,
-  +onRightClick: (IndexIntoCallNodeTable | null) => void,
-  +onDoubleClick: (IndexIntoCallNodeTable | null) => void,
+  +onRightClick: (IndexIntoCallNodeTable | null, SyntheticMouseEvent<>) => void,
+  +onDoubleClick: (
+    IndexIntoCallNodeTable | null,
+    SyntheticMouseEvent<>
+  ) => void,
   +shouldDisplayTooltips: () => boolean,
   +scrollToSelectionGeneration: number,
   +categories: CategoryList,
@@ -378,16 +381,22 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
     this.props.onSelectionChange(callNodeIndex);
   };
 
-  _onRightClick = (hoveredItem: HoveredStackTiming | null) => {
+  _onRightClick = (
+    hoveredItem: HoveredStackTiming | null,
+    event: SyntheticMouseEvent<>
+  ) => {
     // Change our selection to the hovered item, or deselect (with
     // null) if there's nothing hovered.
     const callNodeIndex = this._getCallNodeIndexFromHoveredItem(hoveredItem);
-    this.props.onRightClick(callNodeIndex);
+    this.props.onRightClick(callNodeIndex, event);
   };
 
-  _onDoubleClick = (hoveredItem: HoveredStackTiming | null) => {
+  _onDoubleClick = (
+    hoveredItem: HoveredStackTiming | null,
+    event: SyntheticMouseEvent<>
+  ): void => {
     const callNodeIndex = this._getCallNodeIndexFromHoveredItem(hoveredItem);
-    this.props.onDoubleClick(callNodeIndex);
+    this.props.onDoubleClick(callNodeIndex, event);
   };
 
   _hitTest = (x: CssPixels, y: CssPixels): HoveredStackTiming | null => {

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -133,7 +133,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
     const { callTree, openSourceView } = this.props;
     callTree.handleOpenSourceView(
       callNodeIndex,
-      (file) => openSourceView(file, 'flame-graph'),
+      (file, name) => openSourceView(file, name, 'flame-graph'),
       event.shiftKey
     );
   };
@@ -222,8 +222,8 @@ class FlameGraphImpl extends React.PureComponent<Props> {
 
     if (event.key === 'Enter') {
       if (selectedCallNodeIndex !== null) {
-        callTree.handleOpenSourceView(selectedCallNodeIndex, (file) =>
-          openSourceView(file, 'flame-graph')
+        callTree.handleOpenSourceView(selectedCallNodeIndex, (file, name) =>
+          openSourceView(file, name, 'flame-graph')
         );
       }
       return;

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -102,7 +102,6 @@ type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class FlameGraphImpl extends React.PureComponent<Props> {
   _viewport: HTMLDivElement | null = null;
-  _isShiftKeyPressed: boolean = false;
 
   _onSelectedCallNodeChange = (
     callNodeIndex: IndexIntoCallNodeTable | null
@@ -124,7 +123,10 @@ class FlameGraphImpl extends React.PureComponent<Props> {
     );
   };
 
-  _onCallNodeDoubleClick = (callNodeIndex: IndexIntoCallNodeTable | null) => {
+  _onCallNodeDoubleClick = (
+    callNodeIndex: IndexIntoCallNodeTable | null,
+    event: SyntheticMouseEvent<>
+  ) => {
     if (callNodeIndex === null) {
       return;
     }
@@ -132,7 +134,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
     callTree.handleOpenSourceView(
       callNodeIndex,
       (file) => openSourceView(file, 'flame-graph'),
-      this._isShiftKeyPressed
+      event.shiftKey
     );
   };
 
@@ -218,8 +220,6 @@ class FlameGraphImpl extends React.PureComponent<Props> {
       openSourceView,
     } = this.props;
 
-    this._isShiftKeyPressed = false;
-
     if (event.key === 'Enter') {
       if (selectedCallNodeIndex !== null) {
         callTree.handleOpenSourceView(selectedCallNodeIndex, (file) =>
@@ -227,10 +227,6 @@ class FlameGraphImpl extends React.PureComponent<Props> {
         );
       }
       return;
-    }
-
-    if (event.key === 'Shift') {
-      this._isShiftKeyPressed = true;
     }
 
     if (
@@ -307,10 +303,6 @@ class FlameGraphImpl extends React.PureComponent<Props> {
     }
   };
 
-  _handleKeyUp = (_) => {
-    this._isShiftKeyPressed = false;
-  };
-
   render() {
     const {
       thread,
@@ -342,11 +334,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
 
     return (
-      <div
-        className="flameGraphContent"
-        onKeyDown={this._handleKeyDown}
-        onKeyUp={this._handleKeyUp}
-      >
+      <div className="flameGraphContent" onKeyDown={this._handleKeyDown}>
         <ContextMenuTrigger
           id="CallNodeContextMenu"
           attributes={{

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -389,7 +389,7 @@ type TreeViewProps<DisplayData> = {|
   +onSelectionChange: (NodeIndex) => mixed,
   +onRightClickSelection?: (NodeIndex) => mixed,
   +onEnterKey?: (NodeIndex) => mixed,
-  +onDoubleClick?: (NodeIndex) => mixed,
+  +onDoubleClick?: (NodeIndex, SyntheticMouseEvent<>) => mixed,
   +rowHeight: CssPixels,
   +indentWidth: CssPixels,
   +onKeyDown?: (SyntheticKeyboardEvent<>) => void,
@@ -587,7 +587,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     if (event.detail === 2 && event.button === 0) {
       // double click
       if (this.props.onDoubleClick) {
-        this.props.onDoubleClick(nodeId);
+        this.props.onDoubleClick(nodeId, event);
       } else {
         this._toggle(nodeId);
       }

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -393,6 +393,7 @@ type TreeViewProps<DisplayData> = {|
   +rowHeight: CssPixels,
   +indentWidth: CssPixels,
   +onKeyDown?: (SyntheticKeyboardEvent<>) => void,
+  +onKeyUp?: (SyntheticKeyboardEvent<>) => void,
 |};
 
 export class TreeView<DisplayData: Object> extends React.PureComponent<
@@ -728,6 +729,12 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     }
   };
 
+  _onKeyUp = (event: SyntheticKeyboardEvent<>) => {
+    if (this.props.onKeyUp) {
+      this.props.onKeyUp(event);
+    }
+  };
+
   /* This method is used by users of this component. */
   /* eslint-disable-next-line react/no-unused-class-component-methods */
   focus() {
@@ -748,7 +755,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       selectedNodeId,
     } = this.props;
     return (
-      <div className="treeView">
+      <div className="treeView" onKeyUp={this._onKeyUp}>
         <TreeViewHeader fixedColumns={fixedColumns} mainColumn={mainColumn} />
         <ContextMenuTrigger
           id={contextMenuId ?? 'unknown'}

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -15,8 +15,11 @@ type Props<HoveredItem> = {|
   +containerHeight: CssPixels,
   +className: string,
   +onSelectItem?: (HoveredItem | null) => void,
-  +onRightClick?: (HoveredItem | null) => void,
-  +onDoubleClickItem: (HoveredItem | null) => void,
+  +onRightClick?: (HoveredItem | null, event: SyntheticMouseEvent<>) => void,
+  +onDoubleClickItem: (
+    HoveredItem | null,
+    event: SyntheticMouseEvent<>
+  ) => void,
   +getHoveredItemInfo: (HoveredItem) => React.Node,
   +drawCanvas: (
     CanvasRenderingContext2D,
@@ -188,7 +191,7 @@ export class ChartCanvas<HoveredItem> extends React.Component<
       // It is important that we call the right click callback at mousedown so
       // that the state is updated and the context menus are rendered before the
       // contextmenu events.
-      this.props.onRightClick(this.state.hoveredItem);
+      this.props.onRightClick(this.state.hoveredItem, e);
     }
   };
 
@@ -262,8 +265,8 @@ export class ChartCanvas<HoveredItem> extends React.Component<
     }
   };
 
-  _onDoubleClick = () => {
-    this.props.onDoubleClickItem(this.state.hoveredItem);
+  _onDoubleClick = (event: SyntheticMouseEvent<Element>) => {
+    this.props.onDoubleClickItem(this.state.hoveredItem, event);
   };
 
   _getHoveredItemInfo = (): React.Node => {

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -371,7 +371,7 @@ export class CallTree {
   getRawFileNameAndMethodInfoForCallNode(
     callNodeIndex: IndexIntoCallNodeTable
   ): {
-    file: string,
+    file: string | null,
     line: number | null,
     method: string,
     column: number | null,
@@ -379,9 +379,6 @@ export class CallTree {
   } | null {
     const funcIndex = this._callNodeTable.func[callNodeIndex];
     const fileName = this._funcTable.fileName[funcIndex];
-    if (fileName === null) {
-      return null;
-    }
     const line = this._funcTable.lineNumber[funcIndex];
     const method = this._stringTable.getString(this._funcTable.name[funcIndex]);
     const column = this._funcTable.columnNumber[funcIndex];
@@ -395,7 +392,7 @@ export class CallTree {
       );
     }
     return {
-      file: this._stringTable.getString(fileName),
+      file: fileName !== null ? this._stringTable.getString(fileName) : sourceUrl,
       line,
       method,
       column,
@@ -413,9 +410,14 @@ export class CallTree {
       return;
     }
     const { file, method, line, column, sourceUrl } = info;
+    if (file === null && sourceUrl === null) {
+      // we have no indication where the file resides
+      return;
+    }
     if (sourceUrl === null) {
       // the simplest case, we don't have an additional source url
       // the file includes it already
+      // $FlowExpectError
       openSourceView(file);
       return;
     }
@@ -434,7 +436,7 @@ export class CallTree {
   }
 
   _triggerSourceViewEventOnRemote(
-    file: string,
+    file: string | null,
     line: number | null,
     method: string,
     column: number | null,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -403,7 +403,7 @@ export class CallTree {
 
   handleOpenSourceView(
     callNodeIndex: IndexIntoCallNodeTable,
-    openSourceView: (file: string) => any,
+    openSourceView: (file: string, name: string | null) => any,
     forceLoadSource: boolean = false
   ) {
     const info = this.getRawFileNameAndMethodInfoForCallNode(callNodeIndex);
@@ -419,17 +419,21 @@ export class CallTree {
       // the simplest case, we don't have an additional source url
       // the file includes it already
       // $FlowExpectError
-      openSourceView(file);
+      openSourceView(file, null);
       return;
     }
     let rawSourceUrl = sourceUrl.replace(/^post|/, '');
     let reallyForceLoadSource = forceLoadSource;
+    let name = file;
     if (rawSourceUrl.includes('|')) {
       // rawSourceUrl = sourceUrl | alternative
       const [first, alternative] = rawSourceUrl.split('|');
       if (first.startsWith(window.location.origin)) {
         // we're serving the file from the same origin, therefore the first URL
         rawSourceUrl = first;
+        if (name === null) {
+          name = alternative;
+        }
       } else {
         // we're not serving the file from the same origin, like from profiler.firefox.com
         // so use the public alternative
@@ -450,7 +454,7 @@ export class CallTree {
         rawSourceUrl
       );
     } else {
-      openSourceView(rawSourceUrl);
+      openSourceView(rawSourceUrl, name);
     }
   }
 

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -392,7 +392,8 @@ export class CallTree {
       );
     }
     return {
-      file: fileName !== null ? this._stringTable.getString(fileName) : sourceUrl,
+      file:
+        fileName !== null ? this._stringTable.getString(fileName) : sourceUrl,
       line,
       method,
       column,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -422,8 +422,26 @@ export class CallTree {
       openSourceView(file);
       return;
     }
-    const rawSourceUrl = sourceUrl.replace(/^post|/, '');
-    if (sourceUrl.startsWith('post|') && !forceLoadSource) {
+    let rawSourceUrl = sourceUrl.replace(/^post|/, '');
+    let reallyForceLoadSource = forceLoadSource;
+    if (rawSourceUrl.includes('|')) {
+      // rawSourceUrl = sourceUrl | alternative
+      const [first, alternative] = rawSourceUrl.split('|');
+      if (first.startsWith(window.location.origin)) {
+        // we're serving the file from the same origin, therefore the first URL
+        rawSourceUrl = first;
+      } else {
+        // we're not serving the file from the same origin, like from profiler.firefox.com
+        // so use the public alternative
+        // if present
+        rawSourceUrl = alternative;
+        reallyForceLoadSource = true;
+      }
+    }
+    if (rawSourceUrl.length === 0) {
+      return;
+    }
+    if (sourceUrl.startsWith('post|') && !reallyForceLoadSource) {
       this._triggerSourceViewEventOnRemote(
         file,
         line,
@@ -432,7 +450,7 @@ export class CallTree {
         rawSourceUrl
       );
     } else {
-      openSourceView(sourceUrl);
+      openSourceView(rawSourceUrl);
     }
   }
 

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -157,6 +157,7 @@ export function shallowCloneFuncTable(funcTable: FuncTable): FuncTable {
     fileName: funcTable.fileName.slice(),
     lineNumber: funcTable.lineNumber.slice(),
     columnNumber: funcTable.columnNumber.slice(),
+    sourceUrl: funcTable.sourceUrl !== undefined ? funcTable.sourceUrl.slice() : undefined,
     length: funcTable.length,
   };
 }

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -157,7 +157,10 @@ export function shallowCloneFuncTable(funcTable: FuncTable): FuncTable {
     fileName: funcTable.fileName.slice(),
     lineNumber: funcTable.lineNumber.slice(),
     columnNumber: funcTable.columnNumber.slice(),
-    sourceUrl: funcTable.sourceUrl !== undefined ? funcTable.sourceUrl.slice() : undefined,
+    sourceUrl:
+      funcTable.sourceUrl !== undefined
+        ? funcTable.sourceUrl.slice()
+        : undefined,
     length: funcTable.length,
   };
 }

--- a/src/profile-logic/line-timings.js
+++ b/src/profile-logic/line-timings.js
@@ -99,7 +99,9 @@ export function getStackLineInfoNonInverted(
     const frame = stackTable.frame[stackIndex];
     const prefixStack = stackTable.prefix[stackIndex];
     const func = frameTable.func[frame];
-    const fileNameStringIndexOfThisStack = funcTable.fileName[func];
+    const fileNameStringIndexOfThisStack =
+      funcTable.fileName[func] ||
+      (funcTable.sourceUrl ? funcTable.sourceUrl[func] : null);
 
     let selfLine: LineNumber | null = null;
     let totalLines: Set<LineNumber> | null =
@@ -176,7 +178,9 @@ export function getStackLineInfoInverted(
     const frame = stackTable.frame[stackIndex];
     const prefixStack = stackTable.prefix[stackIndex];
     const func = frameTable.func[frame];
-    const fileNameStringIndexOfThisStack = funcTable.fileName[func];
+    const fileNameStringIndexOfThisStack =
+      funcTable.fileName[func] ||
+      (funcTable.sourceUrl ? funcTable.sourceUrl[func] : null);
 
     let selfLine: LineNumber | null = null;
     let totalLines: Set<LineNumber> | null = null;

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -654,6 +654,12 @@ function combineFuncTables(
       );
       newFuncTable.lineNumber.push(lineNumber);
       newFuncTable.columnNumber.push(funcTable.columnNumber[i]);
+      if (funcTable.sourceUrl !== undefined) {
+        if (newFuncTable.sourceUrl === undefined) {
+          newFuncTable.sourceUrl = [];
+        }
+        newFuncTable.sourceUrl.push(funcTable.sourceUrl[i]);
+      }
 
       newFuncTable.length++;
     }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -406,6 +406,9 @@ function _extractUnsymbolicatedFunction(
   funcTable.fileName[funcIndex] = null;
   funcTable.lineNumber[funcIndex] = null;
   funcTable.columnNumber[funcIndex] = null;
+  if (funcTable.sourceUrl) {
+    funcTable.sourceUrl[funcIndex] = null;
+  }
   return { funcIndex, frameAddress: addressRelativeToLib };
 }
 
@@ -469,6 +472,9 @@ function _extractCppFunction(
   funcTable.fileName[newFuncIndex] = null;
   funcTable.lineNumber[newFuncIndex] = null;
   funcTable.columnNumber[newFuncIndex] = null;
+  if (funcTable.sourceUrl) {
+    funcTable.sourceUrl[newFuncIndex] = null;
+  }
 
   return newFuncIndex;
 }
@@ -580,6 +586,9 @@ function _extractUnknownFunctionType(
   funcTable.fileName[index] = null;
   funcTable.lineNumber[index] = null;
   funcTable.columnNumber[index] = null;
+  if (funcTable.sourceUrl) {
+    funcTable.sourceUrl[index] = null;
+  }
   return index;
 }
 

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -512,6 +512,9 @@ function sanitizeThreadPII(
           newFuncTable.fileName.push(null);
           newFuncTable.lineNumber.push(null);
           newFuncTable.columnNumber.push(null);
+          if (funcTable.sourceUrl && newFuncTable.sourceUrl) {
+            newFuncTable.sourceUrl.push(null);
+          }
           newFuncTable.length++;
 
           frameIndexes.forEach(
@@ -531,6 +534,9 @@ function sanitizeThreadPII(
           newFuncTable.resource[funcIndex] = -1;
           newFuncTable.lineNumber[funcIndex] = null;
           newFuncTable.columnNumber[funcIndex] = null;
+          if (funcTable.sourceUrl && newFuncTable.sourceUrl) {
+            newFuncTable.sourceUrl.push(null);
+          }
         }
 
         // In both cases, nullify some information in all frames.

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -775,6 +775,9 @@ export function applySymbolicationStep(
           funcTable.fileName[funcIndex] = null;
           funcTable.lineNumber[funcIndex] = null;
           funcTable.columnNumber[funcIndex] = null;
+          if (funcTable.sourceUrl) {
+            funcTable.sourceUrl.push(null);
+          }
           // The name field will be filled below.
           funcTable.length++;
         }

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -942,6 +942,9 @@ export function collapseResource(
             newFuncTable.fileName.push(funcTable.fileName[funcIndex]);
             newFuncTable.lineNumber.push(null);
             newFuncTable.columnNumber.push(null);
+            if (newFuncTable.sourceUrl) {
+              newFuncTable.sourceUrl.push(null);
+            }
           }
 
           // Add the new stack.

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -554,7 +554,7 @@ const timelineTrackOrganization: Reducer<TimelineTrackOrganization> = (
 };
 
 const sourceView: Reducer<SourceViewState> = (
-  state = { activationGeneration: 0, file: null },
+  state = { activationGeneration: 0, file: null, name: null },
   action
 ) => {
   switch (action.type) {
@@ -562,6 +562,7 @@ const sourceView: Reducer<SourceViewState> = (
       return {
         activationGeneration: state.activationGeneration + 1,
         file: action.file,
+        name: action.name,
       };
     }
     default:

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -271,7 +271,9 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
         }
         const selectedFunc =
           callNodeInfo.callNodeTable.func[selectedCallNodeIndex];
-        const selectedFuncFile = funcTable.fileName[selectedFunc];
+        const selectedFuncFile =
+          funcTable.fileName[selectedFunc] ||
+          (funcTable.sourceUrl ? funcTable.sourceUrl[selectedFunc] : null);
         if (
           selectedFuncFile === null ||
           stringTable.getString(selectedFuncFile) !== sourceViewFile

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -245,7 +245,9 @@ export function getStackAndSampleSelectorsPerThread(
   const getSourceViewLineTimings: Selector<LineTimings> = createSelector(
     getSourceViewStackLineInfo,
     threadSelectors.getPreviewFilteredSamplesForCallTree,
-    getLineTimings
+    (x, y) => {
+      return getLineTimings(x, y);
+    }
   );
 
   const getTracedTiming: Selector<TracedTiming | null> = createSelector(

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -78,6 +78,8 @@ export const getShowUserTimings: Selector<boolean> = (state) =>
   getProfileSpecificState(state).showUserTimings;
 export const getSourceViewFile: Selector<string | null> = (state) =>
   getProfileSpecificState(state).sourceView.file;
+export const getSourceViewFileName: Selector<string | null> = (state) =>
+  getProfileSpecificState(state).sourceView.name || getSourceViewFile(state);
 export const getSourceViewActivationGeneration: Selector<number> = (state) =>
   getProfileSpecificState(state).sourceView.activationGeneration;
 export const getisBottomBoxOpenPerPanel: Selector<IsOpenPerPanelState> = (

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -338,6 +338,7 @@ type ProfileAction =
   | {|
       +type: 'OPEN_SOURCE_VIEW',
       +file: string,
+      +name: string | null,
       +currentTab: TabSlug,
     |}
   | {|

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -379,6 +379,15 @@ export type FuncTable = {|
   lineNumber: Array<number | null>,
   columnNumber: Array<number | null>,
 
+  // This is the optional information on the url of the source file
+  // that this function can be seen in specifically.
+  // Prefixing the URL with `post|` signifies that the URL should
+  // be called with a POST request and the response discarded (the request
+  // includes `name`, `file`, `line` and `column` information if present).
+  // The response of the request (and any error) is ignored.
+  // These POST requests are used by imported profiles to trigger events
+  // outside of the profiler.
+  sourceUrl?: Array<IndexIntoStringTable | null>,
   length: number,
 |};
 

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -384,9 +384,14 @@ export type FuncTable = {|
   // Prefixing the URL with `post|` signifies that the URL should
   // be called with a POST request and the response discarded (the request
   // includes `name`, `file`, `line` and `column` information if present).
-  // The response of the request (and any error) is ignored.
+  // `post|` URLs can have another format: `post|url|alternative` where
+  // the alternative URL is used if the origin of the url does not have
+  // the same origin as the profile viewer. This allows to supply a public
+  // fallback URL for local profile URLs.
   // These POST requests are used by imported profiles to trigger events
   // outside of the profiler.
+  // Urls may currently only start with `https://raw.githubusercontent.com/` or
+  // `http://localhost`.
   sourceUrl?: Array<IndexIntoStringTable | null>,
   length: number,
 |};

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -234,6 +234,7 @@ export type ZippedProfilesState = {
 export type SourceViewState = {|
   activationGeneration: number,
   file: string | null,
+  name: string | null,
 |};
 
 export type FileSourceStatus =

--- a/src/utils/special-paths.js
+++ b/src/utils/special-paths.js
@@ -210,6 +210,14 @@ export function getDownloadRecipeForSourceFile(
       };
     }
     case 'normal': {
+      const ALLOWED_URLS = ["https://raw.githubusercontent.com/"];
+      if (ALLOWED_URLS.some((url) => parsedFile.path.startsWith(url))) {
+        // maybe we could remove this check later
+        return {
+          type: 'CORS_ENABLED_SINGLE_FILE',
+          url: parsedFile.path,
+        };
+      }
       return { type: 'NO_KNOWN_CORS_URL' };
     }
     default:

--- a/src/utils/special-paths.js
+++ b/src/utils/special-paths.js
@@ -210,7 +210,11 @@ export function getDownloadRecipeForSourceFile(
       };
     }
     case 'normal': {
-      const ALLOWED_URLS = ["https://raw.githubusercontent.com/"];
+      const ALLOWED_URLS = [
+        'https://raw.githubusercontent.com/',
+        'http://localhost:',
+        'http://localhost/',
+      ];
       if (ALLOWED_URLS.some((url) => parsedFile.path.startsWith(url))) {
         // maybe we could remove this check later
         return {


### PR DESCRIPTION
This PR adds the capability of setting a source URL for every function (via an optional `sourceUrl` array in the `FuncTable`). The URLs have to start with `https://raw.githubusercontent.com/` or `http://localhost` and are used to load files.

![image](https://user-images.githubusercontent.com/490655/193859909-fe791e59-43b5-487d-a091-150684735e59.png)

_Here the URL points to GitHub._


Futhermore, prefixing the URL with `post|` specifies that instead of loading the file at the passed URL, the profiler should instead send a POST request to the URL passing `name`, `file`, `line` and `column` information if present. This is important for coupling the UI with other UIs like IDEs using a server that passes the requests on.

These `post|` URLs are usually not usable when uploaded to a different server, so the `post|` URL can also have the format `post|url|alternative`: The alternative URL is only used if the origin of `url` and the loaded UI location differ, making a fallback option.

_This is really important for imported profiles which might be viewed in a Firefox Profiler inside an IDE._

[Deployment Preview](https://deploy-preview-4259--perf-html.netlify.app/public/yc89hwnnwtgy7hvbwy2k96nj0thzbw393304wd8/calltree/?globalTrackOrder=0&sourceView=https%3A%2F%2Fraw.githubusercontent.com%2Fparttimenerd%2Fjfrtofp%2Fmain%2Fsrc%2Fmain%2Fkotlin%2Fme%2Fbechberger%2Fjfrtofp%2FProcessor.kt&thread=2&v=7)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-582)
