### PR TITLE
Add a transform to filter samples by marker name

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -383,6 +383,12 @@ MarkerContextMenu--copy-url = Copy URL
 MarkerContextMenu--copy-page-url = Copy page URL
 MarkerContextMenu--copy-as-json = Copy as JSON
 
+# This string is used on the marker context menu item when right clicked on any marker.
+# It drops the samples outside of given markers.
+# Variables:
+#   $markerName (String) - Name of the marker that is selected.
+MarkerContextMenu--drop-samples-outside-of-marker = Drop samples outside of “<strong>{ $markerName }</strong>” markers
+
 # This string is used on the marker context menu item when right clicked on an
 # IPC marker.
 # Variables:

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -950,6 +950,11 @@ TransformNavigator--collapse-direct-recursion-only = Collapse direct recursion o
 #   $item (String) - Name of the function that transform applied to.
 TransformNavigator--collapse-function-subtree = Collapse subtree: { $item }
 
+# "Drop samples outside of markers" transform.
+# Variables:
+#   $item (String) - Name of the markers that transform will filter to.
+TransformNavigator--drop-samples-outside-of-markers = Drop samples outside of markers: { $item }
+
 ## "Bottom box" - a view which contains the source view and the assembly view,
 ## at the bottom of the profiler UI
 ##

--- a/res/img/svg/filter.svg
+++ b/res/img/svg/filter.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#0b0b0b">
+   <path fill-opacity=".3" d="M6.6 8.4c0-.6-1.7.3-1.7-.3 0-.4-1.7-2.7-1.7-2.7H13s-1.8 2-1.8 2.7c0 .3-2.1-.1-2.1.3v6.1H7s-.4-4.1-.4-6.1z"></path>
+   <path d="M2 2v2.3L4.7 9H6v5.4l2.1 1 1.8-.9V9h1.3L14 4.3V2H2zm11 2l-2.2 4H9v5.8l-.9.4-1.1-.5V8H5.2L3 4V3h10v1z"></path>
+</svg>

--- a/res/img/svg/filter.svg
+++ b/res/img/svg/filter.svg
@@ -1,7 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#0b0b0b">
-   <path fill-opacity=".3" d="M6.6 8.4c0-.6-1.7.3-1.7-.3 0-.4-1.7-2.7-1.7-2.7H13s-1.8 2-1.8 2.7c0 .3-2.1-.1-2.1.3v6.1H7s-.4-4.1-.4-6.1z"></path>
-   <path d="M2 2v2.3L4.7 9H6v5.4l2.1 1 1.8-.9V9h1.3L14 4.3V2H2zm11 2l-2.2 4H9v5.8l-.9.4-1.1-.5V8H5.2L3 4V3h10v1z"></path>
-</svg>

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -363,6 +363,10 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
         });
         break;
       }
+      case 'filter-samples':
+        throw new Error(
+          "Filter samples transform can't be applied from the call node context menu."
+        );
       default:
         assertExhaustiveCheck(type);
     }

--- a/src/components/shared/MarkerContextMenu.css
+++ b/src/components/shared/MarkerContextMenu.css
@@ -51,6 +51,10 @@
   background-image: url(firefox-profiler-res/img/svg/select-thread.svg);
 }
 
+.markerContextMenuIconFilterSamples {
+  background-image: url(firefox-profiler-res/img/svg/filter.svg);
+}
+
 /* These icons don't look nice when selected, unless if we invert them. However
  * the other icons look better without the filter, so we don't change them in
  * this state. */

