### PR TITLE
Add `config.cache` example to `webpack.local-config.js` note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,13 @@ To get started clone the repo and get the web application started.
  5. Point your browser to [http://localhost:4242](http://localhost:4242).
  6. If port `4242` is taken, then you can run the web app on a different port: `FX_PROFILER_PORT=1234 yarn start`
 
-Other [webpack](https://webpack.js.org/configuration/) and [webpack server](https://webpack.js.org/configuration/dev-server/) options can be set in a `webpack.local-config.js` file at the repo root. For example, if you want the server to automatically open the home page, put in there the following code:
+Other [webpack](https://webpack.js.org/configuration/) and [webpack server](https://webpack.js.org/configuration/dev-server/) options can be set in a `webpack.local-config.js` file at the repo root. For example, if you want the build to be cached on the filesystem and the server to automatically open the home page, put in there the following code:
 
 ```js
 module.exports = function (config, serverConfig) {
+  config.cache = {
+    type: 'filesystem',
+  };
   serverConfig.open = true;
 };
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ To get started clone the repo and get the web application started.
  5. Point your browser to [http://localhost:4242](http://localhost:4242).
  6. If port `4242` is taken, then you can run the web app on a different port: `FX_PROFILER_PORT=1234 yarn start`
 
-Other [webpack](https://webpack.js.org/configuration/) and [webpack server](https://webpack.js.org/configuration/dev-server/) options can be set in a `webpack.local-config.js` file at the repo root. For example, if you want the build to be cached on the filesystem and the server to automatically open the home page, put in there the following code:
+Other [webpack](https://webpack.js.org/configuration/) and [webpack server](https://webpack.js.org/configuration/dev-server/) options can be set in a `webpack.local-config.js` file at the repo root. For example, if you want a persistent build cache and the server to automatically open the home page, put in there the following code:
 
 ```js
 module.exports = function (config, serverConfig) {


### PR DESCRIPTION
This pr adds a `config.cache` example to the `webpack.local-config.js` note in CONTRIBUTING.md, and so now both parameters are being used. This is probably the last change that I want to make to the note.

----

Some side notes:

- I profiled the uncached webpack build, terminating the server with the code below. It seems that babel transformations take up a large chunk of the time.
```js
module.exports = function (config, serverConfig) {
  serverConfig.setupMiddlewares = (middlewares, _devServer) => {
    let attachedOpen = false;
    for (const m of middlewares) {
      if (m.name === 'webpack-dev-middleware' && !attachedOpen) {
        m.middleware.waitUntilValid(() => {
          process.kill(process.pid, 'SIGINT');
        });
        attachedOpen = true;
      }
    }
    return middlewares;
  };
};
```

- With the (cached) build at sub-10 seconds, I had a better user experience with opening the browser tab in parallel with the build, rather than opening it after the build.