### PR TITLE
server.js: Move webpack cache setting into webpack.config.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,9 +26,6 @@ const argv = yargs(hideBin(process.argv))
   .strict()
   .parseSync();
 
-config.cache = {
-  type: 'filesystem',
-};
 const serverConfig = {
   allowedHosts: ['localhost', '.gitpod.io'],
   host,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,9 @@ const config = {
     publicPath: '/',
   },
   mode: process.env.NODE_ENV,
+  cache: {
+    type: 'filesystem',
+  },
   resolve: {
     alias: {
       // Note: the alias for firefox-profiler is defined at the Babel level, so


### PR DESCRIPTION
I found out (through `git grep 'webpack\.config'`) that the only user of webpack.config.js is server.js, so this pr moves the webpack cache setting from server.js into webpack.config.js so that all the webpack settings are in one place.