### PR TITLE
Fix various issues related to vertical indicators and add an LCP indicator

### DIFF
--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -82,7 +82,8 @@ export class VerticalIndicators extends React.PureComponent<Props> {
       // Compute the positioning
       const rangeLength = rangeEnd - rangeStart;
       const xPixelsPerMs = width / rangeLength;
-      const left = (marker.start - rangeStart) * xPixelsPerMs;
+      const markerPos = marker.end !== null ? marker.end : marker.start;
+      const left = (markerPos - rangeStart) * xPixelsPerMs;
 
       // Optionally compute a url.
       let url = null;

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -72,7 +72,7 @@ export class VerticalIndicators extends React.PureComponent<Props> {
           break;
         case 'FirstContentfulPaint':
         case 'FirstContentfulComposite':
-          color = 'var(--green-60)';
+          color = 'var(--magenta-60)';
           break;
         default:
           color = '#000';

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -70,10 +70,13 @@ export class VerticalIndicators extends React.PureComponent<Props> {
         case 'DOMContentLoaded':
           color = 'var(--blue-50)';
           break;
+        case 'FirstContentfulPaint':
+        case 'FirstContentfulComposite':
+          color = 'var(--green-60)';
+          break;
         default:
-          if (marker.name.startsWith('Contentful paint ')) {
-            color = 'var(--green-60)';
-          }
+          color = '#000';
+          break;
       }
 
       // Compute the positioning

--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -72,6 +72,7 @@ export class VerticalIndicators extends React.PureComponent<Props> {
           break;
         case 'FirstContentfulPaint':
         case 'FirstContentfulComposite':
+        case 'LargestContentfulPaint':
           color = 'var(--magenta-60)';
           break;
         default:

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1094,7 +1094,11 @@ export function isNavigationMarker({ name, data }: Marker) {
     return true;
   }
 
-  if (name === 'FirstContentfulPaint' || name === 'FirstContentfulComposite') {
+  if (
+    name === 'FirstContentfulPaint' ||
+    name === 'FirstContentfulComposite' ||
+    name === 'LargestContentfulPaint'
+  ) {
     // Add the performance metric markers.
     return true;
   }

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1093,14 +1093,15 @@ export function isNavigationMarker({ name, data }: Marker) {
     // TTI is only selectable by name, as it doesn't have a structured payload.
     return true;
   }
+
+  if (name === 'FirstContentfulPaint' || name === 'FirstContentfulComposite') {
+    // Add the performance metric markers.
+    return true;
+  }
+
   if (!data) {
     // This marker has no payload, only consider the name.
     if (name === 'Navigation::Start') {
-      return true;
-    }
-    if (name.startsWith('Contentful paint ')) {
-      // This is a long plaintext marker.
-      // e.g. "Contentful paint after 322ms for URL https://developer.mozilla.org/en-US/, foreground tab"
       return true;
     }
     return false;

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -107,7 +107,7 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
             class="timelineVerticalIndicatorsLine"
             data-marker-index="10"
             data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
+            style="--vertical-indicator-color: var(--red-60); left: 200px;"
           />
           <div
             class="timelineVerticalIndicatorsLine"
@@ -119,7 +119,7 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
             class="timelineVerticalIndicatorsLine"
             data-marker-index="12"
             data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--blue-50); left: 200px;"
+            style="--vertical-indicator-color: var(--blue-50); left: 266.6666666666667px;"
           />
           <div
             class="timelineVerticalIndicatorsLine"

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -131,7 +131,7 @@ exports[`timeline/LocalTrack with a network track matches the snapshot of the ne
             class="timelineVerticalIndicatorsLine"
             data-marker-index="14"
             data-testid="vertical-indicator-line"
-            style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
+            style="--vertical-indicator-color: var(--magenta-60); left: 333.33333333333337px;"
           />
         </div>
       </div>

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -726,7 +726,7 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
       class="timelineVerticalIndicatorsLine"
       data-marker-index="14"
       data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--green-60); left: 333.33333333333337px;"
+      style="--vertical-indicator-color: var(--magenta-60); left: 333.33333333333337px;"
     />
   </div>
 </div>

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -702,7 +702,7 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
       class="timelineVerticalIndicatorsLine"
       data-marker-index="10"
       data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--red-60); left: 66.66666666666667px;"
+      style="--vertical-indicator-color: var(--red-60); left: 200px;"
     />
     <div
       class="timelineVerticalIndicatorsLine"
@@ -714,7 +714,7 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
       class="timelineVerticalIndicatorsLine"
       data-marker-index="12"
       data-testid="vertical-indicator-line"
-      style="--vertical-indicator-color: var(--blue-50); left: 200px;"
+      style="--vertical-indicator-color: var(--blue-50); left: 266.6666666666667px;"
     />
     <div
       class="timelineVerticalIndicatorsLine"

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1210,7 +1210,7 @@ export function getNetworkTrackProfile() {
     [
       'Load',
       4,
-      5,
+      6,
       ({
         ...loadPayloadBase,
       }: NavigationMarkerPayload),

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1217,7 +1217,7 @@ export function getNetworkTrackProfile() {
     ],
     ['TTI', 6],
     ['Navigation::Start', 7],
-    ['Contentful paint at something', 8],
+    ['FirstContentfulPaint', 8],
     [
       'DOMContentLoaded',
       6,

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1217,7 +1217,7 @@ export function getNetworkTrackProfile() {
     ],
     ['TTI', 6],
     ['Navigation::Start', 7],
-    ['FirstContentfulPaint', 8],
+    ['FirstContentfulPaint', 7, 8],
     [
       'DOMContentLoaded',
       6,

--- a/src/test/store/__snapshots__/markers.test.js.snap
+++ b/src/test/store/__snapshots__/markers.test.js.snap
@@ -46,9 +46,9 @@ Array [
   Object {
     "category": 0,
     "data": null,
-    "end": null,
+    "end": 8,
     "name": "FirstContentfulPaint",
-    "start": 8,
+    "start": 7,
     "threadId": null,
   },
 ]

--- a/src/test/store/__snapshots__/markers.test.js.snap
+++ b/src/test/store/__snapshots__/markers.test.js.snap
@@ -10,7 +10,7 @@ Array [
       "innerWindowID": 1,
       "type": "tracing",
     },
-    "end": 5,
+    "end": 6,
     "name": "Load",
     "start": 4,
     "threadId": null,

--- a/src/test/store/__snapshots__/markers.test.js.snap
+++ b/src/test/store/__snapshots__/markers.test.js.snap
@@ -47,7 +47,7 @@ Array [
     "category": 0,
     "data": null,
     "end": null,
-    "name": "Contentful paint at something",
+    "name": "FirstContentfulPaint",
     "start": 8,
     "threadId": null,
   },


### PR DESCRIPTION
This PR fixes multiple issues. Initially I wanted to add LCP indicator but also came across some problems while doing it. Here's a list of the things I did:

- Fix showing the vertical indicator for `FirstContentfulPaint` and `FirstContentfulComposite`. It looks like we wanted to show them before, but they were actually matching incorrect text. After this PR, they will be visible as well.
- If a marker is a duration marker, use the `end` time rather than `start` time. Markers like FirstContentfulPaint have a start time of navigation start, and they and when the first contentful pain happens. The correct point should be the end instead.
- Change the colors of metric indicator. Previously they were using green, which wasn't really visible on top of blue network markers. Magenta is a lot easier to find.
- Add an indicator for `LCP` metric.

Note that LCP markers are being added in [Bug 1862937](https://bugzilla.mozilla.org/show_bug.cgi?id=1862937)

Example profile: [Before](https://share.firefox.dev/3QLBvWX) / [After](https://deploy-preview-4793--perf-html.netlify.app/public/epfmt2kghds43r7ym5fqk89jx83npkmc4569ec0/marker-chart/?globalTrackOrder=c0wb&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=32105-23~32134-0~32110-0~32109-0~32118-01~32133-0~32145-0~32112-0~32127-0~32111-0&markerSearch=contentful%2Cnavigation&thread=h&v=10)