### PR TITLE
Fix some category colors and add magenta

### DIFF
--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -6,10 +6,10 @@
   --category-color-transparent: #fff;
   --category-color-purple: var(--purple-70);
   --category-color-green: var(--green-60);
-  --category-color-orange: var(--orange-60);
+  --category-color-orange: var(--orange-50);
   --category-color-lightblue: var(--blue-40);
   --category-color-blue: var(--blue-60);
-  --category-color-brown: var(--yellow-70);
+  --category-color-brown: var(--magenta-60);
 
   /* it is hard to create a lighter version of the following colors  */
   --category-color-grey: var(--grey-30);

--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -13,13 +13,13 @@
   --category-color-magenta: var(--magenta-60);
 
   /* it is hard to create a lighter version of the following colors  */
-  --category-color-gray: var(--grey-30);
-  --category-color-grey: var(--grey-30);
-  --category-color-yellow: var(--yellow-50);
+  --category-color-gray: var(--grey-40);
+  --category-color-grey: var(--grey-40);
+  --category-color-yellow: #ffe129; /* this yellow has more contrast than yellow-50 */
   --category-color-red: var(--red-60);
   --category-color-lightred: #a4000f9a; /* red-70 with 60 alpha */
-  --category-color-darkgray: var(--grey-40);
-  --category-color-darkgrey: var(--grey-40);
+  --category-color-darkgray: var(--grey-50);
+  --category-color-darkgrey: var(--grey-50);
 }
 
 /**

--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -9,7 +9,7 @@
   --category-color-orange: var(--orange-50);
   --category-color-lightblue: var(--blue-40);
   --category-color-blue: var(--blue-60);
-  --category-color-brown: var(--magenta-60);
+  --category-color-brown: var(--orange-70);
   --category-color-magenta: var(--magenta-60);
 
   /* it is hard to create a lighter version of the following colors  */

--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -13,11 +13,13 @@
   --category-color-magenta: var(--magenta-60);
 
   /* it is hard to create a lighter version of the following colors  */
+  --category-color-gray: var(--grey-30);
   --category-color-grey: var(--grey-30);
   --category-color-yellow: var(--yellow-50);
   --category-color-red: var(--red-60);
   --category-color-lightred: #a4000f9a; /* red-70 with 60 alpha */
   --category-color-darkgray: var(--grey-40);
+  --category-color-darkgrey: var(--grey-40);
 }
 
 /**
@@ -51,6 +53,7 @@
   background-color: var(--category-color-lightblue);
 }
 
+.category-color-gray,
 .category-color-grey {
   background-color: var(--category-color-grey);
 }
@@ -67,8 +70,9 @@
   background-color: var(--category-color-lightred);
 }
 
-.category-color-darkgray {
-  background-color: var(--category-color-darkgray);
+.category-color-darkgray,
+.category-color-darkgrey {
+  background-color: var(--category-color-darkgrey);
 }
 
 .category-color-brown {

--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -10,6 +10,7 @@
   --category-color-lightblue: var(--blue-40);
   --category-color-blue: var(--blue-60);
   --category-color-brown: var(--magenta-60);
+  --category-color-magenta: var(--magenta-60);
 
   /* it is hard to create a lighter version of the following colors  */
   --category-color-grey: var(--grey-30);
@@ -72,4 +73,8 @@
 
 .category-color-brown {
   background-color: var(--category-color-brown);
+}
+
+.category-color-magenta {
+  background-color: var(--category-color-magenta);
 }

--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -7,17 +7,15 @@
   --category-color-purple: var(--purple-70);
   --category-color-green: var(--green-60);
   --category-color-orange: var(--orange-50);
+  --category-color-yellow: #ffe129; /* this yellow has more contrast than yellow-50 */
   --category-color-lightblue: var(--blue-40);
   --category-color-blue: var(--blue-60);
   --category-color-brown: var(--orange-70);
   --category-color-magenta: var(--magenta-60);
-
-  /* it is hard to create a lighter version of the following colors  */
-  --category-color-gray: var(--grey-40);
-  --category-color-grey: var(--grey-40);
-  --category-color-yellow: #ffe129; /* this yellow has more contrast than yellow-50 */
   --category-color-red: var(--red-60);
   --category-color-lightred: #a4000f9a; /* red-70 with 60 alpha */
+  --category-color-gray: var(--grey-40);
+  --category-color-grey: var(--grey-40);
   --category-color-darkgray: var(--grey-50);
   --category-color-darkgrey: var(--grey-50);
 }
@@ -53,13 +51,16 @@
   background-color: var(--category-color-lightblue);
 }
 
