### PR TITLE
Use the meta.profilingStartTime and meta.profilingEndTime fields

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -506,6 +506,8 @@ MenuButtons--metaInfo--logical-cpu =
        *[other] { $logicalCPUs } logical cores
     }
 
+MenuButtons--metaInfo--profiling-started = Recording started:
+MenuButtons--metaInfo--profiling-session = Recording length:
 MenuButtons--metaInfo--main-process-started = Main process started:
 MenuButtons--metaInfo--main-process-ended = Main process ended:
 MenuButtons--metaInfo--interval = Interval:
@@ -525,6 +527,7 @@ MenuButtons--metaInfo--buffer-duration-seconds =
 MenuButtons--metaInfo--buffer-duration-unlimited = Unlimited
 MenuButtons--metaInfo--application = Application
 MenuButtons--metaInfo--name-and-version = Name and version:
+MenuButtons--metaInfo--application-uptime = Uptime:
 MenuButtons--metaInfo--update-channel = Update channel:
 MenuButtons--metaInfo--build-id = Build ID:
 MenuButtons--metaInfo--build-type = Build type:

--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -218,7 +218,27 @@ class MetaInfoPanelImpl extends React.PureComponent<Props, State> {
     return (
       <>
         <div className="metaInfoSection">
-          {meta.startTime ? (
+          {meta.profilingStartTime !== undefined ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--profiling-started">
+                  Recording started:
+                </Localized>
+              </span>
+              {_formatDate(meta.startTime + meta.profilingStartTime)}
+            </div>
+          ) : null}
+          {meta.profilingStartTime !== undefined && meta.profilingEndTime ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--profiling-session">
+                  Recording length:
+                </Localized>
+              </span>
+              {formatTimestamp(meta.profilingEndTime - meta.profilingStartTime)}
+            </div>
+          ) : null}
+          {meta.profilingStartTime === undefined && meta.startTime ? (
             <div className="metaInfoRow">
               <span className="metaInfoLabel">
                 <Localized id="MenuButtons--metaInfo--main-process-started">
@@ -308,6 +328,16 @@ class MetaInfoPanelImpl extends React.PureComponent<Props, State> {
                 </Localized>
               </span>
               {formatProductAndVersion(meta)}
+            </div>
+          ) : null}
+          {meta.profilingStartTime ? (
+            <div className="metaInfoRow">
+              <span className="metaInfoLabel">
+                <Localized id="MenuButtons--metaInfo--application-uptime">
+                  Uptime:
+                </Localized>
+              </span>
+              {formatTimestamp(meta.profilingStartTime)}
             </div>
           ) : null}
           {meta.updateChannel ? (

--- a/src/components/app/WindowTitle.js
+++ b/src/components/app/WindowTitle.js
@@ -71,7 +71,9 @@ class WindowTitleImpl extends PureComponent<Props> {
           if (formattedMetaInfoString) {
             title += formattedMetaInfoString + SEPARATOR;
           }
-          title += _formatDateTime(meta.startTime);
+          title += _formatDateTime(
+            meta.startTime + (meta.profilingStartTime || 0)
+          );
           if (dataSource === 'public') {
             title += ` (${dataSource})`;
           }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1508,7 +1508,7 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
     pages = pages.concat(subprocessProfile.pages || []);
   }
 
-  const meta = {
+  const meta: ProfileMeta = {
     interval: geckoProfile.meta.interval,
     startTime: geckoProfile.meta.startTime,
     abi: geckoProfile.meta.abi,
@@ -1544,6 +1544,11 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
     device: geckoProfile.meta.device,
   };
 
+  if (geckoProfile.meta.profilingStartTime !== undefined) {
+    meta.profilingStartTime = geckoProfile.meta.profilingStartTime;
+    meta.profilingEndTime = geckoProfile.meta.profilingEndTime;
+  }
+
   const profilerOverhead: ProfilerOverhead[] = nullableProfilerOverhead.reduce(
     (acc, overhead) => {
       if (overhead !== null) {
@@ -1578,7 +1583,7 @@ export function processGeckoProfile(geckoProfile: GeckoProfile): Profile {
       const jsTracerThread = convertJsTracerToThread(
         thread,
         jsTracer,
-        meta.categories
+        geckoProfile.meta.categories
       );
       jsTracerThread.isJsTracer = true;
       jsTracerThread.name = `JS Tracer of ${friendlyThreadName}`;

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -919,6 +919,15 @@ export function getTimeRangeIncludingAllThreads(
   profile: Profile
 ): StartEndRange {
   const completeRange = { start: Infinity, end: -Infinity };
+  if (
+    profile.meta.profilingStartTime !== undefined &&
+    profile.meta.profilingEndTime
+  ) {
+    return {
+      start: profile.meta.profilingStartTime,
+      end: profile.meta.profilingEndTime,
+    };
+  }
   profile.threads.forEach((thread) => {
     const threadRange = memoizedGetTimeRangeForThread(
       thread,

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -191,6 +191,12 @@ export function sanitizePII(
       : undefined,
   };
 
+  if (PIIToBeRemoved.shouldFilterToCommittedRange !== null) {
+    const { start, end } = PIIToBeRemoved.shouldFilterToCommittedRange;
+    newProfile.meta.profilingStartTime = start;
+    newProfile.meta.profilingEndTime = end;
+  }
+
   return {
     profile: newProfile,
     // Note that the profile was sanitized.

--- a/src/test/components/MenuButtons.test.js
+++ b/src/test/components/MenuButtons.test.js
@@ -524,6 +524,21 @@ describe('app/MenuButtons', function () {
       expect(getMetaInfoPanel()).toMatchSnapshot();
     });
 
+    it('matches the snapshot with uptime', async () => {
+      // Using gecko profile because it has metadata and profilerOverhead data in it.
+      const profile = processGeckoProfile(createGeckoProfile());
+      // The profiler was started 500ms after the parent process.
+      profile.meta.profilingStartTime = 500;
+
+      const { displayMetaInfoPanel, getMetaInfoPanel } =
+        await setupForMetaInfoPanel(profile);
+      await displayMetaInfoPanel();
+
+      const uptime = ensureExists(screen.getByText(/Uptime:/).nextSibling);
+      expect(uptime).toHaveTextContent('500ms');
+      expect(getMetaInfoPanel()).toMatchSnapshot();
+    });
+
     it('with no statistics object should not make the app crash', async () => {
       // Using gecko profile because it has metadata and profilerOverhead data in it.
       const profile = processGeckoProfile(createGeckoProfile());

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -415,9 +415,19 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
         <span
           class="metaInfoLabel"
         >
-          Main process started:
+          Recording started:
         </span>
         toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Recording length:
+        </span>
+        1.007s
       </div>
       <div
         class="metaInfoRow"
@@ -804,9 +814,19 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device inform
         <span
           class="metaInfoLabel"
         >
-          Main process started:
+          Recording started:
         </span>
         toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Recording length:
+        </span>
+        1.007s
       </div>
       <div
         class="metaInfoRow"
@@ -1132,6 +1152,368 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device inform
 </div>
 `;
 
+exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with uptime 1`] = `
+<div
+  class="arrowPanel open metaInfoPanel"
+>
+  <div
+    class="arrowPanelArrow"
+  />
+  <div
+    class="arrowPanelContent"
+  >
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Profile Information
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Recording started:
+        </span>
+        toLocaleString Sat, 09 Apr 2016 17:02:33 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Recording length:
+        </span>
+        507ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Interval:
+        </span>
+        1ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer capacity:
+        </span>
+        8MB
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Buffer duration:
+        </span>
+        Unlimited
+      </div>
+      <div
+        class="metaInfoSection"
+      />
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Symbols:
+        </span>
+        Profile is not symbolicated
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        />
+        <button
+          class="photon-button photon-button-micro"
+          type="button"
+        >
+          Symbolicate profile
+        </button>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Application
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Name and version:
+        </span>
+        Firefox 48
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Uptime:
+        </span>
+        500ms
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Update channel:
+        </span>
+        nightly
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build ID:
+        </span>
+        20181126165837
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Build type:
+        </span>
+        Debug
+      </div>
+      <div
+        class="metaInfoRow metaInfoListRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Extensions:
+        </span>
+        <ul
+          class="metaInfoList"
+        >
+          <li
+            class="metaInfoListItem"
+          >
+            Firefox Screenshots
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Form Autofill
+          </li>
+          <li
+            class="metaInfoListItem"
+          >
+            Gecko Profiler
+          </li>
+        </ul>
+      </div>
+    </div>
+    <h2
+      class="metaInfoSubTitle"
+    >
+      Platform
+    </h2>
+    <div
+      class="metaInfoSection"
+    >
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          OS:
+        </span>
+        macOS 10.11
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          ABI:
+        </span>
+        x86_64-gcc3
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          CPU cores:
+        </span>
+        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+      </div>
+    </div>
+    <details>
+      <summary
+        class="arrowPanelSubTitle"
+      >
+        ⁨Profiler⁩ overhead
+      </summary>
+      <div
+        class="arrowPanelSection"
+      >
+        <div
+          class="metaInfoGrid"
+        >
+          <div />
+          <div>
+            Mean
+          </div>
+          <div>
+            Max
+          </div>
+          <div>
+            Min
+          </div>
+          <div
+            title="Time to sample all threads."
+          >
+            Overhead
+          </div>
+          <div>
+            227μs
+          </div>
+          <div>
+            410μs
+          </div>
+          <div>
+            38μs
+          </div>
+          <div
+            title="Time to discard expired data."
+          >
+            Cleaning
+          </div>
+          <div>
+            54μs
+          </div>
+          <div>
+            100μs
+          </div>
+          <div>
+            7.0μs
+          </div>
+          <div
+            title="Time to gather all counters."
+          >
+            Counter
+          </div>
+          <div>
+            59μs
+          </div>
+          <div>
+            105μs
+          </div>
+          <div>
+            12μs
+          </div>
+          <div
+            title="Observed interval between two samples."
+          >
+            Interval
+          </div>
+          <div>
+            857μs
+          </div>
+          <div>
+            1,000μs
+          </div>
+          <div>
+            0.000μs
+          </div>
+          <div
+            title="Time to acquire the lock before sampling."
+          >
+            Lockings
+          </div>
+          <div>
+            49μs
+          </div>
+          <div>
+            95μs
+          </div>
+          <div>
+            2.0μs
+          </div>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead durations:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            1,586μs
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Overhead percentage:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            26,433%
+          </span>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoWideLabel"
+          >
+            Profiled duration:
+          </span>
+          <span
+            class="metaInfoValueRight"
+          >
+            6.0μs
+          </span>
+        </div>
+      </div>
+    </details>
+  </div>
+</div>
+`;
+
 exports[`app/MenuButtons <MetaInfoPanel> with more extra info, opens more info section if clicked 1`] = `
 <div
   class="moreInfoPart"
@@ -1237,9 +1619,19 @@ exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not ma
         <span
           class="metaInfoLabel"
         >
-          Main process started:
+          Recording started:
         </span>
         toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+      </div>
+      <div
+        class="metaInfoRow"
+      >
+        <span
+          class="metaInfoLabel"
+        >
+          Recording length:
+        </span>
+        1.007s
       </div>
       <div
         class="metaInfoRow"
@@ -1819,7 +2211,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
           class="menuButtonsDownloadSize"
         >
           (
-          1.55 kB
+          1.57 kB
           )
         </span>
       </a>
@@ -2050,7 +2442,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          1.55 kB
+          1.57 kB
           )
         </span>
       </a>

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -195,6 +195,8 @@ export function createGeckoProfile(): GeckoProfile {
     stackwalk: 1,
     debug: 1,
     startTime: 1460221352723.438,
+    profilingStartTime: 0,
+    profilingEndTime: 1007,
     shutdownTime: 1560221352723,
     toolkit: 'cocoa',
     version: GECKO_PROFILE_VERSION,

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -677,6 +677,34 @@ describe('profile meta processing', function () {
     // Checking if it keeps the sampleUnits object.
     expect(processedMeta.sampleUnits).toEqual(geckoMeta.sampleUnits);
   });
+
+  it('keeps the profilingStartTime and profilingEndTime', function () {
+    const geckoProfile = createGeckoProfile();
+    const geckoMeta = geckoProfile.meta;
+
+    // Processing the profile.
+    const processedProfile = processGeckoProfile(geckoProfile);
+    const processedMeta = processedProfile.meta;
+
+    expect(processedMeta.profilingStartTime).toEqual(
+      geckoMeta.profilingStartTime
+    );
+    expect(processedMeta.profilingEndTime).toEqual(geckoMeta.profilingEndTime);
+  });
+
+  it('does not create the profilingStartTime and profilingEndTime fields', function () {
+    const geckoProfile = createGeckoProfile();
+    const geckoMeta = geckoProfile.meta;
+    delete geckoMeta.profilingStartTime;
+    delete geckoMeta.profilingEndTime;
+
+    // Processing the profile.
+    const processedProfile = processGeckoProfile(geckoProfile);
+    const processedMeta = processedProfile.meta;
+
+    expect(processedMeta.profilingStartTime).toEqual(undefined);
+    expect(processedMeta.profilingEndTime).toEqual(undefined);
+  });
 });
 
 describe('visualMetrics processing', function () {

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -186,6 +186,12 @@ describe('sanitizePII', function () {
       );
     }
 
+    // Make sure the meta data contains the new profile range
+    expect(sanitizedProfile.meta.profilingStartTime).toEqual(
+      sanitizedRange.start
+    );
+    expect(sanitizedProfile.meta.profilingEndTime).toEqual(sanitizedRange.end);
+
     // Make sure that we still have the same number of counters.
     expect(ensureExists(originalProfile.counters).length).toEqual(1);
     expect(ensureExists(sanitizedProfile.counters).length).toEqual(1);

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -303,6 +303,8 @@ export type GeckoProfilerOverhead = {|
  * */
 export type GeckoProfileShortMeta = {|
   version: number,
+  // When the main process started. Timestamp expressed in milliseconds since
+  // midnight January 1, 1970 GMT.
   startTime: Milliseconds,
   shutdownTime: Milliseconds | null,
   categories: CategoryList,
@@ -315,6 +317,10 @@ export type GeckoProfileShortMeta = {|
  * */
 export type GeckoProfileFullMeta = {|
   ...GeckoProfileShortMeta,
+  // When the recording started (in milliseconds after startTime).
+  profilingStartTime?: Milliseconds,
+  // When the recording ended (in milliseconds after startTime).
+  profilingEndTime?: Milliseconds,
   interval: Milliseconds,
   stackwalk: 0 | 1,
   // This value represents a boolean, but for some reason is written out as an int

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -750,10 +750,15 @@ export type ExtraProfileInfoSection = {|
 export type ProfileMeta = {|
   // The interval at which the threads are sampled.
   interval: Milliseconds,
-  // The number of milliseconds since midnight January 1, 1970 GMT.
+  // When the main process started. Timestamp expressed in milliseconds since
+  // midnight January 1, 1970 GMT.
   startTime: Milliseconds,
   // The number of milliseconds since midnight January 1, 1970 GMT.
   endTime?: Milliseconds,
+  // When the recording started (in milliseconds after startTime).
+  profilingStartTime?: Milliseconds,
+  // When the recording ended (in milliseconds after startTime).
+  profilingEndTime?: Milliseconds,
   // The process type where the Gecko profiler was started. This is the raw enum
   // numeric value as defined here:
   // https://searchfox.org/mozilla-central/rev/819cd31a93fd50b7167979607371878c4d6f18e8/xpcom/build/nsXULAppAPI.h#365


### PR DESCRIPTION
They can be used to decide what the profile root range should be. This fixes #4425 and handles most of #3458 (which can be refocused on what remains, ie. using `meta.contentEarliestTime` to show if/when the buffer overflowed).

Additionally, I tweaked the Profile Info panel to show when the profiler started and for how long it recorded, instead of showing when the parent process started. I'm also showing the uptime of the application when the profiler started (I think that information is more useful than the process start time).

Requesting review from Julien as I already put multiple PRs in Nazim's review queue, but I'm equally happy if Nazim wants to take it.