### PR TITLE
Rename activation generation to scroll generation.

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -576,13 +576,13 @@ export function stateFromLocation(
   const selectedTab =
     toValidTabSlug(pathParts[selectedTabPathPart]) || 'calltree';
   const sourceView: SourceViewState = {
-    activationGeneration: 0,
+    scrollGeneration: 0,
     libIndex: null,
     sourceFile: null,
   };
   const assemblyView: AssemblyViewState = {
     isOpen: false,
-    activationGeneration: 0,
+    scrollGeneration: 0,
     nativeSymbol: null,
     allNativeSymbolsForInitiatingCallNode: [],
   };

--- a/src/components/app/BottomBox.js
+++ b/src/components/app/BottomBox.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import { SourceView } from '../shared/SourceView';
 import {
   getSourceViewFile,
-  getSourceViewActivationGeneration,
+  getSourceViewScrollGeneration,
 } from 'firefox-profiler/selectors/url-state';
 import {
   selectedThreadSelectors,
@@ -34,7 +34,7 @@ type StateProps = {|
   +sourceViewSource: FileSourceStatus | void,
   +globalLineTimings: LineTimings,
   +selectedCallNodeLineTimings: LineTimings,
-  +sourceViewActivationGeneration: number,
+  +sourceViewScrollGeneration: number,
   +disableOverscan: boolean,
 |};
 
@@ -218,7 +218,7 @@ class BottomBoxImpl extends React.PureComponent<Props> {
       sourceViewSource,
       globalLineTimings,
       disableOverscan,
-      sourceViewActivationGeneration,
+      sourceViewScrollGeneration,
       selectedCallNodeLineTimings,
     } = this.props;
     const source =
@@ -253,7 +253,7 @@ class BottomBoxImpl extends React.PureComponent<Props> {
               timings={globalLineTimings}
               source={source}
               filePath={path}
-              scrollToHotSpotGeneration={sourceViewActivationGeneration}
+              scrollToHotSpotGeneration={sourceViewScrollGeneration}
               hotSpotTimings={selectedCallNodeLineTimings}
               ref={this._sourceView}
             />
@@ -275,7 +275,7 @@ export const BottomBox = explicitConnect<{||}, StateProps, DispatchProps>({
     globalLineTimings: selectedThreadSelectors.getSourceViewLineTimings(state),
     selectedCallNodeLineTimings:
       selectedNodeSelectors.getSourceViewLineTimings(state),
-    sourceViewActivationGeneration: getSourceViewActivationGeneration(state),
+    sourceViewScrollGeneration: getSourceViewScrollGeneration(state),
     disableOverscan: getPreviewSelection(state).isModifying,
   }),
   mapDispatchToProps: {

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -555,13 +555,13 @@ const timelineTrackOrganization: Reducer<TimelineTrackOrganization> = (
 };
 
 const sourceView: Reducer<SourceViewState> = (
-  state = { activationGeneration: 0, libIndex: null, sourceFile: null },
+  state = { scrollGeneration: 0, libIndex: null, sourceFile: null },
   action
 ) => {
   switch (action.type) {
     case 'UPDATE_BOTTOM_BOX': {
       return {
-        activationGeneration: state.activationGeneration + 1,
+        scrollGeneration: state.scrollGeneration + 1,
         libIndex: action.libIndex,
         sourceFile: action.sourceFile,
       };
@@ -573,7 +573,7 @@ const sourceView: Reducer<SourceViewState> = (
 
 const assemblyView: Reducer<AssemblyViewState> = (
   state = {
-    activationGeneration: 0,
+    scrollGeneration: 0,
     nativeSymbol: null,
     allNativeSymbolsForInitiatingCallNode: [],
     isOpen: false,
@@ -583,7 +583,7 @@ const assemblyView: Reducer<AssemblyViewState> = (
   switch (action.type) {
     case 'UPDATE_BOTTOM_BOX': {
       return {
-        activationGeneration: state.activationGeneration + 1,
+        scrollGeneration: state.scrollGeneration + 1,
         nativeSymbol: action.nativeSymbol,
         allNativeSymbolsForInitiatingCallNode:
           action.allNativeSymbolsForInitiatingCallNode,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -78,8 +78,8 @@ export const getShowUserTimings: Selector<boolean> = (state) =>
   getProfileSpecificState(state).showUserTimings;
 export const getSourceViewFile: Selector<string | null> = (state) =>
   getProfileSpecificState(state).sourceView.sourceFile;
-export const getSourceViewActivationGeneration: Selector<number> = (state) =>
-  getProfileSpecificState(state).sourceView.activationGeneration;
+export const getSourceViewScrollGeneration: Selector<number> = (state) =>
+  getProfileSpecificState(state).sourceView.scrollGeneration;
 export const getShowJsTracerSummary: Selector<boolean> = (state) =>
   getFullProfileSpecificState(state).showJsTracerSummary;
 export const getTimelineTrackOrganization: Selector<

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -246,7 +246,7 @@ export type ZippedProfilesState = {
 };
 
 export type SourceViewState = {|
-  activationGeneration: number,
+  scrollGeneration: number,
   // Non-null if this source file was opened for a function from native code.
   // In theory, multiple different libraries can have source files with the same
   // path but different content.
@@ -264,7 +264,7 @@ export type AssemblyViewState = {|
   // true even if the bottom box itself is closed.
   isOpen: boolean,
   // When this is incremented, the assembly view scrolls to the "hotspot" line.
-  activationGeneration: number,
+  scrollGeneration: number,
   // The native symbol for which the assembly code is being shown at the moment.
   // Null if the initiating call node did not have a native symbol.
   nativeSymbol: NativeSymbolInfo | null,


### PR DESCRIPTION
As requested in review comments in #4478.