### PR TITLE
Make traced durations honor the preview selection.

### DIFF
--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -350,7 +350,7 @@ export function getStackAndSampleSelectorsPerThread(
     );
 
   const getTracedTiming: Selector<TracedTiming | null> = createSelector(
-    threadSelectors.getFilteredSamplesForCallTree,
+    threadSelectors.getPreviewFilteredSamplesForCallTree,
     getCallNodeInfo,
     ProfileSelectors.getProfileInterval,
     UrlState.getInvertCallstack,


### PR DESCRIPTION
Fixes #3557.

[Production](https://profiler.firefox.com/public/g38mznjkwaygmtgs583f9vfh3n9ce3wdty6c678/flame-graph/?globalTrackOrder=0w8&hiddenGlobalTracks=0w7&hiddenLocalTracksByPid=49712-0w4~49713-0~49722-0~49714-0~49719-0~49721-0~49716-0~49715-01~49718-0&implementation=js&thread=e&v=10) | [Deploy preview](https://deploy-preview-4817--perf-html.netlify.app/public/g38mznjkwaygmtgs583f9vfh3n9ce3wdty6c678/flame-graph/?globalTrackOrder=0w8&hiddenGlobalTracks=0w7&hiddenLocalTracksByPid=49712-0w4~49713-0~49722-0~49714-0~49719-0~49721-0~49716-0~49715-01~49718-0&implementation=js&thread=e&v=10)

Steps to reproduce:

 1. Click a jank marker to select a single keypress.
 2. Hover the `_accumulateSampleCategories` function to see how long this function took during a single key press.

Before the fix, the tooltip always says 638ms in the top left corner.
After the fix, it shows values around 37ms.