### PR TITLE
Make arrow panels more versatile.

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.css
+++ b/src/components/app/MenuButtons/MetaInfo.css
@@ -6,11 +6,8 @@
   width: 350px;
   font-size: 12px;
   line-height: 20px;
-}
 
-.metaInfoPanel,
-.metaInfoPanel .arrowPanelArrow::before {
-  background-color: white;
+  --arrow-panel-background: white;
 }
 
 .metaInfoSection {

--- a/src/components/app/MenuButtons/Permalink.css
+++ b/src/components/app/MenuButtons/Permalink.css
@@ -8,12 +8,11 @@
   background-image: url(firefox-profiler-res/img/svg/link-dark-12.svg);
 }
 
-.menuButtonsPermalinkPanel .arrowPanelContent {
-  /* Override the default padding for ArrowPanel */
-  padding: 4px;
+.menuButtonsPermalinkPanel {
+  --arrow-panel-padding: 4px;
 }
 
 .menuButtonsPermalinkTextField {
-  width: 16em;
+  /* the width of the text field is determined by the panel size (set in JS) + align-items:stretch */
   height: 19px;
 }

--- a/src/components/app/MenuButtons/Permalink.js
+++ b/src/components/app/MenuButtons/Permalink.js
@@ -75,6 +75,7 @@ export class MenuButtonsPermalink extends React.PureComponent<Props, State> {
           onPanelOpen={this._shortenUrlAndFocusTextFieldOnCompletion}
           onPanelClose={this._onPermalinkPanelClose}
           panelClassName="menuButtonsPermalinkPanel"
+          panelWidth={260}
           panelContent={
             <input
               data-testid="MenuButtonsPermalink-input"

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -30,10 +30,6 @@
   background-image: url(firefox-profiler-res/img/svg/error.svg);
 }
 
-.menuButtonsPublishPanel {
-  --width: 510px;
-}
-
 .menuButtonsPublishContent {
   position: relative;
 

--- a/src/components/app/MenuButtons/index.js
+++ b/src/components/app/MenuButtons/index.js
@@ -318,6 +318,7 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
             }
           )}
           panelClassName="menuButtonsPublishPanel"
+          panelWidth={510}
           // The value for the label following will be replaced
           label=""
           panelContent={<MenuButtonsPublish isRepublish={isRepublish} />}

--- a/src/components/shared/ButtonWithPanel/ArrowPanel.css
+++ b/src/components/shared/ButtonWithPanel/ArrowPanel.css
@@ -2,36 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.arrowPanelAnchor {
-  position: absolute;
-  z-index: 10;
-  top: 75%;
-  left: 50%;
-}
-
+/**
+ * .arrowPanel is a wrapper which renders nothing by itself and
+ * just establishes the bounds of the panel. The actual panel appearance is
+ * rendered by .arrowPanelInnerWrapper.
+ * The bottom edge of .arrowPanel is always at the bottom of the viewport.
+ * This allows .arrowPanelInnerWrapper to grow as needed and then to stop
+ * growing (and become scrollable) once it hits the bottom.
+ *
+ * The following properties are set by inline style: left, top, width
+ * The following CSS variables may be set by users: --arrow-panel-background, --arrow-panel-padding
+ */
 .arrowPanel {
-  --internal-offset-from-right: var(--offset-from-right, 60px);
-  --internal-offset-from-top: 15px;
-  --internal-width: var(--width, initial);
-  --internal-button-height: 30px;
+  --internal-arrow-clip-height: 15px;
+  --internal-background: var(--arrow-panel-background, hsl(0deg 0% 97%));
+  --internal-padding: var(--arrow-panel-padding, 16px);
 
-  position: absolute;
-  top: var(--internal-offset-from-top);
-  right: calc(var(--internal-offset-from-right) * -1);
-  min-width: var(--internal-width);
-  border: 0.5px solid rgb(0 0 0 / 0.25);
-  border-radius: 5px;
-  background: hsl(0deg 0% 97%);
-  background-clip: padding-box;
-  box-shadow: 0 8px 12px rgb(0 0 0 / 0.35);
+  position: fixed;
+  z-index: 2;
+  bottom: 5px; /* leave a small gap at the bottom of the viewport */
+  display: flex;
+  flex-flow: column nowrap;
+  padding-top: var(--internal-arrow-clip-height);
+  margin-bottom: auto;
   color: black;
   line-height: 1.3;
+  pointer-events: none;
   text-align: left;
-  transform-origin: calc(100% - var(--internal-offset-from-right))
-    calc(var(--internal-offset-from-top) * -1);
 }
 
