### PR TITLE
Make the localStorage access optional for persistent locales and don't throw an error if it's blocked by the browser

### DIFF
--- a/src/components/app/AppLocalizationProvider.js
+++ b/src/components/app/AppLocalizationProvider.js
@@ -117,8 +117,15 @@ class AppLocalizationInit extends React.PureComponent<InitProps> {
   }
 
   _getPersistedLocale(): string[] | null {
-    const strPreviouslyRequestedLocales =
-      localStorage.getItem('requestedLocales');
+    let strPreviouslyRequestedLocales;
+    try {
+      strPreviouslyRequestedLocales = localStorage.getItem('requestedLocales');
+    } catch (err) {
+      console.warn(
+        'We got an error while trying to retrieve the previously requested locale. Cookies might be blocked in this browser.',
+        err
+      );
+    }
 
     if (strPreviouslyRequestedLocales) {
       try {


### PR DESCRIPTION
Fixes #4706.

`localStorage` throws an error in Firefox when the user set the cookie settings to block all the cookies. This PR makes it fallible, so people can still use it when the cookies are disabled.