### PR TITLE
Add start time to marker tooltip

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -390,17 +390,23 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
   }
 
   _maybeRenderMarkerDuration() {
-    const { marker } = this.props;
-    if (marker.end === null) {
-      return null;
+    const { marker, zeroAt } = this.props;
+
+    let duration = '';
+    if (marker.end !== null) {
+      // We only know the duration if it's complete.
+      duration = marker.incomplete
+        ? 'unknown duration'
+        : formatTimestamp(marker.end - marker.start, 3, 1);
     }
 
-    // We only know the duration if it's complete.
-    const duration = marker.incomplete
-      ? 'unknown duration'
-      : formatTimestamp(marker.end - marker.start, 3, 1);
+    const start = formatTimestamp(marker.start - zeroAt, undefined, 3);
 
-    return <div className="tooltipTiming">{duration}</div>;
+    return (
+      <div className="tooltipTiming">
+        {duration} @ {start}
+      </div>
+    );
   }
 
   _maybeRenderBacktrace() {

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -289,6 +289,8 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
           class="tooltipTiming"
         >
           6ms
+           @ 
+          2ms
         </div>
         <div
           class="tooltipTitle"
@@ -1227,6 +1229,8 @@ exports[`MarkerChart with active tab renders the hovered marker properly 2`] = `
           class="tooltipTiming"
         >
           7ms
+           @ 
+          6ms
         </div>
         <div
           class="tooltipTitle"

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -20,6 +20,8 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
             class="tooltipTiming"
           >
             unknown duration
+             @ 
+            107.50ms
           </div>
           <div
             class="tooltipTitle"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -878,6 +878,8 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
           class="tooltipTiming"
         >
           4ms
+           @ 
+          2ms
         </div>
         <div
           class="tooltipTitle"

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -14,6 +14,8 @@ exports[`TooltipMarker renders profiled off-main thread FileIO markers properly 
         class="tooltipTiming"
       >
         500μs
+         @ 
+        114.50ms
       </div>
       <div
         class="tooltipTitle"
@@ -160,6 +162,8 @@ exports[`TooltipMarker renders properly network markers that were aborted 1`] = 
         class="tooltipTiming"
       >
         1.4s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -263,6 +267,8 @@ exports[`TooltipMarker renders properly network markers where content type is bl
         class="tooltipTiming"
       >
         1.4s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -434,6 +440,8 @@ exports[`TooltipMarker renders properly network markers where content type is mi
         class="tooltipTiming"
       >
         1.4s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -630,6 +638,8 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
         class="tooltipTiming"
       >
         1.4s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -890,6 +900,8 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
         class="tooltipTiming"
       >
         1.4s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1076,6 +1088,8 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
         class="tooltipTiming"
       >
         1.4s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1330,6 +1344,8 @@ exports[`TooltipMarker renders properly redirect network markers for a Internal 
         class="tooltipTiming"
       >
         18.7s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1443,6 +1459,8 @@ exports[`TooltipMarker renders properly redirect network markers for a Permanent
         class="tooltipTiming"
       >
         18.7s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1556,6 +1574,8 @@ exports[`TooltipMarker renders properly redirect network markers for a Temporary
         class="tooltipTiming"
       >
         18.7s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1669,6 +1689,8 @@ exports[`TooltipMarker renders properly redirect network markers for an internal
         class="tooltipTiming"
       >
         18.7s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1782,6 +1804,8 @@ exports[`TooltipMarker renders properly redirect network markers without additio
         class="tooltipTiming"
       >
         18.7s
+         @ 
+        0s
       </div>
       <div
         class="tooltipTitle"
@@ -1890,6 +1914,8 @@ exports[`TooltipMarker renders the tooltip of CompositorScreenshotWindowDestroye
             class="tooltipTiming"
           >
             1ms
+             @ 
+            0s
           </div>
           <div
             class="tooltipTitle"
@@ -1939,6 +1965,12 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout_ShapeGuard 
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        10ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         Bailout_ShapeGuard after getelem on line 3666 of resource://foo.js -&gt; resource://bar.js:3662
@@ -1969,6 +2001,12 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
     <div
       class="tooltipOneLine"
     >
+      <div
+        class="tooltipTiming"
+      >
+         @ 
+        10ms
+      </div>
       <div
         class="tooltipTitle"
       >
@@ -2008,6 +2046,12 @@ exports[`TooltipMarker renders tooltips for various markers: BailoutKind::Argume
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        10ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         BailoutKind::ArgumentCheck at Uninitialized on line 388 of self-hosted:388
@@ -2042,6 +2086,8 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
         class="tooltipTiming"
       >
         800μs
+         @ 
+        10.500ms
       </div>
       <div
         class="tooltipTitle"
@@ -2106,6 +2152,8 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.6 1`] =
         class="tooltipTiming"
       >
         500μs
+         @ 
+        10.600ms
       </div>
       <div
         class="tooltipTitle"
@@ -2168,6 +2216,8 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.7 1`] =
         class="tooltipTiming"
       >
         500μs
+         @ 
+        10.700ms
       </div>
       <div
         class="tooltipTitle"
@@ -2230,6 +2280,8 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.8 1`] =
         class="tooltipTiming"
       >
         500μs
+         @ 
+        10.800ms
       </div>
       <div
         class="tooltipTitle"
@@ -2293,6 +2345,8 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO (non-profile
         class="tooltipTiming"
       >
         500μs
+         @ 
+        114.50ms
       </div>
       <div
         class="tooltipTitle"
@@ -2623,6 +2677,8 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
         class="tooltipTiming"
       >
         1ms
+         @ 
+        114ms
       </div>
       <div
         class="tooltipTitle"
@@ -2943,6 +2999,12 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        16.500ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         GCMajor
@@ -3093,6 +3155,12 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        15.500ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         GCMinor
@@ -3215,6 +3283,12 @@ exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = 
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        17.500ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         GCSlice
@@ -3291,6 +3365,8 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
         class="tooltipTiming"
       >
         unknown duration
+         @ 
+        120ms
       </div>
       <div
         class="tooltipTitle"
@@ -3380,6 +3456,12 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate http://m
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        10ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         Invalidate http://mozilla.com/script.js:1234
@@ -3410,6 +3492,12 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
     <div
       class="tooltipOneLine"
     >
+      <div
+        class="tooltipTiming"
+      >
+         @ 
+        10ms
+      </div>
       <div
         class="tooltipTitle"
       >
@@ -3448,6 +3536,12 @@ exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
     <div
       class="tooltipOneLine"
     >
+      <div
+        class="tooltipTiming"
+      >
+         @ 
+        21.700ms
+      </div>
       <div
         class="tooltipTitle"
       >
@@ -3494,6 +3588,12 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        14.500ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         NotifyDidPaint
@@ -3535,6 +3635,8 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.
         class="tooltipTiming"
       >
         800μs
+         @ 
+        112.50ms
       </div>
       <div
         class="tooltipTitle"
@@ -3574,6 +3676,12 @@ exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] =
     <div
       class="tooltipOneLine"
     >
+      <div
+        class="tooltipTiming"
+      >
+         @ 
+        115ms
+      </div>
       <div
         class="tooltipTitle"
       >
@@ -3619,6 +3727,12 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
     <div
       class="tooltipOneLine"
     >
+      <div
+        class="tooltipTiming"
+      >
+         @ 
+        114.90ms
+      </div>
       <div
         class="tooltipTitle"
       >
@@ -3682,6 +3796,8 @@ exports[`TooltipMarker renders tooltips for various markers: RefreshObserver-122
         class="tooltipTiming"
       >
         4ms
+         @ 
+        122ms
       </div>
       <div
         class="tooltipTitle"
@@ -3986,6 +4102,8 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
         class="tooltipTiming"
       >
         500μs
+         @ 
+        18.500ms
       </div>
       <div
         class="tooltipTitle"
@@ -4295,6 +4413,8 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
         class="tooltipTiming"
       >
         500μs
+         @ 
+        20ms
       </div>
       <div
         class="tooltipTitle"
@@ -4629,6 +4749,12 @@ exports[`TooltipMarker renders tooltips for various markers: TimeToFirstInteract
       class="tooltipOneLine"
     >
       <div
+        class="tooltipTiming"
+      >
+         @ 
+        21.400ms
+      </div>
+      <div
         class="tooltipTitle"
       >
         TimeToFirstInteractive (TTFI)
@@ -4670,6 +4796,8 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
         class="tooltipTiming"
       >
         0s
+         @ 
+        12.500ms
       </div>
       <div
         class="tooltipTitle"
@@ -4742,6 +4870,8 @@ exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
         class="tooltipTiming"
       >
         70ms
+         @ 
+        -16,000,000ns
       </div>
       <div
         class="tooltipTitle"
@@ -4789,6 +4919,8 @@ exports[`TooltipMarker shows image of CompositorScreenshot markers 1`] = `
         class="tooltipTiming"
       >
         2ms
+         @ 
+        1ms
       </div>
       <div
         class="tooltipTitle"
@@ -4862,6 +4994,8 @@ exports[`TooltipMarker shows the source thread for markers from a merged thread 
             class="tooltipTiming"
           >
             1ms
+             @ 
+            1ms
           </div>
           <div
             class="tooltipTitle"
@@ -4930,6 +5064,8 @@ exports[`TooltipMarker shows the source thread for markers from a merged thread 
             class="tooltipTiming"
           >
             1ms
+             @ 
+            2ms
           </div>
           <div
             class="tooltipTitle"

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -51,6 +51,8 @@ exports[`timeline/TrackNetwork draws differently a request and displays a toolti
           class="tooltipTiming"
         >
           1ms
+           @ 
+          0s
         </div>
         <div
           class="tooltipTitle"


### PR DESCRIPTION
This adds the start time to the marker tooltip in the marker chart. The information was previously only shown in the marker table view, but adding it in the chart view makes it easier to assess if one thing happened before or after another.

I've done this as `<duration> @ <start time>`, but happy for any suggestions as to how to make this readable & obvious.
<img width="385" alt="Screenshot 2023-02-12 at 20 41 33" src="https://user-images.githubusercontent.com/91716/218333778-77a1f2b5-5fc2-4bf3-ac8c-924794db2634.png">

If it's only a marker (i.e. no duration), then we _only_ show the `@ <start time>`
<img width="236" alt="Screenshot 2023-02-12 at 20 41 45" src="https://user-images.githubusercontent.com/91716/218333863-18bb1736-027b-4651-97fc-43ce4e89bf4e.png">

(First PR to this repo, always happy for feedback - i missed this feature whilst reviewing some profiles)
