### PR TITLE
Improve call tree performance for large profiles

### DIFF
--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -860,15 +860,16 @@ function _accumulateInBuffer(
     (sampleCategoryStartTime - bufferTimeRangeStart) * xPixelsPerMs;
   let sampleCategoryEndPixel =
     (sampleCategoryEndTime - bufferTimeRangeStart) * xPixelsPerMs;
-  sampleCategoryStartPixel = Math.max(0, sampleCategoryStartPixel);
-  sampleCategoryEndPixel = Math.min(
-    percentageBuffer.length - 1,
-    sampleCategoryEndPixel
-  );
+  if (sampleCategoryStartPixel < 0) {
+    sampleCategoryStartPixel = 0;
+  }
+  if (sampleCategoryEndPixel > percentageBuffer.length - 1) {
+    sampleCategoryEndPixel = percentageBuffer.length - 1;
+  }
   const samplePixel = (sampleTime - bufferTimeRangeStart) * xPixelsPerMs;
-  const intCategoryStartPixel = Math.floor(sampleCategoryStartPixel);
-  const intCategoryEndPixel = Math.floor(sampleCategoryEndPixel);
-  const intSamplePixel = Math.floor(samplePixel);
+  const intCategoryStartPixel = sampleCategoryStartPixel | 0;
+  const intCategoryEndPixel = sampleCategoryEndPixel | 0;
+  const intSamplePixel = samplePixel | 0;
   const sampleTimeDeltaBefore = sampleTime - prevSampleTime;
   const sampleTimeDeltaAfter = nextSampleTime - sampleTime;
 

--- a/src/components/shared/thread/CPUGraph.js
+++ b/src/components/shared/thread/CPUGraph.js
@@ -15,18 +15,19 @@ import type {
   Milliseconds,
   CallNodeInfo,
   IndexIntoCallNodeTable,
+  SelectedState,
 } from 'firefox-profiler/types';
 import type { HeightFunctionParams } from './HeightGraph';
 
 type Props = {|
   +className: string,
   +thread: Thread,
-  +tabFilteredThread: Thread,
+  +samplesSelectedStates: null | SelectedState[],
+  +sampleCallNodes: Array<IndexIntoCallNodeTable | null>,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +callNodeInfo: CallNodeInfo,
-  +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +categories: CategoryList,
   +onSampleClick: (
     event: SyntheticMouseEvent<>,
@@ -62,12 +63,11 @@ export class ThreadCPUGraph extends PureComponent<Props> {
     const {
       className,
       thread,
-      tabFilteredThread,
+      sampleCallNodes,
+      samplesSelectedStates,
       interval,
       rangeStart,
       rangeEnd,
-      callNodeInfo,
-      selectedCallNodeIndex,
       categories,
       trackName,
       maxThreadCPUDeltaPerMs,
@@ -85,11 +85,10 @@ export class ThreadCPUGraph extends PureComponent<Props> {
         trackName={trackName}
         interval={interval}
         thread={thread}
-        tabFilteredThread={tabFilteredThread}
+        sampleCallNodes={sampleCallNodes}
+        samplesSelectedStates={samplesSelectedStates}
         rangeStart={rangeStart}
         rangeEnd={rangeEnd}
-        callNodeInfo={callNodeInfo}
-        selectedCallNodeIndex={selectedCallNodeIndex}
         categories={categories}
         onSampleClick={onSampleClick}
       />

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -14,18 +14,19 @@ import type {
   Milliseconds,
   CallNodeInfo,
   IndexIntoCallNodeTable,
+  SelectedState,
 } from 'firefox-profiler/types';
 import type { HeightFunctionParams } from './HeightGraph';
 
 type Props = {|
   +className: string,
   +thread: Thread,
-  +tabFilteredThread: Thread,
+  +samplesSelectedStates: null | SelectedState[],
+  +sampleCallNodes: Array<IndexIntoCallNodeTable | null>,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +callNodeInfo: CallNodeInfo,
-  +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +categories: CategoryList,
   +onSampleClick: (
     event: SyntheticMouseEvent<>,
@@ -51,12 +52,12 @@ export class ThreadStackGraph extends PureComponent<Props> {
     const {
       className,
       thread,
-      tabFilteredThread,
+      sampleCallNodes,
+      samplesSelectedStates,
       interval,
       rangeStart,
       rangeEnd,
       callNodeInfo,
-      selectedCallNodeIndex,
       categories,
       trackName,
       onSampleClick,
@@ -78,11 +79,10 @@ export class ThreadStackGraph extends PureComponent<Props> {
         trackName={trackName}
         interval={interval}
         thread={thread}
-        tabFilteredThread={tabFilteredThread}
+        sampleCallNodes={sampleCallNodes}
+        samplesSelectedStates={samplesSelectedStates}
         rangeStart={rangeStart}
         rangeEnd={rangeEnd}
-        callNodeInfo={callNodeInfo}
-        selectedCallNodeIndex={selectedCallNodeIndex}
         categories={categories}
         onSampleClick={onSampleClick}
       />

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -469,14 +469,11 @@ function _getStackSelf(
  */
 export function computeCallTreeCountsAndSummary(
   samples: SamplesLikeTable,
-  { callNodeTable, stackIndexToCallNodeIndex }: CallNodeInfo,
+  sampleIndexToCallNodeIndex: Array<IndexIntoCallNodeTable | null>,
+  { callNodeTable }: CallNodeInfo,
   interval: Milliseconds,
   invertCallstack: boolean
 ): CallTreeCountsAndSummary {
-  const sampleIndexToCallNodeIndex = getSampleIndexToCallNodeIndex(
-    samples.stack,
-    stackIndexToCallNodeIndex
-  );
   // Inverted trees need a different method for computing the timing.
   const { callNodeSelf, callNodeLeaf } = invertCallstack
     ? _getInvertedStackSelf(samples, callNodeTable, sampleIndexToCallNodeIndex)

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -701,7 +701,6 @@ export function getTimingsForCallNodeIndex(
       value: number,
     },
     sampleIndex: IndexIntoSamplesTable,
-    stackIndex: IndexIntoStackTable,
     duration: Milliseconds
   ): void {
     // Step 1: increment the total value
@@ -774,7 +773,6 @@ export function getTimingsForCallNodeIndex(
         accumulateDataToTimings(
           pathTimings.selfTime,
           sampleIndex,
-          thisStackIndex,
           weight
         );
       }
@@ -805,7 +803,6 @@ export function getTimingsForCallNodeIndex(
           accumulateDataToTimings(
             pathTimings.totalTime,
             sampleIndex,
-            thisStackIndex,
             weight
           );
         }
@@ -840,7 +837,6 @@ export function getTimingsForCallNodeIndex(
           accumulateDataToTimings(
             pathTimings.totalTime,
             sampleIndex,
-            currentStackIndex,
             weight
           );
         }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -770,11 +770,7 @@ export function getTimingsForCallNodeIndex(
     if (!isInvertedTree) {
       // For non-inverted trees, we compute the self time from the stacks' leaf nodes.
       if (thisNodeIndex === needleNodeIndex) {
-        accumulateDataToTimings(
-          pathTimings.selfTime,
-          sampleIndex,
-          weight
-        );
+        accumulateDataToTimings(pathTimings.selfTime, sampleIndex, weight);
       }
     }
 
@@ -795,18 +791,7 @@ export function getTimingsForCallNodeIndex(
 
       if (currentNodeIndex === needleNodeIndex) {
         // One of the parents is the exact passed path.
-        // For non-inverted trees, we can contribute the data to the
-        // implementation breakdown now.
-        // Note that for inverted trees, we need to traverse up to the root node
-        // first, see below for this.
-        if (!isInvertedTree) {
-          accumulateDataToTimings(
-            pathTimings.totalTime,
-            sampleIndex,
-            weight
-          );
-        }
-
+        accumulateDataToTimings(pathTimings.totalTime, sampleIndex, weight);
         pathFound = true;
       }
 
@@ -829,16 +814,6 @@ export function getTimingsForCallNodeIndex(
           // This is the only place where we don't accumulate timings, mainly
           // because this would be the same as for the total time.
           pathTimings.selfTime.value += weight;
-        }
-
-        if (pathFound) {
-          // We contribute the implementation information if the passed path was
-          // found in this stack earlier.
-          accumulateDataToTimings(
-            pathTimings.totalTime,
-            sampleIndex,
-            weight
-          );
         }
       }
     }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -521,8 +521,8 @@ export type TimingsForPath = {|
 |};
 
 /**
- * This function is the same as getTimingsForPath, but accepts an IndexIntoCallNodeTable
- * instead of a CallNodePath.
+ * This function is the same as getTimingsForCallNodeIndex, but accepts a CallNodePath
+ * instead of an IndexIntoCallNodeTable.
  */
 export function getTimingsForPath(
   needlePath: CallNodePath,
@@ -553,7 +553,7 @@ export function getTimingsForPath(
 }
 
 /**
- * This function returns the timings for a specific path. The algorithm is
+ * This function returns the timings for a specific call node. The algorithm is
  * adjusted when the call tree is inverted.
  * Note that the unfilteredThread should be the original thread before any filtering
  * (by range or other) happens. Also sampleIndexOffset needs to be properly

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -726,11 +726,11 @@ export function getTimingsForCallNodeIndex(
     // Step 1: increment the total value
     timings.value += duration;
 
-    // Step 2: find the implementation value for this sample
-    const implementation = getImplementationForStack(sampleIndex);
-
-    // Step 3: increment the right value in the implementation breakdown
     if (displayImplementation) {
+      // Step 2: find the implementation value for this sample
+      const implementation = getImplementationForStack(sampleIndex);
+
+      // Step 3: increment the right value in the implementation breakdown
       if (timings.breakdownByImplementation === null) {
         timings.breakdownByImplementation = {};
       }

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -8,7 +8,7 @@ import {
   type CallTree,
 } from 'firefox-profiler/profile-logic/call-tree';
 import { getEmptyThread } from 'firefox-profiler/profile-logic/data-structures';
-import { getCallNodeInfo } from 'firefox-profiler/profile-logic/profile-data';
+import { getCallNodeInfo, getSampleIndexToCallNodeIndex } from 'firefox-profiler/profile-logic/profile-data';
 
 import type {
   IndexIntoCallNodeTable,
@@ -127,6 +127,7 @@ export function callTreeFromProfile(
   );
   const callTreeCountsAndSummary = computeCallTreeCountsAndSummary(
     thread.samples,
+    getSampleIndexToCallNodeIndex(thread.samples.stack, callNodeInfo.stackIndexToCallNodeIndex),
     callNodeInfo,
     interval,
     false

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -2114,69 +2114,6 @@ exports[`snapshots of selectors/profile matches the last stored run of markerThr
 
 exports[`snapshots of selectors/profile matches the last stored run of selectedNodeSelectors.getTimingsForSidebar 1`] = `
 Object {
-  "forFunc": Object {
-    "selfTime": Object {
-      "breakdownByCategory": null,
-      "breakdownByImplementation": null,
-      "value": 0,
-    },
-    "totalTime": Object {
-      "breakdownByCategory": Array [
-        Object {
-          "entireCategoryValue": 2,
-          "subcategoryBreakdown": Array [
-            2,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-        Object {
-          "entireCategoryValue": 0,
-          "subcategoryBreakdown": Array [
-            0,
-          ],
-        },
-      ],
-      "breakdownByImplementation": Object {
-        "native": 2,
-      },
-      "value": 2,
-    },
-  },
   "forPath": Object {
     "selfTime": Object {
       "breakdownByCategory": null,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1996,9 +1996,6 @@ describe('getTimingsForSidebar', () => {
       } = setup();
 
       // This is a root node: it should have no self time but all the total time.
-      // Also, because the function is only present once in the tree, forPath
-      // and forFunc timings are the same, so we're extracting them in one
-      // object for a better readability.
       const timings = getTimingsForPath([A]);
 
       const expectedTiming = {
@@ -2020,7 +2017,6 @@ describe('getTimingsForSidebar', () => {
       };
       expect(timings).toEqual({
         forPath: expectedTiming,
-        forFunc: expectedTiming,
         rootTime: 5,
       });
     });
@@ -2036,9 +2032,6 @@ describe('getTimingsForSidebar', () => {
       //
       // This is also a JS node so it should have some js engine implementation
       // implementations.
-      //
-      // The same func is also present in 2 different stacks so it should have
-      // different timings for the `forFunc` property.
       const timings = getTimingsForPath([A, B, Cjs, D, Ejs]);
       expect(timings).toEqual({
         forPath: {
@@ -2071,36 +2064,6 @@ describe('getTimingsForSidebar', () => {
             ]),
           },
         },
-        forFunc: {
-          selfTime: {
-            value: 3,
-            breakdownByImplementation: { ion: 2, baseline: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              0,
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-          totalTime: {
-            value: 3,
-            breakdownByImplementation: { ion: 2, baseline: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              0,
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
         rootTime: 5,
       });
     });
@@ -2115,9 +2078,6 @@ describe('getTimingsForSidebar', () => {
       // have some running time that's different than the self time.
       const timings = getTimingsForPath([A, B, H]);
 
-      // This node is present only once in the tree, so its forPath and forFunc
-      // timing values are identical. Extracting them provides a better
-      // readability.
       const expectedTiming = {
         selfTime: {
           value: 1,
@@ -2152,7 +2112,6 @@ describe('getTimingsForSidebar', () => {
 
       expect(timings).toEqual({
         forPath: expectedTiming,
-        forFunc: expectedTiming,
         rootTime: 5,
       });
     });
@@ -2215,9 +2174,6 @@ describe('getTimingsForSidebar', () => {
         // This is a root node: it should have no self time but all the total time.
         const timings = getTimingsForPath([A]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. So we extract the
-        // expectation to make this a bit more readable.
         const expectedTiming = {
           selfTime: EMPTY_TIMING,
           totalTime: {
@@ -2242,7 +2198,6 @@ describe('getTimingsForSidebar', () => {
         };
         expect(timings).toEqual({
           forPath: expectedTiming,
-          forFunc: expectedTiming,
           rootTime: 4,
         });
       });
@@ -2255,9 +2210,6 @@ describe('getTimingsForSidebar', () => {
 
         const timings = getTimingsForPath([A, Bjs]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. So we extract the
-        // expectation to make this a bit more readable.
         const expectedTiming = {
           selfTime: {
             value: 1,
@@ -2295,7 +2247,6 @@ describe('getTimingsForSidebar', () => {
         };
         expect(timings).toEqual({
           forPath: expectedTiming,
-          forFunc: expectedTiming,
           rootTime: 4,
         });
       });
@@ -2309,8 +2260,7 @@ describe('getTimingsForSidebar', () => {
         // This node is a native stack inhering the ion jit information.
         const timings = getTimingsForPath([A, Bjs, E]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. Also it only has a self
+        // This function has a self
         // time occurrence, so selfTime and totalTime show the same timing.
         // We extract the expectations to make this a bit more readable.
         const expectedTiming = {
@@ -2329,7 +2279,6 @@ describe('getTimingsForSidebar', () => {
         };
         expect(timings).toEqual({
           forPath: { selfTime: expectedTiming, totalTime: expectedTiming },
-          forFunc: { selfTime: expectedTiming, totalTime: expectedTiming },
           rootTime: 4,
         });
       });
@@ -2342,9 +2291,6 @@ describe('getTimingsForSidebar', () => {
 
         const timings = getTimingsForPath([A, Bjs, C]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. So we extract the
-        // expectation to make this a bit more readable.
         const expectedTiming = {
           selfTime: {
             value: 1,
@@ -2380,7 +2326,6 @@ describe('getTimingsForSidebar', () => {
         };
         expect(timings).toEqual({
           forPath: expectedTiming,
-          forFunc: expectedTiming,
           rootTime: 4,
         });
       });
@@ -2394,8 +2339,7 @@ describe('getTimingsForSidebar', () => {
         // This node is a native stack inhering the ion jit information.
         const timings = getTimingsForPath([A, Bjs, C, D]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. Also it only has a self
+        // This function only has a self
         // time occurrence, so selfTime and totalTime show the same timing.
         // We extract the expectations to make this a bit more readable.
         const expectedTiming = {
@@ -2414,7 +2358,6 @@ describe('getTimingsForSidebar', () => {
         };
         expect(timings).toEqual({
           forPath: { selfTime: expectedTiming, totalTime: expectedTiming },
-          forFunc: { selfTime: expectedTiming, totalTime: expectedTiming },
           rootTime: 4,
         });
       });
@@ -2445,9 +2388,7 @@ describe('getTimingsForSidebar', () => {
       } = setupForInvertedTree();
       const timings = getTimingsForPath([Ejs]);
 
-      // A root node will have the same values for total and selftime. Also this
-      // function is present once so forPath and forFunc will have the same
-      // values.
+      // A root node will have the same values for total and selftime.
       const expectedTiming = {
         value: 3,
         breakdownByImplementation: { ion: 2, baseline: 1 },
@@ -2473,7 +2414,6 @@ describe('getTimingsForSidebar', () => {
           },
           totalTime: expectedTiming,
         },
-        forFunc: { selfTime: expectedTiming, totalTime: expectedTiming },
         rootTime: 5,
       });
     });
@@ -2495,27 +2435,6 @@ describe('getTimingsForSidebar', () => {
               0,
               0,
               2, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
-        forFunc: {
-          selfTime: EMPTY_TIMING,
-          totalTime: {
-            value: 5,
-            breakdownByImplementation: {
-              ion: 2,
-              baseline: 1,
-              native: 2,
-            },
-            breakdownByCategory: withSingleSubcategory([
-              0, // Other
-              1, // Idle
-              1, // Layout
-              3, // JavaScript
               0,
               0,
               0,
@@ -2556,36 +2475,6 @@ describe('getTimingsForSidebar', () => {
             ]),
           },
         },
-        forFunc: {
-          selfTime: {
-            value: 1,
-            breakdownByImplementation: { native: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-          totalTime: {
-            value: 2,
-            breakdownByImplementation: { native: 2 },
-            breakdownByCategory: withSingleSubcategory([
-              0, // Other
-              1, // Idle
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
         rootTime: 5,
       });
 
@@ -2601,36 +2490,6 @@ describe('getTimingsForSidebar', () => {
               0,
               1, // Idle
               0,
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-        },
-        forFunc: {
-          selfTime: {
-            value: 1,
-            breakdownByImplementation: { native: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              0,
-              1, // Layout
-              0,
-              0,
-              0,
-              0,
-              0,
-            ]),
-          },
-          totalTime: {
-            value: 2,
-            breakdownByImplementation: { native: 2 },
-            breakdownByCategory: withSingleSubcategory([
-              0,
-              1, // Idle
-              1, // Layout
               0,
               0,
               0,
@@ -2665,23 +2524,6 @@ describe('getTimingsForSidebar', () => {
               0,
               0,
             ]),
-          },
-        },
-        forFunc: {
-          selfTime: EMPTY_TIMING,
-          totalTime: {
-            value: 5,
-            breakdownByImplementation: { native: 2, ion: 2, baseline: 1 },
-            breakdownByCategory: withSingleSubcategory([
-              0, // Other
-              1, // Idle
-              1, // Layout
-              3, // JavaScript
-              0,
-              0,
-              0,
-              0,
-            ]), // [Idle, Other, Layout, JavaScript]
           },
         },
         rootTime: 5,
@@ -2753,8 +2595,7 @@ describe('getTimingsForSidebar', () => {
         // This is a root node: it should have all self time.
         const timings = getTimingsForPath([D]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. Also it's a root node in
+        // This function is a root node in
         // an inverted tree, so selfTime and totalTime show the same timing.
         // We extract the expectations to make this a bit more readable.
         const expectedTiming = {
@@ -2782,7 +2623,6 @@ describe('getTimingsForSidebar', () => {
             },
             totalTime: expectedTiming,
           },
-          forFunc: { selfTime: expectedTiming, totalTime: expectedTiming },
           rootTime: 4,
         });
       });
@@ -2796,8 +2636,7 @@ describe('getTimingsForSidebar', () => {
         // This is a root node: it should have all self time.
         const timings = getTimingsForPath([E]);
 
-        // This function is present only once in the call tree, so we'll get the
-        // same timing results for forPath and forFunc. Also it's a root node in
+        // This function is a root node in
         // an inverted tree, so selfTime and totalTime show the same timing.
         // We extract the expectations to make this a bit more readable.
         const expectedTiming = {
@@ -2825,7 +2664,6 @@ describe('getTimingsForSidebar', () => {
             },
             totalTime: expectedTiming,
           },
-          forFunc: { selfTime: expectedTiming, totalTime: expectedTiming },
           rootTime: 4,
         });
       });
@@ -2851,41 +2689,6 @@ describe('getTimingsForSidebar', () => {
                 0,
                 1, // Layout
                 0,
-                0,
-                0,
-                0,
-                0,
-              ]),
-            },
-          },
-          forFunc: {
-            selfTime: {
-              value: 1,
-              breakdownByImplementation: { blinterp: 1 },
-              breakdownByCategory: withSingleSubcategory([
-                0,
-                0,
-                0,
-                1, // JavaScript
-                0,
-                0,
-                0,
-                0,
-              ]),
-            },
-            totalTime: {
-              value: 4,
-              breakdownByImplementation: {
-                ion: 1,
-                blinterp: 1,
-                interpreter: 1,
-                native: 1,
-              },
-              breakdownByCategory: withSingleSubcategory([
-                0,
-                0,
-                1, // Layout
-                3, // JavaScript
                 0,
                 0,
                 0,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -17,6 +17,7 @@ import {
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
   filterThreadSamplesToRange,
+  getSampleIndexToCallNodeIndex,
 } from '../../profile-logic/profile-data';
 import { resourceTypes } from '../../profile-logic/data-structures';
 import {
@@ -72,6 +73,10 @@ describe('unfiltered call tree', function () {
       expect(
         computeCallTreeCountsAndSummary(
           thread.samples,
+          getSampleIndexToCallNodeIndex(
+            thread.samples.stack,
+            callNodeInfo.stackIndexToCallNodeIndex
+          ),
           callNodeInfo,
           profile.meta.interval,
           false
@@ -115,6 +120,10 @@ describe('unfiltered call tree', function () {
       const { callNodeChildCount, callNodeSummary } =
         computeCallTreeCountsAndSummary(
           thread.samples,
+          getSampleIndexToCallNodeIndex(
+            thread.samples.stack,
+            callNodeInfo.stackIndexToCallNodeIndex
+          ),
           callNodeInfo,
           profile.meta.interval,
           false /* inverted */
@@ -454,6 +463,10 @@ describe('inverted call tree', function () {
     );
     const callTreeCountsAndSummary = computeCallTreeCountsAndSummary(
       thread.samples,
+      getSampleIndexToCallNodeIndex(
+        thread.samples.stack,
+        callNodeInfo.stackIndexToCallNodeIndex
+      ),
       callNodeInfo,
       interval,
       true
@@ -494,6 +507,10 @@ describe('inverted call tree', function () {
     );
     const invertedCallTreeCountsAndSummary = computeCallTreeCountsAndSummary(
       invertedThread.samples,
+      getSampleIndexToCallNodeIndex(
+        invertedThread.samples.stack,
+        invertedCallNodeInfo.stackIndexToCallNodeIndex
+      ),
       invertedCallNodeInfo,
       interval,
       true
@@ -631,6 +648,10 @@ describe('diffing trees', function () {
     );
     const callTreeCountsAndSummary = computeCallTreeCountsAndSummary(
       thread.samples,
+      getSampleIndexToCallNodeIndex(
+        thread.samples.stack,
+        callNodeInfo.stackIndexToCallNodeIndex
+      ),
       callNodeInfo,
       interval,
       false


### PR DESCRIPTION
[Production (call tree)](https://profiler.firefox.com/public/rj5fsez7z9z4ewj4frmeabm02r7dm754ah2mh9g/calltree/?globalTrackOrder=0&thread=0&v=10) | [Deploy preview (call tree)](https://deploy-preview-4766--perf-html.netlify.app/public/rj5fsez7z9z4ewj4frmeabm02r7dm754ah2mh9g/calltree/?globalTrackOrder=0&thread=0&v=10)
[Production (flame graph)](https://profiler.firefox.com/public/th3n9mr8x6q862z9qbkrbdf5w6r8p30fh6ndwn8/flame-graph/?globalTrackOrder=01&hiddenGlobalTracks=1&hiddenLocalTracksByPid=13653-0wc~13878-0w8&thread=0&v=10) | [Deploy preview (flame graph)](https://deploy-preview-4766--perf-html.netlify.app/public/th3n9mr8x6q862z9qbkrbdf5w6r8p30fh6ndwn8/flame-graph/?globalTrackOrder=01&hiddenGlobalTracks=1&hiddenLocalTracksByPid=13653-0wc~13878-0w8&thread=0&v=10)

This patch stack makes the UI less sluggish when interacting with large profiles. For example, in the call tree, changing the selection with the arrow keys is much improved, as is moving the mouse across the flame graph.

Fixes #4589.
Fixes #1120.

The biggest costs were activity graph computation (including the computation of "sample selected states"), and `getTimingsForCallNodeIndex` which is used for the call tree sidebar information and for the flame graph tooltip.

Profiles with function names:
Before: https://share.firefox.dev/46dY5hg (500ms per keypress)
After: https://share.firefox.dev/3rJCtu1 (64ms per keypress)