### PR TITLE
Sanitize the counters to the filtered time range

### DIFF
--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -163,7 +163,7 @@ export function sanitizePII(
             oldThreadIndexToNew
           );
 
-          // Filtering out the counter if it's its thread was removed.
+          // Filter out the counter completely if its thread has been removed.
           if (newCounter !== null) {
             acc.push(newCounter);
           }

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -687,7 +687,7 @@ function sanitizeCounterPII(
 ): Counter | null {
   const newThreadIndex = oldThreadIndexToNew.get(counter.mainThreadIndex);
   if (newThreadIndex === undefined) {
-    // Sanitize the counter if the thread that it belongs is sanitized as well.
+    // Remove the counter completely if the thread that it belongs to is sanitized as well.
     return null;
   }
 

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -20,7 +20,10 @@ import {
   sanitizeFromMarkerSchema,
 } from './marker-data';
 import { getSchemaFromMarker } from './marker-schema';
-import { filterThreadSamplesToRange } from './profile-data';
+import {
+  filterThreadSamplesToRange,
+  filterCounterSamplesToRange,
+} from './profile-data';
 import type {
   Profile,
   Thread,
@@ -32,6 +35,7 @@ import type {
   IndexIntoFuncTable,
   InnerWindowID,
   MarkerSchemaByName,
+  Counter,
 } from 'firefox-profiler/types';
 
 export type SanitizeProfileResult = {|
@@ -153,18 +157,16 @@ export function sanitizePII(
     // Also adjust other counters to point to the right thread.
     counters: profile.counters
       ? profile.counters.reduce((acc, counter) => {
-          const newThreadIndex = oldThreadIndexToNew.get(
-            counter.mainThreadIndex
+          const newCounter: Counter | null = sanitizeCounterPII(
+            counter,
+            PIIToBeRemoved,
+            oldThreadIndexToNew
           );
 
-          // Filtering out the counter if it's undefined.
-          if (newThreadIndex !== undefined) {
-            acc.push({
-              ...counter,
-              mainThreadIndex: newThreadIndex,
-            });
+          // Filtering out the counter if it's its thread was removed.
+          if (newCounter !== null) {
+            acc.push(newCounter);
           }
-
           return acc;
         }, [])
       : undefined,
@@ -403,7 +405,7 @@ function sanitizeThreadPII(
       PIIToBeRemoved.shouldFilterToCommittedRange
     ).rawMarkerTable;
 
-    // While we are here, we are also filterig the thread samples
+    // While we are here, we are also filtering the thread samples
     // to range.
     if (PIIToBeRemoved.shouldFilterToCommittedRange !== null) {
       const { start, end } = PIIToBeRemoved.shouldFilterToCommittedRange;
@@ -667,4 +669,38 @@ function isThreadNonEmpty(thread: Thread): boolean {
   );
 
   return hasSamples;
+}
+
+/**
+ * Sanitize the counter PII.
+ *
+ * - If the thread that the counter belongs to is removed, then remove the
+ *   counter as well.
+ * - If the time range is sanitized, then filter the counter samples to the
+ *   sanitized time range.
+ * - Update the thread index with the new thread index.
+ */
+function sanitizeCounterPII(
+  counter: Counter,
+  PIIToBeRemoved: RemoveProfileInformation,
+  oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex>
+): Counter | null {
+  const newThreadIndex = oldThreadIndexToNew.get(counter.mainThreadIndex);
+  if (newThreadIndex === undefined) {
+    // Sanitize the counter if the thread that it belongs is sanitized as well.
+    return null;
+  }
+
+  // Sanitize the counter if the time range should be sanitized.
+  let newCounter = counter;
+  if (PIIToBeRemoved.shouldFilterToCommittedRange !== null) {
+    const { start, end } = PIIToBeRemoved.shouldFilterToCommittedRange;
+    newCounter = filterCounterSamplesToRange(newCounter, start, end);
+  }
+
+  return {
+    ...newCounter,
+    // Update the main thread index with the new thread index.
+    mainThreadIndex: newThreadIndex,
+  };
 }

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -164,6 +164,56 @@ describe('sanitizePII', function () {
     expect(ensureExists(sanitizedProfile.counters).length).toEqual(1);
   });
 
+  it('should sanitize the counter range if range is filtered', function () {
+    const originalProfile = processGeckoProfile(createGeckoProfile());
+    const timeRangeForThread = getTimeRangeForThread(
+      originalProfile.threads[0],
+      originalProfile.meta.interval
+    );
+    // Make sure that the original time range is 0-7.
+    expect(timeRangeForThread).toEqual({ start: 0, end: 7 });
+    const sanitizedRange = { start: 3, end: 5 };
+    const { sanitizedProfile } = setup(
+      {
+        shouldFilterToCommittedRange: sanitizedRange,
+      },
+      originalProfile
+    );
+
+    if (ensureExists(originalProfile.counters)[0].mainThreadIndex !== 0) {
+      throw new Error(
+        'This test assumes the the counters mainThreadIndex is 0'
+      );
+    }
+
+    // Make sure that we still have the same number of counters.
+    expect(ensureExists(originalProfile.counters).length).toEqual(1);
+    expect(ensureExists(sanitizedProfile.counters).length).toEqual(1);
+    const counterSamples = ensureExists(sanitizedProfile.counters)[0]
+      .sampleGroups[0].samples;
+
+    // Make sure that all the table fields are consistent.
+    expect(counterSamples.time).toHaveLength(counterSamples.length);
+    expect(counterSamples.count).toHaveLength(counterSamples.length);
+    expect(counterSamples.number).toHaveLength(counterSamples.length);
+
+    // Make sure that all the samples are between the sanitized time range.
+    for (
+      let sampleIndex = 0;
+      sampleIndex < counterSamples.length;
+      sampleIndex++
+    ) {
+      // We are using inclusive range, so we need to add 1 and subtract 1 to the
+      // start and end ranges.
+      expect(counterSamples.time[sampleIndex]).toBeGreaterThanOrEqual(
+        sanitizedRange.start - 1
+      );
+      expect(counterSamples.time[sampleIndex]).toBeLessThanOrEqual(
+        sanitizedRange.end + 1
+      );
+    }
+  });
+
   it('should sanitize profiler overhead if its thread is deleted', function () {
     const { originalProfile, sanitizedProfile } = setup({
       shouldRemoveThreads: new Set([0]),


### PR DESCRIPTION
Fixes #4180.

Counters don't include the PII usually, but we should still filter them to filtered range to reduce the profiler size while uploading. This PR does that filtering to the committed range when user doesn't want to include the hidden range.

Example profile: [Production](https://share.firefox.dev/3xcCyW9) / [Deploy preview](https://deploy-preview-4460--perf-html.netlify.app/public/8naf76g3pxregh5da3xnjxtxa266kzbh40hf2d0/flame-graph/?globalTrackOrder=a0w9&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=82054-02w4~82319-0~82060-0~82323-0~82063-0~82331-0~82058-01~82055-0~82325-0&range=419m272~438m193&thread=f&transforms=df-14~fg-18&v=8)
You can try to run `profile.counters[0].sampleGroups[0].samples.length` on devtools console to compare the before after lengths.