### PR TITLE
Improve flame graph rendering performance

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -123,16 +123,6 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
     }
   }
 
-  // Provide a memoized function that maps the category color names to specific color
-  // choices that are used across this project's charts.
-  _mapCategoryColorNameToStyles = memoize(
-    mapCategoryColorNameToStackChartStyles,
-    {
-      // Memoize every color that is seen.
-      limit: Infinity,
-    }
-  );
-
   _scrollSelectionIntoView = () => {
     const {
       selectedCallNodeIndex,
@@ -228,7 +218,9 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
 
         const categoryIndex = callNodeTable.category[callNodeIndex];
         const category = categories[categoryIndex];
-        const colorStyles = this._mapCategoryColorNameToStyles(category.color);
+        const colorStyles = mapCategoryColorNameToStackChartStyles(
+          category.color
+        );
 
         const background = isHighlighted
           ? colorStyles.selectedFillStyle

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -163,8 +163,6 @@ type State = {|
   viewportTop: CssPixels,
   viewportBottom: CssPixels,
   horizontalViewport: HorizontalViewport,
-  dragX: CssPixels,
-  dragY: CssPixels,
   isDragging: boolean,
   isScrollHintVisible: boolean,
   isSizeSet: boolean,
@@ -229,6 +227,8 @@ export const withChartViewport: WithChartViewport<*, *> =
       _lastKeyboardNavigationFrame: number = 0;
       _keysDown: Set<NavigationKey> = new Set();
       _deltaToZoomFactor = (delta) => Math.pow(ZOOM_SPEED, delta);
+      _dragX: number = 0;
+      _dragY: number = 0;
 
       constructor(props: ViewportProps) {
         super(props);
@@ -267,8 +267,6 @@ export const withChartViewport: WithChartViewport<*, *> =
           viewportTop: 0,
           viewportBottom: startsAtBottom ? maxViewportHeight : 0,
           horizontalViewport,
-          dragX: 0,
-          dragY: 0,
           isDragging: false,
           isScrollHintVisible: false,
           isSizeSet: false,
@@ -560,7 +558,7 @@ export const withChartViewport: WithChartViewport<*, *> =
       _mouseMoveListener = (event: MouseEvent) => {
         event.preventDefault();
 
-        let { dragX, dragY } = this.state;
+        let { _dragX: dragX, _dragY: dragY } = this;
         if (!this.state.isDragging) {
           dragX = event.clientX;
           dragY = event.clientY;
@@ -569,11 +567,9 @@ export const withChartViewport: WithChartViewport<*, *> =
         const offsetX = event.clientX - dragX;
         const offsetY = event.clientY - dragY;
 
-        this.setState({
-          dragX: event.clientX,
-          dragY: event.clientY,
-          isDragging: true,
-        });
+        this._dragX = event.clientX;
+        this._dragY = event.clientY;
+        this.setState({ isDragging: true });
 
         this.moveViewport(offsetX, offsetY);
       };

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -5,7 +5,6 @@
 // @flow
 import { GREY_30 } from 'photon-colors';
 import * as React from 'react';
-import memoize from 'memoize-immutable';
 import { TIMELINE_MARGIN_RIGHT } from '../../app-logic/constants';
 import {
   withChartViewport,
@@ -333,7 +332,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
             depth === hoveredItem.depth &&
             i === hoveredItem.stackTimingIndex;
 
-          const colorStyles = this._mapCategoryColorNameToStyles(
+          const colorStyles = mapCategoryColorNameToStackChartStyles(
             category.color
           );
           // Draw the box.
@@ -395,16 +394,6 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       devicePixelsHeight
     );
   };
-
-  // Provide a memoized function that maps the category color names to specific color
-  // choices that are used across this project's charts.
-  _mapCategoryColorNameToStyles = memoize(
-    mapCategoryColorNameToStackChartStyles,
-    {
-      // Memoize every color that is seen.
-      limit: Infinity,
-    }
-  );
 
   _getHoveredStackInfo = ({
     depth,

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -482,20 +482,9 @@ Array [
   ],
   Array [
     "fillRect",
-    0,
-    284,
-    200,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    284,
     1,
+    284,
+    199,
     15,
   ],
   Array [
@@ -518,20 +507,9 @@ Array [
   ],
   Array [
     "fillRect",
-    0,
-    268,
-    200,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    268,
     1,
+    268,
+    199,
     15,
   ],
   Array [
@@ -554,20 +532,9 @@ Array [
   ],
   Array [
     "fillRect",
-    0,
-    252,
-    133.33333333333331,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    252,
     1,
+    252,
+    132.33333333333331,
     15,
   ],
   Array [
@@ -590,20 +557,9 @@ Array [
   ],
   Array [
     "fillRect",
-    133.33333333333331,
+    134.33333333333331,
     252,
-    66.66666666666667,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    133.33333333333331,
-    252,
-    1,
+    65.66666666666667,
     15,
   ],
   Array [
@@ -626,20 +582,9 @@ Array [
   ],
   Array [
     "fillRect",
-    0,
-    236,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    236,
     1,
+    236,
+    65.66666666666666,
     15,
   ],
   Array [
@@ -662,20 +607,9 @@ Array [
   ],
   Array [
     "fillRect",
-    66.66666666666666,
+    67.66666666666666,
     236,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    66.66666666666666,
-    236,
-    1,
+    65.66666666666666,
     15,
   ],
   Array [
@@ -698,20 +632,9 @@ Array [
   ],
   Array [
     "fillRect",
-    133.33333333333331,
+    134.33333333333331,
     236,
-    66.66666666666667,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    133.33333333333331,
-    236,
-    1,
+    65.66666666666667,
     15,
   ],
   Array [
@@ -734,20 +657,9 @@ Array [
   ],
   Array [
     "fillRect",
-    0,
-    220,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    220,
     1,
+    220,
+    65.66666666666666,
     15,
   ],
   Array [
@@ -770,20 +682,9 @@ Array [
   ],
   Array [
     "fillRect",
-    66.66666666666666,
+    67.66666666666666,
     220,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    66.66666666666666,
-    220,
-    1,
+    65.66666666666666,
     15,
   ],
   Array [
@@ -806,20 +707,9 @@ Array [
   ],
   Array [
     "fillRect",
-    66.66666666666666,
+    67.66666666666666,
     204,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    66.66666666666666,
-    204,
-    1,
+    65.66666666666666,
     15,
   ],
   Array [

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -81,6 +81,99 @@ type ColorStyles = {|
   +gravity: number,
 |};
 
+const GRAY_STYLE = {
+  selectedFillStyle: GREY_40,
+  unselectedFillStyle: GREY_40 + '60',
+  selectedTextColor: '#000',
+  gravity: 10,
+};
+const DARK_GRAY_STYLE = {
+  selectedFillStyle: GREY_50,
+  unselectedFillStyle: GREY_50 + '60',
+  selectedTextColor: '#fff',
+  gravity: 11,
+};
+const STYLE_MAP: { [string]: ColorStyles } = {
+  transparent: {
+    selectedFillStyle: 'transparent',
+    unselectedFillStyle: 'transparent',
+    selectedTextColor: '#000',
+    gravity: 0,
+  },
+  lightblue: {
+    selectedFillStyle: BLUE_40,
+    // Colors are assumed to have the form #RRGGBB, so concatenating 2 more digits to
+    // the end defines the transparency #RRGGBBAA.
+    unselectedFillStyle: BLUE_40 + '60',
+    selectedTextColor: '#000',
+    gravity: 1,
+  },
+  red: {
+    selectedFillStyle: RED_60,
+    unselectedFillStyle: RED_60 + '60',
+    selectedTextColor: '#fff',
+    gravity: 1,
+  },
+  lightred: {
+    selectedFillStyle: RED_70 + '60',
+    unselectedFillStyle: RED_70 + '30',
+    selectedTextColor: '#000',
+    gravity: 1,
+  },
+  orange: {
+    selectedFillStyle: ORANGE_50,
+    unselectedFillStyle: ORANGE_50 + '60',
+    selectedTextColor: '#fff',
+    gravity: 2,
+  },
+  blue: {
+    selectedFillStyle: BLUE_60,
+    unselectedFillStyle: BLUE_60 + '60',
+    selectedTextColor: '#fff',
+    gravity: 3,
+  },
+  green: {
+    selectedFillStyle: GREEN_60,
+    unselectedFillStyle: GREEN_60 + '60',
+    selectedTextColor: '#fff',
+    gravity: 4,
+  },
+  purple: {
+    selectedFillStyle: PURPLE_70,
+    unselectedFillStyle: PURPLE_70 + '60',
+    selectedTextColor: '#fff',
+    gravity: 5,
+  },
+  yellow: {
+    selectedFillStyle: '#ffe129', // This yellow has more contrast than YELLOW_50.
+    unselectedFillStyle: YELLOW_50 + '70',
+    selectedTextColor: '#000',
+    gravity: 6,
+  },
+  brown: {
+    selectedFillStyle: ORANGE_70,
+    unselectedFillStyle: ORANGE_70 + '60',
+    selectedTextColor: '#fff',
+    gravity: 7,
+  },
+  magenta: {
+    selectedFillStyle: MAGENTA_60,
+    unselectedFillStyle: MAGENTA_60 + '60',
+    selectedTextColor: '#fff',
+    gravity: 8,
+  },
+  lightgreen: {
+    selectedFillStyle: GREEN_50,
+    unselectedFillStyle: GREEN_50 + '60',
+    selectedTextColor: '#fff',
+    gravity: 9,
+  },
+  gray: GRAY_STYLE,
+  grey: GRAY_STYLE,
+  darkgray: DARK_GRAY_STYLE,
+  darkgrey: DARK_GRAY_STYLE,
+};
+
 /**
  * Map a color name, which comes from Gecko, into a CSS style color. These colors cannot
  * be changed without considering the values coming from Gecko, and from old profiles
@@ -90,120 +183,14 @@ type ColorStyles = {|
  * https://searchfox.org/mozilla-central/rev/9193635dca8cfdcb68f114306194ffc860456044/js/public/ProfilingCategory.h#33
  */
 export function mapCategoryColorNameToStyles(colorName: string): ColorStyles {
-  switch (colorName) {
-    case 'transparent':
-      return {
-        selectedFillStyle: 'transparent',
-        unselectedFillStyle: 'transparent',
-        selectedTextColor: '#000',
-        gravity: 0,
-      };
-    case 'lightblue':
-      return {
-        selectedFillStyle: BLUE_40,
-        // Colors are assumed to have the form #RRGGBB, so concatenating 2 more digits to
-        // the end defines the transparency #RRGGBBAA.
-        unselectedFillStyle: BLUE_40 + '60',
-        selectedTextColor: '#000',
-        gravity: 1,
-      };
-    case 'red':
-      return {
-        selectedFillStyle: RED_60,
-        unselectedFillStyle: RED_60 + '60',
-        selectedTextColor: '#fff',
-        gravity: 1,
-      };
-    case 'lightred':
-      return {
-        selectedFillStyle: RED_70 + '60',
-        unselectedFillStyle: RED_70 + '30',
-        selectedTextColor: '#000',
-        gravity: 1,
-      };
-    case 'orange':
-      return {
-        selectedFillStyle: ORANGE_50,
-        unselectedFillStyle: ORANGE_50 + '60',
-        selectedTextColor: '#fff',
-        gravity: 2,
-      };
-    case 'blue':
-      return {
-        selectedFillStyle: BLUE_60,
-        unselectedFillStyle: BLUE_60 + '60',
-        selectedTextColor: '#fff',
-        gravity: 3,
-      };
-    case 'green':
-      return {
-        selectedFillStyle: GREEN_60,
-        unselectedFillStyle: GREEN_60 + '60',
-        selectedTextColor: '#fff',
-        gravity: 4,
-      };
-    case 'purple':
-      return {
-        selectedFillStyle: PURPLE_70,
-        unselectedFillStyle: PURPLE_70 + '60',
-        selectedTextColor: '#fff',
-        gravity: 5,
-      };
-    case 'yellow':
-      return {
-        selectedFillStyle: '#ffe129', // This yellow has more contrast than YELLOW_50.
-        unselectedFillStyle: YELLOW_50 + '70',
-        selectedTextColor: '#000',
-        gravity: 6,
-      };
-    case 'brown':
-      return {
-        selectedFillStyle: ORANGE_70,
-        unselectedFillStyle: ORANGE_70 + '60',
-        selectedTextColor: '#fff',
-        gravity: 7,
-      };
-    case 'magenta':
-      return {
-        selectedFillStyle: MAGENTA_60,
-        unselectedFillStyle: MAGENTA_60 + '60',
-        selectedTextColor: '#fff',
-        gravity: 8,
-      };
-    case 'lightgreen':
-      return {
-        selectedFillStyle: GREEN_50,
-        unselectedFillStyle: GREEN_50 + '60',
-        selectedTextColor: '#fff',
-        gravity: 9,
-      };
-    case 'grey':
-    case 'gray':
-      return {
-        selectedFillStyle: GREY_40,
-        unselectedFillStyle: GREY_40 + '60',
-        selectedTextColor: '#000',
-        gravity: 10,
-      };
-    case 'darkgrey':
-    case 'darkgray':
-      return {
-        selectedFillStyle: GREY_50,
-        unselectedFillStyle: GREY_50 + '60',
-        selectedTextColor: '#fff',
-        gravity: 11,
-      };
-    default:
-      console.error(
-        `Unknown color name '${colorName}' encountered. Consider updating this code to handle it.`
-      );
-      return {
-        selectedFillStyle: GREY_40,
-        unselectedFillStyle: GREY_40 + '60',
-        selectedTextColor: '#fff',
-        gravity: 10,
-      };
+  const colorStyles = STYLE_MAP[colorName];
+  if (colorStyles !== undefined) {
+    return colorStyles;
   }
+  console.error(
+    `Unknown color name '${colorName}' encountered. Consider updating this code to handle it.`
+  );
+  return GRAY_STYLE;
 }
 
 /**

--- a/src/utils/text-measurement.js
+++ b/src/utils/text-measurement.js
@@ -57,17 +57,6 @@ class TextMeasurement {
   }
 
   /**
-   * Gets an approximate width of the specified text. This is much faster
-   * than `_getTextWidth`, but inexact.
-   *
-   * @param {string} text - The text to analyze.
-   * @return {number} The approximate text width.
-   */
-  getTextWidthApprox(text: string): number {
-    return text.length * this._averageCharWidth;
-  }
-
-  /**
    * Massage a text to fit inside a given width. This clamps the string
    * at the end to avoid overflowing.
    *
@@ -76,21 +65,20 @@ class TextMeasurement {
    * @return {string} The fitted text.
    */
   getFittedText(text: string, maxWidth: number): string {
-    if (this.minWidth > maxWidth) {
-      return '';
-    }
-    const textWidth = this.getTextWidth(text);
-    if (textWidth < maxWidth) {
+    if (this.getTextWidth(text) < maxWidth) {
       return text;
     }
-    for (let i = 1, len = text.length; i <= len; i++) {
-      const trimmedText = text.substring(0, len - i);
-      const trimmedWidth = this.getTextWidthApprox(trimmedText) + this.minWidth;
-      if (trimmedWidth < maxWidth) {
-        return trimmedText + this.overflowChar;
-      }
+
+    // Approximate the number of characters to truncate to,
+    // using avg character width as reference.
+    const f = (maxWidth - this.minWidth) / this._averageCharWidth;
+    let n = Math.floor(f);
+    if (n === f) {
+      // The approximate width of `n` characters is exactly max width,
+      // so take one character less just in case.
+      n -= 1;
     }
-    return '';
+    return n > 0 ? text.substring(0, n) + this.overflowChar : '';
   }
 }
 


### PR DESCRIPTION
I'm not sure if I'm missing something more obvious, but these are the things being done in this PR:
- Reduce `fillStyle` and `fillRect` calls:
   - By using `FastFillStyle`.
   - By drawing the fill rectangle at an offset instead of drawing another white border.
- Removing the need to memoize style colors by storing them in a map ahead of time.
- Reduce render calls by pulling `dragX/dragY` out of chart viewport state.
- Replace `getFittedText` with an equivalent implementation that does less work.

Fixes #4451

[Production](https://share.firefox.dev/3WLDzil) | [Profile of panning the flame graph in production](https://share.firefox.dev/3jwjOxR)
[Deploy preview](https://deploy-preview-4455--perf-html.netlify.app/public/48hra4hvn9nn9g2rbnm3xsmxcaetx92kctwtja0/flame-graph/?globalTrackOrder=0w3&hiddenGlobalTracks=0w2&hiddenLocalTracksByPid=11281-0w9&range=9564m3470&thread=9&transforms=df-20&v=8) | [Profile of panning the flame graph with PR changes](https://share.firefox.dev/3HwSrvv)
<hr>

Some other things I tried:
1. Splitting the flame graph rendering into two passes (pass 1 draws rectangles and pushes visible texts to a list, pass 2 draws visible texts). It seemed to have made it ever so slightly more smoother, but numbers only showed average `_drawCanvas` time reducing from 4 ms to 3.8 ms.
2. Re-enabling `requestAnimationFrame` for FlameGraph canvas. This seems to make it slightly smoother, but not sure how to confirm. [Profile](https://share.firefox.dev/40toWDq)
3. Disabling highlighting when panning. This also seems to make it slightly smoother but can't say for certain. [Profile](https://profiler.firefox.com/public/9xsg93703w5qy576hc5snwdjw9xw6t73vnnw73r/flame-graph/?globalTrackOrder=0w2&implementation=js&thread=3&v=8)