### PR TITLE
Avoid showing the calltree panel in profiles without samples

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -99,6 +99,7 @@ type StateProps = {|
   +isExperimentalCPUGraphsEnabled: boolean,
   +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
+  +callTreeVisible: boolean,
 |};
 
 type DispatchProps = {|
@@ -137,6 +138,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       focusCallTree,
       invertCallstack,
       selectedThreadIndexes,
+      callTreeVisible,
     } = this.props;
 
     // Sample clicking only works for one thread. See issue #2709
@@ -149,7 +151,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
         selectLeafCallNode(threadsKey, sampleIndex);
       }
 
-      if (sampleIndex !== null) {
+      if (sampleIndex !== null && callTreeVisible) {
         // If the user clicked outside of the activity graph (sampleIndex === null),
         // then we don't need to focus the call tree. This action also selects
         // the call tree panel, which we don't want either in this case.
@@ -396,6 +398,7 @@ export const TimelineTrackThread = explicitConnect<
       isExperimentalCPUGraphsEnabled: getIsExperimentalCPUGraphsEnabled(state),
       maxThreadCPUDeltaPerMs: getMaxThreadCPUDeltaPerMs(state),
       implementationFilter: getImplementationFilter(state),
+      callTreeVisible: selectors.getUsefulTabs(state).includes('calltree'),
     };
   },
   mapDispatchToProps: {

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -95,6 +95,7 @@ const selectedTab: Reducer<TabSlug> = (state = 'calltree', action) => {
   switch (action.type) {
     case 'CHANGE_SELECTED_TAB':
     case 'SELECT_TRACK':
+    case 'VIEW_FULL_PROFILE':
       return action.selectedTab;
     case 'FOCUS_CALL_TREE':
       return 'calltree';

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -266,6 +266,7 @@ describe('ThreadActivityGraph', function () {
   it('when clicking a stack, this selects the call tree panel', function () {
     const { dispatch, getState, clickActivityGraph } = setup();
 
+    expect(getSelectedTab(getState())).toBe('calltree');
     dispatch(changeSelectedTab('marker-chart'));
 
     // The full call node at this sample is:
@@ -278,12 +279,23 @@ describe('ThreadActivityGraph', function () {
   it(`when clicking outside of the graph, this doesn't select the call tree panel`, function () {
     const { dispatch, getState, clickActivityGraph } = setup();
 
+    expect(getSelectedTab(getState())).toBe('calltree');
     dispatch(changeSelectedTab('marker-chart'));
 
     // There's no sample at this location.
     clickActivityGraph(0, 1);
     expect(getSelectedTab(getState())).toBe('marker-chart');
     expect(getLastVisibleThreadTabSlug(getState())).toBe('marker-chart');
+  });
+
+  it("when clicking a sample in a track with only '(root)' samples, this doesn't select the hidden call tree panel", function () {
+    const { profile } = getProfileFromTextSamples('(root)');
+    const { getState, clickActivityGraph } = setup(profile);
+
+    expect(getSelectedTab(getState())).toBe('marker-chart');
+
+    clickActivityGraph(1, 0.2);
+    expect(getSelectedTab(getState())).toBe('marker-chart');
   });
 
   it('will redraw even when there are no samples in range', function () {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -416,14 +416,16 @@ describe('actions/ProfileView', function () {
         pid: '0',
       };
 
-      it('starts out with the thread track and call tree selected', function () {
+      it('starts out with the thread track and marker chart selected', function () {
         const profile = getNetworkTrackProfile();
         const { getState } = storeWithProfile(profile);
         expect(UrlStateSelectors.getSelectedThreadIndexes(getState())).toEqual(
           new Set([0])
         );
+        // The profile contains only markers, so the default tab is the
+        // marker-chart rather than the calltree.
         expect(UrlStateSelectors.getSelectedTab(getState())).toEqual(
-          'calltree'
+          'marker-chart'
         );
       });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -407,6 +407,7 @@ type ReceiveProfileAction =
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
       +timelineType: TimelineType | null,
+      +selectedTab: TabSlug,
     |}
   | {|
       +type: 'VIEW_ORIGINS_PROFILE',


### PR DESCRIPTION
This makes the "marker-chart" the default panel for profiles without samples. It also prevents from switching to the calltree panel when clicking the activity graph of a profile without samples (eg. where all samples are only "(root)").

Example of profile without samples to test with: https://profiler.firefox.com/public/w6a188gqfkm227vmvqgc69tj5edj49kqwyntefr/
Deploy preview: https://deploy-preview-4744--perf-html.netlify.app/public/w6a188gqfkm227vmvqgc69tj5edj49kqwyntefr/