### PR TITLE
Chrome importer: Add 1 to line numbers of cpu profile

### DIFF
--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -517,6 +517,7 @@ async function processTracingEvents(
       threadInfo;
 
     let profileChunks = [];
+    let lineNumberAdjustment = 0;
     if (profileEvent.name === 'Profile') {
       threadInfo.lastSeenTime = (profileEvent.args.data.startTime: any) / 1000;
       const { id, pid } = profileEvent;
@@ -529,6 +530,7 @@ async function processTracingEvents(
       threadInfo.lastSeenTime =
         (profileEvent.args.data.cpuProfile.startTime: any) / 1000;
       profileChunks = [profileEvent];
+      lineNumberAdjustment = +1;
     }
 
     for (const profileChunk of profileChunks) {
@@ -570,6 +572,9 @@ async function processTracingEvents(
           let { url, lineNumber, columnNumber } = callFrame;
           if (lineNumber === -1) {
             lineNumber = undefined;
+          }
+          if (lineNumber !== undefined) {
+            lineNumber += lineNumberAdjustment;
           }
           if (columnNumber === -1) {
             columnNumber = undefined;


### PR DESCRIPTION
The line numbers in a `.cpuprofile` generated by a contemporary `node --cpu-prof` start from 0, but all editors or code viewers that I know of have line numbers that start from 1 (this list includes VSCode, Emacs, Vim and the GitHub code browser). Node DevTools handles this by adding 1 to the line number as can be seen in the right pane of the comparison table below:

| Firefox Profiler                                            | Node Devtools
|------------------------------------------------------|--------------------
| ![firefox-profiler-executeUserEntryPoint](https://user-images.githubusercontent.com/12002672/211014837-442507cf-2465-4099-89cf-357317f76de3.png) | ![node-devtools-executeUserEntryPoint](https://user-images.githubusercontent.com/12002672/211014879-26c3e27d-e474-4da9-b8e5-84d926dbc5fb.png)

The Node version in use at the time was v16.17.0, and I have checked that indeed `executeUserEntryPoint` is [at line 74](https://github.com/nodejs/node/blob/v16.17.0/lib/internal/modules/run_main.js#L74). Therefore, this PR makes Firefox Profiler add 1 to the line numbers in a Chrome cpu profile.

One of the snapshots has been updated, apparently because the line numbers in [this cpu profile](https://github.com/firefox-devtools/profiler/blob/2f7dd0df14e83b0b27606e003fec2eeaec550d06/src/test/fixtures/upgrades/test.chrome-unchunked.json#L195-L248) are off by one.  I do not have access to the referenced source code to confirm whether this is the case.
