### PR TITLE
Make repoPathRegex more permissive.

### DIFF
--- a/src/test/unit/special-paths.test.js
+++ b/src/test/unit/special-paths.test.js
@@ -54,6 +54,16 @@ describe('parseFileNameFromSymbolication', function () {
       path: 'core/fdrm/fx_crypt.cpp',
       rev: 'dab1161c861cc239e48a17e1a5d729aa12785a53',
     });
+    expect(
+      parseFileNameFromSymbolication(
+        'git:github.com/torvalds/linux:arch/x86/mm/fault.c:v5.15'
+      )
+    ).toEqual({
+      type: 'git',
+      repo: 'github.com/torvalds/linux',
+      path: 'arch/x86/mm/fault.c',
+      rev: 'v5.15',
+    });
   });
 
   it('parses s3 paths', function () {

--- a/src/utils/special-paths.js
+++ b/src/utils/special-paths.js
@@ -81,7 +81,7 @@ export type SourceFileDownloadRecipe =
 // Some rust stdlib functions: (https://bugzilla.mozilla.org/show_bug.cgi?id=1717973)
 //   "/builds/worker/fetches/rustc/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs"
 const repoPathRegex =
-  /^(?<vcs>hg|git):(?<repo>[^:]*):(?<path>[^:]*):(?<rev>[0-9a-f]*)$/;
+  /^(?<vcs>hg|git):(?<repo>[^:]*):(?<path>[^:]*):(?<rev>.*)$/;
 const s3PathRegex =
   /^s3:(?<bucket>[^:]*):(?<digest>[0-9a-f]*)\/(?<path>[^:]*):$/;
 const cargoPathRegex =


### PR DESCRIPTION
It will now accept "revisions" which are git tag names. For example: `git:github.com/torvalds/linux:arch/x86/mm/fault.c:v5.15`
In this example, the tag name / "revision" is "v5.15". The CORS-URL for this file would then be
https://raw.githubusercontent.com/torvalds/linux/v5.15/arch/x86/mm/fault.c

I'm not planning to use this capability, but maybe it'll be useful for somebody at some point.

I was initially planning to use it for kernel sources in samply, but then I noticed that Ubuntu has its own patches on top of the original kernel source, so I'll need to get the source from somewhere else after all.