--- a/src/components/shared/MarkerContextMenu.css
+++ b/src/components/shared/MarkerContextMenu.css
@@ -52,7 +52,7 @@
 }
 
 .markerContextMenuIconFilterSamples {
-  background-image: url(firefox-profiler-res/img/svg/filter.svg);
+  background-image: url(firefox-profiler-res/img/svg/drop-icon.svg);
 }
 
 /* These icons don't look nice when selected, unless if we invert them. However

--- a/src/components/shared/MarkerContextMenu.css
+++ b/src/components/shared/MarkerContextMenu.css
@@ -67,6 +67,7 @@
 .react-contextmenu-item--selected .markerContextMenuIconCopyPayload,
 .react-contextmenu-item:hover .markerContextMenuIconCopyPayload,
 .react-contextmenu-item--selected .markerContextMenuSelectThread,
-.react-contextmenu-item:hover .markerContextMenuSelectThread {
+.react-contextmenu-item:hover .markerContextMenuSelectThread,
+.react-contextmenu-item:hover .markerContextMenuIconFilterSamples {
   filter: invert(1);
 }

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -62,7 +62,7 @@ type StateProps = {|
   +markerIndex: MarkerIndex,
   +previewSelection: PreviewSelection,
   +committedRange: StartEndRange,
-  +thread: Thread | null,
+  +thread: Thread,
   +implementationFilter: ImplementationFilter,
   +getMarkerLabelToCopy: (MarkerIndex) => string,
   +profiledThreadIds: Set<Tid>,
@@ -192,12 +192,13 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
       marker,
       addTransformToStack,
       changeSelectedTab,
+      thread,
     } = this.props;
     const { threadsKey } = rightClickedMarkerInfo;
     addTransformToStack(threadsKey, {
       type: 'filter-samples',
       filterType: 'marker',
-      filter: marker.name,
+      filter: thread.stringTable.indexForString(marker.name),
     });
 
     // Then change the selected tab to call tree.

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -515,6 +515,7 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
                 }}
                 elems={{ strong: <strong /> }}
               >
+                {/* Using a fragment here so we can have a  strong tag inside. */}
                 <>
                   Drop samples outside of “<strong>{marker.name}</strong>”
                   markers

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -507,8 +507,7 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
             <div className="react-contextmenu-separator" />
 
             <MenuItem onClick={this.filterByMarkerName}>
