### PR TITLE
Stop showing the component stack in case of an error, and show a more…

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -222,17 +222,19 @@ Details--open-sidebar-button =
     .title = Open the sidebar
 Details--close-sidebar-button =
     .title = Close the sidebar
-Details--error-boundary-message2 =
-    .message = Uh oh, some unknown error happened in this panel
+Details--error-boundary-message =
+    .message = Uh oh, some unknown error happened in this panel.
 
 ## ErrorBoundary
 ## This component is shown when an unexpected error is encountered in the application.
 ## Note that the localization won't be always applied in this component.
 
+# This message will always be displayed after another context-specific message.
 ErrorBoundary--report-error-to-developers-description =
     Please report this issue to the developers, including the full
     error as displayed in the Developer Tools’ Web Console.
 
+# This is used in a call to action button, displayed inside the error box.
 ErrorBoundary--report-error-on-github = Report the error on GitHub
 
 ## Footer Links
@@ -681,7 +683,7 @@ ProfileRootMessage--additional = Back to home
 ## Root
 
 Root--error-boundary-message =
-    .message = Uh oh, some error happened in profiler.firefox.com
+    .message = Uh oh, some unknown error happened in profiler.firefox.com.
 
 ## ServiceWorkerManager
 ## This is the component responsible for handling the service worker installation

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -222,8 +222,18 @@ Details--open-sidebar-button =
     .title = Open the sidebar
 Details--close-sidebar-button =
     .title = Close the sidebar
-Details--error-boundary-message =
-    .message = Uh oh, some unknown error happened in this panel.
+Details--error-boundary-message2 =
+    .message = Uh oh, some unknown error happened in this panel
+
+## ErrorBoundary
+## This component is shown when an unexpected error is encountered in the application.
+## Note that the localization won't be always applied in this component.
+
+ErrorBoundary--report-error-to-developers-description =
+    Please report this issue to the developers, including the full
+    error as displayed in the Developer Tools’ Web Console.
+
+ErrorBoundary--report-error-on-github = Report the error on GitHub
 
 ## Footer Links
 
@@ -667,6 +677,11 @@ ProfileLoaderAnimation--loading-view-not-found = View not found
 
 ProfileRootMessage--title = { -profiler-brand-name }
 ProfileRootMessage--additional = Back to home
+
+## Root
+
+Root--error-boundary-message =
+    .message = Uh oh, some error happened in profiler.firefox.com
 
 ## ServiceWorkerManager
 ## This is the component responsible for handling the service worker installation

