### PR TITLE
Remove the sample_groups / sampleGroups object from the counter data structures

### DIFF
--- a/docs-developer/CHANGELOG-formats.md
+++ b/docs-developer/CHANGELOG-formats.md
@@ -6,6 +6,10 @@ Note that this is not an exhaustive list. Processed profile format upgraders can
 
 ## Processed profile format
 
+### Version 48
+
+Removed the 'sampleGroups' object from the Counter structure.
+
 ### Version 47
 
 The `pid` field of the `Thread` type is changed from `string | number` to `string`. The same happened to the `data.otherPid` field of IPC markers, and to the pid fields in the `profiler.counters` and `profile.profilerOverhead` lists.
@@ -65,6 +69,10 @@ We've also cleaned up the ResourceTable format:
 Older versions are not documented in this changelog but can be found in [processed-profile-versioning.js](../src/profile-logic/processed-profile-versioning.js).
 
 ## Gecko profile format
+
+### Version 29
+
+Removed the 'sample_groups' object from the GeckoCounter structure.
 
 ### Version 28
 

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -9,12 +9,12 @@ import type { MarkerPhase } from 'firefox-profiler/types';
 // The current version of the Gecko profile format.
 // Please don't forget to update the gecko profile format changelog in
 // `docs-developer/CHANGELOG-formats.md`.
-export const GECKO_PROFILE_VERSION = 28;
+export const GECKO_PROFILE_VERSION = 29;
 
 // The current version of the "processed" profile format.
 // Please don't forget to update the processed profile format changelog in
 // `docs-developer/CHANGELOG-formats.md`.
-export const PROCESSED_PROFILE_VERSION = 47;
+export const PROCESSED_PROFILE_VERSION = 48;
 
 // The following are the margin sizes for the left and right of the timeline. Independent
 // components need to share these values.

