### PR TITLE
Provide an option and a double-click gesture to show all local tracks for a process

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -722,6 +722,7 @@ TrackContextMenu--hide-other-screenshots-tracks = Hide other Screenshots tracks
 #   $trackName (String) - Name of the selected track to hide.
 TrackContextMenu--hide-track = Hide “{ $trackName }”
 TrackContextMenu--show-all-tracks = Show all tracks
+TrackContextMenu--show-local-tracks-in-process = Show all tracks in this process
 
 # This is used in the tracks context menu as a button to show all the tracks
 # that match the search filter.

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1174,6 +1174,28 @@ export function showGlobalTrack(trackIndex: TrackIndex): ThunkAction<void> {
 }
 
 /**
+ * This action shows a specific global track and its local tracks.
+ */
+export function showGlobalTrackIncludingLocalTracks(
+  trackIndex: TrackIndex,
+  pid: Pid
+): ThunkAction<void> {
+  return (dispatch) => {
+    sendAnalytics({
+      hitType: 'event',
+      eventCategory: 'timeline',
+      eventAction: 'show global track including local tracks',
+    });
+
+    dispatch({
+      type: 'SHOW_GLOBAL_TRACK_INCLUDING_LOCAL_TRACKS',
+      trackIndex,
+      pid,
+    });
+  };
+}
+
+/**
  * This function isolates a process global track, and leaves its local tracks visible.
  */
 export function isolateProcess(

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -213,6 +213,20 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     );
   };
 
