### PR TITLE
Skip idle nodes when procuring an initial selection in the call tree

### DIFF
--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -315,8 +315,9 @@ describe('calltree/ProfileCallTreeView', function () {
       B  C[cat:Idle]  C[cat:Idle]  C[cat:Idle]  D
       E                                         E
     `);
-    const { container } = setup(profile);
-    expect(container.querySelector('.treeViewRow.isSelected')).toBeFalsy();
+    const { getRowElement } = setup(profile);
+    expect(getRowElement('E', { selected: true })).toHaveClass('isSelected');
+    expect(getRowElement('B', { expanded: true })).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Please skip the first commit, as this is #4382.

This is also a smaller extract of #4357.

The goal is still to provide a more interesting selection in the call tree than what we're doing now. Especially currently we expand always the first node, but very often at one point the first node will be an idle function. So in this patch I'm picking the first non-idle node, unless that's not existing, in that case I'm picking the first node like today.

Here is an example:
[Production](https://profiler.firefox.com/public/6k8tn6wc7gvrzwmtnewb4t7pkc6h7exnkvx8vc8/calltree/?thread=3)
[Deploy preview](https://deploy-preview-4383--perf-html.netlify.app/public/6k8tn6wc7gvrzwmtnewb4t7pkc6h7exnkvx8vc8/calltree/?thread=3)
