### PR TITLE
Do not trigger transforms when searching in the stack chart

### DIFF
--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -192,7 +192,6 @@ class StackChartImpl extends React.PureComponent<Props> {
         id="stack-chart-tab"
         role="tabpanel"
         aria-labelledby="stack-chart-tab-button"
-        onKeyDown={this._handleKeyDown}
       >
         <StackSettings />
         <TransformNavigator />
@@ -205,7 +204,7 @@ class StackChartImpl extends React.PureComponent<Props> {
               className: 'treeViewContextMenu',
             }}
           >
-            <div className="stackChartContent">
+            <div className="stackChartContent" onKeyDown={this._handleKeyDown}>
               <StackChartCanvas
                 viewportProps={{
                   previewSelection,


### PR DESCRIPTION
STR:
1. In the stack chart, select a node.
2. Then focus the search input, and type something with letters triggering a transform, for example f, d

Expected: no transform should happen.
Actual: a transform is applied.

[production](https://profiler.firefox.com/public/671cf336e06a20333fbbfa599c76e0f496410cc0/stack-chart/?globalTrackOrder=0wa&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=7814-2&localTrackOrderByPid=7814-120~8868-0~2413-0~10453-0~5302-0~863-0~588-0~4829-0~6209-0~567-0~10361-01&thread=0&timelineType=category&v=8)
[deploy preview](https://deploy-preview-4387--perf-html.netlify.app/public/671cf336e06a20333fbbfa599c76e0f496410cc0/stack-chart/?globalTrackOrder=0wa&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=7814-2&localTrackOrderByPid=7814-120~8868-0~2413-0~10453-0~5302-0~863-0~588-0~4829-0~6209-0~567-0~10361-01&thread=0&timelineType=category&v=8)
