### PR TITLE
Add support for marker selection in the marker chart

### DIFF
--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -19,6 +19,7 @@ import {
   typeof updatePreviewSelection as UpdatePreviewSelection,
   typeof changeRightClickedMarker as ChangeRightClickedMarker,
   typeof changeMouseTimePosition as ChangeMouseTimePosition,
+  typeof changeSelectedMarker as ChangeSelectedMarker,
 } from 'firefox-profiler/actions/profile-view';
 import { TIMELINE_MARGIN_LEFT } from 'firefox-profiler/app-logic/constants';
 import type {
@@ -81,9 +82,11 @@ type OwnProps = {|
   +threadsKey: ThreadsKey,
   +updatePreviewSelection: WrapFunctionInDispatch<UpdatePreviewSelection>,
   +changeMouseTimePosition: ChangeMouseTimePosition,
+  +changeSelectedMarker: ChangeSelectedMarker,
   +changeRightClickedMarker: ChangeRightClickedMarker,
   +marginLeft: CssPixels,
   +marginRight: CssPixels,
+  +selectedMarkerIndex: MarkerIndex | null,
   +rightClickedMarkerIndex: MarkerIndex | null,
   +shouldDisplayTooltips: () => boolean,
   +timelineTrackOrganization: TimelineTrackOrganization,
@@ -394,6 +397,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
       marginLeft,
       marginRight,
       rightClickedMarkerIndex,
+      selectedMarkerIndex,
       viewport: {
         containerWidth,
         containerHeight,
@@ -474,7 +478,8 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
 
           const isHighlighted =
             rightClickedMarkerIndex === markerIndex ||
-            hoveredItem === markerIndex;
+            hoveredItem === markerIndex ||
+            selectedMarkerIndex === markerIndex;
 
           if (isHighlighted) {
             highlightedMarkers.push({ x, y, w, h, isInstantMarker, text });
@@ -812,6 +817,12 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
     });
   };
 
+  onSelectItem = (hoveredItems: HoveredMarkerChartItems | null) => {
+    const markerIndex = hoveredItems === null ? null : hoveredItems.markerIndex;
+    const { changeSelectedMarker, threadsKey } = this.props;
+    changeSelectedMarker(threadsKey, markerIndex, { source: 'pointer' });
+  };
+
   onRightClickMarker = (hoveredItems: HoveredMarkerChartItems | null) => {
     const markerIndex = hoveredItems === null ? null : hoveredItems.markerIndex;
     const { changeRightClickedMarker, threadsKey } = this.props;
@@ -846,6 +857,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
         containerHeight={containerHeight}
         isDragging={isDragging}
         scaleCtxToCssPixels={true}
+        onSelectItem={this.onSelectItem}
         onDoubleClickItem={this.onDoubleClickMarker}
         onRightClick={this.onRightClickMarker}
         getHoveredItemInfo={this.getHoveredMarkerInfo}

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -24,6 +24,7 @@ import {
   updatePreviewSelection,
   changeRightClickedMarker,
   changeMouseTimePosition,
+  changeSelectedMarker,
 } from 'firefox-profiler/actions/profile-view';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
 
@@ -49,6 +50,7 @@ type DispatchProps = {|
   +updatePreviewSelection: typeof updatePreviewSelection,
   +changeRightClickedMarker: typeof changeRightClickedMarker,
   +changeMouseTimePosition: typeof changeMouseTimePosition,
+  +changeSelectedMarker: typeof changeSelectedMarker,
 |};
 
 type StateProps = {|
@@ -59,6 +61,7 @@ type StateProps = {|
   +threadsKey: ThreadsKey,
   +previewSelection: PreviewSelection,
   +rightClickedMarkerIndex: MarkerIndex | null,
+  +selectedMarkerIndex: MarkerIndex | null,
   +timelineMarginLeft: CssPixels,
   +timelineTrackOrganization: TimelineTrackOrganization,
 |};
@@ -111,6 +114,8 @@ class MarkerChartImpl extends React.PureComponent<Props> {
       changeMouseTimePosition,
       changeRightClickedMarker,
       rightClickedMarkerIndex,
+      selectedMarkerIndex,
+      changeSelectedMarker,
       timelineMarginLeft,
       timelineTrackOrganization,
     } = this.props;
@@ -161,6 +166,8 @@ class MarkerChartImpl extends React.PureComponent<Props> {
                 threadsKey,
                 marginLeft: timelineMarginLeft,
                 marginRight: TIMELINE_MARGIN_RIGHT,
+                changeSelectedMarker,
+                selectedMarkerIndex,
                 rightClickedMarkerIndex,
                 shouldDisplayTooltips: this._shouldDisplayTooltips,
                 timelineTrackOrganization,
@@ -194,6 +201,8 @@ export const MarkerChart = explicitConnect<{||}, StateProps, DispatchProps>({
       previewSelection: getPreviewSelection(state),
       rightClickedMarkerIndex:
         selectedThreadSelectors.getRightClickedMarkerIndex(state),
+      selectedMarkerIndex:
+        selectedThreadSelectors.getSelectedMarkerIndex(state),
       timelineMarginLeft: getTimelineMarginLeft(state),
       timelineTrackOrganization: getTimelineTrackOrganization(state),
     };
@@ -202,6 +211,7 @@ export const MarkerChart = explicitConnect<{||}, StateProps, DispatchProps>({
     updatePreviewSelection,
     changeMouseTimePosition,
     changeRightClickedMarker,
+    changeSelectedMarker,
   },
   component: MarkerChartImpl,
 });

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -188,6 +188,9 @@ class MarkerTableImpl extends PureComponent<Props> {
 
   componentDidMount() {
     this.focus();
+    if (this._treeView) {
+      this._treeView.scrollSelectionIntoView();
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -26,7 +26,7 @@ import { changeSelectedTab } from '../../actions/app';
 import { changeTimelineTrackOrganization } from '../../actions/receive-profile';
 import { getPreviewSelection } from '../../selectors/profile';
 import { ensureExists } from '../../utils/flow';
-
+import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import {
   autoMockCanvasContext,
   flushDrawLog,
@@ -420,6 +420,19 @@ describe('MarkerChart', function () {
         return positioningOptions;
       }
 
+      function leftClick(where: { x: CssPixels, y: CssPixels }) {
+        const positioningOptions = getPositioningOptions(where);
+        const canvas = ensureExists(
+          container.querySelector('canvas'),
+          `Couldn't find the canvas element`
+        );
+        // Because different components listen to different events, we trigger
+        // all the right events, to be as close as possible to the real stuff.
+        fireMouseEvent('mousemove', positioningOptions);
+        fireFullClick(canvas, positioningOptions);
+        flushRafCalls();
+      }
+
       function rightClick(where: { x: CssPixels, y: CssPixels }) {
         const positioningOptions = getPositioningOptions(where);
         const canvas = ensureExists(
@@ -459,6 +472,7 @@ describe('MarkerChart', function () {
 
       return {
         ...setupResult,
+        leftClick,
         rightClick,
         mouseOver,
         getContextMenu,
@@ -525,6 +539,34 @@ describe('MarkerChart', function () {
           operation === 'set fillStyle' && argument === BLUE_60
       );
       expect(callsWithHighlightColor).toHaveLength(2);
+    });
+
+    it('allows selecting markers and highlights them', () => {
+      const { leftClick, findFillTextPosition, getState } =
+        setupForContextMenus();
+
+      function getHighlightCalls() {
+        const drawCalls = flushDrawLog();
+        return drawCalls.filter(
+          ([operation, argument]) =>
+            operation === 'set fillStyle' && argument === BLUE_60
+        );
+      }
+
+      // No highlights have been drawn yet.
+      expect(getHighlightCalls()).toHaveLength(0);
+      expect(selectedThreadSelectors.getSelectedMarker(getState())).toBe(null);
+
+      // Clicking on a marker highlights it.
+      leftClick(findFillTextPosition('UserTiming A'));
+      expect(getHighlightCalls()).toHaveLength(1);
+      const marker: any = selectedThreadSelectors.getSelectedMarker(getState());
+      expect(marker.data.name).toBe('UserTiming A');
+
+      // Clicking off of a marker unselects it.
+      leftClick({ x: 0, y: 0 });
+      expect(getHighlightCalls()).toHaveLength(0);
+      expect(selectedThreadSelectors.getSelectedMarker(getState())).toBe(null);
     });
 
     it('changes selection range when clicking on submenu', () => {


### PR DESCRIPTION
This adds support for selecting markers in the marker chart. Specifically this is helping solve an issue where you can't click URLs in the tooltips. This allows you to click a marker in the marker chart, and switch to the marker table to find the link to click. I'm needing this ability for Firefox Translations work that integrates with Taskcluster tasks. These tasks have lots of useful links associated with them.