### PR TITLE
Fix various stack chart issues

### DIFF
--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -525,9 +525,9 @@ export const withChartViewport: WithChartViewport<*, *> =
 
         const mouseX = event.clientX;
         const { containerLeft, containerWidth } = this.state;
-        const innerContainerWidth = containerWidth - marginLeft - marginRight;
+        const viewportPixelWidth = containerWidth - marginLeft - marginRight;
         const mouseCenter =
-          (mouseX - containerLeft - marginLeft) / innerContainerWidth;
+          (mouseX - containerLeft - marginLeft) / viewportPixelWidth;
         this.zoomRangeSelection(mouseCenter, zoomFactor);
       }
 
@@ -715,6 +715,8 @@ export const withChartViewport: WithChartViewport<*, *> =
             timeRange,
             startsAtBottom,
             disableHorizontalMovement,
+            marginLeft,
+            marginRight,
           },
         } = this.props;
         const { containerWidth, containerHeight, viewportTop, isSizeSet } =
@@ -768,7 +770,10 @@ export const withChartViewport: WithChartViewport<*, *> =
                   isModifying: false,
                 };
               }
-              const unitOffsetX = (viewportLength * offsetX) / containerWidth;
+              const viewportPixelWidth =
+                containerWidth - marginLeft - marginRight;
+              const unitOffsetX =
+                offsetX * (viewportLength / viewportPixelWidth);
               let newViewportLeft = viewportLeft - unitOffsetX;
               let newViewportRight = viewportRight - unitOffsetX;
               if (newViewportLeft < 0) {

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -267,6 +267,31 @@ Array [
   ],
   Array [
     "set fillStyle",
+    "#ffe90070",
+  ],
+  Array [
+    "fillRect",
+    350,
+    48,
+    66.4,
+    15,
+  ],
+  Array [
+    "measureText",
+    "componentC",
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "componentC",
+    353,
+    59,
+  ],
+  Array [
+    "set fillStyle",
     "#0060df60",
   ],
   Array [


### PR DESCRIPTION
Fixes #4790 .

The panning distance was computed without taking margins into account, and ended up being too short.
Boxes in the right margin weren't being drawn.
The shortened panning distance meant that panning / horizontal scrolling in device pixel increments didn't move the chart in device pixel increments.