### PR TITLE
Sanitize URL properties in markers

### DIFF
--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -123,7 +123,11 @@ class MarkerTree {
         start: _formatStart(marker.start, this._zeroAt),
         duration,
         name,
-        type: getMarkerSchemaName(this._markerSchemaByName, marker),
+        type: getMarkerSchemaName(
+          this._markerSchemaByName,
+          marker.name,
+          marker.data
+        ),
       };
       this._displayDataByIndex.set(markerIndex, displayData);
     }

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -230,7 +230,11 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
 
     if (data) {
       // Add the details for the markers based on their Marker schema.
-      const schema = getSchemaFromMarker(markerSchemaByName, marker);
+      const schema = getSchemaFromMarker(
+        markerSchemaByName,
+        marker.name,
+        marker.data
+      );
       if (schema) {
         for (const schemaData of schema.data) {
           // Check for a schema that is looking up and formatting a value from

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1320,6 +1320,41 @@ export function sanitizeExtensionTextMarker(
   return payload;
 }
 
+export function sanitizeFromMarkerSchema(
+  markerSchema: MarkerSchema,
+  markerPayload: MarkerPayload
+): MarkerPayload {
+  for (const propertyDescription of markerSchema.data) {
+    if (
+      propertyDescription.key !== undefined &&
+      propertyDescription.format !== undefined
+    ) {
+      const key = propertyDescription.key;
+      const format = propertyDescription.format;
+      if (!(key in markerPayload)) {
+        continue;
+      }
+
+      // We're typing the result of the sanitization with `any` because Flow
+      // doesn't like much our enormous enum of non-exact objects that's used as
+      // MarkerPayload type, and this code is too generic for Flow in this context.
+      if (format === 'url') {
+        markerPayload = ({
+          ...markerPayload,
+          [key]: removeURLs(markerPayload[key]),
+        }: any);
+      } else if (format === 'file-path') {
+        markerPayload = ({
+          ...markerPayload,
+          [key]: removeFilePath(markerPayload[key]),
+        }: any);
+      }
+    }
+  }
+
+  return markerPayload;
+}
+
 /**
  * Markers can be filtered by display area using the marker schema. Get a list of
  * marker "types" (the type field in the Payload) for a specific location.

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -161,7 +161,11 @@ export function getSearchFilteredMarkerIndexes(
       }
 
       // Now check the schema for the marker payload for searchable
-      const markerSchema = getSchemaFromMarker(markerSchemaByName, marker);
+      const markerSchema = getSchemaFromMarker(
+        markerSchemaByName,
+        marker.name,
+        marker.data
+      );
       if (
         markerSchema &&
         markerPayloadMatchesSearch(markerSchema, marker, regExp)
@@ -1362,7 +1366,9 @@ export function filterMarkerByDisplayLocation(
       return additionalResult;
     }
 
-    return markerTypes.has(getMarkerSchemaName(markerSchemaByName, marker));
+    return markerTypes.has(
+      getMarkerSchemaName(markerSchemaByName, marker.name, marker.data)
+    );
   });
 }
 

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -35,7 +35,6 @@ import type {
   IPCMarkerPayload,
   NetworkPayload,
   PrefMarkerPayload,
-  FileIoPayload,
   TextMarkerPayload,
   StartEndRange,
   IndexedArray,
@@ -1266,22 +1265,6 @@ export function removePrefMarkerPreferenceValues(
   payload: PrefMarkerPayload
 ): PrefMarkerPayload {
   return { ...payload, prefValue: '' };
-}
-
-/**
- * Sanitize FileIO marker's filename property if it's non-empty.
- */
-export function sanitizeFileIOMarkerFilenamePath(
-  payload: FileIoPayload
-): FileIoPayload {
-  if (!payload.filename) {
-    return payload;
-  }
-
-  return {
-    ...payload,
-    filename: removeFilePath(payload.filename),
-  };
 }
 
 /**

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -274,40 +274,33 @@ function sanitizeThreadPII(
         markerTable.data[i] = removePrefMarkerPreferenceValues(currentMarker);
       }
 
-      // Remove the all network URLs if user wants to remove them.
-      if (
-        PIIToBeRemoved.shouldRemoveUrls &&
-        currentMarker &&
-        currentMarker.type === 'Network'
-      ) {
-        // Remove the URI fields from marker payload.
-        markerTable.data[i] = removeNetworkMarkerURLs(currentMarker);
+      if (currentMarker && PIIToBeRemoved.shouldRemoveUrls) {
+        // Remove the all network URLs if user wants to remove them.
+        if (currentMarker.type === 'Network') {
+          // Remove the URI fields from marker payload.
+          markerTable.data[i] = removeNetworkMarkerURLs(currentMarker);
 
-        // Strip the URL from the marker name
-        const stringIndex = markerTable.name[i];
-        stringArray[stringIndex] = stringArray[stringIndex].replace(/:.*/, '');
-      }
+          // Strip the URL from the marker name
+          const stringIndex = markerTable.name[i];
+          stringArray[stringIndex] = stringArray[stringIndex].replace(
+            /:.*/,
+            ''
+          );
+        }
 