-.category-color-gray,
-.category-color-grey {
-  background-color: var(--category-color-grey);
-}
-
 .category-color-blue {
   background-color: var(--category-color-blue);
+}
+
+.category-color-brown {
+  background-color: var(--category-color-brown);
+}
+
+.category-color-magenta {
+  background-color: var(--category-color-magenta);
 }
 
 .category-color-red {
@@ -70,15 +71,12 @@
   background-color: var(--category-color-lightred);
 }
 
+.category-color-gray,
+.category-color-grey {
+  background-color: var(--category-color-grey);
+}
+
 .category-color-darkgray,
 .category-color-darkgrey {
   background-color: var(--category-color-darkgrey);
-}
-
-.category-color-brown {
-  background-color: var(--category-color-brown);
-}
-
-.category-color-magenta {
-  background-color: var(--category-color-magenta);
 }

--- a/res/css/categories.css
+++ b/res/css/categories.css
@@ -15,7 +15,7 @@
   --category-color-grey: var(--grey-30);
   --category-color-yellow: var(--yellow-50);
   --category-color-red: var(--red-60);
-  --category-color-lightred: var(--red-70);
+  --category-color-lightred: #a4000f9a; /* red-70 with 60 alpha */
   --category-color-darkgray: var(--grey-40);
 }
 

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -198,7 +198,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -223,7 +223,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -248,7 +248,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -715,7 +715,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -740,7 +740,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -765,7 +765,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -790,7 +790,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",
@@ -815,7 +815,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "fillRect",

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -17,12 +17,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -37,12 +37,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -61,11 +61,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
@@ -77,11 +77,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
@@ -443,12 +443,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -463,12 +463,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -487,11 +487,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
@@ -503,11 +503,11 @@ Array [
           ],
           Array [
             0.5,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
@@ -1144,15 +1144,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -1160,15 +1160,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -1287,15 +1287,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -1303,15 +1303,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -2655,12 +2655,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -2675,12 +2675,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -2699,11 +2699,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
@@ -2715,11 +2715,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
@@ -3081,12 +3081,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -3101,12 +3101,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -3125,11 +3125,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
@@ -3141,11 +3141,11 @@ Array [
           ],
           Array [
             0.5,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
@@ -3782,15 +3782,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -3798,15 +3798,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -3925,15 +3925,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -3941,15 +3941,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -5303,12 +5303,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -5323,12 +5323,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -5347,11 +5347,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
@@ -5363,11 +5363,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
@@ -5729,12 +5729,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -5749,12 +5749,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -5773,11 +5773,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
@@ -5789,11 +5789,11 @@ Array [
           ],
           Array [
             0.5,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
@@ -6430,15 +6430,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -6446,15 +6446,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -6573,15 +6573,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -6589,15 +6589,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -7951,12 +7951,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -7971,12 +7971,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "addColorStop",
@@ -7995,11 +7995,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.25,
@@ -8011,11 +8011,11 @@ Array [
           ],
           Array [
             0.5,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
-            "#d7d7db60",
+            "#b1b1b360",
           ],
           Array [
             0.75,
@@ -8377,12 +8377,12 @@ Array [
   Array [
     "addColorStop",
     0,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.25,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -8397,12 +8397,12 @@ Array [
   Array [
     "addColorStop",
     0.5,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
     0.75,
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "addColorStop",
@@ -8421,11 +8421,11 @@ Array [
         "calls": Array [
           Array [
             0,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.25,
@@ -8437,11 +8437,11 @@ Array [
           ],
           Array [
             0.5,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
-            "#ffe90060",
+            "#ffe90070",
           ],
           Array [
             0.75,
@@ -9078,15 +9078,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -9094,15 +9094,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -9221,11 +9221,11 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "beginPath",
@@ -9913,7 +9913,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -9921,15 +9921,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
@@ -10076,11 +10076,11 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
-    "#d7d7db",
+    "#b1b1b3",
   ],
   Array [
     "beginPath",
@@ -10668,7 +10668,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#d7d7db60",
+    "#b1b1b360",
   ],
   Array [
     "set fillStyle",
@@ -10676,15 +10676,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",
-    "#ffe900",
+    "#ffe129",
   ],
   Array [
     "set fillStyle",
-    "#ffe90060",
+    "#ffe90070",
   ],
   Array [
     "set fillStyle",

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -98,21 +98,28 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedTextColor: '#000',
         gravity: 0,
       };
-    case 'purple':
+    case 'lightblue':
       return {
-        selectedFillStyle: PURPLE_70,
+        selectedFillStyle: BLUE_40,
         // Colors are assumed to have the form #RRGGBB, so concatenating 2 more digits to
         // the end defines the transparency #RRGGBBAA.
-        unselectedFillStyle: PURPLE_70 + '60',
-        selectedTextColor: '#fff',
-        gravity: 5,
+        unselectedFillStyle: BLUE_40 + '60',
+        selectedTextColor: '#000',
+        gravity: 1,
       };
-    case 'green':
+    case 'red':
       return {
-        selectedFillStyle: GREEN_60,
-        unselectedFillStyle: GREEN_60 + '60',
+        selectedFillStyle: RED_60,
+        unselectedFillStyle: RED_60 + '60',
         selectedTextColor: '#fff',
-        gravity: 4,
+        gravity: 1,
+      };
+    case 'lightred':
+      return {
+        selectedFillStyle: RED_70 + '60',
+        unselectedFillStyle: RED_70 + '30',
+        selectedTextColor: '#000',
+        gravity: 1,
       };
     case 'orange':
       return {
@@ -121,33 +128,33 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedTextColor: '#fff',
         gravity: 2,
       };
-    case 'yellow':
-      return {
-        selectedFillStyle: YELLOW_50,
-        unselectedFillStyle: YELLOW_50 + '60',
-        selectedTextColor: '#000',
-        gravity: 6,
-      };
-    case 'lightblue':
-      return {
-        selectedFillStyle: BLUE_40,
-        unselectedFillStyle: BLUE_40 + '60',
-        selectedTextColor: '#000',
-        gravity: 1,
-      };
-    case 'grey':
-      return {
-        selectedFillStyle: GREY_30,
-        unselectedFillStyle: GREY_30 + '60',
-        selectedTextColor: '#000',
-        gravity: 9,
-      };
     case 'blue':
       return {
         selectedFillStyle: BLUE_60,
         unselectedFillStyle: BLUE_60 + '60',
         selectedTextColor: '#fff',
         gravity: 3,
+      };
+    case 'green':
+      return {
+        selectedFillStyle: GREEN_60,
+        unselectedFillStyle: GREEN_60 + '60',
+        selectedTextColor: '#fff',
+        gravity: 4,
+      };
+    case 'purple':
+      return {
+        selectedFillStyle: PURPLE_70,
+        unselectedFillStyle: PURPLE_70 + '60',
+        selectedTextColor: '#fff',
+        gravity: 5,
+      };
+    case 'yellow':
+      return {
+        selectedFillStyle: YELLOW_50,
+        unselectedFillStyle: YELLOW_50 + '60',
+        selectedTextColor: '#000',
+        gravity: 6,
       };
     case 'brown':
       return {
@@ -170,19 +177,12 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedTextColor: '#fff',
         gravity: 8,
       };
-    case 'red':
+    case 'grey':
       return {
-        selectedFillStyle: RED_60,
-        unselectedFillStyle: RED_60 + '60',
-        selectedTextColor: '#fff',
-        gravity: 1,
-      };
-    case 'lightred':
-      return {
-        selectedFillStyle: RED_70 + '60',
-        unselectedFillStyle: RED_70 + '30',
+        selectedFillStyle: GREY_30,
+        unselectedFillStyle: GREY_30 + '60',
         selectedTextColor: '#000',
-        gravity: 1,
+        gravity: 9,
       };
     case 'darkgray':
       return {

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -178,12 +178,14 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         gravity: 8,
       };
     case 'grey':
+    case 'gray':
       return {
         selectedFillStyle: GREY_30,
         unselectedFillStyle: GREY_30 + '60',
         selectedTextColor: '#000',
         gravity: 9,
       };
+    case 'darkgrey':
     case 'darkgray':
       return {
         selectedFillStyle: GREY_40,

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -158,8 +158,8 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
       };
     case 'brown':
       return {
-        selectedFillStyle: MAGENTA_60,
-        unselectedFillStyle: MAGENTA_60 + '60',
+        selectedFillStyle: ORANGE_70,
+        unselectedFillStyle: ORANGE_70 + '60',
         selectedTextColor: '#fff',
         gravity: 7,
       };

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -156,6 +156,13 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedTextColor: '#fff',
         gravity: 7,
       };
+    case 'magenta':
+      return {
+        selectedFillStyle: MAGENTA_60,
+        unselectedFillStyle: MAGENTA_60 + '60',
+        selectedTextColor: '#fff',
+        gravity: 7,
+      };
     case 'lightgreen':
       return {
         selectedFillStyle: GREEN_50,

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -151,8 +151,8 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
       };
     case 'yellow':
       return {
-        selectedFillStyle: YELLOW_50,
-        unselectedFillStyle: YELLOW_50 + '60',
+        selectedFillStyle: '#ffe129', // This yellow has more contrast than YELLOW_50.
+        unselectedFillStyle: YELLOW_50 + '70',
         selectedTextColor: '#000',
         gravity: 6,
       };
@@ -180,17 +180,17 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
     case 'grey':
     case 'gray':
       return {
-        selectedFillStyle: GREY_30,
-        unselectedFillStyle: GREY_30 + '60',
+        selectedFillStyle: GREY_40,
+        unselectedFillStyle: GREY_40 + '60',
         selectedTextColor: '#000',
         gravity: 9,
       };
     case 'darkgrey':
     case 'darkgray':
       return {
-        selectedFillStyle: GREY_40,
-        unselectedFillStyle: GREY_40 + '60',
-        selectedTextColor: '#000',
+        selectedFillStyle: GREY_50,
+        unselectedFillStyle: GREY_50 + '60',
+        selectedTextColor: '#fff',
         gravity: 10,
       };
     default:
@@ -198,9 +198,9 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         `Unknown color name '${colorName}' encountered. Consider updating this code to handle it.`
       );
       return {
-        selectedFillStyle: GREY_30,
-        unselectedFillStyle: GREY_30 + '60',
-        selectedTextColor: '#000',
+        selectedFillStyle: GREY_40,
+        unselectedFillStyle: GREY_40 + '60',
+        selectedTextColor: '#fff',
         gravity: 9,
       };
   }
@@ -216,7 +216,7 @@ export function mapCategoryColorNameToStackChartStyles(
   if (colorName === 'transparent') {
     return {
       selectedFillStyle: GREY_30,
-      unselectedFillStyle: GREY_20 + '60',
+      unselectedFillStyle: GREY_30 + '60',
       selectedTextColor: '#000',
       gravity: 8,
     };

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -168,14 +168,14 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedFillStyle: MAGENTA_60,
         unselectedFillStyle: MAGENTA_60 + '60',
         selectedTextColor: '#fff',
-        gravity: 7,
+        gravity: 8,
       };
     case 'lightgreen':
       return {
         selectedFillStyle: GREEN_50,
         unselectedFillStyle: GREEN_50 + '60',
         selectedTextColor: '#fff',
-        gravity: 8,
+        gravity: 9,
       };
     case 'grey':
     case 'gray':
@@ -183,7 +183,7 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedFillStyle: GREY_40,
         unselectedFillStyle: GREY_40 + '60',
         selectedTextColor: '#000',
-        gravity: 9,
+        gravity: 10,
       };
     case 'darkgrey':
     case 'darkgray':
@@ -191,7 +191,7 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedFillStyle: GREY_50,
         unselectedFillStyle: GREY_50 + '60',
         selectedTextColor: '#fff',
-        gravity: 10,
+        gravity: 11,
       };
     default:
       console.error(
@@ -201,7 +201,7 @@ export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
         selectedFillStyle: GREY_40,
         unselectedFillStyle: GREY_40 + '60',
         selectedTextColor: '#fff',
-        gravity: 9,
+        gravity: 10,
       };
   }
 }


### PR DESCRIPTION
This makes the following changes (each in its own commit):
* This reverts the changes from #4193, that changed the orange and brown colors by mistake.
* This makes `lightred` really light red in the CSS tooltips and the call tree.
* This adds the magenta color.
* This reorders the color in the order of their gravity, to make it easier to reason about them. I considered changing some gravity values but I thought this was opening a pandora box, and I didn't want to do that now.
* This adds aliases for grey and darkgrey (previously we had `grey` and `darkgray` and I didn't like this inconsistency much)
* This uses a brown color for the "brown" color (Fixes #4303)
* Adds some more contrast to the grey and yellow colors (Fixes #2674, fixes #2427)

The order for these commits isn't the most logical, I think the reorder should have come earlier, but reording the commit would yield some conflicts and I admit I didn't want to resolve them. I think it's still OK.

Tell me what you think!

[Production](https://profiler.firefox.com/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/stack-chart/?globalTrackOrder=l0wk&hiddenGlobalTracks=0wikl&hiddenLocalTracksByPid=1100-0w3~33180-0~34076-01~33692-0~6580-0~45328-0~30192-0~19508-0~39544-0~41396-0~40940-0~9832-0~32968-0~41520-0~13128-01~21060-01~41716-013w8&range=24851m3826~25497m2840&thread=o&v=8)
[deploy preview](https://deploy-preview-4347--perf-html.netlify.app/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/stack-chart/?globalTrackOrder=l0wk&hiddenGlobalTracks=0wikl&hiddenLocalTracksByPid=1100-0w3~33180-0~34076-01~33692-0~6580-0~45328-0~30192-0~19508-0~39544-0~41396-0~40940-0~9832-0~32968-0~41520-0~13128-01~21060-01~41716-013w8&range=24851m3826~25497m2840&thread=o&v=8)

As a reminder, the CSS colors are used in the tooltips and the call tree, while the colors from colors.js are used in the activity graph as well as the flame graph and the stack chart.