### PR TITLE
Don't expose the inverted stackTable

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -158,18 +158,19 @@ export function selectLeafCallNode(
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const threadSelectors = getThreadSelectorsFromThreadsKey(threadsKey);
-    const filteredThread = threadSelectors.getFilteredThread(getState());
+    const sampleCallNodes =
+      threadSelectors.getSampleIndexToCallNodeIndexForFilteredThread(
+        getState()
+      );
     const callNodeInfo = threadSelectors.getCallNodeInfo(getState());
 
     let newSelectedCallNode = -1;
-    if (sampleIndex !== null) {
-      // The newSelectedStack could be undefined if there are 0 samples.
-      const newSelectedStack = filteredThread.samples.stack[sampleIndex];
-
-      if (newSelectedStack !== null && newSelectedStack !== undefined) {
-        newSelectedCallNode =
-          callNodeInfo.stackIndexToCallNodeIndex[newSelectedStack];
-      }
+    if (
+      sampleIndex !== null &&
+      sampleIndex >= 0 &&
+      sampleIndex < sampleCallNodes.length
+    ) {
+      newSelectedCallNode = sampleCallNodes[sampleIndex] ?? -1;
     }
 
     dispatch(

--- a/src/profile-logic/line-timings.js
+++ b/src/profile-logic/line-timings.js
@@ -17,6 +17,8 @@ import type {
   LineNumber,
 } from 'firefox-profiler/types';
 
+import { getMatchingAncestorStackForInvertedCallNode } from './profile-data';
+
 /**
  * For each stack in `stackTable`, and one specific source file, compute the
  * sets of line numbers in file that are hit by the stack.
@@ -26,31 +28,6 @@ import type {
  *       Answer: result.selfLine[stack] === X
  *  - "Does this stack contribute to line X's total time?"
  *       Answer: result.stackLines[stack].has(X)
- */
-export function getStackLineInfo(
-  stackTable: StackTable,
-  frameTable: FrameTable,
-  funcTable: FuncTable,
-  fileNameStringIndex: IndexIntoStringTable,
-  isInvertedTree: boolean
-): StackLineInfo {
-  return isInvertedTree
-    ? getStackLineInfoInverted(
-        stackTable,
-        frameTable,
-        funcTable,
-        fileNameStringIndex
-      )
-    : getStackLineInfoNonInverted(
-        stackTable,
-        frameTable,
-        funcTable,
-        fileNameStringIndex
-      );
-}
-
-/**
- * This function handles the non-inverted case of getStackLineInfo.
  *
  * Compute the sets of line numbers in the given file that are hit by each stack.
  * For each stack in the stack table and each line in the file, we answer the
@@ -79,7 +56,7 @@ export function getStackLineInfo(
  *     of its prefix stack, plus stack.frame.line added to the set.
  *     For all other stacks this is the same as the stackLines set of the stack's prefix.
  */
-export function getStackLineInfoNonInverted(
+export function getStackLineInfo(
   stackTable: StackTable,
   frameTable: FrameTable,
   funcTable: FuncTable,
@@ -132,97 +109,6 @@ export function getStackLineInfoNonInverted(
 }
 
 /**
- * This function handles the inverted case of getStackLineInfo.
- *
- * The return value should exactly match what you'd get if you called `getStackLineInfo`
- * on the corresponding non-inverted thread.
- * This function can probably be removed once we handle call tree inversion differently.
- *
- * Reminder about inverted threads: The self time is in the *root* nodes. Example:
- *
- * Stack node A, line 20
- *   (called by) Stack node B, line 30
- *
- * The inverted stack [A, B] contributes to the self time of line 20.
- *
- * The returned StackLineInfo is computed as follows:
- *   selfLine[stack]:
- *     For (inverted thread) root stack nodes whose stack.frame.func.file is the given
- *     file, this is stack.frame.line.
- *     For (inverted thread) root stack nodes whose frame is in a different file, this
- *     is null.
- *     For (inverted thread) *non-root* stack nodes, this is the same as the selfLine
- *     of the stack's prefix. This way, the selfLine is always inherited from the
- *     subtree root.
- *   stackLines[stack]:
- *     For stacks whose stack.frame.func.file is the given file, this is the stackLines
- *     of its (inverted thread) prefix stack, plus stack.frame.line added to the set.
- *     For all other stacks this is the same as the stackLines set of the stack's prefix.
- */
-export function getStackLineInfoInverted(
-  stackTable: StackTable,
-  frameTable: FrameTable,
-  funcTable: FuncTable,
-  fileNameStringIndex: IndexIntoStringTable
-): StackLineInfo {
-  // "self line" == "the line which a stack's self time is contributed to"
-  const selfLineForAllStacks = [];
-  // "total lines" == "the set of lines whose total time this stack contributes to"
-  const totalLinesForAllStacks = [];
-
-  // This loop takes advantage of the fact that the stack table is topologically ordered:
-  // Prefix stacks are always visited before their descendants.
-  for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
-    const frame = stackTable.frame[stackIndex];
-    const prefixStack = stackTable.prefix[stackIndex];
-    const func = frameTable.func[frame];
-    const fileNameStringIndexOfThisStack = funcTable.fileName[func];
-
-    let selfLine: LineNumber | null = null;
-    let totalLines: Set<LineNumber> | null = null;
-
-    if (prefixStack === null) {
-      // This stack node is a root of the inverted tree. That means that this stack's
-      // frame's line is where the self time is assigned, for the entire subtree of
-      // the inverted stack tree at this root.
-      if (fileNameStringIndexOfThisStack === fileNameStringIndex) {
-        selfLine = frameTable.line[frame];
-        if (selfLine !== null) {
-          totalLines = new Set([selfLine]);
-        }
-      }
-    } else {
-      // This stack node has a prefix, which, in inverted mode, means that *this node
-      // calls someone else, and that's where the time is spent*. The prefix is the callee.
-      // So this stack node contributes its time to its root node's line.
-      // We inherit the prefix's self line.
-      selfLine = selfLineForAllStacks[prefixStack];
-
-      // Add this stack's line to the totalLines set.
-      totalLines = totalLinesForAllStacks[prefixStack];
-      if (fileNameStringIndexOfThisStack === fileNameStringIndex) {
-        const thisStackLine = frameTable.line[frame];
-        if (thisStackLine !== null) {
-          if (totalLines === null) {
-            totalLines = new Set([thisStackLine]);
-          } else if (!totalLines.has(thisStackLine)) {
-            totalLines = new Set(totalLines);
-            totalLines.add(thisStackLine);
-          }
-        }
-      }
-    }
-
-    selfLineForAllStacks.push(selfLine);
-    totalLinesForAllStacks.push(totalLines);
-  }
-  return {
-    selfLine: selfLineForAllStacks,
-    stackLines: totalLinesForAllStacks,
-  };
-}
-
-/**
  * Gathers the line numbers which are hit by a given call node.
  * This is different from `getStackLineInfo`: `getStackLineInfo` counts line hits
  * anywhere in the stack, and this function only counts hits *in the given call node*.
@@ -237,10 +123,9 @@ export function getStackLineInfoForCallNode(
   stackTable: StackTable,
   frameTable: FrameTable,
   callNodeIndex: IndexIntoCallNodeTable,
-  callNodeInfo: CallNodeInfo,
-  isInvertedTree: boolean
+  callNodeInfo: CallNodeInfo
 ): StackLineInfo {
-  return isInvertedTree
+  return callNodeInfo.isInverted
     ? getStackLineInfoForCallNodeInverted(
         stackTable,
         frameTable,
@@ -394,50 +279,52 @@ export function getStackLineInfoForCallNodeInverted(
   stackTable: StackTable,
   frameTable: FrameTable,
   callNodeIndex: IndexIntoCallNodeTable,
-  { stackIndexToCallNodeIndex }: CallNodeInfo
+  callNodeInfo: CallNodeInfo
 ): StackLineInfo {
+  const invertedCallNodeTable = callNodeInfo.callNodeTable;
+  const depth = invertedCallNodeTable.depth[callNodeIndex];
+  const endIndex = invertedCallNodeTable.subtreeRangeEnd[callNodeIndex];
+  const callNodeIsRootOfInvertedTree =
+    invertedCallNodeTable.prefix[callNodeIndex] === -1;
+  const { stackIndexToCallNodeIndex } = callNodeInfo;
+  const stackTablePrefixCol = stackTable.prefix;
+
   // "self line" == "the line which a stack's self time is contributed to"
   const callNodeSelfLineForAllStacks = [];
   // "total lines" == "the set of lines whose total time this stack contributes to"
   // Either null or a single-element set.
   const callNodeTotalLinesForAllStacks = [];
 
-  // This loop takes advantage of the fact that the stack table is topologically ordered:
-  // Prefix stacks are always visited before their descendants.
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
     let selfLine: LineNumber | null = null;
     let totalLines: Set<LineNumber> | null = null;
 
-    const prefixStack = stackTable.prefix[stackIndex];
-    if (stackIndexToCallNodeIndex[stackIndex] === callNodeIndex) {
-      // This stack contributes to the call node's self time.
+    const stackForCallNode = getMatchingAncestorStackForInvertedCallNode(
+      stackIndex,
+      callNodeIndex,
+      endIndex,
+      depth,
+      stackIndexToCallNodeIndex,
+      stackTablePrefixCol
+    );
+    if (stackForCallNode !== null) {
+      const frameForCallNode = stackTable.frame[stackForCallNode];
+      // assert(frameTable.func[frameForCallNode] === suffixPath[0]);
+
+      // This stack contributes to the call node's total time.
       // We don't need to check the stack's func or file because it'll be
       // the same as the given call node's func and file.
-      const frame = stackTable.frame[stackIndex];
-      const line = frameTable.line[frame];
+      const line = frameTable.line[frameForCallNode];
       if (line !== null) {
         totalLines = new Set([line]);
-        if (prefixStack === null) {
+        if (callNodeIsRootOfInvertedTree) {
           // This is a root of the inverted tree, and it is the given
-          // call node. That means that we have a self line.
+          // call node. That means that we have a self address.
           selfLine = line;
         } else {
           // This is not a root stack node, so no self time is spent
           // in the given call node for this stack node.
         }
-      }
-    } else {
-      if (prefixStack === null) {
-        // This is a root of the inverted tree, but it doesn't map
-        // to the given call node. It doesn't contribute to the call node's
-        // self time or total time.
-      } else {
-        // This is not a root stack node. Samples that hit this stack node
-        // spend their time in the root node of our subtree. If that root
-        // maps to the given call node, we may have self time.
-        // Inherit both self and total time contribution from the parent stack.
-        selfLine = callNodeSelfLineForAllStacks[prefixStack];
-        totalLines = callNodeTotalLinesForAllStacks[prefixStack];
       }
     }
 

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2018,11 +2018,11 @@ export function computeCallNodeMaxDepthPlusOne(
   return maxDepth + 1;
 }
 
-export function invertCallstack(
+export function computeThreadWithInvertedStackTable(
   thread: Thread,
   defaultCategory: IndexIntoCategoryList
 ): Thread {
-  return timeCode('invertCallstack', () => {
+  return timeCode('computeThreadWithInvertedStackTable', () => {
     const { stackTable, frameTable } = thread;
 
     const newStackTable = {

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -280,13 +280,11 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
       UrlState.getSourceViewFile,
       selectedThreadSelectors.getCallNodeInfo,
       selectedThreadSelectors.getSelectedCallNodeIndex,
-      UrlState.getInvertCallstack,
       (
         { stackTable, frameTable, funcTable, stringTable }: Thread,
         sourceViewFile,
         callNodeInfo,
-        selectedCallNodeIndex,
-        invertCallStack
+        selectedCallNodeIndex
       ): StackLineInfo | null => {
         if (sourceViewFile === null || selectedCallNodeIndex === null) {
           return null;
@@ -304,8 +302,7 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
           stackTable,
           frameTable,
           selectedCallNodeIndex,
-          callNodeInfo,
-          invertCallStack
+          callNodeInfo
         );
       }
     );
@@ -322,13 +319,11 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
       selectedThreadSelectors.getAssemblyViewNativeSymbolIndex,
       selectedThreadSelectors.getCallNodeInfo,
       selectedThreadSelectors.getSelectedCallNodeIndex,
-      UrlState.getInvertCallstack,
       (
         { stackTable, frameTable }: Thread,
         nativeSymbolIndex,
         callNodeInfo,
-        selectedCallNodeIndex,
-        invertCallStack
+        selectedCallNodeIndex
       ): StackAddressInfo | null => {
         if (nativeSymbolIndex === null || selectedCallNodeIndex === null) {
           return null;
@@ -338,8 +333,7 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
           frameTable,
           selectedCallNodeIndex,
           callNodeInfo,
-          nativeSymbolIndex,
-          invertCallStack
+          nativeSymbolIndex
         );
       }
     );

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -93,7 +93,7 @@ export function getStackAndSampleSelectorsPerThread(
     }
   );
 
-  // A selector for getCallNodeInfo.
+  // A selector for the non-inverted call node info.
   // getCallNodeInfo can be very expensive, so we want to minimize the number of
   // times it gets called, in particular when transforms are applied and unapplied
   // or when the filtered time range changes.
@@ -104,7 +104,7 @@ export function getStackAndSampleSelectorsPerThread(
   // In addition, we use createSelectorWithTwoCacheSlots so that removing the last
   // transform is fast. This lets you quickly go back and forth between a focused
   // function and the whole profile.
-  const getCallNodeInfo: Selector<CallNodeInfo> =
+  const _getNonInvertedCallNodeInfo: Selector<CallNodeInfo> =
     createSelectorWithTwoCacheSlots(
       (state) => threadSelectors.getFilteredThread(state).stackTable,
       (state) => threadSelectors.getFilteredThread(state).frameTable,
@@ -113,15 +113,27 @@ export function getStackAndSampleSelectorsPerThread(
       ProfileData.getCallNodeInfo
     );
 
+  const _getInvertedCallNodeInfo: Selector<CallNodeInfo> =
+    createSelectorWithTwoCacheSlots(
+      threadSelectors.getFilteredThread,
+      ProfileSelectors.getDefaultCategory,
+      ProfileData.getInvertedCallNodeInfo
+    );
+
+  const getCallNodeInfo: Selector<CallNodeInfo> = (state) => {
+    if (UrlState.getInvertCallstack(state)) {
+      return _getInvertedCallNodeInfo(state);
+    }
+    return _getNonInvertedCallNodeInfo(state);
+  };
+
   const getSourceViewStackLineInfo: Selector<StackLineInfo | null> =
     createSelector(
       threadSelectors.getFilteredThread,
       UrlState.getSourceViewFile,
-      UrlState.getInvertCallstack,
       (
         { stackTable, frameTable, funcTable, stringTable }: Thread,
-        sourceViewFile,
-        invertCallStack
+        sourceViewFile
       ): StackLineInfo | null => {
         if (sourceViewFile === null) {
           return null;
@@ -130,8 +142,7 @@ export function getStackAndSampleSelectorsPerThread(
           stackTable,
           frameTable,
           funcTable,
-          stringTable.indexForString(sourceViewFile),
-          invertCallStack
+          stringTable.indexForString(sourceViewFile)
         );
       }
     );
@@ -157,11 +168,9 @@ export function getStackAndSampleSelectorsPerThread(
     createSelector(
       threadSelectors.getFilteredThread,
       getAssemblyViewNativeSymbolIndex,
-      UrlState.getInvertCallstack,
       (
         { stackTable, frameTable, funcTable }: Thread,
-        nativeSymbolIndex,
-        invertCallStack
+        nativeSymbolIndex
       ): StackAddressInfo | null => {
         if (nativeSymbolIndex === null) {
           return null;
@@ -170,8 +179,7 @@ export function getStackAndSampleSelectorsPerThread(
           stackTable,
           frameTable,
           funcTable,
-          nativeSymbolIndex,
-          invertCallStack
+          nativeSymbolIndex
         );
       }
     );

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -469,7 +469,7 @@ export function getThreadSelectorsWithMarkersPerThread(
   const _getInvertedThread: Selector<Thread> = createSelector(
     _getImplementationAndSearchFilteredThread,
     ProfileSelectors.getDefaultCategory,
-    ProfileData.invertCallstack
+    ProfileData.computeThreadWithInvertedStackTable
   );
 
   const getFilteredThread: Selector<Thread> = (state) => {

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -457,26 +457,11 @@ export function getThreadSelectorsWithMarkersPerThread(
     ProfileData.filterThreadByImplementation
   );
 
-  const _getImplementationAndSearchFilteredThread: Selector<Thread> =
-    createSelector(
-      _getImplementationFilteredThread,
-      UrlState.getSearchStrings,
-      (thread, searchStrings) => {
-        return ProfileData.filterThreadToSearchStrings(thread, searchStrings);
-      }
-    );
-
-  const _getInvertedThread: Selector<Thread> = createSelector(
-    _getImplementationAndSearchFilteredThread,
-    ProfileSelectors.getDefaultCategory,
-    ProfileData.computeThreadWithInvertedStackTable
+  const getFilteredThread: Selector<Thread> = createSelector(
+    _getImplementationFilteredThread,
+    UrlState.getSearchStrings,
+    ProfileData.filterThreadToSearchStrings
   );
-
-  const getFilteredThread: Selector<Thread> = (state) => {
-    return UrlState.getInvertCallstack(state)
-      ? _getInvertedThread(state)
-      : _getImplementationAndSearchFilteredThread(state);
-  };
 
   const getPreviewFilteredThread: Selector<Thread> = createSelector(
     getFilteredThread,

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -2277,7 +2277,8 @@ Object {
       8,
     ],
   },
-  "stackIndexToCallNodeIndex": Uint32Array [
+  "isInverted": false,
+  "stackIndexToCallNodeIndex": Int32Array [
     0,
     1,
     2,
@@ -2397,7 +2398,8 @@ CallTree {
         8,
       ],
     },
-    "stackIndexToCallNodeIndex": Uint32Array [
+    "isInverted": false,
+    "stackIndexToCallNodeIndex": Int32Array [
       0,
       1,
       2,

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1215,8 +1215,7 @@ describe('"collapse-direct-recursion" transform', function () {
         stackTable,
         frameTable,
         funcTable,
-        fileStringIndex,
-        false
+        fileStringIndex
       );
       const lineTimings = getLineTimings(stackLineInfo, samples);
 
@@ -1398,8 +1397,7 @@ describe('"collapse-recursion" transform', function () {
         stackTable,
         frameTable,
         funcTable,
-        fileStringIndex,
-        false
+        fileStringIndex
       );
       const lineTimings = getLineTimings(stackLineInfo, samples);
 
@@ -1510,8 +1508,7 @@ describe('"collapse-recursion" transform', function () {
         stackTable,
         frameTable,
         funcTable,
-        fileStringIndex,
-        false
+        fileStringIndex
       );
       const lineTimings = getLineTimings(stackLineInfo, samples);
 
@@ -1645,8 +1642,7 @@ describe('"collapse-recursion" transform', function () {
         stackTable,
         frameTable,
         funcTable,
-        fileStringIndex,
-        false
+        fileStringIndex
       );
       const lineTimings = getLineTimings(stackLineInfo, samples);
 

--- a/src/test/unit/address-timings.test.js
+++ b/src/test/unit/address-timings.test.js
@@ -11,7 +11,7 @@ import {
   getAddressTimings,
 } from 'firefox-profiler/profile-logic/address-timings';
 import {
-  invertCallstack,
+  computeThreadWithInvertedStackTable,
   getCallNodeInfo,
   getCallNodeIndexFromPath,
 } from '../../profile-logic/profile-data';
@@ -170,7 +170,7 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     const [thread] = profile.threads;
     const [{ Asym, Bsym, Csym, Dsym }] = nativeSymbolsDictPerThread;
     const defaultCategory = categories.findIndex((c) => c.color === 'grey');
-    const invertedThread = invertCallstack(thread, defaultCategory);
+    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
 
     const addressTimingsA = getTimings(thread, Asym, false);
     const addressTimingsInvertedA = getTimings(invertedThread, Asym, true);
@@ -348,7 +348,7 @@ describe('getAddressTimings for getStackAddressInfoForCallNode', function () {
     const [{ C, D }] = funcNamesDictPerThread;
     const [{ Csym, Dsym }] = nativeSymbolsDictPerThread;
     const [thread] = profile.threads;
-    const invertedThread = invertCallstack(thread, defaultCat);
+    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCat);
 
     // For the root D of the inverted tree, we have 3 self address hits.
     const addressTimingsD = getTimings(

--- a/src/test/unit/address-timings.test.js
+++ b/src/test/unit/address-timings.test.js
@@ -11,8 +11,8 @@ import {
   getAddressTimings,
 } from 'firefox-profiler/profile-logic/address-timings';
 import {
-  computeThreadWithInvertedStackTable,
   getCallNodeInfo,
+  getInvertedCallNodeInfo,
   getCallNodeIndexFromPath,
 } from '../../profile-logic/profile-data';
 import { ensureExists } from 'firefox-profiler/utils/flow';
@@ -39,8 +39,7 @@ describe('getStackAddressInfo', function () {
       stackTable,
       frameTable,
       funcTable,
-      Asym,
-      false
+      Asym
     );
 
     // Expect the returned arrays to have the same length as the stackTable.
@@ -51,18 +50,13 @@ describe('getStackAddressInfo', function () {
 });
 
 describe('getAddressTimings for getStackAddressInfo', function () {
-  function getTimings(
-    thread: Thread,
-    sym: IndexIntoNativeSymbolTable,
-    isInverted: boolean
-  ) {
+  function getTimings(thread: Thread, sym: IndexIntoNativeSymbolTable) {
     const { stackTable, frameTable, funcTable, samples } = thread;
     const stackLineInfo = getStackAddressInfo(
       stackTable,
       frameTable,
       funcTable,
-      sym,
-      isInverted
+      sym
     );
     return getAddressTimings(stackLineInfo, samples);
   }
@@ -76,7 +70,7 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     `);
     const [thread] = profile.threads;
     const [{ Asym }] = nativeSymbolsDictPerThread;
-    const addressTimings = getTimings(thread, Asym, false);
+    const addressTimings = getTimings(thread, Asym);
     expect(addressTimings.totalAddressHits.get(0x20)).toBe(1);
     expect(addressTimings.totalAddressHits.get(0x30)).toBe(1);
     expect(addressTimings.totalAddressHits.size).toBe(2); // no other hits
@@ -96,7 +90,7 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     `);
     const [thread] = profile.threads;
     const [{ Asym }] = nativeSymbolsDictPerThread;
-    const addressTimings = getTimings(thread, Asym, false);
+    const addressTimings = getTimings(thread, Asym);
     expect(addressTimings.totalAddressHits.get(0x20)).toBe(1);
     expect(addressTimings.totalAddressHits.get(0x30)).toBe(1);
     expect(addressTimings.totalAddressHits.size).toBe(2); // no other hits
@@ -115,7 +109,7 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     const [thread] = profile.threads;
     const [{ Asym, Bsym, Csym, Dsym }] = nativeSymbolsDictPerThread;
 
-    const addressTimingsA = getTimings(thread, Asym, false);
+    const addressTimingsA = getTimings(thread, Asym);
     expect(addressTimingsA.totalAddressHits.get(0x20)).toBe(2);
     expect(addressTimingsA.totalAddressHits.get(0x21)).toBe(1);
     // 0x30 is in the righ lib (one) but in the wrong native symbol (B instead
@@ -128,7 +122,7 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     expect(addressTimingsA.selfAddressHits.get(0x30)).toBe(undefined);
     expect(addressTimingsA.selfAddressHits.size).toBe(0); // no other hits
 
-    const addressTimingsB = getTimings(thread, Bsym, false);
+    const addressTimingsB = getTimings(thread, Bsym);
     // Address 0x30 was hit in every sample, twice in the first sample
     // (due to recursion) but that still only counts as one sample
     expect(addressTimingsB.totalAddressHits.get(0x30)).toBe(3);
@@ -139,7 +133,7 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     expect(addressTimingsB.selfAddressHits.get(0x30)).toBe(1);
     expect(addressTimingsB.selfAddressHits.size).toBe(1); // no other hits
 
-    const addressTimingsC = getTimings(thread, Csym, false);
+    const addressTimingsC = getTimings(thread, Csym);
     expect(addressTimingsC.totalAddressHits.get(0x10)).toBe(1);
     expect(addressTimingsC.totalAddressHits.get(0x11)).toBe(1);
     expect(addressTimingsC.totalAddressHits.size).toBe(2); // no other hits
@@ -147,46 +141,12 @@ describe('getAddressTimings for getStackAddressInfo', function () {
     expect(addressTimingsC.selfAddressHits.get(0x11)).toBe(1);
     expect(addressTimingsC.selfAddressHits.size).toBe(1); // no other hits
 
-    const addressTimingsD = getTimings(thread, Dsym, false);
+    const addressTimingsD = getTimings(thread, Dsym);
     expect(addressTimingsD.totalAddressHits.get(0x40)).toBe(1);
     expect(addressTimingsD.totalAddressHits.size).toBe(1); // no other hits
     // Dsym's address 0x40 recursed but should only be counted as 1 sample
     expect(addressTimingsD.selfAddressHits.get(0x40)).toBe(1);
     expect(addressTimingsD.selfAddressHits.size).toBe(1); // no other hits
-  });
-
-  it('computes the same values on an inverted thread', function () {
-    const { profile, nativeSymbolsDictPerThread } = getProfileFromTextSamples(`
-      A[lib:one][address:20][sym:Asym:20:]  A[lib:one][address:21][sym:Asym:20:]  A[lib:one][address:20][sym:Asym:20:]
-      B[lib:one][address:30][sym:Bsym:30:]  B[lib:one][address:30][sym:Bsym:30:]  B[lib:one][address:30][sym:Bsym:30:]
-      C[lib:two][address:10][sym:Csym:10:]  C[lib:two][address:11][sym:Csym:10:]  D[lib:two][address:40][sym:Dsym:40:]
-      B[lib:one][address:30][sym:Bsym:30:]                                        D[lib:two][address:40][sym:Dsym:40:]
-    `);
-    const categories = ensureExists(
-      profile.meta.categories,
-      'Expected to find categories'
-    );
-
-    const [thread] = profile.threads;
-    const [{ Asym, Bsym, Csym, Dsym }] = nativeSymbolsDictPerThread;
-    const defaultCategory = categories.findIndex((c) => c.color === 'grey');
-    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
-
-    const addressTimingsA = getTimings(thread, Asym, false);
-    const addressTimingsInvertedA = getTimings(invertedThread, Asym, true);
-    expect(addressTimingsInvertedA).toEqual(addressTimingsA);
-
-    const addressTimingsB = getTimings(thread, Bsym, false);
-    const addressTimingsInvertedB = getTimings(invertedThread, Bsym, true);
-    expect(addressTimingsInvertedB).toEqual(addressTimingsB);
-
-    const addressTimingsC = getTimings(thread, Csym, false);
-    const addressTimingsInvertedC = getTimings(invertedThread, Csym, true);
-    expect(addressTimingsInvertedC).toEqual(addressTimingsC);
-
-    const addressTimingsD = getTimings(thread, Dsym, false);
-    const addressTimingsInvertedD = getTimings(invertedThread, Dsym, true);
-    expect(addressTimingsInvertedD).toEqual(addressTimingsD);
   });
 });
 
@@ -199,12 +159,9 @@ describe('getAddressTimings for getStackAddressInfoForCallNode', function () {
     isInverted: boolean
   ) {
     const { stackTable, frameTable, funcTable, samples } = thread;
-    const callNodeInfo = getCallNodeInfo(
-      stackTable,
-      frameTable,
-      funcTable,
-      defaultCat
-    );
+    const callNodeInfo = isInverted
+      ? getInvertedCallNodeInfo(thread, defaultCat)
+      : getCallNodeInfo(stackTable, frameTable, funcTable, defaultCat);
     const callNodeIndex = ensureExists(
       getCallNodeIndexFromPath(callNodePath, callNodeInfo.callNodeTable),
       'invalid call node path'
@@ -214,8 +171,7 @@ describe('getAddressTimings for getStackAddressInfoForCallNode', function () {
       frameTable,
       callNodeIndex,
       callNodeInfo,
-      nativeSymbol,
-      isInverted
+      nativeSymbol
     );
     return getAddressTimings(stackLineInfo, samples);
   }
@@ -348,16 +304,8 @@ describe('getAddressTimings for getStackAddressInfoForCallNode', function () {
     const [{ C, D }] = funcNamesDictPerThread;
     const [{ Csym, Dsym }] = nativeSymbolsDictPerThread;
     const [thread] = profile.threads;
-    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCat);
-
     // For the root D of the inverted tree, we have 3 self address hits.
-    const addressTimingsD = getTimings(
-      invertedThread,
-      [D],
-      defaultCat,
-      Dsym,
-      true
-    );
+    const addressTimingsD = getTimings(thread, [D], defaultCat, Dsym, true);
     expect(addressTimingsD.totalAddressHits.get(0x51)).toBe(2);
     expect(addressTimingsD.totalAddressHits.get(0x52)).toBe(1);
     expect(addressTimingsD.totalAddressHits.size).toBe(2); // no other hits
@@ -367,13 +315,7 @@ describe('getAddressTimings for getStackAddressInfoForCallNode', function () {
 
     // For the C call node which is a child (direct caller) of D, we have
     // no self address hit and one hit at address 0x12.
-    const addressTimingsDC = getTimings(
-      invertedThread,
-      [D, C],
-      defaultCat,
-      Csym,
-      true
-    );
+    const addressTimingsDC = getTimings(thread, [D, C], defaultCat, Csym, true);
     expect(addressTimingsDC.totalAddressHits.get(0x12)).toBe(1);
     expect(addressTimingsDC.totalAddressHits.size).toBe(1); // no other hits
     expect(addressTimingsDC.selfAddressHits.size).toBe(0); // no self address hits

--- a/src/test/unit/line-timings.test.js
+++ b/src/test/unit/line-timings.test.js
@@ -11,8 +11,8 @@ import {
   getLineTimings,
 } from 'firefox-profiler/profile-logic/line-timings';
 import {
-  computeThreadWithInvertedStackTable,
   getCallNodeInfo,
+  getInvertedCallNodeInfo,
   getCallNodeIndexFromPath,
 } from '../../profile-logic/profile-data';
 import { ensureExists } from 'firefox-profiler/utils/flow';
@@ -38,8 +38,7 @@ describe('getStackLineInfo', function () {
       stackTable,
       frameTable,
       funcTable,
-      fileOne,
-      false
+      fileOne
     );
 
     // Expect the returned arrays to have the same length as the stackTable.
@@ -50,15 +49,14 @@ describe('getStackLineInfo', function () {
 });
 
 describe('getLineTimings for getStackLineInfo', function () {
-  function getTimings(thread: Thread, file: string, isInverted: boolean) {
+  function getTimings(thread: Thread, file: string) {
     const { stackTable, frameTable, funcTable, samples, stringTable } = thread;
     const fileStringIndex = stringTable.indexForString(file);
     const stackLineInfo = getStackLineInfo(
       stackTable,
       frameTable,
       funcTable,
-      fileStringIndex,
-      isInverted
+      fileStringIndex
     );
     return getLineTimings(stackLineInfo, samples);
   }
@@ -71,7 +69,7 @@ describe('getLineTimings for getStackLineInfo', function () {
       B[file:file.js][line:30]
     `);
     const [thread] = profile.threads;
-    const lineTimings = getTimings(thread, 'file.js', false);
+    const lineTimings = getTimings(thread, 'file.js');
     expect(lineTimings.totalLineHits.get(20)).toBe(1);
     expect(lineTimings.totalLineHits.get(30)).toBe(1);
     expect(lineTimings.totalLineHits.size).toBe(2); // no other hits
@@ -89,7 +87,7 @@ describe('getLineTimings for getStackLineInfo', function () {
     `);
     const [thread] = profile.threads;
 
-    const lineTimingsOne = getTimings(thread, 'one.js', false);
+    const lineTimingsOne = getTimings(thread, 'one.js');
     expect(lineTimingsOne.totalLineHits.get(20)).toBe(2);
     expect(lineTimingsOne.totalLineHits.get(21)).toBe(1);
     // one.js line 30 was hit in every sample, twice in the first sample
@@ -103,7 +101,7 @@ describe('getLineTimings for getStackLineInfo', function () {
     expect(lineTimingsOne.selfLineHits.get(30)).toBe(1);
     expect(lineTimingsOne.selfLineHits.size).toBe(1); // no other hits
 
-    const lineTimingsTwo = getTimings(thread, 'two.js', false);
+    const lineTimingsTwo = getTimings(thread, 'two.js');
     expect(lineTimingsTwo.totalLineHits.get(10)).toBe(1);
     expect(lineTimingsTwo.totalLineHits.get(11)).toBe(1);
     expect(lineTimingsTwo.totalLineHits.get(40)).toBe(1);
@@ -113,31 +111,6 @@ describe('getLineTimings for getStackLineInfo', function () {
     // two.js line 40 recursed but should only be counted as 1 sample
     expect(lineTimingsTwo.selfLineHits.get(40)).toBe(1);
     expect(lineTimingsTwo.selfLineHits.size).toBe(2); // no other hits
-  });
-
-  it('computes the same values on an inverted thread', function () {
-    const { profile } = getProfileFromTextSamples(`
-      A[file:one.js][line:20]  A[file:one.js][line:21]  A[file:one.js][line:20]
-      B[file:one.js][line:30]  B[file:one.js][line:30]  B[file:one.js][line:30]
-      C[file:two.js][line:10]  C[file:two.js][line:11]  D[file:two.js][line:40]
-      B[file:one.js][line:30]                           D[file:two.js][line:40]
-    `);
-    const categories = ensureExists(
-      profile.meta.categories,
-      'Expected to find categories'
-    );
-
-    const [thread] = profile.threads;
-    const defaultCategory = categories.findIndex((c) => c.color === 'grey');
-    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
-
-    const lineTimingsOne = getTimings(thread, 'one.js', false);
-    const lineTimingsInvertedOne = getTimings(invertedThread, 'one.js', true);
-    expect(lineTimingsInvertedOne).toEqual(lineTimingsOne);
-
-    const lineTimingsTwo = getTimings(thread, 'two.js', false);
-    const lineTimingsInvertedTwo = getTimings(invertedThread, 'two.js', true);
-    expect(lineTimingsInvertedTwo).toEqual(lineTimingsTwo);
   });
 });
 
@@ -149,12 +122,9 @@ describe('getLineTimings for getStackLineInfoForCallNode', function () {
     isInverted: boolean
   ) {
     const { stackTable, frameTable, funcTable, samples } = thread;
-    const callNodeInfo = getCallNodeInfo(
-      stackTable,
-      frameTable,
-      funcTable,
-      defaultCat
-    );
+    const callNodeInfo = isInverted
+      ? getInvertedCallNodeInfo(thread, defaultCat)
+      : getCallNodeInfo(stackTable, frameTable, funcTable, defaultCat);
     const callNodeIndex = ensureExists(
       getCallNodeIndexFromPath(callNodePath, callNodeInfo.callNodeTable),
       'invalid call node path'
@@ -163,8 +133,7 @@ describe('getLineTimings for getStackLineInfoForCallNode', function () {
       stackTable,
       frameTable,
       callNodeIndex,
-      callNodeInfo,
-      isInverted
+      callNodeInfo
     );
     return getLineTimings(stackLineInfo, samples);
   }
@@ -269,12 +238,11 @@ describe('getLineTimings for getStackLineInfoForCallNode', function () {
     );
     const defaultCat = categories.findIndex((c) => c.color === 'grey');
 
-    const [{ C, D }] = funcNamesDictPerThread;
+    const [{ A, B, C, D }] = funcNamesDictPerThread;
     const [thread] = profile.threads;
-    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCat);
 
     // For the root D of the inverted tree, we have 3 self line hits.
-    const lineTimingsD = getTimings(invertedThread, [D], defaultCat, true);
+    const lineTimingsD = getTimings(thread, [D], defaultCat, true);
     expect(lineTimingsD.totalLineHits.get(51)).toBe(2);
     expect(lineTimingsD.totalLineHits.get(52)).toBe(1);
     expect(lineTimingsD.totalLineHits.size).toBe(2); // no other hits
@@ -284,9 +252,17 @@ describe('getLineTimings for getStackLineInfoForCallNode', function () {
 
     // For the C call node which is a child (direct caller) of D, we have
     // no self line hit and one hit in line 12.
-    const lineTimingsDC = getTimings(invertedThread, [D, C], defaultCat, true);
+    const lineTimingsDC = getTimings(thread, [D, C], defaultCat, true);
     expect(lineTimingsDC.totalLineHits.get(12)).toBe(1);
     expect(lineTimingsDC.totalLineHits.size).toBe(1); // no other hits
+    expect(lineTimingsDC.selfLineHits.size).toBe(0); // no self line hits
+
+    // For the D <- B <- A call node, we have no self line hit, and one total
+    // hit in line 20. (No self line hit because that sample's self time is
+    // spent in D, not in A.)
+    const lineTimingsDBA = getTimings(thread, [D, B, A], defaultCat, true);
+    expect(lineTimingsDBA.totalLineHits.get(20)).toBe(1);
+    expect(lineTimingsDBA.totalLineHits.size).toBe(1); // no other hits
     expect(lineTimingsDC.selfLineHits.size).toBe(0); // no self line hits
   });
 });

--- a/src/test/unit/line-timings.test.js
+++ b/src/test/unit/line-timings.test.js
@@ -11,7 +11,7 @@ import {
   getLineTimings,
 } from 'firefox-profiler/profile-logic/line-timings';
 import {
-  invertCallstack,
+  computeThreadWithInvertedStackTable,
   getCallNodeInfo,
   getCallNodeIndexFromPath,
 } from '../../profile-logic/profile-data';
@@ -129,7 +129,7 @@ describe('getLineTimings for getStackLineInfo', function () {
 
     const [thread] = profile.threads;
     const defaultCategory = categories.findIndex((c) => c.color === 'grey');
-    const invertedThread = invertCallstack(thread, defaultCategory);
+    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
 
     const lineTimingsOne = getTimings(thread, 'one.js', false);
     const lineTimingsInvertedOne = getTimings(invertedThread, 'one.js', true);
@@ -271,7 +271,7 @@ describe('getLineTimings for getStackLineInfoForCallNode', function () {
 
     const [{ C, D }] = funcNamesDictPerThread;
     const [thread] = profile.threads;
-    const invertedThread = invertCallstack(thread, defaultCat);
+    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCat);
 
     // For the root D of the inverted tree, we have 3 self line hits.
     const lineTimingsD = getTimings(invertedThread, [D], defaultCat, true);

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -13,7 +13,7 @@ import {
 } from '../../profile-logic/process-profile';
 import {
   getCallNodeInfo,
-  invertCallstack,
+  computeThreadWithInvertedStackTable,
   filterThreadByImplementation,
   getCallNodePathFromIndex,
   getSampleIndexClosestToStartTime,
@@ -1200,7 +1200,7 @@ describe('getNativeSymbolsForCallNode', function () {
       'Expected to find categories'
     );
     const defaultCategory = categories.findIndex((c) => c.name === 'Other');
-    const invertedThread = invertCallstack(thread, defaultCategory);
+    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
     const callNodeInfo = getCallNodeInfo(
       invertedThread.stackTable,
       invertedThread.frameTable,

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -13,7 +13,7 @@ import {
 } from '../../profile-logic/process-profile';
 import {
   getCallNodeInfo,
-  computeThreadWithInvertedStackTable,
+  getInvertedCallNodeInfo,
   filterThreadByImplementation,
   getCallNodePathFromIndex,
   getSampleIndexClosestToStartTime,
@@ -1200,13 +1200,7 @@ describe('getNativeSymbolsForCallNode', function () {
       'Expected to find categories'
     );
     const defaultCategory = categories.findIndex((c) => c.name === 'Other');
-    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
-    const callNodeInfo = getCallNodeInfo(
-      invertedThread.stackTable,
-      invertedThread.frameTable,
-      invertedThread.funcTable,
-      defaultCategory
-    );
+    const callNodeInfo = getInvertedCallNodeInfo(thread, defaultCategory);
     const c = getCallNodeIndexFromPath([funC], callNodeInfo.callNodeTable);
     expect(c).not.toBeNull();
 
@@ -1219,8 +1213,8 @@ describe('getNativeSymbolsForCallNode', function () {
         getNativeSymbolsForCallNode(
           ensureExists(c),
           callNodeInfo,
-          invertedThread.stackTable,
-          invertedThread.frameTable
+          thread.stackTable,
+          thread.frameTable
         )
       )
     ).toEqual(new Set([symB, symD]));

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -13,7 +13,7 @@ import {
 import { computeFlameGraphRows } from '../../profile-logic/flame-graph';
 import {
   getCallNodeInfo,
-  invertCallstack,
+  computeThreadWithInvertedStackTable,
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
   filterThreadSamplesToRange,
@@ -470,7 +470,7 @@ describe('inverted call tree', function () {
     });
 
     // Now compute the inverted tree and check it.
-    const invertedThread = invertCallstack(thread, defaultCategory);
+    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
     const invertedCallNodeInfo = getCallNodeInfo(
       invertedThread.stackTable,
       invertedThread.frameTable,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -13,7 +13,7 @@ import {
 import { computeFlameGraphRows } from '../../profile-logic/flame-graph';
 import {
   getCallNodeInfo,
-  computeThreadWithInvertedStackTable,
+  getInvertedCallNodeInfo,
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
   filterThreadSamplesToRange,
@@ -470,24 +470,21 @@ describe('inverted call tree', function () {
     });
 
     // Now compute the inverted tree and check it.
-    const invertedThread = computeThreadWithInvertedStackTable(thread, defaultCategory);
-    const invertedCallNodeInfo = getCallNodeInfo(
-      invertedThread.stackTable,
-      invertedThread.frameTable,
-      invertedThread.funcTable,
+    const invertedCallNodeInfo = getInvertedCallNodeInfo(
+      thread,
       defaultCategory
     );
     const invertedCallTreeTimings = computeCallTreeTimings(
-      invertedThread.samples,
+      thread.samples,
       getSampleIndexToCallNodeIndex(
-        invertedThread.samples.stack,
+        thread.samples.stack,
         invertedCallNodeInfo.stackIndexToCallNodeIndex
       ),
       invertedCallNodeInfo,
       true
     );
     const invertedCallTree = getCallTree(
-      invertedThread,
+      thread,
       invertedCallNodeInfo,
       categories,
       invertedCallTreeTimings,

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -127,26 +127,56 @@ export type CallNodeTable = {
  */
 export type CallNodeInfo = {
   callNodeTable: CallNodeTable,
-  // IndexIntoStackTable -> IndexIntoCallNodeTable
-  stackIndexToCallNodeIndex: Uint32Array,
+  // IndexIntoStackTable -> IndexIntoCallNodeTable | -1
+  // If this CallNodeInfo is for the non-inverted tree, this maps the stack index
+  // to its corresponding call node index, and all entries are >= 0.
+  // If this CallNodeInfo is for the inverted tree, this maps the non-inverted
+  // stack index to the inverted call node index. For example, the stack
+  // A -> B -> C -> D is mapped to the inverted call node describing the
+  // call path D <- C <- B <- A, i.e. the node with function A under the D root
+  // of the inverted tree. Stacks which are only used as prefixes are not mapped
+  // to an inverted call node; for those, the entry will be -1. In the example
+  // above, if the stack node A -> B -> C only exists so that it can be the prefix
+  // of the A -> B -> C -> D stack and no sample / marker / allocation has
+  // A -> B -> C as its stack, then there is no need to have a call node
+  // C <- B <- A in the inverted call node table.
+  stackIndexToCallNodeIndex: Int32Array,
+  // Whether the call node table in this call node info describes the inverted
+  // call tree.
+  isInverted: boolean,
 };
 
 export type LineNumber = number;
 
-// Stores, for all stacks of a thread and for one specific file, the line
-// numbers in that file that are hit by each stack.
-// This can be computed once for a filtered thread, and then queried cheaply
-// as the preview selection changes.
+// Stores the line numbers which are hit by each stack, for one specific source
+// file.
+// Used to compute LineTimings in combination with a SamplesLikeTable.
+//
+// StackLineInfo can be computed once for a filtered thread. Then it is reused
+// for the computation of different LineTimings as the preview selection changes.
+//
 // The order of these arrays is the same as the order of thread.stackTable;
-// the array index is a stackIndex.
+// the array index is a stackIndex. Not all stacks are guaranteed to have a useful
+// value; only stacks which are used as "self" stacks, i.e. stacks which are used
+// in thread.samples.stack or in marker stacks / allocation stacks, are required
+// to have their values computed - only these values will be accessed during the
+// LineTimings computation.
+//
+// For stacks which are only used as prefix stack nodes, selfLine and
+// stackLine may be null. This is fine because their values are not accessed
+// during the LineTimings computation.
 export type StackLineInfo = {|
-  // An array that contains, for each stack, the line number that this stack
+  // An array that contains, for each "self" stack, the line number that this stack
   // spends its self time in, in this file, or null if the self time of the
   // stack is in a different file or if the line number is not known.
+  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
+  // never referred to from a SamplesLikeTable, the value may be null.
   selfLine: Array<LineNumber | null>,
-  // An array that contains, for each stack, all the lines that the frames in
+  // An array that contains, for each "self" stack, all the lines that the frames in
   // this stack hit in this file, or null if this stack does not hit any line
   // in the given file.
+  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
+  // never referred to from a SamplesLikeTable, the value may be null.
   stackLines: Array<Set<LineNumber> | null>,
 |};
 
@@ -158,20 +188,35 @@ export type LineTimings = {|
   selfLineHits: Map<LineNumber, number>,
 |};
 
-// Stores, for all stacks of a thread and for one specific file, the addresses
-// in that file that are hit by each stack.
-// This can be computed once for a filtered thread, and then queried cheaply
-// as the preview selection changes.
+// Stores the addresses which are hit by each stack, for addresses belonging to
+// one specific native symbol.
+// Used to compute AddressTimings in combination with a SamplesLikeTable.
+//
+// StackAddressInfo can be computed once for a filtered thread. Then it is reused
+// for the computation of different AddressTimings as the preview selection changes.
+//
 // The order of these arrays is the same as the order of thread.stackTable;
-// the array index is a stackIndex.
+// the array index is a stackIndex. Not all stacks are guaranteed to have a useful
+// value; only stacks which are used as "self" stacks, i.e. stacks which are used
+// in thread.samples.stack or in marker stacks / allocation stacks, are required
+// to have their values computed - only these values will be accessed during the
+// AddressTimings computation.
+//
+// For stacks which are only used as prefix stack nodes, selfAddress and
+// stackAddress may be null. This is fine because their values are not accessed
+// during the AddressTimings computation.
 export type StackAddressInfo = {|
-  // An array that contains, for each stack, the address that this stack
-  // spends its self time in, in this library, or null if the self time of the
-  // stack is in a different library or if the address is not known.
+  // An array that contains, for each "self" stack, the address that this stack
+  // spends its self time in, in this native symbol, or null if the self time of
+  // the stack is in a different native symbol or if the address is not known.
+  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
+  // never referred to from a SamplesLikeTable, the value may be null.
   selfAddress: Array<Address | null>,
-  // An array that contains, for each stack, all the addresses that the frames
-  // in this stack hit in this library, or null if this stack does not hit any
-  // address in the given library.
+  // An array that contains, for each "self" stack, all the addresses that the
+  // frames in this stack hit in this native symbol, or null if this stack does
+  // not hit any address in the given native symbol.
+  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
+  // never referred to from a SamplesLikeTable, the value may be null.
   stackAddresses: Array<Set<Address> | null>,
 |};
 


### PR DESCRIPTION
This is the first step on the long road to a faster inverted call tree.

With this change, we still build an inverted call node table. But the thread remains untouched.
This means that the stackTable and the callNodeTable are upside down with respect to each other when the call tree is inverted. This can be a bit confusing.

Some code needs to match non-inverted stacks to inverted call nodes. For these purposes, a StackToInvertedCallNodeMatcher class is introduced.

Some address timings / line timings code is now unnecessary, specifically the code that was computing global information (and not information about a single call node) with special treatment for the inverted case.
The unnecessary inverted case implementation was removed.