### PR TITLE
Add markers for browsertime visual metrics 

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1748,16 +1748,19 @@ export function processVisualMetrics(
 
   // Find the navigation start time in the tab thread for specifying the marker
   // start times.
-  const navigationStartStrIdx =
-    tabThread.stringTable.indexForString('Navigation::Start');
-  const navigationStartMarkerIdx = tabThread.markers.name.findIndex(
-    (m) => m === navigationStartStrIdx
-  );
   let navigationStartTime = null;
-  if (navigationStartMarkerIdx === -1) {
-    console.error('Failed to find the navigation start marker.');
-  } else {
-    navigationStartTime = tabThread.markers.startTime[navigationStartMarkerIdx];
+  if (tabThread.stringTable.hasString('Navigation::Start')) {
+    const navigationStartStrIdx =
+      tabThread.stringTable.indexForString('Navigation::Start');
+    const navigationStartMarkerIdx = tabThread.markers.name.findIndex(
+      (m) => m === navigationStartStrIdx
+    );
+    if (navigationStartMarkerIdx === -1) {
+      console.error('Failed to find the navigation start marker.');
+    } else {
+      navigationStartTime =
+        tabThread.markers.startTime[navigationStartMarkerIdx];
+    }
   }
 
   // Add the visual metrics markers to the parent process and tab process main threads.

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -25,7 +25,11 @@ import {
   convertPerfScriptProfile,
 } from './import/linux-perf';
 import { isArtTraceFormat, convertArtTraceProfile } from './import/art-trace';
-import { PROCESSED_PROFILE_VERSION } from '../app-logic/constants';
+import {
+  PROCESSED_PROFILE_VERSION,
+  INTERVAL,
+  INSTANT,
+} from '../app-logic/constants';
 import {
   getFriendlyThreadName,
   getOrCreateURIResource,
@@ -79,6 +83,8 @@ import type {
   PhaseTimes,
   SerializableProfile,
   MarkerSchema,
+  ProfileMeta,
+  PageList,
 } from 'firefox-profiler/types';
 
 type RegExpResult = null | string[];
@@ -1539,6 +1545,11 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
     }
   }
 
+  if (meta.visualMetrics) {
+    // Process the visual metrics to add markers for them.
+    processVisualMetrics(threads, meta, pages);
+  }
+
   const { libs } = globalDataCollector.finish();
 
   const result = {
@@ -1674,4 +1685,171 @@ export async function unserializeProfileOfArbitraryFormat(
     console.error('UnserializationError:', e);
     throw new Error(`Unserializing the profile failed: ${e}`);
   }
+}
+
+/**
+ * Processes the visual metrics data if the profile has it and adds some markers
+ * to the parent process and tab process main threads to show the visual progress.
+ * Mutates the markers inside parent process and tab process main threads.
+ */
+export function processVisualMetrics(
+  threads: Thread[],
+  meta: ProfileMeta,
+  pages: PageList
+) {
+  const { visualMetrics } = meta;
+  if (pages.length === 0 || !visualMetrics) {
+    // No pages or visualMetrics were found in the profile. Skip this step.
+    return;
+  }
+
+  // Find the parent process and the tab process main threads.
+  const mainThreadIdx = threads.findIndex(
+    (thread) => thread.name === 'GeckoMain' && thread.processType === 'default'
+  );
+  const tabThreadIdx = findTabMainThreadForVisualMetrics(threads, pages);
+
+  if (mainThreadIdx === -1 || !tabThreadIdx) {
+    // Failed to find the parent process or tab process main threads. Return early.
+    return;
+  }
+  const mainThread = threads[mainThreadIdx];
+  const tabThread = threads[tabThreadIdx];
+
+  // These metrics are currently present inside profile.meta.visualMetrics.
+  const metrics = ['Visual', 'ContentfulSpeedIndex', 'PerceptualSpeedIndex'];
+  // Find the Test category so we can add the visual metrics markers with it.
+  if (meta.categories === undefined) {
+    // Making Flow happy. This means that this is a very old profile.
+    return;
+  }
+  const testingCategoryIdx = meta.categories.findIndex(
+    (cat) => cat.name === 'Test'
+  );
+
+  function addMetricMarker(
+    thread: Thread,
+    name: string,
+    startTime: number,
+    endTime?: number,
+    payload?: any
+  ) {
+    // Add the marker to the given thread.
+    thread.markers.name.push(thread.stringTable.indexForString(name));
+    thread.markers.startTime.push(startTime);
+    thread.markers.endTime.push(endTime ? endTime : 0);
+    thread.markers.phase.push(endTime ? INTERVAL : INSTANT);
+    thread.markers.category.push(testingCategoryIdx);
+    thread.markers.data.push(payload ?? null);
+    thread.markers.length++;
+  }
+
+  for (const metricName of metrics) {
+    const metric = visualMetrics[`${metricName}Progress`];
+    if (!metric) {
+      // Skip it if we don't have this metric.
+      continue;
+    }
+
+    const startTime = metric[0].timestamp;
+    const endTime = metric[metric.length - 1].timestamp;
+
+    // Add the progress marker to the parent process main thread.
+    const markerName = `${metricName} Progress`;
+    addMetricMarker(mainThread, markerName, startTime, endTime);
+    // Add the progress marker to the tab process main thread.
+    addMetricMarker(tabThread, markerName, startTime, endTime);
+
+    // Add progress markers for every visual progress change for more fine grained information.
+    const progressMarkerSchema = {
+      name: 'VisualMetricProgress',
+      tableLabel: '{marker.name} — {marker.data.percentage}',
+      display: ['marker-chart', 'marker-table', 'timeline-overview'],
+      data: [{ key: 'percentage', label: 'Percentage', format: 'percentage' }],
+    };
+    meta.markerSchema = [...meta.markerSchema, progressMarkerSchema];
+
+    const changeMarkerName = `${metricName} Change`;
+    for (const { timestamp, percent } of metric) {
+      const payload = {
+        type: 'VisualMetricProgress',
+        // 'percentage' type expects a value between 0 and 1.
+        percentage: percent / 100,
+      };
+
+      // Add it to the parent process main thread.
+      addMetricMarker(
+        mainThread,
+        changeMarkerName,
+        timestamp,
+        undefined, // endTime
+        payload
+      );
+      // Add it to the tab process main thread.
+      addMetricMarker(
+        tabThread,
+        changeMarkerName,
+        timestamp,
+        undefined, // endTime
+        payload
+      );
+    }
+  }
+}
+
+/**
+ * This function finds the main thread of the tab that is responsible of the visual metrics.
+ * It finds the tab main thread by looking at the RefreshDriverTick markers.
+ * These markers have innerWindowID fields inside their payloads that indicate
+ * which window they are coming from. If they are coming from a window with
+ * embedderInnerWindowID == 0, then it means that this is the top level window.
+ * We find the first tab main thread with this marker and return it.
+ *
+ * DO NOT use it for any other purpose than visual metrics as it's not going to be accurate.
+ */
+function findTabMainThreadForVisualMetrics(
+  threads: Thread[],
+  pages: PageList
+): number | null {
+  for (let threadIdx = 0; threadIdx < threads.length; threadIdx++) {
+    const thread = threads[threadIdx];
+
+    if (thread.name !== 'GeckoMain' || thread.processType !== 'tab') {
+      // It isn't a tab process main thread, skip it.
+      continue;
+    }
+
+    // Find the top level pages that are not an iframe.
+    // We could map `embedderInnerWindowID` to also find the main page here but
+    // we don't really need to do that since all browsertime profiles most likely
+    // to include refresh driver ticks in their tab process thread.
+    const topLevelPagesSet = new Set(
+      pages
+        .filter((page) => page.embedderInnerWindowID === 0)
+        .map((page) => page.innerWindowID)
+    );
+
+    if (!thread.stringTable.hasString('RefreshDriverTick')) {
+      // No RefreshDriver tick marker, skip the thread.
+      continue;
+    }
+    const markerNameIndex =
+      thread.stringTable.indexForString('RefreshDriverTick');
+
+    const { markers } = thread;
+    for (let markerIndex = 0; markerIndex < markers.length; markerIndex++) {
+      if (
+        markers.name[markerIndex] === markerNameIndex &&
+        markers.data[markerIndex] &&
+        markers.data[markerIndex].innerWindowID &&
+        topLevelPagesSet.has(markers.data[markerIndex].innerWindowID)
+      ) {
+        // Found a RefreshDriverTick marker that is coming from a top level page.
+        // This is the tab process main thread we are looking for.
+        return threadIdx;
+      }
+    }
+  }
+
+  return null;
 }

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -856,6 +856,18 @@ function _createGeckoThread(extraMarkers = []): GeckoThread {
           },
         ],
 
