### PR TITLE
Tweak CSS for the call tree settings bar

### DIFF
--- a/src/components/shared/PanelSettingsList.css
+++ b/src/components/shared/PanelSettingsList.css
@@ -5,14 +5,15 @@
 .panelSettingsList {
   display: flex;
   flex: 1;
-  align-items: flex-start;
+  align-items: stretch;
+  justify-content: flex-start;
   padding: 0;
   margin: 0;
   list-style: none;
 }
 
 .panelSettingsListItem {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   padding: 0;
   margin: 0 5px;

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -6,8 +6,8 @@
   display: flex;
   height: 25px;
   flex-flow: row nowrap;
+  align-items: stretch;
   padding: 0;
-  line-height: 25px;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
This tweaks the settings bar CSS to make a little more sense, with no visual changes.