### PR TITLE
Always use CPU usage information if available.

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -26,7 +26,6 @@ import type {
   SelectedState,
   Milliseconds,
   CssPixels,
-  TimelineType,
 } from 'firefox-profiler/types';
 import type {
   ActivityFillGraphQuerier,
@@ -52,10 +51,9 @@ export type Props = {|
     IndexIntoSamplesTable,
     IndexIntoSamplesTable
   ) => number,
-  +enableCPUUsage: boolean,
+  +hasCPUUsageInformation: boolean,
   +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
-  +timelineType: TimelineType,
   ...SizeProps,
 |};
 
@@ -165,11 +163,10 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
       samplesSelectedStates,
       treeOrderSampleComparator,
       maxThreadCPUDeltaPerMs,
-      enableCPUUsage,
+      hasCPUUsageInformation,
       implementationFilter,
       width,
       height,
-      timelineType,
     } = this.props;
     const { hoveredPixelState, mouseX, mouseY } = this.state;
     return (
@@ -196,7 +193,6 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
           categories={categories}
           passFillsQuerier={this._setFillsQuerier}
           onClick={this._onClick}
-          enableCPUUsage={enableCPUUsage}
           maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
           width={width}
           height={height}
@@ -206,7 +202,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
             <SampleTooltipContents
               sampleIndex={hoveredPixelState.sample}
               cpuRatioInTimeRange={
-                timelineType === 'cpu-category'
+                hasCPUUsageInformation
                   ? hoveredPixelState.cpuRatioInTimeRange
                   : null
               }

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -41,7 +41,6 @@ type CanvasProps = {|
   +categories: CategoryList,
   +passFillsQuerier: (ActivityFillGraphQuerier) => void,
   +onClick: (SyntheticMouseEvent<HTMLCanvasElement>) => void,
-  +enableCPUUsage: boolean,
   +maxThreadCPUDeltaPerMs: number,
   ...SizeProps,
 |};
@@ -127,7 +126,6 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       samplesSelectedStates,
       treeOrderSampleComparator,
       categories,
-      enableCPUUsage,
       maxThreadCPUDeltaPerMs,
       width,
       height,
@@ -149,7 +147,6 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       rangeEnd,
       sampleIndexOffset,
       samplesSelectedStates,
-      enableCPUUsage,
       maxThreadCPUDeltaPerMs,
       xPixelsPerMs: canvasPixelWidth / (rangeEnd - rangeStart),
       treeOrderSampleComparator,

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -39,7 +39,6 @@ type RenderedComponentSettings = {|
   +rangeEnd: Milliseconds,
   +sampleIndexOffset: number,
   +xPixelsPerMs: number,
-  +enableCPUUsage: boolean,
   +maxThreadCPUDeltaPerMs: number,
   +treeOrderSampleComparator: ?(
     IndexIntoSamplesTable,
@@ -219,7 +218,6 @@ export class ActivityGraphFillComputer {
       rangeFilteredThread: { samples, stackTable },
       interval,
       greyCategoryIndex,
-      enableCPUUsage,
       sampleIndexOffset,
     } = this.renderedComponentSettings;
 
@@ -251,7 +249,7 @@ export class ActivityGraphFillComputer {
 
       let cpuBeforeSample = null;
       let cpuAfterSample = null;
-      if (enableCPUUsage && threadCPUDelta) {
+      if (threadCPUDelta !== undefined) {
         // It must be non-null because we are checking this in the processing
         // step and eliminating all the null values.
         cpuBeforeSample = ensureExists(threadCPUDelta[i]);
@@ -283,7 +281,7 @@ export class ActivityGraphFillComputer {
 
     let cpuBeforeSample = null;
     let cpuAfterSample = null;
-    if (enableCPUUsage && threadCPUDelta) {
+    if (threadCPUDelta !== undefined) {
       cpuBeforeSample = ensureExists(threadCPUDelta[lastIdx]);
 
       const nextIdxInFullThread = sampleIndexOffset + lastIdx + 1;
@@ -676,7 +674,6 @@ export class ActivityFillGraphQuerier {
   ): number {
     const {
       rangeFilteredThread: { samples },
-      enableCPUUsage,
       interval,
       sampleIndexOffset,
       fullThread,
@@ -700,7 +697,7 @@ export class ActivityFillGraphQuerier {
     let cpuDeltaBeforeSample = null;
     let cpuDeltaAfterSample = null;
     const { threadCPUDelta } = samples;
-    if (enableCPUUsage && threadCPUDelta) {
+    if (threadCPUDelta !== undefined) {
       // It must be non-null because we are checking this in the processing
       // step and eliminating all the null values.
       cpuDeltaBeforeSample = ensureExists(threadCPUDelta[sample]);

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -92,7 +92,7 @@ type StateProps = {|
     IndexIntoSamplesTable
   ) => number,
   +selectedThreadIndexes: Set<ThreadIndex>,
-  +enableCPUUsage: boolean,
+  +hasCPUUsageInformation: boolean,
   +isExperimentalCPUGraphsEnabled: boolean,
   +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
@@ -203,7 +203,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       treeOrderSampleComparator,
       trackType,
       trackName,
-      enableCPUUsage,
+      hasCPUUsageInformation,
       maxThreadCPUDeltaPerMs,
       isExperimentalCPUGraphsEnabled,
       implementationFilter,
@@ -272,10 +272,9 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               categories={categories}
               samplesSelectedStates={samplesSelectedStates}
               treeOrderSampleComparator={treeOrderSampleComparator}
-              enableCPUUsage={enableCPUUsage}
+              hasCPUUsageInformation={hasCPUUsageInformation}
               maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
               implementationFilter={implementationFilter}
-              timelineType={timelineType}
             />
             {trackType === 'expanded' ? (
               <ThreadSampleGraph
@@ -346,8 +345,7 @@ export const TimelineTrackThread = explicitConnect<
     const committedRange = getCommittedRange(state);
     const fullThread = selectors.getCPUProcessedThread(state);
     const timelineType = getTimelineType(state);
-    const enableCPUUsage =
-      timelineType === 'cpu-category' &&
+    const hasCPUUsageInformation =
       fullThread.samples.threadCPUDelta !== undefined;
 
     return {
@@ -373,7 +371,7 @@ export const TimelineTrackThread = explicitConnect<
       treeOrderSampleComparator:
         selectors.getTreeOrderComparatorInFilteredThread(state),
       selectedThreadIndexes,
-      enableCPUUsage,
+      hasCPUUsageInformation,
       isExperimentalCPUGraphsEnabled: getIsExperimentalCPUGraphsEnabled(state),
       maxThreadCPUDeltaPerMs: getMaxThreadCPUDeltaPerMs(state),
       implementationFilter: getImplementationFilter(state),


### PR DESCRIPTION
We can use `?timelineType=category` in the URL in order to pick the CPU-unaware activity graph even for profiles which include CPU usage information. This causes us to draw the graph as if CPU usage was 100% all the time.

I think this ability to switch between CPU activity graph and no-CPU activity graph is no longer useful. It is time to simplify some code.

@canova Thoughts?

Example profiles (all links go to current production):

 1. Old profile without CPU usage information: [timelineType=category](https://share.firefox.dev/3RkeADp) | [timelineType=category-cpu](https://share.firefox.dev/46ztoCv)
 3. Profile with CPU usage information: [timelineType=category](https://share.firefox.dev/3GlxIdV) | [timelineType=category-cpu](https://share.firefox.dev/3sRwHav)
 2. [Old profile without CPU usage information with categories, but with timelineType=stack](https://share.firefox.dev/3SXjNSU)

We can make some simplifications to `determineTimelineType` as a result. I'll keep this PR as a draft until I've looked at those in more detail. We may also want a URL upgrader, but I'm not sure if that's valuable.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-13)