+  _hideRightClickedTrack = (): void => {
+    const { rightClickedTrack, hideLocalTrack, hideGlobalTrack } = this.props;
+    if (rightClickedTrack === null) {
+      return;
+    }
+
+    if (rightClickedTrack.type === 'global') {
+      hideGlobalTrack(rightClickedTrack.trackIndex);
+      return;
+    }
+
+    hideLocalTrack(rightClickedTrack.pid, rightClickedTrack.trackIndex);
+  };
+
   _toggleGlobalTrackVisibility = (
     _,
     data: { trackIndex: TrackIndex }
@@ -731,29 +745,11 @@ class TimelineTrackContextMenuImpl extends PureComponent<
     const rightClickedTrackName =
       this.getRightClickedTrackName(rightClickedTrack);
 
-    if (rightClickedTrack.type === 'global') {
-      return (
-        <MenuItem
-          key={trackIndex}
-          preventClose={false}
-          data={rightClickedTrack}
-          onClick={this._toggleGlobalTrackVisibility}
-        >
-          <Localized
-            id="TrackContextMenu--hide-track"
-            vars={{ trackName: rightClickedTrackName }}
-          >
-            <>Hide {`“${rightClickedTrackName}”`}</>
-          </Localized>
-        </MenuItem>
-      );
-    }
     return (
       <MenuItem
         key={trackIndex}
         preventClose={false}
-        data={rightClickedTrack}
-        onClick={this._toggleLocalTrackVisibility}
+        onClick={this._hideRightClickedTrack}
       >
         <Localized
           id="TrackContextMenu--hide-track"

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -737,7 +737,12 @@ class TimelineTrackContextMenuImpl extends PureComponent<
   }
 
   renderShowLocalTracksInThisProcess() {
-    const { rightClickedTrack, globalTracks } = this.props;
+    const {
+      rightClickedTrack,
+      globalTracks,
+      localTracksByPid,
+      hiddenLocalTracksByPid,
+    } = this.props;
     if (rightClickedTrack === null) {
       return null;
     }
@@ -754,9 +759,18 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       pid = rightClickedTrack.pid;
     }
 
+    const localTracks = localTracksByPid.get(pid);
+    if (!localTracks || !localTracks.length) {
+      return null;
+    }
+
+    const hiddenLocalTracks = hiddenLocalTracksByPid.get(pid);
+    const isDisabled = !hiddenLocalTracks || hiddenLocalTracks.size === 0;
+
     return (
       <MenuItem
         onClick={this._showLocalTracksInProcess}
+        disabled={isDisabled}
         data={{ trackIndex, pid }}
       >
         <Localized id="TrackContextMenu--show-local-tracks-in-process">

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -230,11 +230,31 @@ class TimelineTrackContextMenuImpl extends PureComponent<
   };
 
   _toggleGlobalTrackVisibility = (
-    _,
+    e: SyntheticMouseEvent<>,
     data: { trackIndex: TrackIndex }
   ): void => {
     const { trackIndex } = data;
-    const { hiddenGlobalTracks, hideGlobalTrack, showGlobalTrack } = this.props;
+    const {
+      hiddenGlobalTracks,
+      hideGlobalTrack,
+      showGlobalTrack,
+      globalTracks,
+    } = this.props;
+
+    if (e.detail > 2) {
+      // Ignore triple (and more) clicks
+      return;
+    }
+
+    if (e.detail === 2) {
+      // This is a double click.
+      const track = globalTracks[trackIndex];
+      if (track.type === 'process') {
+        this._showLocalTracksInProcess(e, { trackIndex, pid: track.pid });
+        return;
+      }
+    }
+
     if (hiddenGlobalTracks.has(trackIndex)) {
       showGlobalTrack(trackIndex);
     } else {

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -1152,12 +1152,15 @@ class TimelineTrackContextMenuImpl extends PureComponent<
         {rightClickedTrack === null ? (
           <div className="react-contextmenu-separator" />
         ) : null}
-        {showLocalTracksInProcess}
         {isolateProcessMainThread}
         {isolateProcess}
         {isolateLocalTrack}
         {isolateScreenshot}
         {hideTrack}
+        {showLocalTracksInProcess ? (
+          <div className="react-contextmenu-separator" />
+        ) : null}
+        {showLocalTracksInProcess}
         {separator}
         {isTrackListEmpty ? (
           <Localized

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -131,6 +131,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'SHOW_PROVIDED_TRACKS':
     case 'HIDE_PROVIDED_TRACKS':
     case 'SHOW_GLOBAL_TRACK':
+    case 'SHOW_GLOBAL_TRACK_INCLUDING_LOCAL_TRACKS':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'HIDE_LOCAL_TRACK':

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -357,7 +357,8 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
       );
       return hiddenGlobalTracks;
     }
-    case 'SHOW_GLOBAL_TRACK': {
+    case 'SHOW_GLOBAL_TRACK':
+    case 'SHOW_GLOBAL_TRACK_INCLUDING_LOCAL_TRACKS': {
       const hiddenGlobalTracks = new Set(state);
       hiddenGlobalTracks.delete(action.trackIndex);
       return hiddenGlobalTracks;
@@ -421,6 +422,12 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
       const hiddenLocalTracks = new Set(hiddenLocalTracksByPid.get(action.pid));
       hiddenLocalTracks.delete(action.trackIndex);
       hiddenLocalTracksByPid.set(action.pid, hiddenLocalTracks);
+      return hiddenLocalTracksByPid;
+    }
+    case 'SHOW_GLOBAL_TRACK_INCLUDING_LOCAL_TRACKS': {
+      // Show all local tracks for this global track
+      const hiddenLocalTracksByPid = new Map(state);
+      hiddenLocalTracksByPid.set(action.pid, new Set());
       return hiddenLocalTracksByPid;
     }
     case 'HIDE_PROVIDED_TRACKS': {

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -885,8 +885,57 @@ describe('timeline/TrackContextMenu', function () {
         '  - show [thread Renderer]',
       ]);
 
+      // This ensures that the displayed tracks are only from the first process.
+      // Please make sure the test here is the same than in the next test.
+      expect(screen.queryByText('DOM Worker')).not.toBeInTheDocument();
+
       // Carry on the test
       fireFullClick(screen.getByText('Show all tracks in this process'));
+      expect(getHumanReadableTracks(getState())).toEqual([
+        'show [thread GeckoMain default]',
+        '  - show [thread ThreadPool#1]',
+        '  - show [thread ThreadPool#2]',
+        '  - show [thread ThreadPool#3]',
+        '  - show [thread ThreadPool#4]',
+        '  - show [thread ThreadPool#5]',
+        'show [thread GeckoMain tab] SELECTED',
+        '  - show [thread DOM Worker]',
+        '  - show [thread Style]',
+        'show [thread GeckoMain tab]',
+        '  - show [thread AudioPool#1]',
+        '  - show [thread AudioPool#2]',
+        '  - show [thread Renderer]',
+      ]);
+    });
+
+    it('by double clicking the global process item', () => {
+      const { getState, clickAllThreadPoolTracks } = setupMoreTracks();
+      clickAllThreadPoolTracks();
+      // First, check that the initial state is what we expect.
+      expect(getHumanReadableTracks(getState())).toEqual([
+        'show [thread GeckoMain default]',
+        '  - hide [thread ThreadPool#1]',
+        '  - hide [thread ThreadPool#2]',
+        '  - hide [thread ThreadPool#3]',
+        '  - hide [thread ThreadPool#4]',
+        '  - hide [thread ThreadPool#5]',
+        'show [thread GeckoMain tab] SELECTED',
+        '  - show [thread DOM Worker]',
+        '  - show [thread Style]',
+        'show [thread GeckoMain tab]',
+        '  - show [thread AudioPool#1]',
+        '  - show [thread AudioPool#2]',
+        '  - show [thread Renderer]',
+      ]);
+
+      // This ensures that the displayed tracks are for the whole profile.
+      // Please make sure the test here is the same than in the previous test.
+      expect(screen.getByText('DOM Worker')).toBeInTheDocument();
+
+      // Then carry one with the test.
+      const globalTrack = screen.getByText('Parent Process');
+      fireFullClick(globalTrack, { detail: 1 });
+      fireFullClick(globalTrack, { detail: 2 });
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default]',
         '  - show [thread ThreadPool#1]',

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -6,10 +6,14 @@
 
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { fireEvent } from '@testing-library/react';
 import { showMenu } from '@firefox-devtools/react-contextmenu';
 
-import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from 'firefox-profiler/test/fixtures/testing-library';
 import { ensureExists } from '../../utils/flow';
 import {
   changeSelectedThreads,
@@ -41,6 +45,32 @@ describe('timeline/TrackContextMenu', function () {
     jest.useFakeTimers();
   });
 
+  const clickTracksWithExpectation = async (
+    matchers: Array<string | RegExp>,
+    expectations: {|
+      +checked: boolean,
+    |}
+  ) => {
+    const elements = matchers.map((matcher) =>
+      screen.getByRole('menuitemcheckbox', { name: matcher })
+    );
+    elements.forEach((element) => fireFullClick(element));
+
+    await waitFor(() => {
+      for (const element of elements) {
+        const menuItem = element.closest('.react-contextmenu-item');
+        expect(menuItem).toHaveAttribute(
+          'aria-checked',
+          String(expectations.checked)
+        );
+        if (expectations.checked) {
+          expect(menuItem).toBeChecked();
+        } else {
+          expect(menuItem).not.toBeChecked();
+        }
+      }
+    });
+  };
   /**
    *  getProfileWithNiceTracks() looks like: [
    *    'show [thread GeckoMain default]',
@@ -100,23 +130,21 @@ describe('timeline/TrackContextMenu', function () {
       const results = setup();
       const selectAllTracksItem = () => screen.getByText('Show all tracks');
 
-      const clickAllTracks = () => {
-        // To hide the tracks before testing 'Show all tracks'
-        fireFullClick(screen.getByText('Parent Process'));
-        fireFullClick(screen.getByText('DOM Worker'));
-        fireFullClick(screen.getByText('Style'));
+      const hideAllTracks = async () => {
+        // We want to hide this tracks before testing 'Show all tracks'
+        const matchers = [/Parent Process/, 'DOM Worker', 'Style'];
+        await clickTracksWithExpectation(matchers, { checked: false });
       };
 
       return {
         ...results,
         selectAllTracksItem,
-        clickAllTracks,
+        hideAllTracks,
       };
     }
 
-    it('selects all tracks', () => {
-      const { getState, selectAllTracksItem, clickAllTracks } =
-        setupAllTracks();
+    it('selects all tracks', async () => {
+      const { getState, selectAllTracksItem, hideAllTracks } = setupAllTracks();
       // Test behavior when all tracks are already shown
       fireFullClick(selectAllTracksItem());
       expect(getHumanReadableTracks(getState())).toEqual([
@@ -127,7 +155,7 @@ describe('timeline/TrackContextMenu', function () {
       ]);
 
       // Hide all tracks to test behavior
-      clickAllTracks();
+      await hideAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden
         'hide [thread GeckoMain default]',
@@ -153,36 +181,34 @@ describe('timeline/TrackContextMenu', function () {
       const selectShowAllMatchingTracksItem = () =>
         screen.getByText('Show all matching tracks');
 
-      const clickAllTracks = () => {
+      const hideAllTracks = async () => {
         // To hide the tracks before testing 'Show all tracks'
-        fireFullClick(screen.getByText('Parent Process'));
-        fireFullClick(screen.getByText('DOM Worker'));
-        fireFullClick(screen.getByText('Style'));
+        const matchers = [/Parent Process/, 'DOM Worker', 'Style'];
+        await clickTracksWithExpectation(matchers, { checked: false });
       };
 
-      const clickAllTracksExceptMain = () => {
-        fireFullClick(screen.getByText('DOM Worker'));
-        fireFullClick(screen.getByText('Style'));
-        fireFullClick(screen.getByText('Content Process'));
+      const hideAllTracksExceptMain = async () => {
+        const matchers = [/Content Process/, 'DOM Worker', 'Style'];
+        await clickTracksWithExpectation(matchers, { checked: false });
       };
 
       return {
         ...results,
         selectShowAllMatchingTracksItem,
-        clickAllTracks,
-        clickAllTracksExceptMain,
+        hideAllTracks,
+        hideAllTracksExceptMain,
       };
     }
 
-    it('shows a single track', () => {
+    it('shows a single track', async () => {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        clickAllTracks,
+        hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      clickAllTracks();
+      await hideAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain default]',
@@ -206,15 +232,15 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it('shows children of a global track', () => {
+    it('shows children of a global track', async () => {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        clickAllTracks,
+        hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      clickAllTracks();
+      await hideAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain default]',
@@ -238,15 +264,15 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it('shows a local track', () => {
+    it('shows a local track', async () => {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        clickAllTracks,
+        hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      clickAllTracks();
+      await hideAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain default]',
@@ -270,15 +296,15 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it('does not show anything if the list is empty', () => {
+    it('does not show anything if the list is empty', async () => {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        clickAllTracks,
+        hideAllTracks,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks to test the behavior.
-      clickAllTracks();
+      await hideAllTracks();
       expect(getHumanReadableTracks(getState())).toEqual([
         // Check if the tracks have been hidden.
         'hide [thread GeckoMain default]',
@@ -302,15 +328,15 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it("shows local track's global track even if it wasn't visible before", () => {
+    it("shows local track's global track even if it wasn't visible before", async () => {
       const {
         getState,
         selectShowAllMatchingTracksItem,
-        clickAllTracksExceptMain,
+        hideAllTracksExceptMain,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide the local tracks and tehe global track with children for this behavior.
-      clickAllTracksExceptMain();
+      await hideAllTracksExceptMain();
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default] SELECTED',
         // These tracks must be hidden at the start.
@@ -340,16 +366,15 @@ describe('timeline/TrackContextMenu', function () {
       const hideAllMatchingTracksItem = () =>
         screen.getByText('Hide all matching tracks');
 
-      const clickAllTracksExceptMain = () => {
-        fireFullClick(screen.getByText('DOM Worker'));
-        fireFullClick(screen.getByText('Style'));
-        fireFullClick(screen.getByText('Content Process'));
+      const hideAllTracksExceptMain = async () => {
+        const matchers = [/Content Process/, 'DOM Worker', 'Style'];
+        await clickTracksWithExpectation(matchers, { checked: false });
       };
 
       return {
         ...setupResults,
         hideAllMatchingTracksItem,
-        clickAllTracksExceptMain,
+        hideAllTracksExceptMain,
       };
     }
 
@@ -428,15 +453,15 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it('does not hide if it is the last visible track', () => {
+    it('does not hide if it is the last visible track', async () => {
       const {
         getState,
         hideAllMatchingTracksItem,
-        clickAllTracksExceptMain,
+        hideAllTracksExceptMain,
         changeSearchFilter,
       } = setupAllTracks();
       // Hide all tracks except the main to test the behavior.
-      clickAllTracksExceptMain();
+      await hideAllTracksExceptMain();
       expect(getHumanReadableTracks(getState())).toEqual([
         // This must be the only visible track.
         'show [thread GeckoMain default] SELECTED',
@@ -583,7 +608,6 @@ describe('timeline/TrackContextMenu', function () {
       // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
       const isolateProcessMainThreadItem = () =>
         screen.getByText(/Only show “\u2068Content Process\u2069”/);
-      const trackItem = () => screen.getByText('Content Process');
       const isolateScreenshotTrack = () =>
         screen.getByText(/Hide other Screenshots tracks/);
       // Fluent adds isolation characters \u2068 and \u2069 around Content Process.
@@ -599,7 +623,6 @@ describe('timeline/TrackContextMenu', function () {
         isolateProcessMainThreadItem,
         isolateScreenshotTrack,
         hideContentProcess,
-        trackItem,
       };
     }
 
@@ -702,12 +725,14 @@ describe('timeline/TrackContextMenu', function () {
       ]);
     });
 
-    it('can toggle a global track by clicking it', function () {
-      const { trackItem, trackIndex, getState } = setupGlobalTrack();
+    it('can toggle a global track by clicking it', async function () {
+      const { trackIndex, getState } = setupGlobalTrack();
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(false);
-      fireFullClick(trackItem());
+      await clickTracksWithExpectation([/^Content Process/], {
+        checked: false,
+      });
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(true);
-      fireFullClick(trackItem());
+      await clickTracksWithExpectation([/^Content Process/], { checked: true });
       expect(getHiddenGlobalTracks(getState()).has(trackIndex)).toBe(false);
     });
 
@@ -956,8 +981,8 @@ describe('timeline/TrackContextMenu', function () {
 
   describe('global / local track visibility interplay', function () {
     function setupTracks() {
-      const results = setup();
-      const { dispatch, getState } = results;
+      const setupResult = setup();
+      const { dispatch, getState } = setupResult;
 
       const trackIndex = 1;
       const trackReference = {
@@ -976,20 +1001,15 @@ describe('timeline/TrackContextMenu', function () {
       dispatch(changeSelectedThreads(new Set([threadIndex])));
       dispatch(changeRightClickedTrack(trackReference));
 
-      const globalTrackItem = () => screen.getByText('Content Process');
-      const localTrackItem = () => screen.getByText('DOM Worker');
-
-      return {
-        ...results,
-        globalTrackItem,
-        localTrackItem,
-      };
+      return setupResult;
     }
 
-    it('will unhide the global track when unhiding one of its local tracks', function () {
-      const { getState, globalTrackItem, localTrackItem } = setupTracks();
+    it('will unhide the global track when unhiding one of its local tracks', async function () {
+      const { getState } = setupTracks();
       // Hide the global track.
-      fireFullClick(globalTrackItem());
+      await clickTracksWithExpectation([/^Content Process/], {
+        checked: false,
+      });
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default] SELECTED',
         // The "GeckoMain tab" process is now hidden.
@@ -1001,7 +1021,7 @@ describe('timeline/TrackContextMenu', function () {
       ]);
 
       // Unhide "DOM Worker" local track.
-      fireFullClick(localTrackItem());
+      fireFullClick(screen.getByText('DOM Worker'));
       expect(getHumanReadableTracks(getState())).toEqual([
         'show [thread GeckoMain default] SELECTED',
         // The "GeckoMain tab" process is visible again.

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -57,6 +57,14 @@ exports[`timeline/TrackContextMenu when a global track is right clicked matches 
     role="menuitem"
     tabindex="-1"
   >
+    Show all tracks in this process
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
     Only show “⁨Content Process⁩”
   </div>
   <div
@@ -134,8 +142,19 @@ exports[`timeline/TrackContextMenu when a global track is right clicked network 
     role="menuitem"
     tabindex="-1"
   >
+    Show all tracks in this process
+  </div>
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
     Hide “⁨Process 0⁩”
   </div>
+  <div
+    class="react-contextmenu-separator"
+  />
   <div
     aria-checked="true"
     aria-disabled="false"
@@ -186,6 +205,14 @@ exports[`timeline/TrackContextMenu when a local track is right clicked matches t
   style="position: fixed; opacity: 0; pointer-events: none;"
   tabindex="-1"
 >
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Show all tracks in this process
+  </div>
   <div
     aria-disabled="false"
     class="react-contextmenu-item"

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -79,8 +79,8 @@ exports[`timeline/TrackContextMenu when a global track is right clicked matches 
     class="react-contextmenu-separator"
   />
   <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
+    aria-disabled="true"
+    class="react-contextmenu-item react-contextmenu-item--disabled"
     role="menuitem"
     tabindex="-1"
   >
@@ -151,8 +151,8 @@ exports[`timeline/TrackContextMenu when a global track is right clicked network 
     class="react-contextmenu-separator"
   />
   <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
+    aria-disabled="true"
+    class="react-contextmenu-item react-contextmenu-item--disabled"
     role="menuitem"
     tabindex="-1"
   >
@@ -231,8 +231,8 @@ exports[`timeline/TrackContextMenu when a local track is right clicked matches t
     class="react-contextmenu-separator"
   />
   <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
+    aria-disabled="true"
+    class="react-contextmenu-item react-contextmenu-item--disabled"
     role="menuitem"
     tabindex="-1"
   >

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -57,14 +57,6 @@ exports[`timeline/TrackContextMenu when a global track is right clicked matches 
     role="menuitem"
     tabindex="-1"
   >
-    Show all tracks in this process
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
     Only show “⁨Content Process⁩”
   </div>
   <div
@@ -82,6 +74,17 @@ exports[`timeline/TrackContextMenu when a global track is right clicked matches 
     tabindex="-1"
   >
     Hide “⁨Content Process⁩”
+  </div>
+  <div
+    class="react-contextmenu-separator"
+  />
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Show all tracks in this process
   </div>
   <div
     class="react-contextmenu-separator"
@@ -142,15 +145,18 @@ exports[`timeline/TrackContextMenu when a global track is right clicked network 
     role="menuitem"
     tabindex="-1"
   >
-    Show all tracks in this process
+    Hide “⁨Process 0⁩”
   </div>
+  <div
+    class="react-contextmenu-separator"
+  />
   <div
     aria-disabled="false"
     class="react-contextmenu-item"
     role="menuitem"
     tabindex="-1"
   >
-    Hide “⁨Process 0⁩”
+    Show all tracks in this process
   </div>
   <div
     class="react-contextmenu-separator"
@@ -211,14 +217,6 @@ exports[`timeline/TrackContextMenu when a local track is right clicked matches t
     role="menuitem"
     tabindex="-1"
   >
-    Show all tracks in this process
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
     Only show “⁨DOM Worker⁩”
   </div>
   <div
@@ -228,6 +226,17 @@ exports[`timeline/TrackContextMenu when a local track is right clicked matches t
     tabindex="-1"
   >
     Hide “⁨DOM Worker⁩”
+  </div>
+  <div
+    class="react-contextmenu-separator"
+  />
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Show all tracks in this process
   </div>
   <div
     class="react-contextmenu-separator"

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -265,6 +265,11 @@ type ProfileAction =
       +trackIndex: TrackIndex,
     |}
   | {|
+      +type: 'SHOW_GLOBAL_TRACK_INCLUDING_LOCAL_TRACKS',
+      +trackIndex: TrackIndex,
+      +pid: Pid,
+    |}
+  | {|
       // Isolate only the process track, and not the local tracks.
       +type: 'ISOLATE_PROCESS',
       +hiddenGlobalTracks: Set<TrackIndex>,


### PR DESCRIPTION
The goal for this patch is to provide various ways to easily display all local tracks for a process.

I tested with this profile: https://profiler.firefox.com/public/qsseyk7p9rz207y5eqnytyg1aap2hvdse6eky3g/

The initial request from @padenot was that when he hides then shows a track, all its local tracks should be displayed. But this has some drawbacks:
* if the process is the last one shown, clicking it won't hide it => therefore the manipulation won't work
* when testing it, I also realized that showing all tracks in a process can be cumbersome (a lot of new tracks will appear) and this can also be a performance problem with our current code.

Therefore I thought that we could do the same with a doubleclick instead. I added a small timeout for the simple click so that when double clicking we wouldn't first hide the process. As you'll see I had to change a few existing tests because of that, that's why I did this change in a separate commit at the end of the patch queue.

Because a doubleclick isn't discoverable easily, I also added options to the right click menus for the tracks.

You should look at the commits separately for an easier review. But do not look at commits when their log starts with `[Do not review`.

Here are the changes:
* added an item to both global track's and local track's context menu
* double clicking a global track in any context menu or the track popup will display all of its local tracks

[production](https://profiler.firefox.com/public/qsseyk7p9rz207y5eqnytyg1aap2hvdse6eky3g/)
[deploy preview](https://deploy-preview-4286--perf-html.netlify.app/public/qsseyk7p9rz207y5eqnytyg1aap2hvdse6eky3g/)