### PR TITLE
Assembly view part 4: Make some parts of fetchSource reusable and harden against bad responses

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -984,6 +984,21 @@ SourceView--browser-api-error-when-obtaining-source =
 SourceView--local-symbol-server-api-error-when-obtaining-source =
     The local symbol server’s symbolication API returned an error: { $apiErrorMessage }
 
+# Displayed below SourceView--cannot-obtain-source, if the browser was queried
+# for source code using the symbolication API, and this query returned a malformed response.
+# Variables:
+#   $apiErrorMessage (String) - The raw internal error message from the API, not localized
+SourceView--browser-api-malformed-response-when-obtaining-source =
+    The browser’s symbolication API returned a malformed response: { $apiErrorMessage }
+
+# Displayed below SourceView--cannot-obtain-source, if a symbol server which is
+# running locally was queried for source code using the symbolication API, and
+# this query returned a malformed response.
+# Variables:
+#   $apiErrorMessage (String) - The raw internal error message from the API, not localized
+SourceView--local-symbol-server-api-malformed-response-when-obtaining-source =
+    The local symbol server’s symbolication API returned a malformed response: { $apiErrorMessage }
+
 # Displayed below SourceView--cannot-obtain-source, if a file could not be found in
 # an archive file (.tar.gz) which was downloaded from crates.io.
 # Variables:

--- a/src/components/app/BottomBox.js
+++ b/src/components/app/BottomBox.js
@@ -169,6 +169,28 @@ function SourceStatusOverlay({ status }: SourceStatusOverlayProps) {
                       </Localized>
                     );
                   }
+                  case 'BROWSER_API_MALFORMED_RESPONSE': {
+                    const { errorMessage } = error;
+                    return (
+                      <Localized
+                        id="SourceView--browser-api-malformed-response-when-obtaining-source"
+                        vars={{ errorMessage }}
+                      >
+                        <li>{`The browser’s symbolication API returned a malformed response: ${errorMessage}`}</li>
+                      </Localized>
+                    );
+                  }
+                  case 'SYMBOL_SERVER_API_MALFORMED_RESPONSE': {
+                    const { errorMessage } = error;
+                    return (
+                      <Localized
+                        id="SourceView--local-symbol-server-api-malformed-response-when-obtaining-source"
+                        vars={{ errorMessage }}
+                      >
+                        <li>{`The local symbol server’s symbolication API returned a malformed response: ${errorMessage}`}</li>
+                      </Localized>
+                    );
+                  }
                   case 'NOT_PRESENT_IN_ARCHIVE': {
                     const { url, pathInArchive } = error;
                     return (

--- a/src/test/unit/fetch-source.test.js
+++ b/src/test/unit/fetch-source.test.js
@@ -422,4 +422,89 @@ describe('fetchSource', function () {
       errors: [{ type: 'NO_KNOWN_CORS_URL' }],
     });
   });
