### PR TITLE
Fix `loading-in-profiles.md` URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The web app doesn't include any performance profiles by default, so you'll need 
  - On the web, replace the https://profiler.firefox.com with your local server, usually `http://localhost:4242`. Be sure that that the protocol is `http` and not `https` when running the server locally.
  - Alternatively, if a profile has been previously downloaded, drag and drop it to the loading screen. Compared to the previous solution, refreshing won't work with this particular solution.
 
-For more information on loading a profile, visit its [documentation](loading-in-profiles.md).
+For more information on loading a profile, visit its [documentation](./docs-developer/loading-in-profiles.md).
 
 ## Running the tests
 


### PR DESCRIPTION
The [diff](https://github.com/firefox-devtools/profiler/compare/main...kazarmy:firefox-profiler:fix-loading-profiles-url?expand=1#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) seems obvious enough.