### PR TITLE
Add sort buttons (▲/▼) to TreeView columns

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -91,7 +91,7 @@ class CallTreeImpl extends PureComponent<Props> {
   _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
   _sortableColumns = new Set(['self', 'total']);
-  _sortedColumns = new ColumnSortState([]);
+  _sortedColumns = new ColumnSortState([{ column: 'total', ascending: false }]);
 
   _compareColumn = (
     first: CallNodeDisplayData,

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -6,7 +6,10 @@
 import React, { PureComponent } from 'react';
 import memoize from 'memoize-immutable';
 import explicitConnect from 'firefox-profiler/utils/connect';
-import { TreeView } from 'firefox-profiler/components/shared/TreeView';
+import {
+  TreeView,
+  ColumnSortState,
+} from 'firefox-profiler/components/shared/TreeView';
 import { CallTreeEmptyReasons } from './CallTreeEmptyReasons';
 import { Icon } from 'firefox-profiler/components/shared/Icon';
 import { getCallNodePathFromIndex } from 'firefox-profiler/profile-logic/profile-data';
@@ -87,6 +90,22 @@ class CallTreeImpl extends PureComponent<Props> {
   };
   _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
+  _sortedColumns = new ColumnSortState([]);
+
+  _compareColumn = (
+    first: CallNodeDisplayData,
+    second: CallNodeDisplayData,
+    column: number
+  ) => {
+    switch (column) {
+      case 2:
+        return second.rawTotal - first.rawTotal;
+      case 3:
+        return second.rawSelf - first.rawSelf;
+      default:
+        throw new Error('Invalid column');
+    }
+  };
 
   /**
    * Call Trees can have different types of "weights" for the data. Choose the
@@ -260,6 +279,10 @@ class CallTreeImpl extends PureComponent<Props> {
     }
   }
 
+  _onSort = (sortedColumns: ColumnSortState) => {
+    this._sortedColumns = sortedColumns;
+  };
+
   render() {
     const {
       tree,
@@ -296,6 +319,10 @@ class CallTreeImpl extends PureComponent<Props> {
         onKeyDown={this._onKeyDown}
         onEnterKey={this._onEnterOrDoubleClick}
         onDoubleClick={this._onEnterOrDoubleClick}
+        initialSortedColumns={this._sortedColumns}
+        onSort={this._onSort}
+        compareColumn={this._compareColumn}
+        sortableColumns={new Set([2, 3])}
       />
     );
   }

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -90,20 +90,21 @@ class CallTreeImpl extends PureComponent<Props> {
   };
   _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
+  _sortableColumns = new Set(['self', 'total']);
   _sortedColumns = new ColumnSortState([]);
 
   _compareColumn = (
     first: CallNodeDisplayData,
     second: CallNodeDisplayData,
-    column: number
+    column: string
   ) => {
     switch (column) {
-      case 2:
+      case 'total':
         return second.rawTotal - first.rawTotal;
-      case 3:
+      case 'self':
         return second.rawSelf - first.rawSelf;
       default:
-        throw new Error('Invalid column');
+        throw new Error('Invalid column ' + column);
     }
   };
 
@@ -322,7 +323,7 @@ class CallTreeImpl extends PureComponent<Props> {
         initialSortedColumns={this._sortedColumns}
         onSort={this._onSort}
         compareColumn={this._compareColumn}
-        sortableColumns={new Set([2, 3])}
+        sortableColumns={this._sortableColumns}
       />
     );
   }

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -173,7 +173,7 @@ class MarkerTableImpl extends PureComponent<Props> {
   _onExpandedNodeIdsChange = () => {};
   _treeView: ?TreeView<MarkerDisplayData>;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
-  _sortedColumns = new ColumnSortState([]);
+  _sortedColumns = new ColumnSortState([{ column: 'start', ascending: true }]);
 
   getMarkerTree = memoize((...args) => new MarkerTree(...args), { limit: 1 });
 

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import memoize from 'memoize-immutable';
 
 import explicitConnect from '../../utils/connect';
-import { TreeView } from '../shared/TreeView';
+import { TreeView, ColumnSortState } from '../shared/TreeView';
 import { MarkerTableEmptyReasons } from './MarkerTableEmptyReasons';
 import {
   getZeroAt,
@@ -42,7 +42,9 @@ const MAX_DESCRIPTION_CHARACTERS = 500;
 
 type MarkerDisplayData = {|
   start: string,
+  rawStart: Milliseconds,
   duration: string | null,
+  rawDuration: Milliseconds | null,
   name: string,
   type: string,
 |};
@@ -113,10 +115,13 @@ class MarkerTree {
       }
 
       let duration = null;
+      let rawDuration: number | null = null;
       if (marker.incomplete) {
         duration = 'unknown';
       } else if (marker.end !== null) {
         duration = formatTimestamp(marker.end - marker.start);
+        // $FlowFixMe
+        rawDuration = marker.end - marker.start;
       }
 
       displayData = {
@@ -124,6 +129,8 @@ class MarkerTree {
         duration,
         name,
         type: getMarkerSchemaName(this._markerSchemaByName, marker),
+        rawDuration: rawDuration,
+        rawStart: marker.start,
       };
       this._displayDataByIndex.set(markerIndex, displayData);
     }
@@ -165,6 +172,7 @@ class MarkerTableImpl extends PureComponent<Props> {
   _onExpandedNodeIdsChange = () => {};
   _treeView: ?TreeView<MarkerDisplayData>;
   _takeTreeViewRef = (treeView) => (this._treeView = treeView);
+  _sortedColumns = new ColumnSortState([]);
 
   getMarkerTree = memoize((...args) => new MarkerTree(...args), { limit: 1 });
 
@@ -200,6 +208,33 @@ class MarkerTableImpl extends PureComponent<Props> {
     changeRightClickedMarker(threadsKey, selectedMarker);
   };
 
+  _compareColumn = (
+    first: MarkerDisplayData,
+    second: MarkerDisplayData,
+    column: number
+  ) => {
+    switch (column) {
+      case 1:
+        return second.rawStart - first.rawStart;
+      case 2:
+        if (first.rawDuration === null) {
+          return -1;
+        }
+        if (second.rawDuration === null) {
+          return 1;
+        }
+        return second.rawDuration - first.rawDuration;
+      case 3:
+        return first.type.localeCompare(second.type);
+      default:
+        throw new Error('Invalid column');
+    }
+  };
+
+  _onSort = (sortedColumns: ColumnSortState) => {
+    this._sortedColumns = sortedColumns;
+  };
+
   render() {
     const {
       getMarker,
@@ -210,7 +245,7 @@ class MarkerTableImpl extends PureComponent<Props> {
       markerSchemaByName,
       getMarkerLabel,
     } = this.props;
-    const tree = this.getMarkerTree(
+    const tree: MarkerTree = this.getMarkerTree(
       getMarker,
       markerIndexes,
       zeroAt,
@@ -243,6 +278,10 @@ class MarkerTableImpl extends PureComponent<Props> {
             contextMenuId="MarkerContextMenu"
             rowHeight={16}
             indentWidth={10}
+            initialSortedColumns={this._sortedColumns}
+            onSort={this._onSort}
+            compareColumn={this._compareColumn}
+            sortableColumns={new Set([1, 2, 3])}
           />
         )}
       </div>

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -116,12 +116,12 @@ class MarkerTree {
 
       let duration = null;
       let rawDuration: number | null = null;
+      const markerEnd = marker.end;
       if (marker.incomplete) {
         duration = 'unknown';
-      } else if (marker.end !== null) {
-        duration = formatTimestamp(marker.end - marker.start);
-        // $FlowFixMe
-        rawDuration = marker.end - marker.start;
+      } else if (markerEnd !== null) {
+        duration = formatTimestamp(markerEnd - marker.start);
+        rawDuration = markerEnd - marker.start;
       }
 
       displayData = {
@@ -167,6 +167,7 @@ class MarkerTableImpl extends PureComponent<Props> {
     { propName: 'duration', titleL10nId: 'MarkerTable--duration' },
     { propName: 'type', titleL10nId: 'MarkerTable--type' },
   ];
+  _sortableColumns = new Set(['start', 'duration', 'type', 'name']);
   _mainColumn = { propName: 'name', titleL10nId: 'MarkerTable--description' };
   _expandedNodeIds: Array<MarkerIndex | null> = [];
   _onExpandedNodeIdsChange = () => {};
@@ -211,12 +212,12 @@ class MarkerTableImpl extends PureComponent<Props> {
   _compareColumn = (
     first: MarkerDisplayData,
     second: MarkerDisplayData,
-    column: number
+    column: string
   ) => {
     switch (column) {
-      case 1:
+      case 'start':
         return second.rawStart - first.rawStart;
-      case 2:
+      case 'duration':
         if (first.rawDuration === null) {
           return -1;
         }
@@ -224,10 +225,10 @@ class MarkerTableImpl extends PureComponent<Props> {
           return 1;
         }
         return second.rawDuration - first.rawDuration;
-      case 3:
+      case 'type':
         return first.type.localeCompare(second.type);
       default:
-        throw new Error('Invalid column');
+        throw new Error('Invalid column ' + column);
     }
   };
 
@@ -281,7 +282,7 @@ class MarkerTableImpl extends PureComponent<Props> {
             initialSortedColumns={this._sortedColumns}
             onSort={this._onSort}
             compareColumn={this._compareColumn}
-            sortableColumns={new Set([1, 2, 3])}
+            sortableColumns={this._sortableColumns}
           />
         )}
       </div>

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -107,11 +107,11 @@
   opacity: 0;
 }
 
-.treeViewHeaderColumn.sortAscending::after {
+.treeViewHeaderColumn.sortDescending::after {
   content: ' ▲';
 }
 
-.treeViewHeaderColumn.sortDescending::after {
+.treeViewHeaderColumn.sortAscending::after {
   content: ' ▼ ';
 }
 

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -102,12 +102,17 @@
   border-right: 1px solid var(--grey-30);
 }
 
+.treeViewHeaderColumn.sortInactive::after {
+  content: " ▲";
+  opacity: 0;
+}
+
 .treeViewHeaderColumn.sortAscending::after {
-  content: '▲ ';
+  content: ' ▲';
 }
 
 .treeViewHeaderColumn.sortDescending::after {
-  content: '▼ ';
+  content: ' ▼ ';
 }
 
 .treeBadge {

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -102,6 +102,14 @@
   border-right: 1px solid var(--grey-30);
 }
 
+.treeViewHeaderColumn.sortAscending::after {
+  content: '▲ ';
+}
+
+.treeViewHeaderColumn.sortDescending::after {
+  content: '▼ ';
+}
+
 .treeBadge {
   display: inline-block;
   overflow: hidden;

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -489,7 +489,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
 > {
   _list: VirtualList<NodeIndex> | null = null;
   _takeListRef = (list: VirtualList<NodeIndex> | null) => (this._list = list);
-  state = { sortedColumns: new ColumnSortState([]) };
+  state = { sortedColumns: new ColumnSortState([], '') };
 
   constructor(props: TreeViewProps<DisplayData>) {
     super(props);
@@ -531,7 +531,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
         }
         let sortedNodeIds = nodeIds;
         for (const { column, ascending } of sortedColumns.sortedColumns) {
-          const sign = ascending ? 1 : -1;
+          const sign = ascending ? -1 : 1;
           sortedNodeIds = sortedNodeIds.sort((a, b) => {
             return (
               sign *

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -56,37 +56,100 @@ export type Column<DisplayData: Object> = {|
 type TreeViewHeaderProps<DisplayData: Object> = {|
   +fixedColumns: Column<DisplayData>[],
   +mainColumn: Column<DisplayData>,
+  +onSort: (number) => void,
+  +columnSortDirections?: Array<boolean | null>,
 |};
 
-const TreeViewHeader = <DisplayData: Object>({
-  fixedColumns,
-  mainColumn,
-}: TreeViewHeaderProps<DisplayData>) => {
-  if (fixedColumns.length === 0 && !mainColumn.titleL10nId) {
-    // If there is nothing to display in the header, do not render it.
-    return null;
+// columns start at 1
+export class ColumnSortState {
+  sortedColumns: number[];
+
+  // -column: sort descending, +column: sort ascending, start by sorting last column
+  constructor(sortedColumns: number[]) {
+    this.sortedColumns = sortedColumns;
   }
-  return (
-    <div className="treeViewHeader">
-      {fixedColumns.map((col) => (
+
+  _sortColumn(column: number) {
+    const sortedColumns = this.sortedColumns.filter(
+      (c) => c !== column && c !== -column
+    );
+    sortedColumns.push(column);
+    return new ColumnSortState(sortedColumns);
+  }
+
+  push(column: number) {
+    return this._sortColumn(-this._sortState(column));
+  }
+
+  _sortState(column: number) {
+    return this.sortedColumns
+      .filter((c) => c === column || c === -column)
+      .concat(-column)[0];
+  }
+
+  getSortStateArr(sortableColumns: Set<number>): Array<boolean | null> {
+    const arr = new Array(Math.max(...sortableColumns) + 1).fill(null);
+    for (const column of sortableColumns) {
+      arr[column] = this._sortState(column) < 0;
+    }
+    return arr;
+  }
+}
+
+class TreeViewHeader<DisplayData: Object> extends React.PureComponent<
+  TreeViewHeaderProps<DisplayData>
+> {
+  _onSort = (e: MouseEvent) => {
+    const { onSort } = this.props;
+    const target = e.target;
+    if (target instanceof HTMLElement) {
+      onSort(Number(target.getAttribute('data-column')));
+    }
+  };
+
+  render() {
+    const { fixedColumns, mainColumn, columnSortDirections } = this.props;
+    if (fixedColumns.length === 0 && !mainColumn.titleL10nId) {
+      // If there is nothing to display in the header, do not render it.
+      return null;
+    }
+    return (
+      <div className="treeViewHeader">
+        {fixedColumns.map((col, i) => {
+          let sortClass = '';
+          if (columnSortDirections) {
+            if (columnSortDirections[i + 1] === true) {
+              sortClass = 'sortAscending';
+            } else if (columnSortDirections[i + 1] === false) {
+              sortClass = 'sortDescending';
+            }
+          }
+          return (
+            <PermissiveLocalized
+              id={col.titleL10nId}
+              attrs={{ title: true }}
+              key={col.propName}
+            >
+              <span
+                className={`treeViewHeaderColumn treeViewFixedColumn ${col.propName} ${sortClass}`}
+                data-column={i + 1}
+                onClick={this._onSort}
+              ></span>
+            </PermissiveLocalized>
+          );
+        })}
         <PermissiveLocalized
-          id={col.titleL10nId}
+          id={mainColumn.titleL10nId}
           attrs={{ title: true }}
-          key={col.propName}
         >
           <span
-            className={`treeViewHeaderColumn treeViewFixedColumn ${col.propName}`}
+            className={`treeViewHeaderColumn treeViewMainColumn ${mainColumn.propName}`}
           ></span>
         </PermissiveLocalized>
-      ))}
-      <PermissiveLocalized id={mainColumn.titleL10nId} attrs={{ title: true }}>
-        <span
-          className={`treeViewHeaderColumn treeViewMainColumn ${mainColumn.propName}`}
-        ></span>
-      </PermissiveLocalized>
-    </div>
-  );
-};
+      </div>
+    );
+  }
+}
 
 function reactStringWithHighlightedSubstrings(
   string: string,
@@ -393,13 +456,31 @@ type TreeViewProps<DisplayData> = {|
   +rowHeight: CssPixels,
   +indentWidth: CssPixels,
   +onKeyDown?: (SyntheticKeyboardEvent<>) => void,
+  // number: column number, -1: first larger, 0: same, 1: first smaller
+  +compareColumn?: (DisplayData, DisplayData, number) => number,
+  +initialSortedColumns?: ColumnSortState,
+  +onSort?: (ColumnSortState) => void,
+  +sortableColumns?: Set<number>,
+|};
+
+type TreeViewState = {|
+  sortedColumns: ColumnSortState,
 |};
 
 export class TreeView<DisplayData: Object> extends React.PureComponent<
-  TreeViewProps<DisplayData>
+  TreeViewProps<DisplayData>,
+  TreeViewState
 > {
   _list: VirtualList<NodeIndex> | null = null;
   _takeListRef = (list: VirtualList<NodeIndex> | null) => (this._list = list);
+  state = { sortedColumns: new ColumnSortState([]) };
+
+  constructor(props: TreeViewProps<DisplayData>) {
+    super(props);
+    if (props.initialSortedColumns) {
+      this.state.sortedColumns = props.initialSortedColumns;
+    }
+  }
 
   // The tuple `specialItems` always contains 2 elements: the first element is
   // the selected node id (if any), and the second element is the right clicked
@@ -422,19 +503,51 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
   );
 
   _computeAllVisibleRowsMemoized = memoize(
-    (tree: Tree<DisplayData>, expandedNodes: Set<NodeIndex | null>) => {
+    (
+      tree: Tree<DisplayData>,
+      expandedNodes: Set<NodeIndex | null>,
+      sortedColumns: ColumnSortState,
+      compareColumn: ?(DisplayData, DisplayData, number) => number
+    ) => {
+      function sortNodes(nodeIds: Array<NodeIndex>): Array<NodeIndex> {
+        if (!compareColumn) {
+          return nodeIds;
+        }
+        let sortedNodeIds = nodeIds;
+        for (let i = 0; i < sortedColumns.sortedColumns.length; i++) {
+          const column = sortedColumns.sortedColumns[i];
+          const absColumn = Math.abs(column);
+          const sign = column < 0 ? -1 : 1;
+          sortedNodeIds = sortedNodeIds.sort((a, b) => {
+            return (
+              sign *
+              ((compareColumn: any): (
+                DisplayData,
+                DisplayData,
+                number
+              ) => number)(
+                tree.getDisplayData(a),
+                tree.getDisplayData(b),
+                absColumn
+              )
+            );
+          });
+        }
+        return sortedNodeIds;
+      }
+
       function _addVisibleRowsFromNode(tree, expandedNodes, arr, nodeId) {
         arr.push(nodeId);
         if (!expandedNodes.has(nodeId)) {
           return;
         }
-        const children = tree.getChildren(nodeId);
+        const children = sortNodes(tree.getChildren(nodeId));
         for (let i = 0; i < children.length; i++) {
           _addVisibleRowsFromNode(tree, expandedNodes, arr, children[i]);
         }
       }
 
-      const roots = tree.getRoots();
+      const roots = sortNodes(tree.getRoots());
       const allRows = [];
       for (let i = 0; i < roots.length; i++) {
         _addVisibleRowsFromNode(tree, expandedNodes, allRows, roots[i]);
@@ -458,7 +571,6 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
 
   _renderRow = (nodeId: NodeIndex, index: number, columnIndex: number) => {
     const {
-      tree,
       fixedColumns,
       mainColumn,
       appendageColumn,
@@ -468,6 +580,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       rowHeight,
       indentWidth,
     } = this.props;
+    const { tree } = this.props;
     const displayData = tree.getDisplayData(nodeId);
     // React converts height into 'px' values, while lineHeight is valid in
     // non-'px' units.
@@ -518,8 +631,13 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
   }
 
   _getAllVisibleRows(): NodeIndex[] {
-    const { tree } = this.props;
-    return this._computeAllVisibleRowsMemoized(tree, this._getExpandedNodes());
+    const { tree, compareColumn } = this.props;
+    return this._computeAllVisibleRowsMemoized(
+      tree,
+      this._getExpandedNodes(),
+      this.state.sortedColumns,
+      compareColumn
+    );
   }
 
   _getSpecialItems(): [NodeIndex | void, NodeIndex | void] {
@@ -591,7 +709,8 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
 
   _onCopy = (event: ClipboardEvent) => {
     event.preventDefault();
-    const { tree, selectedNodeId, mainColumn } = this.props;
+    const { selectedNodeId, mainColumn } = this.props;
+    const { tree } = this.props;
     if (selectedNodeId) {
       const displayData = tree.getDisplayData(selectedNodeId);
       const clipboardData: DataTransfer = (event: any).clipboardData;
@@ -732,6 +851,25 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     }
   }
 
+  _onSort = (column: number) => {
+    if (
+      !this.props.sortableColumns ||
+      !this.props.sortableColumns.has(column)
+    ) {
+      return;
+    }
+
+    this.setState((x) => {
+      const newSortedColumns = x.sortedColumns.push(column);
+      if (this.props.onSort) {
+        this.props.onSort(newSortedColumns);
+      }
+      return {
+        sortedColumns: newSortedColumns,
+      };
+    });
+  };
+
   render() {
     const {
       fixedColumns,
@@ -742,10 +880,21 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       maxNodeDepth,
       rowHeight,
       selectedNodeId,
+      sortableColumns,
     } = this.props;
+    const { sortedColumns } = this.state;
+    const columnSortDirections =
+      sortableColumns && sortedColumns
+        ? sortedColumns.getSortStateArr(sortableColumns)
+        : undefined;
     return (
       <div className="treeView">
-        <TreeViewHeader fixedColumns={fixedColumns} mainColumn={mainColumn} />
+        <TreeViewHeader
+          fixedColumns={fixedColumns}
+          mainColumn={mainColumn}
+          onSort={this._onSort}
+          columnSortDirections={columnSortDirections}
+        />
         <ContextMenuTrigger
           id={contextMenuId ?? 'unknown'}
           disable={!contextMenuId}

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -53,46 +53,57 @@ export type Column<DisplayData: Object> = {|
   |}>,
 |};
 
+type SingleColumnSortState = {|
+  column: string,
+  ascending: boolean,
+|};
+
 type TreeViewHeaderProps<DisplayData: Object> = {|
   +fixedColumns: Column<DisplayData>[],
   +mainColumn: Column<DisplayData>,
-  +onSort: (number) => void,
-  +columnSortDirections?: Array<boolean | null>,
+  +onSort: (string) => void,
+  +currentSortedColumn: SingleColumnSortState | null,
 |};
 
-// columns start at 1
 export class ColumnSortState {
-  sortedColumns: number[];
+  sortedColumns: SingleColumnSortState[];
 
-  // -column: sort descending, +column: sort ascending, start by sorting last column
-  constructor(sortedColumns: number[]) {
+  // start by sorting last column
+  constructor(sortedColumns: SingleColumnSortState[]) {
     this.sortedColumns = sortedColumns;
   }
 
-  _sortColumn(column: number) {
-    const sortedColumns = this.sortedColumns.filter(
-      (c) => c !== column && c !== -column
-    );
-    sortedColumns.push(column);
+  sortColumn(column: string, ascending: boolean | null = null) {
+    const current = this.getStateForColumn(column);
+    const sortedColumns = this.sortedColumns.filter((c) => c.column !== column);
+    if (ascending === true || current === null) {
+      sortedColumns.push({ column, ascending: true });
+    } else {
+      sortedColumns.push(this._invertSortState(current));
+    }
     return new ColumnSortState(sortedColumns);
   }
 
-  push(column: number) {
-    return this._sortColumn(-this._sortState(column));
+  _invertSortState(state: SingleColumnSortState): SingleColumnSortState {
+    return { column: state.column, ascending: !state.ascending };
   }
 
-  _sortState(column: number) {
+  getStateForColumn(column: string): SingleColumnSortState | null {
     return this.sortedColumns
-      .filter((c) => c === column || c === -column)
-      .concat(-column)[0];
+      .filter((c) => c.column === column)
+      .concat(null)[0];
   }
 
-  getSortStateArr(sortableColumns: Set<number>): Array<boolean | null> {
-    const arr = new Array(Math.max(...sortableColumns) + 1).fill(null);
-    for (const column of sortableColumns) {
-      arr[column] = this._sortState(column) < 0;
-    }
-    return arr;
+  getStateForColumnOrDefault(column: string): SingleColumnSortState {
+    return this.sortedColumns
+      .filter((c) => c.column === column)
+      .concat({ column: column, ascending: true })[0];
+  }
+
+  current(): SingleColumnSortState | null {
+    return this.sortedColumns.length > 0
+      ? this.sortedColumns[this.sortedColumns.length - 1]
+      : null;
   }
 }
 
@@ -103,26 +114,31 @@ class TreeViewHeader<DisplayData: Object> extends React.PureComponent<
     const { onSort } = this.props;
     const target = e.target;
     if (target instanceof HTMLElement) {
-      onSort(Number(target.getAttribute('data-column')));
+      onSort(String(target.getAttribute('data-column')));
     }
   };
 
   render() {
-    const { fixedColumns, mainColumn, columnSortDirections } = this.props;
+    const { fixedColumns, mainColumn, currentSortedColumn } = this.props;
     if (fixedColumns.length === 0 && !mainColumn.titleL10nId) {
       // If there is nothing to display in the header, do not render it.
       return null;
     }
     return (
       <div className="treeViewHeader">
-        {fixedColumns.map((col, i) => {
+        {fixedColumns.map((col) => {
           let sortClass = '';
-          if (columnSortDirections) {
-            if (columnSortDirections[i + 1] === true) {
-              sortClass = 'sortAscending';
-            } else if (columnSortDirections[i + 1] === false) {
+          if (
+            currentSortedColumn &&
+            currentSortedColumn.column === col.propName
+          ) {
+            if (currentSortedColumn.ascending) {
               sortClass = 'sortDescending';
+            } else {
+              sortClass = 'sortAscending';
             }
+          } else {
+            sortClass = 'sortInactive';
           }
           return (
             <PermissiveLocalized
@@ -132,7 +148,7 @@ class TreeViewHeader<DisplayData: Object> extends React.PureComponent<
             >
               <span
                 className={`treeViewHeaderColumn treeViewFixedColumn ${col.propName} ${sortClass}`}
-                data-column={i + 1}
+                data-column={col.propName}
                 onClick={this._onSort}
               ></span>
             </PermissiveLocalized>
@@ -457,10 +473,10 @@ type TreeViewProps<DisplayData> = {|
   +indentWidth: CssPixels,
   +onKeyDown?: (SyntheticKeyboardEvent<>) => void,
   // number: column number, -1: first larger, 0: same, 1: first smaller
-  +compareColumn?: (DisplayData, DisplayData, number) => number,
+  +compareColumn?: (DisplayData, DisplayData, string) => number,
   +initialSortedColumns?: ColumnSortState,
   +onSort?: (ColumnSortState) => void,
-  +sortableColumns?: Set<number>,
+  +sortableColumns?: Set<string>,
 |};
 
 type TreeViewState = {|
@@ -507,28 +523,26 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       tree: Tree<DisplayData>,
       expandedNodes: Set<NodeIndex | null>,
       sortedColumns: ColumnSortState,
-      compareColumn: ?(DisplayData, DisplayData, number) => number
+      compareColumn: ?(DisplayData, DisplayData, string) => number
     ) => {
       function sortNodes(nodeIds: Array<NodeIndex>): Array<NodeIndex> {
         if (!compareColumn) {
           return nodeIds;
         }
         let sortedNodeIds = nodeIds;
-        for (let i = 0; i < sortedColumns.sortedColumns.length; i++) {
-          const column = sortedColumns.sortedColumns[i];
-          const absColumn = Math.abs(column);
-          const sign = column < 0 ? -1 : 1;
+        for (const { column, ascending } of sortedColumns.sortedColumns) {
+          const sign = ascending ? 1 : -1;
           sortedNodeIds = sortedNodeIds.sort((a, b) => {
             return (
               sign *
               ((compareColumn: any): (
                 DisplayData,
                 DisplayData,
-                number
+                string
               ) => number)(
                 tree.getDisplayData(a),
                 tree.getDisplayData(b),
-                absColumn
+                column
               )
             );
           });
@@ -541,12 +555,12 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
         if (!expandedNodes.has(nodeId)) {
           return;
         }
-        const children = sortNodes(tree.getChildren(nodeId));
+        const children = tree.getChildren(nodeId);
         for (let i = 0; i < children.length; i++) {
           _addVisibleRowsFromNode(tree, expandedNodes, arr, children[i]);
         }
       }
-
+      // we only sort the root nodes for now
       const roots = sortNodes(tree.getRoots());
       const allRows = [];
       for (let i = 0; i < roots.length; i++) {
@@ -851,7 +865,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     }
   }
 
-  _onSort = (column: number) => {
+  _onSort = (column: string) => {
     if (
       !this.props.sortableColumns ||
       !this.props.sortableColumns.has(column)
@@ -860,7 +874,7 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
     }
 
     this.setState((x) => {
-      const newSortedColumns = x.sortedColumns.push(column);
+      const newSortedColumns = x.sortedColumns.sortColumn(column);
       if (this.props.onSort) {
         this.props.onSort(newSortedColumns);
       }
@@ -880,20 +894,16 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       maxNodeDepth,
       rowHeight,
       selectedNodeId,
-      sortableColumns,
     } = this.props;
     const { sortedColumns } = this.state;
-    const columnSortDirections =
-      sortableColumns && sortedColumns
-        ? sortedColumns.getSortStateArr(sortableColumns)
-        : undefined;
+    const currentSortedColumn = sortedColumns.current();
     return (
       <div className="treeView">
         <TreeViewHeader
           fixedColumns={fixedColumns}
           mainColumn={mainColumn}
           onSort={this._onSort}
-          columnSortDirections={columnSortDirections}
+          currentSortedColumn={currentSortedColumn}
         />
         <ContextMenuTrigger
           id={contextMenuId ?? 'unknown'}

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -353,6 +353,8 @@ export class CallTree {
         iconSrc,
         icon,
         ariaLabel,
+        rawTotal: total,
+        rawSelf: self,
       };
       this._displayDataByIndex.set(callNodeIndex, displayData);
     }

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -103,6 +103,17 @@ describe('MarkerTable', function () {
     expect(scrolledRows()).toHaveLength(2);
   });
 
+  it('sorts when the start header and duration header is clicked', () => {
+    const { container, getByText } = setup();
+
+    fireFullClick(getByText('Start'));
+    expect(container).toMatchSnapshot();
+    fireFullClick(getByText('Start'));
+    expect(container).toMatchSnapshot();
+    fireFullClick(getByText('Duration'));
+    expect(container).toMatchSnapshot();
+  });
+
   it('selects a row when left clicking', () => {
     const { getByText, getRowElement } = setup();
 

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -303,6 +303,17 @@ describe('calltree/ProfileCallTreeView', function () {
     fireFullClick(getByText('Total (samples)'));
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('sorts when the total header and self header is clicked', () => {
+    const { container, getByText } = setup();
+
+    fireFullClick(getByText('Total (samples)'));
+    expect(container).toMatchSnapshot();
+    fireFullClick(getByText('Total (samples)'));
+    expect(container).toMatchSnapshot();
+    fireFullClick(getByText('Self'));
+    expect(container).toMatchSnapshot();
+  });
 });
 
 describe('calltree/ProfileCallTreeView EmptyReasons', function () {

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -292,6 +292,17 @@ describe('calltree/ProfileCallTreeView', function () {
     const { container } = setup(profile);
     expect(container.querySelector('.treeViewRow.isSelected')).toBeFalsy();
   });
+
+  it('sorts when the total column header is clicked', () => {
+    const { container, getByText } = setup();
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireFullClick(getByText('Total (samples)'));
+    expect(container.firstChild).toMatchSnapshot();
+    fireFullClick(getByText('Total (samples)'));
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });
 
 describe('calltree/ProfileCallTreeView EmptyReasons', function () {

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -87,7 +87,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn start sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn start sortDescending"
         data-column="start"
       >
         Start
@@ -514,7 +514,7 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
         class="treeViewHeader"
       >
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn start sortDescending"
+          class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
           data-column="start"
         >
           Start
@@ -942,7 +942,7 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
         class="treeViewHeader"
       >
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
+          class="treeViewHeaderColumn treeViewFixedColumn start sortDescending"
           data-column="start"
         >
           Start
@@ -1422,19 +1422,21 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                 >
                   <span
                     class="treeViewRowColumn treeViewFixedColumn start"
-                    title="0.158s"
+                    title="0.000s"
                   >
-                    0.158s
+                    0.000s
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn duration"
-                    title=""
-                  />
+                    title="0s"
+                  >
+                    0s
+                  </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn type"
-                    title="Log"
+                    title="UserTiming"
                   >
-                    Log
+                    UserTiming
                   </span>
                 </div>
                 <div
@@ -1443,21 +1445,21 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                 >
                   <span
                     class="treeViewRowColumn treeViewFixedColumn start"
-                    title="0.108s"
+                    title="0.153s"
                   >
-                    0.108s
+                    0.153s
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn duration"
-                    title="unknown"
+                    title="584.00ns"
                   >
-                    unknown
+                    584.00ns
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn type"
-                    title="IPC"
+                    title="Text"
                   >
-                    IPC
+                    Text
                   </span>
                 </div>
                 <div
@@ -1466,19 +1468,21 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                 >
                   <span
                     class="treeViewRowColumn treeViewFixedColumn start"
-                    title="0.002s"
+                    title="0.153s"
                   >
-                    0.002s
+                    0.153s
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn duration"
-                    title=""
-                  />
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn type"
-                    title="Paint"
+                    title="Text"
                   >
-                    Paint
+                    Text
                   </span>
                 </div>
                 <div
@@ -1510,21 +1514,19 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                 >
                   <span
                     class="treeViewRowColumn treeViewFixedColumn start"
-                    title="0.153s"
+                    title="0.002s"
                   >
-                    0.153s
+                    0.002s
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn duration"
-                    title="584.00ns"
-                  >
-                    584.00ns
-                  </span>
+                    title=""
+                  />
                   <span
                     class="treeViewRowColumn treeViewFixedColumn type"
-                    title="Text"
+                    title="Paint"
                   >
-                    Text
+                    Paint
                   </span>
                 </div>
                 <div
@@ -1533,21 +1535,21 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                 >
                   <span
                     class="treeViewRowColumn treeViewFixedColumn start"
-                    title="0.153s"
+                    title="0.108s"
                   >
-                    0.153s
+                    0.108s
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn duration"
-                    title="584.00ns"
+                    title="unknown"
                   >
-                    584.00ns
+                    unknown
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn type"
-                    title="Text"
+                    title="IPC"
                   >
-                    Text
+                    IPC
                   </span>
                 </div>
                 <div
@@ -1556,21 +1558,19 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                 >
                   <span
                     class="treeViewRowColumn treeViewFixedColumn start"
-                    title="0.000s"
+                    title="0.158s"
                   >
-                    0.000s
+                    0.158s
                   </span>
                   <span
                     class="treeViewRowColumn treeViewFixedColumn duration"
-                    title="0s"
-                  >
-                    0s
-                  </span>
+                    title=""
+                  />
                   <span
                     class="treeViewRowColumn treeViewFixedColumn type"
-                    title="UserTiming"
+                    title="Log"
                   >
-                    UserTiming
+                    Log
                   </span>
                 </div>
               </div>
@@ -1590,7 +1590,7 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   aria-level="1"
                   aria-selected="false"
                   class="treeViewRow treeViewRowScrolledColumns even"
-                  id="treeViewRow-5"
+                  id="treeViewRow-0"
                   role="treeitem"
                   style="height: 16px; line-height: 16px;"
                 >
@@ -1604,15 +1604,14 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   <span
                     class="treeViewRowColumn treeViewMainColumn name"
                   >
-                    (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
-
+                    foobar
                   </span>
                 </div>
                 <div
                   aria-level="1"
                   aria-selected="false"
                   class="treeViewRow treeViewRowScrolledColumns odd"
-                  id="treeViewRow-2"
+                  id="treeViewRow-3"
                   role="treeitem"
                   style="height: 16px; line-height: 16px;"
                 >
@@ -1626,14 +1625,14 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   <span
                     class="treeViewRowColumn treeViewMainColumn name"
                   >
-                    IPCOut — PContent::Msg_PreferenceUpdate — sent to 2222
+                    setTimeout — 5.5
                   </span>
                 </div>
                 <div
                   aria-level="1"
                   aria-selected="false"
                   class="treeViewRow treeViewRowScrolledColumns even"
-                  id="treeViewRow-1"
+                  id="treeViewRow-4"
                   role="treeitem"
                   style="height: 16px; line-height: 16px;"
                 >
@@ -1647,7 +1646,7 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   <span
                     class="treeViewRowColumn treeViewMainColumn name"
                   >
-                    NotifyDidPaint
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Q…
                   </span>
                 </div>
                 <div
@@ -1675,7 +1674,7 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   aria-level="1"
                   aria-selected="false"
                   class="treeViewRow treeViewRowScrolledColumns even"
-                  id="treeViewRow-3"
+                  id="treeViewRow-1"
                   role="treeitem"
                   style="height: 16px; line-height: 16px;"
                 >
@@ -1689,14 +1688,14 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   <span
                     class="treeViewRowColumn treeViewMainColumn name"
                   >
-                    setTimeout — 5.5
+                    NotifyDidPaint
                   </span>
                 </div>
                 <div
                   aria-level="1"
                   aria-selected="false"
                   class="treeViewRow treeViewRowScrolledColumns odd"
-                  id="treeViewRow-4"
+                  id="treeViewRow-2"
                   role="treeitem"
                   style="height: 16px; line-height: 16px;"
                 >
@@ -1710,14 +1709,14 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   <span
                     class="treeViewRowColumn treeViewMainColumn name"
                   >
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Q…
+                    IPCOut — PContent::Msg_PreferenceUpdate — sent to 2222
                   </span>
                 </div>
                 <div
                   aria-level="1"
                   aria-selected="false"
                   class="treeViewRow treeViewRowScrolledColumns even"
-                  id="treeViewRow-0"
+                  id="treeViewRow-5"
                   role="treeitem"
                   style="height: 16px; line-height: 16px;"
                 >
@@ -1731,7 +1730,8 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
                   <span
                     class="treeViewRowColumn treeViewMainColumn name"
                   >
-                    foobar
+                    (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
+
                   </span>
                 </div>
               </div>

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -87,17 +87,20 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn start"
+        class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
+        data-column="1"
       >
         Start
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn duration"
+        class="treeViewHeaderColumn treeViewFixedColumn duration sortAscending"
+        data-column="2"
       >
         Duration
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn type"
+        class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
+        data-column="3"
       >
         Type
       </span>
@@ -447,6 +450,1290 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                 >
                   (PoisonIOInterposer) create/open — /foo/bar
                 </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerTable sorts when the start header and duration header is clicked 1`] = `
+<div>
+  <div
+    aria-labelledby="marker-table-tab-button"
+    class="markerTable"
+    id="marker-table-tab"
+    role="tabpanel"
+  >
+    <div
+      class="markerSettings"
+    >
+      <div
+        class="markerSettingsSpacer"
+      />
+      <div
+        class="panelSearchField markerSettingsSearchField"
+      >
+        <label
+          class="panelSearchFieldLabel"
+        >
+          Filter Markers: 
+          <form
+            class="idleSearchField panelSearchFieldInput"
+          >
+            <input
+              class="idleSearchFieldInput photon-input"
+              name="search"
+              placeholder="Enter filter terms"
+              required=""
+              title="Only display markers that match a certain name"
+              type="search"
+              value=""
+            />
+            <input
+              class="idleSearchFieldButton"
+              tabindex="-1"
+              type="reset"
+            />
+          </form>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="treeView"
+    >
+      <div
+        class="treeViewHeader"
+      >
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn start sortDescending"
+          data-column="1"
+        >
+          Start
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn duration sortAscending"
+          data-column="2"
+        >
+          Duration
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
+          data-column="3"
+        >
+          Type
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewMainColumn name"
+        >
+          Description
+        </span>
+      </div>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          aria-label="Call tree"
+          class="treeViewBody"
+          role="tree"
+          tabindex="0"
+        >
+          <div
+            class="treeViewBodyInnerWrapper"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0"
+              style="height: 128px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+              >
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.162s"
+                  >
+                    0.162s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="1ms"
+                  >
+                    1ms
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="FileIO"
+                  >
+                    FileIO
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.158s"
+                  >
+                    0.158s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title=""
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Log"
+                  >
+                    Log
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.153s"
+                  >
+                    0.153s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Text"
+                  >
+                    Text
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.153s"
+                  >
+                    0.153s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Text"
+                  >
+                    Text
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.108s"
+                  >
+                    0.108s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="unknown"
+                  >
+                    unknown
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="IPC"
+                  >
+                    IPC
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.002s"
+                  >
+                    0.002s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title=""
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Paint"
+                  >
+                    Paint
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.000s"
+                  >
+                    0.000s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="0s"
+                  >
+                    0s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="UserTiming"
+                  >
+                    UserTiming
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="treeViewBodyInner treeViewBodyInner1"
+              style="height: 128px; min-width: 3000px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+              >
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-6"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    (PoisonIOInterposer) create/open — /foo/bar
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-5"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
+
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-3"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    setTimeout — 5.5
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-4"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Q…
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-2"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    IPCOut — PContent::Msg_PreferenceUpdate — sent to 2222
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-1"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    NotifyDidPaint
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-0"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    foobar
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerTable sorts when the start header and duration header is clicked 2`] = `
+<div>
+  <div
+    aria-labelledby="marker-table-tab-button"
+    class="markerTable"
+    id="marker-table-tab"
+    role="tabpanel"
+  >
+    <div
+      class="markerSettings"
+    >
+      <div
+        class="markerSettingsSpacer"
+      />
+      <div
+        class="panelSearchField markerSettingsSearchField"
+      >
+        <label
+          class="panelSearchFieldLabel"
+        >
+          Filter Markers: 
+          <form
+            class="idleSearchField panelSearchFieldInput"
+          >
+            <input
+              class="idleSearchFieldInput photon-input"
+              name="search"
+              placeholder="Enter filter terms"
+              required=""
+              title="Only display markers that match a certain name"
+              type="search"
+              value=""
+            />
+            <input
+              class="idleSearchFieldButton"
+              tabindex="-1"
+              type="reset"
+            />
+          </form>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="treeView"
+    >
+      <div
+        class="treeViewHeader"
+      >
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
+          data-column="1"
+        >
+          Start
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn duration sortAscending"
+          data-column="2"
+        >
+          Duration
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
+          data-column="3"
+        >
+          Type
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewMainColumn name"
+        >
+          Description
+        </span>
+      </div>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          aria-label="Call tree"
+          class="treeViewBody"
+          role="tree"
+          tabindex="0"
+        >
+          <div
+            class="treeViewBodyInnerWrapper"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0"
+              style="height: 128px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+              >
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.000s"
+                  >
+                    0.000s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="0s"
+                  >
+                    0s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="UserTiming"
+                  >
+                    UserTiming
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.002s"
+                  >
+                    0.002s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title=""
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Paint"
+                  >
+                    Paint
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.108s"
+                  >
+                    0.108s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="unknown"
+                  >
+                    unknown
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="IPC"
+                  >
+                    IPC
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.153s"
+                  >
+                    0.153s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Text"
+                  >
+                    Text
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.153s"
+                  >
+                    0.153s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Text"
+                  >
+                    Text
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.158s"
+                  >
+                    0.158s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title=""
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Log"
+                  >
+                    Log
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.162s"
+                  >
+                    0.162s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="1ms"
+                  >
+                    1ms
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="FileIO"
+                  >
+                    FileIO
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="treeViewBodyInner treeViewBodyInner1"
+              style="height: 128px; min-width: 3000px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+              >
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-0"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    foobar
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-1"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    NotifyDidPaint
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-2"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    IPCOut — PContent::Msg_PreferenceUpdate — sent to 2222
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-3"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    setTimeout — 5.5
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-4"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Q…
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-5"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
+
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-6"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    (PoisonIOInterposer) create/open — /foo/bar
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerTable sorts when the start header and duration header is clicked 3`] = `
+<div>
+  <div
+    aria-labelledby="marker-table-tab-button"
+    class="markerTable"
+    id="marker-table-tab"
+    role="tabpanel"
+  >
+    <div
+      class="markerSettings"
+    >
+      <div
+        class="markerSettingsSpacer"
+      />
+      <div
+        class="panelSearchField markerSettingsSearchField"
+      >
+        <label
+          class="panelSearchFieldLabel"
+        >
+          Filter Markers: 
+          <form
+            class="idleSearchField panelSearchFieldInput"
+          >
+            <input
+              class="idleSearchFieldInput photon-input"
+              name="search"
+              placeholder="Enter filter terms"
+              required=""
+              title="Only display markers that match a certain name"
+              type="search"
+              value=""
+            />
+            <input
+              class="idleSearchFieldButton"
+              tabindex="-1"
+              type="reset"
+            />
+          </form>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="treeView"
+    >
+      <div
+        class="treeViewHeader"
+      >
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
+          data-column="1"
+        >
+          Start
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn duration sortDescending"
+          data-column="2"
+        >
+          Duration
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
+          data-column="3"
+        >
+          Type
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewMainColumn name"
+        >
+          Description
+        </span>
+      </div>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          aria-label="Call tree"
+          class="treeViewBody"
+          role="tree"
+          tabindex="0"
+        >
+          <div
+            class="treeViewBodyInnerWrapper"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0"
+              style="height: 128px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+              >
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.158s"
+                  >
+                    0.158s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title=""
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Log"
+                  >
+                    Log
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.108s"
+                  >
+                    0.108s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="unknown"
+                  >
+                    unknown
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="IPC"
+                  >
+                    IPC
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.002s"
+                  >
+                    0.002s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title=""
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Paint"
+                  >
+                    Paint
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.162s"
+                  >
+                    0.162s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="1ms"
+                  >
+                    1ms
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="FileIO"
+                  >
+                    FileIO
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.153s"
+                  >
+                    0.153s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Text"
+                  >
+                    Text
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.153s"
+                  >
+                    0.153s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="584.00ns"
+                  >
+                    584.00ns
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="Text"
+                  >
+                    Text
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn start"
+                    title="0.000s"
+                  >
+                    0.000s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn duration"
+                    title="0s"
+                  >
+                    0s
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn type"
+                    title="UserTiming"
+                  >
+                    UserTiming
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="treeViewBodyInner treeViewBodyInner1"
+              style="height: 128px; min-width: 3000px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+              >
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-5"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
+
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-2"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    IPCOut — PContent::Msg_PreferenceUpdate — sent to 2222
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-1"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    NotifyDidPaint
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-6"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    (PoisonIOInterposer) create/open — /foo/bar
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-3"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    setTimeout — 5.5
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-4"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Q…
+                  </span>
+                </div>
+                <div
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-0"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    foobar
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -87,20 +87,20 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn start sortInactive"
+        data-column="start"
       >
         Start
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn duration sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn duration sortInactive"
+        data-column="duration"
       >
         Duration
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn type sortInactive"
+        data-column="type"
       >
         Type
       </span>
@@ -515,19 +515,19 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
       >
         <span
           class="treeViewHeaderColumn treeViewFixedColumn start sortDescending"
-          data-column="1"
+          data-column="start"
         >
           Start
         </span>
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn duration sortAscending"
-          data-column="2"
+          class="treeViewHeaderColumn treeViewFixedColumn duration sortInactive"
+          data-column="duration"
         >
           Duration
         </span>
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
-          data-column="3"
+          class="treeViewHeaderColumn treeViewFixedColumn type sortInactive"
+          data-column="type"
         >
           Type
         </span>
@@ -943,19 +943,19 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
       >
         <span
           class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
-          data-column="1"
+          data-column="start"
         >
           Start
         </span>
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn duration sortAscending"
-          data-column="2"
+          class="treeViewHeaderColumn treeViewFixedColumn duration sortInactive"
+          data-column="duration"
         >
           Duration
         </span>
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
-          data-column="3"
+          class="treeViewHeaderColumn treeViewFixedColumn type sortInactive"
+          data-column="type"
         >
           Type
         </span>
@@ -1370,20 +1370,20 @@ exports[`MarkerTable sorts when the start header and duration header is clicked 
         class="treeViewHeader"
       >
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn start sortAscending"
-          data-column="1"
+          class="treeViewHeaderColumn treeViewFixedColumn start sortInactive"
+          data-column="start"
         >
           Start
         </span>
         <span
           class="treeViewHeaderColumn treeViewFixedColumn duration sortDescending"
-          data-column="2"
+          data-column="duration"
         >
           Duration
         </span>
         <span
-          class="treeViewHeaderColumn treeViewFixedColumn type sortAscending"
-          data-column="3"
+          class="treeViewHeaderColumn treeViewFixedColumn type sortInactive"
+          data-column="type"
         >
           Type
         </span>

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -153,7 +153,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
@@ -828,7 +828,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
@@ -1503,7 +1503,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
@@ -2166,7 +2166,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
@@ -2829,7 +2829,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
@@ -3788,7 +3788,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -4418,7 +4418,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -5048,7 +5048,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -5501,7 +5501,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -6131,7 +6131,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -6702,7 +6702,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -7273,7 +7273,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -7727,7 +7727,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -8181,7 +8181,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -8756,7 +8756,7 @@ exports[`calltree/ProfileCallTreeView sorts when the total column header is clic
         data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
         data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
@@ -10507,6 +10507,1902 @@ for understanding where time was actually spent in a program."
                 >
                   libH.so
                 </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`calltree/ProfileCallTreeView sorts when the total header and self header is clicked 1`] = `
+<div>
+  <div
+    aria-labelledby="calltree-tab-button"
+    class="treeAndSidebarWrapper"
+    id="calltree-tab"
+    role="tabpanel"
+  >
+    <div
+      class="stackSettings"
+    >
+      <ul
+        class="stackSettingsList"
+      >
+        <li
+          class="stackSettingsListItem stackSettingsFilter"
+        >
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              checked=""
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="combined"
+            />
+            All stacks
+          </label>
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="js"
+            />
+            JavaScript
+          </label>
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="cpp"
+            />
+            Native
+          </label>
+        </li>
+        <li
+          class="stackSettingsListItem"
+        >
+          <label
+            class="photon-label photon-label-micro stackSettingsLabel"
+          >
+            <input
+              class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+              type="checkbox"
+            />
+            <span
+              title="Sort by the time spent in a call node, ignoring its children."
+            >
+              Invert call stack
+            </span>
+          </label>
+        </li>
+      </ul>
+      <div
+        class="panelSearchField stackSettingsSearchField"
+      >
+        <label
+          class="panelSearchFieldLabel"
+        >
+          Filter stacks: 
+          <form
+            class="idleSearchField panelSearchFieldInput"
+          >
+            <input
+              class="idleSearchFieldInput photon-input"
+              name="search"
+              placeholder="Enter filter terms"
+              required=""
+              title="Only display stacks which contain a function whose name matches this substring"
+              type="search"
+              value=""
+            />
+            <input
+              class="idleSearchFieldButton"
+              tabindex="-1"
+              type="reset"
+            />
+          </form>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </label>
+      </div>
+    </div>
+    <ol
+      class="filterNavigatorBar calltreeTransformNavigator"
+    >
+      <li
+        class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      >
+        <span
+          class="filterNavigatorBarItemContent"
+        >
+          Complete “⁨Empty⁩”
+        </span>
+      </li>
+    </ol>
+    <div
+      class="treeView"
+    >
+      <div
+        class="treeViewHeader"
+      >
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+          data-column="totalPercent"
+        />
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn total sortDescending"
+          data-column="total"
+          title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+        >
+          Total (samples)
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+          data-column="self"
+          title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+        >
+          Self
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+          data-column="icon"
+        />
+        <span
+          class="treeViewHeaderColumn treeViewMainColumn name"
+        />
+      </div>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          aria-activedescendant="treeViewRow-4"
+          aria-label="Call tree"
+          class="treeViewBody"
+          role="tree"
+          tabindex="0"
+        >
+          <div
+            class="treeViewBodyInnerWrapper"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0"
+              style="height: 128px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+              >
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="100%"
+                  >
+                    100%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="3"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="100%"
+                  >
+                    100%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="3"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="67%"
+                  >
+                    67%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="2"
+                  >
+                    2
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even isSelected"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="treeViewBodyInner treeViewBodyInner1"
+              style="height: 128px; min-width: 3000px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+              >
+                <div
+                  aria-expanded="true"
+                  aria-label="A, running count is 3 samples (100%), self count is 0 samples"
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-0"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    A
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="B, running count is 3 samples (100%), self count is 0 samples"
+                  aria-level="2"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-1"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 10px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    B
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                  aria-level="3"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-2"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 20px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    C
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="4"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-3"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 30px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    D
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                  aria-level="5"
+                  aria-selected="true"
+                  class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                  id="treeViewRow-4"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 40px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    E
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="false"
+                  aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="4"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-5"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 30px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    F
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="false"
+                  aria-label="H, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="3"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-7"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 20px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    H
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  >
+                    libH.so
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`calltree/ProfileCallTreeView sorts when the total header and self header is clicked 2`] = `
+<div>
+  <div
+    aria-labelledby="calltree-tab-button"
+    class="treeAndSidebarWrapper"
+    id="calltree-tab"
+    role="tabpanel"
+  >
+    <div
+      class="stackSettings"
+    >
+      <ul
+        class="stackSettingsList"
+      >
+        <li
+          class="stackSettingsListItem stackSettingsFilter"
+        >
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              checked=""
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="combined"
+            />
+            All stacks
+          </label>
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="js"
+            />
+            JavaScript
+          </label>
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="cpp"
+            />
+            Native
+          </label>
+        </li>
+        <li
+          class="stackSettingsListItem"
+        >
+          <label
+            class="photon-label photon-label-micro stackSettingsLabel"
+          >
+            <input
+              class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+              type="checkbox"
+            />
+            <span
+              title="Sort by the time spent in a call node, ignoring its children."
+            >
+              Invert call stack
+            </span>
+          </label>
+        </li>
+      </ul>
+      <div
+        class="panelSearchField stackSettingsSearchField"
+      >
+        <label
+          class="panelSearchFieldLabel"
+        >
+          Filter stacks: 
+          <form
+            class="idleSearchField panelSearchFieldInput"
+          >
+            <input
+              class="idleSearchFieldInput photon-input"
+              name="search"
+              placeholder="Enter filter terms"
+              required=""
+              title="Only display stacks which contain a function whose name matches this substring"
+              type="search"
+              value=""
+            />
+            <input
+              class="idleSearchFieldButton"
+              tabindex="-1"
+              type="reset"
+            />
+          </form>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </label>
+      </div>
+    </div>
+    <ol
+      class="filterNavigatorBar calltreeTransformNavigator"
+    >
+      <li
+        class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      >
+        <span
+          class="filterNavigatorBarItemContent"
+        >
+          Complete “⁨Empty⁩”
+        </span>
+      </li>
+    </ol>
+    <div
+      class="treeView"
+    >
+      <div
+        class="treeViewHeader"
+      >
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+          data-column="totalPercent"
+        />
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+          data-column="total"
+          title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+        >
+          Total (samples)
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+          data-column="self"
+          title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+        >
+          Self
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+          data-column="icon"
+        />
+        <span
+          class="treeViewHeaderColumn treeViewMainColumn name"
+        />
+      </div>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          aria-activedescendant="treeViewRow-4"
+          aria-label="Call tree"
+          class="treeViewBody"
+          role="tree"
+          tabindex="0"
+        >
+          <div
+            class="treeViewBodyInnerWrapper"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0"
+              style="height: 128px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+              >
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="100%"
+                  >
+                    100%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="3"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="100%"
+                  >
+                    100%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="3"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="67%"
+                  >
+                    67%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="2"
+                  >
+                    2
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even isSelected"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="treeViewBodyInner treeViewBodyInner1"
+              style="height: 128px; min-width: 3000px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+              >
+                <div
+                  aria-expanded="true"
+                  aria-label="A, running count is 3 samples (100%), self count is 0 samples"
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-0"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    A
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="B, running count is 3 samples (100%), self count is 0 samples"
+                  aria-level="2"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-1"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 10px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    B
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                  aria-level="3"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-2"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 20px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    C
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="4"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-3"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 30px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    D
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                  aria-level="5"
+                  aria-selected="true"
+                  class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                  id="treeViewRow-4"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 40px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    E
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="false"
+                  aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="4"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-5"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 30px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    F
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="false"
+                  aria-label="H, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="3"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-7"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 20px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    H
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  >
+                    libH.so
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`calltree/ProfileCallTreeView sorts when the total header and self header is clicked 3`] = `
+<div>
+  <div
+    aria-labelledby="calltree-tab-button"
+    class="treeAndSidebarWrapper"
+    id="calltree-tab"
+    role="tabpanel"
+  >
+    <div
+      class="stackSettings"
+    >
+      <ul
+        class="stackSettingsList"
+      >
+        <li
+          class="stackSettingsListItem stackSettingsFilter"
+        >
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              checked=""
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="combined"
+            />
+            All stacks
+          </label>
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="js"
+            />
+            JavaScript
+          </label>
+          <label
+            class="photon-label photon-label-micro stackSettingsFilterLabel"
+          >
+            <input
+              class="photon-radio photon-radio-micro stackSettingsFilterInput"
+              name="stack-settings-filter"
+              title="Filter stack frames to a type."
+              type="radio"
+              value="cpp"
+            />
+            Native
+          </label>
+        </li>
+        <li
+          class="stackSettingsListItem"
+        >
+          <label
+            class="photon-label photon-label-micro stackSettingsLabel"
+          >
+            <input
+              class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+              type="checkbox"
+            />
+            <span
+              title="Sort by the time spent in a call node, ignoring its children."
+            >
+              Invert call stack
+            </span>
+          </label>
+        </li>
+      </ul>
+      <div
+        class="panelSearchField stackSettingsSearchField"
+      >
+        <label
+          class="panelSearchFieldLabel"
+        >
+          Filter stacks: 
+          <form
+            class="idleSearchField panelSearchFieldInput"
+          >
+            <input
+              class="idleSearchFieldInput photon-input"
+              name="search"
+              placeholder="Enter filter terms"
+              required=""
+              title="Only display stacks which contain a function whose name matches this substring"
+              type="search"
+              value=""
+            />
+            <input
+              class="idleSearchFieldButton"
+              tabindex="-1"
+              type="reset"
+            />
+          </form>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </label>
+      </div>
+    </div>
+    <ol
+      class="filterNavigatorBar calltreeTransformNavigator"
+    >
+      <li
+        class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      >
+        <span
+          class="filterNavigatorBarItemContent"
+        >
+          Complete “⁨Empty⁩”
+        </span>
+      </li>
+    </ol>
+    <div
+      class="treeView"
+    >
+      <div
+        class="treeViewHeader"
+      >
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+          data-column="totalPercent"
+        />
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+          data-column="total"
+          title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+        >
+          Total (samples)
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn self sortDescending"
+          data-column="self"
+          title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+        >
+          Self
+        </span>
+        <span
+          class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+          data-column="icon"
+        />
+        <span
+          class="treeViewHeaderColumn treeViewMainColumn name"
+        />
+      </div>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          aria-activedescendant="treeViewRow-4"
+          aria-label="Call tree"
+          class="treeViewBody"
+          role="tree"
+          tabindex="0"
+        >
+          <div
+            class="treeViewBodyInnerWrapper"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0"
+              style="height: 128px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+              >
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="100%"
+                  >
+                    100%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="3"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="100%"
+                  >
+                    100%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="3"
+                  >
+                    3
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="67%"
+                  >
+                    67%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="2"
+                  >
+                    2
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even isSelected"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns odd"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+                <div
+                  class="treeViewRow treeViewRowFixedColumns even"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                    title="33%"
+                  >
+                    33%
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn total"
+                    title="1"
+                  >
+                    1
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn self"
+                    title="—"
+                  >
+                    —
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewFixedColumn icon"
+                    title=""
+                  >
+                    <div
+                      class="nodeIcon "
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="treeViewBodyInner treeViewBodyInner1"
+              style="height: 128px; min-width: 3000px;"
+            >
+              <div
+                class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+                style="height: 0px;"
+              />
+              <div
+                class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+              >
+                <div
+                  aria-expanded="true"
+                  aria-label="A, running count is 3 samples (100%), self count is 0 samples"
+                  aria-level="1"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-0"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 0px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    A
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="B, running count is 3 samples (100%), self count is 0 samples"
+                  aria-level="2"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-1"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 10px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    B
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                  aria-level="3"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-2"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 20px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    C
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="true"
+                  aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="4"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-3"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 30px;"
+                  />
+                  <span
+                    class="treeRowToggleButton expanded canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    D
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                  aria-level="5"
+                  aria-selected="true"
+                  class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                  id="treeViewRow-4"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 40px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed leaf"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    E
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="false"
+                  aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="4"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns odd"
+                  id="treeViewRow-5"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 30px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name dim"
+                  >
+                    F
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  />
+                </div>
+                <div
+                  aria-expanded="false"
+                  aria-label="H, running count is 1 sample (33%), self count is 0 samples"
+                  aria-level="3"
+                  aria-selected="false"
+                  class="treeViewRow treeViewRowScrolledColumns even"
+                  id="treeViewRow-7"
+                  role="treeitem"
+                  style="height: 16px; line-height: 16px;"
+                >
+                  <span
+                    class="treeRowIndentSpacer"
+                    style="width: 20px;"
+                  />
+                  <span
+                    class="treeRowToggleButton collapsed canBeExpanded"
+                  />
+                  <span
+                    class="colored-square category-color-grey"
+                    title="Other"
+                  />
+                  <span
+                    class="treeViewRowColumn treeViewMainColumn name"
+                  >
+                    H
+                  </span>
+                  <span
+                    class="treeViewRowColumn treeViewAppendageColumn lib"
+                  >
+                    libH.so
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -149,10 +149,12 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -161,7 +163,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -171,7 +174,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -820,10 +824,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -832,7 +838,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -842,7 +849,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -1491,10 +1499,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -1503,7 +1513,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -1513,7 +1524,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -2150,10 +2162,12 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -2162,7 +2176,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -2172,7 +2187,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -2809,10 +2825,12 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -2821,7 +2839,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -2831,7 +2850,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -3764,10 +3784,12 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -3776,7 +3798,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -3785,7 +3808,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -4390,10 +4414,12 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -4402,7 +4428,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -4411,7 +4438,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -5016,10 +5044,12 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -5028,7 +5058,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -5037,7 +5068,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -5465,10 +5497,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -5477,7 +5511,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -5486,7 +5521,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -6091,10 +6127,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -6103,7 +6141,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -6112,7 +6151,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -6658,10 +6698,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -6670,7 +6712,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -6679,7 +6722,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -7225,10 +7269,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -7237,7 +7283,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -7246,7 +7293,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -7675,10 +7723,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -7687,7 +7737,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -7696,7 +7747,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -8125,10 +8177,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -8137,7 +8191,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -8146,7 +8201,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon"
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -8538,6 +8594,1896 @@ for understanding where time was actually spent in a program."
                 aria-level="4"
                 aria-selected="false"
                 class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`calltree/ProfileCallTreeView sorts when the total column header is clicked 1`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Sort by the time spent in a call node, ignoring its children."
+          >
+            Invert call stack
+          </span>
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete “⁨Empty⁩”
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
+        title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+      >
+        Total (samples)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
+        title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+      >
+        Self
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-4"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 128px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="67%"
+                >
+                  67%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="2"
+                >
+                  2
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 128px; min-width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, running count is 3 samples (100%), self count is 0 samples"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, running count is 3 samples (100%), self count is 0 samples"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="H, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-7"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  H
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  libH.so
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`calltree/ProfileCallTreeView sorts when the total column header is clicked 2`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Sort by the time spent in a call node, ignoring its children."
+          >
+            Invert call stack
+          </span>
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete “⁨Empty⁩”
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn total sortDescending"
+        data-column="2"
+        title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+      >
+        Total (samples)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
+        title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+      >
+        Self
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-4"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 128px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="67%"
+                >
+                  67%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="2"
+                >
+                  2
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 128px; min-width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, running count is 3 samples (100%), self count is 0 samples"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, running count is 3 samples (100%), self count is 0 samples"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="H, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-7"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  H
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  libH.so
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`calltree/ProfileCallTreeView sorts when the total column header is clicked 3`] = `
+<div
+  aria-labelledby="calltree-tab-button"
+  class="treeAndSidebarWrapper"
+  id="calltree-tab"
+  role="tabpanel"
+>
+  <div
+    class="stackSettings"
+  >
+    <ul
+      class="stackSettingsList"
+    >
+      <li
+        class="stackSettingsListItem stackSettingsFilter"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro stackSettingsFilterLabel"
+        >
+          <input
+            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+      <li
+        class="stackSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro stackSettingsLabel"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Sort by the time spent in a call node, ignoring its children."
+          >
+            Invert call stack
+          </span>
+        </label>
+      </li>
+    </ul>
+    <div
+      class="panelSearchField stackSettingsSearchField"
+    >
+      <label
+        class="panelSearchFieldLabel"
+      >
+        Filter stacks: 
+        <form
+          class="idleSearchField panelSearchFieldInput"
+        >
+          <input
+            class="idleSearchFieldInput photon-input"
+            name="search"
+            placeholder="Enter filter terms"
+            required=""
+            title="Only display stacks which contain a function whose name matches this substring"
+            type="search"
+            value=""
+          />
+          <input
+            class="idleSearchFieldButton"
+            tabindex="-1"
+            type="reset"
+          />
+        </form>
+        <div
+          class="panelSearchFieldIntroduction isHidden"
+        >
+          Did you know you can use the comma (,) to search using several terms?
+        </div>
+      </label>
+    </div>
+  </div>
+  <ol
+    class="filterNavigatorBar calltreeTransformNavigator"
+  >
+    <li
+      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    >
+      <span
+        class="filterNavigatorBarItemContent"
+      >
+        Complete “⁨Empty⁩”
+      </span>
+    </li>
+  </ol>
+  <div
+    class="treeView"
+  >
+    <div
+      class="treeViewHeader"
+    >
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
+        data-column="1"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
+        data-column="2"
+        title="The “total” sample count includes a summary of every sample where this
+function was observed to be on the stack. This includes the time where the
+function was actually running, and the time spent in the callers from this
+function."
+      >
+        Total (samples)
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
+        data-column="3"
+        title="The “self” sample count only includes the samples where the function was
+the end of the stack. If this function called into other functions,
+then the “other” functions’ counts are not included. The “self” count is useful
+for understanding where time was actually spent in a program."
+      >
+        Self
+      </span>
+      <span
+        class="treeViewHeaderColumn treeViewFixedColumn icon "
+        data-column="4"
+      />
+      <span
+        class="treeViewHeaderColumn treeViewMainColumn name"
+      />
+    </div>
+    <div
+      class="react-contextmenu-wrapper treeViewContextMenu"
+    >
+      <div
+        aria-activedescendant="treeViewRow-4"
+        aria-label="Call tree"
+        class="treeViewBody"
+        role="tree"
+        tabindex="0"
+      >
+        <div
+          class="treeViewBodyInnerWrapper"
+        >
+          <div
+            class="treeViewBodyInner treeViewBodyInner0"
+            style="height: 128px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner0TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner0InnerChunk"
+            >
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="67%"
+                >
+                  67%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="2"
+                >
+                  2
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd isSelected"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="treeViewBodyInner treeViewBodyInner1"
+            style="height: 128px; min-width: 3000px;"
+          >
+            <div
+              class="treeViewBodyInner treeViewBodyInner1TopSpacer"
+              style="height: 0px;"
+            />
+            <div
+              class="treeViewBodyInner treeViewBodyInner1InnerChunk"
+            >
+              <div
+                aria-expanded="true"
+                aria-label="A, running count is 3 samples (100%), self count is 0 samples"
+                aria-level="1"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-0"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 0px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  A
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="B, running count is 3 samples (100%), self count is 0 samples"
+                aria-level="2"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-1"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 10px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  B
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="H, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-7"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name"
+                >
+                  H
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                >
+                  libH.so
+                </span>
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -149,12 +149,12 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -163,8 +163,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -174,8 +174,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -824,12 +824,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -838,8 +838,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -849,8 +849,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -1499,12 +1499,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -1513,8 +1513,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -1524,8 +1524,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -2162,12 +2162,12 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -2176,8 +2176,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -2187,8 +2187,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -2825,12 +2825,12 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -2839,8 +2839,8 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -2850,8 +2850,8 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -3784,12 +3784,12 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -3798,8 +3798,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -3808,8 +3808,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -4414,12 +4414,12 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -4428,8 +4428,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -4438,8 +4438,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -5044,12 +5044,12 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -5058,8 +5058,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -5068,8 +5068,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -5497,12 +5497,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -5511,8 +5511,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -5521,8 +5521,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -6127,12 +6127,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -6141,8 +6141,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -6151,8 +6151,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -6698,12 +6698,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -6712,8 +6712,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -6722,8 +6722,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -7269,12 +7269,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -7283,8 +7283,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -7293,8 +7293,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -7723,12 +7723,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -7737,8 +7737,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -7747,8 +7747,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -8177,12 +8177,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -8191,8 +8191,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -8201,8 +8201,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -8752,12 +8752,12 @@ exports[`calltree/ProfileCallTreeView sorts when the total column header is clic
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        class="treeViewHeaderColumn treeViewFixedColumn total sortInactive"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -8766,8 +8766,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -8776,8 +8776,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -9382,12 +9382,12 @@ exports[`calltree/ProfileCallTreeView sorts when the total column header is clic
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total sortDescending"
-        data-column="2"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -9396,8 +9396,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -9406,8 +9406,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -10012,12 +10012,12 @@ exports[`calltree/ProfileCallTreeView sorts when the total column header is clic
       class="treeViewHeader"
     >
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn totalPercent "
-        data-column="1"
+        class="treeViewHeaderColumn treeViewFixedColumn totalPercent sortInactive"
+        data-column="totalPercent"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total sortAscending"
-        data-column="2"
+        data-column="total"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -10026,8 +10026,8 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn self sortAscending"
-        data-column="3"
+        class="treeViewHeaderColumn treeViewFixedColumn self sortInactive"
+        data-column="self"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -10036,8 +10036,8 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn icon "
-        data-column="4"
+        class="treeViewHeaderColumn treeViewFixedColumn icon sortInactive"
+        data-column="icon"
       />
       <span
         class="treeViewHeaderColumn treeViewMainColumn name"
@@ -10135,37 +10135,6 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="33%"
-                >
-                  33%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="1"
-                >
-                  1
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns odd"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
                   title="67%"
                 >
                   67%
@@ -10192,7 +10161,7 @@ for understanding where time was actually spent in a program."
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns even"
+                class="treeViewRow treeViewRowFixedColumns odd"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -10223,7 +10192,7 @@ for understanding where time was actually spent in a program."
                 </span>
               </div>
               <div
-                class="treeViewRow treeViewRowFixedColumns odd isSelected"
+                class="treeViewRow treeViewRowFixedColumns even isSelected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -10243,6 +10212,37 @@ for understanding where time was actually spent in a program."
                   title="1"
                 >
                   1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -10358,6 +10358,125 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
+                aria-expanded="true"
+                aria-label="C, running count is 2 samples (67%), self count is 0 samples"
+                aria-level="3"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-2"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 20px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="false"
+                aria-label="F, running count is 1 sample (33%), self count is 0 samples"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-5"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
                 aria-expanded="false"
                 aria-label="H, running count is 1 sample (33%), self count is 0 samples"
                 aria-level="3"
@@ -10388,125 +10507,6 @@ for understanding where time was actually spent in a program."
                 >
                   libH.so
                 </span>
-              </div>
-              <div
-                aria-expanded="true"
-                aria-label="C, running count is 2 samples (67%), self count is 0 samples"
-                aria-level="3"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
-                id="treeViewRow-2"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 20px;"
-                />
-                <span
-                  class="treeRowToggleButton expanded canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  C
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-expanded="true"
-                aria-label="D, running count is 1 sample (33%), self count is 0 samples"
-                aria-level="4"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
-                id="treeViewRow-3"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 30px;"
-                />
-                <span
-                  class="treeRowToggleButton expanded canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  D
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
-                aria-level="5"
-                aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns odd isSelected"
-                id="treeViewRow-4"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 40px;"
-                />
-                <span
-                  class="treeRowToggleButton collapsed leaf"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  E
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-expanded="false"
-                aria-label="F, running count is 1 sample (33%), self count is 0 samples"
-                aria-level="4"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
-                id="treeViewRow-5"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 30px;"
-                />
-                <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  F
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
               </div>
             </div>
           </div>

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -48,6 +48,8 @@ describe('actions/icons', function () {
       icon,
       iconSrc: 'https://edition.cnn.com/favicon.ico',
       ariaLabel: 'fake aria label',
+      rawTotal: 0,
+      rawSelf: 0,
     };
   }
 

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -335,6 +335,9 @@ describe('unfiltered call tree', function () {
           totalPercent: '100%',
           categoryColor: 'grey',
           categoryName: 'Other',
+          rawSelf: 0,
+          rawTotal: 3,
+          badge: undefined,
         });
         expect(callTree.getDisplayData(I)).toEqual({
           ariaLabel:
@@ -351,6 +354,9 @@ describe('unfiltered call tree', function () {
           totalPercent: '33%',
           categoryColor: 'grey',
           categoryName: 'Other',
+          rawSelf: 1,
+          rawTotal: 1,
+          badge: undefined,
         });
       });
     });

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -244,6 +244,9 @@ export type CallNodeDisplayData = $Exact<
     badge?: ExtraBadgeInfo,
     icon: string | null,
     ariaLabel: string,
+    // just used for sorting
+    rawSelf: number,
+    rawTotal: number,
   }>
 >;
 


### PR DESCRIPTION
_I botched the rebase for #4203, so I created a new PR._

his change adds sorts buttons to the MarkerTable and CallTree, allowing to sort the columns of both views.
An example: Before this change the marker table looked like:

<img width="671" alt="image" src="https://user-images.githubusercontent.com/490655/194098034-a91e03df-1cc9-49e1-bb1c-89443ce415cb.png">

After this change it looks initially like:

<img width="671" alt="image" src="https://user-images.githubusercontent.com/490655/194100821-ad3d56be-995f-4c07-8b45-9f8c9a6de1d0.png">

Making it clear to the user that sorting is available (and that the table is sorted by the first column). Clicking on the "Start" column changes this to:

<img width="671" alt="image" src="https://user-images.githubusercontent.com/490655/194101199-6035fa2c-2df7-49f3-95ae-728379826ba0.png">

Clicking on another column like "Duration" sorts by this column:

<img width="671" alt="image" src="https://user-images.githubusercontent.com/490655/194101408-5d805475-1fe3-4209-a4e1-b5e82eb6abb1.png">

It includes tests for the expected behavior.
