### PR TITLE
When launching a file automatically, provides the file name to the UR…

### DIFF
--- a/server.js
+++ b/server.js
@@ -110,7 +110,9 @@ if (argv.profile) {
   // Open on profile.
   profileServer.listen(0, host, () => {
     const profileFromUrl = `${profilerUrl}/from-url/${encodeURIComponent(
-      `http://${host}:${profileServer.address().port}/`
+      `http://${host}:${profileServer.address().port}/${encodeURIComponent(
+        path.basename(argv.profile)
+      )}`
     )}`;
     open(profileFromUrl, openOptions);
   });


### PR DESCRIPTION
…L so that the content-type guesser works for zip files

This was recently added in #4452. But when I wanted to try it with a local zip file, this didn't work as expected because the simple HTTP server doesn't send any content-type, and we weren't using the file name. Therefore the logic couldn't find that this was really a zip file (because we don't sniff the content).

By providing the file name in the requested URL, this now works as expected. You can try it locally by running `launch-fp.sh file.zip` (`launch-fp.sh` is in our `bin` directory).