### PR TITLE
Display a 'Name' column in the marker table instead of the 'Type' column

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -427,8 +427,8 @@ MarkerSidebar--select-a-marker = Select a marker to display information about it
 
 MarkerTable--start = Start
 MarkerTable--duration = Duration
-MarkerTable--type = Type
-MarkerTable--description = Description
+MarkerTable--name = Name
+MarkerTable--details = Details
 
 ## MenuButtons
 ## These strings are used for the buttons at the top of the profile viewer.

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -20,14 +20,11 @@
   text-align: right;
 }
 
-.treeViewHeaderColumn.name {
-  padding: 0 20px;
-}
-
-.treeViewFixedColumn.type {
+.treeViewFixedColumn.name {
   width: 100px;
+  text-align: right;
 }
 
-.treeViewRowColumn.type {
-  text-align: left;
+.markerTable .treeRowToggleButton {
+  display: none;
 }

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -39,7 +39,6 @@ import type {
 } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from '../../utils/connect';
-import { getMarkerSchemaName } from '../../profile-logic/marker-schema';
 
 // Limit how many characters in the description get sent to the DOM.
 const MAX_DESCRIPTION_CHARACTERS = 500;
@@ -48,7 +47,7 @@ type MarkerDisplayData = {|
   start: string,
   duration: string | null,
   name: string,
-  type: string,
+  details: string,
 |};
 
 class MarkerTree {
@@ -107,13 +106,12 @@ class MarkerTree {
     let displayData = this._displayDataByIndex.get(markerIndex);
     if (displayData === undefined) {
       const marker = this._getMarker(markerIndex);
+      let details = this._getMarkerLabel(markerIndex);
 
-      let name = this._getMarkerLabel(markerIndex);
-
-      if (name.length > MAX_DESCRIPTION_CHARACTERS) {
+      if (details.length > MAX_DESCRIPTION_CHARACTERS) {
         // This was adapted from the log marker payloads as a general rule for
         // the marker table. This way no special handling is needed.
-        name = name.substring(0, MAX_DESCRIPTION_CHARACTERS) + '…';
+        details = details.substring(0, MAX_DESCRIPTION_CHARACTERS) + '…';
       }
 
       let duration = null;
@@ -126,12 +124,8 @@ class MarkerTree {
       displayData = {
         start: _formatStart(marker.start, this._zeroAt),
         duration,
-        name,
-        type: getMarkerSchemaName(
-          this._markerSchemaByName,
-          marker.name,
-          marker.data
-        ),
+        name: marker.name,
+        details,
       };
       this._displayDataByIndex.set(markerIndex, displayData);
     }
@@ -181,14 +175,14 @@ class MarkerTableImpl extends PureComponent<Props> {
       resizable: true,
     },
     {
-      propName: 'type',
-      titleL10nId: 'MarkerTable--type',
+      propName: 'name',
+      titleL10nId: 'MarkerTable--name',
       minWidth: 30,
       initialWidth: 150,
       resizable: true,
     },
   ];
-  _mainColumn = { propName: 'name', titleL10nId: 'MarkerTable--description' };
+  _mainColumn = { propName: 'details', titleL10nId: 'MarkerTable--details' };
   _expandedNodeIds: Array<MarkerIndex | null> = [];
   _onExpandedNodeIdsChange = () => {};
   _treeView: ?TreeView<MarkerDisplayData>;

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -461,7 +461,15 @@ export function getMarkerSelectorsPerThread(
    * in the marker table.
    */
   const getMarkerLabelToCopyGetter: Selector<(MarkerIndex) => string> =
-    getMarkerTableLabelGetter;
+    createSelector(
+      getMarkerGetter,
+      ProfileSelectors.getMarkerSchema,
+      ProfileSelectors.getMarkerSchemaByName,
+      ProfileSelectors.getCategories,
+      threadSelectors.getStringTable,
+      () => 'copyLabel',
+      getLabelGetter
+    );
 
   /**
    * This organizes the result of the previous selector in rows to be nicely

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -481,7 +481,7 @@ describe('MarkerChart', function () {
       expect(getContextMenu()).toMatchSnapshot();
 
       clickOnMenuItem('Copy description');
-      expect(copy).toHaveBeenLastCalledWith('UserTiming A');
+      expect(copy).toHaveBeenLastCalledWith('UserTiming — UserTiming A');
       expect(getContextMenu()).not.toHaveClass('react-contextmenu--visible');
 
       jest.runAllTimers();
@@ -504,7 +504,7 @@ describe('MarkerChart', function () {
 
       expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
       clickOnMenuItem('Copy description');
-      expect(copy).toHaveBeenLastCalledWith('UserTiming B');
+      expect(copy).toHaveBeenLastCalledWith('UserTiming — UserTiming B');
     });
 
     it('displays and still highlights other markers when hovering them', () => {

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -286,7 +286,7 @@ describe('TimelineMarkers', function () {
       expect(getContextMenu()).toHaveClass('react-contextmenu--visible');
 
       clickOnMenuItem('Copy description');
-      expect(copy).toHaveBeenLastCalledWith('mousedown');
+      expect(copy).toHaveBeenLastCalledWith('DOMEvent — mousedown');
       expect(getContextMenu()).not.toHaveClass('react-contextmenu--visible');
 
       jest.runAllTimers();

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -185,19 +185,19 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
         data-column-index="1"
       />
       <span
-        class="treeViewHeaderColumn treeViewFixedColumn type"
+        class="treeViewHeaderColumn treeViewFixedColumn name"
         style="width: 150px;"
       >
-        Type
+        Name
       </span>
       <span
         class="treeViewColumnDivider isResizable"
         data-column-index="2"
       />
       <span
-        class="treeViewHeaderColumn treeViewMainColumn name"
+        class="treeViewHeaderColumn treeViewMainColumn details"
       >
-        Description
+        Details
       </span>
     </div>
     <div
@@ -248,7 +248,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
                   title="UserTiming"
                 >
@@ -281,11 +281,11 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
-                  title="Paint"
+                  title="NotifyDidPaint"
                 >
-                  Paint
+                  NotifyDidPaint
                 </span>
                 <span
                   class="treeViewColumnDivider"
@@ -316,11 +316,11 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
-                  title="IPC"
+                  title="IPCOut"
                 >
-                  IPC
+                  IPCOut
                 </span>
                 <span
                   class="treeViewColumnDivider"
@@ -351,11 +351,11 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
-                  title="Text"
+                  title="setTimeout"
                 >
-                  Text
+                  setTimeout
                 </span>
                 <span
                   class="treeViewColumnDivider"
@@ -386,11 +386,11 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
-                  title="Text"
+                  title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Quisque pulvinar blandit ullamcorper. Donec id justo at metus scelerisque pulvinar. Proin suscipit suscipit nisi, quis tempus ipsum vulputate quis. Pellentesque sodales rutrum eros, eget pulvinar ante condimentum a. Donec accumsan, ante ut facilisis cursus, nibh quam congue eros, vitae placerat tortor magna vel lacus. Etiam odio diam, venenatis eu sollicitudin non, ultrices ut urna. Aliquam vehicula diam eu eros eleifend, ac vulputate purus faucibus."
                 >
-                  Text
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Quisque pulvinar blandit ullamcorper. Donec id justo at metus scelerisque pulvinar. Proin suscipit suscipit nisi, quis tempus ipsum vulputate quis. Pellentesque sodales rutrum eros, eget pulvinar ante condimentum a. Donec accumsan, ante ut facilisis cursus, nibh quam congue eros, vitae placerat tortor magna vel lacus. Etiam odio diam, venenatis eu sollicitudin non, ultrices ut urna. Aliquam vehicula diam eu eros eleifend, ac vulputate purus faucibus.
                 </span>
                 <span
                   class="treeViewColumnDivider"
@@ -419,11 +419,11 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
-                  title="Log"
+                  title="LogMessages"
                 >
-                  Log
+                  LogMessages
                 </span>
                 <span
                   class="treeViewColumnDivider"
@@ -454,7 +454,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeViewColumnDivider"
                 />
                 <span
-                  class="treeViewRowColumn treeViewFixedColumn type"
+                  class="treeViewRowColumn treeViewFixedColumn name"
                   style="width: 150px;"
                   title="FileIO"
                 >
@@ -493,7 +493,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewRowColumn treeViewMainColumn details"
                 >
                   foobar
                 </span>
@@ -514,10 +514,8 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
-                >
-                  NotifyDidPaint
-                </span>
+                  class="treeViewRowColumn treeViewMainColumn details"
+                />
               </div>
               <div
                 aria-level="1"
@@ -535,9 +533,9 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewRowColumn treeViewMainColumn details"
                 >
-                  IPCOut — PContent::Msg_PreferenceUpdate — sent to 2222
+                  PContent::Msg_PreferenceUpdate — sent to 2222
                 </span>
               </div>
               <div
@@ -556,9 +554,9 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewRowColumn treeViewMainColumn details"
                 >
-                  setTimeout — 5.5
+                  5.5
                 </span>
               </div>
               <div
@@ -577,9 +575,9 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewRowColumn treeViewMainColumn details"
                 >
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Q…
+                  5.5
                 </span>
               </div>
               <div
@@ -598,7 +596,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewRowColumn treeViewMainColumn details"
                 >
                   (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
 
@@ -620,7 +618,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewRowColumn treeViewMainColumn details"
                 >
                   (PoisonIOInterposer) create/open — /foo/bar
                 </span>


### PR DESCRIPTION
The "Type" column currently exposes an implementation detail (ie. the marker schema name). Showing the marker names in a well aligned column and removing the marker name from the tableLabel would make the marker table look cleaner.

Example profiles:
- mach build profile: [deployed](https://share.firefox.dev/46zHjt6), [preview](https://deploy-preview-4776--perf-html.netlify.app/public/a1kvwkfjvtfyr5429qpxm8gvg8ggvmbpq2b97e8/marker-table/)
- Firefox profile: [deployed](https://share.firefox.dev/48Wp42t), [preview](https://deploy-preview-4776--perf-html.netlify.app/public/3w8depn1he4mnayfzme4cafpqxv5p171amkdg0r/marker-table/)