### PR TITLE
Fix the selection's vertical bar being clamped to round millisecond values

### DIFF
--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -254,11 +254,10 @@ class TimelineRulerAndSelection extends React.PureComponent<Props> {
       changeMouseTimePosition(null);
     } else {
       const hoverPositionInPixels = event.pageX - rect.left;
-      const pixelsToMouseTimePosition = Math.round(
+      const pixelsToMouseTimePosition =
         ((committedRange.end - committedRange.start) * hoverPositionInPixels) /
           width +
-          committedRange.start
-      );
+        committedRange.start;
       changeMouseTimePosition(pixelsToMouseTimePosition);
     }
   };


### PR DESCRIPTION
Fixes #4419

[production](https://share.firefox.dev/3GHGouQ)
[deploy preview](https://deploy-preview-4421--perf-html.netlify.app/public/3w8jee2csq0hxgpzykkwcj02ddd07b0rsf8af88/calltree/?globalTrackOrder=90w8&hiddenGlobalTracks=1w7&hiddenLocalTracksByPid=3312-02~3313-0~3324-0~3314-0~3319-0~3318-0~3315-0~3316-0&profileName=baseline&range=5326m363~5524m31&thread=b&v=8)