### PR TITLE
Reserve functions for collapsed resources ahead-of-time.

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -40,6 +40,7 @@ import { getCallNodePathFromIndex } from 'firefox-profiler/profile-logic/profile
 import {
   assertExhaustiveCheck,
   getFirstItemFromSet,
+  ensureExists,
 } from 'firefox-profiler/utils/flow';
 import { sendAnalytics } from 'firefox-profiler/utils/analytics';
 import { objectShallowEquals } from 'firefox-profiler/utils/index';
@@ -65,6 +66,7 @@ import type {
   CallNodePath,
   CallNodeInfo,
   IndexIntoCallNodeTable,
+  IndexIntoResourceTable,
   TrackIndex,
   MarkerIndex,
   Transform,
@@ -1881,6 +1883,30 @@ export function addTransformToStack(
   };
 }
 
+export function addCollapseResourceTransformToStack(
+  threadsKey: ThreadsKey,
+  resourceIndex: IndexIntoResourceTable,
+  implementation: ImplementationFilter
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const threadSelectors = getThreadSelectorsFromThreadsKey(threadsKey);
+    const reservedFunctionsForResources =
+      threadSelectors.getReservedFunctionsForResources(getState());
+    const collapsedFuncIndex = ensureExists(
+      ensureExists(reservedFunctionsForResources).get(resourceIndex)
+    );
+
+    dispatch(
+      addTransformToStack(threadsKey, {
+        type: 'collapse-resource',
+        resourceIndex,
+        collapsedFuncIndex,
+        implementation,
+      })
+    );
+  };
+}
+
 export function popTransformsFromStack(
   firstPoppedFilterIndex: number
 ): ThunkAction<void> {
@@ -2057,16 +2083,12 @@ export function handleCallNodeTransformShortcut(
       case 'C': {
         const { funcTable } = unfilteredThread;
         const resourceIndex = funcTable.resource[funcIndex];
-        // A new collapsed func will be inserted into the table at the end. Deduce
-        // the index here.
-        const collapsedFuncIndex = funcTable.length;
         dispatch(
-          addTransformToStack(threadsKey, {
-            type: 'collapse-resource',
+          addCollapseResourceTransformToStack(
+            threadsKey,
             resourceIndex,
-            collapsedFuncIndex,
-            implementation,
-          })
+            implementation
+          )
         );
         break;
       }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -48,7 +48,7 @@ import {
 } from '../utils/uintarray-encoding';
 import { tabSlugs } from '../app-logic/tabs-handling';
 
-export const CURRENT_URL_VERSION = 9;
+export const CURRENT_URL_VERSION = 10;
 
 /**
  * This static piece of state might look like an anti-pattern, but it's a relatively
@@ -1178,6 +1178,57 @@ const _upgraders: {|
       const transformStrings = query.transforms.split('~');
       query.transforms = transformStrings.map(upgradeTransformString).join('~');
     }
+  },
+  [10]: ({ query }: ProcessedLocationBeforeUpgrade, profile?: Profile) => {
+    // This version changes the "collapse resource" transform to have a different
+    // collapsedFuncIndex: In version 9, "collapsed resource" functions were
+    // added to the funcTable by the transform as needed. In version 10, the
+    // "collapsed resource" functions are reserved at the beginning of the
+    // profile processing pipeline and instead get the following funcIndex:
+    // funcTable.length + resourceIndex.
+    // This was done so that funcIndexes are unaffected by the transform stack.
+    //
+    // The "collapse resource" transform is not used a lot, and there are
+    // probably not a lot of URLs with it in circulation, so we just do the bare
+    // minimum here: If a single thread is selected, and we have access to the
+    // funcTable for that thread, then we compute the correct collapsed funcIndex.
+    // Otherwise we don't bother and leave incorrect funcIndexes in the URL.
+    // These funcIndexes will match *some* reserved resource func, so the UI
+    // shouldn't break in that case.
+    //
+    // Furthermore, we're not fixing up any subsequent transforms that may be
+    // referring to the funcIndex. For example, if you collapse a resource and
+    // then drop or merge the collapsed function, this upgrader will not adjust
+    // the drop or merge transform. This could be added if it seems worth doing.
+
+    if (!query.transforms || !query.thread || !profile) {
+      return;
+    }
+
+    const selectedThreads = decodeUintArrayFromUrlComponent(query.thread);
+    if (selectedThreads.length !== 1) {
+      return;
+    }
+
+    const threadIndex = selectedThreads[0];
+    const funcTableLength = profile.threads[threadIndex].funcTable.length;
+
+    //     cr-{implementation}-{resourceIndex}-{wrongFuncIndex}
+    //  -> cr-{implementation}-{resourceIndex}-{correctFuncIndex}
+    function upgradeTransformString(transformString) {
+      if (transformString.startsWith('cr-')) {
+        const [, implementation, resourceIndex] = transformString.split('-');
+        const funcIndex = funcTableLength + +resourceIndex;
+        if (!isNaN(funcIndex)) {
+          return `cr-${implementation}-${resourceIndex}-${funcIndex}`;
+        }
+      }
+
+      return transformString;
+    }
+
+    const transformStrings = query.transforms.split('~');
+    query.transforms = transformStrings.map(upgradeTransformString).join('~');
   },
 };
 

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -21,6 +21,7 @@ import { getCategories } from 'firefox-profiler/selectors';
 import copy from 'copy-to-clipboard';
 import {
   addTransformToStack,
+  addCollapseResourceTransformToStack,
   expandAllCallNodeDescendants,
   updateBottomBoxContentsAndMaybeOpen,
   setContextMenuVisibility,
@@ -71,6 +72,7 @@ type StateProps = {|
 
 type DispatchProps = {|
   +addTransformToStack: typeof addTransformToStack,
+  +addCollapseResourceTransformToStack: typeof addCollapseResourceTransformToStack,
   +expandAllCallNodeDescendants: typeof expandAllCallNodeDescendants,
   +updateBottomBoxContentsAndMaybeOpen: typeof updateBottomBoxContentsAndMaybeOpen,
   +setContextMenuVisibility: typeof setContextMenuVisibility,
@@ -268,7 +270,12 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
   };
 
   addTransformToStack(type: TransformType): void {
-    const { addTransformToStack, implementation, inverted } = this.props;
+    const {
+      addTransformToStack,
+      addCollapseResourceTransformToStack,
+      implementation,
+      inverted,
+    } = this.props;
     const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
     if (rightClickedCallNodeInfo === null) {
@@ -323,15 +330,11 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
       case 'collapse-resource': {
         const { funcTable } = thread;
         const resourceIndex = funcTable.resource[selectedFunc];
-        // A new collapsed func will be inserted into the table at the end. Deduce
-        // the index here.
-        const collapsedFuncIndex = funcTable.length;
-        addTransformToStack(threadsKey, {
-          type: 'collapse-resource',
+        addCollapseResourceTransformToStack(
+          threadsKey,
           resourceIndex,
-          collapsedFuncIndex,
-          implementation,
-        });
+          implementation
+        );
         break;
       }
       case 'collapse-direct-recursion': {
@@ -823,6 +826,7 @@ export const CallNodeContextMenu = explicitConnect<
   },
   mapDispatchToProps: {
     addTransformToStack,
+    addCollapseResourceTransformToStack,
     expandAllCallNodeDescendants,
     updateBottomBoxContentsAndMaybeOpen,
     setContextMenuVisibility,

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -20,6 +20,7 @@ import {
 
 import {
   addTransformToStack,
+  addCollapseResourceTransformToStack,
   popTransformsFromStack,
   changeInvertCallstack,
   changeImplementationFilter,
@@ -844,12 +845,6 @@ describe('"collapse-resource" transform', function () {
     if (firefoxResourceIndex === -1) {
       throw new Error('Unable to find the firefox resource');
     }
-    const collapseTransform = {
-      type: 'collapse-resource',
-      resourceIndex: firefoxResourceIndex,
-      collapsedFuncIndex: thread.funcTable.length,
-      implementation: 'combined',
-    };
 
     it('starts as an unfiltered call tree', function () {
       const { getState } = storeWithProfile(profile);
@@ -867,7 +862,13 @@ describe('"collapse-resource" transform', function () {
 
     it('can collapse the "firefox" library', function () {
       const { dispatch, getState } = storeWithProfile(profile);
-      dispatch(addTransformToStack(threadIndex, collapseTransform));
+      dispatch(
+        addCollapseResourceTransformToStack(
+          threadIndex,
+          firefoxResourceIndex,
+          'combined'
+        )
+      );
       expect(
         formatTree(selectedThreadSelectors.getCallTree(getState()))
       ).toEqual([
@@ -887,7 +888,13 @@ describe('"collapse-resource" transform', function () {
           ['A', 'B', 'C', 'D'].map((name) => collapsedFuncNames.indexOf(name))
         )
       );
-      dispatch(addTransformToStack(threadIndex, collapseTransform));
+      dispatch(
+        addCollapseResourceTransformToStack(
+          threadIndex,
+          firefoxResourceIndex,
+          'combined'
+        )
+      );
       expect(
         selectedThreadSelectors.getSelectedCallNodePath(getState())
       ).toEqual(

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -6,11 +6,13 @@
 import type { Milliseconds, StartEndRange, Address, Bytes } from './units';
 import type { MarkerPayload, MarkerSchema } from './markers';
 import type {
-  IndexIntoFuncTable,
   ThreadIndex,
+  Thread,
   Pid,
+  IndexIntoFuncTable,
   IndexIntoJsTracerEvents,
   IndexIntoCategoryList,
+  IndexIntoResourceTable,
   IndexIntoNativeSymbolTable,
   IndexIntoLibs,
   CounterIndex,
@@ -248,6 +250,14 @@ export type CallNodeDisplayData = $Exact<
     ariaLabel: string,
   }>
 >;
+
+export type ThreadWithReservedFunctions = {|
+  thread: Thread,
+  reservedFunctionsForResources: Map<
+    IndexIntoResourceTable,
+    IndexIntoFuncTable
+  >,
+|};
 
 /**
  * The marker timing contains the necessary information to draw markers very quickly


### PR DESCRIPTION
This is needed for #4682 - if we want to store funcIndexes separately from the transform stack, then we need to make it so that transforms never change the funcTable. The "collapse resource" transform was the only transform to do so. After this PR, it will no longer change the funcTable and instead use one of the the pre-reserved functions.