### PR TITLE
server.js: Change working dir to `__dirname` before starting server

### DIFF
--- a/bin/launch-fp.sh
+++ b/bin/launch-fp.sh
@@ -8,16 +8,6 @@
 #   launch-fp.sh
 # then only the server will be launched.
 
-if [ "x$1" != "x" ]; then
-  PROFILEPATH=$(realpath "$1")
-fi
-PWD=$(pwd)
 SCRIPTPATH=$(realpath "$0")
 SCRIPTDIR=$(dirname "$SCRIPTPATH")
-cd "$SCRIPTDIR/.." || exit
-if [ "x$1" = "x" ]; then
-  yarn start
-else
-  yarn start "$PROFILEPATH"
-fi
-cd "$PWD" || exit
+NODE_ENV=development node "$SCRIPTDIR/../server.js" "$@"

--- a/server.js
+++ b/server.js
@@ -86,6 +86,9 @@ if (localConfigExists) {
 
 const profilerUrl = `http://${host}:${port}`;
 if (argv.profile) {
+  // Needed because of a later working directory change.
+  argv.profile = path.resolve(argv.profile);
+
   // Spin up a simple http server serving the profile file.
   const profileServer = http.createServer((req, res) => {
     res.setHeader('Access-Control-Allow-Origin', profilerUrl);
@@ -124,6 +127,7 @@ if (argv.profile) {
   });
 }
 
+process.chdir(__dirname); // Allow server.js to be run from anywhere.
 const server = new WebpackDevServer(serverConfig, webpack(config));
 server
   .start()


### PR DESCRIPTION
This pr makes `server.js` change its working directory to `__dirname` before starting the webpack server, thus allowing `server.js` to be run from anywhere on the file system and greatly simplifying `bin/launch-fp.sh`.