### PR TITLE
Do not offer to reload the page after a service worker update for a from-url datasource with a profile coming from localhost

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -5,6 +5,7 @@
 // @flow
 import { oneLine } from 'common-tags';
 import queryString from 'query-string';
+import JSZip from 'jszip';
 import {
   processGeckoProfile,
   unserializeProfileOfArbitraryFormat,
@@ -19,7 +20,7 @@ import { mergeProfilesForDiffing } from 'firefox-profiler/profile-logic/merge-co
 import { decompress, isGzip } from 'firefox-profiler/utils/gz';
 import { expandUrl } from 'firefox-profiler/utils/shorten-url';
 import { TemporaryError } from 'firefox-profiler/utils/errors';
-import JSZip from 'jszip';
+import { localhostHostnames } from 'firefox-profiler/utils/url';
 import {
   getSelectedThreadIndexesOrNull,
   getGlobalTrackOrder,
@@ -1072,9 +1073,7 @@ function _loadProbablyFailedDueToSafariLocalhostHTTPRestriction(
   return (
     error.name === 'TypeError' &&
     parsedUrl.protocol === 'http:' &&
-    (parsedUrl.hostname === 'localhost' ||
-      parsedUrl.hostname === '127.0.0.1' ||
-      parsedUrl.hostname === '::1') &&
+    localhostHostnames.includes(parsedUrl.hostname) &&
     location.protocol === 'https:'
   );
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -20,7 +20,7 @@ import { mergeProfilesForDiffing } from 'firefox-profiler/profile-logic/merge-co
 import { decompress, isGzip } from 'firefox-profiler/utils/gz';
 import { expandUrl } from 'firefox-profiler/utils/shorten-url';
 import { TemporaryError } from 'firefox-profiler/utils/errors';
-import { localhostHostnames } from 'firefox-profiler/utils/url';
+import { isLocalURL } from 'firefox-profiler/utils/url';
 import {
   getSelectedThreadIndexesOrNull,
   getGlobalTrackOrder,
@@ -1073,7 +1073,7 @@ function _loadProbablyFailedDueToSafariLocalhostHTTPRestriction(
   return (
     error.name === 'TypeError' &&
     parsedUrl.protocol === 'http:' &&
-    localhostHostnames.includes(parsedUrl.hostname) &&
+    isLocalURL(parsedUrl) &&
     location.protocol === 'https:'
   );
 }

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -58,6 +58,8 @@ import type {
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
+import { isLocalURL } from 'firefox-profiler/utils/url';
+
 type OwnProps = {|
   // This is for injecting a URL shortener for tests. Normally we would use a Jest mock
   // that would mock out a local module, but I was having trouble getting it working
@@ -109,10 +111,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
       case 'local':
         return 'local';
       case 'from-url':
-        return profileUrl.startsWith('http://127.0.0.1') ||
-          profileUrl.startsWith('http://localhost')
-          ? 'local'
-          : 'uploaded';
+        return isLocalURL(profileUrl) ? 'local' : 'uploaded';
       case 'none':
       case 'uploaded-recordings':
         throw new Error(`The datasource ${dataSource} shouldn't happen here.`);

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -11,6 +11,7 @@ import { getThreadsKey } from '../profile-logic/profile-data';
 import { getProfileNameFromZipPath } from 'firefox-profiler/profile-logic/zip-files';
 import { SYMBOL_SERVER_URL } from '../app-logic/constants';
 import { splitSearchString, stringsToRegExp } from '../utils/string';
+import { localhostHostnames } from '../utils/url';
 
 import type {
   ThreadIndex,
@@ -330,7 +331,6 @@ export const getCommittedRangeLabels: Selector<string[]> = createSelector(
 
 function _shouldAllowSymbolServerUrl(symbolServerUrl) {
   try {
-    const localhostHostnames = ['localhost', '127.0.0.1'];
     const url = new URL(symbolServerUrl);
     if (localhostHostnames.includes(url.hostname)) {
       return true;

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -11,7 +11,7 @@ import { getThreadsKey } from '../profile-logic/profile-data';
 import { getProfileNameFromZipPath } from 'firefox-profiler/profile-logic/zip-files';
 import { SYMBOL_SERVER_URL } from '../app-logic/constants';
 import { splitSearchString, stringsToRegExp } from '../utils/string';
-import { localhostHostnames } from '../utils/url';
+import { isLocalURL } from '../utils/url';
 
 import type {
   ThreadIndex,
@@ -332,7 +332,7 @@ export const getCommittedRangeLabels: Selector<string[]> = createSelector(
 function _shouldAllowSymbolServerUrl(symbolServerUrl) {
   try {
     const url = new URL(symbolServerUrl);
-    if (localhostHostnames.includes(url.hostname)) {
+    if (isLocalURL(url)) {
       return true;
     }
 

--- a/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
+++ b/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
@@ -123,6 +123,78 @@ was fully loaded. You might see malfunctions.
 </div>
 `;
 
+exports[`app/ServiceWorkerManager with the \`from-url\` datasource shows a notice when the SW is updated 1`] = `
+<body>
+  <div>
+    <div
+      class="serviceworker-ready-notice-wrapper"
+    >
+      <div
+        class="photon-message-bar serviceworker-ready-notice"
+      >
+        <div
+          class="photon-message-bar-inner-content"
+        >
+          <div
+            class="photon-message-bar-inner-text"
+          >
+            A new version of the application has been downloaded and is ready to use.
+          </div>
+          <button
+            class="photon-button photon-button-micro photon-message-bar-action-button"
+            type="button"
+          >
+            Apply and reload
+          </button>
+        </div>
+        <button
+          aria-label="Hide the reload notice"
+          class="photon-button photon-message-bar-close-button"
+          title="Hide the reload notice"
+          type="button"
+        />
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`app/ServiceWorkerManager with the \`public\` datasource shows a notice when the SW is updated 1`] = `
+<body>
+  <div>
+    <div
+      class="serviceworker-ready-notice-wrapper"
+    >
+      <div
+        class="photon-message-bar serviceworker-ready-notice"
+      >
+        <div
+          class="photon-message-bar-inner-content"
+        >
+          <div
+            class="photon-message-bar-inner-text"
+          >
+            A new version of the application has been downloaded and is ready to use.
+          </div>
+          <button
+            class="photon-button photon-button-micro photon-message-bar-action-button"
+            type="button"
+          >
+            Apply and reload
+          </button>
+        </div>
+        <button
+          aria-label="Hide the reload notice"
+          class="photon-button photon-message-bar-close-button"
+          title="Hide the reload notice"
+          type="button"
+        />
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`app/ServiceWorkerManager with the \`public\` datasource shows a warning notice if the SW was updated before we were ready 1`] = `
 <div
   class="serviceworker-ready-notice-wrapper"

--- a/src/utils/fetch-source.js
+++ b/src/utils/fetch-source.js
@@ -11,6 +11,7 @@ import {
 } from './special-paths';
 import { isGzip, decompress } from './gz';
 import { UntarFileStream } from './untar';
+import { isLocalURL } from './url';
 import type { SourceLoadingError, AddressProof } from 'firefox-profiler/types';
 
 export type FetchSourceCallbacks = {|
@@ -207,14 +208,5 @@ export async function fetchSource(
 // official Mozilla symbolication server with requests it can't handle.
 // This check can be removed once it adds support for /source/v1.
 function _serverMightSupportSource(symbolServerUrl: string): boolean {
-  try {
-    const url = new URL(symbolServerUrl);
-    return (
-      url.hostname === 'localhost' ||
-      url.hostname === '127.0.0.1' ||
-      url.hostname === '::1'
-    );
-  } catch (e) {
-    return false;
-  }
+  return isLocalURL(symbolServerUrl);
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -14,9 +14,9 @@ export const localhostHostnames: $ReadOnlyArray<string> = [
 // is local, and therefore likely to have gone away, meaning we should
 // be careful offering tools to the user that refresh the page or
 // otherwise lose state, as refetching that state may not work.
-export function isLocalURL(url: string): boolean {
+export function isLocalURL(url: string | URL): boolean {
   try {
-    const parsedUrl = new URL(url);
+    const parsedUrl = url instanceof URL ? url : new URL(url);
     return localhostHostnames.includes(parsedUrl.hostname);
   } catch (e) {
     return false;

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+export const localhostHostnames: $ReadOnlyArray<string> = [
+  'localhost',
+  '127.0.0.1',
+  '::1',
+];
+
+// Used to determine if a URL (usually one that's provided a profile)
+// is local, and therefore likely to have gone away, meaning we should
+// be careful offering tools to the user that refresh the page or
+// otherwise lose state, as refetching that state may not work.
+export function isLocalURL(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return localhostHostnames.includes(parsedUrl.hostname);
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixes #4437

The changes in this PR are difficult to test manually, and some of them difficult to test at all. Hopefully they're not too risky. It would be good if @mstange could try the use cases around the symbol server before merging.