### PR TITLE
Display the event type from DOM events in chrome profiles

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -218,6 +218,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
         filteredThread.name === 'Compositor' ||
         filteredThread.name === 'Renderer' ||
         filteredThread.name === 'AndroidUI (JVM)' ||
+        filteredThread.name === 'CrRendererMain' ||
         filteredThread.name === 'Merged thread' ||
         filteredThread.name.startsWith('MediaDecoderStateMachine')) &&
       processType !== 'plugin';

--- a/src/test/unit/profile-conversion.test.js
+++ b/src/test/unit/profile-conversion.test.js
@@ -323,6 +323,31 @@ describe('converting Google Chrome profile', function () {
           tid: 259,
           ts: 12,
         },
+        {
+          args: {
+            data: {
+              stackTrace: [
+                {
+                  columnNumber: 38358,
+                  functionName: 'buildFragment',
+                  lineNumber: 40,
+                  scriptId: '117',
+                  url: 'https://journals.physiology.org/products/physio/releasedAssets/js/main.bundle-1bbca34150268d61be9d.js',
+                },
+              ],
+              type: 'DOMSubtreeModified',
+            },
+          },
+          cat: 'devtools.timeline',
+          dur: 51,
+          name: 'EventDispatch',
+          ph: 'X',
+          pid: 54782,
+          tdur: 4,
+          tid: 259,
+          ts: 13,
+          tts: 3934607,
+        },
       ],
     };
     const strChromeProfile = JSON.stringify(chromeProfile);
@@ -345,7 +370,15 @@ describe('converting Google Chrome profile', function () {
       'Instant 2',
       'async event',
       'async event instant',
+      'EventDispatch',
     ]);
+    expect(markers[6]).toMatchObject({
+      name: 'EventDispatch',
+      data: {
+        type: 'EventDispatch',
+        type2: 'DOMSubtreeModified',
+      },
+    });
     expect(markers).toMatchSnapshot();
   });
 });

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -548,26 +548,11 @@ export type TextMarkerPayload = {|
   innerWindowID?: number,
 |};
 
-// ph: 'X' in the Trace Event Format
-export type ChromeCompleteTraceEventPayload = {|
-  type: 'CompleteTraceEvent',
+// Any import from a Chrome profile
+export type ChromeEventPayload = {|
+  type: string,
   category: string,
   data: MixedObject | null,
-|};
-
-// ph: 'I' in the Trace Event Format
-export type ChromeInstantTraceEventPayload = {|
-  type: 'InstantTraceEvent',
-  category: string,
-  data: MixedObject | null,
-|};
-
-// ph: 'B' | 'E' in the Trace Event Format
-export type ChromeDurationTraceEventPayload = {|
-  type: 'tracing',
-  category: string,
-  data: MixedObject | null,
-  cause?: CauseBacktrace,
 |};
 
 /**
@@ -780,9 +765,6 @@ export type MarkerPayload =
   | NavigationMarkerPayload
   | PrefMarkerPayload
   | IPCMarkerPayload
-  | ChromeCompleteTraceEventPayload
-  | ChromeDurationTraceEventPayload
-  | ChromeInstantTraceEventPayload
   | MediaSampleMarkerPayload
   | JankPayload
   | BrowsertimeMarkerPayload


### PR DESCRIPTION
With this change, it's now possible to see the dom event types in the marker chart and table. They also show up in the timeline.
Moreover now it should be easier to display data for other events.

The more difficult thing left is to map the stack trace that's part of some of these events to the stack table, so that we could display the cause in the tooltip... A task for a follow-up.

Here is a profile imported from this deploy preview: https://share.firefox.dev/3npso3p (notice that the dom event names show up in the marker chart and table)
And here is [the same profile displayed with this deploy preview](https://deploy-preview-4604--perf-html.netlify.app/public/gvczkfkghn4tvcm821ykh307g1ge9z61sdcpvdr/marker-chart/?globalTrackOrder=0w5&hiddenGlobalTracks=03w5&hiddenLocalTracksByPid=874122-0w4~1046378-0we~1046454-0wd~874186-0w4~1046432-0w2~0-0&range=251024m11396~254849m7570~256041m2940&thread=6&timelineType=category&v=9) (notice they also show up in the timeline now)

Design notes: I used this `type2` property so that we still have `type` to pick the schema. Ideally we'd make the name pick up the schema too but I was afraid of regressions with gecko profiles, so I'd like to have some more available time to work on the profiler codebase to be able to do that. Tell me what you think!