### PR TITLE
Add removing Firefox Profiler user guide

### DIFF
--- a/docs-user/_sidebar.md
+++ b/docs-user/_sidebar.md
@@ -9,6 +9,7 @@
     * [Remote Profiling](./guide-remote-profiling.md)
     * [Profiling directly on the device](./guide-profiling-android-directly-on-device.md)
   * [Memory Allocations](./memory-allocations.md)
+  * [Removing Profiler](./guide-removing-profiler.md)
 * [Advanced Topics](./advanced-topics.md)
   * [Profiling Firefox Startup & Shutdown](./guide-startup-shutdown.md)
   * [Perf profiling on Linux](./guide-perf-profiling.md)

--- a/docs-user/guide-removing-profiler.md
+++ b/docs-user/guide-removing-profiler.md
@@ -1,0 +1,4 @@
+# Removing profiler
+To remove the Firefox Profiler from the toolbar, right-click on the Profiler icon and choose "Remove from Toolbar" in the context menu.
+
+The Firefox Profiler is built in Firefox. The icon is only a menu button (that you can remove). There is no need and no way to remove the whole Firefox Profiler.


### PR DESCRIPTION
Short page explaining how to remove Firefox Profiler icon in the toolbar, and why one can't really remove Profiler.

Close #3184