### PR TITLE
Simplify heightFunction.

### DIFF
--- a/src/components/shared/thread/CPUGraph.js
+++ b/src/components/shared/thread/CPUGraph.js
@@ -14,16 +14,13 @@ import type {
   IndexIntoSamplesTable,
   Milliseconds,
   CallNodeInfo,
-  IndexIntoCallNodeTable,
   SelectedState,
 } from 'firefox-profiler/types';
-import type { HeightFunctionParams } from './HeightGraph';
 
 type Props = {|
   +className: string,
   +thread: Thread,
   +samplesSelectedStates: null | SelectedState[],
-  +sampleCallNodes: Array<IndexIntoCallNodeTable | null>,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -40,10 +37,7 @@ type Props = {|
 |};
 
 export class ThreadCPUGraph extends PureComponent<Props> {
-  _heightFunction = ({
-    sampleIndex,
-    yPixelsPerHeight,
-  }: HeightFunctionParams): number => {
+  _heightFunction = (sampleIndex: IndexIntoSamplesTable): number | null => {
     const { thread } = this.props;
     const { samples } = thread;
 
@@ -56,14 +50,13 @@ export class ThreadCPUGraph extends PureComponent<Props> {
     const cpuDelta = ensureExists(samples.threadCPUDelta)[sampleIndex + 1] || 0;
     const interval = samples.time[sampleIndex + 1] - samples.time[sampleIndex];
     const currentCPUPerMs = cpuDelta / interval;
-    return currentCPUPerMs * yPixelsPerHeight;
+    return currentCPUPerMs;
   };
 
   render() {
     const {
       className,
       thread,
-      sampleCallNodes,
       samplesSelectedStates,
       interval,
       rangeStart,
@@ -85,7 +78,6 @@ export class ThreadCPUGraph extends PureComponent<Props> {
         trackName={trackName}
         interval={interval}
         thread={thread}
-        sampleCallNodes={sampleCallNodes}
         samplesSelectedStates={samplesSelectedStates}
         rangeStart={rangeStart}
         rangeEnd={rangeEnd}

--- a/src/components/shared/thread/HeightGraph.js
+++ b/src/components/shared/thread/HeightGraph.js
@@ -17,34 +17,15 @@ import type {
   CategoryList,
   IndexIntoSamplesTable,
   Milliseconds,
-  IndexIntoCallNodeTable,
   SelectedState,
 } from 'firefox-profiler/types';
 
-/**
- * Parameters for the height function of the HeightGraph component.
- * Shared HeightGraph component gets a `heightFunc` as a prop and executes this
- * function for each sample to determine the height of the given sample in the graph.
- * Therefore, each height per sample is determined by the parent component. This
- * helps us reuse the same height graph component with different values.
- *
- * These parameters are exposed because the parent component needs them to find
- * out the height of the sample with different logics. These parameters are added
- * on an as-needed basis.
- */
-export type HeightFunctionParams = {|
-  +sampleIndex: number,
-  +callNodeIndex: number,
-  +yPixelsPerHeight: number,
-|};
-
 type Props = {|
-  +heightFunc: (HeightFunctionParams) => number,
+  +heightFunc: (IndexIntoSamplesTable) => number | null,
   +maxValue: number,
   +className: string,
   +thread: Thread,
   +samplesSelectedStates: null | SelectedState[],
-  +sampleCallNodes: Array<IndexIntoCallNodeTable | null>,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
@@ -86,7 +67,6 @@ export class ThreadHeightGraph extends PureComponent<Props> {
     const {
       thread,
       samplesSelectedStates,
-      sampleCallNodes,
       interval,
       rangeStart,
       rangeEnd,
@@ -149,16 +129,12 @@ export class ThreadHeightGraph extends PureComponent<Props> {
       if (sampleTime < nextMinTime) {
         continue;
       }
-      const callNodeIndex = sampleCallNodes[i];
-      if (callNodeIndex === null) {
+      const heightFuncResult = heightFunc(i);
+      if (heightFuncResult === null) {
         continue;
       }
 
-      const height = heightFunc({
-        sampleIndex: i,
-        callNodeIndex,
-        yPixelsPerHeight,
-      });
+      const height = heightFuncResult * yPixelsPerHeight;
 
       const xPos = (sampleTime - range[0]) * xPixelsPerMs;
       let samplesBucket;

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -16,7 +16,6 @@ import type {
   IndexIntoCallNodeTable,
   SelectedState,
 } from 'firefox-profiler/types';
-import type { HeightFunctionParams } from './HeightGraph';
 
 type Props = {|
   +className: string,
@@ -38,21 +37,20 @@ type Props = {|
 |};
 
 export class ThreadStackGraph extends PureComponent<Props> {
-  _heightFunction = ({
-    callNodeIndex,
-    yPixelsPerHeight,
-  }: HeightFunctionParams): number => {
-    const { callNodeInfo } = this.props;
-    const { callNodeTable } = callNodeInfo;
+  _heightFunction = (sampleIndex: IndexIntoSamplesTable): number | null => {
+    const { callNodeInfo, sampleCallNodes } = this.props;
+    const callNodeIndex = sampleCallNodes[sampleIndex];
+    if (callNodeIndex === null) {
+      return null;
+    }
 
-    return callNodeTable.depth[callNodeIndex] * yPixelsPerHeight;
+    return callNodeInfo.callNodeTable.depth[callNodeIndex];
   };
 
   render() {
     const {
       className,
       thread,
-      sampleCallNodes,
       samplesSelectedStates,
       interval,
       rangeStart,
@@ -79,7 +77,6 @@ export class ThreadStackGraph extends PureComponent<Props> {
         trackName={trackName}
         interval={interval}
         thread={thread}
-        sampleCallNodes={sampleCallNodes}
         samplesSelectedStates={samplesSelectedStates}
         rangeStart={rangeStart}
         rangeEnd={rangeEnd}

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -301,7 +301,6 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
                 rangeStart={rangeStart}
                 rangeEnd={rangeEnd}
                 callNodeInfo={callNodeInfo}
-                sampleCallNodes={sampleCallNodes}
                 samplesSelectedStates={samplesSelectedStates}
                 categories={categories}
                 onSampleClick={this._onSampleClick}


### PR DESCRIPTION
Pass it just the sample index, and have it return the depth. The yPixelsPerHeight multiplication can happen in the caller.