### PR TITLE
Expand more interesting nodes and provide a more interesting selection when opening the call tree for the first time

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -144,27 +144,29 @@ class CallTreeImpl extends PureComponent<Props> {
 
   componentDidMount() {
     this.focus();
-    if (this.props.selectedCallNodeIndex === null) {
-      this.procureInterestingInitialSelection();
-    } else if (this._treeView) {
+    this.maybeProcureInterestingInitialSelection();
+
+    if (this.props.selectedCallNodeIndex === null && this._treeView) {
       this._treeView.scrollSelectionIntoView();
     }
   }
 
   componentDidUpdate(prevProps) {
     if (
-      this.props.scrollToSelectionGeneration >
-      prevProps.scrollToSelectionGeneration
-    ) {
-      if (this._treeView) {
-        this._treeView.scrollSelectionIntoView();
-      }
-    }
-
-    if (
       this.props.focusCallTreeGeneration > prevProps.focusCallTreeGeneration
     ) {
       this.focus();
+    }
+
+    this.maybeProcureInterestingInitialSelection();
+
+    if (
+      this.props.selectedCallNodeIndex !== null &&
+      this.props.scrollToSelectionGeneration >
+        prevProps.scrollToSelectionGeneration &&
+      this._treeView
+    ) {
+      this._treeView.scrollSelectionIntoView();
     }
   }
 
@@ -228,10 +230,16 @@ class CallTreeImpl extends PureComponent<Props> {
     openSourceView(file, 'calltree');
   };
 
-  procureInterestingInitialSelection() {
+  maybeProcureInterestingInitialSelection() {
     // Expand the heaviest callstack up to a certain depth and select the frame
     // at that depth.
-    const { tree, expandedCallNodeIndexes } = this.props;
+    const { tree, expandedCallNodeIndexes, selectedCallNodeIndex } = this.props;
+
+    if (selectedCallNodeIndex !== null || expandedCallNodeIndexes.length > 0) {
+      // Let's not change some existing state.
+      return;
+    }
+
     const newExpandedCallNodeIndexes = expandedCallNodeIndexes.slice();
     const maxInterestingDepth = 17; // scientifically determined
     let currentCallNodeIndex = tree.getRoots()[0];

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -283,14 +283,14 @@ describe('calltree/ProfileCallTreeView', function () {
     expect(getRowElement('C')).toHaveClass('isSelected');
   });
 
-  it('does not select the heaviest stack if it is idle', () => {
+  it('does select a non-idle stack if the heaviest stack is idle', () => {
     const { profile } = getProfileFromTextSamples(`
-      A  A            A            A            A
-      B  C[cat:Idle]  C[cat:Idle]  C[cat:Idle]  D
-      E                                         E
+      A  A            A            A            A  A
+      B  C[cat:Idle]  C[cat:Idle]  C[cat:Idle]  B  D
+      E                                         E  F
     `);
-    const { container } = setup(profile);
-    expect(container.querySelector('.treeViewRow.isSelected')).toBeFalsy();
+    const { getRowElement } = setup(profile);
+    expect(getRowElement('E')).toHaveClass('isSelected');
   });
 });
 

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -192,7 +192,7 @@ allocated or deallocated in the program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 160px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -418,11 +418,73 @@ allocated or deallocated in the program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="20%"
+                >
+                  20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="20%"
+                >
+                  20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 160px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -615,7 +677,7 @@ allocated or deallocated in the program."
                 </span>
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="C, total size is 3 bytes (20%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
@@ -629,7 +691,7 @@ allocated or deallocated in the program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -639,6 +701,65 @@ allocated or deallocated in the program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, total size is 3 bytes (20%), self size is 0 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, total size is 3 bytes (20%), self size is 3 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -863,7 +984,7 @@ allocated or deallocated in the program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 160px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -1089,11 +1210,73 @@ allocated or deallocated in the program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-20%"
+                >
+                  -20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-3"
+                >
+                  -3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-20%"
+                >
+                  -20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-3"
+                >
+                  -3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="-3"
+                >
+                  -3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 160px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -1286,7 +1469,7 @@ allocated or deallocated in the program."
                 </span>
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="C, total size is -3 bytes (-20%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
@@ -1300,7 +1483,7 @@ allocated or deallocated in the program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -1310,6 +1493,65 @@ allocated or deallocated in the program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, total size is -3 bytes (-20%), self size is 0 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, total size is -3 bytes (-20%), self size is -3 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -1534,7 +1776,7 @@ allocated or deallocated in the program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 160px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -1760,11 +2002,73 @@ allocated or deallocated in the program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="27%"
+                >
+                  27%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="11"
+                >
+                  11
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="27%"
+                >
+                  27%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="11"
+                >
+                  11
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="11"
+                >
+                  11
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 160px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -1957,7 +2261,7 @@ allocated or deallocated in the program."
                 </span>
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="C, total size is 11 bytes (27%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
@@ -1971,7 +2275,7 @@ allocated or deallocated in the program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -1981,6 +2285,65 @@ allocated or deallocated in the program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, total size is 11 bytes (27%), self size is 0 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, total size is 11 bytes (27%), self size is 11 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -2193,7 +2556,7 @@ allocated or deallocated in the program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 160px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -2419,11 +2782,73 @@ allocated or deallocated in the program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="20%"
+                >
+                  20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="—"
+                >
+                  —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="20%"
+                >
+                  20%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="3"
+                >
+                  3
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 160px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -2616,7 +3041,7 @@ allocated or deallocated in the program."
                 </span>
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="C, total size is 3 bytes (20%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
@@ -2630,7 +3055,7 @@ allocated or deallocated in the program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -2640,6 +3065,65 @@ allocated or deallocated in the program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="D, total size is 3 bytes (20%), self size is 0 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-3"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  D
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, total size is 3 bytes (20%), self size is 3 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-4"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -2852,7 +3336,7 @@ allocated or deallocated in the program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 96px;"
+            style="height: 128px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -2960,6 +3444,68 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-59%"
+                >
+                  -59%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-24"
+                >
+                  -24
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="-11"
+                >
+                  -11
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="-32%"
+                >
+                  -32%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="-13"
+                >
+                  -13
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="-13"
+                >
+                  -13
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
                   title="-41%"
                 >
                   -41%
@@ -3020,7 +3566,7 @@ allocated or deallocated in the program."
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 96px; min-width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -3090,7 +3636,7 @@ allocated or deallocated in the program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="C, total size is -24 bytes (-59%), self size is 0 bytes"
                 aria-level="3"
                 aria-selected="false"
@@ -3104,7 +3650,7 @@ allocated or deallocated in the program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -3114,6 +3660,65 @@ allocated or deallocated in the program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   C
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
+                aria-label="J, total size is -24 bytes (-59%), self size is -11 bytes"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns odd"
+                id="treeViewRow-9"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton expanded canBeExpanded"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  J
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="K, total size is -13 bytes (-32%), self size is -13 bytes"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-10"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  K
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -3795,7 +4400,7 @@ for understanding where time was actually spent in a program."
       class="react-contextmenu-wrapper treeViewContextMenu"
     >
       <div
-        aria-activedescendant="treeViewRow-9"
+        aria-activedescendant="treeViewRow-5"
         aria-label="Call tree"
         class="treeViewBody"
         role="tree"
@@ -3806,7 +4411,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 48px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -3816,150 +4421,26 @@ for understanding where time was actually spent in a program."
               class="treeViewBodyInner treeViewBodyInner0InnerChunk"
             >
               <div
-                class="treeViewRow treeViewRowFixedColumns even"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="67%"
-                >
-                  67%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="2"
-                >
-                  2
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="2"
-                >
-                  2
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns odd"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="67%"
-                >
-                  67%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="2"
-                >
-                  2
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns even"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="67%"
-                >
-                  67%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="2"
-                >
-                  2
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns odd"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="33%"
-                >
-                  33%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="1"
-                >
-                  1
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
                 class="treeViewRow treeViewRowFixedColumns even isSelected"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="33%"
+                  title="67%"
                 >
-                  33%
+                  67%
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn total"
-                  title="1"
+                  title="2"
                 >
-                  1
+                  2
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
+                  title="2"
                 >
-                  —
+                  2
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -3972,37 +4453,6 @@ for understanding where time was actually spent in a program."
               </div>
               <div
                 class="treeViewRow treeViewRowFixedColumns odd"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  title="33%"
-                >
-                  33%
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn total"
-                  title="1"
-                >
-                  1
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn self"
-                  title="—"
-                >
-                  —
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn icon"
-                  title=""
-                >
-                  <div
-                    class="nodeIcon "
-                  />
-                </span>
-              </div>
-              <div
-                class="treeViewRow treeViewRowFixedColumns even"
                 style="height: 16px; line-height: 16px;"
               >
                 <span
@@ -4036,7 +4486,7 @@ for understanding where time was actually spent in a program."
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 48px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -4046,11 +4496,11 @@ for understanding where time was actually spent in a program."
               class="treeViewBodyInner treeViewBodyInner1InnerChunk"
             >
               <div
-                aria-expanded="true"
+                aria-expanded="false"
                 aria-label="Z, running count is 2 samples (67%), self count is 2 samples"
                 aria-level="1"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                aria-selected="true"
+                class="treeViewRow treeViewRowScrolledColumns even isSelected"
                 id="treeViewRow-5"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4060,7 +4510,7 @@ for understanding where time was actually spent in a program."
                   style="width: 0px;"
                 />
                 <span
-                  class="treeRowToggleButton expanded canBeExpanded"
+                  class="treeRowToggleButton collapsed canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -4076,162 +4526,11 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="true"
-                aria-label="Y, running count is 2 samples (67%), self count is 0 samples"
-                aria-level="2"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
-                id="treeViewRow-6"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 10px;"
-                />
-                <span
-                  class="treeRowToggleButton expanded canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  Y
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-expanded="true"
-                aria-label="X, running count is 2 samples (67%), self count is 0 samples"
-                aria-level="3"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
-                id="treeViewRow-7"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 20px;"
-                />
-                <span
-                  class="treeRowToggleButton expanded canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name"
-                >
-                  X
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                >
-                  libX.so
-                </span>
-              </div>
-              <div
-                aria-expanded="true"
-                aria-label="B, running count is 1 sample (33%), self count is 0 samples"
-                aria-level="4"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
-                id="treeViewRow-8"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 30px;"
-                />
-                <span
-                  class="treeRowToggleButton expanded canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  B
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-label="A, running count is 1 sample (33%), self count is 0 samples"
-                aria-level="5"
-                aria-selected="true"
-                class="treeViewRow treeViewRowScrolledColumns even isSelected"
-                id="treeViewRow-9"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 40px;"
-                />
-                <span
-                  class="treeRowToggleButton collapsed leaf"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  A
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
-                aria-expanded="false"
-                aria-label="C, running count is 1 sample (33%), self count is 0 samples"
-                aria-level="4"
-                aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns odd"
-                id="treeViewRow-10"
-                role="treeitem"
-                style="height: 16px; line-height: 16px;"
-              >
-                <span
-                  class="treeRowIndentSpacer"
-                  style="width: 30px;"
-                />
-                <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
-                />
-                <span
-                  class="colored-square category-color-grey"
-                  title="Other"
-                />
-                <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
-                >
-                  C
-                </span>
-                <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
-                />
-              </div>
-              <div
                 aria-expanded="false"
                 aria-label="E, running count is 1 sample (33%), self count is 1 sample"
                 aria-level="1"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 id="treeViewRow-0"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4432,7 +4731,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 160px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -4645,9 +4944,71 @@ for understanding where time was actually spent in a program."
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
                   title="—"
                 >
                   —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -4662,7 +5023,7 @@ for understanding where time was actually spent in a program."
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 160px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -4821,7 +5182,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (33%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -4835,7 +5196,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -4851,11 +5212,40 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
                 aria-label="H, running count is 1 sample (33%), self count is 0 samples"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 id="treeViewRow-7"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -4865,7 +5255,7 @@ for understanding where time was actually spent in a program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -4881,6 +5271,35 @@ for understanding where time was actually spent in a program."
                 >
                   libH.so
                 </span>
+              </div>
+              <div
+                aria-label="I, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-8"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  I
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
               </div>
             </div>
           </div>
@@ -5507,7 +5926,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 128px;"
+            style="height: 160px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -5720,9 +6139,71 @@ for understanding where time was actually spent in a program."
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns odd"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
                   title="—"
                 >
                   —
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="33%"
+                >
+                  33%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
                 </span>
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
@@ -5737,7 +6218,7 @@ for understanding where time was actually spent in a program."
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 128px; min-width: 3000px;"
+            style="height: 160px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -5896,7 +6377,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (33%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -5910,7 +6391,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -5926,11 +6407,40 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-label="E, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-expanded="true"
                 aria-label="H, running count is 1 sample (33%), self count is 0 samples"
                 aria-level="3"
                 aria-selected="false"
-                class="treeViewRow treeViewRowScrolledColumns even"
+                class="treeViewRow treeViewRowScrolledColumns odd"
                 id="treeViewRow-7"
                 role="treeitem"
                 style="height: 16px; line-height: 16px;"
@@ -5940,7 +6450,7 @@ for understanding where time was actually spent in a program."
                   style="width: 20px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -5956,6 +6466,35 @@ for understanding where time was actually spent in a program."
                 >
                   libH.so
                 </span>
+              </div>
+              <div
+                aria-label="I, running count is 1 sample (33%), self count is 1 sample"
+                aria-level="4"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-8"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 30px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  I
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
               </div>
             </div>
           </div>
@@ -6133,7 +6672,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 112px;"
+            style="height: 128px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -6328,11 +6867,42 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="50%"
+                >
+                  50%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 112px; min-width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -6495,7 +7065,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (50%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -6509,7 +7079,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -6519,6 +7089,35 @@ for understanding where time was actually spent in a program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (50%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -6700,7 +7299,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 112px;"
+            style="height: 128px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -6895,11 +7494,42 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="50%"
+                >
+                  50%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 112px; min-width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -7062,7 +7692,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (50%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -7076,7 +7706,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -7086,6 +7716,35 @@ for understanding where time was actually spent in a program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (50%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -7267,7 +7926,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 80px;"
+            style="height: 96px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -7400,11 +8059,42 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 80px; min-width: 3000px;"
+            style="height: 96px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -7508,7 +8198,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (100%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -7522,7 +8212,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -7536,6 +8226,35 @@ for understanding where time was actually spent in a program."
                   >
                     F
                   </span>
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (100%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  E
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"
@@ -7717,7 +8436,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 80px;"
+            style="height: 96px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -7850,11 +8569,42 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="100%"
+                >
+                  100%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 80px; min-width: 3000px;"
+            style="height: 96px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -7958,7 +8708,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (100%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -7972,7 +8722,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -7985,6 +8735,39 @@ for understanding where time was actually spent in a program."
                     class="treeViewHighlighting"
                   >
                     F
+                  </span>
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (100%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  <span
+                    class="treeViewHighlighting"
+                  >
+                    E
                   </span>
                 </span>
                 <span
@@ -8167,7 +8950,7 @@ for understanding where time was actually spent in a program."
         >
           <div
             class="treeViewBodyInner treeViewBodyInner0"
-            style="height: 112px;"
+            style="height: 128px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner0TopSpacer"
@@ -8362,11 +9145,42 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
               </div>
+              <div
+                class="treeViewRow treeViewRowFixedColumns even"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn totalPercent"
+                  title="50%"
+                >
+                  50%
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn total"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn self"
+                  title="1"
+                >
+                  1
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn icon"
+                  title=""
+                >
+                  <div
+                    class="nodeIcon "
+                  />
+                </span>
+              </div>
             </div>
           </div>
           <div
             class="treeViewBodyInner treeViewBodyInner1"
-            style="height: 112px; min-width: 3000px;"
+            style="height: 128px; min-width: 3000px;"
           >
             <div
               class="treeViewBodyInner treeViewBodyInner1TopSpacer"
@@ -8533,7 +9347,7 @@ for understanding where time was actually spent in a program."
                 />
               </div>
               <div
-                aria-expanded="false"
+                aria-expanded="true"
                 aria-label="F, running count is 1 sample (50%), self count is 0 samples"
                 aria-level="4"
                 aria-selected="false"
@@ -8547,7 +9361,7 @@ for understanding where time was actually spent in a program."
                   style="width: 30px;"
                 />
                 <span
-                  class="treeRowToggleButton collapsed canBeExpanded"
+                  class="treeRowToggleButton expanded canBeExpanded"
                 />
                 <span
                   class="colored-square category-color-grey"
@@ -8557,6 +9371,39 @@ for understanding where time was actually spent in a program."
                   class="treeViewRowColumn treeViewMainColumn name dim"
                 >
                   F
+                </span>
+                <span
+                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                />
+              </div>
+              <div
+                aria-label="E, running count is 1 sample (50%), self count is 1 sample"
+                aria-level="5"
+                aria-selected="false"
+                class="treeViewRow treeViewRowScrolledColumns even"
+                id="treeViewRow-6"
+                role="treeitem"
+                style="height: 16px; line-height: 16px;"
+              >
+                <span
+                  class="treeRowIndentSpacer"
+                  style="width: 40px;"
+                />
+                <span
+                  class="treeRowToggleButton collapsed leaf"
+                />
+                <span
+                  class="colored-square category-color-grey"
+                  title="Other"
+                />
+                <span
+                  class="treeViewRowColumn treeViewMainColumn name dim"
+                >
+                  <span
+                    class="treeViewHighlighting"
+                  >
+                    E
+                  </span>
                 </span>
                 <span
                   class="treeViewRowColumn treeViewAppendageColumn lib"


### PR DESCRIPTION
**Please do not test for now, I see quite obvious bugs that would impair the experience**

We have a logic to provide some initial view when opening the call tree for the first time. This logic hasn't been updated for a long time and has some drawbacks:
* it's run only the first time the call tree is displayed. As a result it's not run when switching threads, changing transforms, and similar things.
* it doesn't take the categories into account when deciding to expand nodes, especially the idle category.
* it only expands the heaviest stack, even though other sieblings might be interesting as well.
* it only expands up to some depth, while the user usually have more space available.

This patch tries to fix all these shortcomings. There will probably need some more adjustments.

Possible drawbacks I'm seeing already:
1. when looking at the category, we use the category of the current node. This might not be what we want: instead we may want to look at the categories for the actual samples for this node. But this is needs probably a lot more computations.
2. it would be good to look at the actual container size to decide the number of expanded lines, but in this component we don't easily have access to this DOM size.
3. If the first items already expand to a lot of nodes, then we will have a shallower depth as a result.

Happy to hear feedback!

Here are a few examples:
[production](https://profiler.firefox.com/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/) / [deploy preview 4357](https://deploy-preview-4357--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/) / [deploy preview 4358](https://deploy-preview-4358--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/) #4358 / [deploy preview 4359](https://deploy-preview-4359--perf-html.netlify.app/public/def4zbt1tyg8w0x7nkdtq8g7s6h3ad0ndz7jbzg/) #4359
[production](https://profiler.firefox.com/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/) / [deploy preview 4357](https://deploy-preview-4357--perf-html.netlify.app/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/) / [deploy preview 4358](https://deploy-preview-4358--perf-html.netlify.app/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/) #4358 / [deploy preview 4359](https://deploy-preview-4359--perf-html.netlify.app/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/) #4359
[production](https://profiler.firefox.com/public/yq2tkdj68prevxabfzd8ecdg090raxxg24zg720/) / [deploy preview 4357](https://deploy-preview-4357--perf-html.netlify.app/public/yq2tkdj68prevxabfzd8ecdg090raxxg24zg720/) / [deploy preview 4358](https://deploy-preview-4358--perf-html.netlify.app/public/yq2tkdj68prevxabfzd8ecdg090raxxg24zg720/) #4358 / [deploy preview 4359](https://deploy-preview-4359--perf-html.netlify.app/public/yq2tkdj68prevxabfzd8ecdg090raxxg24zg720/) #4359


These deploy previews include links to the much simpler PR #4358, where we don't try to open interesting siblings, and #4359 where we open interesting siblings but otherwise do not loop through their children.

Things to try: move between threads, add transforms / remove transforms, inverted tree (I didn't look at the inverted tree much).

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-595)
