### PR TITLE
Implement marker based stack strategies

### DIFF
--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -56,6 +56,7 @@ type StateProps = {|
   +hasNativeAllocations: boolean,
   +canShowRetainedMemory: boolean,
   +allowSwitchingStackType: boolean,
+  +additionalStrategies: Array<{ name: string, label: string }>,
 |};
 
 type DispatchProps = {|
@@ -140,9 +141,13 @@ class StackSettingsImpl extends PureComponent<Props> {
       canShowRetainedMemory,
       callTreeSummaryStrategy,
       allowSwitchingStackType,
+      additionalStrategies,
     } = this.props;
 
-    const hasAllocations = hasJsAllocations || hasNativeAllocations;
+    const hasMultipleDataStrategies =
+      hasJsAllocations ||
+      hasNativeAllocations ||
+      additionalStrategies.length > 0;
 
     return (
       <div className="stackSettings">
@@ -163,7 +168,7 @@ class StackSettingsImpl extends PureComponent<Props> {
               )}
             </li>
           ) : null}
-          {hasAllocations ? (
+          {hasMultipleDataStrategies ? (
             <li className="stackSettingsListItem stackSettingsFilter">
               <label>
                 <Localized id="StackSettings--use-data-source-label" />{' '}
@@ -206,6 +211,11 @@ class StackSettingsImpl extends PureComponent<Props> {
                         'native-deallocations-sites'
                       )
                     : null}
+                  {additionalStrategies.map((strategy) => (
+                    <option key={strategy.name} value={strategy.name}>
+                      {strategy.label}
+                    </option>
+                  ))}
                 </select>
               </label>
             </li>
@@ -280,6 +290,8 @@ export const StackSettings = explicitConnect<
     callTreeSummaryStrategy:
       selectedThreadSelectors.getCallTreeSummaryStrategy(state),
     allowSwitchingStackType: getProfileUsesMultipleStackTypes(state),
+    additionalStrategies:
+      selectedThreadSelectors.getAdditionalStrategies(state),
   }),
   mapDispatchToProps: {
     changeImplementationFilter,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -9,6 +9,7 @@ import {
   getSampleIndexToCallNodeIndex,
   getOriginAnnotationForFunc,
   getCategoryPairLabel,
+  getAdditionalStrategiesForThread,
 } from './profile-data';
 import { resourceTypes } from './data-structures';
 import { getFunctionName } from './function-info';
@@ -634,7 +635,15 @@ export function extractSamplesLikeTable(
     }
     /* istanbul ignore next */
     default:
-      throw assertExhaustiveCheck(strategy);
+      if (
+        getAdditionalStrategiesForThread(thread).find(
+          (s) => s.name === strategy
+        )
+      ) {
+        return ProfileData.applyAdditionalStrategy(thread, strategy);
+      }
+      console.warn('unsupported strategy', strategy);
+      return thread.samples;
   }
 }
 

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -1072,6 +1072,8 @@ export function mergeThreads(threads: Thread[]): Thread {
   let processShutdownTime = -Infinity;
   let registerTime = Infinity;
   let unregisterTime = -Infinity;
+  const sampleLikeMarkersConfig = [];
+  const sampleLikeMarkersConfigNameSet = new Set();
   for (const thread of threads) {
     processStartupTime = Math.min(
       thread.processStartupTime,
@@ -1086,6 +1088,12 @@ export function mergeThreads(threads: Thread[]): Thread {
       thread.unregisterTime || Infinity,
       unregisterTime
     );
+    for (const marker of thread.sampleLikeMarkersConfig || []) {
+      if (!sampleLikeMarkersConfigNameSet.has(marker.name)) {
+        sampleLikeMarkersConfig.push(marker);
+        sampleLikeMarkersConfigNameSet.add(marker.name);
+      }
+    }
   }
 
   const mergedThread = {
@@ -1107,6 +1115,7 @@ export function mergeThreads(threads: Thread[]): Thread {
     funcTable: newFuncTable,
     nativeSymbols: newNativeSymbols,
     resourceTable: newResourceTable,
+    sampleLikeMarkersConfig,
   };
 
   return mergedThread;

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -75,6 +75,9 @@ import type {
   Address,
   AddressProof,
   TimelineType,
+  SampleLikeMarkerConfig,
+  RawMarkerTable,
+  WeightType,
 } from 'firefox-profiler/types';
 import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
 
@@ -982,22 +985,10 @@ export function toValidImplementationFilter(
 export function toValidCallTreeSummaryStrategy(
   strategy: mixed
 ): CallTreeSummaryStrategy {
-  switch (strategy) {
-    case 'timing':
-    case 'js-allocations':
-    case 'native-retained-allocations':
-    case 'native-allocations':
-    case 'native-deallocations-sites':
-    case 'native-deallocations-memory':
-      return strategy;
-    default:
-      // Default to "timing" if the strategy is not recognized. This value can come
-      // from a user-generated URL.
-      // e.g. `profiler.firefox.com/public/hash/ctSummary=tiiming` (note the typo.)
-      // This default branch will ensure we don't send values we don't understand to
-      // the store.
-      return 'timing';
+  if (typeof strategy !== 'string') {
+    return 'timing';
   }
+  return strategy;
 }
 
 export function filterThreadByImplementation(
@@ -3470,4 +3461,73 @@ export function determineTimelineType(profile: Profile): TimelineType {
 
   // Have both category and CPU usage information. Use 'cpu-category'.
   return 'cpu-category';
+}
+
+export const getAdditionalStrategiesForThread = memoize((thread: Thread) => {
+  const ret = [];
+  (thread.sampleLikeMarkersConfig || []).forEach((config) => {
+    ret.push({ name: config.name, label: config.label });
+  });
+  return ret;
+});
+
+export const applyAdditionalStrategy: (
+  thread: Thread,
+  additionalStrategy: string
+) => SamplesLikeTable = memoize(
+  (thread: Thread, additionalStrategy: string) => {
+    if (thread.sampleLikeMarkersConfig === undefined) {
+      throw new Error("Thread doesn't have sampleLikeMarkersConfig");
+    }
+    const config = thread.sampleLikeMarkersConfig.find(
+      (config) => config.name === additionalStrategy
+    );
+
+    if (config === undefined) {
+      throw new Error(
+        `Thread doesn't have sampleLikeMarkersConfig for ${additionalStrategy}`
+      );
+    }
+
+    return applyAdditionalStrategyOnMarkers(thread.markers, config, thread);
+  }
+);
+
+function applyAdditionalStrategyOnMarkers(
+  rawTable: RawMarkerTable,
+  config: SampleLikeMarkerConfig,
+  { stringTable }: Thread
+): SamplesLikeTable {
+  const stack: (IndexIntoStackTable | null)[] = [];
+  const time: Milliseconds[] = [];
+  const weight: number[] = [];
+  const weightType: WeightType = config.weightType || 'samples';
+  let length = 0;
+  const configNameId = stringTable.indexForString(config.marker);
+  const stackField = config.stackField || 'cause';
+  rawTable.data.forEach((data, i) => {
+    if (rawTable.name[i] !== configNameId) {
+      return;
+    }
+    time[length] = rawTable.startTime[i] || rawTable.endTime[i] || -1;
+    const rawData = rawTable.data[i] || {};
+    if (config.weightField !== undefined) {
+      const rawVal = rawData[config.weightField];
+      weight[length] = rawVal !== undefined ? rawVal || 0.000001 : -1;
+    } else {
+      weight[length] = 1;
+    }
+    // $FlowExpectError - This is a dynamic field.
+    stack[length] = rawData[stackField]
+      ? rawData[stackField].stack || null
+      : null;
+    length++;
+  });
+  return {
+    stack,
+    time,
+    weight,
+    weightType,
+    length,
+  };
 }

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -16,11 +16,7 @@ import * as CallTree from '../../profile-logic/call-tree';
 import * as ProfileSelectors from '../profile';
 import * as JsTracer from '../../profile-logic/js-tracer';
 import * as Cpu from '../../profile-logic/cpu';
-import {
-  assertExhaustiveCheck,
-  ensureExists,
-  getFirstItemFromSet,
-} from '../../utils/flow';
+import { ensureExists, getFirstItemFromSet } from '../../utils/flow';
 
 import type {
   Thread,
@@ -275,10 +271,7 @@ export function getThreadSelectorsPerThread(
             }
             break;
           default:
-            assertExhaustiveCheck(
-              lastSelectedCallTreeSummaryStrategy,
-              'Unhandled call tree sumary strategy.'
-            );
+            return lastSelectedCallTreeSummaryStrategy;
         }
         return lastSelectedCallTreeSummaryStrategy;
       }
@@ -461,6 +454,12 @@ export function getThreadSelectorsPerThread(
       'Could not get the processed event delays'
     );
 
+  const getAdditionalStrategies: Selector<
+    Array<{ name: string, label: string }>
+  > = (state) => {
+    return ProfileData.getAdditionalStrategiesForThread(getThread(state));
+  };
+
   return {
     getThread,
     getStringTable,
@@ -494,5 +493,6 @@ export function getThreadSelectorsPerThread(
     getActiveTabFilteredThread,
     getProcessedEventDelays,
     getCallTreeSummaryStrategy,
+    getAdditionalStrategies,
   };
 }

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -1728,15 +1728,6 @@ describe('last requested call tree summary strategy', function () {
       'native-allocations'
     );
   });
-
-  it('will use the default "timing" when an unknown value is received', function () {
-    const { getState } = _getStoreWithURL({
-      search: '?ctSummary=unknown-value',
-    });
-    expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(
-      'timing'
-    );
-  });
 });
 
 describe('symbolServerUrl', function () {

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -147,7 +147,8 @@ export type CallTreeSummaryStrategy =
   | 'native-retained-allocations'
   | 'native-allocations'
   | 'native-deallocations-memory'
-  | 'native-deallocations-sites';
+  | 'native-deallocations-sites'
+  | string;
 
 /**
  * This type determines what kind of information gets sanitized from published profiles.

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -663,6 +663,29 @@ export type Thread = {|
   // It's absent in Firefox 97 and before, or in Firefox 98+ when this thread
   // had no extra attribute at all.
   userContextId?: number,
+  sampleLikeMarkersConfig?: SampleLikeMarkerConfig[],
+|};
+
+/**
+ * Configute markers for which a SamplesLikeTable can be generated
+ * (using the cause property for the stacktrace)
+ */
+export type SampleLikeMarkerConfig = {|
+  // Name of the strategy, used as a unique identifier
+  // and in the URL state. Configs with the same name are
+  // considered to be the same.
+  name: string,
+  // label of the strategy
+  label: string,
+  // marker type
+  marker: string,
+  // defaults to samples
+  weightType?: WeightType,
+  // field to obtain the weight from if present,
+  // else 1 is used as the weight for every marker
+  weightField?: string,
+  // field where the stack is stored, defaults to the cause field
+  stackField?: string,
 |};
 
 export type ExtensionTable = {|


### PR DESCRIPTION
The stack strategies (`timing`, `js-allocations`, `native-retained-allocations`, ...) are currently restrained to what is useful in the browser. But this might not work for imported profiles where we want to show data like exception throws (to see where code throws the most exception). This information is already present in markers. So the natural conclusion is to create a stack strategy that uses this information.

I propose to configure the marker strategies on a thread level, using a list of `SampleLikeMarkerConfig`s:

```js
/**
 * Configute markers for which a SamplesLikeTable can be generated
 * (using the cause property for the stacktrace)
 */
export type SampleLikeMarkerConfig = {|
  // Name of the strategy, used as a unique identifier
  // and in the URL state. Configs with the same name are
  // considered to be the same.
  name: string,
  // label of the strategy
  label: string,
  // marker type
  marker: string,
  // defaults to samples
  weightType?: WeightType,
  // field to obtain the weight from if present,
  // else 1 is used as the weight for every marker
  weightField?: string,
  // field where the stack is stored, defaults to the cause field
  stackField?: string,
|};
```

Example:

```js
{
    "name": "error-throw",
    "label": "Java Error",
    "marker": "jdk.JavaErrorThrow"
},
{
    "name": "monitor-wait",
    "label": "Java Monitor Wait",
    "marker": "jdk.JavaMonitorWait",
    "weightType": "tracing-ms",
    "weightField": "timeout"
},
```

I used it now for quite a while and it's quite useful, while the implementation is straightforward and simple.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/490655/198375156-0cea1b4b-90ef-44c8-b61f-6037c685abc4.png">

[Sample Profile](https://github.com/firefox-devtools/profiler/files/9882396/JVM.Application.me.bechberger.jfrtofp.MainKt.samples_flight_large.jfr.2075-05-29.10.27.profile.1.json.gz)
