### PR TITLE
Slightly simplify the implementation of the draw log in the canvas mock

### DIFF
--- a/src/test/fixtures/mocks/canvas-context.js
+++ b/src/test/fixtures/mocks/canvas-context.js
@@ -88,9 +88,7 @@ function mockCanvasContext() {
       })),
       createPattern: spyLog('createPattern', () => ({})),
       __flushDrawLog: (): Array<any> => {
-        const oldLog = log.slice();
-        log.splice(0, log.length);
-        return oldLog;
+        return log.splice(0, log.length);
       },
     },
     {


### PR DESCRIPTION
This is a very simple change that I've made while working on something else. This should bring no visible change to tests, and maybe make them slightly faster.