### PR TITLE
Show the correct time for vertical indicators with duration markers

### DIFF
--- a/src/components/timeline/VerticalIndicators.js
+++ b/src/components/timeline/VerticalIndicators.js
@@ -128,7 +128,7 @@ export class VerticalIndicators extends React.PureComponent<Props> {
                     {' at '}
                   </span>
                   <span className="timelineVerticalIndicatorsTime">
-                    {formatSeconds(marker.start - zeroAt)}
+                    {formatSeconds(markerPos - zeroAt)}
                   </span>{' '}
                 </div>
                 {url}

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -20,7 +20,7 @@ exports[`VerticalIndicators displays tooltips 1`] = `
     <span
       class="timelineVerticalIndicatorsTime"
     >
-      0.001s
+      0.003s
     </span>
      
   </div>


### PR DESCRIPTION
Fixes #4800.

[For example see this profile](https://share.firefox.dev/3G2wynn)
If you hover over `FirstContentfulPaint` indicator, it says `FirstContentfulPaint at 1.111s` in the tooltip. But the actual time is around `1.77s`. Looking into it, it looks like it's still using the `start` time instead of the `end` time for duration markers.

[Deploy preview](https://deploy-preview-4801--perf-html.netlify.app/public/5y2x0b4baqt4nzd54y9caxpye3j39xc2q4hfe68/marker-chart/?globalTrackOrder=a0213w9&hiddenGlobalTracks=0w8&hiddenLocalTracksByPid=62727-2w4~62731-0~62735-0~62759-0~62732-0~62733-0~62754-1&range=937m1630&thread=f&v=10) - this should show the correct end time stamp with the duration marker ones.