### PR TITLE
Use larger resource classes in CircleCI for some jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ commands:
 jobs:
   lint:
     executor: node
+    resource_class: large
     steps:
       - checkout-and-dependencies
       - run: yarn lint
@@ -49,6 +50,7 @@ jobs:
 
   build-prod:
     executor: node
+    resource_class: large
     steps:
       - checkout-and-dependencies
       - run: yarn build-prod:quiet
@@ -61,6 +63,7 @@ jobs:
 
   flow:
     executor: node
+    resource_class: large
     steps:
       - checkout-and-dependencies
       - run: yarn flow:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,12 @@ jobs:
 
   tests:
     executor: node
+    resource_class: large
     steps:
       - checkout-and-dependencies
-      - run: yarn test --coverage --runInBand
+      # We use workerIdleMemoryLimit to work around a memory issue with node.
+      # See https://github.com/facebook/jest/issues/11956
+      - run: yarn test --coverage --logHeapUsage -w=4 --workerIdleMemoryLimit=1.5G
       - run: yarn codecov
 
   build-prod:


### PR DESCRIPTION
This increases the resource classes (`large` is the biggest resource class we're allowed to use with the free plan) for some of our most resource-intensive jobs as well as increase the number of workers we use for jest.

From my tests, this cuts down the needed time quite a bit.

* tests: 1m28, down from 4m9
* flow: 36s down from 55s
* lint: 49s down from 56s
* build-prod: 55s down from 1m

total: 1m32, down from 4m12