### PR TITLE
Do not scroll the various views as a result of a pointer click

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -74,6 +74,7 @@ import type {
   GlobalTrack,
   KeyboardModifiers,
   TableViewOptions,
+  SelectionContext,
 } from 'firefox-profiler/types';
 import {
   funcHasDirectRecursiveCall,
@@ -99,6 +100,7 @@ import { intersectSets } from 'firefox-profiler/utils/set';
 export function changeSelectedCallNode(
   threadsKey: ThreadsKey,
   selectedCallNodePath: CallNodePath,
+  context: SelectionContext = { source: 'auto' },
   optionalExpandedToCallNodePath?: CallNodePath
 ): Action {
   if (optionalExpandedToCallNodePath) {
@@ -119,6 +121,7 @@ export function changeSelectedCallNode(
     selectedCallNodePath,
     optionalExpandedToCallNodePath,
     threadsKey,
+    context,
   };
 }
 
@@ -206,7 +209,12 @@ export function selectRootCallNode(
     const rootCallNodePath = [selectedCallNodePath[0]];
 
     dispatch(
-      changeSelectedCallNode(threadsKey, rootCallNodePath, selectedCallNodePath)
+      changeSelectedCallNode(
+        threadsKey,
+        rootCallNodePath,
+        { source: 'auto' },
+        selectedCallNodePath
+      )
     );
   };
 }
@@ -1635,22 +1643,26 @@ export function changeExpandedCallNodes(
 
 export function changeSelectedMarker(
   threadsKey: ThreadsKey,
-  selectedMarker: MarkerIndex | null
+  selectedMarker: MarkerIndex | null,
+  context: SelectionContext = { source: 'auto' }
 ): Action {
   return {
     type: 'CHANGE_SELECTED_MARKER',
     selectedMarker,
     threadsKey,
+    context,
   };
 }
 export function changeSelectedNetworkMarker(
   threadsKey: ThreadsKey,
-  selectedNetworkMarker: MarkerIndex | null
+  selectedNetworkMarker: MarkerIndex | null,
+  context: SelectionContext = { source: 'auto' }
 ): Action {
   return {
     type: 'CHANGE_SELECTED_NETWORK_MARKER',
     selectedNetworkMarker,
     threadsKey,
+    context,
   };
 }
 

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -45,6 +45,7 @@ import type {
   CallNodeDisplayData,
   WeightType,
   TableViewOptions,
+  SelectionContext,
 } from 'firefox-profiler/types';
 import type { CallTree as CallTreeType } from 'firefox-profiler/profile-logic/call-tree';
 
@@ -238,11 +239,15 @@ class CallTreeImpl extends PureComponent<Props> {
     }
   }
 
-  _onSelectedCallNodeChange = (newSelectedCallNode: IndexIntoCallNodeTable) => {
+  _onSelectedCallNodeChange = (
+    newSelectedCallNode: IndexIntoCallNodeTable,
+    context: SelectionContext
+  ) => {
     const { callNodeInfo, threadsKey, changeSelectedCallNode } = this.props;
     changeSelectedCallNode(
       threadsKey,
-      getCallNodePathFromIndex(newSelectedCallNode, callNodeInfo.callNodeTable)
+      getCallNodePathFromIndex(newSelectedCallNode, callNodeInfo.callNodeTable),
+      context
     );
   };
 
@@ -345,7 +350,7 @@ class CallTreeImpl extends PureComponent<Props> {
       // completely dimmed activity graph because idle stacks are not drawn in
       // this graph. Because this isn't probably what the average user wants we
       // do it only when the category is something different.
-      this._onSelectedCallNodeChange(currentCallNodeIndex);
+      this._onSelectedCallNodeChange(currentCallNodeIndex, { source: 'auto' });
     }
   }
 

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -35,6 +35,7 @@ import type {
   Milliseconds,
   MarkerSchemaByName,
   TableViewOptions,
+  SelectionContext,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -217,9 +218,12 @@ class MarkerTableImpl extends PureComponent<Props> {
     }
   }
 
-  _onSelectionChange = (selectedMarker: MarkerIndex) => {
+  _onSelectionChange = (
+    selectedMarker: MarkerIndex,
+    context: SelectionContext
+  ) => {
     const { threadsKey, changeSelectedMarker } = this.props;
-    changeSelectedMarker(threadsKey, selectedMarker);
+    changeSelectedMarker(threadsKey, selectedMarker, context);
   };
 
   _onRightClickSelection = (selectedMarker: MarkerIndex) => {

--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -324,7 +324,6 @@ type NetworkChartRowProps = {|
   +isRightClicked: boolean,
   +isSelected: boolean,
   +isHoveredFromState: boolean,
-  +select: (MarkerIndex) => mixed,
   +onLeftClick?: (MarkerIndex) => mixed,
   +onRightClick?: (MarkerIndex) => mixed,
   +onHover?: (MarkerIndex | null) => mixed,

--- a/src/components/network-chart/index.js
+++ b/src/components/network-chart/index.js
@@ -34,6 +34,7 @@ import type {
   MarkerIndex,
   StartEndRange,
   ThreadsKey,
+  SelectionContext,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -162,7 +163,7 @@ class NetworkChartImpl extends React.PureComponent<Props> {
 
     if (selected === null || selectedRowIndex === -1) {
       // the first condition is redundant, but it makes flow happy
-      this._select(allRows[0]);
+      this._selectWithKeyboard(allRows[0]);
       return;
     }
     if (isNavigationKey) {
@@ -170,30 +171,30 @@ class NetworkChartImpl extends React.PureComponent<Props> {
         case 'ArrowUp': {
           if (event.metaKey) {
             // On MacOS this is a common shortcut for the Home gesture
-            this._select(allRows[0]);
+            this._selectWithKeyboard(allRows[0]);
             break;
           }
 
           if (selectedRowIndex > 0) {
-            this._select(allRows[selectedRowIndex - 1]);
+            this._selectWithKeyboard(allRows[selectedRowIndex - 1]);
           }
           break;
         }
         case 'ArrowDown': {
           if (event.metaKey) {
             // On MacOS this is a common shortcut for the End gesture
-            this._select(allRows[allRows.length - 1]);
+            this._selectWithKeyboard(allRows[allRows.length - 1]);
             break;
           }
           if (selectedRowIndex < allRows.length - 1) {
-            this._select(allRows[selectedRowIndex + 1]);
+            this._selectWithKeyboard(allRows[selectedRowIndex + 1]);
           }
           break;
         }
         case 'PageUp': {
           if (selectedRowIndex > 0) {
             const nextRow = Math.max(0, selectedRowIndex - ROW_HEIGHT);
-            this._select(allRows[nextRow]);
+            this._selectWithKeyboard(allRows[nextRow]);
           }
           break;
         }
@@ -203,16 +204,16 @@ class NetworkChartImpl extends React.PureComponent<Props> {
               allRows.length - 1,
               selectedRowIndex + ROW_HEIGHT
             );
-            this._select(allRows[nextRow]);
+            this._selectWithKeyboard(allRows[nextRow]);
           }
           break;
         }
         case 'Home': {
-          this._select(allRows[0]);
+          this._selectWithKeyboard(allRows[0]);
           break;
         }
         case 'End': {
-          this._select(allRows[allRows.length - 1]);
+          this._selectWithKeyboard(allRows[allRows.length - 1]);
           break;
         }
         default:
@@ -227,16 +228,23 @@ class NetworkChartImpl extends React.PureComponent<Props> {
   };
 
   _onLeftClick = (selectedNetworkMarkerIndex: MarkerIndex) => {
-    this._onSelectionChange(selectedNetworkMarkerIndex);
+    this._onSelectionChange(selectedNetworkMarkerIndex, { source: 'pointer' });
   };
 
-  _select(selectedNetworkMarkerIndex: MarkerIndex) {
-    this._onSelectionChange(selectedNetworkMarkerIndex);
+  _selectWithKeyboard(selectedNetworkMarkerIndex: MarkerIndex) {
+    this._onSelectionChange(selectedNetworkMarkerIndex, { source: 'keyboard' });
   }
 
-  _onSelectionChange = (selectedNetworkMarkerIndex: MarkerIndex) => {
+  _onSelectionChange = (
+    selectedNetworkMarkerIndex: MarkerIndex,
+    context: SelectionContext
+  ) => {
     const { threadsKey, changeSelectedNetworkMarker } = this.props;
-    changeSelectedNetworkMarker(threadsKey, selectedNetworkMarkerIndex);
+    changeSelectedNetworkMarker(
+      threadsKey,
+      selectedNetworkMarkerIndex,
+      context
+    );
   };
 
   _onRowHovered = (hoveredMarkerIndex: MarkerIndex | null) => {
@@ -289,7 +297,6 @@ class NetworkChartImpl extends React.PureComponent<Props> {
         isHoveredFromState={hoveredMarkerIndexFromState === markerIndex}
         onRightClick={this._onRightClick}
         isSelected={selectedNetworkMarkerIndex === markerIndex}
-        select={this._select}
         onLeftClick={this._onLeftClick}
         onHover={this._onRowHovered}
       />

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -485,17 +485,24 @@ const previewSelection: Reducer<PreviewSelection> = (
 const scrollToSelectionGeneration: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
-    case 'CHANGE_SELECTED_CALL_NODE':
     case 'CHANGE_SELECTED_THREAD':
     case 'SELECT_TRACK':
     case 'HIDE_GLOBAL_TRACK':
     case 'HIDE_LOCAL_TRACK':
     case 'HIDE_PROVIDED_TRACKS':
-    case 'CHANGE_SELECTED_MARKER':
-    case 'CHANGE_SELECTED_NETWORK_MARKER':
     case 'CHANGE_CALL_TREE_SEARCH_STRING':
     case 'CHANGE_MARKER_SEARCH_STRING':
     case 'CHANGE_NETWORK_SEARCH_STRING':
+      return state + 1;
+    case 'CHANGE_SELECTED_CALL_NODE':
+    case 'CHANGE_SELECTED_MARKER':
+    case 'CHANGE_SELECTED_NETWORK_MARKER':
+      if (action.context.source === 'pointer') {
+        // If the call node was changed as a result of a pointer click, do not
+        // scroll the table. Indeed this is disturbing and prevents double
+        // clicks.
+        return state;
+      }
       return state + 1;
     default:
       return state;

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -42,6 +42,7 @@ import {
   getHumanReadableTracks,
 } from '../fixtures/profiles/tracks';
 import * as UrlStateSelectors from '../../selectors/url-state';
+import { getScrollToSelectionGeneration } from 'firefox-profiler/selectors/profile';
 
 import type { CauseBacktrace } from 'firefox-profiler/types';
 
@@ -109,14 +110,20 @@ describe('MarkerTable', function () {
   });
 
   it('selects a row when left clicking', () => {
-    const { getByText, getRowElement } = setup();
+    const { getByText, getRowElement, getState } = setup();
 
+    const initialScrollGeneration = getScrollToSelectionGeneration(getState());
     fireFullClick(getByText(/setTimeout/));
     expect(getRowElement(/setTimeout/)).toHaveClass('isSelected');
 
     fireFullClick(getByText('foobar'));
     expect(getRowElement(/setTimeout/)).not.toHaveClass('isSelected');
     expect(getRowElement('foobar')).toHaveClass('isSelected');
+
+    // The scroll generation hasn't moved.
+    expect(getScrollToSelectionGeneration(getState())).toEqual(
+      initialScrollGeneration
+    );
   });
 
   it('displays a context menu when right clicking', () => {

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -171,6 +171,15 @@ export type Localization = ReactLocalization;
 // stored in the same property to accommodate all OSes.
 export type KeyboardModifiers = {| ctrlOrMeta: boolean, shift: boolean |};
 
+/**
+ * This type gives some context about the action leading to a selection.
+ */
+export type SelectionContext = {|
+  // This is the source for this selection: is it a keyboard or a pointer event,
+  // or is it the result of some automatic selection.
+  +source: 'keyboard' | 'pointer' | 'auto',
+|};
+
 type ProfileAction =
   | {|
       +type: 'ROUTE_NOT_FOUND',
@@ -186,6 +195,7 @@ type ProfileAction =
       +threadsKey: ThreadsKey,
       +selectedCallNodePath: CallNodePath,
       +optionalExpandedToCallNodePath: ?CallNodePath,
+      +context: SelectionContext,
     |}
   | {|
       +type: 'UPDATE_TRACK_THREAD_HEIGHT',
@@ -209,11 +219,13 @@ type ProfileAction =
       +type: 'CHANGE_SELECTED_MARKER',
       +threadsKey: ThreadsKey,
       +selectedMarker: MarkerIndex | null,
+      +context: SelectionContext,
     |}
   | {|
       +type: 'CHANGE_SELECTED_NETWORK_MARKER',
       +threadsKey: ThreadsKey,
       +selectedNetworkMarker: MarkerIndex | null,
+      +context: SelectionContext,
     |}
   | {|
       +type: 'CHANGE_RIGHT_CLICKED_MARKER',


### PR DESCRIPTION
Fixes #4381

STR:
1. In the call tree, the marker table, or the network chart, try to double click on a line that's close to the border.

[Production](https://profiler.firefox.com/public/6k8tn6wc7gvrzwmtnewb4t7pkc6h7exnkvx8vc8/)
[deploy preview](https://deploy-preview-4386--perf-html.netlify.app/public/6k8tn6wc7gvrzwmtnewb4t7pkc6h7exnkvx8vc8/)

This fixes the issue by providing some more context to the action about how the selection happened. I hope you'll find this solution elegant :-)