### PR TITLE
Fix that clicking an empty area of the timeline should not switch the…

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -148,7 +148,13 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       } else {
         selectLeafCallNode(threadsKey, sampleIndex);
       }
-      focusCallTree();
+
+      if (sampleIndex !== null) {
+        // If the user clicked outside of the activity graph (sampleIndex === null),
+        // then we don't need to focus the call tree. This action also selects
+        // the call tree panel, which we don't want either in this case.
+        focusCallTree();
+      }
     }
     if (
       typeof threadsKey === 'number' &&

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -15,10 +15,12 @@ import { Provider } from 'react-redux';
 
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getTimelineType } from '../../selectors/url-state';
+import { getTimelineType, getSelectedTab } from '../../selectors/url-state';
+import { getLastVisibleThreadTabSlug } from '../../selectors/app';
 import { ensureExists } from '../../utils/flow';
 import { TimelineTrackThread } from '../../components/timeline/TrackThread';
 import { commitRange } from '../../actions/profile-view';
+import { changeSelectedTab } from '../../actions/app';
 
 import {
   autoMockCanvasContext,
@@ -259,6 +261,29 @@ describe('ThreadActivityGraph', function () {
     // There's no sample at this location.
     clickActivityGraph(0, 1);
     expect(getCallNodePath()).toEqual([]);
+  });
+
+  it('when clicking a stack, this selects the call tree panel', function () {
+    const { dispatch, getState, clickActivityGraph } = setup();
+
+    dispatch(changeSelectedTab('marker-chart'));
+
+    // The full call node at this sample is:
+    //  A -> B -> C -> F -> G
+    clickActivityGraph(1, 0.2);
+    expect(getSelectedTab(getState())).toBe('calltree');
+    expect(getLastVisibleThreadTabSlug(getState())).toBe('calltree');
+  });
+
+  it(`when clicking outside of the graph, this doesn't select the call tree panel`, function () {
+    const { dispatch, getState, clickActivityGraph } = setup();
+
+    dispatch(changeSelectedTab('marker-chart'));
+
+    // There's no sample at this location.
+    clickActivityGraph(0, 1);
+    expect(getSelectedTab(getState())).toBe('marker-chart');
+    expect(getLastVisibleThreadTabSlug(getState())).toBe('marker-chart');
   });
 
   it('will redraw even when there are no samples in range', function () {

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -16,12 +16,9 @@ import {
   changeInvertCallstack,
   changeSelectedCallNode,
 } from '../../actions/profile-view';
-import { changeSelectedTab } from '../../actions/app';
 import { TimelineTrackThread } from '../../components/timeline/TrackThread';
 import { getPreviewSelection } from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { getSelectedTab } from '../../selectors/url-state';
-import { getLastVisibleThreadTabSlug } from '../../selectors/app';
 import { ensureExists } from '../../utils/flow';
 
 import {
@@ -189,19 +186,6 @@ describe('timeline/TrackThread', function () {
 
     fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 3));
     expect(getCallNodePath()).toEqual(['j', 'k', 'l']);
-  });
-
-  it('when clicking a stack, this selects the call tree panel', function () {
-    const { dispatch, getState, stackGraphCanvas, getFillRectCenterByIndex } =
-      setup(getSamplesProfile());
-
-    dispatch(changeSelectedTab('marker-chart'));
-
-    const log = flushDrawLog();
-
-    fireFullClick(stackGraphCanvas(), getFillRectCenterByIndex(log, 0));
-    expect(getSelectedTab(getState())).toBe('calltree');
-    expect(getLastVisibleThreadTabSlug(getState())).toBe('calltree');
   });
 
   it('can click a stack in the stack graph in inverted call trees', function () {


### PR DESCRIPTION
… selected panel to the call tree

Fixes #4415

[production](https://profiler.firefox.com/public/re57by85t1ew68339mmkw1n2z3mjkyb6kcz9dqr/marker-chart/?globalTrackOrder=cd0wb&hiddenGlobalTracks=13w7a&hiddenLocalTracksByPid=250248-03w68~250443-0~250491-0~250408-0~268753-0~268750-0~268827-0~268649-0~250659-0w2&thread=0&v=8)
[deploy preview](https://deploy-preview-4416--perf-html.netlify.app/public/re57by85t1ew68339mmkw1n2z3mjkyb6kcz9dqr/marker-chart/?globalTrackOrder=cd0wb&hiddenGlobalTracks=13w7a&hiddenLocalTracksByPid=250248-03w68~250443-0~250491-0~250408-0~268753-0~268750-0~268827-0~268649-0~250659-0w2&thread=0&v=8)

STR:
1. open the link, notice the marker chart is opened.
2. click an empty space in the activity graph (note: take care that you're clicking on the activity graph lane, as the bug doesn't appear on other lanes such as the empty space in the marker track)