+
+  it('reports appropriate errors when the API response is not valid JSON', async function () {
+    expect(
+      await fetchSource(
+        '/Users/mstange/code/mozilla/gfx/wr/webrender/src/renderer/mod.rs',
+        'https://symbolication.services.mozilla.com',
+        {
+          debugName: 'FAKE_DEBUGNAME',
+          breakpadId: 'FAKE_DEBUGID',
+          address: 0x1234,
+        },
+        new Map(),
+        {
+          fetchUrlResponse: async (_url: string, _postData?: MixedObject) => {
+            throw new Error('Some network error');
+          },
+          queryBrowserSymbolicationApi: async (
+            path: string,
+            _requestJson: string
+          ) => {
+            if (path !== '/source/v1') {
+              throw new Error(`Unrecognized API path ${path}`);
+            }
+            return '[Invalid \\ JSON}';
+          },
+        }
+      )
+    ).toEqual({
+      type: 'ERROR',
+      errors: [
+        {
+          type: 'BROWSER_API_MALFORMED_RESPONSE',
+          errorMessage: 'SyntaxError: Unexpected token I in JSON at position 1',
+        },
+        {
+          type: 'NO_KNOWN_CORS_URL',
+        },
+      ],
+    });
+  });
+
+  it('reports appropriate errors when the API response is malformed', async function () {
+    expect(
+      await fetchSource(
+        '/Users/mstange/code/mozilla/gfx/wr/webrender/src/renderer/mod.rs',
+        'https://symbolication.services.mozilla.com',
+        {
+          debugName: 'FAKE_DEBUGNAME',
+          breakpadId: 'FAKE_DEBUGID',
+          address: 0x1234,
+        },
+        new Map(),
+        {
+          fetchUrlResponse: async (_url: string, _postData?: MixedObject) => {
+            throw new Error('Some network error');
+          },
+          queryBrowserSymbolicationApi: async (
+            path: string,
+            _requestJson: string
+          ) => {
+            if (path !== '/source/v1') {
+              throw new Error(`Unrecognized API path ${path}`);
+            }
+            return JSON.stringify({
+              symbolsLastModified: null,
+              sourceLastModified: null,
+              file: '/Users/mstange/code/mozilla/gfx/wr/webrender/src/renderer/mod.rs',
+              hahaYouThoughtThereWouldBeSourceHereButNo: 42,
+            });
+          },
+        }
+      )
+    ).toEqual({
+      type: 'ERROR',
+      errors: [
+        {
+          type: 'BROWSER_API_MALFORMED_RESPONSE',
+          errorMessage: 'Error: No string "source" property on API response',
+        },
+        {
+          type: 'NO_KNOWN_CORS_URL',
+        },
+      ],
+    });
+  });
 });

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -291,17 +291,31 @@ export type ApiQueryError =
       url: string,
       networkErrorMessage: string,
     |}
+  // Used when the symbol server reported an error, for example because our
+  // request was bad.
   | {|
       type: 'SYMBOL_SERVER_API_ERROR',
       apiErrorMessage: string,
     |}
+  // Used when the symbol server's response was bad.
+  | {|
+      type: 'SYMBOL_SERVER_API_MALFORMED_RESPONSE',
+      errorMessage: string,
+    |}
+  // Used when the browser API reported an error, for example because our
+  // request was bad.
   | {|
       type: 'BROWSER_CONNECTION_ERROR',
       browserConnectionErrorMessage: string,
     |}
+  // Used when the browser's response was bad.
   | {|
       type: 'BROWSER_API_ERROR',
       apiErrorMessage: string,
+    |}
+  | {|
+      type: 'BROWSER_API_MALFORMED_RESPONSE',
+      errorMessage: string,
     |};
 
 export type SourceLoadingError =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -285,22 +285,11 @@ export type FileSourceLoadingSource =
   | {| type: 'URL', url: string |}
   | {| type: 'BROWSER_CONNECTION' |};
 