--- a/src/components/tooltip/TrackPower.js
+++ b/src/components/tooltip/TrackPower.js
@@ -50,7 +50,7 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
   // This compute the sum of the power in the range. This returns a value in Wh.
   _computePowerSumForRange(start: Milliseconds, end: Milliseconds): number {
     const { counter } = this.props;
-    const samples = counter.sampleGroups[0].samples;
+    const samples = counter.samples;
     const [beginIndex, endIndex] = getSampleIndexRangeForSelection(
       samples,
       start,
@@ -144,7 +144,7 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
       committedRange,
       previewSelection,
     } = this.props;
-    const samples = counter.sampleGroups[0].samples;
+    const samples = counter.samples;
 
     const powerUsageInPwh = samples.count[counterSampleIndex]; // picowatt-hour
     const sampleTimeDeltaInMs =

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -1452,6 +1452,28 @@ const _upgraders = {
     // marker data with unique-string typed data, and no modification is needed in the
     // frontend to display older formats.
   },
+  [29]: (profile) => {
+    // Remove the 'sample_groups' object from the GeckoCounter structure.
+    function convertToVersion29Recursive(p) {
+      if (p.counters && p.counters.length > 0) {
+        for (const counter of p.counters) {
+          if (!counter.sample_groups) {
+            // Running Firefox 121 with external power counters coming from an
+            // already updated script may result in this code seeing already
+            // upgraded counters; ignore them.
+            continue;
+          }
+          counter.samples = counter.sample_groups[0].samples;
+          delete counter.sample_groups;
+        }
+      }
+      for (const subprocessProfile of p.processes) {
+        convertToVersion29Recursive(subprocessProfile);
+      }
+    }
+    convertToVersion29Recursive(profile);
+  },
+
   // If you add a new upgrader here, please document the change in
   // `docs-developer/CHANGELOG-formats.md`.
 };

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1028,20 +1028,12 @@ function _processCounters(
   }
 
   return geckoCounters.reduce(
-    (result, { name, category, description, sample_groups }) => {
-      if (sample_groups.length === 0) {
+    (result, { name, category, description, samples }) => {
+      if (samples.data.length === 0) {
         // It's possible that no sample has been collected during our capture
         // session, ignore this counter if that's the case.
         return result;
       }
-
-      const sampleGroups = sample_groups.map((sampleGroup) => ({
-        id: sampleGroup.id,
-        samples: adjustTableTimestamps(
-          _toStructOfArrays(sampleGroup.samples),
-          delta
-        ),
-      }));
 
       result.push({
         name,
@@ -1049,7 +1041,7 @@ function _processCounters(
         description,
         pid: mainThreadPid,
         mainThreadIndex,
-        sampleGroups,
+        samples: adjustTableTimestamps(_toStructOfArrays(samples), delta),
       });
       return result;
     },
@@ -1392,7 +1384,7 @@ export function insertExternalPowerCountersIntoProfile(
   geckoProfile: GeckoProfile
 ): void {
   for (const counter of counters) {
-    const samples = counter.sample_groups[0].samples;
+    const { samples } = counter;
     const timeColumnIndex = samples.schema.time;
     for (const sample of samples.data) {
       // Adjust the sample times to be relative to meta.startTime,

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2255,6 +2255,15 @@ const _upgraders = {
       }
     }
   },
+  [48]: (profile) => {
+    // Remove the 'sampleGroups' object from the Counter structure.
+    if (profile.counters && profile.counters.length > 0) {
+      for (const counter of profile.counters) {
+        counter.samples = counter.sampleGroups[0].samples;
+        delete counter.sampleGroups;
+      }
+    }
+  },
   // If you add a new upgrader here, please document the change in
   // `docs-developer/CHANGELOG-formats.md`.
 };

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1517,76 +1517,56 @@ export function filterCounterSamplesToRange(
   rangeEnd: number
 ): Counter {
   const newCounter = { ...counter };
-  newCounter.sampleGroups = [...newCounter.sampleGroups];
-  const { sampleGroups } = newCounter;
+  const { samples } = newCounter;
 
-  for (
-    let sampleGroupIdx = 0;
-    sampleGroupIdx < sampleGroups.length;
-    sampleGroupIdx++
-  ) {
-    sampleGroups[sampleGroupIdx] = { ...sampleGroups[sampleGroupIdx] };
-    const sampleGroup = sampleGroups[sampleGroupIdx];
-    // Intentionally get the inclusive sample indexes with this one instead of
-    // getSampleIndexRangeForSelection because graphs like memory graph requires
-    // one sample before and after to be in the sample range so the graph doesn't
-    // look cut off.
-    const [beginSampleIndex, endSampleIndex] =
-      getInclusiveSampleIndexRangeForSelection(
-        sampleGroup.samples,
-        rangeStart,
-        rangeEnd
-      );
+  // Intentionally get the inclusive sample indexes with this one instead of
+  // getSampleIndexRangeForSelection because graphs like memory graph requires
+  // one sample before and after to be in the sample range so the graph doesn't
+  // look cut off.
+  const [beginSampleIndex, endSampleIndex] =
+    getInclusiveSampleIndexRangeForSelection(samples, rangeStart, rangeEnd);
 
-    sampleGroup.samples = {
-      length: endSampleIndex - beginSampleIndex,
-      time: sampleGroup.samples.time.slice(beginSampleIndex, endSampleIndex),
-      count: sampleGroup.samples.count.slice(beginSampleIndex, endSampleIndex),
-      number: sampleGroup.samples.number
-        ? sampleGroup.samples.number.slice(beginSampleIndex, endSampleIndex)
-        : undefined,
-    };
-  }
+  newCounter.samples = {
+    length: endSampleIndex - beginSampleIndex,
+    time: samples.time.slice(beginSampleIndex, endSampleIndex),
+    count: samples.count.slice(beginSampleIndex, endSampleIndex),
+    number: samples.number
+      ? samples.number.slice(beginSampleIndex, endSampleIndex)
+      : undefined,
+  };
 
   return newCounter;
 }
 
 /**
- * Process the samples in the counter sample groups.
+ * Process the samples in the counter.
  */
 export function processCounter(counter: Counter): Counter {
-  const processedGroups = counter.sampleGroups.map((sampleGroup) => {
-    const { samples } = sampleGroup;
-    const count = samples.count.slice();
-    const number =
-      samples.number !== undefined ? samples.number.slice() : undefined;
+  const { samples } = counter;
+  const count = samples.count.slice();
+  const number =
+    samples.number !== undefined ? samples.number.slice() : undefined;
 
-    // These lines zero out the first values of the counters, as they are unreliable. In
-    // addition, there are probably some missed counts in the memory counters, so the
-    // first memory number slowly creeps up over time, and becomes very unrealistic.
-    // In order to not be affected by these platform limitations, zero out the first
-    // counter values.
-    //
-    // "Memory counter in Gecko Profiler isn't cleared when starting a new capture"
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1520587
-    count[0] = 0;
-    if (number !== undefined) {
-      number[0] = 0;
-    }
-
-    return {
-      ...sampleGroup,
-      samples: {
-        ...samples,
-        number,
-        count,
-      },
-    };
-  });
+  // These lines zero out the first values of the counters, as they are unreliable. In
+  // addition, there are probably some missed counts in the memory counters, so the
+  // first memory number slowly creeps up over time, and becomes very unrealistic.
+  // In order to not be affected by these platform limitations, zero out the first
+  // counter values.
+  //
+  // "Memory counter in Gecko Profiler isn't cleared when starting a new capture"
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1520587
+  count[0] = 0;
+  if (number !== undefined) {
+    number[0] = 0;
+  }
 
   return {
     ...counter,
-    sampleGroups: processedGroups,
+    samples: {
+      ...samples,
+      number,
+      count,
+    },
   };
 }
 
@@ -1597,40 +1577,32 @@ export function processCounter(counter: Counter): Counter {
  * accumulatedCounts array.
  */
 export function accumulateCounterSamples(
-  samplesArray: Array<CounterSamplesTable>,
-  sampleRanges?: Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>
-): Array<AccumulatedCounterSamples> {
-  const accumulatedSamples = samplesArray.map((samples, index) => {
-    let minCount = 0;
-    let maxCount = 0;
-    let accumulated = 0;
-    const accumulatedCounts = Array(samples.length).fill(0);
-    // If a range is provided, use it instead. This will also include the
-    // samples right before and after the range.
-    const startSampleIndex =
-      sampleRanges && sampleRanges[index] ? sampleRanges[index][0] : 0;
-    const endSampleIndex =
-      sampleRanges && sampleRanges[index]
-        ? sampleRanges[index][1]
-        : samples.length;
+  samples: CounterSamplesTable,
+  sampleRange?: [IndexIntoSamplesTable, IndexIntoSamplesTable]
+): AccumulatedCounterSamples {
+  let minCount = 0;
+  let maxCount = 0;
+  let accumulated = 0;
+  const accumulatedCounts = Array(samples.length).fill(0);
+  // If a range is provided, use it instead. This will also include the
+  // samples right before and after the range.
+  const startSampleIndex = sampleRange ? sampleRange[0] : 0;
+  const endSampleIndex = sampleRange ? sampleRange[1] : samples.length;
 
-    for (let i = startSampleIndex; i < endSampleIndex; i++) {
-      accumulated += samples.count[i];
-      minCount = Math.min(accumulated, minCount);
-      maxCount = Math.max(accumulated, maxCount);
-      accumulatedCounts[i] = accumulated;
-    }
-    const countRange = maxCount - minCount;
+  for (let i = startSampleIndex; i < endSampleIndex; i++) {
+    accumulated += samples.count[i];
+    minCount = Math.min(accumulated, minCount);
+    maxCount = Math.max(accumulated, maxCount);
+    accumulatedCounts[i] = accumulated;
+  }
+  const countRange = maxCount - minCount;
 
-    return {
-      minCount,
-      maxCount,
-      countRange,
-      accumulatedCounts,
-    };
-  });
-
-  return accumulatedSamples;
+  return {
+    minCount,
+    maxCount,
+    countRange,
+    accumulatedCounts,
+  };
 }
 
 /**
@@ -1639,34 +1611,26 @@ export function accumulateCounterSamples(
  * If a start-end range is provided, it only computes the max value between that
  * range.
  */
-export function computeMaxCounterSampleCountsPerMs(
-  samplesArray: Array<CounterSamplesTable>,
+export function computeMaxCounterSampleCountPerMs(
+  samples: CounterSamplesTable,
   profileInterval: Milliseconds,
-  sampleRanges?: Array<[IndexIntoSamplesTable, IndexIntoSamplesTable]>
-): Array<number> {
-  const maxSampleCounts = samplesArray.map((samples, index) => {
-    let maxCount = 0;
-    // If a range is provided, use it instead. This will also include the
-    // samples right before and after the range.
-    const startSampleIndex =
-      sampleRanges && sampleRanges[index] ? sampleRanges[index][0] : 0;
-    const endSampleIndex =
-      sampleRanges && sampleRanges[index]
-        ? sampleRanges[index][1]
-        : samples.length;
+  sampleRange?: [IndexIntoSamplesTable, IndexIntoSamplesTable]
+): number {
+  let maxCount = 0;
+  // If a range is provided, use it instead. This will also include the
+  // samples right before and after the range.
+  const startSampleIndex = sampleRange ? sampleRange[0] : 0;
+  const endSampleIndex = sampleRange ? sampleRange[1] : samples.length;
 
-    for (let i = startSampleIndex; i < endSampleIndex; i++) {
-      const count = samples.count[i];
-      const sampleTimeDeltaInMs =
-        i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
-      const countPerMs = count / sampleTimeDeltaInMs;
-      maxCount = Math.max(countPerMs, maxCount);
-    }
+  for (let i = startSampleIndex; i < endSampleIndex; i++) {
+    const count = samples.count[i];
+    const sampleTimeDeltaInMs =
+      i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
+    const countPerMs = count / sampleTimeDeltaInMs;
+    maxCount = Math.max(countPerMs, maxCount);
+  }
 
-    return maxCount;
-  });
-
-  return maxSampleCounts;
+  return maxCount;
 }
 
 /**

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -336,9 +336,9 @@ export function computeLocalTracksByPid(
   const { counters } = profile;
   if (counters) {
     for (let counterIndex = 0; counterIndex < counters.length; counterIndex++) {
-      const { pid, category, sampleGroups } = counters[counterIndex];
+      const { pid, category, samples } = counters[counterIndex];
       if (category === 'Memory' || category === 'power') {
-        if (category === 'power' && sampleGroups[0].samples.length <= 2) {
+        if (category === 'power' && samples.length <= 2) {
           // If we have only 2 samples, they are likely both 0 and we don't have a real counter.
           continue;
         }

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -1024,19 +1024,14 @@ export function createGeckoCounter(thread: GeckoThread): GeckoCounter {
     name: 'My Counter',
     category: 'My Category',
     description: 'My Description',
-    sample_groups: [
-      {
-        id: 0,
-        samples: {
-          schema: {
-            time: 0,
-            number: 1,
-            count: 2,
-          },
-          data: [],
-        },
+    samples: {
+      schema: {
+        time: 0,
+        count: 1,
+        number: 2,
       },
-    ],
+      data: [],
+    },
   };
   for (let i = 0; i < thread.samples.data.length; i++) {
     // Go through all the thread samples and create a corresponding counter entry.
@@ -1045,7 +1040,7 @@ export function createGeckoCounter(thread: GeckoThread): GeckoCounter {
     const number = Math.floor(50 * Math.sin(i) + 50);
     // Create some arbitrary values for the count.
     const count = Math.sin(i);
-    geckoCounter.sample_groups[0].samples.data.push([time, number, count]);
+    geckoCounter.samples.data.push([time, number, count]);
   }
   return geckoCounter;
 }

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1467,23 +1467,16 @@ export function getCounterForThread(
     description: 'My Description',
     pid: thread.pid,
     mainThreadIndex,
-    sampleGroups: [
-      {
-        id: 0,
-        samples: {
-          time: thread.samples.time.slice(),
-          // Create some arbitrary (positive integer) values for the number.
-          number: config.hasCountNumber
-            ? thread.samples.time.map((_, i) =>
-                Math.floor(50 * Math.sin(i) + 50)
-              )
-            : undefined,
-          // Create some arbitrary values for the count.
-          count: thread.samples.time.map((_, i) => Math.sin(i)),
-          length: thread.samples.length,
-        },
-      },
-    ],
+    samples: {
+      time: thread.samples.time.slice(),
+      // Create some arbitrary (positive integer) values for the number.
+      number: config.hasCountNumber
+        ? thread.samples.time.map((_, i) => Math.floor(50 * Math.sin(i) + 50))
+        : undefined,
+      // Create some arbitrary values for the count.
+      count: thread.samples.time.map((_, i) => Math.sin(i)),
+      length: thread.samples.length,
+    },
   };
   return counter;
 }
@@ -1520,12 +1513,7 @@ export function getCounterForThreadWithSamples(
     description: 'My Description',
     pid: thread.pid,
     mainThreadIndex,
-    sampleGroups: [
-      {
-        id: 0,
-        samples: newSamples,
-      },
-    ],
+    samples: newSamples,
   };
   return counter;
 }

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -423,7 +423,7 @@ Object {
     "oscpu": "",
     "physicalCPUs": 0,
     "platform": "",
-    "preprocessedProfileVersion": 47,
+    "preprocessedProfileVersion": 48,
     "processType": 0,
     "product": "Firefox",
     "sourceURL": "",
@@ -431,7 +431,7 @@ Object {
     "startTime": 0,
     "symbolicated": true,
     "toolkit": "",
-    "version": 28,
+    "version": 29,
   },
   "pages": Array [
     Object {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3015,7 +3015,7 @@ describe('counter selectors', function () {
 
   it('can accumulate samples', function () {
     const { getState, counterA } = setup();
-    counterA.sampleGroups[0].samples.count = [
+    counterA.samples.count = [
       // The first value gets zeroed out due to a work-around for Bug 1520587. It
       // can be much larger than all the rest of the values, as it doesn't ever
       // get reset.
@@ -3023,7 +3023,7 @@ describe('counter selectors', function () {
       -2, 3, -5, 7, -11, 13, -17, 19, 23,
     ];
     expect(
-      getCounterSelectors(0).getAccumulateCounterSamples(getState())[0]
+      getCounterSelectors(0).getAccumulateCounterSamples(getState())
     ).toEqual({
       accumulatedCounts: [0, -2, 1, -4, 3, -8, 5, -12, 7, 30],
       countRange: 42,

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -40,7 +40,7 @@ Object {
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,
-    "preprocessedProfileVersion": 47,
+    "preprocessedProfileVersion": 48,
     "processType": 0,
     "product": "Firefox",
     "sampleUnits": undefined,
@@ -50,7 +50,7 @@ Object {
     "symbolicated": true,
     "toolkit": undefined,
     "updateChannel": undefined,
-    "version": 28,
+    "version": 29,
     "visualMetrics": undefined,
   },
   "pages": Array [],
@@ -7975,7 +7975,7 @@ Object {
     "stackwalk": 1,
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
-    "version": 28,
+    "version": 29,
   },
   "pausedRanges": Array [],
   "processes": Array [
@@ -8937,55 +8937,50 @@ Object {
       "category": "Memory",
       "description": "Amount of allocated memory",
       "name": "malloc",
-      "sample_groups": Array [
-        Object {
-          "id": 0,
-          "samples": Object {
-            "data": Array [
-              Array [
-                0,
-                1,
-                1,
-              ],
-              Array [
-                2,
-                2,
-                2,
-              ],
-              Array [
-                4,
-                3,
-                3,
-              ],
-              Array [
-                5,
-                4,
-                4,
-              ],
-              Array [
-                8,
-                5,
-                5,
-              ],
-              Array [
-                9,
-                6,
-                6,
-              ],
-              Array [
-                10,
-                7,
-                7,
-              ],
-            ],
-            "schema": Object {
-              "count": 2,
-              "number": 1,
-              "time": 0,
-            },
-          },
+      "samples": Object {
+        "data": Array [
+          Array [
+            0,
+            1,
+            1,
+          ],
+          Array [
+            2,
+            2,
+            2,
+          ],
+          Array [
+            4,
+            3,
+            3,
+          ],
+          Array [
+            5,
+            4,
+            4,
+          ],
+          Array [
+            8,
+            5,
+            5,
+          ],
+          Array [
+            9,
+            6,
+            6,
+          ],
+          Array [
+            10,
+            7,
+            7,
+          ],
+        ],
+        "schema": Object {
+          "count": 2,
+          "number": 1,
+          "time": 0,
         },
-      ],
+      },
     },
   ],
   "libs": Array [
@@ -9436,7 +9431,7 @@ Object {
     "stackwalk": 1,
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
-    "version": 28,
+    "version": 29,
   },
   "pages": Array [
     Object {
@@ -10976,7 +10971,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 47,
+    "preprocessedProfileVersion": 48,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -12630,7 +12625,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 47,
+    "preprocessedProfileVersion": 48,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -13965,41 +13960,36 @@ Object {
       "mainThreadIndex": 0,
       "name": "malloc",
       "pid": "11111",
-      "sampleGroups": Array [
-        Object {
-          "id": 0,
-          "samples": Object {
-            "count": Array [
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-            ],
-            "length": 7,
-            "number": Array [
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-            ],
-            "time": Array [
-              0,
-              2,
-              4,
-              5,
-              8,
-              9,
-              10,
-            ],
-          },
-        },
-      ],
+      "samples": Object {
+        "count": Array [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+        ],
+        "length": 7,
+        "number": Array [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+        ],
+        "time": Array [
+          0,
+          2,
+          4,
+          5,
+          8,
+          9,
+          10,
+        ],
+      },
     },
   ],
   "libs": Array [
@@ -14432,7 +14422,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 47,
+    "preprocessedProfileVersion": 48,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -200,7 +200,14 @@ describe('gecko counters processing', function () {
       name: 'Empty counter',
       category: 'Some category',
       description: 'Some description',
-      sample_groups: [],
+      samples: {
+        schema: {
+          time: 0,
+          count: 1,
+          number: 2,
+        },
+        data: [],
+      },
     };
 
     parentGeckoProfile.counters = [parentCounter, emptyCounterEntry];
@@ -247,23 +254,19 @@ describe('gecko counters processing', function () {
     const offsetTime = originalTime.map((n) => n + 1000);
 
     const extractTime = (counter) => {
-      if (counter.sample_groups.length === 0) {
+      if (counter.samples.data.length === 0) {
         return [];
       }
-      return counter.sample_groups[0].samples.data.map((tuple) => tuple[0]);
+      return counter.samples.data.map((tuple) => tuple[0]);
     };
 
     // The original times and parent process are not offset.
     expect(extractTime(parentCounter)).toEqual(originalTime);
     expect(extractTime(childCounter)).toEqual(originalTime);
-    expect(processedCounters[0].sampleGroups[0].samples.time).toEqual(
-      originalTime
-    );
+    expect(processedCounters[0].samples.time).toEqual(originalTime);
 
     // The subprocess times are offset when processed:
-    expect(processedCounters[1].sampleGroups[0].samples.time).toEqual(
-      offsetTime
-    );
+    expect(processedCounters[1].samples.time).toEqual(offsetTime);
   });
 });
 

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -195,8 +195,7 @@ describe('sanitizePII', function () {
     // Make sure that we still have the same number of counters.
     expect(ensureExists(originalProfile.counters).length).toEqual(1);
     expect(ensureExists(sanitizedProfile.counters).length).toEqual(1);
-    const counterSamples = ensureExists(sanitizedProfile.counters)[0]
-      .sampleGroups[0].samples;
+    const counterSamples = ensureExists(sanitizedProfile.counters)[0].samples;
 
     // Make sure that all the table fields are consistent.
     expect(counterSamples.time).toHaveLength(counterSamples.length);

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -267,17 +267,14 @@ export type GeckoCounter = {|
   name: string,
   category: string,
   description: string,
-  sample_groups: $ReadOnlyArray<{|
-    id: number,
-    samples: {|
-      schema: {|
-        time: 0,
-        number: 1,
-        count: 2,
-      |},
-      data: $ReadOnlyArray<[number, number, number]>,
+  samples: {|
+    schema: {|
+      time: 0,
+      count: 1,
+      number: 2,
     |},
-  |}>,
+    data: $ReadOnlyArray<[number, number, number]>,
+  |},
 |};
 
 export type GeckoProfilerOverhead = {|

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -533,10 +533,7 @@ export type Counter = {|
   color?: GraphColor,
   pid: Pid,
   mainThreadIndex: ThreadIndex,
-  sampleGroups: $ReadOnlyArray<{|
-    id: number,
-    samples: CounterSamplesTable,
-  |}>,
+  samples: CounterSamplesTable,
 |};
 
 /**


### PR DESCRIPTION
IMO this makes the code significantly less confusing. No user-visible change.