### PR TITLE
Improves / fixes grammar related to screenshots track in guide-ui-tour-timeline

### DIFF
--- a/docs-user/guide-ui-tour-timeline.md
+++ b/docs-user/guide-ui-tour-timeline.md
@@ -24,8 +24,7 @@ Committing a range selection by clicking the zoom button is a useful way to zoom
 
 ![A screenshot highlighting the screenshot track in the timeline.](images/ui-tour-timeline-screenshots.png)
 
-The screenshots track help navigate in the profile and focus on the part that are
-more interesting to analyze.
+The screenshots track helps users navigate through the profile by providing visual context within the timeline.
 
 ## Timeline's activity graph
 


### PR DESCRIPTION
Original sentence: "The screenshots help navigate in the profile and focus on the part that are more interesting to analyze."

Revised sentence: "The screenshots track helps users navigate through the profile by providing visual context within the timeline."

Summary:

The original sentence is a bit unclear, as it is not clear what "help navigate" means, and it is also unclear what "the part that are more interesting to analyze" refers to. The revised sentence is more specific. It explains that the screenshots track helps users navigate through the profile by providing visual context within the timeline, which is a more concrete and specific explanation of how the feature works.