### PR TITLE
Speed up switching to the JS-only view

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1082,44 +1082,31 @@ export function toValidCallTreeSummaryStrategy(
 
 export function filterThreadByImplementation(
   thread: Thread,
-  implementation: string,
-  defaultCategory: IndexIntoCategoryList
+  implementation: string
 ): Thread {
   const { funcTable, stringTable } = thread;
 
   switch (implementation) {
     case 'cpp':
-      return _filterThreadByFunc(
-        thread,
-        (funcIndex) => {
-          // Return quickly if this is a JS frame.
-          if (funcTable.isJS[funcIndex]) {
-            return false;
-          }
-          // Regular C++ functions are associated with a resource that describes the
-          // shared library that these C++ functions were loaded from. Jitcode is not
-          // loaded from shared libraries but instead generated at runtime, so Jitcode
-          // frames are not associated with a shared library and thus have no resource
-          const locationString = stringTable.getString(
-            funcTable.name[funcIndex]
-          );
-          const isProbablyJitCode =
-            funcTable.resource[funcIndex] === -1 &&
-            locationString.startsWith('0x');
-          return !isProbablyJitCode;
-        },
-        defaultCategory
-      );
+      return _filterThreadByFunc(thread, (funcIndex) => {
+        // Return quickly if this is a JS frame.
+        if (funcTable.isJS[funcIndex]) {
+          return false;
+        }
+        // Regular C++ functions are associated with a resource that describes the
+        // shared library that these C++ functions were loaded from. Jitcode is not
+        // loaded from shared libraries but instead generated at runtime, so Jitcode
+        // frames are not associated with a shared library and thus have no resource
+        const locationString = stringTable.getString(funcTable.name[funcIndex]);
+        const isProbablyJitCode =
+          funcTable.resource[funcIndex] === -1 &&
+          locationString.startsWith('0x');
+        return !isProbablyJitCode;
+      });
     case 'js':
-      return _filterThreadByFunc(
-        thread,
-        (funcIndex) => {
-          return (
-            funcTable.isJS[funcIndex] || funcTable.relevantForJS[funcIndex]
-          );
-        },
-        defaultCategory
-      );
+      return _filterThreadByFunc(thread, (funcIndex) => {
+        return funcTable.isJS[funcIndex] || funcTable.relevantForJS[funcIndex];
+      });
     default:
       return thread;
   }
@@ -1127,10 +1114,9 @@ export function filterThreadByImplementation(
 
 function _filterThreadByFunc(
   thread: Thread,
-  filter: (IndexIntoFuncTable) => boolean,
-  defaultCategory: IndexIntoCallNodeTable
+  shouldIncludeFuncInFilteredThread: (IndexIntoFuncTable) => boolean
 ): Thread {
-  return timeCode('filterThread', () => {
+  return timeCode('_filterThreadByFunc', () => {
     const { stackTable, frameTable } = thread;
 
     const newStackTable = {
@@ -1140,55 +1126,34 @@ function _filterThreadByFunc(
       category: [],
       subcategory: [],
     };
+    const oldStackToNewStack = new Int32Array(stackTable.length);
 
-    const oldStackToNewStack = new Map();
-    const frameCount = frameTable.length;
-    const prefixStackAndFrameToStack = new Map(); // prefixNewStack * frameCount + frame => newStackIndex
-
-    function convertStack(stackIndex) {
-      if (stackIndex === null) {
-        return null;
+    for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
+      const oldPrefix = stackTable.prefix[stackIndex];
+      const frame = stackTable.frame[stackIndex];
+      const func = frameTable.func[frame];
+      const newPrefix = oldPrefix === null ? -1 : oldStackToNewStack[oldPrefix];
+      if (shouldIncludeFuncInFilteredThread(func)) {
+        const newStackIndex = newStackTable.length++;
+        newStackTable.frame[newStackIndex] = frame;
+        newStackTable.prefix[newStackIndex] =
+          newPrefix !== -1 ? newPrefix : null;
+        newStackTable.category[newStackIndex] = stackTable.category[stackIndex];
+        newStackTable.subcategory[newStackIndex] =
+          stackTable.subcategory[stackIndex];
+        oldStackToNewStack[stackIndex] = newStackIndex;
+      } else {
+        oldStackToNewStack[stackIndex] = newPrefix;
       }
-      let newStack = oldStackToNewStack.get(stackIndex);
-      if (newStack === undefined) {
-        const prefixNewStack = convertStack(stackTable.prefix[stackIndex]);
-        const frameIndex = stackTable.frame[stackIndex];
-        const funcIndex = frameTable.func[frameIndex];
-        if (filter(funcIndex)) {
-          const prefixStackAndFrameIndex =
-            (prefixNewStack === null ? -1 : prefixNewStack) * frameCount +
-            frameIndex;
-          newStack = prefixStackAndFrameToStack.get(prefixStackAndFrameIndex);
-          if (newStack === undefined) {
-            newStack = newStackTable.length++;
-            newStackTable.prefix[newStack] = prefixNewStack;
-            newStackTable.frame[newStack] = frameIndex;
-            newStackTable.category[newStack] = stackTable.category[stackIndex];
-            newStackTable.subcategory[newStack] =
-              stackTable.subcategory[stackIndex];
-          } else if (
-            newStackTable.category[newStack] !== stackTable.category[stackIndex]
-          ) {
-            // Conflicting origin stack categories -> default category + subcategory.
-            newStackTable.category[newStack] = defaultCategory;
-            newStackTable.subcategory[newStack] = 0;
-          } else if (
-            newStackTable.subcategory[stackIndex] !==
-            stackTable.subcategory[stackIndex]
-          ) {
-            // Conflicting origin stack subcategories -> "Other" subcategory.
-            newStackTable.subcategory[stackIndex] = 0;
-          }
-          oldStackToNewStack.set(stackIndex, newStack);
-          prefixStackAndFrameToStack.set(prefixStackAndFrameIndex, newStack);
-        } else {
-          newStack = prefixNewStack;
-        }
-      }
-      return newStack;
     }
 
-    return updateThreadStacks(thread, newStackTable, convertStack);
+    return updateThreadStacks(thread, newStackTable, (oldStack) => {
+      if (oldStack === null) {
+        return null;
+      }
+      const newStack = oldStackToNewStack[oldStack];
+      return newStack !== -1 ? newStack : null;
+    });
   });
 }
 

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -454,7 +454,6 @@ export function getThreadSelectorsWithMarkersPerThread(
   const _getImplementationFilteredThread: Selector<Thread> = createSelector(
     getRangeAndTransformFilteredThread,
     UrlState.getImplementationFilter,
-    ProfileSelectors.getDefaultCategory,
     ProfileData.filterThreadByImplementation
   );
 

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -714,10 +714,6 @@ describe('symbolication', function () {
 
 describe('filter-by-implementation', function () {
   const profile = processGeckoProfile(createGeckoProfileWithJsTimings());
-  const defaultCategory = ensureExists(
-    profile.meta.categories,
-    'Expected to find categories'
-  ).findIndex((c) => c.name === 'Other');
   const thread = profile.threads[0];
 
   function stackIsJS(filteredThread, stackIndex) {
@@ -730,17 +726,11 @@ describe('filter-by-implementation', function () {
   }
 
   it('will return the same thread if filtering to "all"', function () {
-    expect(
-      filterThreadByImplementation(thread, 'combined', defaultCategory)
-    ).toEqual(thread);
+    expect(filterThreadByImplementation(thread, 'combined')).toEqual(thread);
   });
 
   it('will return only JS samples if filtering to "js"', function () {
-    const jsOnlyThread = filterThreadByImplementation(
-      thread,
-      'js',
-      defaultCategory
-    );
+    const jsOnlyThread = filterThreadByImplementation(thread, 'js');
     const nonNullSampleStacks = jsOnlyThread.samples.stack.filter(
       (stack) => stack !== null
     );
@@ -753,11 +743,7 @@ describe('filter-by-implementation', function () {
   });
 
   it('will return only C++ samples if filtering to "cpp"', function () {
-    const cppOnlyThread = filterThreadByImplementation(
-      thread,
-      'cpp',
-      defaultCategory
-    );
+    const cppOnlyThread = filterThreadByImplementation(thread, 'cpp');
     const nonNullSampleStacks = cppOnlyThread.samples.stack.filter(
       (stack) => stack !== null
     );
@@ -775,16 +761,8 @@ describe('get-sample-index-closest-to-time', function () {
     const { profile } = getProfileFromTextSamples(
       Array(10).fill('A').join('  ')
     );
-    const defaultCategory = ensureExists(
-      profile.meta.categories,
-      'Expected to find categories'
-    ).findIndex((c) => c.name === 'Other');
     const thread = profile.threads[0];
-    const { samples } = filterThreadByImplementation(
-      thread,
-      'js',
-      defaultCategory
-    );
+    const { samples } = filterThreadByImplementation(thread, 'js');
 
     const interval = profile.meta.interval;
     expect(getSampleIndexClosestToStartTime(samples, 0, interval)).toBe(0);


### PR DESCRIPTION
[Production](https://share.firefox.dev/3t1PUq3) | [Deploy preview](https://deploy-preview-4838--perf-html.netlify.app/public/yys1g46mp9bqebf3e53x9j70gsbhj5gwdbd0be8/calltree/?globalTrackOrder=0&profileName=Firefox%20Sp3-BrowserWin-Nov9&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F0w8w9zzww3wj7206gj417x2wbv4sfbnbb8vy1nk&thread=0&v=10)

Profiles of switching to JavaScript-only mode:
Before: https://share.firefox.dev/471ttzj (1.1 seconds)
After: https://share.firefox.dev/3uEVnmY (300ms, 3.6x faster)

`_filterThreadByFunc` function was doing two things that are not necessary:

 - It was ensuring that we didn't create two sibling stack nodes with the same frame.
 - It was resolving category conflicts when collapsing those sibling nodes.

We don't need to do this - it's fine to have multiple sibling stacks with the same frame. Only in the call node table we have to worry about having just one sibling with the same func, but the creation of the call node table takes care of that.

So this new implementation just maps existing stacks one-to-one to new stacks if their function remains in the thread, and skips them otherwise.