### PR TITLE
Use Float64Array for stack chart timestamps.

### DIFF
--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -104,7 +104,7 @@ export function getStackTimingByDepth(
   // deepestOpenBoxCallNodeIndex.
   let deepestOpenBoxCallNodeIndex = -1;
   let deepestOpenBoxDepth = -1;
-  const openBoxStartTimeByDepth = new Float32Array(maxDepthPlusOne);
+  const openBoxStartTimeByDepth = new Float64Array(maxDepthPlusOne);
 
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
     const sampleTime = samples.time[sampleIndex];


### PR DESCRIPTION
[Production](https://share.firefox.dev/3TtEK8b) | [Deploy preview](https://deploy-preview-4853--perf-html.netlify.app/public/jaf36k6vtezdfttmvt1axg2b2737fz0gktjs72g/stack-chart/?globalTrackOrder=01&hiddenGlobalTracks=0&symbolServer=http%3A%2F%2F127.0.0.1%3A3001%2F0ayz8b8j491r3jmdz05pmq0djdrv9qipj5gdn8q&thread=1&v=10)

32-bit floats don't have enough precision to represent unix timestamps.

Fixes #4852.