### PR TITLE
Handle duplicate category names gracefully.

### DIFF
--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -189,6 +189,7 @@ class CategoryBreakdownImpl extends React.PureComponent<CategoryBreakdownAllProp
           value: oneCategoryBreakdown.entireCategoryValue || 0,
           subcategories: category.subcategories
             .map((subcategoryName, subcategoryIndex) => ({
+              index: subcategoryIndex,
               name: subcategoryName,
               value:
                 oneCategoryBreakdown.subcategoryBreakdown[subcategoryIndex],
@@ -219,7 +220,7 @@ class CategoryBreakdownImpl extends React.PureComponent<CategoryBreakdownAllProp
           const expanded =
             openCats !== undefined && openCats.has(categoryIndex);
           return (
-            <React.Fragment key={category.name}>
+            <React.Fragment key={`category-${categoryIndex}`}>
               <SidebarDetail
                 label={
                   hasSubcategory ? (
@@ -251,9 +252,9 @@ class CategoryBreakdownImpl extends React.PureComponent<CategoryBreakdownAllProp
               </div>
 
               {hasSubcategory && expanded
-                ? subcategories.map(({ name, value }) => (
+                ? subcategories.map(({ index, name, value }) => (
                     <SidebarDetail
-                      key={name}
+                      key={`subcategory-${index}`}
                       label={name}
                       value={number(value)}
                       percentage={formatPercent(value / totalTime)}


### PR DESCRIPTION
We were using the category name as the React key, so in profiles with duplicate category names we ended up with broken UI.

Steps to reproduce:

 1. Load https://share.firefox.dev/3l4ViVq - this is a profile where two different categories have the same name "BaselineInterpreter".
 2. Use the arrow keys to go up and down in the call tree a bit.

Expected results: Normal behavior
Actual results: The "BaselineInterpreter" category shows up multiple times in the sidebar. Also, in development builds, there is a warning from react on the console.