### PR TITLE
Display a blue border for selected tracks

### DIFF
--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -8,9 +8,7 @@
  */
 .timelineTrack {
   padding: 0;
-  border-top: 1px solid var(--grey-30);
   margin: 0;
-  box-shadow: 0 1px var(--grey-30);
 }
 
 .timelineTrackLocal {
@@ -18,13 +16,59 @@
 }
 
 .timelineTrackRow {
+  /* This is the width of the blue left border when a track is selected.
+   * This variable will be used every time we need to calculate some width that
+   * depends on this value, from the intended perceived width. */
+  --selected-left-border-width: 3px;
+
   display: flex;
   flex-flow: row nowrap;
+
+  /* This padding is added to the button's padding as the perceived padding. For
+   * a global row, it will be replaced with a margin when it's selected. */
+  padding-left: var(--selected-left-border-width);
+  border-top: 1px solid var(--grey-30);
   background-color: #fff;
 }
 
 .timelineTrackRow.selected {
   background-color: #edf6ff;
+
+  /* We use a box-shadow on the track row instead of using border, so
+   * that when we select adjacent tracks, we see just one line, without any
+   * border on top of it. */
+  box-shadow: calc(-1 * var(--selected-left-border-width)) 0 var(--blue-60);
+}
+
+.timelineTrackGlobalRow.selected {
+  /* We replace the padding by some margin. Indeed the box-shadow used to draw
+   * the blue selected left border is drawn outside of the border box, so the
+   * 3px margin makes this space available. */
+  padding-left: 0;
+  margin-left: var(--selected-left-border-width);
+}
+
+/* In the active tab view, we don't want any margin or padding, because
+ * otherwise we lose the alignment with the other panels. Therefore we won't
+ * have the blue left border when a track is selected in this view. */
+.timelineTrackRow.activeTab {
+  padding: 0;
+  margin: 0;
+}
+
+.timelineTrackLocalRow {
+  border-left: 1px solid var(--grey-30);
+}
+
+.timelineTrackLocalRow.selected {
+  /* By removing the left border, it looks like the blue border is on top of it.
+   * But we need to account for the missing 1px, that's why we add this
+   * margin-left.
+   * Note that we don't need to replace the padding with some margin for the
+   * local rows because we already have some space besides. The border looks
+   * like it's alongside the label, instead of inside like for global rows. */
+  border-left: none;
+  margin-left: 1px;
 }
 
 .timelineTrackHidden {
@@ -34,7 +78,9 @@
 
 .timelineTrackLabel {
   display: flex;
-  width: 150px;
+
+  /* We want the width to look like it's 150px, but need to substract the 3px padding/margin */
+  width: calc(150px - var(--selected-left-border-width));
   box-sizing: border-box;
   flex-flow: row nowrap;
   align-items: center;
@@ -48,7 +94,10 @@
   /* The 8px are used by the box-shadow when the button receives focus */
   width: calc(100% - 8px);
   height: calc(100% - 8px);
-  padding: 0 0 0 10px;
+
+  /* We want the left padding to look like 10px, but need to remove 3px to
+   * account for the padding/margin on the row. */
+  padding: 0 0 0 calc(10px - var(--selected-left-border-width));
   border: none;
   background: none;
   font: inherit;
@@ -123,6 +172,6 @@
 }
 
 .timelineTrackLocalLabel {
-  width: 135px;
-  border-left: 1px solid var(--grey-30);
+  /* We want the width to look like it's 150px, but need to substract the 3px padding/margin and the 1px border */
+  width: calc(135px - var(--selected-left-border-width) - 1px);
 }

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -32,20 +32,17 @@
 }
 
 .timelineTrackRow.selected {
+  /* We replace the padding by some margin. Indeed the box-shadow used to draw
+   * the blue selected left border is drawn outside of the border box, so the
+   * 3px margin makes this space available. */
+  padding-left: 0;
+  margin-left: var(--selected-left-border-width);
   background-color: #edf6ff;
 
   /* We use a box-shadow on the track row instead of using border, so
    * that when we select adjacent tracks, we see just one line, without any
    * border on top of it. */
   box-shadow: calc(-1 * var(--selected-left-border-width)) 0 var(--blue-60);
-}
-
-.timelineTrackGlobalRow.selected {
-  /* We replace the padding by some margin. Indeed the box-shadow used to draw
-   * the blue selected left border is drawn outside of the border box, so the
-   * 3px margin makes this space available. */
-  padding-left: 0;
-  margin-left: var(--selected-left-border-width);
 }
 
 /* In the active tab view, we don't want any margin or padding, because
@@ -62,13 +59,9 @@
 
 .timelineTrackLocalRow.selected {
   /* By removing the left border, it looks like the blue border is on top of it.
-   * But we need to account for the missing 1px, that's why we add this
-   * margin-left.
-   * Note that we don't need to replace the padding with some margin for the
-   * local rows because we already have some space besides. The border looks
-   * like it's alongside the label, instead of inside like for global rows. */
-  border-left: none;
-  margin-left: 1px;
+   * By using the transparent color instead of removing it altogether, we keep
+   * the 1px space. */
+  border-left-color: transparent;
 }
 
 .timelineTrackHidden {


### PR DESCRIPTION
This is a draft because I still want to review the changes, see if the same thing can be made in a better way, and add comments explaining some logic.
Before:
![image](https://user-images.githubusercontent.com/454175/199568643-9bb7f299-52b9-4a83-ab3d-f065a30bf26e.png)

After:
![image](https://user-images.githubusercontent.com/454175/199563481-37cb95ea-7810-41e5-9012-137d37491ac5.png)

Note that we see that the blue border is on top of the top grey border, but stops before the bottom grey border. This is visible when looking closely and zoomed in, but otherwise it's barely visible. I'm not sure how to avoid that without changing more the HTML structure, so I thought this was good enough.

[main branch](https://main--perf-html.netlify.app/public/zs55368mcasjyq6svm1754p177qm7ym9cb3rtm8/calltree/?globalTrackOrder=0w3&hiddenLocalTracksByPid=150683-3~246869-0~150948-0~150857-0&thread=4&v=8)
[deploy preview](https://deploy-preview-4305--perf-html.netlify.app/public/zs55368mcasjyq6svm1754p177qm7ym9cb3rtm8/calltree/?globalTrackOrder=0w3&hiddenLocalTracksByPid=150683-3~246869-0~150948-0~150857-0&thread=0&v=7)