### PR TITLE
Avoid drawing a 1px line for 0 values in marker bar charts to make sl…

### DIFF
--- a/src/test/components/__snapshots__/TrackCustomMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TrackCustomMarker.test.js.snap
@@ -104,12 +104,12 @@ Array [
   Array [
     "lineTo",
     20,
-    21,
+    20,
   ],
   Array [
     "lineTo",
     30,
-    21,
+    20,
   ],
   Array [
     "lineTo",
@@ -124,12 +124,12 @@ Array [
   Array [
     "lineTo",
     40,
-    18,
+    17,
   ],
   Array [
     "lineTo",
     50,
-    18,
+    17,
   ],
   Array [
     "lineTo",
@@ -144,12 +144,12 @@ Array [
   Array [
     "lineTo",
     60,
-    15,
+    14,
   ],
   Array [
     "lineTo",
     70,
-    15,
+    14,
   ],
   Array [
     "lineTo",
@@ -171,13 +171,6 @@ Array [
   Array [
     "set fillStyle",
     "#30e60b",
-  ],
-  Array [
-    "fillRect",
-    0,
-    24,
-    10,
-    1,
   ],
   Array [
     "fillRect",


### PR DESCRIPTION
…ightly above 0 values visible.

When looking at marker bar graphs where there are lots of values that are 0, it's impossible to find the slightly-above-0 values without slowly hovering the graph. I think we could change that as this 1px line doesn't have any obvious purpose. Reading the code, it's a side effect of something that is needed to accommodate the stroke width of the darker line drawn on line charts.

Example profile: https://share.firefox.dev/3M8gnZn