### PR TITLE
Support zip files on windows

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1407,7 +1407,7 @@ export function retrieveProfileFromFile(
     dispatch(waitingForProfileFromFile());
 
     try {
-      if (file.type === 'application/zip') {
+      if (_deduceContentType(file.name, file.type) === 'application/zip') {
         // Open a zip file in the zip file viewer
         const buffer = await fileReader(file).asArrayBuffer();
         const zip = await JSZip.loadAsync(buffer);

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -1426,6 +1426,7 @@ describe('actions/receive-profile', function () {
      */
     function mockFile({ type, payload }): File {
       const file = {
+        name: '',
         type,
         _payload: payload,
       };


### PR DESCRIPTION
STR (Windows only AFAIK):
1. Try and load a zip

Zip previously wouldn't load because the MIME type is the non-standard deprecated `application/x-zip-compressed`: 
![image](https://user-images.githubusercontent.com/25255817/213030152-42d980e2-3642-4b54-98e5-0a2127f9ac70.png)
