### PR TITLE
Use scrollTop instead of getBoundingClientRect to control VirtualList rendering

### DIFF
--- a/src/components/shared/VirtualList.js
+++ b/src/components/shared/VirtualList.js
@@ -154,21 +154,6 @@ type VirtualListInnerProps<Item> = {|
 class VirtualListInner<Item> extends React.PureComponent<
   VirtualListInnerProps<Item>
 > {
-  _container: ?HTMLElement;
-
-  _takeContainerRef = (element: ?HTMLDivElement) => {
-    this._container = element;
-  };
-
-  /* This method is used by users of this component. */
-  /* eslint-disable-next-line react/no-unused-class-component-methods */
-  getBoundingClientRect() {
-    if (this._container) {
-      return this._container.getBoundingClientRect();
-    }
-    return new DOMRect(0, 0, 0, 0);
-  }
-
   render() {
     const {
       itemHeight,
@@ -194,7 +179,6 @@ class VirtualListInner<Item> extends React.PureComponent<
     return (
       <div
         className={className}
-        ref={this._takeContainerRef}
         // Add padding to list height to account for overlay scrollbars.
         style={{
           height: `${(items.length + 1) * itemHeight}px`,
@@ -261,21 +245,17 @@ type VirtualListProps<Item> = {|
   +ariaActiveDescendant?: null | string,
 |};
 
-type Geometry = {
-  // getBoundingClientRect in the Flow definitions is wrong, and labels the return values
-  // as a ClientRect, and not a DOMRect. https://github.com/facebook/flow/issues/5475
-  //
-  // Account for that here:
-  outerRect: DOMRect | ClientRect,
-  innerRectY: CssPixels,
-};
+type VirtualListState = {|
+  scrollTop: number,
+  clientHeight: number,
+|};
 
 export class VirtualList<Item> extends React.PureComponent<
-  VirtualListProps<Item>
+  VirtualListProps<Item>,
+  VirtualListState
 > {
   _container: {| current: HTMLDivElement | null |} = React.createRef();
-  _inner: {| current: VirtualListInner<Item> | null |} = React.createRef();
-  _geometry: ?Geometry;
+  state = { scrollTop: 0, clientHeight: 0 };
 
   componentDidMount() {
     document.addEventListener('copy', this._onCopy, false);
@@ -285,8 +265,6 @@ export class VirtualList<Item> extends React.PureComponent<
         'The container was assumed to exist while mounting The VirtualList.'
       );
     }
-    container.addEventListener('scroll', this._onScroll);
-    this._onScroll(); // for initial size
   }
 
   componentWillUnmount() {
@@ -297,12 +275,13 @@ export class VirtualList<Item> extends React.PureComponent<
         'The container was assumed to exist while unmounting The VirtualList.'
       );
     }
-    container.removeEventListener('scroll', this._onScroll);
   }
 
-  _onScroll = () => {
-    this._geometry = this._queryGeometry();
-    this.forceUpdate();
+  _onScroll = (event: SyntheticEvent<HTMLElement>) => {
+    this.setState({
+      scrollTop: event.currentTarget.scrollTop,
+      clientHeight: event.currentTarget.clientHeight,
+    });
   };
 
   _onCopy = (event: ClipboardEvent) => {
@@ -312,29 +291,14 @@ export class VirtualList<Item> extends React.PureComponent<
     }
   };
 
-  _queryGeometry(): Geometry | void {
-    const container = this._container.current;
-    const inner = this._inner.current;
-    if (!container || !inner) {
-      return undefined;
-    }
-    const outerRect = container.getBoundingClientRect();
-    const innerRectY = inner.getBoundingClientRect().top;
-    return { outerRect, innerRectY };
-  }
-
   computeVisibleRange() {
     const { itemHeight, disableOverscan } = this.props;
-    if (!this._geometry) {
-      return { visibleRangeStart: 0, visibleRangeEnd: 100 };
-    }
-    const { outerRect, innerRectY } = this._geometry;
+    const { scrollTop, clientHeight } = this.state;
     const overscan = disableOverscan ? 0 : 25;
     const chunkSize = 16;
-    let visibleRangeStart =
-      Math.floor((outerRect.top - innerRectY) / itemHeight) - overscan;
+    let visibleRangeStart = Math.floor(scrollTop / itemHeight) - overscan;
     let visibleRangeEnd =
-      Math.ceil((outerRect.bottom - innerRectY) / itemHeight) + overscan;
+      Math.ceil((scrollTop + clientHeight) / itemHeight) + overscan;
     if (!disableOverscan) {
       visibleRangeStart = Math.floor(visibleRangeStart / chunkSize) * chunkSize;
       visibleRangeEnd = Math.ceil(visibleRangeEnd / chunkSize) * chunkSize;
@@ -502,6 +466,7 @@ export class VirtualList<Item> extends React.PureComponent<
         role={ariaRole}
         aria-label={ariaLabel}
         aria-activedescendant={ariaActiveDescendant}
+        onScroll={this._onScroll}
       >
         <div
           className={`${className}InnerWrapper`}
@@ -523,7 +488,6 @@ export class VirtualList<Item> extends React.PureComponent<
               containerWidth={containerWidth}
               forceRender={forceRender}
               key={columnIndex}
-              ref={columnIndex === 0 ? this._inner : undefined}
             />
           ))}
         </div>

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -44,13 +44,14 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
+import { triggerResizeObservers } from '../fixtures/mocks/resize-observer';
 
 import type { Profile } from 'firefox-profiler/types';
 
 autoMockCanvasContext();
 
 // This makes the bounding box large enough so that we don't trigger
-// VirtualList's virtualization. We assert this above.
+// VirtualList's virtualization. We assert this below.
 autoMockElementSize({ width: 1000, height: 2000 });
 
 describe('calltree/ProfileCallTreeView', function () {
@@ -380,6 +381,9 @@ describe('calltree/ProfileCallTreeView navigation keys', () => {
         <ProfileCallTreeView />
       </Provider>
     );
+
+    // This automatically uses the bounding box set in autoMockElementSize.
+    triggerResizeObservers();
 
     // Assert that we used a large enough bounding box to include all children.
     const renderedRows = container.querySelectorAll(

--- a/src/utils/resize-observer-wrapper.js
+++ b/src/utils/resize-observer-wrapper.js
@@ -58,7 +58,7 @@ function createResizeObserverWrapper() {
 
   function stopResizeObserver() {
     _resizeObserver = null;
-    window.removeEventListener('visibilityChange', visibilityChangeListener);
+    window.removeEventListener('visibilitychange', visibilityChangeListener);
   }
 
   return {


### PR DESCRIPTION
This patch does more things than what I initially wanted:

* commit 1: minor refactoring in our ResizeObserver wrapper, that makes the commit 2 easier to follow. It's also more correct, because I believe that the current version would stop working if we unregistered all customers and register some new ones without creating the wrapper again.
* commit 2: move the `visibilitychange` event handling from WithSize to the ResizeObserver wrapper, so that this behavior is present even when we don't use `WithSize`. I wonder if WithSize is even needed after this, we could just use the ResizeObserver wrapper directly now...
* commit 3: this is the initial goal for this patch: `scrollTop` is used instead of `getBoundingClientRect`.
* commit 4: this uses the ResizeObserver wrapper to capture the content height. This fixes another (not very visible) issue:
   1. reduce the height of the window,
   2. scroll in the marker table or the call tree,
   3. increase the height of the window

    => at one point, the panel is blank because it's not rerendered when the window's size changes.

[production](https://profiler.firefox.com/public/vdnnt7qjjzp3qhxd7erkzgc4n2y3hng8kg96kh0/marker-table/?globalTrackOrder=0w7&hiddenGlobalTracks=1w6&hiddenLocalTracksByPid=1487-2w4~1500-0~1499-0~1510-0~1511-0~1508-0~1509-0&profileName=1827894%20-%20BUG&thread=0&v=9) (notice that the marker table is blank below approximately half the height)
[deploy preview](https://deploy-preview-4607--perf-html.netlify.app/public/vdnnt7qjjzp3qhxd7erkzgc4n2y3hng8kg96kh0/marker-table/?globalTrackOrder=0w7&hiddenGlobalTracks=1w6&hiddenLocalTracksByPid=1487-2w4~1500-0~1499-0~1510-0~1511-0~1508-0~1509-0&profileName=1827894%20-%20BUG&thread=0&v=9)