+        [
+          22, // Navigation::Start
+          28, // Start time
+          29, // End time
+          INTERVAL,
+          0, // Other
+          {
+            type: 'NoPayloadUserData',
+            innerWindowID: 1, // https://github.com/rustwasm/wasm-bindgen/issues/5
+          },
+        ],
+
         // INSERT NEW MARKERS HERE
         // Please make sure that the marker below always have a time
         // larger than the previous ones.
@@ -902,6 +914,7 @@ function _createGeckoThread(extraMarkers = []): GeckoThread {
       '0x100001bcd', // 19
       '0x100001bce', // 20
       'RefreshDriverTick', // 21
+      'Navigation::Start', // 22
     ],
   };
 }

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -21,6 +21,7 @@ import type {
   MarkerPayload_Gecko,
   IPCMarkerPayload_Gecko,
   GeckoMarkerTuple,
+  VisualMetrics,
 } from 'firefox-profiler/types';
 
 import {
@@ -1114,5 +1115,44 @@ export function createGeckoProfilerOverhead(
       data: data,
     },
     statistics: statistics,
+  };
+}
+
+export function getVisualMetrics(): VisualMetrics {
+  return {
+    SpeedIndex: 2942,
+    FirstVisualChange: 960,
+    LastVisualChange: 10480,
+    VisualProgress: [
+      { timestamp: 4431.321044921875, percent: 0 },
+      { timestamp: 5391.321044921875, percent: 17 },
+      { timestamp: 5511.321044921875, percent: 17 },
+      { timestamp: 5591.321044921875, percent: 22 },
+      { timestamp: 5631.321044921875, percent: 42 },
+      { timestamp: 5751.321044921875, percent: 70 },
+      { timestamp: 5911.321044921875, percent: 76 },
+    ],
+    ContentfulSpeedIndex: 2303,
+    ContentfulSpeedIndexProgress: [
+      { timestamp: 4431.321044921875, percent: 0 },
+      { timestamp: 5391.321044921875, percent: 41 },
+      { timestamp: 5511.321044921875, percent: 46 },
+      { timestamp: 5591.321044921875, percent: 48 },
+      { timestamp: 5631.321044921875, percent: 49 },
+      { timestamp: 5751.321044921875, percent: 49 },
+    ],
+    PerceptualSpeedIndex: 8314,
+    PerceptualSpeedIndexProgress: [
+      { timestamp: 4431.321044921875, percent: 0 },
+      { timestamp: 5391.321044921875, percent: 11 },
+      { timestamp: 5511.321044921875, percent: 12 },
+      { timestamp: 5591.321044921875, percent: 13 },
+      { timestamp: 5631.321044921875, percent: 13 },
+      { timestamp: 5751.321044921875, percent: 15 },
+    ],
+    VisualReadiness: 9520,
+    VisualComplete85: 6480,
+    VisualComplete95: 10200,
+    VisualComplete99: 10200,
   };
 }

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -843,6 +843,19 @@ function _createGeckoThread(extraMarkers = []): GeckoThread {
           },
         ],
 
