### PR TITLE
Make the marker sort case insensitive in the marker chart.

### DIFF
--- a/src/profile-logic/marker-timing.js
+++ b/src/profile-logic/marker-timing.js
@@ -224,7 +224,7 @@ export function getMarkerTiming(
     }
 
     // Sort by names second
-    return a.name > b.name ? 1 : -1;
+    return a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1;
   });
 
   return allMarkerTimings;


### PR DESCRIPTION
In profiles with lots of timer markers, I find it difficult to find one specific marker by name because some have a lower case first letter and some an upper case first later, and the sorting is case sensitive. I don't think this was intended.

Example profile: https://share.firefox.dev/3mC1qEY