### PR TITLE
Do not throw an error when browsertime provides null timestamps incorrectly

### DIFF
--- a/src/components/timeline/TrackVisualProgressGraph.js
+++ b/src/components/timeline/TrackVisualProgressGraph.js
@@ -102,7 +102,7 @@ class TrackVisualProgressCanvas extends React.PureComponent<CanvasProps> {
         // Create a path for the top of the chart. This is the line that will have
         // a stroke applied to it.
         x =
-          (deviceWidth * (progressGraphData[i].timestamp - rangeStart)) /
+          (deviceWidth * ((progressGraphData[i].timestamp ?? 0) - rangeStart)) /
           rangeLength;
         // Add on half the stroke's line width so that it won't be cut off the edge
         // of the graph.
@@ -133,7 +133,7 @@ class TrackVisualProgressCanvas extends React.PureComponent<CanvasProps> {
       // of the canvas.
       ctx.lineTo(x + interval, deviceHeight);
       ctx.lineTo(
-        (deviceWidth * (progressGraphData[0].timestamp - rangeStart)) /
+        (deviceWidth * ((progressGraphData[0].timestamp ?? 0) - rangeStart)) /
           rangeLength +
           interval,
         deviceHeight
@@ -221,15 +221,16 @@ class TrackVisualProgressGraphImpl extends React.PureComponent<Props, State> {
     const rangeLength = rangeEnd - rangeStart;
     const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
     if (
-      timeAtMouse < progressGraphData[0].timestamp ||
+      timeAtMouse < (progressGraphData[0].timestamp ?? 0) ||
       timeAtMouse >
-        progressGraphData[progressGraphData.length - 1].timestamp + interval
+        (progressGraphData[progressGraphData.length - 1].timestamp ?? 0) +
+          interval
     ) {
       // We are outside the range of the samples, do not display hover information.
       this.setState({ hoveredVisualProgress: null });
     } else {
       const graphTimestamps = progressGraphData.map(
-        ({ timestamp }) => timestamp
+        ({ timestamp }) => timestamp ?? 0
       );
       let hoveredVisualProgress = bisectionRight(graphTimestamps, timeAtMouse);
       if (hoveredVisualProgress === progressGraphData.length) {
@@ -277,7 +278,8 @@ class TrackVisualProgressGraphImpl extends React.PureComponent<Props, State> {
     } = this.props;
     const rangeLength = rangeEnd - rangeStart;
     const left =
-      (width * (progressGraphData[graphDataIndex].timestamp - rangeStart)) /
+      (width *
+        ((progressGraphData[graphDataIndex].timestamp ?? 0) - rangeStart)) /
       rangeLength;
 
     const unitSampleCount = progressGraphData[graphDataIndex].percent / 100;

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1778,6 +1778,12 @@ export function processVisualMetrics(
       continue;
     }
 
+    if (metric.every((m) => m.timestamp === null)) {
+      // Skip it if we don't have any timestamps.
+      // This is due to https://github.com/sitespeedio/browsertime/issues/1746.
+      continue;
+    }
+
     const startTime = navigationStartTime ?? metric[0].timestamp;
     const endTime = metric[metric.length - 1].timestamp;
 
@@ -1798,6 +1804,11 @@ export function processVisualMetrics(
 
     const changeMarkerName = `${metricName} Change`;
     for (const { timestamp, percent } of metric) {
+      if (timestamp === null) {
+        // Skip it if we don't have a timestamp.
+        // This might be due to https://github.com/sitespeedio/browsertime/issues/1746.
+        continue;
+      }
       const payload = {
         type: 'VisualMetricProgress',
         // 'percentage' type expects a value between 0 and 1.

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -753,16 +753,12 @@ describe('visualMetrics processing', function () {
     const visualMetrics = getVisualMetrics();
 
     // Make all the VisualProgress timestamps null on purpose.
-    // Flow doesn't like null because it thinks that the timestamp can't be null.
-    // But this is a bug on browsertime.
     visualMetrics.VisualProgress = visualMetrics.VisualProgress.map(
-      (progress) => ({ ...progress, timestamp: (null: any) })
+      (progress) => ({ ...progress, timestamp: null })
     );
     // Make only one ContentfulSpeedIndexProgress timestamp null on purpose.
-    // Flow doesn't like null because it thinks that the timestamp can't be null.
-    // But this is a bug on browsertime.
     ensureExists(visualMetrics.ContentfulSpeedIndexProgress)[0].timestamp =
-      (null: any);
+      null;
 
     // Add the visual metrics to the profile.
     geckoProfile.meta.visualMetrics = visualMetrics;

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -666,18 +666,13 @@ describe('profile meta processing', function () {
 describe('visualMetrics processing', function () {
   function checkVisualMetricsForThread(
     thread: Thread,
-    expectedMetricMarkers?: Array<{|
+    metrics: Array<{|
       name: string,
+      hasProgressMarker: boolean,
       changeMarkerLength: number,
     |}>
   ) {
-    const metrics = expectedMetricMarkers ?? [
-      { name: 'Visual', changeMarkerLength: 7 },
-      { name: 'ContentfulSpeedIndex', changeMarkerLength: 6 },
-      { name: 'PerceptualSpeedIndex', changeMarkerLength: 6 },
-    ];
-
-    for (const { name, changeMarkerLength } of metrics) {
+    for (const { name, hasProgressMarker, changeMarkerLength } of metrics) {
       // Check the visual metric progress markers.
       const metricProgressMarkerIndex = thread.stringTable.indexForString(
         `${name} Progress`
@@ -686,7 +681,7 @@ describe('visualMetrics processing', function () {
         (name) => name === metricProgressMarkerIndex
       );
 
-      if (changeMarkerLength > 0) {
+      if (hasProgressMarker) {
         expect(metricProgressMarker).toBeTruthy();
       } else {
         expect(metricProgressMarker).toBeFalsy();
@@ -723,7 +718,19 @@ describe('visualMetrics processing', function () {
       throw new Error('Could not find the parent process main thread.');
     }
 
-    checkVisualMetricsForThread(parentProcessMainThread);
+    checkVisualMetricsForThread(parentProcessMainThread, [
+      { name: 'Visual', hasProgressMarker: true, changeMarkerLength: 7 },
+      {
+        name: 'ContentfulSpeedIndex',
+        hasProgressMarker: true,
+        changeMarkerLength: 6,
+      },
+      {
+        name: 'PerceptualSpeedIndex',
+        hasProgressMarker: true,
+        changeMarkerLength: 6,
+      },
+    ]);
   });
 
   it('adds markers to the tab process', function () {
@@ -745,7 +752,19 @@ describe('visualMetrics processing', function () {
       throw new Error('Could not find the tab process main thread.');
     }
 
-    checkVisualMetricsForThread(tabProcessMainThread);
+    checkVisualMetricsForThread(tabProcessMainThread, [
+      { name: 'Visual', hasProgressMarker: true, changeMarkerLength: 7 },
+      {
+        name: 'ContentfulSpeedIndex',
+        hasProgressMarker: true,
+        changeMarkerLength: 6,
+      },
+      {
+        name: 'PerceptualSpeedIndex',
+        hasProgressMarker: true,
+        changeMarkerLength: 6,
+      },
+    ]);
   });
 
   it('does not add markers to the parent process if metric timestamps are null', function () {
@@ -781,11 +800,19 @@ describe('visualMetrics processing', function () {
     checkVisualMetricsForThread(parentProcessMainThread, [
       // Instead of 7, we should have 0 markers for Visual because we made all
       // the timestamps null.
-      { name: 'Visual', changeMarkerLength: 0 },
+      { name: 'Visual', hasProgressMarker: false, changeMarkerLength: 0 },
       // Instead of 6, we should have 5 markers for ContentfulSpeedIndex.
-      { name: 'ContentfulSpeedIndex', changeMarkerLength: 5 },
+      {
+        name: 'ContentfulSpeedIndex',
+        hasProgressMarker: true,
+        changeMarkerLength: 5,
+      },
       // We didn't change the PerceptualSpeedIndexProgress, so we should have 6.
-      { name: 'PerceptualSpeedIndex', changeMarkerLength: 6 },
+      {
+        name: 'PerceptualSpeedIndex',
+        hasProgressMarker: true,
+        changeMarkerLength: 6,
+      },
     ]);
   });
 });

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -681,7 +681,8 @@ export type ProgressGraphData = {|
   // A percentage that describes the visual completeness of the webpage, ranging from 0% - 100%
   percent: number,
   // The time in milliseconds which the sample was taken.
-  timestamp: Milliseconds,
+  // This can be null due to https://github.com/sitespeedio/browsertime/issues/1746.
+  timestamp: Milliseconds | null,
 |};
 
 /**


### PR DESCRIPTION
It looks like browsertime sometimes provides null timestamps for the visual metrics due to https://github.com/sitespeedio/browsertime/issues/1746. We should be more careful and do not throw any errors in case of this. This PR fixes that.

[Example profile](https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/D99DCd4TTQKO6GuVPE30tw/runs/0/artifacts/public/test_info/profile_instagram.zip)