### PR TITLE
Optimize some colors by using rgb values directly

### DIFF
--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -330,7 +330,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
       if (w2 > textMeasurement.minWidth) {
         const fittedText = textMeasurement.getFittedText(text, w2);
         if (fittedText) {
-          ctx.fillStyle = isHighlighted ? 'white' : 'black';
+          ctx.fillStyle = isHighlighted ? 'rgb(255, 255, 255)' : 'rgb(0, 0, 0)';
           ctx.fillText(fittedText, x2, y + TEXT_OFFSET_TOP);
         }
       }

--- a/src/profile-logic/marker-styles.js
+++ b/src/profile-logic/marker-styles.js
@@ -18,7 +18,7 @@ type MarkerStyle = {|
 const defaultStyle = {
   top: 0,
   height: 6,
-  background: 'black',
+  background: 'rgb(0, 0, 0)',
   squareCorners: false,
   borderLeft: null,
   borderRight: null,

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -228,7 +228,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "white",
+    "rgb(255, 255, 255)",
   ],
   Array [
     "fillText",
@@ -620,7 +620,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillText",
@@ -746,7 +746,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillText",
@@ -1067,7 +1067,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillText",
@@ -1151,7 +1151,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "white",
+    "rgb(255, 255, 255)",
   ],
   Array [
     "fillText",
@@ -1420,7 +1420,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillText",

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -98,7 +98,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillRect",
@@ -123,7 +123,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillRect",
@@ -148,7 +148,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillRect",
@@ -173,7 +173,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillRect",
@@ -198,7 +198,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillRect",
@@ -223,7 +223,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "black",
+    "rgb(0, 0, 0)",
   ],
   Array [
     "fillRect",


### PR DESCRIPTION
This came up from [Bug 1796684](https://bugzilla.mozilla.org/show_bug.cgi?id=1796684#c8).
It looks like using colors by their identifiers have some drawbacks in the performance because it allocates since these strings need to be preserved for serialization. Let's change them to use rgb values directly.