### PR TITLE
Add shortenUrl and selectedNode to the console API

### DIFF
--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -15,7 +15,10 @@ export * from './cpu';
 export * from './code';
 
 import * as app from './app';
-import { selectedThreadSelectors as selectedThread } from './per-thread';
+import {
+  selectedThreadSelectors as selectedThread,
+  selectedNodeSelectors as selectedNode,
+} from './per-thread';
 import * as profile from './profile';
 import * as urlState from './url-state';
 import * as icons from './icons';
@@ -33,6 +36,7 @@ const _selectorsForConsole = {
   publish,
   zippedProfiles,
   selectedThread,
+  selectedNode,
   l10n,
   cpu,
   code,

--- a/src/test/unit/window-console.test.js
+++ b/src/test/unit/window-console.test.js
@@ -26,6 +26,7 @@ describe('console-accessible values on the window object', function () {
     expect(target.profile).toBeTruthy();
     expect(target.filteredThread).toBeTruthy();
     expect(target.callTree).toBeTruthy();
+    expect(target.shortenUrl).toBeTruthy();
   });
 
   it('logs a friendly message', function () {

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -5,7 +5,8 @@
 import { stripIndent } from 'common-tags';
 import type { GetState, Dispatch, MixedObject } from 'firefox-profiler/types';
 import { selectorsForConsole } from 'firefox-profiler/selectors';
-import actions from '../actions';
+import actions from 'firefox-profiler/actions';
+import { shortenUrl } from 'firefox-profiler/utils/shorten-url';
 
 // Despite providing a good libdef for Object.defineProperty, Flow still
 // special-cases the `value` property: if it's missing it throws an error. Using
@@ -147,6 +148,7 @@ export function addDataToWindowObject(
     `);
   };
 
+  target.shortenUrl = shortenUrl;
   target.getState = getState;
   target.selectors = selectorsForConsole;
   target.dispatch = dispatch;


### PR DESCRIPTION
Fixes #4489

Exposing `shortenUrl` is useful when writing snippets to easily share parts of a profile.
Exposing `selectedNode` was requested by Markus in #4489.

[Deploy preview](https://deploy-preview-4529--perf-html.netlify.app/public/jksf9brt7fksxy1b66q5ykrwrxs7vdb650eynj0/calltree/?globalTrackOrder=l0wk&hiddenGlobalTracks=126wh&hiddenLocalTracksByPid=1100-0w3~33180-0~34076-01~33692-0~6580-0~45328-0~30192-0~19508-0~39544-0~41396-0~40940-0~9832-0~32968-0~41520-0~13128-01~41716-013w8&thread=8&v=8)