### PR TITLE
Add an optional gramsOfCO2ePerKWh field to the meta data of processed profiles

### DIFF
--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -16,6 +16,7 @@ import {
   getCommittedRange,
   getPreviewSelection,
   getProfileInterval,
+  getMeta,
 } from 'firefox-profiler/selectors/profile';
 import { getSampleIndexRangeForSelection } from 'firefox-profiler/profile-logic/profile-data';
 
@@ -26,6 +27,7 @@ import type {
   Milliseconds,
   PreviewSelection,
   StartEndRange,
+  ProfileMeta,
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -37,6 +39,7 @@ type OwnProps = {|
 
 type StateProps = {|
   interval: Milliseconds,
+  meta: ProfileMeta,
   committedRange: StartEndRange,
   previewSelection: PreviewSelection,
 |};
@@ -68,8 +71,9 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
   _computeCO2eFromPower(power: number): number {
     // total energy Wh to kWh
     const energy = power / 1000;
-    const { WORLD } = averageIntensity.data;
-    return energy * WORLD;
+    const intensity =
+      this.props.meta.gramsOfCO2ePerKWh || averageIntensity.data.WORLD;
+    return energy * intensity;
   }
 
   _computePowerSumForCommittedRange = memoize(
@@ -187,6 +191,7 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
 export const TooltipTrackPower = explicitConnect<OwnProps, StateProps, {||}>({
   mapStateToProps: (state) => ({
     interval: getProfileInterval(state),
+    meta: getMeta(state),
     committedRange: getCommittedRange(state),
     previewSelection: getPreviewSelection(state),
   }),

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -905,6 +905,10 @@ export type ProfileMeta = {|
   initialSelectedThreads?: ThreadIndex[],
   // Keep the defined thread order
   keepProfileThreadOrder?: boolean,
+
+  // Grams of CO2 equivalent per kWh. Used to display power track tooltips.
+  // Will fallback to the global average if this is missing.
+  gramsOfCO2ePerKWh?: number,
 |};
 
 /**


### PR DESCRIPTION
I see this as a first step towards fixing #4479:
- if someone is power profiling Firefox and knows the carbon intensity of the electricity they used, it's possible to set the meta field from the devtools console before uploading (or reuploading) the profile.
- for profiles generated by sources other than the GeckoProfiler, it's possible to specify the carbon intensity explicitly in the profile JSON. (I have a use case where I am power profiling various appliances running in my house.)

If we want to go one step further towards fixing #4479, I think the next step would be to have a preference in Firefox that could be set using about:config to customize the carbon intensity in Firefox, and have it included in all captured power profiles.

And a last step could be to allow setting this preference from an input field in about:profiling. I think each of these steps provides an incremental improvement and they could be done separately.