### PR TITLE
Use a call node path to make the stack copy string.

### DIFF
--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -197,7 +197,7 @@ describe('calltree/CallNodeContextMenu', function () {
       // Copy is a mocked module, clear it both before and after.
       fireFullClick(getByText('Copy stack'));
       expect(copy).toHaveBeenCalledWith(
-        `B.js [https://example.com/script.js:2:222]\nA.js [https://example.com/script.js:1:111]\n`
+        `B.js [https://example.com/script.js:2:222]\nA.js [https://example.com/script.js:1:111]`
       );
     });
   });


### PR DESCRIPTION
This is a minor simplification and removes some raw callNodeTable usage.