### PR TITLE
linux perf: fix parsing frames with whitespaces in the path

### DIFF
--- a/src/profile-logic/import/linux-perf.js
+++ b/src/profile-logic/import/linux-perf.js
@@ -304,7 +304,9 @@ export function convertPerfScriptProfile(
       }
 
       // 	         23fe921 _ZN7mozilla3ipc14MessageChannel11MessageTask3RunEv (/home/mstange/Desktop/firefox/libxul.so)
-      const stackFrameMatch = /^\s*(\w+)\s*(.+) \((\S*)\)/.exec(stackFrameLine);
+      const stackFrameMatch = /^\s*(\w+)\s*(.+) \(([^)]*)\)/.exec(
+        stackFrameLine
+      );
       if (stackFrameMatch) {
         // const pc = stackFrameMatch[1];
         let rawFunc = stackFrameMatch[2];


### PR DESCRIPTION
Resolves: https://github.com/firefox-devtools/profiler/issues/4406

I simply applied the regex changed suggested by @julienw which indeed makes the file that was previously missing traces parse correctly! I also ran `yarn test` and the amount of tests that fail remained constant compared to `main`.