-              {/* TODO: Find an icon. */}
-              <span className="react-contextmenu-icon markerContextMenuIconCopyDescription" />
+              <span className="react-contextmenu-icon markerContextMenuIconFilterSamples" />
               <Localized
                 id="MarkerContextMenu--drop-samples-outside-of-marker"
                 vars={{

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -543,6 +543,7 @@ export function applyTransformToCallNodePath(
       // generic mechanism for: if the selected call node (after the transformation
       // has been applied to the call path) is not present in the call tree, run
       // some generic code that finds a close-by call node which is present.
+      // See: https://github.com/firefox-devtools/profiler/issues/4618
       return callNodePath;
     default:
       throw assertExhaustiveCheck(transform);

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -13,7 +13,7 @@ import * as ProfileSelectors from '../profile';
 import { getRightClickedMarkerInfo } from '../right-clicked-marker';
 import { getLabelGetter } from '../../profile-logic/marker-schema';
 
-import type { ThreadSelectorsPerThread } from './thread';
+import type { BasicThreadSelectorsPerThread } from './thread';
 import type {
   RawMarkerTable,
   ThreadIndex,
@@ -43,7 +43,7 @@ export type MarkerSelectorsPerThread = $ReturnType<
  * Create the selectors for a thread that have to do with either markers.
  */
 export function getMarkerSelectorsPerThread(
-  threadSelectors: ThreadSelectorsPerThread,
+  threadSelectors: BasicThreadSelectorsPerThread,
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
 ) {
@@ -610,6 +610,7 @@ export function getMarkerSelectorsPerThread(
     getTimelineJankMarkerIndexes,
     getDerivedMarkerInfo,
     getMarkerIndexToRawMarkerIndexes,
+    getFullMarkerList,
     getFullMarkerListIndexes,
     getNetworkMarkerIndexes,
     getSearchFilteredNetworkMarkerIndexes,

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -44,6 +44,7 @@ import type {
 } from 'firefox-profiler/types';
 
 import type { ThreadSelectorsPerThread } from './thread';
+import type { MarkerSelectorsPerThread } from './markers';
 
 /**
  * Infer the return type from the getStackAndSampleSelectorsPerThread function. This
@@ -54,11 +55,16 @@ export type StackAndSampleSelectorsPerThread = $ReturnType<
   typeof getStackAndSampleSelectorsPerThread
 >;
 
+type ThreadAndMarkerSelectorsPerThread = {|
+  ...ThreadSelectorsPerThread,
+  ...MarkerSelectorsPerThread,
+|};
+
 /**
  * Create the selectors for a thread that have to do with either stacks or samples.
  */
 export function getStackAndSampleSelectorsPerThread(
-  threadSelectors: ThreadSelectorsPerThread,
+  threadSelectors: ThreadAndMarkerSelectorsPerThread,
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
 ) {

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -44,24 +44,30 @@ import type {
 
 import type { UniqueStringArray } from '../../utils/unique-string-array';
 import type { TransformLabeL10nIds } from 'firefox-profiler/profile-logic/transforms';
+import type { MarkerSelectorsPerThread } from './markers';
 
 import { mergeThreads } from '../../profile-logic/merge-compare';
 import { defaultThreadViewOptions } from '../../reducers/profile-view';
 
 /**
- * Infer the return type from the getThreadSelectorsPerThread function. This
- * is done that so that the local type definition with `Selector<T>` is the canonical
- * definition for the type of the selector.
+ * Infer the return type from the getBasicThreadSelectorsPerThread and
+ * getThreadSelectorsWithMarkersPerThread functions. This is done that so that
+ * the local type definition with `Selector<T>` is the canonical definition for
+ * the type of the selector.
  */
-export type ThreadSelectorsPerThread = $ReturnType<
-  typeof getThreadSelectorsPerThread
+export type BasicThreadSelectorsPerThread = $ReturnType<
+  typeof getBasicThreadSelectorsPerThread
 >;
+export type ThreadSelectorsPerThread = {|
+  ...BasicThreadSelectorsPerThread,
+  ...$ReturnType<typeof getThreadSelectorsWithMarkersPerThread>,
+|};
 
 /**
  * Create the selectors for a thread that have to do with an entire thread. This includes
  * the general filtering pipeline for threads.
  */
-export function getThreadSelectorsPerThread(
+export function getBasicThreadSelectorsPerThread(
   threadIndexes: Set<ThreadIndex>,
   threadsKey: ThreadsKey
 ) {
@@ -172,74 +178,6 @@ export function getThreadSelectorsPerThread(
     }
   );
 
-  // It becomes very expensive to apply each transform over and over again as they
-  // typically take around 100ms to run per transform on a fast machine. Memoize
-  // memoize each step individually so that they transform stack can be pushed and
-  // popped frequently and easily.
-  const _applyTransformMemoized = memoize(Transforms.applyTransform, {
-    cache: new MixedTupleMap(),
-  });
-
-  const getTransformStack: Selector<TransformStack> = (state) =>
-    UrlState.getTransformStack(state, threadsKey);
-
-  const getRangeAndTransformFilteredThread: Selector<Thread> = createSelector(
-    getRangeFilteredThread,
-    getTransformStack,
-    ProfileSelectors.getDefaultCategory,
-    (startingThread, transforms, defaultCategory) => {
-      return transforms.reduce(
-        // Apply the reducer using an arrow function to ensure correct memoization.
-        (thread, transform) =>
-          _applyTransformMemoized(thread, transform, defaultCategory),
-        startingThread
-      );
-    }
-  );
-
-  const _getImplementationFilteredThread: Selector<Thread> = createSelector(
-    getRangeAndTransformFilteredThread,
-    UrlState.getImplementationFilter,
-    ProfileSelectors.getDefaultCategory,
-    ProfileData.filterThreadByImplementation
-  );
-
-  const _getImplementationAndSearchFilteredThread: Selector<Thread> =
-    createSelector(
-      _getImplementationFilteredThread,
-      UrlState.getSearchStrings,
-      (thread, searchStrings) => {
-        return ProfileData.filterThreadToSearchStrings(thread, searchStrings);
-      }
-    );
-
-  const getFilteredThread: Selector<Thread> = createSelector(
-    _getImplementationAndSearchFilteredThread,
-    UrlState.getInvertCallstack,
-    ProfileSelectors.getDefaultCategory,
-    (thread, shouldInvertCallstack, defaultCategory) => {
-      return shouldInvertCallstack
-        ? ProfileData.invertCallstack(thread, defaultCategory)
-        : thread;
-    }
-  );
-
-  const getPreviewFilteredThread: Selector<Thread> = createSelector(
-    getFilteredThread,
-    ProfileSelectors.getPreviewSelection,
-    (thread, previewSelection): Thread => {
-      if (!previewSelection.hasSelection) {
-        return thread;
-      }
-      const { selectionStart, selectionEnd } = previewSelection;
-      return ProfileData.filterThreadSamplesToRange(
-        thread,
-        selectionStart,
-        selectionEnd
-      );
-    }
-  );
-
   /**
    * The CallTreeSummaryStrategy determines how the call tree summarizes the
    * the current thread. By default, this is done by timing, but other
@@ -295,20 +233,6 @@ export function getThreadSelectorsPerThread(
       CallTree.extractSamplesLikeTable
     );
 
-  const getFilteredSamplesForCallTree: Selector<SamplesLikeTable> =
-    createSelector(
-      getFilteredThread,
-      getCallTreeSummaryStrategy,
-      CallTree.extractSamplesLikeTable
-    );
-
-  const getPreviewFilteredSamplesForCallTree: Selector<SamplesLikeTable> =
-    createSelector(
-      getPreviewFilteredThread,
-      getCallTreeSummaryStrategy,
-      CallTree.extractSamplesLikeTable
-    );
-
   /**
    * This selector returns the offset to add to a sampleIndex when accessing the
    * base thread, if your thread is a range filtered thread (all but the base
@@ -328,29 +252,6 @@ export function getThreadSelectorsPerThread(
       }
     );
 
-  /**
-   * This selector returns the offset to add to a sampleIndex when accessing the
-   * base thread, if your thread is the preview filtered thread.
-   */
-  const getSampleIndexOffsetFromPreviewRange: Selector<number> = createSelector(
-    getFilteredSamplesForCallTree,
-    ProfileSelectors.getPreviewSelection,
-    getSampleIndexOffsetFromCommittedRange,
-    (samples, previewSelection, sampleIndexFromCommittedRange) => {
-      if (!previewSelection.hasSelection) {
-        return sampleIndexFromCommittedRange;
-      }
-
-      const [beginSampleIndex] = ProfileData.getSampleIndexRangeForSelection(
-        samples,
-        previewSelection.selectionStart,
-        previewSelection.selectionEnd
-      );
-
-      return sampleIndexFromCommittedRange + beginSampleIndex;
-    }
-  );
-
   const getFriendlyThreadName: Selector<string> = createSelector(
     ProfileSelectors.getThreads,
     getThread,
@@ -361,27 +262,6 @@ export function getThreadSelectorsPerThread(
     getThread,
     getFriendlyThreadName,
     ProfileData.getThreadProcessDetails
-  );
-
-  const getTransformLabelL10nIds: Selector<TransformLabeL10nIds[]> =
-    createSelector(
-      ProfileSelectors.getMeta,
-      getRangeAndTransformFilteredThread,
-      getFriendlyThreadName,
-      getTransformStack,
-      Transforms.getTransformLabelL10nIds
-    );
-
-  const getLocalizedTransformLabels: Selector<React.Node[]> = createSelector(
-    getTransformLabelL10nIds,
-    (transformL10nIds) =>
-      transformL10nIds.map((transform) => (
-        <Localized
-          id={transform.l10nId}
-          vars={{ item: transform.item }}
-          key={transform.item}
-        ></Localized>
-      ))
   );
 
   const getViewOptions: Selector<ThreadViewOptions> = (state) =>
@@ -478,20 +358,11 @@ export function getThreadSelectorsPerThread(
     getNativeAllocations,
     getJsAllocations,
     getThreadRange,
-    getFilteredThread,
     getRangeFilteredThread,
-    getRangeAndTransformFilteredThread,
-    getPreviewFilteredThread,
     getUnfilteredSamplesForCallTree,
-    getFilteredSamplesForCallTree,
-    getPreviewFilteredSamplesForCallTree,
     getSampleIndexOffsetFromCommittedRange,
-    getSampleIndexOffsetFromPreviewRange,
     getFriendlyThreadName,
     getThreadProcessDetails,
-    getTransformLabelL10nIds,
-    getLocalizedTransformLabels,
-    getTransformStack,
     getViewOptions,
     getJsTracerTable,
     getExpensiveJsTracerTiming,
@@ -505,5 +376,154 @@ export function getThreadSelectorsPerThread(
     getActiveTabFilteredThread,
     getProcessedEventDelays,
     getCallTreeSummaryStrategy,
+  };
+}
+
+type BasicThreadAndMarkerSelectorsPerThread = {|
+  ...BasicThreadSelectorsPerThread,
+  ...MarkerSelectorsPerThread,
+|};
+
+export function getThreadSelectorsWithMarkersPerThread(
+  threadSelectors: BasicThreadAndMarkerSelectorsPerThread,
+  threadIndexes: Set<ThreadIndex>,
+  threadsKey: ThreadsKey
+) {
+  // It becomes very expensive to apply each transform over and over again as they
+  // typically take around 100ms to run per transform on a fast machine. Memoize
+  // memoize each step individually so that they transform stack can be pushed and
+  // popped frequently and easily.
+  const _applyTransformMemoized = memoize(Transforms.applyTransform, {
+    cache: new MixedTupleMap(),
+  });
+
+  const getTransformStack: Selector<TransformStack> = (state) =>
+    UrlState.getTransformStack(state, threadsKey);
+
+  const getRangeAndTransformFilteredThread: Selector<Thread> = createSelector(
+    threadSelectors.getRangeFilteredThread,
+    getTransformStack,
+    ProfileSelectors.getDefaultCategory,
+    (startingThread, transforms, defaultCategory) => {
+      return transforms.reduce(
+        // Apply the reducer using an arrow function to ensure correct memoization.
+        (thread, transform) =>
+          _applyTransformMemoized(thread, transform, defaultCategory),
+        startingThread
+      );
+    }
+  );
+
+  const _getImplementationFilteredThread: Selector<Thread> = createSelector(
+    getRangeAndTransformFilteredThread,
+    UrlState.getImplementationFilter,
+    ProfileSelectors.getDefaultCategory,
+    ProfileData.filterThreadByImplementation
+  );
+
+  const _getImplementationAndSearchFilteredThread: Selector<Thread> =
+    createSelector(
+      _getImplementationFilteredThread,
+      UrlState.getSearchStrings,
+      (thread, searchStrings) => {
+        return ProfileData.filterThreadToSearchStrings(thread, searchStrings);
+      }
+    );
+
+  const getFilteredThread: Selector<Thread> = createSelector(
+    _getImplementationAndSearchFilteredThread,
+    UrlState.getInvertCallstack,
+    ProfileSelectors.getDefaultCategory,
+    (thread, shouldInvertCallstack, defaultCategory) => {
+      return shouldInvertCallstack
+        ? ProfileData.invertCallstack(thread, defaultCategory)
+        : thread;
+    }
+  );
+
+  const getPreviewFilteredThread: Selector<Thread> = createSelector(
+    getFilteredThread,
+    ProfileSelectors.getPreviewSelection,
+    (thread, previewSelection): Thread => {
+      if (!previewSelection.hasSelection) {
+        return thread;
+      }
+      const { selectionStart, selectionEnd } = previewSelection;
+      return ProfileData.filterThreadSamplesToRange(
+        thread,
+        selectionStart,
+        selectionEnd
+      );
+    }
+  );
+
+  const getFilteredSamplesForCallTree: Selector<SamplesLikeTable> =
+    createSelector(
+      getFilteredThread,
+      threadSelectors.getCallTreeSummaryStrategy,
+      CallTree.extractSamplesLikeTable
+    );
+
+  const getPreviewFilteredSamplesForCallTree: Selector<SamplesLikeTable> =
+    createSelector(
+      getPreviewFilteredThread,
+      threadSelectors.getCallTreeSummaryStrategy,
+      CallTree.extractSamplesLikeTable
+    );
+
+  /**
+   * This selector returns the offset to add to a sampleIndex when accessing the
+   * base thread, if your thread is the preview filtered thread.
+   */
+  const getSampleIndexOffsetFromPreviewRange: Selector<number> = createSelector(
+    getFilteredSamplesForCallTree,
+    ProfileSelectors.getPreviewSelection,
+    threadSelectors.getSampleIndexOffsetFromCommittedRange,
+    (samples, previewSelection, sampleIndexFromCommittedRange) => {
+      if (!previewSelection.hasSelection) {
+        return sampleIndexFromCommittedRange;
+      }
+
+      const [beginSampleIndex] = ProfileData.getSampleIndexRangeForSelection(
+        samples,
+        previewSelection.selectionStart,
+        previewSelection.selectionEnd
+      );
+
+      return sampleIndexFromCommittedRange + beginSampleIndex;
+    }
+  );
+
+  const getTransformLabelL10nIds: Selector<TransformLabeL10nIds[]> =
+    createSelector(
+      ProfileSelectors.getMeta,
+      getRangeAndTransformFilteredThread,
+      threadSelectors.getFriendlyThreadName,
+      getTransformStack,
+      Transforms.getTransformLabelL10nIds
+    );
+
+  const getLocalizedTransformLabels: Selector<React.Node[]> = createSelector(
+    getTransformLabelL10nIds,
+    (transformL10nIds) =>
+      transformL10nIds.map((transform) => (
+        <Localized
+          id={transform.l10nId}
+          vars={{ item: transform.item }}
+          key={transform.item}
+        ></Localized>
+      ))
+  );
+
+  return {
+    getTransformStack,
+    getRangeAndTransformFilteredThread,
+    getFilteredThread,
+    getPreviewFilteredThread,
+    getFilteredSamplesForCallTree,
+    getPreviewFilteredSamplesForCallTree,
+    getSampleIndexOffsetFromPreviewRange,
+    getTransformLabelL10nIds,
+    getLocalizedTransformLabels,
   };
 }

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -404,11 +404,12 @@ export function getThreadSelectorsWithMarkersPerThread(
     threadSelectors.getRangeFilteredThread,
     getTransformStack,
     ProfileSelectors.getDefaultCategory,
-    (startingThread, transforms, defaultCategory) => {
+    threadSelectors.getFullMarkerList,
+    (startingThread, transforms, defaultCategory, markers) => {
       return transforms.reduce(
         // Apply the reducer using an arrow function to ensure correct memoization.
         (thread, transform) =>
-          _applyTransformMemoized(thread, transform, defaultCategory),
+          _applyTransformMemoized(thread, transform, defaultCategory, markers),
         startingThread
       );
     }

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -141,7 +141,8 @@ describe('MarkerTable', function () {
 
     fireFullContextMenu(getByText(/setTimeout/));
     checkMenuIsDisplayedForNode(/setTimeout/);
-    expect(getRowElement(/setTimeout/)).toHaveClass('isRightClicked');
+    // There is another text with setTimeout inside the context menu. Pick the right one.
+    expect(getRowElement(/setTimeout\s/)).toHaveClass('isRightClicked');
 
     // Wait that all timers are done before trying again.
     jest.runAllTimers();

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -142,6 +142,24 @@ exports[`MarkerChart context menus displays when right clicking on a marker 1`] 
     <span
       class="react-contextmenu-icon markerContextMenuIconCopyDescription"
     />
+    Drop samples outside of “
+    <strong>
+      ⁨UserTiming⁩
+    </strong>
+    ” markers
+  </div>
+  <div
+    class="react-contextmenu-separator"
+  />
+  <div
+    aria-disabled="false"
+    class="react-contextmenu-item"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <span
+      class="react-contextmenu-icon markerContextMenuIconCopyDescription"
+    />
     Copy description
   </div>
   <div

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -140,7 +140,7 @@ exports[`MarkerChart context menus displays when right clicking on a marker 1`] 
     tabindex="-1"
   >
     <span
-      class="react-contextmenu-icon markerContextMenuIconCopyDescription"
+      class="react-contextmenu-icon markerContextMenuIconFilterSamples"
     />
     Drop samples outside of “
     <strong>

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1836,7 +1836,7 @@ describe('"filter-samples" transform', function () {
     const threadIndex = 0;
     addMarkersToThreadWithCorrespondingSamples(profile.threads[threadIndex], [
       [
-        'Marker A',
+        'DOMEvent',
         0,
         0.5,
         {
@@ -1846,17 +1846,17 @@ describe('"filter-samples" transform', function () {
         },
       ],
       [
-        'Marker B',
+        'Log',
         0.5,
         1.5,
         {
-          type: 'UserTiming',
-          name: 'measure-1',
-          entryType: 'measure',
+          type: 'Log',
+          name: 'Random log message',
+          module: 'RandomModule',
         },
       ],
       [
-        'Marker C',
+        'UserTiming',
         1.5,
         2.5,
         {
@@ -1866,7 +1866,7 @@ describe('"filter-samples" transform', function () {
         },
       ],
       [
-        'Marker C',
+        'UserTiming',
         2.5,
         3.5,
         {
@@ -1892,12 +1892,12 @@ describe('"filter-samples" transform', function () {
       ]);
     });
 
-    it('filtered to range of "Marker A"', function () {
+    it('filtered to range of "DOMEvent"', function () {
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'Marker A',
+          filter: 'DOMEvent',
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());
@@ -1910,12 +1910,12 @@ describe('"filter-samples" transform', function () {
       dispatch(popTransformsFromStack(0));
     });
 
-    it('filtered to range of "Marker B"', function () {
+    it('filtered to range of "Log"', function () {
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'Marker B',
+          filter: 'Log',
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());
@@ -1929,12 +1929,12 @@ describe('"filter-samples" transform', function () {
       dispatch(popTransformsFromStack(0));
     });
 
-    it('filtered to multiple ranges of "Marker C"', function () {
+    it('filtered to multiple ranges of "UserTiming"', function () {
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'Marker C',
+          filter: 'UserTiming',
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1834,7 +1834,8 @@ describe('"filter-samples" transform', function () {
          D
     `);
     const threadIndex = 0;
-    addMarkersToThreadWithCorrespondingSamples(profile.threads[threadIndex], [
+    const thread = profile.threads[threadIndex];
+    addMarkersToThreadWithCorrespondingSamples(thread, [
       [
         'DOMEvent',
         0,
@@ -1893,11 +1894,12 @@ describe('"filter-samples" transform', function () {
     });
 
     it('filtered to range of "DOMEvent"', function () {
+      const DOMEventStringIndex = thread.stringTable.indexForString('DOMEvent');
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'DOMEvent',
+          filter: DOMEventStringIndex,
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());
@@ -1911,11 +1913,12 @@ describe('"filter-samples" transform', function () {
     });
 
     it('filtered to range of "Log"', function () {
+      const logStringIndex = thread.stringTable.indexForString('Log');
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'Log',
+          filter: logStringIndex,
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());
@@ -1930,11 +1933,13 @@ describe('"filter-samples" transform', function () {
     });
 
     it('filtered to multiple ranges of "UserTiming"', function () {
+      const userTimingStringIndex =
+        thread.stringTable.indexForString('UserTiming');
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'UserTiming',
+          filter: userTimingStringIndex,
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());
@@ -1949,11 +1954,13 @@ describe('"filter-samples" transform', function () {
     });
 
     it('filtered to a non-existent marker name', function () {
+      const nonExistentStringIndex =
+        thread.stringTable.indexForString('non-existent');
       dispatch(
         addTransformToStack(threadIndex, {
           type: 'filter-samples',
           filterType: 'marker',
-          filter: 'non-existent',
+          filter: nonExistentStringIndex,
         })
       );
       const callTree = selectedThreadSelectors.getCallTree(getState());

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -20,6 +20,7 @@ import type {
   IndexIntoFuncTable,
   IndexIntoResourceTable,
   IndexIntoCategoryList,
+  IndexIntoStringTable,
 } from './profile';
 import type { CallNodePath, ThreadsKey } from './profile-derived';
 import type { ImplementationFilter } from './actions';
@@ -342,7 +343,7 @@ export type TransformDefinitions = {
     +type: 'filter-samples',
     // Expand this type when you need to support more than just the marker.
     +filterType: FilterSamplesType,
-    +filter: string,
+    +filter: IndexIntoStringTable,
   |},
 };
 

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -24,6 +24,13 @@ import type {
 import type { CallNodePath, ThreadsKey } from './profile-derived';
 import type { ImplementationFilter } from './actions';
 
+/**
+ * This type represents the filter types for the 'filter-samples' transform.
+ * Currently the only filter type is 'marker', but in the future we may add
+ * more types of filters.
+ */
+export type FilterSamplesType = 'marker';
+
 /*
  * Define all of the transforms on an object to conveniently access $ObjMap and do
  * nice things like iterate over every transform type. There is no way to create a
@@ -324,6 +331,18 @@ export type TransformDefinitions = {
   'focus-category': {|
     +type: 'focus-category',
     +category: IndexIntoCategoryList,
+  |},
+
+  /**
+   * Filter the samples in the thread by the filter.
+   * Currently it only supports filtering by the marker name but can be extended
+   * to support more filters in the future.
+   */
+  'filter-samples': {|
+    +type: 'filter-samples',
+    // Expand this type when you need to support more than just the marker.
+    +filterType: FilterSamplesType,
+    +filter: string,
   |},
 };
 

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -93,6 +93,7 @@ export function convertToTransformType(type: string): TransformType | null {
     case 'collapse-recursion':
     case 'collapse-function-subtree':
     case 'drop-function':
+    case 'filter-samples':
       return coercedType;
     default: {
       // The coerced type SHOULD be empty here. If in reality we get


### PR DESCRIPTION
Fixes #4590.
This PR is ready for feedback and review

[Deploy preview](https://deploy-preview-4610--perf-html.netlify.app/public/s52pym4tna59ry0tt3qmhak6empcqkh8rgk1gvr/calltree/?globalTrackOrder=0&thread=0&transforms=fs-m-1290&v=9) 

This PR adds a marker context menu item called `Filter samples by “<marker name>” markers`.

It also changes the per-thread selectors creation pipeline so we can have derived marker selectors for the transform computation. Previously, we created the thread selectors, and then the marker selectors .It made it impossible to get the derived markers for transform applied thread computation. Now we do the thread selectors in 2 steps. We create basic thread selectors first, then we craate the marker selectors, and then we create the more advanced thread selectors that require markers to be computed.

Things I would like to get feedback on:
- Wording on the context menu item. This is the best I could come up with but happy to get feedback for improvements. 
- How we get the "marker name". Currently this is a bit ad hoc. Because we can either have names in the marker payload (e.g. UserTiming markers) or in the name itself. So how I get is that, first I check if marker payload has a `name` and use it if it has. Otherwise I get the marker name. This is how it's done `marker.data && marker.data.name ? marker.data.name : marker.name`. We can possible use marker schema for this, but not sure what to pick there as we have multiple labels.
- The context menu item icon. I found it from the [photon icons here](https://icons.design.firefox.com/viewer/#).

It could be better to look at the commits one by one. 


Here's a screenshot of the new context menu item:
<img width="727" alt="Screenshot 2023-05-09 at 11 57 27 AM" src="https://user-images.githubusercontent.com/466239/237062386-5c2ebb92-c1c8-47f3-9317-cb3c09aa73e0.png">

Here's a screenshot of the transform navigator:
<img width="891" alt="Screenshot 2023-05-09 at 11 58 11 AM" src="https://user-images.githubusercontent.com/466239/237062571-409e87f6-def8-496d-89a4-ac9b3ab5327f.png">

