### PR TITLE
Set the CanvasRenderingContext2D.lineJoin to bevel on power tracks

### DIFF
--- a/src/components/timeline/TrackPowerGraph.js
+++ b/src/components/timeline/TrackPowerGraph.js
@@ -124,6 +124,7 @@ class TrackPowerCanvas extends React.PureComponent<CanvasProps> {
       // power graph.
 
       ctx.lineWidth = deviceLineWidth;
+      ctx.lineJoin = 'bevel';
       ctx.strokeStyle = GREY_50;
       ctx.fillStyle = '#73737388'; // Grey 50 with transparency.
       ctx.beginPath();

--- a/src/test/components/__snapshots__/TrackPower.test.js.snap
+++ b/src/test/components/__snapshots__/TrackPower.test.js.snap
@@ -46,6 +46,10 @@ Array [
     2,
   ],
   Array [
+    "set lineJoin",
+    "bevel",
+  ],
+  Array [
     "set strokeStyle",
     "#737373",
   ],


### PR DESCRIPTION
The power tracks have very noisy graphs on https://share.firefox.dev/3OKB7bB

Per discussion on matrix, the way to fix it is to set https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin

[deploy preview](https://deploy-preview-4634--perf-html.netlify.app/public/qvm42wqngw9c2k41q3qbas9h61jcnd43b6f27xr/marker-chart/?globalTrackOrder=0&hiddenLocalTracksByPid=0-013568&thread=0&timelineType=category&v=9)