-export type SourceLoadingError =
-  | {| type: 'NO_KNOWN_CORS_URL' |}
+export type ApiQueryError =
   | {|
       type: 'NETWORK_ERROR',
       url: string,
       networkErrorMessage: string,
-    |}
-  | {|
-      type: 'NOT_PRESENT_IN_ARCHIVE',
-      url: string,
-      pathInArchive: string,
-    |}
-  | {|
-      type: 'ARCHIVE_PARSING_ERROR',
-      url: string,
-      parsingErrorMessage: string,
     |}
   | {|
       type: 'SYMBOL_SERVER_API_ERROR',
@@ -313,6 +302,20 @@ export type SourceLoadingError =
   | {|
       type: 'BROWSER_API_ERROR',
       apiErrorMessage: string,
+    |};
+
+export type SourceLoadingError =
+  | ApiQueryError
+  | {| type: 'NO_KNOWN_CORS_URL' |}
+  | {|
+      type: 'NOT_PRESENT_IN_ARCHIVE',
+      url: string,
+      pathInArchive: string,
+    |}
+  | {|
+      type: 'ARCHIVE_PARSING_ERROR',
+      url: string,
+      parsingErrorMessage: string,
     |};
 
 /**

--- a/src/utils/fetch-source.js
+++ b/src/utils/fetch-source.js
@@ -12,20 +12,9 @@ import {
 import { isGzip, decompress } from './gz';
 import { UntarFileStream } from './untar';
 import { isLocalURL } from './url';
+import { queryApiWithFallback } from './query-api';
+import type { ExternalCommunicationDelegate } from './query-api';
 import type { SourceLoadingError, AddressProof } from 'firefox-profiler/types';
-
-export type FetchSourceCallbacks = {|
-  // Fetch a cross-origin URL and return its Response. If postData is specified,
-  // the method should be POST.
-  fetchUrlResponse: (url: string, postData?: MixedObject) => Promise<Response>,
-
-  // Query the symbolication API of the browser, if a connection to the browser
-  // is available.
-  queryBrowserSymbolicationApi: (
-    path: string,
-    requestJson: string
-  ) => Promise<string>,
-|};
 
 export type FetchSourceResult =
   | { type: 'SUCCESS', source: string }
@@ -43,13 +32,14 @@ export type FetchSourceResult =
  * @param addressProof - An "address proof" for the requested file, if known. Otherwise null.
  * @param archiveCache - A map which allows reusing the bytes of the archive file.
  *    Stores promises to the bytes of uncompressed tar files.
+ * @param delegate - An object which handles web requests and browser connection queries.
  */
 export async function fetchSource(
   file: string,
   symbolServerUrl: string,
   addressProof: AddressProof | null,
   archiveCache: Map<string, Promise<Uint8Array>>,
-  callbacks: FetchSourceCallbacks
+  delegate: ExternalCommunicationDelegate
 ): Promise<FetchSourceResult> {
   const errors: SourceLoadingError[] = [];
 
@@ -58,62 +48,42 @@ export async function fetchSource(
     // at https://github.com/mstange/profiler-get-symbols/blob/master/API.md#sourcev1
     // This API is used both by the browser connection's querySymbolicationApi method
     // as well as by the local symbol server.
-    const path = '/source/v1';
+    const symbolServerUrlForFallback = _serverMightSupportSource(
+      symbolServerUrl
+    )
+      ? symbolServerUrl
+      : null;
     const { debugName, breakpadId, address } = addressProof;
-    const requestJson = JSON.stringify({
-      debugName,
-      debugId: breakpadId,
-      moduleOffset: `0x${address.toString(16)}`,
-      file,
-    });
 
-    // See if we can get sources from the browser.
-    try {
-      const response = await callbacks.queryBrowserSymbolicationApi(
-        path,
-        requestJson
-      );
-      const responseJson = await JSON.parse(response);
-      if (!responseJson.error) {
-        // The browser gave us the source. Success!
-        return { type: 'SUCCESS', source: responseJson.source };
+    // See if we can get sources via the API, either from the browser or from a
+    // symbol server.
+    const queryResult = await queryApiWithFallback(
+      '/source/v1',
+      JSON.stringify({
+        debugName,
+        debugId: breakpadId,
+        moduleOffset: `0x${address.toString(16)}`,
+        file,
+      }),
+      symbolServerUrlForFallback,
+      delegate
+    );
+    switch (queryResult.type) {
+      case 'SUCCESS':
+        return {
+          type: 'SUCCESS',
+          source: queryResult.responseJson.source,
+        };
+      case 'ERROR': {
+        errors.push(...queryResult.errors);
+        break;
       }
-      errors.push({
-        type: 'BROWSER_API_ERROR',
-        apiErrorMessage: responseJson.error,
-      });
-    } catch (e) {
-      errors.push({
-        type: 'BROWSER_CONNECTION_ERROR',
-        browserConnectionErrorMessage: e.toString(),
-      });
-    }
-
-    // See if we can get sources from a local symbol server.
-    if (_serverMightSupportSource(symbolServerUrl)) {
-      const url = symbolServerUrl + path;
-      try {
-        const response = await callbacks.fetchUrlResponse(url, requestJson);
-        const responseJson = await response.json();
-        if (!responseJson.error) {
-          // Local symbol server gave us the source. Success!
-          return { type: 'SUCCESS', source: responseJson.source };
-        }
-        errors.push({
-          type: 'SYMBOL_SERVER_API_ERROR',
-          apiErrorMessage: responseJson.error,
-        });
-      } catch (e) {
-        errors.push({
-          type: 'NETWORK_ERROR',
-          url,
-          networkErrorMessage: e.toString(),
-        });
-      }
+      default:
+        throw assertExhaustiveCheck(queryResult.type);
     }
   }
 
-  // Try to obtain the source from the web.
+  // Try to obtain the source by downloading a file from the web.
 
   const parsedName = parseFileNameFromSymbolication(file);
   const downloadRecipe = getDownloadRecipeForSourceFile(parsedName);
@@ -122,7 +92,7 @@ export async function fetchSource(
     case 'CORS_ENABLED_SINGLE_FILE': {
       const { url } = downloadRecipe;
       try {
-        const response = await callbacks.fetchUrlResponse(url);
+        const response = await delegate.fetchUrlResponse(url);
         const source = await response.text();
         return { type: 'SUCCESS', source };
       } catch (e) {
@@ -149,7 +119,7 @@ export async function fetchSource(
       if (promise === undefined) {
         // Create a promise to load the archive, but don't await it yet.
         promise = (async () => {
-          const response = await callbacks.fetchUrlResponse(url);
+          const response = await delegate.fetchUrlResponse(url);
           const bytes = new Uint8Array(await response.arrayBuffer());
           return isGzip(bytes) ? decompress(bytes) : bytes;
         })();

--- a/src/utils/fetch-source.js
+++ b/src/utils/fetch-source.js
@@ -66,13 +66,14 @@ export async function fetchSource(
         file,
       }),
       symbolServerUrlForFallback,
-      delegate
+      delegate,
+      convertResponseJsonToSourceCode
     );
     switch (queryResult.type) {
       case 'SUCCESS':
         return {
           type: 'SUCCESS',
-          source: queryResult.responseJson.source,
+          source: queryResult.convertedResponse,
         };
       case 'ERROR': {
         errors.push(...queryResult.errors);
@@ -170,6 +171,13 @@ export async function fetchSource(
       throw assertExhaustiveCheck(downloadRecipe.type);
   }
   return { type: 'ERROR', errors };
+}
+
+function convertResponseJsonToSourceCode(responseJson: MixedObject): string {
+  if (!('source' in responseJson) || typeof responseJson.source !== 'string') {
+    throw new Error('No string "source" property on API response');
+  }
+  return responseJson.source;
 }
 
 // At the moment, the official Mozilla symbolication server does not have an

--- a/src/utils/query-api.js
+++ b/src/utils/query-api.js
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type { ApiQueryError } from 'firefox-profiler/types';
+import type { BrowserConnection } from 'firefox-profiler/app-logic/browser-connection';
+
+/**
+ * An abstraction which simplifies writing tests for things like source and assembly
+ * fetching. These things get their data from external sources like the browser or the
+ * network.
+ *
+ * In most cases you'll want to use RegularExternalCommunicationDelegate.
+ */
+export interface ExternalCommunicationDelegate {
+  // Fetch a cross-origin URL and return its Response. If postData is specified,
+  // the method should be POST.
+  fetchUrlResponse(url: string, postData?: MixedObject): Promise<Response>;
+
+  // Query the symbolication API of the browser, if a connection to the browser
+  // is available.
+  queryBrowserSymbolicationApi(
+    path: string,
+    requestJson: string
+  ): Promise<string>;
+}
+
+export type ApiQueryResult =
+  | { type: 'SUCCESS', responseJson: any }
+  | { type: 'ERROR', errors: ApiQueryError[] };
+
+/**
+ * Sends a JSON query to the browser symbolication API and, if supplied, to a
+ * symbol server.
+ */
+export async function queryApiWithFallback(
+  path: string,
+  requestJson: string,
+  symbolServerUrlForFallback: string | null,
+  delegate: ExternalCommunicationDelegate
+): Promise<ApiQueryResult> {
+  const errors: ApiQueryError[] = [];
+
+  // See if we can get an API result from the browser.
+  try {
+    const response = await delegate.queryBrowserSymbolicationApi(
+      path,
+      requestJson
+    );
+    const responseJson = await JSON.parse(response);
+    if (!responseJson.error) {
+      // The browser gave us a successful response.
+      return { type: 'SUCCESS', responseJson };
+    }
+    errors.push({
+      type: 'BROWSER_API_ERROR',
+      apiErrorMessage: responseJson.error,
+    });
+  } catch (e) {
+    errors.push({
+      type: 'BROWSER_CONNECTION_ERROR',
+      browserConnectionErrorMessage: e.toString(),
+    });
+  }
+
+  // See if we can get sources from a local symbol server.
+  if (symbolServerUrlForFallback !== null) {
+    const url = symbolServerUrlForFallback + path;
+    try {
+      const response = await delegate.fetchUrlResponse(url, requestJson);
+      const responseJson = await response.json();
+      if (!responseJson.error) {
+        // Local symbol server gave us the source. Success!
+        return { type: 'SUCCESS', responseJson };
+      }
+      errors.push({
+        type: 'SYMBOL_SERVER_API_ERROR',
+        apiErrorMessage: responseJson.error,
+      });
+    } catch (e) {
+      errors.push({
+        type: 'NETWORK_ERROR',
+        url,
+        networkErrorMessage: e.toString(),
+      });
+    }
+  }
+
+  return { type: 'ERROR', errors };
+}
+
+export interface ExternalCommunicationCallbacks {
+  onBeginUrlRequest(url: string): void;
+  onBeginBrowserConnectionQuery(): void;
+}
+
+/**
+ * The default implementation of the ExternalCommunicationDelegate interface.
+ * Uses fetch for URL requests and the supplied browser connection for browser
+ * connection requests.
+ *
+ * It also takes an object with callbacks, for loading indicators.
+ */
+export class RegularExternalCommunicationDelegate
+  implements ExternalCommunicationDelegate
+{
+  _browserConnection: BrowserConnection | null;
+  _callbacks: ExternalCommunicationCallbacks;
+
+  constructor(
+    browserConnection: BrowserConnection | null,
+    callbacks: ExternalCommunicationCallbacks
+  ) {
+    this._browserConnection = browserConnection;
+    this._callbacks = callbacks;
+  }
+
+  async fetchUrlResponse(url: string, postData?: MixedObject) {
+    this._callbacks.onBeginUrlRequest(url);
+    const requestInit =
+      postData !== undefined
+        ? {
+            body: postData,
+            method: 'POST',
+            mode: 'cors',
+            credentials: 'omit',
+          }
+        : { credentials: 'omit' };
+    const response = await fetch(url, requestInit);
+    if (response.status !== 200) {
+      throw new Error(
+        `The request to ${url} returned HTTP status ${response.status}`
+      );
+    }
+    return response;
+  }
+
+  async queryBrowserSymbolicationApi(path: string, requestJson: string) {
+    const browserConnection = this._browserConnection;
+    if (browserConnection === null) {
+      throw new Error('No connection to the browser.');
+    }
+    this._callbacks.onBeginBrowserConnectionQuery();
+    return browserConnection.querySymbolicationApi(path, requestJson);
+  }
+}


### PR DESCRIPTION
Two patches:

 1. Add a `queryApiWithFallback` helper, which I intend to use from `fetchAssembly`.
 2. Harden `fetchSource` against malformed responses.