### PR TITLE
Fix various performance problems with power graphs and counters in general

### DIFF
--- a/src/components/timeline/TrackPowerGraph.js
+++ b/src/components/timeline/TrackPowerGraph.js
@@ -5,6 +5,7 @@
 // @flow
 
 import * as React from 'react';
+import { InView } from 'react-intersection-observer';
 import { withSize } from 'firefox-profiler/components/shared/WithSize';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { bisectionRight } from 'firefox-profiler/utils/bisect';
@@ -58,6 +59,10 @@ type CanvasProps = {|
 class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
   _canvas: null | HTMLCanvasElement = null;
   _requestedAnimationFrame: boolean = false;
+  _canvasState: {| renderScheduled: boolean, inView: boolean |} = {
+    renderScheduled: false,
+    inView: false,
+  };
 
   drawCanvas(canvas: HTMLCanvasElement): void {
     const {
@@ -175,6 +180,16 @@ class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
   }
 
   _scheduleDraw() {
+    if (!this._canvasState.inView) {
+      // Canvas is not in the view. Schedule the render for a later intersection
+      // observer callback.
+      this._canvasState.renderScheduled = true;
+      return;
+    }
+
+    // Canvas is in the view. Render the canvas and reset the schedule state.
+    this._canvasState.renderScheduled = false;
+
     if (!this._requestedAnimationFrame) {
       this._requestedAnimationFrame = true;
       window.requestAnimationFrame(() => {
@@ -191,11 +206,26 @@ class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
     this._canvas = canvas;
   };
 
+  _observerCallback = (inView: boolean, _entry: IntersectionObserverEntry) => {
+    this._canvasState.inView = inView;
+    if (!this._canvasState.renderScheduled) {
+      // Skip if render is not scheduled.
+      return;
+    }
+
+    this._scheduleDraw();
+  };
+
   render() {
     this._scheduleDraw();
 
     return (
-      <canvas className="timelineTrackPowerCanvas" ref={this._takeCanvasRef} />
+      <InView onChange={this._observerCallback}>
+        <canvas
+          className="timelineTrackPowerCanvas"
+          ref={this._takeCanvasRef}
+        />
+      </InView>
     );
   }
 }

--- a/src/components/timeline/TrackPowerGraph.js
+++ b/src/components/timeline/TrackPowerGraph.js
@@ -58,7 +58,6 @@ type CanvasProps = {|
  */
 class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
   _canvas: null | HTMLCanvasElement = null;
-  _requestedAnimationFrame: boolean = false;
   _canvasState: {| renderScheduled: boolean, inView: boolean |} = {
     renderScheduled: false,
     inView: false,
@@ -179,7 +178,7 @@ class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
     }
   }
 
-  _scheduleDraw() {
+  _renderCanvas() {
     if (!this._canvasState.inView) {
       // Canvas is not in the view. Schedule the render for a later intersection
       // observer callback.
@@ -190,15 +189,9 @@ class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
     // Canvas is in the view. Render the canvas and reset the schedule state.
     this._canvasState.renderScheduled = false;
 
-    if (!this._requestedAnimationFrame) {
-      this._requestedAnimationFrame = true;
-      window.requestAnimationFrame(() => {
-        this._requestedAnimationFrame = false;
-        const canvas = this._canvas;
-        if (canvas) {
-          this.drawCanvas(canvas);
-        }
-      });
+    const canvas = this._canvas;
+    if (canvas) {
+      this.drawCanvas(canvas);
     }
   }
 
@@ -213,11 +206,11 @@ class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
       return;
     }
 
-    this._scheduleDraw();
+    this._renderCanvas();
   };
 
   render() {
-    this._scheduleDraw();
+    this._renderCanvas();
 
     return (
       <InView onChange={this._observerCallback}>

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -282,13 +282,14 @@ export const getCounterSelectors = (index: CounterIndex): CounterSelectors => {
  * type of the function.
  */
 function _createCounterSelectors(counterIndex: CounterIndex) {
-  const getCounter: Selector<Counter> = (state) =>
+  const getCounter: Selector<Counter> = createSelector(getProfile, (profile) =>
     processCounter(
       ensureExists(
-        getProfile(state).counters,
+        profile.counters,
         'Attempting to get a counter by index, but no counters exist.'
       )[counterIndex]
-    );
+    )
+  );
 
   const getDescription: Selector<string> = (state) =>
     getCounter(state).description;

--- a/src/test/components/__snapshots__/TrackPower.test.js.snap
+++ b/src/test/components/__snapshots__/TrackPower.test.js.snap
@@ -128,11 +128,13 @@ exports[`TrackPower matches the component snapshot 1`] = `
   <div
     class="timelineTrackPowerGraph"
   >
-    <canvas
-      class="timelineTrackPowerCanvas"
-      height="25"
-      width="80"
-    />
+    <div>
+      <canvas
+        class="timelineTrackPowerCanvas"
+        height="25"
+        width="80"
+      />
+    </div>
     <div
       class="timelineEmptyThreadIndicator"
     />

--- a/src/utils/react.js
+++ b/src/utils/react.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+// This file contains some functions that might be interesting when debugging
+// react code.
+
+// This function keeps track of the props of a React component and logs the
+// changes between two calls. This is best used in render() or
+// componentDidUpdate() like this:
+// import { logPropChanges } from 'firefox-profiler/utils/react';
+// ...
+// render() {
+//   logPropChanges(this);
+// }
+export function logPropChanges(component: any) {
+  if (!component.__DEBUG__oldProps) {
+    component.__DEBUG__oldProps = component.props;
+    return;
+  }
+
+  for (const [prop, value] of Object.entries(component.props)) {
+    const oldValue = component.__DEBUG__oldProps[prop];
+    if (oldValue !== value) {
+      console.log(
+        `prop "${prop}" changed: old value is`,
+        oldValue,
+        ', new value is',
+        value
+      );
+    }
+  }
+
+  component.__DEBUG__oldProps = component.props;
+}


### PR DESCRIPTION
STR:
1. Open [this profile](https://share.firefox.dev/3Qlfahr)
2. Just hover with the mouse in the timeline

=> This is painfully slow.

There are many problems:
* (unfixed) the power graphs in this profile are very costly, I believe this is because the profile itself is very long. It probably isn't a good idea to draw every counter values when we're zoomed out, but I didn't want to tackle this. The same problem probably exists in some other graphs such as the memory graph.
* commit 1: since https://github.com/firefox-devtools/profiler/pull/4114, the counter object was renewed at each state change, which triggered a full rerender of many of our counter-based graphs. This is even more visible since #3000 landed. I fixed this by simply using createSelector to memoize the result.
* commit 3: the power graphs didn't use the intersection observer, so even if out of view they would costly render. Note: other default tracks still don't have it, such as the network track. Non-default tracks such as the process CPU or event delay tracks also don't have it. Ideally the InView should be moved above, maybe at the LocalTrack or GlobalTrack location, I'd like to look at it eventually.
* commit 4: not a problem by itself but I took this opportunity to remove the requestAnimationFrame calls. My understanding is that this is not needed in recent versions of React as the render mechanism is throttled by React already, so this introduces an additional unwanted delay. I already removed it in some other places in the past.

The commit 2 is a simple tool I used to discover which props were changed. I think it's useful to keep this in the codebase for whenever we need to debug react rerender issues.

[production](https://share.firefox.dev/3Qlfahr)
[deploy preview](https://deploy-preview-4428--perf-html.netlify.app/public/vfqmdfmjbmnb0zzestgswh87t65wqmje0fa1pb8/marker-chart/?globalTrackOrder=0w9&thread=0&v=8)

Tell me what you think!