--- a/res/css/photon/button.css
+++ b/res/css/photon/button.css
@@ -4,6 +4,9 @@
 
 /* See https://design.firefox.com/photon/components/buttons.html for the spec */
 .photon-button {
+  /* These two flex options aren't necessary when a real <button> is used, but they are when a <a> element is used as abutton */
+  display: flex;
+  align-items: center;
   padding: 0 8px;
   border: none;
   border-radius: 2px;
@@ -15,7 +18,10 @@
   /* photon styles */
   background-color: var(--grey-90-a10);
   color: var(--grey-90);
+  cursor: initial; /* reset the defaut link style when used as a button */
   font: inherit;
+  text-decoration: none; /* reset the defaut link style when used as a button */
+  user-select: none;
 }
 
 /* This is a Firefox-specific style because Firefox adds a focusring at a bad

--- a/res/css/photon/message-bar.css
+++ b/res/css/photon/message-bar.css
@@ -46,9 +46,6 @@
 }
 
 .photon-message-bar-inner-text {
-  display: flex;
-  align-items: center;
-
   /* This padding is carefully computed so that multi-line message bars have the
    * same top padding than single-line message bars. Having this property
    * shouldn't change anything for single-line message bars.

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -103,7 +103,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
           ) : null}
         </div>
         <Localized
-          id="Details--error-boundary-message2"
+          id="Details--error-boundary-message"
           attrs={{ message: true }}
         >
           <LocalizedErrorBoundary

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -10,7 +10,7 @@ import { Localized } from '@fluent/react';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { TabBar } from './TabBar';
-import { ErrorBoundary } from './ErrorBoundary';
+import { LocalizedErrorBoundary } from './ErrorBoundary';
 import { ProfileCallTreeView } from 'firefox-profiler/components/calltree/ProfileCallTreeView';
 import { MarkerTable } from 'firefox-profiler/components/marker-table';
 import { StackChart } from 'firefox-profiler/components/stack-chart/';
@@ -103,12 +103,12 @@ class ProfileViewerImpl extends PureComponent<Props> {
           ) : null}
         </div>
         <Localized
-          id="Details--error-boundary-message"
+          id="Details--error-boundary-message2"
           attrs={{ message: true }}
         >
-          <ErrorBoundary
+          <LocalizedErrorBoundary
             key={selectedTab}
-            message="Uh oh, some unknown error happened in this panel."
+            message="Uh oh, some unknown error happened in this panel"
           >
             {
               {
@@ -121,7 +121,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
                 'js-tracer': <JsTracer />,
               }[selectedTab]
             }
-          </ErrorBoundary>
+          </LocalizedErrorBoundary>
         </Localized>
         <CallNodeContextMenu />
         <MaybeMarkerContextMenu />

--- a/src/components/app/ErrorBoundary.css
+++ b/src/components/app/ErrorBoundary.css
@@ -13,39 +13,19 @@
 .appErrorBoundaryContents {
   display: flex;
   width: 100%;
-  max-width: 600px;
-  max-height: calc(100%);
+  max-width: 800px;
+  max-height: 100%;
   box-sizing: border-box;
   flex-direction: column;
 }
 
-.appErrorBoundaryMessage {
-  flex: none;
+.appErrorBoundaryInnerText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.appErrorBoundaryDetails {
-  padding: 25px;
-  border-radius: 4px;
-  margin: 12px 0;
-  background: #fff;
-  box-shadow: 0 0 10px rgb(0 0 0 / 0.1);
-  color: var(--grey-70);
-  font-family: monospace;
-  line-height: 1.3;
-  opacity: 1;
-  overflow-y: auto;
-
-  /* Transition opacity, but do not delay changing the visibility. */
-  transition: opacity 150ms, visibility 0s;
-  visibility: visible;
-  white-space: pre-wrap;
-}
-
-.appErrorBoundaryDetails.hide {
-  opacity: 0;
-
-  /* Transition opacity, and create a delay on hiding the visibility to allow
-     time for the fade out. */
-  transition: opacity 150ms, visibility 0s 150ms;
-  visibility: hidden;
+.appErrorBoundaryInnerText > p {
+  padding: 0;
+  margin: 0;
 }

--- a/src/components/app/ErrorBoundary.js
+++ b/src/components/app/ErrorBoundary.js
@@ -74,11 +74,11 @@ class ErrorBoundaryInternal extends React.Component<InternalProps, State> {
       return (
         <div className="appErrorBoundary">
           <div className="appErrorBoundaryContents">
-            <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content appErrorBoundaryMessage">
-              <div className="photon-message-bar-inner-text">
-                {this.props.message}
-                {errorString ? ` (${errorString})` : null}.{' '}
-                {this.props.reportExplanationMessage}
+            <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">
+              <div className="photon-message-bar-inner-text appErrorBoundaryInnerText">
+                <p>{this.props.message}</p>
+                {errorString ? <p>{errorString}.</p> : null}
+                <p>{this.props.reportExplanationMessage}</p>
               </div>
               <a
                 className="photon-button photon-button-micro photon-message-bar-action-button"

--- a/src/components/app/ErrorBoundary.js
+++ b/src/components/app/ErrorBoundary.js
@@ -4,19 +4,24 @@
 // @flow
 
 import * as React from 'react';
+import { Localized } from '@fluent/react';
 import { reportError } from 'firefox-profiler/utils/analytics';
 import './ErrorBoundary.css';
 
 type State = {|
   hasError: boolean,
-  showDetails: boolean,
   errorString: string | null,
-  componentStack?: string,
 |};
 
-type Props = {|
+type ExternalProps = {|
   +children: React.Node,
   +message: string,
+|};
+
+type InternalProps = {|
+  ...ExternalProps,
+  buttonContent: React.Node,
+  reportExplanationMessage: React.Node,
 |};
 
 /**
@@ -25,10 +30,9 @@ type Props = {|
  *
  * See: https://reactjs.org/docs/error-boundaries.html
  */
-export class ErrorBoundary extends React.Component<Props, State> {
+class ErrorBoundaryInternal extends React.Component<InternalProps, State> {
   state = {
     hasError: false,
-    showDetails: false,
     errorString: null,
   };
 
@@ -52,7 +56,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
         errorString = result;
       }
     }
-    this.setState({ hasError: true, errorString, componentStack });
+    this.setState({
+      hasError: true,
+      errorString,
+    });
     reportError({
       exDescription: errorString
         ? errorString + '\n' + componentStack
@@ -61,35 +68,26 @@ export class ErrorBoundary extends React.Component<Props, State> {
     });
   }
 
-  _toggleErrorDetails = () => {
-    this.setState((state) => ({ showDetails: !state.showDetails }));
-  };
-
   render() {
     if (this.state.hasError) {
-      const { errorString, componentStack, showDetails } = this.state;
+      const { errorString } = this.state;
       return (
         <div className="appErrorBoundary">
           <div className="appErrorBoundaryContents">
             <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content appErrorBoundaryMessage">
               <div className="photon-message-bar-inner-text">
                 {this.props.message}
+                {errorString ? ` (${errorString})` : null}.{' '}
+                {this.props.reportExplanationMessage}
               </div>
-              <button
+              <a
                 className="photon-button photon-button-micro photon-message-bar-action-button"
-                type="button"
-                onClick={this._toggleErrorDetails}
-                aria-expanded={showDetails ? 'true' : 'false'}
+                href="https://github.com/firefox-devtools/profiler/issues/new?title=An%20error%20occurred%20in%20Firefox%20Profiler"
+                target="_blank"
+                rel="noreferrer"
               >
-                {showDetails ? 'Hide error details' : 'View full error details'}
-              </button>
-            </div>
-            <div
-              data-testid="error-technical-details"
-              className={`appErrorBoundaryDetails ${showDetails ? '' : 'hide'}`}
-            >
-              {errorString ? <div>{errorString}</div> : null}
-              {componentStack ? <div>{componentStack}</div> : null}
+                {this.props.buttonContent}
+              </a>
             </div>
           </div>
         </div>
@@ -98,4 +96,39 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
     return this.props.children;
   }
+}
+
+/**
+ * Use this error boundary when outside of the AppLocalizationProvider hierarchy
+ */
+export function NonLocalizedErrorBoundary(props: ExternalProps) {
+  return (
+    <ErrorBoundaryInternal
+      {...props}
+      buttonContent="Report the error on GitHub"
+      reportExplanationMessage="Please report this error to the developers, including the full error as displayed in the Developer Tools’ Web Console."
+    />
+  );
+}
+
+/**
+ * Use this error boundary when inside of the AppLocalizationProvider hierarchy
+ */
+export function LocalizedErrorBoundary(props: ExternalProps) {
+  return (
+    <ErrorBoundaryInternal
+      {...props}
+      buttonContent={
+        <Localized id="ErrorBoundary--report-error-on-github">
+          Report the error on GitHub
+        </Localized>
+      }
+      reportExplanationMessage={
+        <Localized id="ErrorBoundary--report-error-to-developers-description">
+          Please report this issue to the developers, including the full error
+          as displayed in the Developer Tools’ Web Console.
+        </Localized>
+      }
+    />
+  );
 }

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -32,14 +32,14 @@ export class Root extends PureComponent<RootProps> {
   render() {
     const { store } = this.props;
     return (
-      <NonLocalizedErrorBoundary message="Uh oh, some error happened in profiler.firefox.com">
+      <NonLocalizedErrorBoundary message="Uh oh, some unknown error happened in profiler.firefox.com.">
         <Provider store={store}>
           <AppLocalizationProvider>
             <Localized
               id="Root--error-boundary-message"
               attrs={{ message: true }}
             >
-              <LocalizedErrorBoundary message="Uh oh, some error happened in profiler.firefox.com">
+              <LocalizedErrorBoundary message="Uh oh, some unknown error happened in profiler.firefox.com.">
                 <DragAndDrop>
                   <UrlManager>
                     <ServiceWorkerManager />

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -4,10 +4,14 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
 import { Provider } from 'react-redux';
 import { UrlManager } from './UrlManager';
 import { FooterLinks } from './FooterLinks';
-import { ErrorBoundary } from './ErrorBoundary';
+import {
+  NonLocalizedErrorBoundary,
+  LocalizedErrorBoundary,
+} from './ErrorBoundary';
 import { AppViewRouter } from './AppViewRouter';
 import { ProfileLoader } from './ProfileLoader';
 import { ServiceWorkerManager } from './ServiceWorkerManager';
@@ -28,21 +32,28 @@ export class Root extends PureComponent<RootProps> {
   render() {
     const { store } = this.props;
     return (
-      <ErrorBoundary message="Uh oh, some error happened in profiler.firefox.com.">
+      <NonLocalizedErrorBoundary message="Uh oh, some error happened in profiler.firefox.com">
         <Provider store={store}>
           <AppLocalizationProvider>
-            <DragAndDrop>
-              <UrlManager>
-                <ServiceWorkerManager />
-                <ProfileLoader />
-                <AppViewRouter />
-                <FooterLinks />
-                <WindowTitle />
-              </UrlManager>
-            </DragAndDrop>
+            <Localized
+              id="Root--error-boundary-message"
+              attrs={{ message: true }}
+            >
+              <LocalizedErrorBoundary message="Uh oh, some error happened in profiler.firefox.com">
+                <DragAndDrop>
+                  <UrlManager>
+                    <ServiceWorkerManager />
+                    <ProfileLoader />
+                    <AppViewRouter />
+                    <FooterLinks />
+                    <WindowTitle />
+                  </UrlManager>
+                </DragAndDrop>
+              </LocalizedErrorBoundary>
+            </Localized>
           </AppLocalizationProvider>
         </Provider>
-      </ErrorBoundary>
+      </NonLocalizedErrorBoundary>
     );
   }
 }

--- a/src/test/components/__snapshots__/ErrorBoundary.test.js.snap
+++ b/src/test/components/__snapshots__/ErrorBoundary.test.js.snap
@@ -10,17 +10,22 @@ exports[`app/LocalizedErrorBoundary matches the snapshot 1`] = `
         class="appErrorBoundaryContents"
       >
         <div
-          class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content appErrorBoundaryMessage"
+          class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content"
         >
           <div
-            class="photon-message-bar-inner-text"
+            class="photon-message-bar-inner-text appErrorBoundaryInnerText"
           >
-            Oops, there was an error
-             (Error: This is an error.)
-            .
-             
-            Please report this issue to the developers, including the full
+            <p>
+              Oops, there was an error
+            </p>
+            <p>
+              Error: This is an error.
+              .
+            </p>
+            <p>
+              Please report this issue to the developers, including the full
 error as displayed in the Developer Tools’ Web Console.
+            </p>
           </div>
           <a
             class="photon-button photon-button-micro photon-message-bar-action-button"
@@ -45,16 +50,21 @@ exports[`app/NonLocalizedErrorBoundary matches the snapshot 1`] = `
     class="appErrorBoundaryContents"
   >
     <div
-      class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content appErrorBoundaryMessage"
+      class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content"
     >
       <div
-        class="photon-message-bar-inner-text"
+        class="photon-message-bar-inner-text appErrorBoundaryInnerText"
       >
-        Oops, there was an error
-         (Error: This is an error.)
-        .
-         
-        Please report this error to the developers, including the full error as displayed in the Developer Tools’ Web Console.
+        <p>
+          Oops, there was an error
+        </p>
+        <p>
+          Error: This is an error.
+          .
+        </p>
+        <p>
+          Please report this error to the developers, including the full error as displayed in the Developer Tools’ Web Console.
+        </p>
       </div>
       <a
         class="photon-button photon-button-micro photon-message-bar-action-button"

--- a/src/test/components/__snapshots__/ErrorBoundary.test.js.snap
+++ b/src/test/components/__snapshots__/ErrorBoundary.test.js.snap
@@ -1,6 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/ErrorBoundary matches the snapshot 1`] = `
+exports[`app/LocalizedErrorBoundary matches the snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="appErrorBoundary"
+    >
+      <div
+        class="appErrorBoundaryContents"
+      >
+        <div
+          class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content appErrorBoundaryMessage"
+        >
+          <div
+            class="photon-message-bar-inner-text"
+          >
+            Oops, there was an error
+             (Error: This is an error.)
+            .
+             
+            Please report this issue to the developers, including the full
+error as displayed in the Developer Tools’ Web Console.
+          </div>
+          <a
+            class="photon-button photon-button-micro photon-message-bar-action-button"
+            href="https://github.com/firefox-devtools/profiler/issues/new?title=An%20error%20occurred%20in%20Firefox%20Profiler"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Report the error on GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`app/NonLocalizedErrorBoundary matches the snapshot 1`] = `
 <div
   class="appErrorBoundary"
 >
@@ -14,28 +51,19 @@ exports[`app/ErrorBoundary matches the snapshot 1`] = `
         class="photon-message-bar-inner-text"
       >
         Oops, there was an error
+         (Error: This is an error.)
+        .
+         
+        Please report this error to the developers, including the full error as displayed in the Developer Tools’ Web Console.
       </div>
-      <button
-        aria-expanded="false"
+      <a
         class="photon-button photon-button-micro photon-message-bar-action-button"
-        type="button"
+        href="https://github.com/firefox-devtools/profiler/issues/new?title=An%20error%20occurred%20in%20Firefox%20Profiler"
+        rel="noreferrer"
+        target="_blank"
       >
-        View full error details
-      </button>
-    </div>
-    <div
-      class="appErrorBoundaryDetails hide"
-      data-testid="error-technical-details"
-    >
-      <div>
-        Error: This is an error.
-      </div>
-      <div>
-        
-    at ThrowingComponent (REDACTED)/src/test/components/ErrorBoundary.test.js:20:11)
-    at ErrorBoundary (REDACTED)/src/components/app/ErrorBoundary.js:28:66)
-    at LocalizationProvider (REDACTED)/node_modules/@fluent/react/index.js:(REDACTED)
-      </div>
+        Report the error on GitHub
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
… helpful message

We get too many reports with useless stacks. So now I removed the stack output and instead advise the user to look at the devtools web console. I also provided a button for an easier access to github.

I also made it localized when possible.

![image](https://user-images.githubusercontent.com/454175/225334226-10425a32-3364-46fc-a0bb-0af88fe33a81.png)

~~The localization isn't perfect, because we concatenate strings instead of providing them in their entirety. The reason is that I didn't want to spend too much time on it, and I thought that because this is an error component that the users shouldn't see much that would be good enough.~~ I think it's better now, thanks for your feedback.