### PR TITLE
Create a changelog for processed and gecko profile formats

### DIFF
--- a/docs-developer/CHANGELOG-formats.md
+++ b/docs-developer/CHANGELOG-formats.md
@@ -1,0 +1,79 @@
+# Processed and Gecko Profile Format Changelog
+
+This file documents all changes in the profiler gecko and processed formats.
+
+Note that this is not an exhaustive list. Processed profile format upgraders can be found in [processed-profile-versioning.js](../src/profile-logic/processed-profile-versioning.js) and gecko profile format upgraders can be found in [gecko-profile-versioning.js](../src/profile-logic/gecko-profile-versioning.js). Please refer to them for older upgraders or for exact implementations.
+
+## Processed profile format
+
+### Version 47
+
+The `pid` field of the `Thread` type is changed from `string | number` to `string`. The same happened to the `data.otherPid` field of IPC markers, and to the pid fields in the `profiler.counters` and `profile.profilerOverhead` lists.
+
+### Version 46
+
+An `isMainThread` field was added to the Thread type.
+
+This replaces the following function:
+
+```js
+export function isMainThread(thread: Thread): boolean {
+  return (
+    thread.name === 'GeckoMain' ||
+    // If the pid is a string, then it's not one that came from the system.
+    // These threads should all be treated as main threads.
+    typeof thread.pid === 'string' ||
+    // On Linux the tid of the main thread is the pid. This is useful for
+    // profiles imported from the Linux 'perf' tool.
+    String(thread.pid) === thread.tid
+  );
+}
+```
+
+### Version 45
+
+The `optimizations` field is removed from the `frameTable`.
+
+### Version 44
+
+The `searchable` property is implemented in the marker schema. Previously all the `name` and `category` marker schema properties were automatically searchable and we had manual handling for `FileIO`, `Log`, `DOMEvent`, `TraceEvent` marker types.
+
+### Version 43
+
+The `number` property in counters is now optional.
+
+### Version 42
+
+The `nativeSymbols` table now has a new column: `functionSize`. Its values can be null.
+
+### Version 41
+
+The `libs` list has moved from `Thread` to `Profile` - it is now shared between all threads in the profile. And it only contains libs which are used by at least one resource.
+
+The Lib fields have changed, too:
+
+- The `start`/`end`/`offset` fields are gone: They are not needed after profile processing, when all frame addresses have been made library-relative; and these values usually differ in the different processes, so the fields could not have a meaningful value in the shared list.
+- There is a `codeId` field which defaults to `null`. This will be used in the future to store another ID which lets the symbol server look up correct binary. On Windows this is the dll / exe CodeId, and on Linux and Android this is the full ELF build ID.
+
+We've also cleaned up the ResourceTable format:
+
+- All resources now have names.
+- Resources without a `host` or `lib` field have these fields set to `null` consistently.
+
+### Older Versions
+
+Older versions are not documented in this changelog but can be found in [processed-profile-versioning.js](../src/profile-logic/processed-profile-versioning.js).
+
+## Gecko profile format
+
+### Version 27
+
+The `optimizations` field is removed from the `frameTable` schema.
+
+### Version 26
+
+The `searchable` property is implemented in the marker schema. Previously all the `name` and `category` marker schema properties were automatically searchable and we had manual handling for `FileIO`, `Log`, `DOMEvent`, `TraceEvent` marker types.
+
+### Older Versions
+
+Older versions are not documented in this changelog but can be found in [gecko-profile-versioning.js](../src/profile-logic/gecko-profile-versioning.js).

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -7,9 +7,13 @@
 import type { MarkerPhase } from 'firefox-profiler/types';
 
 // The current version of the Gecko profile format.
+// Please don't forget to update the gecko profile format changelog in
+// `docs-developer/CHANGELOG-formats.md`.
 export const GECKO_PROFILE_VERSION = 27;
 
 // The current version of the "processed" profile format.
+// Please don't forget to update the processed profile format changelog in
+// `docs-developer/CHANGELOG-formats.md`.
 export const PROCESSED_PROFILE_VERSION = 47;
 
 // The following are the margin sizes for the left and right of the timeline. Independent

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -9,6 +9,9 @@
  * run profiler.firefox.com on non-Nightly versions of Firefox, and we want
  * to be able to load old saved profiles, so this file upgrades old profiles
  * to the current format.
+ *
+ * Please don't forget to update the gecko profile format changelog in
+ * `docs-developer/CHANGELOG-formats.md`.
  */
 
 import { UniqueStringArray } from '../utils/unique-string-array';
@@ -1442,5 +1445,7 @@ const _upgraders = {
     }
     convertToVersion27Recursive(profile);
   },
+  // If you add a new upgrader here, please document the change in
+  // `docs-developer/CHANGELOG-formats.md`.
 };
 /* eslint-enable no-useless-computed-key */

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -10,6 +10,9 @@
  * want to be able to display profiles that were saved at any point in the
  * past, regardless of their version. So this file upgrades old profiles to
  * the current format.
+ *
+ * Please don't forget to update the processed profile format changelog in
+ * `docs-developer/CHANGELOG-formats.md`.
  */
 
 import { sortDataTable } from '../utils/data-table-utils';
@@ -2251,5 +2254,7 @@ const _upgraders = {
       }
     }
   },
+  // If you add a new upgrader here, please document the change in
+  // `docs-developer/CHANGELOG-formats.md`.
 };
 /* eslint-enable no-useless-computed-key */


### PR DESCRIPTION
This was requested by some of our external users who implement their own importers or their own fork before. I believe this will help them.

I only implemented the versions that were implemented in the past year. I didn't want to write all of them, instead linked to the versioning files for more information about them.

Let me know what you think!

[Here's a preview of this file](https://github.com/canova/perf.html/blob/profile-changelog/docs-developer/CHANGELOG.md)