### PR TITLE
Improve the behavior when the profile compression step fails for any reason

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -590,6 +590,7 @@ MenuButtons--publish--message-something-went-wrong = Uh oh, something went wrong
 MenuButtons--publish--message-try-again = Try again
 MenuButtons--publish--download = Download
 MenuButtons--publish--compressing = Compressing…
+MenuButtons--publish--error-while-compressing = Error while compressing, try unchecking some checkboxes to reduce the profile size.
 
 ## NetworkSettings
 ## This is used in the network chart.

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -25,7 +25,6 @@ import {
   getShouldSanitizeByDefault as getShouldSanitizeByDefaultImpl,
   type SanitizeProfileResult,
 } from '../profile-logic/sanitize';
-import prettyBytes from '../utils/pretty-bytes';
 import { ensureExists } from '../utils/flow';
 import { formatNumber } from '../utils/format-numbers';
 import {
@@ -243,20 +242,6 @@ export const getSanitizedProfileData: Selector<Promise<Uint8Array>> =
     // due to memory issues thanks to that.
     Promise.resolve().then(() => compress(serializeProfile(profile)))
   );
-
-/**
- * The blob is needed for both the download size, and the ObjectURL.
- */
-export const getCompressedProfileBlob: Selector<Promise<Blob>> = createSelector(
-  getSanitizedProfileData,
-  async (profileData) =>
-    new Blob([await profileData], { type: 'application/octet-binary' })
-);
-
-export const getDownloadSize: Selector<Promise<string>> = createSelector(
-  getCompressedProfileBlob,
-  (blobPromise) => blobPromise.then((blob) => prettyBytes(blob.size))
-);
 
 export const getUploadState: Selector<UploadState> = (state) =>
   getPublishState(state).upload;

--- a/src/selectors/publish.js
+++ b/src/selectors/publish.js
@@ -238,7 +238,10 @@ export const getSanitizedProfile: Selector<SanitizeProfileResult> =
  */
 export const getSanitizedProfileData: Selector<Promise<Uint8Array>> =
   createSelector(getSanitizedProfile, ({ profile }) =>
-    compress(serializeProfile(profile))
+    // We use a Promise.resolve() call first so that the calls to compress and
+    // serializeProfile are out of React's rendering pipeline. We avoid crashes
+    // due to memory issues thanks to that.
+    Promise.resolve().then(() => compress(serializeProfile(profile)))
   );
 
 /**

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1497,7 +1497,119 @@ exports[`app/MenuButtons <Publish> can publish and revert 1`] = `
 </body>
 `;
 
-exports[`app/MenuButtons <Publish> matches the snapshot for an error 1`] = `
+exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 1`] = `
+<div
+  data-testid="MenuButtonsPublish-container"
+>
+  <form
+    class="menuButtonsPublishContent photon-body-10"
+  >
+    <h1
+      class="menuButtonsPublishTitle photon-title-40"
+    >
+      Share Performance Profile
+    </h1>
+    <p
+      class="menuButtonsPublishInfoDescription"
+    >
+      Upload your profile and make it accessible to anyone with the link.
+       
+      By default, your personal data is removed.
+    </p>
+    <h3
+      class="photon-title-10"
+    >
+      Include additional data that may be identifiable
+    </h3>
+    <div
+      class="menuButtonsPublishDataChoices"
+    >
+      <label
+        class="photon-label menuButtonsPublishDataChoicesLabel"
+      >
+        <input
+          class="photon-checkbox photon-checkbox-default"
+          name="includeHiddenThreads"
+          type="checkbox"
+        />
+        Include hidden threads
+      </label>
+      <label
+        class="photon-label menuButtonsPublishDataChoicesLabel"
+      >
+        <input
+          class="photon-checkbox photon-checkbox-default"
+          name="includeFullTimeRange"
+          type="checkbox"
+        />
+        Include hidden time range
+      </label>
+      <label
+        class="photon-label menuButtonsPublishDataChoicesLabel"
+      >
+        <input
+          class="photon-checkbox photon-checkbox-default"
+          name="includeScreenshots"
+          type="checkbox"
+        />
+        Include screenshots
+      </label>
+      <label
+        class="photon-label menuButtonsPublishDataChoicesLabel"
+      >
+        <input
+          class="photon-checkbox photon-checkbox-default"
+          name="includeUrls"
+          type="checkbox"
+        />
+        Include resource URLs and paths
+      </label>
+      <label
+        class="photon-label menuButtonsPublishDataChoicesLabel"
+      >
+        <input
+          class="photon-checkbox photon-checkbox-default"
+          name="includeExtension"
+          type="checkbox"
+        />
+        Include extension information
+      </label>
+    </div>
+    <div
+      class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content"
+    >
+      <div
+        class="photon-message-bar-inner-text"
+      >
+        Error while compressing, try unchecking some checkboxes to reduce the profile size.
+      </div>
+    </div>
+    <div
+      class="menuButtonsPublishButtons"
+    >
+      <button
+        class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload"
+        disabled=""
+        type="button"
+      >
+        Download
+      </button>
+      <button
+        class="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
+        disabled=""
+        type="submit"
+      >
+        <span
+          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload"
+        />
+        Upload
+      </button>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`app/MenuButtons <Publish> matches the snapshot for an upload error 1`] = `
 <div
   class="menuButtonsPublishUpload photon-body-10"
   data-testid="MenuButtonsPublish-container"
@@ -1707,7 +1819,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
           class="menuButtonsDownloadSize"
         >
           (
-          9 B
+          1.55 kB
           )
         </span>
       </a>
@@ -1825,7 +1937,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          9 B
+          1.55 kB
           )
         </span>
       </a>
@@ -1938,7 +2050,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          9 B
+          1.55 kB
           )
         </span>
       </a>


### PR DESCRIPTION
You'll find these commits (it's probably better to look at them separately):

1. This adds some code to be able to properly load the profiles that didn't go through serializeProfile (for example by copying it directly from the Web Console).
2. This moves the compress operation out of the rendering pipeline, so that if this breaks the UI doesn't crash.
3. This displays a nice error when the compression fails.
4. This simplify some things around the download button (less selectors, less react components).
5. Finally add a test for the new notification.

See also the inline comments.

![image](https://user-images.githubusercontent.com/454175/232496689-e828d176-778a-4660-920a-2100daedfcfc.png)
![image](https://user-images.githubusercontent.com/454175/232496474-136f3fe4-a65a-4f1e-80d8-681f3e52b172.png)
