### PR TITLE
Make removing a focus function transform faster.

### DIFF
--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -3,7 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { createSelector } from 'reselect';
+import {
+  createSelector,
+  createSelectorCreator,
+  defaultMemoize,
+} from 'reselect';
 import * as UrlState from '../url-state';
 import * as ProfileData from '../../profile-logic/profile-data';
 import * as StackTiming from '../../profile-logic/stack-timing';
@@ -59,6 +63,12 @@ type ThreadAndMarkerSelectorsPerThread = {|
   ...MarkerSelectorsPerThread,
 |};
 
+// A variant of createSelector which caches the value for two most recent keys,
+// not just for the single most recent key.
+const createSelectorWithTwoCacheSlots = createSelectorCreator(defaultMemoize, {
+  maxSize: 2,
+});
+
 /**
  * Create the selectors for a thread that have to do with either stacks or samples.
  */
@@ -91,13 +101,17 @@ export function getStackAndSampleSelectorsPerThread(
   // identity (which changes if e.g. only a thread's samples table changes),
   // but on the identities of just the subset of thread tables that are used by
   // getCallNodeInfo. This avoids recomputations when samples are dropped.
-  const getCallNodeInfo: Selector<CallNodeInfo> = createSelector(
-    (state) => threadSelectors.getFilteredThread(state).stackTable,
-    (state) => threadSelectors.getFilteredThread(state).frameTable,
-    (state) => threadSelectors.getFilteredThread(state).funcTable,
-    ProfileSelectors.getDefaultCategory,
-    ProfileData.getCallNodeInfo
-  );
+  // In addition, we use createSelectorWithTwoCacheSlots so that removing the last
+  // transform is fast. This lets you quickly go back and forth between a focused
+  // function and the whole profile.
+  const getCallNodeInfo: Selector<CallNodeInfo> =
+    createSelectorWithTwoCacheSlots(
+      (state) => threadSelectors.getFilteredThread(state).stackTable,
+      (state) => threadSelectors.getFilteredThread(state).frameTable,
+      (state) => threadSelectors.getFilteredThread(state).funcTable,
+      ProfileSelectors.getDefaultCategory,
+      ProfileData.getCallNodeInfo
+    );
 
   const getSourceViewStackLineInfo: Selector<StackLineInfo | null> =
     createSelector(


### PR DESCRIPTION
This speeds up the comparison report generator.
The generator focuses a function, goes back to the full profile, focuses a different function, goes back to the full profile again etc. Every time it goes back to the full profile, we were recomputing the call node info. By caching one more call node info value, we can avoid the repeated computation for the full profile call node info.