### PR TITLE
Add the stack implementation radio buttons to the marker chart and marker table panels, and other small changes

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -713,6 +713,9 @@ StackSettings--implementation-javascript2 = JavaScript
 StackSettings--implementation-native2 = Native
     .title = Show only the stack frames for native code
 
+# This label is displayed in the marker chart and marker table panels only.
+StackSettings--stack-implementation-label = Filter stacks:
+
 StackSettings--use-data-source-label = Data source:
 StackSettings--call-tree-strategy-timing = Timings
     .title = Summarize using sampled stacks of executed code over time

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -706,9 +706,12 @@ ServiceWorkerManager--hide-notice-button =
 ## This is the settings component that is used in Call Tree, Flame Graph and Stack
 ## Chart panels. It's used to switch between different views of the stack.
 
-StackSettings--implementation-all-stacks = All stacks
-StackSettings--implementation-javascript = JavaScript
-StackSettings--implementation-native = Native
+StackSettings--implementation-all-frames = All frames
+    .title = Do not filter the stack frames
+StackSettings--implementation-javascript2 = JavaScript
+    .title = Show only the stack frames related to JavaScript execution
+StackSettings--implementation-native2 = Native
+    .title = Show only the stack frames for native code
 
 StackSettings--use-data-source-label = Data source:
 StackSettings--call-tree-strategy-timing = Timings

--- a/res/css/photon/label.css
+++ b/res/css/photon/label.css
@@ -18,3 +18,7 @@
 .photon-label-micro {
   font-size: 11px;
 }
+
+.photon-label-horiz-padding {
+  padding: 0 3px;
+}

--- a/src/components/shared/MarkerSettings.css
+++ b/src/components/shared/MarkerSettings.css
@@ -9,7 +9,3 @@
   padding: 0;
   line-height: 25px;
 }
-
-.markerSettingsSpacer {
-  flex: 1;
-}

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -11,9 +11,11 @@ import explicitConnect from 'firefox-profiler/utils/connect';
 import { changeMarkersSearchString } from 'firefox-profiler/actions/profile-view';
 import { getMarkersSearchString } from 'firefox-profiler/selectors/url-state';
 import { PanelSearch } from './PanelSearch';