+        [
+          21, // RefreshDriverTick
+          27, // Start time
+          28, // End time
+          INTERVAL,
+          0, // Other
+          {
+            type: 'Text',
+            name: 'Tick reasons: HasObservers (1x Style flush observer)',
+            innerWindowID: 1, // https://github.com/rustwasm/wasm-bindgen/issues/5
+          },
+        ],
+
         // INSERT NEW MARKERS HERE
         // Please make sure that the marker below always have a time
         // larger than the previous ones.
@@ -888,6 +901,7 @@ function _createGeckoThread(extraMarkers = []): GeckoThread {
       'IPC', // 18
       '0x100001bcd', // 19
       '0x100001bce', // 20
+      'RefreshDriverTick', // 21
     ],
   };
 }

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -52,6 +52,7 @@ import {
 import { getTimeRangeForThread } from '../../../profile-logic/profile-data';
 import { markerSchemaForTests } from './marker-schema';
 import { GlobalDataCollector } from 'firefox-profiler/profile-logic/process-profile';
+import { getVisualMetrics } from './gecko-profile';
 
 // Array<[MarkerName, Milliseconds, Data]>
 type MarkerName = string;
@@ -1334,42 +1335,7 @@ export function addIPCMarkerPairToThreads(
 
 export function getVisualProgressTrackProfile(profileString: string): Profile {
   const { profile } = getProfileFromTextSamples(profileString);
-  profile.meta.visualMetrics = {
-    SpeedIndex: 2942,
-    FirstVisualChange: 960,
-    LastVisualChange: 10480,
-    VisualProgress: [
-      { timestamp: 4431.321044921875, percent: 0 },
-      { timestamp: 5391.321044921875, percent: 17 },
-      { timestamp: 5511.321044921875, percent: 17 },
-      { timestamp: 5591.321044921875, percent: 22 },
-      { timestamp: 5631.321044921875, percent: 42 },
-      { timestamp: 5751.321044921875, percent: 70 },
-      { timestamp: 5911.321044921875, percent: 76 },
-    ],
-    ContentfulSpeedIndex: 2303,
-    ContentfulSpeedIndexProgress: [
-      { timestamp: 4431.321044921875, percent: 0 },
-      { timestamp: 5391.321044921875, percent: 41 },
-      { timestamp: 5511.321044921875, percent: 46 },
-      { timestamp: 5591.321044921875, percent: 48 },
-      { timestamp: 5631.321044921875, percent: 49 },
-      { timestamp: 5751.321044921875, percent: 49 },
-    ],
-    PerceptualSpeedIndex: 8314,
-    PerceptualSpeedIndexProgress: [
-      { timestamp: 4431.321044921875, percent: 0 },
-      { timestamp: 5391.321044921875, percent: 11 },
-      { timestamp: 5511.321044921875, percent: 12 },
-      { timestamp: 5591.321044921875, percent: 13 },
-      { timestamp: 5631.321044921875, percent: 13 },
-      { timestamp: 5751.321044921875, percent: 15 },
-    ],
-    VisualReadiness: 9520,
-    VisualComplete85: 6480,
-    VisualComplete95: 10200,
-    VisualComplete99: 10200,
-  };
+  profile.meta.visualMetrics = getVisualMetrics();
   return profile;
 }
 

--- a/src/test/unit/__snapshots__/marker-data.test.js.snap
+++ b/src/test/unit/__snapshots__/marker-data.test.js.snap
@@ -206,6 +206,18 @@ Array [
   Object {
     "category": 0,
     "data": Object {
+      "innerWindowID": 1,
+      "name": "Tick reasons: HasObservers (1x Style flush observer)",
+      "type": "Text",
+    },
+    "end": 28,
+    "name": "RefreshDriverTick",
+    "start": 27,
+    "threadId": null,
+  },
+  Object {
+    "category": 0,
+    "data": Object {
       "direction": "sending",
       "endTime": 1031,
       "messageSeqno": 1,

--- a/src/test/unit/__snapshots__/marker-data.test.js.snap
+++ b/src/test/unit/__snapshots__/marker-data.test.js.snap
@@ -218,6 +218,17 @@ Array [
   Object {
     "category": 0,
     "data": Object {
+      "innerWindowID": 1,
+      "type": "NoPayloadUserData",
+    },
+    "end": 29,
+    "name": "Navigation::Start",
+    "start": 28,
+    "threadId": null,
+  },
+  Object {
+    "category": 0,
+    "data": Object {
       "direction": "sending",
       "endTime": 1031,
       "messageSeqno": 1,

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -426,7 +426,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
     expect(markers).toMatchSnapshot();
   });
 
-  it('creates 18 markers given the test data', function () {
+  it('creates 19 markers given the test data', function () {
     const { markers } = setup();
     const markerNames = markers.map(
       (marker) => (marker.data ? marker.data.type : 'null') + ':' + marker.name
@@ -447,6 +447,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
       'CompositorScreenshot:CompositorScreenshot',
       'PreferenceRead:PreferenceRead',
       'Text:RefreshDriverTick',
+      'NoPayloadUserData:Navigation::Start',
       'IPC:IPCOut',
       'IPC:IPCOut',
       'tracing:Rasterize',
@@ -473,7 +474,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
 
   it('should fold the two reflow markers into one marker', function () {
     const { markers } = setup();
-    expect(markers.length).toEqual(18);
+    expect(markers.length).toEqual(19);
     expect(markers[2]).toMatchObject({
       start: 3,
       end: 8,
@@ -492,7 +493,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
 
   it('should correlate the IPC markers together and fold transferStart/transferEnd markers', function () {
     const { markers, contentMarkers } = setup();
-    expect(markers[15]).toMatchObject({
+    expect(markers[16]).toMatchObject({
       start: 30,
       end: 1031,
       name: 'IPCOut',
@@ -504,7 +505,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
       name: 'IPCIn',
       data: { phase: 'endpoint' },
     });
-    expect(markers[16]).toMatchObject({
+    expect(markers[17]).toMatchObject({
       start: 40,
       end: 40,
       name: 'IPCOut',
@@ -550,7 +551,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
 
   it('should handle markers without an end', function () {
     const { markers } = setup();
-    expect(markers[17]).toMatchObject({
+    expect(markers[18]).toMatchObject({
       start: 100,
       end: 100,
       name: 'Rasterize',
@@ -616,7 +617,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
       category: 0,
       threadId: null,
     });
-    expect(markers[15]).toEqual({
+    expect(markers[16]).toEqual({
       data: {
         type: 'IPC',
         startTime: 30,

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -426,7 +426,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
     expect(markers).toMatchSnapshot();
   });
 
-  it('creates 17 markers given the test data', function () {
+  it('creates 18 markers given the test data', function () {
     const { markers } = setup();
     const markerNames = markers.map(
       (marker) => (marker.data ? marker.data.type : 'null') + ':' + marker.name
@@ -446,6 +446,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
       'FileIO:FileIO',
       'CompositorScreenshot:CompositorScreenshot',
       'PreferenceRead:PreferenceRead',
+      'Text:RefreshDriverTick',
       'IPC:IPCOut',
       'IPC:IPCOut',
       'tracing:Rasterize',
@@ -472,7 +473,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
 
   it('should fold the two reflow markers into one marker', function () {
     const { markers } = setup();
-    expect(markers.length).toEqual(17);
+    expect(markers.length).toEqual(18);
     expect(markers[2]).toMatchObject({
       start: 3,
       end: 8,
@@ -491,7 +492,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
 
   it('should correlate the IPC markers together and fold transferStart/transferEnd markers', function () {
     const { markers, contentMarkers } = setup();
-    expect(markers[14]).toMatchObject({
+    expect(markers[15]).toMatchObject({
       start: 30,
       end: 1031,
       name: 'IPCOut',
@@ -503,7 +504,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
       name: 'IPCIn',
       data: { phase: 'endpoint' },
     });
-    expect(markers[15]).toMatchObject({
+    expect(markers[16]).toMatchObject({
       start: 40,
       end: 40,
       name: 'IPCOut',
@@ -549,7 +550,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
 
   it('should handle markers without an end', function () {
     const { markers } = setup();
-    expect(markers[16]).toMatchObject({
+    expect(markers[17]).toMatchObject({
       start: 100,
       end: 100,
       name: 'Rasterize',
@@ -615,7 +616,7 @@ describe('deriveMarkersFromRawMarkerTable', function () {
       category: 0,
       threadId: null,
     });
-    expect(markers[14]).toEqual({
+    expect(markers[15]).toEqual({
       data: {
         type: 'IPC',
         startTime: 30,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -547,6 +547,7 @@ export type TextMarkerPayload = {|
   type: 'Text',
   name: string,
   cause?: CauseBacktrace,
+  innerWindowID?: number,
 |};
 
 // ph: 'X' in the Trace Event Format

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -724,6 +724,16 @@ export type MediaSampleMarkerPayload = {|
  */
 export type JankPayload = {| type: 'Jank' |};
 
+export type BrowsertimeMarkerPayload = {|
+  type: 'VisualMetricProgress',
+  percentage: number,
+|};
+
+export type NoPayloadUserData = {|
+  type: 'NoPayloadUserData',
+  innerWindowID?: number,
+|};
+
 /**
  * The union of all the different marker payloads that profiler.firefox.com knows about,
  * this is not guaranteed to be all the payloads that we actually get from the Gecko
@@ -755,6 +765,8 @@ export type MarkerPayload =
   | ChromeInstantTraceEventPayload
   | MediaSampleMarkerPayload
   | JankPayload
+  | BrowsertimeMarkerPayload
+  | NoPayloadUserData
   | null;
 
 export type MarkerPayload_Gecko =
@@ -776,6 +788,7 @@ export type MarkerPayload_Gecko =
   | PrefMarkerPayload
   | IPCMarkerPayload_Gecko
   | MediaSampleMarkerPayload
+  | NoPayloadUserData
   // The following payloads come in with a stack property. During the profile processing
   // the "stack" property is are converted into a "cause". See the CauseBacktrace type
   // for more information.


### PR DESCRIPTION
This PR adds markers for visualMetrics progressions that we have in the profile data when the profiles come from browsertime. Browsertime adds this information to `profiler.meta.visualMetrics` and we show some tracks for them already. But it's not always easy to align them with the profiler markers and compare with them. So, this PR adds markers for them during the profile processing phase.
I chose to do it during the profile processing phase instead of creating selectors for them, because I didn't want to add another phase to the marker pipeline especially when we have this information in a very small amount of profiles.

Here's an example gecko profile to try:
[geckoProfile-1.json.gz](https://github.com/firefox-devtools/profiler/files/10041238/geckoProfile-1.json.gz)
You can also capture any profiles from treeherder and it should work fine.

The markers should appear in the `Test` category of both parent process and tab process like this:
<img width="740" alt="Screen Shot 2022-11-18 at 1 32 16 PM" src="https://user-images.githubusercontent.com/466239/202705758-89273a88-4305-4bb6-b5f0-76a438bce627.png">

As always, it's good to look at the PR commit by commit.