### PR TITLE
Rename "collapse indirect recursion".

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -105,14 +105,14 @@ CallNodeContextMenu--transform-collapse-resource =
     .title =
         Collapsing a resource will flatten out all the calls to that
         resource into a single collapsed call node.
-CallNodeContextMenu--transform-collapse-direct-recursion2 = Collapse direct recursion
+CallNodeContextMenu--transform-collapse-recursion = Collapse recursion
+    .title =
+        Collapsing recursion removes calls that repeatedly recurse into
+        the same function, even with intermediate functions on the stack.
+CallNodeContextMenu--transform-collapse-direct-recursion-only = Collapse direct recursion only
     .title =
         Collapsing direct recursion removes calls that repeatedly recurse into
         the same function with no intermediate functions on the stack.
-CallNodeContextMenu--transform-collapse-indirect-recursion = Collapse indirect recursion
-    .title =
-        Collapsing indirect recursion removes calls that repeatedly recurse into
-        the same function, even with intermediate functions on the stack.
 CallNodeContextMenu--transform-drop-function = Drop samples with this function
     .title =
         Dropping samples removes their time from the profile. This is useful to
@@ -925,17 +925,17 @@ TransformNavigator--merge-function = Merge: { $item }
 #   $item (String) - Name of the function that transform applied to.
 TransformNavigator--drop-function = Drop: { $item }
 
+# "Collapse recursion" transform.
+# See: https://profiler.firefox.com/docs/#/./guide-filtering-call-trees?id=collapse
+# Variables:
+#   $item (String) - Name of the function that transform applied to.
+TransformNavigator--collapse-recursion = Collapse recursion: { $item }
+
 # "Collapse direct recursion" transform.
 # See: https://profiler.firefox.com/docs/#/./guide-filtering-call-trees?id=collapse
 # Variables:
 #   $item (String) - Name of the function that transform applied to.
