### PR TITLE
Avoid sorting power tracks if profile.meta.keepProfileThreadOrder is true

### DIFF
--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -119,8 +119,13 @@ function _getDefaultLocalTrackOrder(tracks: LocalTrack[], profile: ?Profile) {
       tracks[a].type === 'power' &&
       tracks[b].type === 'power'
     ) {
-      const nameA = profile.counters[tracks[a].counterIndex].name;
-      const nameB = profile.counters[tracks[b].counterIndex].name;
+      const idxA = tracks[a].counterIndex;
+      const idxB = tracks[b].counterIndex;
+      if (profile.meta.keepProfileThreadOrder) {
+        return idxA - idxB;
+      }
+      const nameA = profile.counters[idxA].name;
+      const nameB = profile.counters[idxB].name;
       return naturalSort.compare(nameA, nameB);
     }
 


### PR DESCRIPTION
When I did the pull request to sort power tracks alphabetically (#4470) I had not noticed that there's a meta flag to disable track sorting (added in PR #4263).

It's a bit unfortunate that the flag is named `keepProfileThreadOrder` rather than `keepProfileTrackOrder` as power counters are not really threads, but I think creating a new flag specifically for power tracks is overkill (but happy to discuss if you disagree).

I didn't bother with tests as it's a trivial patch and it won't be too bad if this ever breaks, but if you think we really need a test I can look into it another day. (Would need to cover #4470 first though.)

Example of a power profile that makes more sense when keeping the initial track order: https://share.firefox.dev/3WNTcHZ