### PR TITLE
Add the kWh unit for tooltips of power tracks.

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -807,6 +807,12 @@ TrackMemoryGraph--operations-since-the-previous-sample = operations since the pr
 ## consumption. The carbon dioxide equivalent represents the equivalent amount
 ## of CO₂ to achieve the same level of global warming potential.
 
+# This is used in the tooltip when the power value uses the kilowatt unit.
+# Variables:
+#   $value (String) - the power value at this location
+TrackPower--tooltip-power-kilowatt = { $value } kW
+  .label = Power
+
 # This is used in the tooltip when the power value uses the watt unit.
 # Variables:
 #   $value (String) - the power value at this location
@@ -818,6 +824,14 @@ TrackPower--tooltip-power-watt = { $value } W
 #   $value (String) - the power value at this location
 TrackPower--tooltip-power-milliwatt = { $value } mW
   .label = Power
+
+# This is used in the tooltip when the energy used in the current range uses the
+# kilowatt-hour unit.
+# Variables:
+#   $value (String) - the energy value for this range
+#   $carbonValue (string) - the carbon dioxide equivalent (CO₂e) value (kilograms)
+TrackPower--tooltip-energy-carbon-used-in-range-kilowatthour = { $value } kWh ({ $carbonValue } kg CO₂e)
+  .label = Energy used in the visible range
 
 # This is used in the tooltip when the energy used in the current range uses the
 # watt-hour unit.
@@ -842,6 +856,14 @@ TrackPower--tooltip-energy-carbon-used-in-range-milliwatthour = { $value } mWh (
 #   $carbonValue (string) - the carbon dioxide equivalent (CO₂e) value (milligrams)
 TrackPower--tooltip-energy-carbon-used-in-range-microwatthour = { $value } µWh ({ $carbonValue } mg CO₂e)
   .label = Energy used in the visible range
+
+# This is used in the tooltip when the energy used in the current preview
+# selection uses the kilowatt-hour unit.
+# Variables:
+#   $value (String) - the energy value for this range
+#   $carbonValue (string) - the carbon dioxide equivalent (CO₂e) value (kilograms)
+TrackPower--tooltip-energy-carbon-used-in-preview-kilowatthour = { $value } kWh ({ $carbonValue } kg CO₂e)
+  .label = Energy used in the current selection
 
 # This is used in the tooltip when the energy used in the current preview
 # selection uses the watt-hour unit.

--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -90,13 +90,18 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
 
   _formatPowerValue(
     power: number,
+    l10nIdKiloUnit,
     l10nIdUnit,
     l10nIdMilliUnit,
     l10nIdMicroUnit
   ): Localized {
     let value, l10nId, carbonValue;
     const carbon = this._computeCO2eFromPower(power);
-    if (power > 1) {
+    if (power > 1000) {
+      value = formatNumber(power / 1000, 3);
+      carbonValue = formatNumber(carbon / 1000, 2);
+      l10nId = l10nIdKiloUnit;
+    } else if (power > 1) {
       value = formatNumber(power, 3);
       carbonValue = formatNumber(carbon, 3);
       l10nId = l10nIdUnit;
@@ -153,12 +158,14 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
         <TooltipDetails>
           {this._formatPowerValue(
             power,
+            'TrackPower--tooltip-power-kilowatt',
             'TrackPower--tooltip-power-watt',
             'TrackPower--tooltip-power-milliwatt'
           )}
           {previewSelection.hasSelection
             ? this._formatPowerValue(
                 this._computePowerSumForPreviewRange(previewSelection),
+                'TrackPower--tooltip-energy-carbon-used-in-preview-kilowatthour',
                 'TrackPower--tooltip-energy-carbon-used-in-preview-watthour',
                 'TrackPower--tooltip-energy-carbon-used-in-preview-milliwatthour',
                 'TrackPower--tooltip-energy-carbon-used-in-preview-microwatthour'
@@ -166,6 +173,7 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
             : null}
           {this._formatPowerValue(
             this._computePowerSumForCommittedRange(committedRange),
+            'TrackPower--tooltip-energy-carbon-used-in-range-kilowatthour',
             'TrackPower--tooltip-energy-carbon-used-in-range-watthour',
             'TrackPower--tooltip-energy-carbon-used-in-range-milliwatthour',
             'TrackPower--tooltip-energy-carbon-used-in-range-microwatthour'


### PR DESCRIPTION
When power profiling something that uses more power than a browser on a laptop (could be an application using all cores for multiple hours on a powerful server, or in my most recent case kitchen appliances or washing machines), having a Wh as the largest unit means we display numbers in the thousands in tooltips of the power track. Adding the 'kilo' version of the existing units is straightforward.

Example profile: https://share.firefox.dev/430KJTk (this is using the washing machine, then the dryer)