### PR TITLE
server.js: Dynamically import `open`

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,6 @@ const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
-const open = require('open');
 const localConfigExists = fs.existsSync(
   path.join(__dirname, './webpack.local-config.js')
 );
@@ -114,7 +113,7 @@ if (argv.profile) {
         path.basename(argv.profile)
       )}`
     )}`;
-    open(profileFromUrl, openOptions);
+    import('open').then((open) => open.default(profileFromUrl, openOptions));
   });
 }
 


### PR DESCRIPTION
This pr fixes the problem shown in https://github.com/firefox-devtools/profiler/pull/4561#issuecomment-1498394282 i.e. [`open`](https://www.npmjs.com/package/open) v9 supports only ESM loading, by using [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import).