### PR TITLE
Scroll item horizontally in the virtuallist, taking into account the fixed size

### DIFF
--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -644,7 +644,9 @@ export class TreeView<DisplayData: Object> extends React.PureComponent<
       } else {
         const rowIndex = this._getAllVisibleRows().indexOf(selectedNodeId);
         const depth = tree.getDepth(selectedNodeId);
-        list.scrollItemIntoView(rowIndex, depth * 10);
+        const totalFixedColumnWidth =
+          this._getCurrentFixedColumnWidths().reduce((a, b) => a + b, 0);
+        list.scrollItemIntoView(rowIndex, depth * 10, totalFixedColumnWidth);
       }
     }
   }


### PR DESCRIPTION
This was bothering me for so much time!

Here is the fix to the following STR:
1. open the call tree completely (with the key "*" for example)
2. scroll down with the keyboard (down or right arrow) to some item with a big depth, that should trigger a horizontal scroll.

This also fixes the STR where clicking in the activity graph should now properly horizontally scroll to the item.

When testing, depending on the size of your screen, you may need to reduce the size of your window, or run the profiler in Firefox mobile view to reduce its viewport, so that horizontally scrolling is necessary for some depths.
You can also increase the size of some columns (not available in production).

[production](https://profiler.firefox.com/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/calltree/?globalTrackOrder=l0wk&hiddenGlobalTracks=126wh&hiddenLocalTracksByPid=1100-0w3~33180-0~34076-01~33692-0~6580-0~45328-0~30192-0~19508-0~39544-0~41396-0~40940-0~9832-0~32968-0~41520-0~13128-01~41716-013w8&thread=0&v=8)
[deploy preview](https://deploy-preview-4401--perf-html.netlify.app/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/calltree/?globalTrackOrder=l0wk&hiddenGlobalTracks=126wh&hiddenLocalTracksByPid=1100-0w3~33180-0~34076-01~33692-0~6580-0~45328-0~30192-0~19508-0~39544-0~41396-0~40940-0~9832-0~32968-0~41520-0~13128-01~41716-013w8&thread=0&v=8)