### PR TITLE
Increase the timeout when clicking to hide a global track in the trac…

### DIFF
--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -269,7 +269,7 @@ class TimelineTrackContextMenuImpl extends PureComponent<
       } else {
         hideGlobalTrack(trackIndex);
       }
-    }, 80);
+    }, 150);
   };
 
   _toggleLocalTrackVisibility = (


### PR DESCRIPTION
…k context menu

We noticed that when a double click on a global track in the track context menu (to show all its local tracks) would usually hide it before showing all tracks.

With a few tracks:
[production](https://profiler.firefox.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/?globalTrackOrder=de0wc&hiddenGlobalTracks=12&hiddenLocalTracksByPid=29495-1w6~5123-0~29556-0~21926-0&thread=0&v=8)
[deploy preview](https://deploy-preview-4325--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/calltree/?globalTrackOrder=de0wc&hiddenGlobalTracks=12&hiddenLocalTracksByPid=29495-1w6~5123-0~29556-0~21926-0&thread=0&v=8)

With more tracks:
[production](https://profiler.firefox.com/public/qsseyk7p9rz207y5eqnytyg1aap2hvdse6eky3g/)
[deploy preview](https://deploy-preview-4325--perf-html.netlify.app/public/qsseyk7p9rz207y5eqnytyg1aap2hvdse6eky3g/)