-TransformNavigator--collapse-direct-recursion2 = Collapse direct recursion: { $item }
-
-# "Collapse indirect recursion" transform.
-# See: https://profiler.firefox.com/docs/#/./guide-filtering-call-trees?id=collapse
-# Variables:
-#   $item (String) - Name of the function that transform applied to.
-TransformNavigator--collapse-indirect-recursion = Collapse indirect recursion: { $item }
+TransformNavigator--collapse-direct-recursion-only = Collapse direct recursion only: { $item }
 
 # "Collapse function subtree" transform.
 # See: https://profiler.firefox.com/docs/#/./guide-filtering-call-trees?id=collapse

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -79,7 +79,7 @@ import type {
 } from 'firefox-profiler/types';
 import {
   funcHasDirectRecursiveCall,
-  funcHasIndirectRecursiveCall,
+  funcHasRecursiveCall,
 } from '../profile-logic/transforms';
 import { changeStoredProfileNameInDb } from 'firefox-profiler/app-logic/uploaded-profiles-db';
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -2070,6 +2070,17 @@ export function handleCallNodeTransformShortcut(
         break;
       }
       case 'r': {
+        if (funcHasRecursiveCall(unfilteredThread, funcIndex)) {
+          dispatch(
+            addTransformToStack(threadsKey, {
+              type: 'collapse-recursion',
+              funcIndex,
+            })
+          );
+        }
+        break;
+      }
+      case 'R': {
         if (
           funcHasDirectRecursiveCall(
             unfilteredThread,
@@ -2080,24 +2091,6 @@ export function handleCallNodeTransformShortcut(
           dispatch(
             addTransformToStack(threadsKey, {
               type: 'collapse-direct-recursion',
-              funcIndex,
-              implementation,
-            })
-          );
-        }
-        break;
-      }
-      case 'R': {
-        if (
-          funcHasIndirectRecursiveCall(
-            unfilteredThread,
-            implementation,
-            funcIndex
-          )
-        ) {
-          dispatch(
-            addTransformToStack(threadsKey, {
-              type: 'collapse-indirect-recursion',
               funcIndex,
               implementation,
             })

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -87,12 +87,12 @@ describe('calltree/CallNodeContextMenu', function () {
       { matcher: /Collapse function/, type: 'collapse-function-subtree' },
       { matcher: /XUL/, type: 'collapse-resource' },
       {
-        matcher: /Collapse direct recursion/,
-        type: 'collapse-direct-recursion',
+        matcher: /Collapse recursion/,
+        type: 'collapse-recursion',
       },
       {
-        matcher: /Collapse indirect recursion/,
-        type: 'collapse-indirect-recursion',
+        matcher: /Collapse direct recursion/,
+        type: 'collapse-direct-recursion',
       },
       { matcher: /Drop samples/, type: 'drop-function' },
     ];

--- a/src/test/components/TransformShortcuts.test.js
+++ b/src/test/components/TransformShortcuts.test.js
@@ -105,20 +105,20 @@ function testTransformKeyboardShortcuts(setup: () => TestSetup) {
     });
   });
 
-  it('handles collapse direct recursion', () => {
+  it('handles collapse recursion', () => {
     const { pressKey, getTransform, expectedFuncIndex } = setup();
     pressKey({ key: 'r' });
     expect(getTransform()).toMatchObject({
-      type: 'collapse-direct-recursion',
+      type: 'collapse-recursion',
       funcIndex: expectedFuncIndex,
     });
   });
 
-  it('handles collapse indirect recursion', () => {
+  it('handles collapse direct recursion', () => {
     const { pressKey, getTransform, expectedFuncIndex } = setup();
     pressKey({ key: 'R' });
     expect(getTransform()).toMatchObject({
-      type: 'collapse-indirect-recursion',
+      type: 'collapse-direct-recursion',
       funcIndex: expectedFuncIndex,
     });
   });

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.js.snap
@@ -171,9 +171,9 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     />
     <div
       class="react-contextmenu-item-content"
-      title="Collapsing direct recursion removes calls that repeatedly recurse into the same function with no intermediate functions on the stack."
+      title="Collapsing recursion removes calls that repeatedly recurse into the same function, even with intermediate functions on the stack."
     >
-      Collapse direct recursion
+      Collapse recursion
     </div>
     <kbd
       class="callNodeContextMenuShortcut"
@@ -192,9 +192,9 @@ exports[`calltree/CallNodeContextMenu basic rendering renders a full context men
     />
     <div
       class="react-contextmenu-item-content"
-      title="Collapsing indirect recursion removes calls that repeatedly recurse into the same function, even with intermediate functions on the stack."
+      title="Collapsing direct recursion removes calls that repeatedly recurse into the same function with no intermediate functions on the stack."
     >
-      Collapse indirect recursion
+      Collapse direct recursion only
     </div>
     <kbd
       class="callNodeContextMenuShortcut"

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1317,11 +1317,11 @@ describe('"collapse-direct-recursion" transform', function () {
   });
 });
 
-describe('"collapse-indirect-recursion" transform', function () {
-  describe('direct combined implementation', function () {
+describe('"collapse-recursion" transform', function () {
+  describe('basic', function () {
     // Same test case as collapse-direct-recursion combined implementation.
     /**
-     *              A    Collapse indirect recursion   A
+     *              A        Collapse recursion        A
      *            ↙   ↘            Func B            ↙   ↘
      *          B       F            ->             B     F
      *        ↙   ↘                              ↙  ↓  ↘
@@ -1343,10 +1343,9 @@ describe('"collapse-indirect-recursion" transform', function () {
     `);
     const B = funcNames.indexOf('B');
     const threadIndex = 0;
-    const collapseIndirectRecursion = {
-      type: 'collapse-indirect-recursion',
+    const collapseRecursion = {
+      type: 'collapse-recursion',
       funcIndex: B,
-      implementation: 'combined',
     };
 
     it('starts as an unfiltered call tree', function () {
@@ -1367,7 +1366,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('can collapse the B function', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
@@ -1382,7 +1381,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('keeps the line number and address of the innermost frame', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       const filteredThread = selectedThreadSelectors.getFilteredThread(
         getState()
       );
@@ -1424,17 +1423,17 @@ describe('"collapse-indirect-recursion" transform', function () {
           ['A', 'B', 'B', 'B', 'C'].map((name) => funcNames.indexOf(name))
         )
       );
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         selectedThreadSelectors.getSelectedCallNodePath(getState())
       ).toEqual(['A', 'B', 'C'].map((name) => funcNames.indexOf(name)));
     });
   });
 
-  describe('small indirect combined implementation', function () {
+  describe('advanced', function () {
     // Like direct combined implementation, but with one indirect recursive call.
     /**
-     *              A    Collapse indirect recursion   A
+     *              A        Collapse recursion        A
      *            ↙   ↘            Func B            ↙   ↘
      *          B       G            ->             B     G
      *        ↙   ↘                              ↙  ↓  ↘
@@ -1456,10 +1455,9 @@ describe('"collapse-indirect-recursion" transform', function () {
     `);
     const B = funcNames.indexOf('B');
     const threadIndex = 0;
-    const collapseIndirectRecursion = {
-      type: 'collapse-indirect-recursion',
+    const collapseRecursion = {
+      type: 'collapse-recursion',
       funcIndex: B,
-      implementation: 'combined',
     };
 
     it('starts as an unfiltered call tree', function () {
@@ -1480,7 +1478,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('can collapse the B function', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
@@ -1496,7 +1494,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('keeps the line number and address of the innermost frame', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       const filteredThread = selectedThreadSelectors.getFilteredThread(
         getState()
       );
@@ -1538,18 +1536,18 @@ describe('"collapse-indirect-recursion" transform', function () {
           ['A', 'B', 'C', 'B', 'D'].map((name) => funcNames.indexOf(name))
         )
       );
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         selectedThreadSelectors.getSelectedCallNodePath(getState())
       ).toEqual(['A', 'B', 'D'].map((name) => funcNames.indexOf(name)));
     });
   });
 
-  describe('big indirect combined implementation', function () {
-    // Extension of small indirect combined implementation with
+  describe('super advanced', function () {
+    // Extension of "advanced" with
     // multiple indirect calls, multiple intermediate functions and direct calls.
     /**
-     *                    A    Collapse indirect recursion      A
+     *                    A        Collapse recursion           A
      *                  ↙   ↘            Func B              ↙    ↘
      *                B       K            ->             B         K
      *              ↙   ↘                            ↙  ↙   ↘  ↘
@@ -1583,10 +1581,9 @@ describe('"collapse-indirect-recursion" transform', function () {
     `);
     const B = funcNames.indexOf('B');
     const threadIndex = 0;
-    const collapseIndirectRecursion = {
-      type: 'collapse-indirect-recursion',
+    const collapseRecursion = {
+      type: 'collapse-recursion',
       funcIndex: B,
-      implementation: 'combined',
     };
 
     it('starts as an unfiltered call tree', function () {
@@ -1613,7 +1610,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('can collapse the B function', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
@@ -1633,7 +1630,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('keeps the line number and address of the innermost frame', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       const filteredThread = selectedThreadSelectors.getFilteredThread(
         getState()
       );
@@ -1678,17 +1675,17 @@ describe('"collapse-indirect-recursion" transform', function () {
           )
         )
       );
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         selectedThreadSelectors.getSelectedCallNodePath(getState())
       ).toEqual(['A', 'B', 'F'].map((name) => funcNames.indexOf(name)));
     });
   });
 
-  describe('direct filtered implementation', function () {
+  describe('incredibly advanced', function () {
     // Same test case as collapse-direct-recursion filtered implementation.
     /**
-     *                   A.js      Collapse indirect recursion      A.js
+     *                   A.js          Collapse recursion           A.js
      *                 ↙     ↘             Func B.js              ↙     ↘
      *               B.js     G.js            ->               B.js      G.js
      *             ↙    ↘                                    ↙   ↓   ↘
@@ -1716,10 +1713,9 @@ describe('"collapse-indirect-recursion" transform', function () {
     // a recursion collapse.
     const B = funcNames.indexOf('B.js');
     const threadIndex = 0;
-    const collapseIndirectRecursion = {
-      type: 'collapse-indirect-recursion',
+    const collapseRecursion = {
+      type: 'collapse-recursion',
       funcIndex: B,
-      implementation: 'js',
     };
 
     it('starts as an unfiltered call tree', function () {
@@ -1741,7 +1737,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('can collapse the B function', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
@@ -1756,10 +1752,10 @@ describe('"collapse-indirect-recursion" transform', function () {
     });
   });
 
-  describe('indirect filtered implementation', function () {
+  describe('unbelievably advanced', function () {
     // Like direct filtered implementation, but with one indirect recursive call.
     /**
-     *                   A.js      Collapse indirect recursion      A.js
+     *                   A.js          Collapse recursion           A.js
      *                 ↙     ↘             Func B.js              ↙     ↘
      *               B.js     H.js            ->               B.js      H.js
      *             ↙    ↘                                    ↙   ↓   ↘
@@ -1787,10 +1783,9 @@ describe('"collapse-indirect-recursion" transform', function () {
     // a recursion collapse.
     const B = funcNames.indexOf('B.js');
     const threadIndex = 0;
-    const collapseIndirectRecursion = {
-      type: 'collapse-indirect-recursion',
+    const collapseRecursion = {
+      type: 'collapse-recursion',
       funcIndex: B,
-      implementation: 'js',
     };
 
     it('starts as an unfiltered call tree', function () {
@@ -1812,7 +1807,7 @@ describe('"collapse-indirect-recursion" transform', function () {
 
     it('can collapse the B function', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseIndirectRecursion));
+      dispatch(addTransformToStack(threadIndex, collapseRecursion));
       expect(
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -45,7 +45,7 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import {
   funcHasDirectRecursiveCall,
-  funcHasIndirectRecursiveCall,
+  funcHasRecursiveCall,
 } from '../../profile-logic/transforms';
 
 import type { Thread, IndexIntoStackTable } from 'firefox-profiler/types';
@@ -818,8 +818,8 @@ describe('funcHasDirectRecursiveCall', function () {
   });
 });
 
-describe('funcHasIndirectRecursiveCall', function () {
-  it('correctly identifies directly recursive functions based taking into account implementation', function () {
+describe('funcHasRecursiveCall', function () {
+  it('correctly identifies directly recursive functions', function () {
     // Same test case as funcHasDirectRecursiveCall
     const {
       profile,
@@ -834,21 +834,13 @@ describe('funcHasIndirectRecursiveCall', function () {
     const [thread] = profile.threads;
 
     expect([
-      funcHasIndirectRecursiveCall(
-        thread,
-        'combined',
-        funcNames.indexOf('A.js')
-      ),
-      funcHasIndirectRecursiveCall(
-        thread,
-        'combined',
-        funcNames.indexOf('B.js')
-      ),
-      funcHasIndirectRecursiveCall(thread, 'js', funcNames.indexOf('B.js')),
+      funcHasRecursiveCall(thread, funcNames.indexOf('A.js')),
+      funcHasRecursiveCall(thread, funcNames.indexOf('B.js')),
+      funcHasRecursiveCall(thread, funcNames.indexOf('B.js')),
     ]).toEqual([false, true, true]);
   });
 
-  it('correctly identifies indirectly recursive functions based taking into account implementation', function () {
+  it('correctly identifies indirectly recursive functions', function () {
     const {
       profile,
       funcNamesPerThread: [funcNames],
@@ -863,12 +855,8 @@ describe('funcHasIndirectRecursiveCall', function () {
     const [thread] = profile.threads;
 
     expect([
-      funcHasIndirectRecursiveCall(
-        thread,
-        'combined',
-        funcNames.indexOf('B.js')
-      ),
-      funcHasIndirectRecursiveCall(thread, 'js', funcNames.indexOf('B.js')),
+      funcHasRecursiveCall(thread, funcNames.indexOf('B.js')),
+      funcHasRecursiveCall(thread, funcNames.indexOf('B.js')),
     ]).toEqual([true, true]);
   });
 });

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -1431,7 +1431,7 @@ describe('url upgrading', function () {
 describe('URL serialization of the transform stack', function () {
   const transformString =
     'f-combined-0w2~mcn-combined-2w4~f-js-3w5-i~mf-6~ff-7~fg-42~cr-combined-8-9~' +
-    'rec-combined-10~irec-combined-11~df-12~cfs-13';
+    'drec-combined-10~rec-11~df-12~cfs-13';
   const { getState } = _getStoreWithURL({
     search: '?transforms=' + transformString,
   });
@@ -1484,9 +1484,8 @@ describe('URL serialization of the transform stack', function () {
         implementation: 'combined',
       },
       {
-        type: 'collapse-indirect-recursion',
+        type: 'collapse-recursion',
         funcIndex: 11,
-        implementation: 'combined',
       },
       {
         type: 'drop-function',

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -262,11 +262,11 @@ export type TransformDefinitions = {
   |},
 
   /**
-   * Collapse indirect recursion takes a function that calls itself recursively and collapses
-   * it into a single stack.
+   * Collapse recursion takes a function that calls itself recursively (directly
+   * or indirectly) and collapses it into a single stack.
    *
    *      A                                 A
-   *      ↓   Collapse indirect recursion   ↓
+   *      ↓       Collapse recursion        ↓
    *      B          function B             B
    *      ↓              ->                 ↓
    *      C                                 D
@@ -277,10 +277,9 @@ export type TransformDefinitions = {
    *      ↓
    *      D
    */
-  'collapse-indirect-recursion': {|
-    +type: 'collapse-indirect-recursion',
+  'collapse-recursion': {|
+    +type: 'collapse-recursion',
     +funcIndex: IndexIntoFuncTable,
-    +implementation: ImplementationFilter,
   |},
 
   /**

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -90,7 +90,7 @@ export function convertToTransformType(type: string): TransformType | null {
     case 'focus-category':
     case 'collapse-resource':
     case 'collapse-direct-recursion':
-    case 'collapse-indirect-recursion':
+    case 'collapse-recursion':
     case 'collapse-function-subtree':
     case 'drop-function':
       return coercedType;


### PR DESCRIPTION
The "collapse indirect recursion" transform collapses both direct and indirect recursion. It is a good default recursion collapsing transform. The "collapse direct recursion" transform is less useful and will be demoted to a secondary choice.

This commit renames things as follows:

"Collapse indirect recursion" -> "Collapse recursion"
"Collapse direct recursion" -> "Collapse direct recursion only"

We also swap the order in the context menu, and we swap the r and R shortcut keys.

This commit also removes the unused "implementation" field from the transform struct, and adjusts the URL encoding, bumping the URL version. This is all in the same commit because the new URL encoding takes both the new name and the removal of the implementation field into account.

You will see some comments in the V3 -> V4 URL upgrader. I'm unsure what to do about them. I think we have three options for what to do with the V4 upgrader:

 - Accept the new breakage in a few cases, by leaving it largely as is.
 - Don't accept any new breakage by making it so that it correctly parses V3 URLs and stringifies V4 URLs. This requires copy-pasting the V3 transform parsing code.
 - Break it entirely by removing most of the V4 upgrader. I'm not sure how many V3 URLs with focus-subtree transforms there are in circulation.