-.arrowPanel:not(.open) {
+.arrowPanelInnerWrapper {
+  display: flex;
+  min-height: 0;
+  flex-flow: column nowrap;
+  border: 0.5px solid rgb(0 0 0 / 0.25);
+  border-radius: 5px;
+  background: var(--internal-background);
+  background-clip: padding-box;
+  box-shadow: 0 8px 12px rgb(0 0 0 / 0.35);
+  pointer-events: initial;
+}
+
+.arrowPanelInnerWrapper:not(.open) {
   opacity: 0;
   pointer-events: none;
 
@@ -42,12 +54,12 @@
   visibility: hidden;
 }
 
-.arrowPanel.open {
+.arrowPanelInnerWrapper.open {
   animation: arrowPanelAppear 200ms cubic-bezier(0.07, 0.95, 0, 1);
 }
 
 @media (prefers-reduced-motion) {
-  .arrowPanel.open {
+  .arrowPanelInnerWrapper.open {
     animation: none;
     opacity: 1;
   }
@@ -65,38 +77,45 @@
   }
 }
 
+/**
+ * This element clips the arrow to its triangle shape.
+ */
+.arrowPanelArrowContainer {
+  position: relative;
+  overflow: hidden;
+  height: var(--internal-arrow-clip-height);
+  flex-shrink: 0;
+  margin-top: calc(-1 * var(--internal-arrow-clip-height));
+}
+
+/**
+ * This element is the actual arrow, as a (clipped) rotated square.
+ *
+ * The `left` property is set by inline style, to the offset at which
+ * the arrow tip should be located.
+ */
 .arrowPanelArrow {
   position: absolute;
-  top: calc(var(--internal-offset-from-top) * -1);
-  right: 0;
-  left: 0;
-  overflow: hidden;
-  height: var(--internal-offset-from-top);
-}
-
-.arrowPanelArrow::before {
-  position: absolute;
   top: 0;
-  left: calc(100% - var(--internal-offset-from-right));
   display: block;
-  width: calc(1.42 * var(--internal-offset-from-top));
-  height: calc(1.42 * var(--internal-offset-from-top));
+  width: calc(1.42 * var(--internal-arrow-clip-height));
+  height: calc(1.42 * var(--internal-arrow-clip-height));
   border: 0.5px solid rgb(0 0 0 / 0.25);
-  background: hsl(0deg 0% 97%);
+  background: var(--internal-background);
   background-clip: padding-box;
-  content: '';
   transform: rotate(45deg);
-  transform-origin: top left;
+  transform-origin: top left; /* rotate around the arrow tip */
 }
 
+/**
+ * This element supplies the padding and optional scrolling for the panel contents.
+ */
 .arrowPanelContent {
+  display: flex;
   overflow: auto;
-  max-height: calc(
-    100vh - var(--internal-approx-distance-from-top) -
-      var(--internal-button-height) - var(--internal-approx-distance-to-bottom)
-  );
-  padding: 16px;
-
-  --internal-approx-distance-from-top: 60px;
-  --internal-approx-distance-to-bottom: 100px;
+  min-height: 0;
+  flex-flow: column nowrap;
+  flex-shrink: 1;
+  align-items: stretch;
+  padding: var(--internal-padding);
 }

--- a/src/components/shared/ButtonWithPanel/index.js
+++ b/src/components/shared/ButtonWithPanel/index.js
@@ -28,6 +28,9 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { ArrowPanel } from './ArrowPanel';
+import type { AnchorPosition } from './ArrowPanel';
+
+import type { CssPixels } from 'firefox-profiler/types';
 
 import './ButtonWithPanel.css';
 
@@ -44,6 +47,8 @@ type Props = {|
   +onPanelOpen?: () => mixed,
   +onPanelClose?: () => mixed,
   +title?: string,
+  +panelWidth?: CssPixels,
+  +panelPosition?: AnchorPosition,
 |};
 
 type State = {|
@@ -104,8 +109,17 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
   };
 
   openPanel() {
-    if (this._panel) {
-      this._panel.open();
+    const button = this._buttonRef.current;
+    if (this._panel && button) {
+      const { panelWidth, panelPosition } = this.props;
+      this._panel.open(
+        button,
+        panelWidth ?? 400,
+        panelPosition ?? {
+          anchorEdge: 'right',
+          distanceFromEdge: 60,
+        }
+      );
     }
   }
 

--- a/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
+++ b/src/test/components/__snapshots__/ButtonWithPanel.test.js.snap
@@ -12,14 +12,20 @@ exports[`shared/ButtonWithPanel opens the panel when the button is clicked and c
     My Button
   </button>
   <div
-    class="arrowPanelAnchor"
+    class="arrowPanel open panel"
+    style="left: 0px; top: 0px; width: 400px;"
   >
     <div
-      class="arrowPanel open panel"
+      class="arrowPanelInnerWrapper open"
     >
       <div
-        class="arrowPanelArrow"
-      />
+        class="arrowPanelArrowContainer"
+      >
+        <div
+          class="arrowPanelArrow"
+          style="left: 0px;"
+        />
+      </div>
       <div
         class="arrowPanelContent"
       >
@@ -59,14 +65,20 @@ exports[`shared/ButtonWithPanel opens the panel when the button is clicked and c
     My Button
   </button>
   <div
-    class="arrowPanelAnchor"
+    class="arrowPanel open panel"
+    style="left: 0px; top: 0px; width: 400px;"
   >
     <div
-      class="arrowPanel open panel"
+      class="arrowPanelInnerWrapper open"
     >
       <div
-        class="arrowPanelArrow"
-      />
+        class="arrowPanelArrowContainer"
+      >
+        <div
+          class="arrowPanelArrow"
+          style="left: 0px;"
+        />
+      </div>
       <div
         class="arrowPanelContent"
       >
@@ -106,14 +118,20 @@ exports[`shared/ButtonWithPanel renders a button with a panel 1`] = `
     My Button
   </button>
   <div
-    class="arrowPanelAnchor"
+    class="arrowPanel open panel"
+    style="left: 0px; top: 0px; width: 400px;"
   >
     <div
-      class="arrowPanel open panel"
+      class="arrowPanelInnerWrapper open"
     >
       <div
-        class="arrowPanelArrow"
-      />
+        class="arrowPanelArrowContainer"
+      >
+        <div
+          class="arrowPanelArrow"
+          style="left: 0px;"
+        />
+      </div>
       <div
         class="arrowPanelContent"
       >

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -3,40 +3,50 @@
 exports[`app/MenuButtons <MetaInfoPanel> deleting a profile clicking on the button shows the confirmation 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
     <div
-      class="confirmDialog"
+      class="arrowPanelArrowContainer"
     >
-      <h2
-        class="confirmDialogTitle"
-      >
-        Delete ⁨PROFILE⁩
-      </h2>
       <div
-        class="confirmDialogContent"
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
+    </div>
+    <div
+      class="arrowPanelContent"
+    >
+      <div
+        class="confirmDialog"
       >
-        Are you sure you want to delete uploaded data for this profile? Links
+        <h2
+          class="confirmDialogTitle"
+        >
+          Delete ⁨PROFILE⁩
+        </h2>
+        <div
+          class="confirmDialogContent"
+        >
+          Are you sure you want to delete uploaded data for this profile? Links
 that were previously shared will no longer work.
-      </div>
-      <div
-        class="confirmDialogButtons"
-      >
-        <input
-          class="photon-button photon-button-default"
-          type="button"
-          value="Cancel"
-        />
-        <input
-          class="photon-button photon-button-destructive"
-          type="button"
-          value="Delete"
-        />
+        </div>
+        <div
+          class="confirmDialogButtons"
+        >
+          <input
+            class="photon-button photon-button-default"
+            type="button"
+            value="Cancel"
+          />
+          <input
+            class="photon-button photon-button-destructive"
+            type="button"
+            value="Delete"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -46,18 +56,28 @@ that were previously shared will no longer work.
 exports[`app/MenuButtons <MetaInfoPanel> deleting a profile confirming the delete should delete on the server and in the db 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <p
-      class="profileDeleteButtonSuccess"
+    <div
+      class="arrowPanelArrowContainer"
     >
-      The uploaded data was successfully deleted.
-    </p>
+      <div
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
+    </div>
+    <div
+      class="arrowPanelContent"
+    >
+      <p
+        class="profileDeleteButtonSuccess"
+      >
+        The uploaded data was successfully deleted.
+      </p>
+    </div>
   </div>
 </div>
 `;
@@ -65,116 +85,126 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile confirming the delet
 exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete button if we have the uploaded data and some JWT token 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="profileInfoUploadedActions"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="profileInfoUploadedDate"
-      >
-        <span
-          class="profileInfoUploadedLabel"
-        >
-          Uploaded:
-        </span>
-        toLocaleString Sat, 04 Jul 2020 13:00:00 GMT
-      </div>
-      <div
-        class="profileInfoUploadedActionsButtons"
-      >
-        <button
-          class="photon-button photon-button-default photon-button-micro"
-          type="button"
-        >
-          Delete
-        </button>
-      </div>
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
     </div>
     <div
-      class="metaInfoSection"
+      class="arrowPanelContent"
     >
-      <div
-        class="metaInfoRow"
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
+        Profile Information
+      </h2>
+      <div
+        class="profileInfoUploadedActions"
+      >
+        <div
+          class="profileInfoUploadedDate"
         >
-          Interval:
-        </span>
-        1ms
+          <span
+            class="profileInfoUploadedLabel"
+          >
+            Uploaded:
+          </span>
+          toLocaleString Sat, 04 Jul 2020 13:00:00 GMT
+        </div>
+        <div
+          class="profileInfoUploadedActionsButtons"
+        >
+          <button
+            class="photon-button photon-button-default photon-button-micro"
+            type="button"
+          >
+            Delete
+          </button>
+        </div>
       </div>
       <div
-        class="metaInfoRow"
+        class="metaInfoSection"
       >
-        <span
-          class="metaInfoLabel"
+        <div
+          class="metaInfoRow"
         >
-          Symbols:
-        </span>
-        Profile is symbolicated
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Symbols:
+          </span>
+          Profile is symbolicated
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
+          >
+            Re-symbolicate profile
+          </button>
+        </div>
       </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
       <div
-        class="metaInfoRow"
+        class="metaInfoSection"
       >
-        <span
-          class="metaInfoLabel"
-        />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
+        <div
+          class="metaInfoRow"
         >
-          Re-symbolicate profile
-        </button>
+          <span
+            class="metaInfoLabel"
+          >
+            Name and version:
+          </span>
+          Firefox
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          release
+        </div>
       </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      />
     </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Update channel:
-        </span>
-        release
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    />
   </div>
 </div>
 `;
@@ -182,118 +212,128 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete 
 exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete button if we have the uploaded data but no JWT token 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="profileInfoUploadedActions"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="profileInfoUploadedDate"
-      >
-        <span
-          class="profileInfoUploadedLabel"
-        >
-          Uploaded:
-        </span>
-        toLocaleString Sat, 04 Jul 2020 13:00:00 GMT
-      </div>
-      <div
-        class="profileInfoUploadedActionsButtons"
-      >
-        <button
-          class="photon-button photon-button-default photon-button-micro"
-          disabled=""
-          title="This profile cannot be deleted because we lack the authorization information."
-          type="button"
-        >
-          Delete
-        </button>
-      </div>
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
     </div>
     <div
-      class="metaInfoSection"
+      class="arrowPanelContent"
     >
-      <div
-        class="metaInfoRow"
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
+        Profile Information
+      </h2>
+      <div
+        class="profileInfoUploadedActions"
+      >
+        <div
+          class="profileInfoUploadedDate"
         >
-          Interval:
-        </span>
-        1ms
+          <span
+            class="profileInfoUploadedLabel"
+          >
+            Uploaded:
+          </span>
+          toLocaleString Sat, 04 Jul 2020 13:00:00 GMT
+        </div>
+        <div
+          class="profileInfoUploadedActionsButtons"
+        >
+          <button
+            class="photon-button photon-button-default photon-button-micro"
+            disabled=""
+            title="This profile cannot be deleted because we lack the authorization information."
+            type="button"
+          >
+            Delete
+          </button>
+        </div>
       </div>
       <div
-        class="metaInfoRow"
+        class="metaInfoSection"
       >
-        <span
-          class="metaInfoLabel"
+        <div
+          class="metaInfoRow"
         >
-          Symbols:
-        </span>
-        Profile is symbolicated
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Symbols:
+          </span>
+          Profile is symbolicated
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
+          >
+            Re-symbolicate profile
+          </button>
+        </div>
       </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
       <div
-        class="metaInfoRow"
+        class="metaInfoSection"
       >
-        <span
-          class="metaInfoLabel"
-        />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
+        <div
+          class="metaInfoRow"
         >
-          Re-symbolicate profile
-        </button>
+          <span
+            class="metaInfoLabel"
+          >
+            Name and version:
+          </span>
+          Firefox
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          release
+        </div>
       </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      />
     </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Update channel:
-        </span>
-        release
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    />
   </div>
 </div>
 `;
@@ -301,92 +341,102 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile displays the delete 
 exports[`app/MenuButtons <MetaInfoPanel> deleting a profile does not display the delete button if the profile is public but without uploaded data 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="metaInfoSection"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Interval:
-        </span>
-        1ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Symbols:
-        </span>
-        Profile is symbolicated
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
-        >
-          Re-symbolicate profile
-        </button>
-      </div>
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
     </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
     <div
-      class="metaInfoSection"
+      class="arrowPanelContent"
     >
-      <div
-        class="metaInfoRow"
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox
-      </div>
+        Profile Information
+      </h2>
       <div
-        class="metaInfoRow"
+        class="metaInfoSection"
       >
-        <span
-          class="metaInfoLabel"
+        <div
+          class="metaInfoRow"
         >
-          Update channel:
-        </span>
-        release
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Symbols:
+          </span>
+          Profile is symbolicated
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
+          >
+            Re-symbolicate profile
+          </button>
+        </div>
       </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Name and version:
+          </span>
+          Firefox
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          release
+        </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      />
     </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    />
   </div>
 </div>
 `;
@@ -394,81 +444,209 @@ exports[`app/MenuButtons <MetaInfoPanel> deleting a profile does not display the
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="metaInfoSection"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="metaInfoRow"
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
+    </div>
+    <div
+      class="arrowPanelContent"
+    >
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording started:
-        </span>
-        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording length:
-        </span>
-        1.007s
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Interval:
-        </span>
-        1ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer capacity:
-        </span>
-        1GB
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer duration:
-        </span>
-        ⁨20⁩ seconds
-      </div>
+        Profile Information
+      </h2>
       <div
         class="metaInfoSection"
       >
         <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Recording started:
+          </span>
+          toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Recording length:
+          </span>
+          1.007s
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer capacity:
+          </span>
+          1GB
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer duration:
+          </span>
+          ⁨20⁩ seconds
+        </div>
+        <div
+          class="metaInfoSection"
+        >
+          <div
+            class="metaInfoRow metaInfoListRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Features:
+            </span>
+            <ul
+              class="metaInfoList"
+            >
+              <li
+                class="metaInfoListItem"
+              >
+                js
+              </li>
+              <li
+                class="metaInfoListItem"
+              >
+                threads
+              </li>
+            </ul>
+          </div>
+          <div
+            class="metaInfoRow metaInfoListRow"
+          >
+            <span
+              class="metaInfoLabel"
+            >
+              Threads filter:
+            </span>
+            <ul
+              class="metaInfoList"
+            >
+              <li
+                class="metaInfoListItem"
+              >
+                GeckoMain
+              </li>
+              <li
+                class="metaInfoListItem"
+              >
+                DOM Worker
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Symbols:
+          </span>
+          Profile is not symbolicated
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
+          >
+            Symbolicate profile
+          </button>
+        </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Name and version:
+          </span>
+          Firefox 48
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          nightly
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Build ID:
+          </span>
+          20181126165837
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Build type:
+          </span>
+          Debug
+        </div>
+        <div
           class="metaInfoRow metaInfoListRow"
         >
           <span
             class="metaInfoLabel"
           >
-            Features:
+            Extensions:
           </span>
           <ul
             class="metaInfoList"
@@ -476,316 +654,198 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
             <li
               class="metaInfoListItem"
             >
-              js
+              Firefox Screenshots
             </li>
             <li
               class="metaInfoListItem"
             >
-              threads
+              Form Autofill
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Gecko Profiler
             </li>
           </ul>
         </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
         <div
-          class="metaInfoRow metaInfoListRow"
+          class="metaInfoRow"
         >
           <span
             class="metaInfoLabel"
           >
-            Threads filter:
+            OS:
           </span>
-          <ul
-            class="metaInfoList"
+          macOS 10.11
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
           >
-            <li
-              class="metaInfoListItem"
+            ABI:
+          </span>
+          x86_64-gcc3
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            CPU cores:
+          </span>
+          ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+        </div>
+      </div>
+      <details>
+        <summary
+          class="arrowPanelSubTitle"
+        >
+          ⁨Profiler⁩ overhead
+        </summary>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoGrid"
+          >
+            <div />
+            <div>
+              Mean
+            </div>
+            <div>
+              Max
+            </div>
+            <div>
+              Min
+            </div>
+            <div
+              title="Time to sample all threads."
             >
-              GeckoMain
-            </li>
-            <li
-              class="metaInfoListItem"
+              Overhead
+            </div>
+            <div>
+              227μs
+            </div>
+            <div>
+              410μs
+            </div>
+            <div>
+              38μs
+            </div>
+            <div
+              title="Time to discard expired data."
             >
-              DOM Worker
-            </li>
-          </ul>
+              Cleaning
+            </div>
+            <div>
+              54μs
+            </div>
+            <div>
+              100μs
+            </div>
+            <div>
+              7.0μs
+            </div>
+            <div
+              title="Time to gather all counters."
+            >
+              Counter
+            </div>
+            <div>
+              59μs
+            </div>
+            <div>
+              105μs
+            </div>
+            <div>
+              12μs
+            </div>
+            <div
+              title="Observed interval between two samples."
+            >
+              Interval
+            </div>
+            <div>
+              857μs
+            </div>
+            <div>
+              1,000μs
+            </div>
+            <div>
+              0.000μs
+            </div>
+            <div
+              title="Time to acquire the lock before sampling."
+            >
+              Lockings
+            </div>
+            <div>
+              49μs
+            </div>
+            <div>
+              95μs
+            </div>
+            <div>
+              2.0μs
+            </div>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Overhead durations:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              1,586μs
+            </span>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Overhead percentage:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              26,433%
+            </span>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Profiled duration:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              6.0μs
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Symbols:
-        </span>
-        Profile is not symbolicated
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
-        >
-          Symbolicate profile
-        </button>
-      </div>
+      </details>
     </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox 48
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Update channel:
-        </span>
-        nightly
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build ID:
-        </span>
-        20181126165837
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build type:
-        </span>
-        Debug
-      </div>
-      <div
-        class="metaInfoRow metaInfoListRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Extensions:
-        </span>
-        <ul
-          class="metaInfoList"
-        >
-          <li
-            class="metaInfoListItem"
-          >
-            Firefox Screenshots
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            Form Autofill
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            Gecko Profiler
-          </li>
-        </ul>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          OS:
-        </span>
-        macOS 10.11
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          ABI:
-        </span>
-        x86_64-gcc3
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          CPU cores:
-        </span>
-        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
-      </div>
-    </div>
-    <details>
-      <summary
-        class="arrowPanelSubTitle"
-      >
-        ⁨Profiler⁩ overhead
-      </summary>
-      <div
-        class="arrowPanelSection"
-      >
-        <div
-          class="metaInfoGrid"
-        >
-          <div />
-          <div>
-            Mean
-          </div>
-          <div>
-            Max
-          </div>
-          <div>
-            Min
-          </div>
-          <div
-            title="Time to sample all threads."
-          >
-            Overhead
-          </div>
-          <div>
-            227μs
-          </div>
-          <div>
-            410μs
-          </div>
-          <div>
-            38μs
-          </div>
-          <div
-            title="Time to discard expired data."
-          >
-            Cleaning
-          </div>
-          <div>
-            54μs
-          </div>
-          <div>
-            100μs
-          </div>
-          <div>
-            7.0μs
-          </div>
-          <div
-            title="Time to gather all counters."
-          >
-            Counter
-          </div>
-          <div>
-            59μs
-          </div>
-          <div>
-            105μs
-          </div>
-          <div>
-            12μs
-          </div>
-          <div
-            title="Observed interval between two samples."
-          >
-            Interval
-          </div>
-          <div>
-            857μs
-          </div>
-          <div>
-            1,000μs
-          </div>
-          <div>
-            0.000μs
-          </div>
-          <div
-            title="Time to acquire the lock before sampling."
-          >
-            Lockings
-          </div>
-          <div>
-            49μs
-          </div>
-          <div>
-            95μs
-          </div>
-          <div>
-            2.0μs
-          </div>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Overhead durations:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            1,586μs
-          </span>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Overhead percentage:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            26,433%
-          </span>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Profiled duration:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            6.0μs
-          </span>
-        </div>
-      </div>
-    </details>
   </div>
 </div>
 `;
@@ -793,361 +853,371 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot 1`] = `
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device information 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="metaInfoSection"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="metaInfoRow"
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
+    </div>
+    <div
+      class="arrowPanelContent"
+    >
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording started:
-        </span>
-        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording length:
-        </span>
-        1.007s
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Interval:
-        </span>
-        1ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer capacity:
-        </span>
-        8MB
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer duration:
-        </span>
-        Unlimited
-      </div>
+        Profile Information
+      </h2>
       <div
         class="metaInfoSection"
-      />
-      <div
-        class="metaInfoRow"
       >
-        <span
-          class="metaInfoLabel"
+        <div
+          class="metaInfoRow"
         >
-          Symbols:
-        </span>
-        Profile is not symbolicated
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
+          <span
+            class="metaInfoLabel"
+          >
+            Recording started:
+          </span>
+          toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Recording length:
+          </span>
+          1.007s
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer capacity:
+          </span>
+          8MB
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer duration:
+          </span>
+          Unlimited
+        </div>
+        <div
+          class="metaInfoSection"
         />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
-        >
-          Symbolicate profile
-        </button>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox 48
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Update channel:
-        </span>
-        nightly
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build ID:
-        </span>
-        20181126165837
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build type:
-        </span>
-        Debug
-      </div>
-      <div
-        class="metaInfoRow metaInfoListRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Extensions:
-        </span>
-        <ul
-          class="metaInfoList"
-        >
-          <li
-            class="metaInfoListItem"
-          >
-            Firefox Screenshots
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            Form Autofill
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            Gecko Profiler
-          </li>
-        </ul>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Device:
-        </span>
-        Android Device
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          OS:
-        </span>
-        macOS 10.11
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          ABI:
-        </span>
-        x86_64-gcc3
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          CPU cores:
-        </span>
-        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
-      </div>
-    </div>
-    <details>
-      <summary
-        class="arrowPanelSubTitle"
-      >
-        ⁨Profiler⁩ overhead
-      </summary>
-      <div
-        class="arrowPanelSection"
-      >
         <div
-          class="metaInfoGrid"
+          class="metaInfoRow"
         >
-          <div />
-          <div>
-            Mean
-          </div>
-          <div>
-            Max
-          </div>
-          <div>
-            Min
-          </div>
-          <div
-            title="Time to sample all threads."
+          <span
+            class="metaInfoLabel"
           >
-            Overhead
-          </div>
-          <div>
-            227μs
-          </div>
-          <div>
-            410μs
-          </div>
-          <div>
-            38μs
-          </div>
-          <div
-            title="Time to discard expired data."
-          >
-            Cleaning
-          </div>
-          <div>
-            54μs
-          </div>
-          <div>
-            100μs
-          </div>
-          <div>
-            7.0μs
-          </div>
-          <div
-            title="Time to gather all counters."
-          >
-            Counter
-          </div>
-          <div>
-            59μs
-          </div>
-          <div>
-            105μs
-          </div>
-          <div>
-            12μs
-          </div>
-          <div
-            title="Observed interval between two samples."
-          >
-            Interval
-          </div>
-          <div>
-            857μs
-          </div>
-          <div>
-            1,000μs
-          </div>
-          <div>
-            0.000μs
-          </div>
-          <div
-            title="Time to acquire the lock before sampling."
-          >
-            Lockings
-          </div>
-          <div>
-            49μs
-          </div>
-          <div>
-            95μs
-          </div>
-          <div>
-            2.0μs
-          </div>
+            Symbols:
+          </span>
+          Profile is not symbolicated
         </div>
         <div
           class="metaInfoRow"
         >
           <span
-            class="metaInfoWideLabel"
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
           >
-            Overhead durations:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            1,586μs
-          </span>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Overhead percentage:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            26,433%
-          </span>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Profiled duration:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            6.0μs
-          </span>
+            Symbolicate profile
+          </button>
         </div>
       </div>
-    </details>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Name and version:
+          </span>
+          Firefox 48
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          nightly
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Build ID:
+          </span>
+          20181126165837
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Build type:
+          </span>
+          Debug
+        </div>
+        <div
+          class="metaInfoRow metaInfoListRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Extensions:
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              Firefox Screenshots
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Form Autofill
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Gecko Profiler
+            </li>
+          </ul>
+        </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Device:
+          </span>
+          Android Device
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            OS:
+          </span>
+          macOS 10.11
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            ABI:
+          </span>
+          x86_64-gcc3
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            CPU cores:
+          </span>
+          ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+        </div>
+      </div>
+      <details>
+        <summary
+          class="arrowPanelSubTitle"
+        >
+          ⁨Profiler⁩ overhead
+        </summary>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoGrid"
+          >
+            <div />
+            <div>
+              Mean
+            </div>
+            <div>
+              Max
+            </div>
+            <div>
+              Min
+            </div>
+            <div
+              title="Time to sample all threads."
+            >
+              Overhead
+            </div>
+            <div>
+              227μs
+            </div>
+            <div>
+              410μs
+            </div>
+            <div>
+              38μs
+            </div>
+            <div
+              title="Time to discard expired data."
+            >
+              Cleaning
+            </div>
+            <div>
+              54μs
+            </div>
+            <div>
+              100μs
+            </div>
+            <div>
+              7.0μs
+            </div>
+            <div
+              title="Time to gather all counters."
+            >
+              Counter
+            </div>
+            <div>
+              59μs
+            </div>
+            <div>
+              105μs
+            </div>
+            <div>
+              12μs
+            </div>
+            <div
+              title="Observed interval between two samples."
+            >
+              Interval
+            </div>
+            <div>
+              857μs
+            </div>
+            <div>
+              1,000μs
+            </div>
+            <div>
+              0.000μs
+            </div>
+            <div
+              title="Time to acquire the lock before sampling."
+            >
+              Lockings
+            </div>
+            <div>
+              49μs
+            </div>
+            <div>
+              95μs
+            </div>
+            <div>
+              2.0μs
+            </div>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Overhead durations:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              1,586μs
+            </span>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Overhead percentage:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              26,433%
+            </span>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Profiled duration:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              6.0μs
+            </span>
+          </div>
+        </div>
+      </details>
+    </div>
   </div>
 </div>
 `;
@@ -1155,361 +1225,371 @@ exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with device inform
 exports[`app/MenuButtons <MetaInfoPanel> matches the snapshot with uptime 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="metaInfoSection"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="metaInfoRow"
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
+    </div>
+    <div
+      class="arrowPanelContent"
+    >
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording started:
-        </span>
-        toLocaleString Sat, 09 Apr 2016 17:02:33 GMT
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording length:
-        </span>
-        507ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Interval:
-        </span>
-        1ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer capacity:
-        </span>
-        8MB
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer duration:
-        </span>
-        Unlimited
-      </div>
+        Profile Information
+      </h2>
       <div
         class="metaInfoSection"
-      />
-      <div
-        class="metaInfoRow"
       >
-        <span
-          class="metaInfoLabel"
+        <div
+          class="metaInfoRow"
         >
-          Symbols:
-        </span>
-        Profile is not symbolicated
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
+          <span
+            class="metaInfoLabel"
+          >
+            Recording started:
+          </span>
+          toLocaleString Sat, 09 Apr 2016 17:02:33 GMT
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Recording length:
+          </span>
+          507ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer capacity:
+          </span>
+          8MB
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer duration:
+          </span>
+          Unlimited
+        </div>
+        <div
+          class="metaInfoSection"
         />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
-        >
-          Symbolicate profile
-        </button>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox 48
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Uptime:
-        </span>
-        500ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Update channel:
-        </span>
-        nightly
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build ID:
-        </span>
-        20181126165837
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build type:
-        </span>
-        Debug
-      </div>
-      <div
-        class="metaInfoRow metaInfoListRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Extensions:
-        </span>
-        <ul
-          class="metaInfoList"
-        >
-          <li
-            class="metaInfoListItem"
-          >
-            Firefox Screenshots
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            Form Autofill
-          </li>
-          <li
-            class="metaInfoListItem"
-          >
-            Gecko Profiler
-          </li>
-        </ul>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          OS:
-        </span>
-        macOS 10.11
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          ABI:
-        </span>
-        x86_64-gcc3
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          CPU cores:
-        </span>
-        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
-      </div>
-    </div>
-    <details>
-      <summary
-        class="arrowPanelSubTitle"
-      >
-        ⁨Profiler⁩ overhead
-      </summary>
-      <div
-        class="arrowPanelSection"
-      >
         <div
-          class="metaInfoGrid"
+          class="metaInfoRow"
         >
-          <div />
-          <div>
-            Mean
-          </div>
-          <div>
-            Max
-          </div>
-          <div>
-            Min
-          </div>
-          <div
-            title="Time to sample all threads."
+          <span
+            class="metaInfoLabel"
           >
-            Overhead
-          </div>
-          <div>
-            227μs
-          </div>
-          <div>
-            410μs
-          </div>
-          <div>
-            38μs
-          </div>
-          <div
-            title="Time to discard expired data."
-          >
-            Cleaning
-          </div>
-          <div>
-            54μs
-          </div>
-          <div>
-            100μs
-          </div>
-          <div>
-            7.0μs
-          </div>
-          <div
-            title="Time to gather all counters."
-          >
-            Counter
-          </div>
-          <div>
-            59μs
-          </div>
-          <div>
-            105μs
-          </div>
-          <div>
-            12μs
-          </div>
-          <div
-            title="Observed interval between two samples."
-          >
-            Interval
-          </div>
-          <div>
-            857μs
-          </div>
-          <div>
-            1,000μs
-          </div>
-          <div>
-            0.000μs
-          </div>
-          <div
-            title="Time to acquire the lock before sampling."
-          >
-            Lockings
-          </div>
-          <div>
-            49μs
-          </div>
-          <div>
-            95μs
-          </div>
-          <div>
-            2.0μs
-          </div>
+            Symbols:
+          </span>
+          Profile is not symbolicated
         </div>
         <div
           class="metaInfoRow"
         >
           <span
-            class="metaInfoWideLabel"
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
           >
-            Overhead durations:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            1,586μs
-          </span>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Overhead percentage:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            26,433%
-          </span>
-        </div>
-        <div
-          class="metaInfoRow"
-        >
-          <span
-            class="metaInfoWideLabel"
-          >
-            Profiled duration:
-          </span>
-          <span
-            class="metaInfoValueRight"
-          >
-            6.0μs
-          </span>
+            Symbolicate profile
+          </button>
         </div>
       </div>
-    </details>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Name and version:
+          </span>
+          Firefox 48
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Uptime:
+          </span>
+          500ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          nightly
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Build ID:
+          </span>
+          20181126165837
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Build type:
+          </span>
+          Debug
+        </div>
+        <div
+          class="metaInfoRow metaInfoListRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Extensions:
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              Firefox Screenshots
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Form Autofill
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Gecko Profiler
+            </li>
+          </ul>
+        </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            OS:
+          </span>
+          macOS 10.11
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            ABI:
+          </span>
+          x86_64-gcc3
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            CPU cores:
+          </span>
+          ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+        </div>
+      </div>
+      <details>
+        <summary
+          class="arrowPanelSubTitle"
+        >
+          ⁨Profiler⁩ overhead
+        </summary>
+        <div
+          class="arrowPanelSection"
+        >
+          <div
+            class="metaInfoGrid"
+          >
+            <div />
+            <div>
+              Mean
+            </div>
+            <div>
+              Max
+            </div>
+            <div>
+              Min
+            </div>
+            <div
+              title="Time to sample all threads."
+            >
+              Overhead
+            </div>
+            <div>
+              227μs
+            </div>
+            <div>
+              410μs
+            </div>
+            <div>
+              38μs
+            </div>
+            <div
+              title="Time to discard expired data."
+            >
+              Cleaning
+            </div>
+            <div>
+              54μs
+            </div>
+            <div>
+              100μs
+            </div>
+            <div>
+              7.0μs
+            </div>
+            <div
+              title="Time to gather all counters."
+            >
+              Counter
+            </div>
+            <div>
+              59μs
+            </div>
+            <div>
+              105μs
+            </div>
+            <div>
+              12μs
+            </div>
+            <div
+              title="Observed interval between two samples."
+            >
+              Interval
+            </div>
+            <div>
+              857μs
+            </div>
+            <div>
+              1,000μs
+            </div>
+            <div>
+              0.000μs
+            </div>
+            <div
+              title="Time to acquire the lock before sampling."
+            >
+              Lockings
+            </div>
+            <div>
+              49μs
+            </div>
+            <div>
+              95μs
+            </div>
+            <div>
+              2.0μs
+            </div>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Overhead durations:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              1,586μs
+            </span>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Overhead percentage:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              26,433%
+            </span>
+          </div>
+          <div
+            class="metaInfoRow"
+          >
+            <span
+              class="metaInfoWideLabel"
+            >
+              Profiled duration:
+            </span>
+            <span
+              class="metaInfoValueRight"
+            >
+              6.0μs
+            </span>
+          </div>
+        </div>
+      </details>
+    </div>
   </div>
 </div>
 `;
@@ -1598,212 +1678,222 @@ exports[`app/MenuButtons <MetaInfoPanel> with more extra info, opens more info s
 exports[`app/MenuButtons <MetaInfoPanel> with no statistics object should not make the app crash 1`] = `
 <div
   class="arrowPanel open metaInfoPanel"
+  style="left: 0px; top: 0px; width: 400px;"
 >
   <div
-    class="arrowPanelArrow"
-  />
-  <div
-    class="arrowPanelContent"
+    class="arrowPanelInnerWrapper open"
   >
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Profile Information
-    </h2>
     <div
-      class="metaInfoSection"
+      class="arrowPanelArrowContainer"
     >
       <div
-        class="metaInfoRow"
+        class="arrowPanelArrow"
+        style="left: 0px;"
+      />
+    </div>
+    <div
+      class="arrowPanelContent"
+    >
+      <h2
+        class="metaInfoSubTitle"
       >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording started:
-        </span>
-        toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Recording length:
-        </span>
-        1.007s
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Interval:
-        </span>
-        1ms
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer capacity:
-        </span>
-        8MB
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Buffer duration:
-        </span>
-        Unlimited
-      </div>
+        Profile Information
+      </h2>
       <div
         class="metaInfoSection"
-      />
-      <div
-        class="metaInfoRow"
       >
-        <span
-          class="metaInfoLabel"
+        <div
+          class="metaInfoRow"
         >
-          Symbols:
-        </span>
-        Profile is not symbolicated
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
+          <span
+            class="metaInfoLabel"
+          >
+            Recording started:
+          </span>
+          toLocaleString Sat, 09 Apr 2016 17:02:32 GMT
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Recording length:
+          </span>
+          1.007s
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Interval:
+          </span>
+          1ms
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer capacity:
+          </span>
+          8MB
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Buffer duration:
+          </span>
+          Unlimited
+        </div>
+        <div
+          class="metaInfoSection"
         />
-        <button
-          class="photon-button photon-button-micro"
-          type="button"
+        <div
+          class="metaInfoRow"
         >
-          Symbolicate profile
-        </button>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Application
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Name and version:
-        </span>
-        Firefox 48
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Update channel:
-        </span>
-        nightly
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build ID:
-        </span>
-        20181126165837
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Build type:
-        </span>
-        Debug
-      </div>
-      <div
-        class="metaInfoRow metaInfoListRow"
-      >
-        <span
-          class="metaInfoLabel"
-        >
-          Extensions:
-        </span>
-        <ul
-          class="metaInfoList"
-        >
-          <li
-            class="metaInfoListItem"
+          <span
+            class="metaInfoLabel"
           >
-            Firefox Screenshots
-          </li>
-          <li
-            class="metaInfoListItem"
+            Symbols:
+          </span>
+          Profile is not symbolicated
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          />
+          <button
+            class="photon-button photon-button-micro"
+            type="button"
           >
-            Form Autofill
-          </li>
-          <li
-            class="metaInfoListItem"
+            Symbolicate profile
+          </button>
+        </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Application
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
           >
-            Gecko Profiler
-          </li>
-        </ul>
-      </div>
-    </div>
-    <h2
-      class="metaInfoSubTitle"
-    >
-      Platform
-    </h2>
-    <div
-      class="metaInfoSection"
-    >
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
+            Name and version:
+          </span>
+          Firefox 48
+        </div>
+        <div
+          class="metaInfoRow"
         >
-          OS:
-        </span>
-        macOS 10.11
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
+          <span
+            class="metaInfoLabel"
+          >
+            Update channel:
+          </span>
+          nightly
+        </div>
+        <div
+          class="metaInfoRow"
         >
-          ABI:
-        </span>
-        x86_64-gcc3
-      </div>
-      <div
-        class="metaInfoRow"
-      >
-        <span
-          class="metaInfoLabel"
+          <span
+            class="metaInfoLabel"
+          >
+            Build ID:
+          </span>
+          20181126165837
+        </div>
+        <div
+          class="metaInfoRow"
         >
-          CPU cores:
-        </span>
-        ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+          <span
+            class="metaInfoLabel"
+          >
+            Build type:
+          </span>
+          Debug
+        </div>
+        <div
+          class="metaInfoRow metaInfoListRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            Extensions:
+          </span>
+          <ul
+            class="metaInfoList"
+          >
+            <li
+              class="metaInfoListItem"
+            >
+              Firefox Screenshots
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Form Autofill
+            </li>
+            <li
+              class="metaInfoListItem"
+            >
+              Gecko Profiler
+            </li>
+          </ul>
+        </div>
+      </div>
+      <h2
+        class="metaInfoSubTitle"
+      >
+        Platform
+      </h2>
+      <div
+        class="metaInfoSection"
+      >
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            OS:
+          </span>
+          macOS 10.11
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            ABI:
+          </span>
+          x86_64-gcc3
+        </div>
+        <div
+          class="metaInfoRow"
+        >
+          <span
+            class="metaInfoLabel"
+          >
+            CPU cores:
+          </span>
+          ⁨⁨4⁩ physical cores⁩, ⁨⁨8⁩ logical cores⁩
+        </div>
       </div>
     </div>
   </div>
@@ -1852,14 +1942,20 @@ exports[`app/MenuButtons <Publish> can publish and revert 1`] = `
         Permalink
       </button>
       <div
-        class="arrowPanelAnchor"
+        class="arrowPanel open menuButtonsPermalinkPanel"
+        style="left: 0px; top: 0px; width: 260px;"
       >
         <div
-          class="arrowPanel open menuButtonsPermalinkPanel"
+          class="arrowPanelInnerWrapper open"
         >
           <div
-            class="arrowPanelArrow"
-          />
+            class="arrowPanelArrowContainer"
+          >
+            <div
+              class="arrowPanelArrow"
+              style="left: 0px;"
+            />
+          </div>
           <div
             class="arrowPanelContent"
           >


### PR DESCRIPTION
This PR implements some changes to the arrow panel code which make arrow panels usable for the dropped functions panel in the call tree settings.

With the previous implementation, I encountered these issues:
 - When the source view was open, the panel would be clipped to the call tree bounds and could not overlap the source view. The overflow:auto clip from the splitter view was applying to the panel.
 - With a narrow viewport or an unusually positioned anchor element, the panel would sometimes be positioned partially offscreen.
 - It was tricky to enforce a maximum height on the panel in a way that squished the list box inside the panel.
 - The panel would reposition itself based on the size of the anchor element *while the panel was open*. E.g. you would click an "x" button to remove a dropped function, and the anchor button's label would change from "10 dropped functions" to "9 dropped functions", causing the button to shrink. Then the panel would shift slightly to the left, moving the "x" button out from under the mouse cursor.

This commit fixes all of these issues.

The most important change is the switch to position:fixed: Now the panel will no longer be clipped by overflow:hidden/auto ancestor of the button that opens the panel.
Furthermore, the panel position is only computed during opening and then remains unchanged while the panel is open.
And there is some logic to make the panel fit onscreen (while also making sure that the arrow still points at the right place).