### PR TITLE
Simplify detecting whether a function recurses.

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -2103,7 +2103,7 @@ export function handleCallNodeTransformShortcut(
         break;
       }
       case 'r': {
-        if (funcHasRecursiveCall(unfilteredThread, funcIndex)) {
+        if (funcHasRecursiveCall(callNodeTable, funcIndex)) {
           dispatch(
             addTransformToStack(threadsKey, {
               type: 'collapse-recursion',
@@ -2114,13 +2114,7 @@ export function handleCallNodeTransformShortcut(
         break;
       }
       case 'R': {
-        if (
-          funcHasDirectRecursiveCall(
-            unfilteredThread,
-            implementation,
-            funcIndex
-          )
-        ) {
+        if (funcHasDirectRecursiveCall(callNodeTable, funcIndex)) {
           dispatch(
             addTransformToStack(threadsKey, {
               type: 'collapse-direct-recursion',


### PR DESCRIPTION
[Production](https://share.firefox.dev/3t1PUq3) | [Deploy preview](https://deploy-preview-4839--perf-html.netlify.app/public/yys1g46mp9bqebf3e53x9j70gsbhj5gwdbd0be8/calltree/?globalTrackOrder=0&profileName=Firefox%20Sp3-BrowserWin-Nov9&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F0w8w9zzww3wj7206gj417x2wbv4sfbnbb8vy1nk&thread=0&v=10)

On the profile linked above, this speeds up opening the context menu on the root node from 650ms to 13ms (50x faster).

We now use the call node table instead of the unfiltered thread's stackTable to detect whether recursion is present. The call node table is much smaller than the stack table, so it's faster to search through.
We also don't need to look at the implementation filter when detecting direct recursion, because the call node table is already filtered by implementation.
And we use a Uint8Array instead of a set.

Using the raw thread's stackTable is the right thing to do in the code where we apply the transforms as part of the derived thread pipeline. But if we're just detecting which context menu items to show, we can use derived state as much as we want.

Before: https://share.firefox.dev/46GjMWI 406 samples in renderContextMenuContents
After: https://share.firefox.dev/418a5iB 8 samples in renderContextMenuContents (50x faster)