### PR TITLE
Support perfs of single letter comms

### DIFF
--- a/src/profile-logic/import/linux-perf.js
+++ b/src/profile-logic/import/linux-perf.js
@@ -56,7 +56,7 @@ export function isPerfScriptFormat(profile: string): boolean {
   //          |        |      |          +- [CPU] (optional, present in SimplePerf output)
   //          |        |      |          |          +- timestamp
   //       vvvvv   vvvvvvvvv vvv   vvvvvvvvvvvvvv vvvvvv
-  return /^\S.+?\s+(?:\d+\/)?\d+\s+(?:\[\d+\]\s+)?[\d.]+:/.test(firstLine);
+  return /^\S.*?\s+(?:\d+\/)?\d+\s+(?:\[\d+\]\s+)?[\d.]+:/.test(firstLine);
 }
 
 // Don't try and type this more specifically.


### PR DESCRIPTION
How to reproduce:

1. Make any binary named `x` (or any other with a single character);
2. perf it;
3. try to load -> fails.

Here's the sample line: `x 3855755 1097011.253518:    6367096 cycles:u:`.