### PR TITLE
Show the tooltip with the CPU usage values even though the samples are not hovered on activity graph

### DIFF
--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -36,8 +36,8 @@ type RestProps = {|
 |};
 
 type Props = {|
-  +cpuRatioInTimeRange: CPUProps | null,
   ...RestProps,
+  +cpuRatioInTimeRange: CPUProps | null,
   +sampleIndex: IndexIntoSamplesTable | null,
 |};
 

--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -38,6 +38,7 @@ type RestProps = {|
 type Props = {|
   +cpuRatioInTimeRange: CPUProps | null,
   ...RestProps,
+  +sampleIndex: IndexIntoSamplesTable | null,
 |};
 
 /**
@@ -122,19 +123,22 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
       implementationFilter,
     } = this.props;
 
-    const { samples, stackTable } = rangeFilteredThread;
-    const stackIndex = samples.stack[sampleIndex];
-    const hasSamples = samples.length > 0 && stackTable.length > 1;
     let hasStack = false;
-    if (hasSamples) {
-      const stack = getFuncNamesAndOriginsForPath(
-        convertStackToCallNodeAndCategoryPath(
-          rangeFilteredThread,
-          ensureExists(stackIndex)
-        ),
-        rangeFilteredThread
-      );
-      hasStack = stack.length > 1 || stack[0].funcName !== '(root)';
+    if (sampleIndex !== null) {
+      const { samples, stackTable } = rangeFilteredThread;
+      const stackIndex = samples.stack[sampleIndex];
+      const hasSamples = samples.length > 0 && stackTable.length > 1;
+
+      if (hasSamples) {
+        const stack = getFuncNamesAndOriginsForPath(
+          convertStackToCallNodeAndCategoryPath(
+            rangeFilteredThread,
+            ensureExists(stackIndex)
+          ),
+          rangeFilteredThread
+        );
+        hasStack = stack.length > 1 || stack[0].funcName !== '(root)';
+      }
     }
 
     return (
@@ -148,7 +152,7 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
         {hasStack && cpuRatioInTimeRange !== null ? (
           <TooltipDetailSeparator />
         ) : null}
-        {!hasStack ? null : (
+        {!hasStack || sampleIndex === null ? null : (
           <SampleTooltipRestContents
             sampleIndex={sampleIndex}
             rangeFilteredThread={rangeFilteredThread}

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -60,7 +60,7 @@ export type Props = {|
 |};
 
 export type HoveredPixelState = {|
-  +sample: IndexIntoSamplesTable,
+  +sample: IndexIntoSamplesTable | null,
   +cpuRatioInTimeRange: CpuRatioInTimeRange | null,
 |};
 
@@ -145,7 +145,10 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
 
   _onClick = (event: SyntheticMouseEvent<HTMLCanvasElement>) => {
     const sampleState = this._getSampleAtMouseEvent(event);
-    this.props.onSampleClick(event, sampleState ? sampleState.sample : null);
+    this.props.onSampleClick(
+      event,
+      sampleState && sampleState.sample ? sampleState.sample : null
+    );
   };
 
   _takeContainerRef = (el: HTMLElement | null) => {

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -145,10 +145,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
 
   _onClick = (event: SyntheticMouseEvent<HTMLCanvasElement>) => {
     const sampleState = this._getSampleAtMouseEvent(event);
-    this.props.onSampleClick(
-      event,
-      sampleState && sampleState.sample ? sampleState.sample : null
-    );
+    this.props.onSampleClick(event, sampleState ? sampleState.sample : null);
   };
 
   _takeContainerRef = (el: HTMLElement | null) => {

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -421,16 +421,22 @@ export class ActivityFillGraphQuerier {
     const deviceX = Math.round(cssX * devicePixelRatio);
     const deviceY = Math.round(cssY * devicePixelRatio);
     const categoryUnderMouse = this._categoryAtDevicePixel(deviceX, deviceY);
+
+    const candidateSamples = this._getSamplesAtTime(time);
+    const cpuRatioInTimeRange = this._getCPURatioAtX(deviceX, candidateSamples);
+
     if (categoryUnderMouse === null) {
-      return null;
+      if (cpuRatioInTimeRange === null) {
+        // If there is not CPU ratio values iun that time range, do not show the tooltip.
+        return null;
+      }
+      // Show only the CPU ratio in the tooltip.
+      return { sample: null, cpuRatioInTimeRange };
     }
 
     // Get all samples that contribute pixels to the clicked category in this
     // pixel column of the graph.
     const { category, categoryLowerEdge, yPercentage } = categoryUnderMouse;
-    const candidateSamples = this._getSamplesAtTime(time);
-
-    const cpuRatioInTimeRange = this._getCPURatioAtX(deviceX, candidateSamples);
 
     // The candidate samples are sorted by gravity, bottom to top.
     // Each sample occupies a non-empty subrange of the [0, 1] range. The height

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -427,7 +427,7 @@ export class ActivityFillGraphQuerier {
 
     if (categoryUnderMouse === null) {
       if (cpuRatioInTimeRange === null) {
-        // If there is not CPU ratio values iun that time range, do not show the tooltip.
+        // If there is not CPU ratio values in that time range, do not show the tooltip.
         return null;
       }
       // Show only the CPU ratio in the tooltip.

--- a/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SampleTooltipContents renders the CPU usage only when outside of the activity graph is hovered 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 11px; top: 10px;"
+>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      CPU:
+    </div>
+    <div>
+      28% (average over 1.0ms)
+    </div>
+  </div>
+</div>
+`;
+
 exports[`SampleTooltipContents renders the sample tooltip properly 1`] = `
 <div
   class="tooltip"


### PR DESCRIPTION
Fixes #3700

This PR changes the tooltip behavior of the activity graph to show the CPU usage values even though the samples are not hovered.
This way it's going to be easier to see the small activities that are happening and whent it's harder to hover.
This can be either because the CPU usage is very low in that area, or because of the smoothing of the graph.

For example: 
<img width="846" alt="Screenshot 2023-06-15 at 4 24 44 PM" src="https://github.com/firefox-devtools/profiler/assets/466239/b0bd2604-d8a6-4989-b236-88465bda99a0">
You can see a 97% CPU usage here but because of the smoothing, it's harder to see. This makes it easier to see without needing to hover that small area necessarily.

[Deploy preview](https://deploy-preview-4666--perf-html.netlify.app/public/s52pym4tna59ry0tt3qmhak6empcqkh8rgk1gvr/calltree/?globalTrackOrder=0&thread=0&v=9)