### PR TITLE
Only set fillStyle once in drawSamples.

### DIFF
--- a/src/components/shared/thread/HeightGraph.js
+++ b/src/components/shared/thread/HeightGraph.js
@@ -190,6 +190,9 @@ export class ThreadHeightGraph extends PureComponent<Props> {
       xPos: number[],
     };
     function drawSamples(samplesBucket: SamplesBucket, color: string) {
+      if (samplesBucket.xPos.length === 0) {
+        return;
+      }
       ctx.fillStyle = color;
       for (let i = 0; i < samplesBucket.height.length; i++) {
         const height = samplesBucket.height[i];

--- a/src/components/shared/thread/SampleGraph.js
+++ b/src/components/shared/thread/SampleGraph.js
@@ -174,8 +174,11 @@ export class ThreadSampleGraphImpl extends PureComponent<Props> {
     }
 
     function drawSamples(samplePositions: number[], color: string) {
+      if (samplePositions.length === 0) {
+        return;
+      }
+      ctx.fillStyle = color;
       for (let i = 0; i < samplePositions.length; i++) {
-        ctx.fillStyle = color;
         const startY = 0;
         const xPos = samplePositions[i];
         ctx.fillRect(xPos, startY, drawnSampleWidth, canvas.height);

--- a/src/test/components/__snapshots__/CPUGraph.test.js.snap
+++ b/src/test/components/__snapshots__/CPUGraph.test.js.snap
@@ -4,10 +4,6 @@ exports[`CPUGraph matches the 2d canvas draw snapshot 1`] = `
 Array [
   Array [
     "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "set fillStyle",
     "#003eaa",
   ],
   Array [
@@ -65,10 +61,6 @@ Array [
     10,
     10,
     0,
-  ],
-  Array [
-    "set fillStyle",
-    "#c5e1fe",
   ],
   Array [
     "clearRect",

--- a/src/test/components/__snapshots__/SampleGraph.test.js.snap
+++ b/src/test/components/__snapshots__/SampleGraph.test.js.snap
@@ -25,19 +25,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     5,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -47,19 +39,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     25,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -69,10 +53,6 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     45,
     0,
@@ -80,19 +60,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     55,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -2542,19 +2542,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     5,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -2564,19 +2556,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     25,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -2586,10 +2570,6 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     45,
     0,
@@ -2597,19 +2577,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     55,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -5190,19 +5162,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     5,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -5212,19 +5176,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     25,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -5234,10 +5190,6 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     45,
     0,
@@ -5245,19 +5197,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     55,
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -7838,10 +7782,6 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     3.3333333333333335,
     0,
@@ -7849,19 +7789,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     10,
     0,
     6.666666666666667,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -7871,19 +7803,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     50,
     0,
     6.666666666666667,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -7893,19 +7817,11 @@ Array [
     10,
   ],
   Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
     "fillRect",
     63.333333333333336,
     0,
     6.666666666666667,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",
@@ -10041,10 +9957,6 @@ Array [
     0,
     10,
     10,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "fillRect",

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -4,10 +4,6 @@ exports[`timeline/TrackThread matches the 2d canvas draw snapshot 1`] = `
 Array [
   Array [
     "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "set fillStyle",
     "#003eaa",
   ],
   Array [
@@ -37,10 +33,6 @@ Array [
     0,
     100,
     50,
-  ],
-  Array [
-    "set fillStyle",
-    "#c5e1fe",
   ],
   Array [
     "clearRect",


### PR DESCRIPTION
Move the fillStyle setting outside of a loop in the SampleGraph implementation. This was likely moved by mistake in f8631ae9aef33000f88ce0a81bec48344a08a7ce .

And don't set the fillStyle at all if there's nothing to draw with this color.