### PR TITLE
Reject out-of-bounds positions.

### DIFF
--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -416,10 +416,23 @@ export class ActivityFillGraphQuerier {
   ): HoveredPixelState | null {
     const {
       rangeFilteredThread: { samples, stackTable },
+      canvasPixelWidth,
+      canvasPixelHeight,
     } = this.renderedComponentSettings;
+
     const { devicePixelRatio } = window;
-    const deviceX = Math.round(cssX * devicePixelRatio);
-    const deviceY = Math.round(cssY * devicePixelRatio);
+    const deviceX = Math.floor(cssX * devicePixelRatio);
+    const deviceY = Math.floor(cssY * devicePixelRatio);
+
+    if (
+      deviceX < 0 ||
+      deviceX >= canvasPixelWidth ||
+      deviceY < 0 ||
+      deviceY >= canvasPixelHeight
+    ) {
+      return null;
+    }
+
     const categoryUnderMouse = this._categoryAtDevicePixel(deviceX, deviceY);
 
     const candidateSamples = this._getSamplesAtTime(time);
@@ -533,17 +546,7 @@ export class ActivityFillGraphQuerier {
     categoryLowerEdge: number,
     yPercentage: number,
   } {
-    const { canvasPixelWidth, canvasPixelHeight } =
-      this.renderedComponentSettings;
-
-    if (
-      deviceX < 0 ||
-      deviceX >= canvasPixelWidth ||
-      deviceY < 0 ||
-      deviceY >= canvasPixelHeight
-    ) {
-      return null;
-    }
+    const { canvasPixelHeight } = this.renderedComponentSettings;
 
     // Convert the device pixel position into the range [0, 1], with 0 being
     // the *lower* edge of the canvas.


### PR DESCRIPTION
Fixes #4763.

Mouse positions towards the right end of the canvas were getting rounded so that deviceX == canvasPixelWidth, and then we were getting undefined out of the array in _getCPURatioAtX.

This commit changes the rounding to use floor, which keeps these almost-right-edge positions in-bounds. Furthermore, the bounds check from _categoryAtDevicePixel is moved into getSampleAndCpuRatioAtClick so that it protects _getCPURatioAtX as well.

I tried to add a test for this in SampleTooltipContents.test.js, but I couldn't get the tooltip to appear at all in the rightmost pixel. I think the test currently spaces out the samples so far that, even with the smoothing, the graph fill doesn't extend far enough to the right that we would show the tooltip.