### PR TITLE
Improve findHeavyPathToSameFunctionAfterInversion.

### DIFF
--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -438,6 +438,13 @@ export function getProfileWithNamedThreads(threadNames: string[]): Profile {
   return profile;
 }
 
+export type ProfileWithDicts = {
+  profile: Profile;
+  funcNamesPerThread: Array<string[]>;
+  funcNamesDictPerThread: Array<{ [funcName: string]: number }>;
+  nativeSymbolsDictPerThread: Array<{ [nativeSymbolName: string]: number }>,
+};
+
 /**
  * Create a profile from text representation of samples. Each column in the text provided
  * represents a sample. Each sample is made up of a list of functions.
@@ -562,12 +569,7 @@ function getStack(thread, stackIndex) {
 getStack(filteredThread, filteredThread.samples.stack[0])
 ```
 */
-export function getProfileFromTextSamples(...allTextSamples: string[]): {
-  profile: Profile,
-  funcNamesPerThread: Array<string[]>,
-  funcNamesDictPerThread: Array<{ [funcName: string]: number }>,
-  nativeSymbolsDictPerThread: Array<{ [nativeSymbolName: string]: number }>,
-} {
+export function getProfileFromTextSamples(...allTextSamples: string[]): ProfileWithDicts {
   let profile = getEmptyProfile();
   // Provide a useful marker schema, rather than an empty one.
   profile.meta.markerSchema = markerSchemaForTests;
@@ -575,10 +577,6 @@ export function getProfileFromTextSamples(...allTextSamples: string[]): {
     profile.meta.categories,
     'Expected to find categories.'
   );
-
-  const funcNamesPerThread = [];
-  const funcNamesDictPerThread = [];
-  const nativeSymbolsDictPerThread = [];
 
   const globalDataCollector = new GlobalDataCollector();
 
@@ -613,11 +611,6 @@ export function getProfileFromTextSamples(...allTextSamples: string[]): {
     }
     const funcNames = [...funcNamesSet];
 
-    const funcNamesDict = funcNames.reduce((result, item, index) => {
-      result[item] = index;
-      return result;
-    }, {});
-
     // Turn this into a real thread.
     const thread = _buildThreadFromTextOnlyStacks(
       textOnlyStacks,
@@ -627,30 +620,15 @@ export function getProfileFromTextSamples(...allTextSamples: string[]): {
       sampleTimes
     );
 
-    const nativeSymbolsDict = {};
-    for (let i = 0; i < thread.nativeSymbols.length; i++) {
-      const name = thread.stringTable.getString(thread.nativeSymbols.name[i]);
-      nativeSymbolsDict[name] = i;
-    }
-
     // Make sure all threads have a unique tid
     thread.tid = i;
-
-    funcNamesPerThread.push(funcNames);
-    funcNamesDictPerThread.push(funcNamesDict);
-    nativeSymbolsDictPerThread.push(nativeSymbolsDict);
 
     return thread;
   });
 
   profile = { ...profile, ...globalDataCollector.finish() };
 
-  return {
-    profile,
-    funcNamesPerThread,
-    funcNamesDictPerThread,
-    nativeSymbolsDictPerThread,
-  };
+  return getProfileWithDicts(profile);
 }
 
 function _getAllMatchRanges(regex, str): Array<{ start: number, end: number }> {
@@ -1059,6 +1037,37 @@ function _buildThreadFromTextOnlyStacks(
   return thread;
 }
 
+export function getFuncNamesDictForThread(thread: Thread): { funcNames: string[], funcNamesDict: { [funcName: string]: number } } {
+  const { funcTable, stringTable } = thread;
+  const funcNames = [];
+  const funcNamesDict = {};
+  for (let i = 0; i < funcTable.length; i++) {
+    const funcName = stringTable.getString(funcTable.name[i]);
+    funcNames[i] = funcName;
+    funcNamesDict[funcName] = i;
+  }
+  return {funcNames, funcNamesDict};
+}
+
+export function getNativeSymbolsDictForThread(thread: Thread): { [nativeSymbolName: string]: number } {
+  const { nativeSymbols, stringTable } = thread;
+  const nativeSymbolsDict = {};
+  for (let i = 0; i < nativeSymbols.length; i++) {
+    const name = stringTable.getString(nativeSymbols.name[i]);
+    nativeSymbolsDict[name] = i;
+  }
+  return nativeSymbolsDict;
+}
+
+export function getProfileWithDicts(profile: Profile): ProfileWithDicts {
+  const funcNameDicts = profile.threads.map(getFuncNamesDictForThread);
+  const funcNamesPerThread = funcNameDicts.map(({ funcNames }) => funcNames);
+  const funcNamesDictPerThread = funcNameDicts.map(({ funcNamesDict }) => funcNamesDict);
+  const nativeSymbolsDictPerThread = profile.threads.map(getNativeSymbolsDictForThread);
+
+  return { profile, funcNamesPerThread, funcNamesDictPerThread, nativeSymbolsDictPerThread };
+}
+
 /**
  * This returns a merged profile from a number of profile strings.
  */
@@ -1068,11 +1077,7 @@ export function getMergedProfileFromTextSamples(
     threadCPUDelta: Array<number | null>,
     threadCPUDeltaUnit: ThreadCPUDeltaUnit,
   |} | null> = []
-): {
-  profile: Profile,
-  funcNamesPerThread: Array<string[]>,
-  funcNamesDictPerThread: Array<{ [funcName: string]: number }>,
-} {
+): ProfileWithDicts {
   const profilesAndFuncNames = profileStrings.map((str) =>
     getProfileFromTextSamples(str)
   );
@@ -1096,15 +1101,7 @@ export function getMergedProfileFromTextSamples(
     profiles,
     profiles.map(() => profileState)
   );
-  return {
-    profile,
-    funcNamesPerThread: profilesAndFuncNames.map(
-      ({ funcNamesPerThread }) => funcNamesPerThread[0]
-    ),
-    funcNamesDictPerThread: profilesAndFuncNames.map(
-      ({ funcNamesDictPerThread }) => funcNamesDictPerThread[0]
-    ),
-  };
+  return getProfileWithDicts(profile);
 }
 
 type NetworkMarkersOptions = {|

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -2407,6 +2407,16 @@ CallTree {
     ],
   },
   "_callNodeSummary": Object {
+    "leaf": Float32Array [
+      0,
+      0,
+      0,
+      0,
+      0,
+      2,
+      0,
+      0,
+    ],
     "self": Float32Array [
       0,
       0,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -86,6 +86,7 @@ describe('unfiltered call tree', function () {
         callNodeChildCount: new Uint32Array([1, 2, 2, 1, 0, 1, 0, 1, 0]),
         callNodeSummary: {
           self: new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 1]),
+          leaf: new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 1]),
           total: new Float32Array([3, 3, 2, 1, 1, 1, 1, 1, 1]),
         },
       });


### PR DESCRIPTION
This fixes a slight imperfection with diff profiles when inverting the call tree and computing the new selection.
It might also be a bit faster.

The second commit fixes `getMergedProfileFromTextSamples` to return a useful `funcNamesDictPerThread`. Previously, we weren't returning the right values if the two input profiles had different funcTables.