### PR TITLE
Fix scrolling selection into view when showing the call tree panel

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -209,7 +209,7 @@ class CallTreeImpl extends PureComponent<Props> {
     this.focus();
     this.maybeProcureInterestingInitialSelection();
 
-    if (this.props.selectedCallNodeIndex === null && this._treeView) {
+    if (this.props.selectedCallNodeIndex !== null && this._treeView) {
       this._treeView.scrollSelectionIntoView();
     }
   }


### PR DESCRIPTION
Fixes #4420

STR:
* Load the profile
* Click in the blue (DOM) area of the activity graph (at the right).

[production](https://share.firefox.dev/3kduWjg)
[deploy preview]()