### PR TITLE
Reduce the time of switching to the stack chart tab for the first time

### DIFF
--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -71,7 +71,7 @@ type StateProps = {|
   +disableOverscan: boolean,
   +invertCallstack: boolean,
   +implementationFilter: ImplementationFilter,
-  +callNodeMaxDepth: number,
+  +callNodeMaxDepthPlusOne: number,
   +weightType: WeightType,
   +tableViewOptions: TableViewOptions,
 |};
@@ -359,7 +359,7 @@ class CallTreeImpl extends PureComponent<Props> {
       expandedCallNodeIndexes,
       searchStringsRegExp,
       disableOverscan,
-      callNodeMaxDepth,
+      callNodeMaxDepthPlusOne,
       weightType,
       tableViewOptions,
       onTableViewOptionsChange,
@@ -383,7 +383,7 @@ class CallTreeImpl extends PureComponent<Props> {
         disableOverscan={disableOverscan}
         ref={this._takeTreeViewRef}
         contextMenuId="CallNodeContextMenu"
-        maxNodeDepth={callNodeMaxDepth}
+        maxNodeDepth={callNodeMaxDepthPlusOne}
         rowHeight={16}
         indentWidth={10}
         onKeyDown={this._onKeyDown}
@@ -417,8 +417,8 @@ export const CallTree = explicitConnect<{||}, StateProps, DispatchProps>({
     // Use the filtered call node max depth, rather than the preview filtered call node
     // max depth so that the width of the TreeView component is stable across preview
     // selections.
-    callNodeMaxDepth:
-      selectedThreadSelectors.getFilteredCallNodeMaxDepth(state),
+    callNodeMaxDepthPlusOne:
+      selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(state),
     weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),
     tableViewOptions: getCurrentTableViewOptions(state),
   }),

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -72,7 +72,7 @@ type StateProps = {|
   +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +unfilteredThread: Thread,
   +sampleIndexOffset: number,
-  +maxStackDepth: number,
+  +maxStackDepthPlusOne: number,
   +timeRange: StartEndRange,
   +previewSelection: PreviewSelection,
   +flameGraphTiming: FlameGraphTiming,
@@ -327,7 +327,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
       unfilteredThread,
       sampleIndexOffset,
       threadsKey,
-      maxStackDepth,
+      maxStackDepthPlusOne,
       flameGraphTiming,
       callTree,
       callNodeInfo,
@@ -349,7 +349,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
       displayStackType,
     } = this.props;
 
-    const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
+    const maxViewportHeight = maxStackDepthPlusOne * STACK_FRAME_HEIGHT;
 
     return (
       <div className="flameGraphContent" onKeyDown={this._handleKeyDown}>
@@ -381,7 +381,7 @@ class FlameGraphImpl extends React.PureComponent<Props> {
               weightType,
               unfilteredThread,
               sampleIndexOffset,
-              maxStackDepth,
+              maxStackDepthPlusOne,
               flameGraphTiming,
               callTree,
               callNodeInfo,
@@ -427,7 +427,8 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
       selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(state),
     // Use the filtered call node max depth, rather than the preview filtered one, so
     // that the viewport height is stable across preview selections.
-    maxStackDepth: selectedThreadSelectors.getFilteredCallNodeMaxDepth(state),
+    maxStackDepthPlusOne:
+      selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(state),
     flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
     callTree: selectedThreadSelectors.getCallTree(state),
     timeRange: getCommittedRange(state),

--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -76,8 +76,9 @@ export const MaybeFlameGraph = explicitConnect<{||}, StateProps, DispatchProps>(
       return {
         invertCallstack: getInvertCallstack(state),
         isPreviewSelectionEmpty:
-          selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(state) ===
-          0,
+          selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
+            state
+          ) === 0,
       };
     },
     mapDispatchToProps: {

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -72,7 +72,7 @@ type StateProps = {|
   +thread: Thread,
   +weightType: WeightType,
   +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
-  +maxStackDepth: number,
+  +maxStackDepthPlusOne: number,
   +combinedTimingRows: CombinedTimingRows,
   +timeRange: StartEndRange,
   +interval: Milliseconds,
@@ -210,7 +210,7 @@ class StackChartImpl extends React.PureComponent<Props> {
     const {
       thread,
       threadsKey,
-      maxStackDepth,
+      maxStackDepthPlusOne,
       combinedTimingRows,
       timeRange,
       interval,
@@ -229,7 +229,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       displayStackType,
     } = this.props;
 
-    const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
+    const maxViewportHeight = maxStackDepthPlusOne * STACK_FRAME_HEIGHT;
 
     return (
       <div
@@ -240,7 +240,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       >
         <StackSettings hideInvertCallstack={true} />
         <TransformNavigator />
-        {maxStackDepth === 0 && userTimings.length === 0 ? (
+        {maxStackDepthPlusOne === 0 && userTimings.length === 0 ? (
           <StackChartEmptyReasons />
         ) : (
           <ContextMenuTrigger
@@ -306,7 +306,8 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       thread: selectedThreadSelectors.getFilteredThread(state),
       // Use the raw WeightType here, as the stack chart does not use the call tree
       weightType: selectedThreadSelectors.getSamplesWeightType(state),
-      maxStackDepth: selectedThreadSelectors.getFilteredCallNodeMaxDepth(state),
+      maxStackDepthPlusOne:
+        selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(state),
       combinedTimingRows,
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -430,6 +430,7 @@ export function getEmptyCallNodeTable(): CallNodeTable {
     innerWindowID: new Float64Array(0),
     sourceFramesInlinedIntoSymbol: [],
     depth: [],
+    maxDepth: -1,
     length: 0,
   };
 }

--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -92,11 +92,10 @@ export function computeFlameGraphRows(
     return [[]];
   }
 
-  const { func, nextSibling, subtreeRangeEnd } = callNodeTable;
+  const { func, nextSibling, subtreeRangeEnd, maxDepth } = callNodeTable;
   const funcTableNameColumn = funcTable.name;
 
-  // flameGraphRows is what we'll return from this function. We add a row to
-  // flameGraphRows any time we go to a deeper level than flameGraphRows.length - 1.
+  // flameGraphRows is what we'll return from this function.
   //
   // Each row is conceptually partitioned into two parts: "Finished nodes" and
   // "pending nodes".
@@ -114,8 +113,8 @@ export function computeFlameGraphRows(
   // children.
   // We need to queue up nodes before we can process their children because
   // we can only process children once their parents are in the right order.
-  const flameGraphRows = [[]];
-  const pendingRangeStartAtDepth = [0];
+  const flameGraphRows = Array.from({ length: maxDepth + 1 }, () => []);
+  const pendingRangeStartAtDepth = new Int32Array(maxDepth + 1);
 
   // At the beginning of each turn of this loop, add currentCallNode and all its
   // siblings as "pending" to row[currentDepth], ordered by name. Then find the
@@ -219,13 +218,6 @@ export function computeFlameGraphRows(
     // the first child of x (if present) is always at x + 1.
     currentCallNode = candidateNode + 1; // "currentCallNode = firstChild[candidateNode];"
     currentDepth = candidateDepth + 1;
-
-    // Make sure flameGraphRows and pendingRangeStartAtDepth are initialized for
-    // the new currentDepth.
-    if (currentDepth === flameGraphRows.length) {
-      flameGraphRows[currentDepth] = [];
-      pendingRangeStartAtDepth[currentDepth] = 0;
-    }
   }
 
   return flameGraphRows;

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2050,22 +2050,24 @@ export function convertStackToCallNodeAndCategoryPath(
 }
 
 /**
- * Compute maximum depth of call stack for a given thread.
+ * Compute maximum depth of call stack for a given thread, and return maxDepth+1.
+ * This value can be used as the length for any per-depth arrays.
  *
- * Returns the depth of the deepest call node, but with a one-based
- * depth instead of a zero-based.
+ * The depth for a root node is zero.
+ * So if you only a single sample whose call node is a root node, this function
+ * returns 1.
  *
- * If there are no samples, or the stacks are all filtered out for the samples, then
- * 0 is returned.
+ * If there are no samples, or the stacks are all filtered out for the samples,
+ * then 0 is returned.
  */
-export function computeCallNodeMaxDepth(
+export function computeCallNodeMaxDepthPlusOne(
   samples: SamplesLikeTable,
   callNodeInfo: CallNodeInfo
 ): number {
   // Compute the depth on a per-sample basis. This is done since the callNodeInfo is
   // computed for the filtered thread, but a samples-like table can use the preview
   // filtered thread, which involves a subset of the total call nodes.
-  let max = -1;
+  let maxDepth = -1;
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
     const stackIndex = samples.stack[sampleIndex];
@@ -2074,10 +2076,12 @@ export function computeCallNodeMaxDepth(
     }
     const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
     const depth = callNodeTable.depth[callNodeIndex];
-    max = Math.max(max, depth);
+    if (depth > maxDepth) {
+      maxDepth = depth;
+    }
   }
 
-  return max + 1;
+  return maxDepth + 1;
 }
 
 export function invertCallstack(

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -308,6 +308,7 @@ function _createCallNodeInfoFromUnorderedComponents(
     const innerWindowIDSorted = new Float64Array(length);
     const sourceFramesInlinedIntoSymbolSorted = new Array(length);
     const depthSorted = new Array(length);
+    let maxDepth = 0;
 
     // Traverse the entire tree, as follows:
     //  1. nextOldIndex is the next node in DFS order. Copy over all values from
@@ -347,6 +348,9 @@ function _createCallNodeInfoFromUnorderedComponents(
         currentNewPrefix = newIndex;
         nextOldIndex = oldFirstChild;
         currentDepth++;
+        if (currentDepth > maxDepth) {
+          maxDepth = currentDepth;
+        }
         continue;
       }
 
@@ -378,6 +382,7 @@ function _createCallNodeInfoFromUnorderedComponents(
       innerWindowID: innerWindowIDSorted,
       sourceFramesInlinedIntoSymbol: sourceFramesInlinedIntoSymbolSorted,
       depth: depthSorted,
+      maxDepth,
       length,
     };
 

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -68,11 +68,11 @@ type LastSeen = {
 export function getStackTimingByDepth(
   samples: SamplesLikeTable,
   callNodeInfo: CallNodeInfo,
-  maxDepth: number,
+  maxDepthPlusOne: number,
   interval: Milliseconds
 ): StackTimingByDepth {
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
-  const stackTimingByDepth = Array.from({ length: maxDepth }, () => ({
+  const stackTimingByDepth = Array.from({ length: maxDepthPlusOne }, () => ({
     start: [],
     end: [],
     callNode: [],

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -7,7 +7,6 @@ import type {
   SamplesLikeTable,
   Milliseconds,
   CallNodeInfo,
-  CallNodeTable,
   IndexIntoCallNodeTable,
 } from 'firefox-profiler/types';
 /**
@@ -57,21 +56,22 @@ export type StackTiming = {|
 
 export type StackTimingByDepth = Array<StackTiming>;
 
-type LastSeen = {
-  startTimeByDepth: number[],
-  callNodeIndexByDepth: IndexIntoCallNodeTable[],
-};
-
 /**
  * Build a StackTimingByDepth table from a given thread.
  */
 export function getStackTimingByDepth(
   samples: SamplesLikeTable,
+  sampleCallNodes: Array<IndexIntoCallNodeTable | null>,
   callNodeInfo: CallNodeInfo,
   maxDepthPlusOne: number,
   interval: Milliseconds
 ): StackTimingByDepth {
-  const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
+  const { callNodeTable } = callNodeInfo;
+  const {
+    prefix: callNodeTablePrefixColumn,
+    subtreeRangeEnd: callNodeTableSubtreeRangeEndColumn,
+    depth: callNodeTableDepthColumn,
+  } = callNodeTable;
   const stackTimingByDepth = Array.from({ length: maxDepthPlusOne }, () => ({
     start: [],
     end: [],
@@ -79,113 +79,100 @@ export function getStackTimingByDepth(
     length: 0,
   }));
 
-  const lastSeen: LastSeen = {
-    startTimeByDepth: [],
-    callNodeIndexByDepth: [],
-  };
-
-  // Go through each sample, and push/pop it on the stack to build up
-  // the stackTimingByDepth.
-  let previousDepth = -1;
-  for (let i = 0; i < samples.length; i++) {
-    const stackIndex = samples.stack[i];
-    const sampleTime = samples.time[i];
-
-    // If this stack index is null (for instance if it was filtered out) then pop back
-    // down to the base stack.
-    if (stackIndex === null) {
-      _popStacks(stackTimingByDepth, lastSeen, -1, previousDepth, sampleTime);
-      previousDepth = -1;
-    } else {
-      const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
-      const depth = callNodeTable.depth[callNodeIndex];
-
-      // Find the depth of the nearest shared stack.
-      const depthToPop = _findNearestSharedCallNodeDepth(
-        callNodeTable,
-        callNodeIndex,
-        lastSeen,
-        depth
-      );
-      _popStacks(
-        stackTimingByDepth,
-        lastSeen,
-        depthToPop,
-        previousDepth,
-        sampleTime
-      );
-      _pushStacks(callNodeTable, lastSeen, depth, callNodeIndex, sampleTime);
-      previousDepth = depth;
-    }
+  if (samples.length === 0) {
+    return stackTimingByDepth;
   }
 
-  // Pop the remaining stacks
-  const lastIndex = samples.length - 1;
-  const endingTime = samples.time[lastIndex] + interval;
-  _popStacks(stackTimingByDepth, lastSeen, -1, previousDepth, endingTime);
+  // Overview of the algorithm:
+  // We go sample by sample.
+  // At the end of each iteration, we have a stack of "open boxes" which are
+  // available for sharing with the next sample; each open box has a call node
+  // and a start time. The number of open boxes matches the length of the call
+  // path.
+  // At the beginning of each iteration, we pick which of the open boxes from
+  // the previous sample we want to share (these boxes remain "open") and which
+  // ones we can't share.
+  // The ones we can't share need to be "committed", i.e. added to stackTimingByDepth.
+  // We share the boxes whose call nodes are ancestors of the current sample's
+  // call node, and commit the rest. Then we open new boxes for the unshared part
+  // of the current sample's call node path.
+
+  // We remember the stack of open boxes by remembering only the deepest call
+  // node; and the start time for each box in the stack.
+  // The call nodes of the remaining "open boxes" are implicit; i.e. the call
+  // node of the open box at depth d is the ancestor at depth d of
+  // deepestOpenBoxCallNodeIndex.
+  let deepestOpenBoxCallNodeIndex = -1;
+  let deepestOpenBoxDepth = -1;
+  const openBoxStartTimeByDepth = new Float32Array(maxDepthPlusOne);
+
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+    const sampleTime = samples.time[sampleIndex];
+    const thisCallNodeIndex = sampleCallNodes[sampleIndex] ?? -1;
+    if (thisCallNodeIndex === deepestOpenBoxCallNodeIndex) {
+      continue;
+    }
+
+    // Phase 1: Commit open boxes which are not shared by the current call node,
+    // i.e. any boxes whose call nodes are not ancestors of the current call node.
+    // These unshared boxes will be committed and added to stackTimingForThisDepth.
+    //
+    // We walk up from the previous sample's depth until we find the lowest
+    // common ancestor with the current sample's call node, commiting all boxes
+    // along the way.
+    //
+    // Here we use the call node table ordering for a cheap "is in subtree of" check.
+    // Any boxes which can stay open are the ones whose call nodes contain
+    // thisCallNodeIndex in their subtree, i.e. the ones which are ancestors af
+    // thisCallNodeIndex.
+    while (
+      deepestOpenBoxDepth !== -1 &&
+      (thisCallNodeIndex < deepestOpenBoxCallNodeIndex ||
+        thisCallNodeIndex >=
+          callNodeTableSubtreeRangeEndColumn[deepestOpenBoxCallNodeIndex])
+    ) {
+      // deepestOpenBoxCallNodeIndex is *not* an ancestors of thisCallNodeIndex.
+      // Commit this box.
+      const start = openBoxStartTimeByDepth[deepestOpenBoxDepth];
+      const stackTimingForThisDepth = stackTimingByDepth[deepestOpenBoxDepth];
+      const index = stackTimingForThisDepth.length++;
+      stackTimingForThisDepth.start[index] = start;
+      stackTimingForThisDepth.end[index] = sampleTime;
+      stackTimingForThisDepth.callNode[index] = deepestOpenBoxCallNodeIndex;
+      deepestOpenBoxCallNodeIndex =
+        callNodeTablePrefixColumn[deepestOpenBoxCallNodeIndex];
+      deepestOpenBoxDepth--;
+    }
+
+    // Phase 2: Enter new boxes for the current call node.
+    // New boxes start from depth `deepestOpenBoxDepth`, which is the depth of
+    // the lowest common ancestor of thisCallNodeIndex and the previous sample's
+    // call node. We "open" boxes going down all the way to thisCallNodeIndex.
+    if (thisCallNodeIndex !== -1) {
+      const thisCallNodeDepth = callNodeTableDepthColumn[thisCallNodeIndex];
+      while (deepestOpenBoxDepth < thisCallNodeDepth) {
+        deepestOpenBoxDepth++;
+        openBoxStartTimeByDepth[deepestOpenBoxDepth] = sampleTime;
+      }
+    }
+
+    deepestOpenBoxCallNodeIndex = thisCallNodeIndex;
+  }
+
+  // We've processed all samples.
+  // Commit the boxes that were left open by the last sample.
+  const endTime = samples.time[samples.length - 1] + interval;
+  while (deepestOpenBoxDepth !== -1) {
+    const stackTimingForThisDepth = stackTimingByDepth[deepestOpenBoxDepth];
+    const index = stackTimingForThisDepth.length++;
+    const start = openBoxStartTimeByDepth[deepestOpenBoxDepth];
+    stackTimingForThisDepth.start[index] = start;
+    stackTimingForThisDepth.end[index] = endTime;
+    stackTimingForThisDepth.callNode[index] = deepestOpenBoxCallNodeIndex;
+    deepestOpenBoxCallNodeIndex =
+      callNodeTablePrefixColumn[deepestOpenBoxCallNodeIndex];
+    deepestOpenBoxDepth--;
+  }
 
   return stackTimingByDepth;
-}
-
-function _findNearestSharedCallNodeDepth(
-  callNodeTable: CallNodeTable,
-  callNodeIndex: IndexIntoCallNodeTable,
-  lastSeen: LastSeen,
-  depthStart: number
-): number {
-  let nextCallNodeIndex = callNodeIndex;
-  for (let depth = depthStart; depth >= 0; depth--) {
-    if (lastSeen.callNodeIndexByDepth[depth] === nextCallNodeIndex) {
-      return depth;
-    }
-    nextCallNodeIndex = callNodeTable.prefix[nextCallNodeIndex];
-  }
-  return -1;
-}
-
-function _popStacks(
-  stackTimingByDepth: StackTimingByDepth,
-  lastSeen: LastSeen,
-  depth: number,
-  previousDepth: number,
-  sampleTime: number
-) {
-  // "Pop" off the stack, and commit the timing of the frames
-  for (let stackDepth = depth + 1; stackDepth <= previousDepth; stackDepth++) {
-    // Push on the new information.
-    stackTimingByDepth[stackDepth].start.push(
-      lastSeen.startTimeByDepth[stackDepth]
-    );
-    stackTimingByDepth[stackDepth].end.push(sampleTime);
-    stackTimingByDepth[stackDepth].callNode.push(
-      lastSeen.callNodeIndexByDepth[stackDepth]
-    );
-    stackTimingByDepth[stackDepth].length++;
-
-    // Delete that this stack frame has been seen.
-    delete lastSeen.callNodeIndexByDepth[stackDepth];
-    delete lastSeen.startTimeByDepth[stackDepth];
-  }
-}
-
-function _pushStacks(
-  callNodeTable: CallNodeTable,
-  lastSeen: LastSeen,
-  depth: number,
-  startingCallNodeIndex: IndexIntoCallNodeTable,
-  sampleTime: number
-) {
-  let callNodeIndex = startingCallNodeIndex;
-  // "Push" onto the stack with new frames
-  for (let parentDepth = depth; parentDepth >= 0; parentDepth--) {
-    if (
-      callNodeIndex === -1 ||
-      lastSeen.callNodeIndexByDepth[parentDepth] !== undefined
-    ) {
-      break;
-    }
-    lastSeen.callNodeIndexByDepth[parentDepth] = callNodeIndex;
-    lastSeen.startTimeByDepth[parentDepth] = sampleTime;
-    callNodeIndex = callNodeTable.prefix[callNodeIndex];
-  }
 }

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -271,17 +271,18 @@ export function getStackAndSampleSelectorsPerThread(
     ProfileData.getTreeOrderComparator
   );
 
-  const getFilteredCallNodeMaxDepth: Selector<number> = createSelector(
+  const getFilteredCallNodeMaxDepthPlusOne: Selector<number> = createSelector(
     threadSelectors.getFilteredSamplesForCallTree,
     getCallNodeInfo,
-    ProfileData.computeCallNodeMaxDepth
+    ProfileData.computeCallNodeMaxDepthPlusOne
   );
 
-  const getPreviewFilteredCallNodeMaxDepth: Selector<number> = createSelector(
-    threadSelectors.getPreviewFilteredSamplesForCallTree,
-    getCallNodeInfo,
-    ProfileData.computeCallNodeMaxDepth
-  );
+  const getPreviewFilteredCallNodeMaxDepthPlusOne: Selector<number> =
+    createSelector(
+      threadSelectors.getPreviewFilteredSamplesForCallTree,
+      getCallNodeInfo,
+      ProfileData.computeCallNodeMaxDepthPlusOne
+    );
 
   /**
    * When computing the call tree, a "samples" table is used, which
@@ -350,7 +351,7 @@ export function getStackAndSampleSelectorsPerThread(
     createSelector(
       threadSelectors.getFilteredSamplesForCallTree,
       getCallNodeInfo,
-      getFilteredCallNodeMaxDepth,
+      getFilteredCallNodeMaxDepthPlusOne,
       ProfileSelectors.getProfileInterval,
       StackTiming.getStackTimingByDepth
     );
@@ -409,8 +410,8 @@ export function getStackAndSampleSelectorsPerThread(
     getAssemblyViewAddressTimings,
     getTracedTiming,
     getStackTimingByDepth,
-    getFilteredCallNodeMaxDepth,
-    getPreviewFilteredCallNodeMaxDepth,
+    getFilteredCallNodeMaxDepthPlusOne,
+    getPreviewFilteredCallNodeMaxDepthPlusOne,
     getFlameGraphTiming,
     getRightClickedCallNodeIndex,
   };

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -350,6 +350,7 @@ export function getStackAndSampleSelectorsPerThread(
   const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> =
     createSelector(
       threadSelectors.getFilteredSamplesForCallTree,
+      getSampleIndexToCallNodeIndexForFilteredThread,
       getCallNodeInfo,
       getFilteredCallNodeMaxDepthPlusOne,
       ProfileSelectors.getProfileInterval,

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -2225,6 +2225,7 @@ Object {
       0,
     ],
     "length": 8,
+    "maxDepth": 3,
     "nextSibling": Int32Array [
       -1,
       -1,
@@ -2344,6 +2345,7 @@ CallTree {
         0,
       ],
       "length": 8,
+      "maxDepth": 3,
       "nextSibling": Int32Array [
         -1,
         -1,
@@ -2480,6 +2482,7 @@ CallTree {
       0,
     ],
     "length": 8,
+    "maxDepth": 3,
     "nextSibling": Int32Array [
       -1,
       -1,

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -279,7 +279,7 @@ describe('selectors/getFlameGraphTiming', function () {
   });
 });
 
-describe('selectors/getCallNodeMaxDepthForFlameGraph', function () {
+describe('selectors/getCallNodeMaxDepthPlusOneForFlameGraph', function () {
   it('calculates the max call node depth', function () {
     const { profile } = getProfileFromTextSamples(`
       A  A  A
@@ -290,7 +290,7 @@ describe('selectors/getCallNodeMaxDepthForFlameGraph', function () {
 
     const store = storeWithProfile(profile);
     const allSamplesMaxDepth =
-      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
+      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
         store.getState()
       );
     expect(allSamplesMaxDepth).toEqual(4);
@@ -300,7 +300,7 @@ describe('selectors/getCallNodeMaxDepthForFlameGraph', function () {
     const { profile } = getProfileFromTextSamples(` `);
     const store = storeWithProfile(profile);
     const allSamplesMaxDepth =
-      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(
+      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
         store.getState()
       );
     expect(allSamplesMaxDepth).toEqual(0);

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1816,17 +1816,19 @@ describe('snapshots of selectors/profile', function () {
     ).toMatchSnapshot();
   });
 
-  it('matches the last stored run of selectedThreadSelector.getFilteredCallNodeMaxDepth', function () {
+  it('matches the last stored run of selectedThreadSelector.getFilteredCallNodeMaxDepthPlusOne', function () {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getFilteredCallNodeMaxDepth(getState())
+      selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(getState())
     ).toEqual(4);
   });
 
-  it('matches the last stored run of selectedThreadSelector.getPreviewFilteredCallNodeMaxDepth', function () {
+  it('matches the last stored run of selectedThreadSelector.getPreviewFilteredCallNodeMaxDepthPlusOne', function () {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepth(getState())
+      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
+        getState()
+      )
     ).toEqual(4);
   });
 

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -115,6 +115,9 @@ export type CallNodeTable = {
   sourceFramesInlinedIntoSymbol: Array<IndexIntoNativeSymbolTable | -1 | null>,
   // The depth of the call node. Roots have depth 0.
   depth: number[],
+  // The maximum value in the depth column, or -1 if this table is empty.
+  maxDepth: number,
+  // The number of call nodes. All columns in this table have this length.
   length: number,
 };
 


### PR DESCRIPTION
On [this profile](https://share.firefox.dev/3N56qMu), switching to the stack chart tab for the first time has a delay of 1.5 seconds.

[Production](https://share.firefox.dev/3N56qMu) | [Deploy preview](https://deploy-preview-4825--perf-html.netlify.app/public/yys1g46mp9bqebf3e53x9j70gsbhj5gwdbd0be8/calltree/?globalTrackOrder=0&profileName=Firefox%20Sp3-BrowserWin-Nov9&thread=0&v=10)

This PR reduces that time by a factor of 3.4x.

Before: https://share.firefox.dev/47CvQto (1471ms)
After: https://share.firefox.dev/47z8Ewb (429ms, 3.4x faster)