+import { StackImplementationSetting } from 'firefox-profiler/components/shared/StackImplementationSetting';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
+import 'firefox-profiler/components/shared/PanelSettingsList.css';
 import './MarkerSettings.css';
 
 type StateProps = {|
@@ -35,7 +37,9 @@ class MarkerSettingsImpl extends PureComponent<Props> {
     const { searchString } = this.props;
     return (
       <div className="markerSettings">
-        <div className="markerSettingsSpacer" />
+        <ul className="panelSettingsList">
+          <StackImplementationSetting />
+        </ul>
         <Localized
           id="MarkerSettings--panel-search"
           attrs={{ label: true, title: true }}

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -38,7 +38,7 @@ class MarkerSettingsImpl extends PureComponent<Props> {
     return (
       <div className="markerSettings">
         <ul className="panelSettingsList">
-          <StackImplementationSetting />
+          <StackImplementationSetting labelL10nId="StackSettings--stack-implementation-label" />
         </ul>
         <Localized
           id="MarkerSettings--panel-search"

--- a/src/components/shared/PanelSearch.css
+++ b/src/components/shared/PanelSearch.css
@@ -2,13 +2,15 @@
   /* so that the introduction is on top of other panels, _but_ still keep it
    * below the input field (see below) */
   z-index: 1;
-  padding: 0 5px;
+  padding: 0 4px;
 }
 
 .panelSearchFieldLabel {
   /* We fix the height so that the panelSearchFieldIntroduction doesn't increase it */
-  display: block;
+  display: inline-flex;
   height: 100%;
+  align-items: center;
+  gap: 4px;
 }
 
 .panelSearchFieldInput {
@@ -17,7 +19,7 @@
 
 .panelSearchFieldIntroduction {
   z-index: -1; /* it needs to be below the input field */
-  padding: 0 5px;
+  padding: 0 4px;
   background-color: white;
   box-shadow: 0 1px 4px rgb(12 12 13 / 0.1); /* This is grey-90 with 10% opacity, according to the photon design document */
   color: var(--grey-50);

--- a/src/components/shared/PanelSearch.js
+++ b/src/components/shared/PanelSearch.js
@@ -54,18 +54,18 @@ export class PanelSearch extends React.PureComponent<Props, State> {
             onBlur={this._onSearchFieldBlur}
             onFocus={this._onSearchFieldFocus}
           />
-          <div
-            className={classNames('panelSearchFieldIntroduction', {
-              isHidden: !showIntroduction,
-              isDisplayed: showIntroduction,
-            })}
-          >
-            <Localized id="PanelSearch--search-field-hint">
-              Did you know you can use the comma (,) to search using several
-              terms?
-            </Localized>
-          </div>
         </label>
+        <div
+          className={classNames('panelSearchFieldIntroduction', {
+            isHidden: !showIntroduction,
+            isDisplayed: showIntroduction,
+          })}
+        >
+          <Localized id="PanelSearch--search-field-hint">
+            Did you know you can use the comma (,) to search using several
+            terms?
+          </Localized>
+        </div>
       </div>
     );
   }

--- a/src/components/shared/PanelSettingsList.css
+++ b/src/components/shared/PanelSettingsList.css
@@ -13,6 +13,7 @@
 
 .panelSettingsListItem {
   display: inline-flex;
+  align-items: center;
   padding: 0;
   margin: 0 5px;
 }

--- a/src/components/shared/PanelSettingsList.css
+++ b/src/components/shared/PanelSettingsList.css
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.panelSettingsList {
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.panelSettingsListItem {
+  display: inline-flex;
+  padding: 0;
+  margin: 0 5px;
+}
+
+.panelSettingsListItem:not(:first-child) {
+  padding-left: 10px;
+  border-left: 1px solid var(--grey-20);
+}

--- a/src/components/shared/StackImplementationSetting.js
+++ b/src/components/shared/StackImplementationSetting.js
@@ -21,7 +21,9 @@ import './PanelSettingsList.css';
 
 import type { ImplementationFilter } from 'firefox-profiler/types';
 
-type OwnProps = {||};
+type OwnProps = {|
+  labelL10nId?: string,
+|};
 
 type StateProps = {|
   +implementationFilter: ImplementationFilter,
@@ -71,10 +73,11 @@ class StackImplementationSettingImpl extends PureComponent<Props> {
   }
 
   render() {
-    const { allowSwitchingStackType } = this.props;
+    const { allowSwitchingStackType, labelL10nId } = this.props;
 
     return allowSwitchingStackType ? (
       <li className="panelSettingsListItem">
+        {labelL10nId ? <Localized id={labelL10nId} /> : null}
         {this._renderImplementationRadioButton(
           'StackSettings--implementation-all-frames',
           'combined'

--- a/src/components/shared/StackImplementationSetting.js
+++ b/src/components/shared/StackImplementationSetting.js
@@ -47,19 +47,26 @@ class StackImplementationSettingImpl extends PureComponent<Props> {
     labelL10nId: string,
     implementationFilter: ImplementationFilter
   ) {
+    const htmlId = `implementation-radio-${implementationFilter}`;
     return (
-      <label className="photon-label photon-label-micro photon-label-horiz-padding">
-        <input
-          type="radio"
-          className="photon-radio photon-radio-micro"
-          value={implementationFilter}
-          name="stack-settings-filter"
-          title="Filter stack frames to a type."
-          onChange={this._onImplementationFilterChange}
-          checked={this.props.implementationFilter === implementationFilter}
-        />
-        <Localized id={labelL10nId}></Localized>
-      </label>
+      <>
+        <Localized id={labelL10nId} attrs={{ title: true }}>
+          <input
+            type="radio"
+            className="photon-radio photon-radio-micro"
+            value={implementationFilter}
+            id={htmlId}
+            onChange={this._onImplementationFilterChange}
+            checked={this.props.implementationFilter === implementationFilter}
+          />
+        </Localized>
+        <Localized id={labelL10nId} attrs={{ title: true }}>
+          <label
+            className="photon-label photon-label-micro photon-label-horiz-padding"
+            htmlFor={htmlId}
+          ></label>
+        </Localized>
+      </>
     );
   }
 
@@ -69,15 +76,15 @@ class StackImplementationSettingImpl extends PureComponent<Props> {
     return allowSwitchingStackType ? (
       <li className="panelSettingsListItem">
         {this._renderImplementationRadioButton(
-          'StackSettings--implementation-all-stacks',
+          'StackSettings--implementation-all-frames',
           'combined'
         )}
         {this._renderImplementationRadioButton(
-          'StackSettings--implementation-javascript',
+          'StackSettings--implementation-javascript2',
           'js'
         )}
         {this._renderImplementationRadioButton(
-          'StackSettings--implementation-native',
+          'StackSettings--implementation-native2',
           'cpp'
         )}
       </li>

--- a/src/components/shared/StackImplementationSetting.js
+++ b/src/components/shared/StackImplementationSetting.js
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import { Localized } from '@fluent/react';
+
+import { changeImplementationFilter } from 'firefox-profiler/actions/profile-view';
+import { getImplementationFilter } from 'firefox-profiler/selectors/url-state';
+
+import { toValidImplementationFilter } from 'firefox-profiler/profile-logic/profile-data';
+import explicitConnect, {
+  type ConnectedProps,
+} from 'firefox-profiler/utils/connect';
+
+import { getProfileUsesMultipleStackTypes } from 'firefox-profiler/selectors/profile';
+
+import './StackSettings.css';
+
+import type { ImplementationFilter } from 'firefox-profiler/types';
+
+type OwnProps = {||};
+
+type StateProps = {|
+  +implementationFilter: ImplementationFilter,
+  +allowSwitchingStackType: boolean,
+|};
+
+type DispatchProps = {|
+  +changeImplementationFilter: typeof changeImplementationFilter,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+class StackImplementationSettingImpl extends PureComponent<Props> {
+  _onImplementationFilterChange = (e: SyntheticEvent<HTMLInputElement>) => {
+    this.props.changeImplementationFilter(
+      // This function is here to satisfy Flow that we are getting a valid
+      // implementation filter.
+      toValidImplementationFilter(e.currentTarget.value)
+    );
+  };
+
+  _renderImplementationRadioButton(
+    labelL10nId: string,
+    implementationFilter: ImplementationFilter
+  ) {
+    return (
+      <label className="photon-label photon-label-micro stackSettingsFilterLabel">
+        <input
+          type="radio"
+          className="photon-radio photon-radio-micro"
+          value={implementationFilter}
+          name="stack-settings-filter"
+          title="Filter stack frames to a type."
+          onChange={this._onImplementationFilterChange}
+          checked={this.props.implementationFilter === implementationFilter}
+        />
+        <Localized id={labelL10nId}></Localized>
+      </label>
+    );
+  }
+
+  render() {
+    const { allowSwitchingStackType } = this.props;
+
+    return allowSwitchingStackType ? (
+      <li className="stackSettingsListItem stackSettingsFilter">
+        {this._renderImplementationRadioButton(
+          'StackSettings--implementation-all-stacks',
+          'combined'
+        )}
+        {this._renderImplementationRadioButton(
+          'StackSettings--implementation-javascript',
+          'js'
+        )}
+        {this._renderImplementationRadioButton(
+          'StackSettings--implementation-native',
+          'cpp'
+        )}
+      </li>
+    ) : null;
+  }
+}
+
+export const StackImplementationSetting = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state) => ({
+    implementationFilter: getImplementationFilter(state),
+    allowSwitchingStackType: getProfileUsesMultipleStackTypes(state),
+  }),
+  mapDispatchToProps: {
+    changeImplementationFilter,
+  },
+  component: StackImplementationSettingImpl,
+});

--- a/src/components/shared/StackImplementationSetting.js
+++ b/src/components/shared/StackImplementationSetting.js
@@ -17,7 +17,7 @@ import explicitConnect, {
 
 import { getProfileUsesMultipleStackTypes } from 'firefox-profiler/selectors/profile';
 
-import './StackSettings.css';
+import './PanelSettingsList.css';
 
 import type { ImplementationFilter } from 'firefox-profiler/types';
 
@@ -48,7 +48,7 @@ class StackImplementationSettingImpl extends PureComponent<Props> {
     implementationFilter: ImplementationFilter
   ) {
     return (
-      <label className="photon-label photon-label-micro stackSettingsFilterLabel">
+      <label className="photon-label photon-label-micro photon-label-horiz-padding">
         <input
           type="radio"
           className="photon-radio photon-radio-micro"
@@ -67,7 +67,7 @@ class StackImplementationSettingImpl extends PureComponent<Props> {
     const { allowSwitchingStackType } = this.props;
 
     return allowSwitchingStackType ? (
-      <li className="stackSettingsListItem stackSettingsFilter">
+      <li className="panelSettingsListItem">
         {this._renderImplementationRadioButton(
           'StackSettings--implementation-all-stacks',
           'combined'

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -11,36 +11,6 @@
   white-space: nowrap;
 }
 
-.stackSettingsList {
-  display: block;
-  display: flex;
-  flex: 1;
-  align-items: flex-start;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.stackSettingsListItem {
-  padding: 0;
-  margin: 0 5px;
-}
-
-.stackSettingsLabel {
-  height: 25px;
-  padding: 0;
-}
-
-.stackSettingsFilter {
-  padding-right: 10px;
-  border-right: 1px solid var(--grey-20);
-}
-
-.stackSettingsFilterLabel {
-  align-items: center;
-  padding: 0 5px 0 0;
-}
-
 .stackSettingsSelect {
   /* Create a new stacking context for the select using a position:relative. This way
    * the focus ring around the select breaks out of its surrounding container. */

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -28,6 +28,7 @@ import explicitConnect, {
 } from 'firefox-profiler/utils/connect';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 
+import './PanelSettingsList.css';
 import './StackSettings.css';
 
 import type { CallTreeSummaryStrategy } from 'firefox-profiler/types';
@@ -107,10 +108,10 @@ class StackSettingsImpl extends PureComponent<Props> {
 
     return (
       <div className="stackSettings">
-        <ul className="stackSettingsList">
+        <ul className="panelSettingsList">
           <StackImplementationSetting />
           {hasAllocations ? (
-            <li className="stackSettingsListItem stackSettingsFilter">
+            <li className="panelSettingsListItem">
               <label>
                 <Localized id="StackSettings--use-data-source-label" />{' '}
                 <select
@@ -158,37 +159,37 @@ class StackSettingsImpl extends PureComponent<Props> {
               </label>
             </li>
           ) : null}
-          {hideInvertCallstack ? null : (
-            <li className="stackSettingsListItem">
-              <label className="photon-label photon-label-micro stackSettingsLabel">
-                <input
-                  type="checkbox"
-                  className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-                  onChange={this._onInvertCallstackClick}
-                  checked={invertCallstack}
-                />
-                <Localized
-                  id="StackSettings--invert-call-stack"
-                  attrs={{ title: true }}
-                >
-                  <span>Invert call stack</span>
-                </Localized>
-              </label>
-            </li>
-          )}
-          {selectedTab !== 'stack-chart' ? null : (
-            <li className="stackSettingsListItem">
-              <label className="photon-label photon-label-micro stackSettingsLabel">
-                <input
-                  type="checkbox"
-                  className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-                  onChange={this._onShowUserTimingsClick}
-                  checked={showUserTimings}
-                />
-                <Localized id="StackSettings--show-user-timing">
-                  Show user timing
-                </Localized>
-              </label>
+          {hideInvertCallstack && selectedTab !== 'stack-chart' ? null : (
+            <li className="panelSettingsListItem">
+              {hideInvertCallstack ? null : (
+                <label className="photon-label photon-label-micro photon-label-horiz-padding">
+                  <input
+                    type="checkbox"
+                    className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                    onChange={this._onInvertCallstackClick}
+                    checked={invertCallstack}
+                  />
+                  <Localized
+                    id="StackSettings--invert-call-stack"
+                    attrs={{ title: true }}
+                  >
+                    <span>Invert call stack</span>
+                  </Localized>
+                </label>
+              )}
+              {selectedTab !== 'stack-chart' ? null : (
+                <label className="photon-label photon-label-micro photon-label-horiz-padding">
+                  <input
+                    type="checkbox"
+                    className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                    onChange={this._onShowUserTimingsClick}
+                    checked={showUserTimings}
+                  />
+                  <Localized id="StackSettings--show-user-timing">
+                    Show user timing
+                  </Localized>
+                </label>
+              )}
             </li>
           )}
         </ul>

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -8,45 +8,35 @@ import React, { PureComponent } from 'react';
 import { Localized } from '@fluent/react';
 
 import {
-  changeImplementationFilter,
   changeInvertCallstack,
   changeCallTreeSearchString,
   changeCallTreeSummaryStrategy,
   changeShowUserTimings,
 } from 'firefox-profiler/actions/profile-view';
 import {
-  getImplementationFilter,
   getInvertCallstack,
   getSelectedTab,
   getShowUserTimings,
   getCurrentSearchString,
 } from 'firefox-profiler/selectors/url-state';
 import { PanelSearch } from './PanelSearch';
+import { StackImplementationSetting } from './StackImplementationSetting';
 
-import {
-  toValidImplementationFilter,
-  toValidCallTreeSummaryStrategy,
-} from 'firefox-profiler/profile-logic/profile-data';
+import { toValidCallTreeSummaryStrategy } from 'firefox-profiler/profile-logic/profile-data';
 import explicitConnect, {
   type ConnectedProps,
 } from 'firefox-profiler/utils/connect';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 
-import { getProfileUsesMultipleStackTypes } from 'firefox-profiler/selectors/profile';
-
 import './StackSettings.css';
 
-import type {
-  ImplementationFilter,
-  CallTreeSummaryStrategy,
-} from 'firefox-profiler/types';
+import type { CallTreeSummaryStrategy } from 'firefox-profiler/types';
 
 type OwnProps = {|
   +hideInvertCallstack?: true,
 |};
 
 type StateProps = {|
-  +implementationFilter: ImplementationFilter,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
   +selectedTab: string,
   +invertCallstack: boolean,
@@ -56,11 +46,9 @@ type StateProps = {|
   +hasUsefulJsAllocations: boolean,
   +hasUsefulNativeAllocations: boolean,
   +canShowRetainedMemory: boolean,
-  +allowSwitchingStackType: boolean,
 |};
 
 type DispatchProps = {|
-  +changeImplementationFilter: typeof changeImplementationFilter,
   +changeInvertCallstack: typeof changeInvertCallstack,
   +changeShowUserTimings: typeof changeShowUserTimings,
   +changeCallTreeSearchString: typeof changeCallTreeSearchString,
@@ -70,14 +58,6 @@ type DispatchProps = {|
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class StackSettingsImpl extends PureComponent<Props> {
-  _onImplementationFilterChange = (e: SyntheticEvent<HTMLInputElement>) => {
-    this.props.changeImplementationFilter(
-      // This function is here to satisfy Flow that we are getting a valid
-      // implementation filter.
-      toValidImplementationFilter(e.currentTarget.value)
-    );
-  };
-
   _onCallTreeSummaryStrategyChange = (e: SyntheticEvent<HTMLInputElement>) => {
     this.props.changeCallTreeSummaryStrategy(
       // This function is here to satisfy Flow that we are getting a valid
@@ -97,26 +77,6 @@ class StackSettingsImpl extends PureComponent<Props> {
   _onSearch = (value: string) => {
     this.props.changeCallTreeSearchString(value);
   };
-
-  _renderImplementationRadioButton(
-    labelL10Id: string,
-    implementationFilter: ImplementationFilter
-  ) {
-    return (
-      <label className="photon-label photon-label-micro stackSettingsFilterLabel">
-        <input
-          type="radio"
-          className="photon-radio photon-radio-micro stackSettingsFilterInput"
-          value={implementationFilter}
-          name="stack-settings-filter"
-          title="Filter stack frames to a type."
-          onChange={this._onImplementationFilterChange}
-          checked={this.props.implementationFilter === implementationFilter}
-        />
-        <Localized id={labelL10Id}></Localized>
-      </label>
-    );
-  }
 
   _renderCallTreeStrategyOption(
     labelL10nId: string,
@@ -141,7 +101,6 @@ class StackSettingsImpl extends PureComponent<Props> {
       hasUsefulNativeAllocations,
       canShowRetainedMemory,
       callTreeSummaryStrategy,
-      allowSwitchingStackType,
     } = this.props;
 
     const hasAllocations = hasUsefulJsAllocations || hasUsefulNativeAllocations;
@@ -149,22 +108,7 @@ class StackSettingsImpl extends PureComponent<Props> {
     return (
       <div className="stackSettings">
         <ul className="stackSettingsList">
-          {allowSwitchingStackType ? (
-            <li className="stackSettingsListItem stackSettingsFilter">
-              {this._renderImplementationRadioButton(
-                'StackSettings--implementation-all-stacks',
-                'combined'
-              )}
-              {this._renderImplementationRadioButton(
-                'StackSettings--implementation-javascript',
-                'js'
-              )}
-              {this._renderImplementationRadioButton(
-                'StackSettings--implementation-native',
-                'cpp'
-              )}
-            </li>
-          ) : null}
+          <StackImplementationSetting />
           {hasAllocations ? (
             <li className="stackSettingsListItem stackSettingsFilter">
               <label>
@@ -274,7 +218,6 @@ export const StackSettings = explicitConnect<
     invertCallstack: getInvertCallstack(state),
     selectedTab: getSelectedTab(state),
     showUserTimings: getShowUserTimings(state),
-    implementationFilter: getImplementationFilter(state),
     currentSearchString: getCurrentSearchString(state),
     hasUsefulTimingSamples:
       selectedThreadSelectors.getHasUsefulTimingSamples(state),
@@ -286,10 +229,8 @@ export const StackSettings = explicitConnect<
       selectedThreadSelectors.getCanShowRetainedMemory(state),
     callTreeSummaryStrategy:
       selectedThreadSelectors.getCallTreeSummaryStrategy(state),
-    allowSwitchingStackType: getProfileUsesMultipleStackTypes(state),
   }),
   mapDispatchToProps: {
-    changeImplementationFilter,
     changeInvertCallstack,
     changeCallTreeSearchString,
     changeCallTreeSummaryStrategy,

--- a/src/test/components/StackSettings.test.js
+++ b/src/test/components/StackSettings.test.js
@@ -66,11 +66,11 @@ describe('StackSettings', function () {
     expect(getImplementationFilter(getState())).toEqual('cpp');
   });
 
-  it('can change the implementation filter to All stacks', function () {
+  it('can change the implementation filter to All frames', function () {
     const { getByLabelText, getState } = setup();
     fireFullClick(getByLabelText(/Native/));
     expect(getImplementationFilter(getState())).toEqual('cpp');
-    const radioButton = getByLabelText(/All stacks/);
+    const radioButton = getByLabelText(/All frames/);
 
     fireFullClick(radioButton);
 

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -320,13 +320,13 @@ exports[`FlameGraph matches the snapshot 1`] = `
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -339,7 +339,7 @@ exports[`FlameGraph matches the snapshot 1`] = `
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -351,7 +351,7 @@ exports[`FlameGraph matches the snapshot 1`] = `
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -325,41 +325,47 @@ exports[`FlameGraph matches the snapshot 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -330,7 +330,7 @@ exports[`FlameGraph matches the snapshot 1`] = `
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -342,7 +342,7 @@ exports[`FlameGraph matches the snapshot 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -354,7 +354,7 @@ exports[`FlameGraph matches the snapshot 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -389,12 +389,12 @@ exports[`FlameGraph matches the snapshot 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -386,12 +386,12 @@ exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <div
@@ -1309,12 +1309,12 @@ exports[`MarkerChart with active tab renders the marker chart and matches the sn
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <div

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -358,9 +358,51 @@ exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`
   <div
     class="markerSettings"
   >
-    <div
-      class="markerSettingsSpacer"
-    />
+    <ul
+      class="panelSettingsList"
+    >
+      <li
+        class="panelSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+    </ul>
     <div
       class="panelSearchField markerSettingsSearchField"
     >
@@ -1281,9 +1323,51 @@ exports[`MarkerChart with active tab renders the marker chart and matches the sn
   <div
     class="markerSettings"
   >
-    <div
-      class="markerSettingsSpacer"
-    />
+    <ul
+      class="panelSettingsList"
+    >
+      <li
+        class="panelSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+    </ul>
     <div
       class="panelSearchField markerSettingsSearchField"
     >

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -364,41 +364,47 @@ exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -1329,41 +1335,47 @@ exports[`MarkerChart with active tab renders the marker chart and matches the sn
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -364,6 +364,7 @@ exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`
       <li
         class="panelSettingsListItem"
       >
+        Filter stacks:
         <input
           checked=""
           class="photon-radio photon-radio-micro"
@@ -1335,6 +1336,7 @@ exports[`MarkerChart with active tab renders the marker chart and matches the sn
       <li
         class="panelSettingsListItem"
       >
+        Filter stacks:
         <input
           checked=""
           class="photon-radio photon-radio-micro"

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -72,12 +72,12 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <div

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -50,41 +50,47 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -50,6 +50,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        Filter stacks:
         <input
           checked=""
           class="photon-radio photon-radio-micro"

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -44,9 +44,51 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
   <div
     class="markerSettings"
   >
-    <div
-      class="markerSettingsSpacer"
-    />
+    <ul
+      class="panelSettingsList"
+    >
+      <li
+        class="panelSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-radio photon-radio-micro"
+            name="stack-settings-filter"
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
+        </label>
+      </li>
+    </ul>
     <div
       class="panelSearchField markerSettingsSearchField"
     >

--- a/src/test/components/__snapshots__/NetworkChart.test.js.snap
+++ b/src/test/components/__snapshots__/NetworkChart.test.js.snap
@@ -55,12 +55,12 @@ exports[`NetworkChart renders NetworkChart correctly 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <div

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -21,7 +21,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -33,7 +33,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -45,7 +45,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -781,7 +781,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -793,7 +793,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -805,7 +805,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -1559,7 +1559,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -1571,7 +1571,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -1583,7 +1583,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -2337,7 +2337,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -2349,7 +2349,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -2361,7 +2361,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3103,7 +3103,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3115,7 +3115,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3127,7 +3127,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3717,7 +3717,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3729,7 +3729,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3741,7 +3741,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3852,7 +3852,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3864,7 +3864,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3876,7 +3876,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3986,7 +3986,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -3999,7 +3999,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4011,7 +4011,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4168,7 +4168,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4180,7 +4180,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4192,7 +4192,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4902,7 +4902,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4914,7 +4914,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -4926,7 +4926,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -5635,7 +5635,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -5647,7 +5647,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -5659,7 +5659,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -6152,7 +6152,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -6164,7 +6164,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -6176,7 +6176,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -6885,7 +6885,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -6897,7 +6897,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -6909,7 +6909,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -7546,7 +7546,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -7558,7 +7558,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -7570,7 +7570,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -8207,7 +8207,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -8219,7 +8219,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -8231,7 +8231,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -8725,7 +8725,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -8737,7 +8737,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -8749,7 +8749,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -9243,7 +9243,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -9255,7 +9255,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -9267,7 +9267,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -11,13 +11,13 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -30,7 +30,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -42,7 +42,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -55,7 +55,7 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
         </label>
       </li>
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label>
           Data source:
@@ -79,10 +79,10 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -771,13 +771,13 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -790,7 +790,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -802,7 +802,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -815,7 +815,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         </label>
       </li>
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label>
           Data source:
@@ -857,10 +857,10 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -1549,13 +1549,13 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -1568,7 +1568,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -1580,7 +1580,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -1593,7 +1593,7 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         </label>
       </li>
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label>
           Data source:
@@ -1635,10 +1635,10 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -2327,13 +2327,13 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -2346,7 +2346,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -2358,7 +2358,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -2371,7 +2371,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         </label>
       </li>
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label>
           Data source:
@@ -2401,10 +2401,10 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -3093,13 +3093,13 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -3112,7 +3112,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3124,7 +3124,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3137,7 +3137,7 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         </label>
       </li>
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label>
           Data source:
@@ -3167,10 +3167,10 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -3707,13 +3707,13 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -3726,7 +3726,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3738,7 +3738,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3751,10 +3751,10 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -3842,13 +3842,13 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -3861,7 +3861,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3873,7 +3873,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3886,10 +3886,10 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -3977,13 +3977,13 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -3995,7 +3995,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -4008,7 +4008,7 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -4021,10 +4021,10 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -4158,13 +4158,13 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -4177,7 +4177,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -4189,7 +4189,7 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -4202,10 +4202,10 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -4892,13 +4892,13 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -4911,7 +4911,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -4923,7 +4923,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -4936,10 +4936,10 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -5625,13 +5625,13 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -5644,7 +5644,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -5656,7 +5656,7 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -5669,10 +5669,10 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -6142,13 +6142,13 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -6161,7 +6161,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -6173,7 +6173,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -6186,10 +6186,10 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -6875,13 +6875,13 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -6894,7 +6894,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -6906,7 +6906,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -6919,10 +6919,10 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -7536,13 +7536,13 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -7555,7 +7555,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -7567,7 +7567,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -7580,10 +7580,10 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -8197,13 +8197,13 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -8216,7 +8216,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -8228,7 +8228,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -8241,10 +8241,10 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -8715,13 +8715,13 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -8734,7 +8734,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -8746,7 +8746,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -8759,10 +8759,10 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -9233,13 +9233,13 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -9252,7 +9252,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -9264,7 +9264,7 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -9277,10 +9277,10 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -121,12 +121,12 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -899,12 +899,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -1677,12 +1677,12 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -2443,12 +2443,12 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -3209,12 +3209,12 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -3793,12 +3793,12 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -3928,12 +3928,12 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -4063,12 +4063,12 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -4245,12 +4245,12 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -4978,12 +4978,12 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -5711,12 +5711,12 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -6228,12 +6228,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -6961,12 +6961,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -7622,12 +7622,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -8283,12 +8283,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -8801,12 +8801,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -9319,12 +9319,12 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -16,41 +16,47 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -776,41 +782,47 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -1554,41 +1566,47 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -2332,41 +2350,47 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -3098,41 +3122,47 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -3712,41 +3742,47 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -3847,41 +3883,47 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -3982,41 +4024,47 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
       <li
         class="panelSettingsListItem"
       >
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -4163,41 +4211,47 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -4897,41 +4951,47 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -5630,41 +5690,47 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -6147,41 +6213,47 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -6880,41 +6952,47 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -7541,41 +7619,47 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -8202,41 +8286,47 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -8720,41 +8810,47 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -9238,41 +9334,47 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -11,13 +11,13 @@ exports[`CombinedChart renders combined stack chart 1`] = `
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -30,7 +30,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -42,7 +42,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -55,10 +55,10 @@ exports[`CombinedChart renders combined stack chart 1`] = `
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -70,12 +70,8 @@ exports[`CombinedChart renders combined stack chart 1`] = `
             Invert call stack
           </span>
         </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -528,13 +524,13 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -547,7 +543,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -559,7 +555,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -572,10 +568,10 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -587,12 +583,8 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
             Invert call stack
           </span>
         </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -999,13 +991,13 @@ exports[`StackChart matches the snapshot 1`] = `
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -1018,7 +1010,7 @@ exports[`StackChart matches the snapshot 1`] = `
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -1030,7 +1022,7 @@ exports[`StackChart matches the snapshot 1`] = `
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -1043,10 +1035,10 @@ exports[`StackChart matches the snapshot 1`] = `
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
@@ -1058,12 +1050,8 @@ exports[`StackChart matches the snapshot 1`] = `
             Invert call stack
           </span>
         </label>
-      </li>
-      <li
-        class="stackSettingsListItem"
-      >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -16,41 +16,47 @@ exports[`CombinedChart renders combined stack chart 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -529,41 +535,47 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>
@@ -996,41 +1008,47 @@ exports[`StackChart matches the snapshot 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -21,7 +21,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -33,7 +33,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -45,7 +45,7 @@ exports[`CombinedChart renders combined stack chart 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -538,7 +538,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -550,7 +550,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -562,7 +562,7 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -1009,7 +1009,7 @@ exports[`StackChart matches the snapshot 1`] = `
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -1021,7 +1021,7 @@ exports[`StackChart matches the snapshot 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -1033,7 +1033,7 @@ exports[`StackChart matches the snapshot 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -110,12 +110,12 @@ exports[`CombinedChart renders combined stack chart 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -627,12 +627,12 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol
@@ -1098,12 +1098,12 @@ exports[`StackChart matches the snapshot 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
   <ol

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -6,13 +6,13 @@ exports[`StackSettings matches the snapshot 1`] = `
     class="stackSettings"
   >
     <ul
-      class="stackSettingsList"
+      class="panelSettingsList"
     >
       <li
-        class="stackSettingsListItem stackSettingsFilter"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             checked=""
@@ -25,7 +25,7 @@ exports[`StackSettings matches the snapshot 1`] = `
           All stacks
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -37,7 +37,7 @@ exports[`StackSettings matches the snapshot 1`] = `
           JavaScript
         </label>
         <label
-          class="photon-label photon-label-micro stackSettingsFilterLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-radio photon-radio-micro"
@@ -50,10 +50,10 @@ exports[`StackSettings matches the snapshot 1`] = `
         </label>
       </li>
       <li
-        class="stackSettingsListItem"
+        class="panelSettingsListItem"
       >
         <label
-          class="photon-label photon-label-micro stackSettingsLabel"
+          class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -16,7 +16,7 @@ exports[`StackSettings matches the snapshot 1`] = `
         >
           <input
             checked=""
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -28,7 +28,7 @@ exports[`StackSettings matches the snapshot 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"
@@ -40,7 +40,7 @@ exports[`StackSettings matches the snapshot 1`] = `
           class="photon-label photon-label-micro stackSettingsFilterLabel"
         >
           <input
-            class="photon-radio photon-radio-micro stackSettingsFilterInput"
+            class="photon-radio photon-radio-micro"
             name="stack-settings-filter"
             title="Filter stack frames to a type."
             type="radio"

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -92,12 +92,12 @@ exports[`StackSettings matches the snapshot 1`] = `
             type="reset"
           />
         </form>
-        <div
-          class="panelSearchFieldIntroduction isHidden"
-        >
-          Did you know you can use the comma (,) to search using several terms?
-        </div>
       </label>
+      <div
+        class="panelSearchFieldIntroduction isHidden"
+      >
+        Did you know you can use the comma (,) to search using several terms?
+      </div>
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/StackSettings.test.js.snap
+++ b/src/test/components/__snapshots__/StackSettings.test.js.snap
@@ -11,41 +11,47 @@ exports[`StackSettings matches the snapshot 1`] = `
       <li
         class="panelSettingsListItem"
       >
+        <input
+          checked=""
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-combined"
+          title="Do not filter the stack frames"
+          type="radio"
+          value="combined"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-combined"
+          title="Do not filter the stack frames"
         >
-          <input
-            checked=""
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="combined"
-          />
-          All stacks
+          All frames
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
+          type="radio"
+          value="js"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-js"
+          title="Show only the stack frames related to JavaScript execution"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="js"
-          />
           JavaScript
         </label>
+        <input
+          class="photon-radio photon-radio-micro"
+          id="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
+          type="radio"
+          value="cpp"
+        />
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
+          for="implementation-radio-cpp"
+          title="Show only the stack frames for native code"
         >
-          <input
-            class="photon-radio photon-radio-micro"
-            name="stack-settings-filter"
-            title="Filter stack frames to a type."
-            type="radio"
-            value="cpp"
-          />
           Native
         </label>
       </li>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/454175/231844776-90a70139-eb6c-40f0-9241-241826c8253f.png)

It's common that I want to switch between the stack implementation filters when I'm in the marker chart, but currently I have to change the panel so that I can do it.

That's why I wanted to implement this.
I considered moving this above the timeline because this applies to the whole view, but I thought that muscle memory is important and didn't want to disturb the existing users. That's why I added it at the exact same place, just added an additional label for more context in the marker-based panels.

This PR also has a few other small changes:
* some (react and css) refactoring so that I could reuse the radio buttons in the marker chart. Some padding may be slightly changed but overall it should look nearly the same.
* the radio button titles are now localized, and are different for each
* `All stacks` => `All frames`

Things I paid attention to:
* When there are timing data (with the native allocations feature), see for example the links below
* In the stack chart, with the "show user timing" checkbox

It may be better to look at this commit by commit. Thoughts?

[production](https://profiler.firefox.com/public/qhwbd1az0g4d4r9bh1egzjbdvzkb36b2j5396fr/calltree/?globalTrackOrder=f0we&hiddenGlobalTracks=1wc&hiddenLocalTracksByPid=34502-03wd~35024-0~34809-0~612047-0~601451-0~173810-0~611943-0~34920-0~35054-0~408035-0~413164-0~407398-0~594557-0~34900-0&thread=t&v=8)
[deploy preview](https://deploy-preview-4572--perf-html.netlify.app/public/qhwbd1az0g4d4r9bh1egzjbdvzkb36b2j5396fr/calltree/?globalTrackOrder=f0we&hiddenGlobalTracks=1wc&hiddenLocalTracksByPid=34502-03wd~35024-0~34809-0~612047-0~601451-0~173810-0~611943-0~34920-0~35054-0~408035-0~413164-0~407398-0~594557-0~34900-0&thread=t&v=8)