-      // Remove the all OS paths from FileIO markers if user wants to remove them.
-      if (
-        PIIToBeRemoved.shouldRemoveUrls &&
-        currentMarker &&
-        currentMarker.type === 'FileIO'
-      ) {
-        // Remove the filename path from marker payload.
-        markerTable.data[i] = sanitizeFileIOMarkerFilenamePath(currentMarker);
-      }
+        // Remove the all OS paths from FileIO markers if user wants to remove them.
+        if (currentMarker.type === 'FileIO') {
+          // Remove the filename path from marker payload.
+          markerTable.data[i] = sanitizeFileIOMarkerFilenamePath(currentMarker);
+        }
 
-      if (
-        PIIToBeRemoved.shouldRemoveUrls &&
-        currentMarker &&
-        currentMarker.type === 'Text'
-      ) {
-        // Sanitize all the name fields of text markers in case they contain URLs.
-        markerTable.data[i] = sanitizeTextMarker(currentMarker);
-        // Re-assign the value of currentMarker as the marker may be
-        // sanitized again to remove extension ids.
-        currentMarker = markerTable.data[i];
+        if (currentMarker.type === 'Text') {
+          // Sanitize all the name fields of text markers in case they contain URLs.
+          markerTable.data[i] = sanitizeTextMarker(currentMarker);
+          // Re-assign the value of currentMarker as the marker may be
+          // sanitized again to remove extension ids.
+          currentMarker = markerTable.data[i];
+        }
       }
 
       if (

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -14,7 +14,6 @@ import { removeURLs } from '../utils/string';
 import {
   removeNetworkMarkerURLs,
   removePrefMarkerPreferenceValues,
-  sanitizeFileIOMarkerFilenamePath,
   filterRawMarkerTableToRangeWithMarkersToDelete,
   sanitizeExtensionTextMarker,
   sanitizeTextMarker,
@@ -307,12 +306,6 @@ function sanitizeThreadPII(
             /:.*/,
             ''
           );
-        }
-
-        // Remove the all OS paths from FileIO markers if user wants to remove them.
-        if (currentMarker.type === 'FileIO') {
-          // Remove the filename path from marker payload.
-          markerTable.data[i] = sanitizeFileIOMarkerFilenamePath(currentMarker);
         }
 
         if (currentMarker.type === 'Text') {

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -16,6 +16,7 @@ import {
   getContainsPrivateBrowsingInformation,
   getThreads,
   getActiveTabID,
+  getMarkerSchemaByName,
 } from './profile';
 import { compress } from '../utils/gz';
 import { serializeProfile } from '../profile-logic/process-profile';
@@ -222,6 +223,7 @@ export const getSanitizedProfile: Selector<SanitizeProfileResult> =
     getProfile,
     getDerivedMarkerInfoForAllThreads,
     getRemoveProfileInformation,
+    getMarkerSchemaByName,
     sanitizePII
   );
 

--- a/src/test/unit/merge-compare.test.js
+++ b/src/test/unit/merge-compare.test.js
@@ -481,7 +481,7 @@ describe('mergeThreads function', function () {
 
     // Check if we properly merged the string tables and have the correct url fields.
     const markerUrlsAfterMerge = mergedMarkers.data.map((markerData) =>
-      markerData && 'url' in markerData && markerData.url
+      markerData && 'url' in markerData && typeof markerData.url === 'number'
         ? markerData.url
         : null
     );

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -65,10 +65,44 @@ describe('sanitizePII', function () {
       }
     );
 
+    const markerSchemaByName = {
+      FileIO: {
+        name: 'FileIO',
+        display: ['marker-chart', 'marker-table', 'timeline-fileio'],
+        data: [
+          {
+            key: 'operation',
+            label: 'Operation',
+            format: 'string',
+            searchable: true,
+          },
+          {
+            key: 'source',
+            label: 'Source',
+            format: 'string',
+            searchable: true,
+          },
+          {
+            key: 'filename',
+            label: 'Filename',
+            format: 'file-path',
+            searchable: true,
+          },
+          {
+            key: 'threadId',
+            label: 'Thread ID',
+            format: 'string',
+            searchable: true,
+          },
+        ],
+      },
+    };
+
     const sanitizedProfile = sanitizePII(
       originalProfile,
       derivedMarkerInfoForAllThreads,
-      PIIToRemove
+      PIIToRemove,
+      markerSchemaByName
     ).profile;
 
     return {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -96,6 +96,17 @@ describe('sanitizePII', function () {
           },
         ],
       },
+      Url: {
+        name: 'Url',
+        tableLabel: '{marker.name} - {marker.data.url}',
+        display: ['marker-chart', 'marker-table'],
+        data: [
+          {
+            key: 'url',
+            format: 'url',
+          },
+        ],
+      },
     };
 
     const sanitizedProfile = sanitizePII(
@@ -580,6 +591,38 @@ describe('sanitizePII', function () {
     // Now check the filename fields and make sure they are sanitized.
     expect(marker1.filename).toBe('<PATH>/' + marker1File);
     expect(marker2.filename).toBe('<PATH>\\' + marker2File);
+  });
+
+  it('should sanitize the URL properties in markers', function () {
+    const { sanitizedProfile } = setup(
+      {
+        shouldRemoveUrls: true,
+      },
+      getProfileWithMarkers([
+        [
+          'SpeculativeConnect',
+          1,
+          2,
+          {
+            type: 'Url',
+            url: 'https://img-getpocket.cdn.mozilla.net',
+          },
+        ],
+      ])
+    );
+    expect(sanitizedProfile.threads.length).toEqual(1);
+    const thread = sanitizedProfile.threads[0];
+    expect(thread.markers.length).toEqual(1);
+
+    const marker = thread.markers.data[0];
+
+    // The url fields should still be there
+    if (!marker || !marker.url) {
+      throw new Error('Failed to find url property in the payload');
+    }
+
+    // Now check the url fields and make sure they are sanitized.
+    expect(marker.url).toBe('https://<URL>');
   });
 
   it('should sanitize the eTLD+1 field if urls are supposed to be sanitized', function () {

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -20,9 +20,7 @@ export type MarkerFormatType =
   // String types.
 
   // Show the URL, and handle PII sanitization
-  // TODO Handle PII sanitization. Issue #2757
   | 'url'
-  // TODO Handle PII sanitization. Issue #2757
   // Show the file path, and handle PII sanitization.
   | 'file-path'
   // Important, do not put URL or file path information here, as it will not be

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -732,6 +732,11 @@ export type NoPayloadUserData = {|
   innerWindowID?: number,
 |};
 
+export type UrlMarkerPayload = {|
+  type: 'Url',
+  url: string,
+|};
+
 /**
  * The union of all the different marker payloads that profiler.firefox.com knows about,
  * this is not guaranteed to be all the payloads that we actually get from the Gecko
@@ -764,7 +769,8 @@ export type MarkerPayload =
   | MediaSampleMarkerPayload
   | JankPayload
   | BrowsertimeMarkerPayload
-  | NoPayloadUserData;
+  | NoPayloadUserData
+  | UrlMarkerPayload;
 
 export type MarkerPayload_Gecko =
   | GPUMarkerPayload
@@ -786,6 +792,7 @@ export type MarkerPayload_Gecko =
   | IPCMarkerPayload_Gecko
   | MediaSampleMarkerPayload
   | NoPayloadUserData
+  | UrlMarkerPayload
   // The following payloads come in with a stack property. During the profile processing
   // the "stack" property is are converted into a "cause". See the CauseBacktrace type
   // for more information.


### PR DESCRIPTION
The first commit is #4368, you can review it separately (or in this PR directly if you prefer).
Then I tried to split the work logically in separate commits.

From Andrew's issue:
[Production](https://profiler.firefox.com/public/4mrzpp5h9eknhm3xgjzdzasc985wt9sk6y2gd5g/marker-table/?globalTrackOrder=a0w9&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=92039-1w4~92064-0~92054-0~92060-0~92048-0~92041-0~92044-0~92053-01~92042-0w2&localTrackOrderByPid=92039-560w4~92064-0~92054-0~92060-0~92048-0~92041-0~92044-0~92053-01~92042-120~92049-01&markerSearch=specula&thread=0&v=8)
[Deploy preview](https://deploy-preview-4369--perf-html.netlify.app/public/4mrzpp5h9eknhm3xgjzdzasc985wt9sk6y2gd5g/marker-table/?globalTrackOrder=a0w9&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=92039-1w4~92064-0~92054-0~92060-0~92048-0~92041-0~92044-0~92053-01~92042-0w2&localTrackOrderByPid=92039-560w4~92064-0~92054-0~92060-0~92048-0~92041-0~92044-0~92053-01~92042-120~92049-01&markerSearch=specula&thread=0&v=8)

I also made this other profile from Andrew's patch, where I also recorded FileIO markers:
[production](https://share.firefox.dev/3BwD9Vk)
[deploy preview](https://deploy-preview-4369--perf-html.netlify.app/public/gqmf5enmjgv754m6b8bg4ak1khzcz28h483n07g/marker-table/?globalTrackOrder=e0wd&hiddenGlobalTracks=13w9d&hiddenLocalTracksByPid=1817772-2w4~1818898-01~1818847-01~1817859-0~1818243-0~1818605-01~1818764-01~1817950-0~1818009-01~1817896-0~1818932-0&thread=k&v=8)
(File IO markers are in the content processes, SpeculativeConnect markers are in the parent process)

There should be no visible changes for FileIO markers: they should be sanitized when unchecking `Include resource URLs and paths` just like on production. However the markers with URL properties such as `SpeculativeConnect` should be properly sanitized in the deploy preview, but they're not in the production deploy.

Fixes https://github.com/firefox-devtools/profiler/issues/2757
Fixes https://github.com/firefox-devtools/profiler/issues/4107