### PR TITLE
Preload the en-US locale because it's always loaded

### DIFF
--- a/res/index.html
+++ b/res/index.html
@@ -7,6 +7,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="initial-scale=1" />
 <title>Firefox Profiler</title>
+<link rel="preload" href="locales/en-US/app.ftl" as="fetch" />
 </head>
 <body style='background-color: #363959; /* ink-70 */'>
 <div id="root"></div>

--- a/src/app-logic/l10n.js
+++ b/src/app-logic/l10n.js
@@ -61,7 +61,21 @@ const RTL_LOCALES = ['ar', 'he', 'fa', 'ps', 'ur'];
  * Returns the locale and the ftl string grouped as an Array.
  */
 export async function fetchMessages(locale: string): Promise<[string, string]> {
-  const response = await fetch(`/locales/${locale}/app.ftl`);
+  const response = await fetch(`/locales/${locale}/app.ftl`, {
+    // We want to be able to preload some files. However there are some
+    // browser limitations when using preloading for fetched resources:
+    // * ideally we'd just use "crossorigin" on the <link rel="preload">
+    //   element, but this doesn't work in Safari (I think this is
+    //   https://bugs.webkit.org/show_bug.cgi?id=236009)
+    // * instead we use this mode. This works because we're in
+    //   same-origin and therefore we can still access the response.
+    mode: 'no-cors',
+    // Chrome also needs this value for "credentials" instead of the default
+    // "same-origin". This should have the same behavior because we're
+    // requesting the file on the same server, but this is likely a bug in Chrome.
+    // See https://bugs.chromium.org/p/chromium/issues/detail?id=1473611
+    credentials: 'include',
+  });
   const messages = await response.text();
   return [locale, messages];
 }

--- a/src/test/components/AppLocalizationProvider.test.js
+++ b/src/test/components/AppLocalizationProvider.test.js
@@ -188,11 +188,14 @@ describe('AppLocalizationProvider', () => {
 
     expect(await screen.findByText(translatedText('de'))).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'de');
-    expect(window.fetch).toHaveBeenCalledWith('/locales/de/app.ftl', undefined);
-    expect(window.fetch).toHaveBeenCalledWith(
-      '/locales/en-US/app.ftl',
-      undefined
-    );
+    expect(window.fetch).toHaveBeenCalledWith('/locales/de/app.ftl', {
+      credentials: 'include',
+      mode: 'no-cors',
+    });
+    expect(window.fetch).toHaveBeenCalledWith('/locales/en-US/app.ftl', {
+      credentials: 'include',
+      mode: 'no-cors',
+    });
     expect(window.fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -217,11 +220,14 @@ describe('AppLocalizationProvider', () => {
       await screen.findByText(translatedText('en-US'))
     ).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'de');
-    expect(window.fetch).toHaveBeenCalledWith('/locales/de/app.ftl', undefined);
-    expect(window.fetch).toHaveBeenCalledWith(
-      '/locales/en-US/app.ftl',
-      undefined
-    );
+    expect(window.fetch).toHaveBeenCalledWith('/locales/de/app.ftl', {
+      credentials: 'include',
+      mode: 'no-cors',
+    });
+    expect(window.fetch).toHaveBeenCalledWith('/locales/en-US/app.ftl', {
+      credentials: 'include',
+      mode: 'no-cors',
+    });
     expect(window.fetch).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Part of #3820

Thanks Nazım for the debugging! I applied your suggestion after also trying the other things that didn't work. I added a comment that should make it clear for future readers about the current solution.

I tested in Firefox, Chrome and Safari.

Tell me what you think!