### PR TITLE
Adjust line number filtering. Fixes #4626.

### DIFF
--- a/src/utils/codemirror-shared.js
+++ b/src/utils/codemirror-shared.js
@@ -67,7 +67,7 @@ function getSortedStartPositionsOfNonZeroLines(state: EditorState): number[] {
   }
   const lineCount = state.doc.lines;
   const positions = [...nonZeroLines]
-    .filter((l) => l <= lineCount)
+    .filter((l) => l >= 1 && l <= lineCount)
     .map((lineNumber) => state.doc.line(lineNumber).from);
   positions.sort((a, b) => a - b);
   return positions;


### PR DESCRIPTION
CodeMirror throws an error if it gets a zero line number. Samply was generating bad profiles because symbolication sometimes returned zero; this is now fixed.