### PR TITLE
Make the flame graph and stack chart always non-inverted

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -105,26 +105,30 @@ export function changeSelectedCallNode(
   selectedCallNodePath: CallNodePath,
   context: SelectionContext = { source: 'auto' },
   optionalExpandedToCallNodePath?: CallNodePath
-): Action {
-  if (optionalExpandedToCallNodePath) {
-    for (let i = 0; i < selectedCallNodePath.length; i++) {
-      if (selectedCallNodePath[i] !== optionalExpandedToCallNodePath[i]) {
-        // This assertion ensures that the selectedCallNode will be correctly expanded.
-        throw new Error(
-          oneLine`
-            The optional expanded call node path provided to the changeSelectedCallNode
-            must contain the selected call node path.
-          `
-        );
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    if (optionalExpandedToCallNodePath) {
+      for (let i = 0; i < selectedCallNodePath.length; i++) {
+        if (selectedCallNodePath[i] !== optionalExpandedToCallNodePath[i]) {
+          // This assertion ensures that the selectedCallNode will be correctly expanded.
+          throw new Error(
+            oneLine`
+              The optional expanded call node path provided to the changeSelectedCallNode
+              must contain the selected call node path.
+            `
+          );
+        }
       }
     }
-  }
-  return {
-    type: 'CHANGE_SELECTED_CALL_NODE',
-    selectedCallNodePath,
-    optionalExpandedToCallNodePath,
-    threadsKey,
-    context,
+    const isInverted = getInvertCallstack(getState());
+    dispatch({
+      type: 'CHANGE_SELECTED_CALL_NODE',
+      isInverted,
+      selectedCallNodePath,
+      optionalExpandedToCallNodePath,
+      threadsKey,
+      context,
+    });
   };
 }
 
@@ -1637,14 +1641,17 @@ export function expandAllCallNodeDescendants(
 export function changeExpandedCallNodes(
   threadsKey: ThreadsKey,
   expandedCallNodePaths: Array<CallNodePath>
-): Action {
-  return {
-    type: 'CHANGE_EXPANDED_CALL_NODES',
-    threadsKey,
-    expandedCallNodePaths,
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const isInverted = getInvertCallstack(getState());
+    dispatch({
+      type: 'CHANGE_EXPANDED_CALL_NODES',
+      isInverted,
+      threadsKey,
+      expandedCallNodePaths,
+    });
   };
 }
-
 export function changeSelectedMarker(
   threadsKey: ThreadsKey,
   selectedMarker: MarkerIndex | null,

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1772,13 +1772,17 @@ export function changeInvertCallstack(
       eventCategory: 'profile',
       eventAction: 'change invert callstack',
     });
+    const callTree = selectedThreadSelectors.getCallTree(getState());
+    const selectedCallNode = selectedThreadSelectors.getSelectedCallNodeIndex(
+      getState()
+    );
+    const newSelectedCallNodePath =
+      callTree.findHeavyPathToSameFunctionAfterInversion(selectedCallNode);
     dispatch({
       type: 'CHANGE_INVERT_CALLSTACK',
       invertCallstack,
       selectedThreadIndexes: getSelectedThreadIndexes(getState()),
-      callTree: selectedThreadSelectors.getCallTree(getState()),
-      callNodeTable: selectedThreadSelectors.getCallNodeInfo(getState())
-        .callNodeTable,
+      newSelectedCallNodePath,
     });
   };
 }

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -16,6 +16,10 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import './MaybeFlameGraph.css';
 
+// TODO: This component isn't needed any more. Whenever the selected tab
+// is "flame-graph", `invertCallstack` will be `false`. <MaybeFlameGraph /> is
+// only used in the "flame-graph" tab.
+
 type StateProps = {|
   +isPreviewSelectionEmpty: boolean,
   +invertCallstack: boolean,

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -238,7 +238,7 @@ class StackChartImpl extends React.PureComponent<Props> {
         role="tabpanel"
         aria-labelledby="stack-chart-tab-button"
       >
-        <StackSettings />
+        <StackSettings hideInvertCallstack={true} />
         <TransformNavigator />
         {maxStackDepth === 0 && userTimings.length === 0 ? (
           <StackChartEmptyReasons />

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -9,7 +9,6 @@ import {
 } from '../utils/uintarray-encoding';
 import {
   toValidImplementationFilter,
-  getCallNodeIndexFromPath,
   updateThreadStacks,
   updateThreadStacksByGeneratingNewStackColumns,
   getMapStackUpdater,
@@ -18,7 +17,6 @@ import {
 import { timeCode } from '../utils/time-code';
 import { assertExhaustiveCheck, convertToTransformType } from '../utils/flow';
 import { canonicalizeRangeSet } from '../utils/range-set';
-import { CallTree } from '../profile-logic/call-tree';
 import { getSearchFilteredMarkerIndexes } from '../profile-logic/marker-data';
 import { shallowCloneFrameTable, getEmptyStackTable } from './data-structures';
 import { getFunctionName } from './function-info';
@@ -696,53 +694,6 @@ function _callNodePathHasPrefixPath(
   return (
     prefixPath.length <= callNodePath.length &&
     prefixPath.every((prefixFunc, i) => prefixFunc === callNodePath[i])
-  );
-}
-
-/**
- * Take a CallNodePath, and invert it given a CallTree. Note that if the CallTree
- * is itself inverted, you will get back the uninverted CallNodePath to the regular
- * CallTree.
- *
- * e.g:
- *   (invertedPath, invertedCallTree) => path
- *   (path, callTree) => invertedPath
- *
- * Call trees are sorted with the CallNodes with the heaviest total time as the first
- * entry. This function walks to the tip of the heaviest branches to find the leaf node,
- * then construct an inverted CallNodePath with the result. This gives a pretty decent
- * result, but it doesn't guarantee that it will select the heaviest CallNodePath for the
- * INVERTED call tree. This would require doing a round trip through the reducers or
- * some other mechanism in order to first calculate the next inverted call tree. This is
- * probably not worth it, so go ahead and use the uninverted call tree, as it's probably
- * good enough.
- */
-export function invertCallNodePath(
-  path: CallNodePath,
-  callTree: CallTree,
-  callNodeTable: CallNodeTable
-): CallNodePath {
-  let callNodeIndex = getCallNodeIndexFromPath(path, callNodeTable);
-  if (callNodeIndex === null) {
-    // No path was found, return an empty CallNodePath.
-    return [];
-  }
-  let children = [callNodeIndex];
-  const pathToLeaf = [];
-  do {
-    // Walk down the tree's depth to construct a path to the leaf node, this should
-    // be the heaviest branch of the tree.
-    callNodeIndex = children[0];
-    pathToLeaf.push(callNodeIndex);
-    children = callTree.getChildren(callNodeIndex);
-  } while (children && children.length > 0);
-
-  return (
-    pathToLeaf
-      // Map the CallNodeIndex to FuncIndex.
-      .map((index) => callNodeTable.func[index])
-      // Reverse it so that it's in the proper inverted order.
-      .reverse()
   );
 }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -266,7 +266,7 @@ const viewOptionsPerThread: Reducer<ThreadViewOptionsPerThreads> = (
       });
     }
     case 'CHANGE_INVERT_CALLSTACK': {
-      const { callTree, callNodeTable, selectedThreadIndexes } = action;
+      const { newSelectedCallNodePath, selectedThreadIndexes } = action;
       return objectMap(state, (viewOptions, threadsKey) => {
         if (
           // `Object.entries` converts number threadsKeys into strings, so
@@ -274,23 +274,14 @@ const viewOptionsPerThread: Reducer<ThreadViewOptionsPerThreads> = (
           threadsKey ===
           ProfileData.getThreadsKey(selectedThreadIndexes).toString()
         ) {
-          // Only attempt this on the current thread, as we need the transformed thread
-          // There is no guarantee that this has been calculated on all the other threads,
-          // and we shouldn't attempt to expect it, as that could be quite a perf cost.
-          const selectedCallNodePath = Transforms.invertCallNodePath(
-            viewOptions.selectedCallNodePath,
-            callTree,
-            callNodeTable
-          );
-
           const expandedCallNodePaths = new PathSet();
-          for (let i = 1; i < selectedCallNodePath.length; i++) {
-            expandedCallNodePaths.add(selectedCallNodePath.slice(0, i));
+          for (let i = 1; i < newSelectedCallNodePath.length; i++) {
+            expandedCallNodePaths.add(newSelectedCallNodePath.slice(0, i));
           }
 
           return {
             ...viewOptions,
-            selectedCallNodePath,
+            selectedCallNodePath: newSelectedCallNodePath,
             expandedCallNodePaths,
           };
         }

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -178,7 +178,11 @@ export function getStackAndSampleSelectorsPerThread(
 
   const getSelectedCallNodePath: Selector<CallNodePath> = createSelector(
     threadSelectors.getViewOptions,
-    (threadViewOptions): CallNodePath => threadViewOptions.selectedCallNodePath
+    UrlState.getInvertCallstack,
+    (threadViewOptions, invertCallStack): CallNodePath =>
+      invertCallStack
+        ? threadViewOptions.selectedInvertedCallNodePath
+        : threadViewOptions.selectedNonInvertedCallNodePath
   );
 
   const getSelectedCallNodeIndex: Selector<IndexIntoCallNodeTable | null> =
@@ -195,7 +199,11 @@ export function getStackAndSampleSelectorsPerThread(
 
   const getExpandedCallNodePaths: Selector<PathSet> = createSelector(
     threadSelectors.getViewOptions,
-    (threadViewOptions) => threadViewOptions.expandedCallNodePaths
+    UrlState.getInvertCallstack,
+    (threadViewOptions, invertCallStack) =>
+      invertCallStack
+        ? threadViewOptions.expandedInvertedCallNodePaths
+        : threadViewOptions.expandedNonInvertedCallNodePaths
   );
 
   const getExpandedCallNodeIndexes: Selector<

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -467,16 +467,17 @@ export function getThreadSelectorsWithMarkersPerThread(
       }
     );
 
-  const getFilteredThread: Selector<Thread> = createSelector(
+  const _getInvertedThread: Selector<Thread> = createSelector(
     _getImplementationAndSearchFilteredThread,
-    UrlState.getInvertCallstack,
     ProfileSelectors.getDefaultCategory,
-    (thread, shouldInvertCallstack, defaultCategory) => {
-      return shouldInvertCallstack
-        ? ProfileData.invertCallstack(thread, defaultCategory)
-        : thread;
-    }
+    ProfileData.invertCallstack
   );
+
+  const getFilteredThread: Selector<Thread> = (state) => {
+    return UrlState.getInvertCallstack(state)
+      ? _getInvertedThread(state)
+      : _getImplementationAndSearchFilteredThread(state);
+  };
 
   const getPreviewFilteredThread: Selector<Thread> = createSelector(
     getFilteredThread,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -73,8 +73,6 @@ export const getLastSelectedCallTreeSummaryStrategy: Selector<
   CallTreeSummaryStrategy,
 > = (state) =>
   getProfileSpecificState(state).lastSelectedCallTreeSummaryStrategy;
-export const getInvertCallstack: Selector<boolean> = (state) =>
-  getProfileSpecificState(state).invertCallstack;
 export const getShowUserTimings: Selector<boolean> = (state) =>
   getProfileSpecificState(state).showUserTimings;
 export const getSourceViewFile: Selector<string | null> = (state) =>
@@ -109,9 +107,12 @@ export const getMarkersSearchString: Selector<string> = (state) =>
   getProfileSpecificState(state).markersSearchString;
 export const getNetworkSearchString: Selector<string> = (state) =>
   getProfileSpecificState(state).networkSearchString;
-
 export const getSelectedTab: Selector<TabSlug> = (state) =>
   getUrlState(state).selectedTab;
+export const getInvertCallstack: Selector<boolean> = (state) =>
+  getSelectedTab(state) === 'calltree' &&
+  getProfileSpecificState(state).invertCallstack;
+
 export const getSelectedThreadIndexesOrNull: Selector<
   Set<ThreadIndex> | null,
 > = (state) => getProfileSpecificState(state).selectedThreads;

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -29,6 +29,7 @@ import {
   updatePreviewSelection,
   changeImplementationFilter,
 } from '../../actions/profile-view';
+import { changeSelectedTab } from '../../actions/app';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
 
 import {
@@ -67,17 +68,12 @@ describe('FlameGraph', function () {
     expect(drawCalls).toMatchSnapshot();
   });
 
-  it('renders a message instead of the graph when call stack is inverted', () => {
-    const { getByText, dispatch } = setupFlameGraph();
+  it('ignores invertCallstack and always displays non-inverted', () => {
+    const { getState, dispatch } = setupFlameGraph();
+    expect(getInvertCallstack(getState())).toBe(false);
     dispatch(changeInvertCallstack(true));
-    expect(getByText(/The Flame Graph is not available/)).toBeInTheDocument();
-  });
-
-  it('switches back to uninverted mode when clicking the button', () => {
-    const { getByText, dispatch, getState } = setupFlameGraph();
-    dispatch(changeInvertCallstack(true));
-    expect(getInvertCallstack(getState())).toBe(true);
-    fireFullClick(getByText(/Switch to the normal call stack/));
+    expect(getInvertCallstack(getState())).toBe(false);
+    dispatch(changeInvertCallstack(false));
     expect(getInvertCallstack(getState())).toBe(false);
   });
 
@@ -298,6 +294,7 @@ function setupFlameGraph(addImplementationData: boolean = true) {
   }
 
   const store = storeWithProfile(profile);
+  store.dispatch(changeSelectedTab('flame-graph'));
 
   const renderResult = render(
     <Provider store={store}>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -70,19 +70,6 @@ exports[`CombinedChart renders combined stack chart 1`] = `
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-          <span
-            title="Sort by the time spent in a call node, ignoring its children."
-          >
-            Invert call stack
-          </span>
-        </label>
-        <label
-          class="photon-label photon-label-micro photon-label-horiz-padding"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
           Show user timing
         </label>
       </li>
@@ -570,19 +557,6 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
-          <span
-            title="Sort by the time spent in a call node, ignoring its children."
-          >
-            Invert call stack
-          </span>
-        </label>
-        <label
-          class="photon-label photon-label-micro photon-label-horiz-padding"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
           Show user timing
         </label>
       </li>
@@ -1028,19 +1002,6 @@ exports[`StackChart matches the snapshot 1`] = `
       <li
         class="panelSettingsListItem"
       >
-        <label
-          class="photon-label photon-label-micro photon-label-horiz-padding"
-        >
-          <input
-            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-            type="checkbox"
-          />
-          <span
-            title="Sort by the time spent in a call node, ignoring its children."
-          >
-            Invert call stack
-          </span>
-        </label>
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
         >

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -4694,7 +4694,10 @@ Process: \\"default\\" (0)"
 
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getViewOptions 1`] = `
 Object {
-  "expandedCallNodePaths": PathSet {
+  "expandedInvertedCallNodePaths": PathSet {
+    "_table": Map {},
+  },
+  "expandedNonInvertedCallNodePaths": PathSet {
     "_table": Map {
       "0" => Array [
         0,
@@ -4705,11 +4708,12 @@ Object {
       ],
     },
   },
-  "selectedCallNodePath": Array [
+  "selectedInvertedCallNodePath": Array [],
+  "selectedMarker": 1,
+  "selectedNetworkMarker": null,
+  "selectedNonInvertedCallNodePath": Array [
     0,
     1,
   ],
-  "selectedMarker": 1,
-  "selectedNetworkMarker": null,
 }
 `;

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -361,11 +361,11 @@ describe('actions/changeInvertCallstack', function () {
     profile,
     funcNamesPerThread: [funcNames],
   } = getProfileFromTextSamples(`
-      A  A  A  A  A
-      B  E  B  B  B
-      C  F  I  I  I
-      D  G  J  J  J
-         H
+      A  A  A  A  A  A
+      B  E  B  B  B  B
+      C  F  I  I  I  I
+      D  G  J  J  J  J
+         H           K
     `);
   const toFuncIndex = (funcName) => funcNames.indexOf(funcName);
   const threadIndex = 0;
@@ -414,7 +414,7 @@ describe('actions/changeInvertCallstack', function () {
       // Do not select the first alphabetical path:
       expect(selectedCallNodePath).not.toEqual(['D', 'C', 'B']);
 
-      // Pick the heaviest path:
+      // Pick the heaviest path, and stops short of K:
       expect(selectedCallNodePath).toEqual(['J', 'I', 'B']);
       expect(expandedCallNodePaths).toEqual([['J'], ['J', 'I']]);
     });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -195,6 +195,7 @@ type ProfileAction =
     |}
   | {|
       +type: 'CHANGE_SELECTED_CALL_NODE',
+      +isInverted: boolean,
       +threadsKey: ThreadsKey,
       +selectedCallNodePath: CallNodePath,
       +optionalExpandedToCallNodePath: ?CallNodePath,
@@ -216,6 +217,7 @@ type ProfileAction =
   | {|
       +type: 'CHANGE_EXPANDED_CALL_NODES',
       +threadsKey: ThreadsKey,
+      +isInverted: boolean,
       +expandedCallNodePaths: Array<CallNodePath>,
     |}
   | {|

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { CallTree } from '../profile-logic/call-tree';
 import { ReactLocalization } from '@fluent/react';
 import type JSZip from 'jszip';
 import type {
@@ -500,8 +499,7 @@ type UrlStateAction =
   | {|
       +type: 'CHANGE_INVERT_CALLSTACK',
       +invertCallstack: boolean,
-      +callTree: CallTree,
-      +callNodeTable: CallNodeTable,
+      +newSelectedCallNodePath: CallNodePath,
       +selectedThreadIndexes: Set<ThreadIndex>,
     |}
   | {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -56,8 +56,10 @@ export type UploadedProfileInformation = ImportedUploadedProfileInformation;
 
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {|
-  +selectedCallNodePath: CallNodePath,
-  +expandedCallNodePaths: PathSet,
+  +selectedNonInvertedCallNodePath: CallNodePath,
+  +selectedInvertedCallNodePath: CallNodePath,
+  +expandedNonInvertedCallNodePaths: PathSet,
+  +expandedInvertedCallNodePaths: PathSet,
   +selectedMarker: MarkerIndex | null,
   +selectedNetworkMarker: MarkerIndex | null,
 |};


### PR DESCRIPTION
[Production](https://share.firefox.dev/3MRAZFC) | [Deploy preview](https://deploy-preview-4804--perf-html.netlify.app/public/rraa0j2yrawd9srsqsswzn034875jnvd1d83zm0/stack-chart/?globalTrackOrder=0wd&hiddenGlobalTracks=0wbd&hiddenLocalTracksByPid=27056-0w9~19556-0~19868-0~23348-0~12120-0~4200-0~5096-0~22852-0~16368-0~15992-0w8~26484-0w8~7132-0w8~7176-0w9~2320-0wxi&invertCallstack&thread=xe&v=10)

Fixes #3961.
Fixes #4803.

As an added benefit, this simplifies the work for #337 because we won't need special code for the inverted stack chart.

This PR doesn't remove the code for the warning on the flame graph; I'd be happy to leave this cleanup to someone else.