### PR TITLE
Use URL.host instead of URL.hostname in the network chart, so that th…

### DIFF
--- a/src/components/network-chart/NetworkChartRow.js
+++ b/src/components/network-chart/NetworkChartRow.js
@@ -429,7 +429,7 @@ export class NetworkChartRow extends React.PureComponent<
           <span className="networkChartRowItemUriOptional">
             {uri.protocol + '//'}
           </span>
-          <span className="networkChartRowItemUriRequired">{uri.hostname}</span>
+          <span className="networkChartRowItemUriRequired">{uri.host}</span>
           {uriPath ? (
             <span className="networkChartRowItemUriOptional">{uriPath}</span>
           ) : null}

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -491,12 +491,12 @@ describe('NetworkChartRowBar URL split', function () {
 
   it('splits up the url by protocol / domain / path / filename / params / hash', function () {
     const { getUrlShorteningParts } = setupForUrl(
-      'https://test.mozilla.org/img/optimized/test.gif?param1=123&param2=321#hashNode2'
+      'https://test.mozilla.org:5000/img/optimized/test.gif?param1=123&param2=321#hashNode2'
     );
     expect(getUrlShorteningParts()).toEqual([
       // Then assert that it's broken up as expected
       ['networkChartRowItemUriOptional', 'https://'],
-      ['networkChartRowItemUriRequired', 'test.mozilla.org'],
+      ['networkChartRowItemUriRequired', 'test.mozilla.org:5000'],
       ['networkChartRowItemUriOptional', '/img/optimized'],
       ['networkChartRowItemUriRequired', '/test.gif'],
       ['networkChartRowItemUriOptional', '?param1=123&param2=321'],


### PR DESCRIPTION
…e port is displayed if present

I've seen that when profiling some local server.