### PR TITLE
Revert the removal of the "optimizations" property in importers for linux perf and ART

### DIFF
--- a/src/profile-logic/import/art-trace.js
+++ b/src/profile-logic/import/art-trace.js
@@ -759,8 +759,9 @@ class ThreadBuilder {
     schema: {
       location: 0,
       implementation: 1,
-      line: 2,
-      category: 3,
+      optimizations: 2,
+      line: 3,
+      category: 4,
     },
     data: [],
   };
@@ -832,7 +833,7 @@ class ThreadBuilder {
       this._stringTable.push(methodString);
       const category = this._categoryInfo.inferJavaCategory(methodString);
       frame = this._frameTable.data.length;
-      this._frameTable.data.push([stringIndex, null, null, category]);
+      this._frameTable.data.push([stringIndex, null, null, null, category]);
       this._frameMap.set(methodId, frame);
     }
     return frame;

--- a/src/profile-logic/import/linux-perf.js
+++ b/src/profile-logic/import/linux-perf.js
@@ -101,10 +101,11 @@ export function convertPerfScriptProfile(
         relevantForJS: 1,
         innerWindowID: 2,
         implementation: 3,
-        line: 4,
-        column: 5,
-        category: 6,
-        subcategory: 7,
+        optimizations: 4,
+        line: 5,
+        column: 6,
+        category: 7,
+        subcategory: 8,
       },
       data: [],
     };
@@ -152,6 +153,7 @@ export function convertPerfScriptProfile(
             ? KERNEL_CATEGORY_INDEX
             : USER_CATEGORY_INDEX;
         const implementation = null;
+        const optimizations = null;
         const line = null;
         const relevantForJS = false;
         const subcategory = null;
@@ -162,6 +164,7 @@ export function convertPerfScriptProfile(
           relevantForJS,
           innerWindowID,
           implementation,
+          optimizations,
           line,
           column,
           category,


### PR DESCRIPTION
This was done in #4432, but because these importers target a specific version of the gecko profile format, we shouldn't change their structure without upgrading the format too.

Fixes #4547

This is also extremely visible on the traces from our fixtures library, just looking at the category graph.
For example with the file `art-trace-regular.trace.gz`:
Import with the production code: https://share.firefox.dev/3FTHP9T
Import with this deploy preview: https://share.firefox.dev/3lHuBq7

I considered trying to detect broken uploaded profiles and upgrade them, but not sure this is worth it because the regression is fairly recent. I would love to get your feedback on this @Karn.