### PR TITLE
Scroll to hotpost after we retrieve the source code

### DIFF
--- a/src/components/shared/SourceView.js
+++ b/src/components/shared/SourceView.js
@@ -160,6 +160,7 @@ export class SourceView extends React.PureComponent<SourceViewProps> {
       this._editor.updateLanguageForFilePath(this.props.filePath);
     }
 
+    let contentsChanged = false;
     if (
       this.props.sourceCode !== prevProps.sourceCode ||
       (this.props.sourceCode === '' &&
@@ -167,11 +168,13 @@ export class SourceView extends React.PureComponent<SourceViewProps> {
         this.props.timings !== prevProps.timings)
     ) {
       this._editor.setContents(this._getSourceCodeOrFallback());
+      contentsChanged = true;
     }
 
     if (
+      contentsChanged ||
       this.props.scrollToHotSpotGeneration !==
-      prevProps.scrollToHotSpotGeneration
+        prevProps.scrollToHotSpotGeneration
     ) {
       this._scrollToHotSpot(this.props.hotSpotTimings);
     }


### PR DESCRIPTION
:smaug mentioned that sometimes source code view wasn't properly scrolling to the correct position.
I did some debugging and figured out that this bug started to happen after `@codemirror/view` version [6.13.0](https://github.com/codemirror/view/releases/tag/6.13.0), most likely due to [this commit](https://github.com/codemirror/view/commit/a3696193507380dafdc3220b762628fab1ec5804).

But apparently this wasn't an issue in the assembly view because we already had a fix for it, which is the same mechanism as this PR:
https://github.com/firefox-devtools/profiler/blob/9ef5a8b149811a84a49cc17f24ff452d92eb2e07/src/components/shared/AssemblyView.js#L170-L187

So in this PR, I'm adding the same mechanism for this view as well.