### PR TITLE
Pass CallNodeDisplayData instead of the full call tree to TooltipCallNode

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -416,7 +416,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
         callNodeInfo={callNodeInfo}
         categories={categories}
         durationText={percentage}
-        callTree={callTree}
+        displayData={callTree.getDisplayData(callNodeIndex)}
         callTreeSummaryStrategy={callTreeSummaryStrategy}
         timings={
           shouldComputeTimings

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -15,11 +15,11 @@ import {
 } from 'firefox-profiler/profile-logic/profile-data';
 import { countPositiveValues } from 'firefox-profiler/utils';
 
-import type { CallTree } from 'firefox-profiler/profile-logic/call-tree';
 import type {
   Thread,
   CategoryList,
   IndexIntoCallNodeTable,
+  CallNodeDisplayData,
   CallNodeInfo,
   WeightType,
   Milliseconds,
@@ -53,7 +53,7 @@ type Props = {|
   // Since this tooltip can be used in different context, provide some kind of duration
   // label, e.g. "100ms" or "33%".
   +durationText: string,
-  +callTree?: CallTree,
+  +displayData?: CallNodeDisplayData,
   +timings?: TimingsForPath,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
   +displayStackType: boolean,
@@ -303,7 +303,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     if (!maybeTimings) {
       return false;
     }
-    return Boolean(maybeTimings.forPath.totalTime.breakdownByImplementation);
+    return maybeTimings.forPath.totalTime.breakdownByImplementation !== null;
   }
 
   _renderImplementationTimings(maybeTimings: ?TimingsForPath) {
@@ -426,7 +426,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
       thread,
       durationText,
       categories,
-      callTree,
+      displayData,
       timings,
       callTreeSummaryStrategy,
       innerWindowIDToPageMap,
@@ -440,11 +440,6 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     const innerWindowID = callNodeTable.innerWindowID[callNodeIndex];
     const funcStringIndex = thread.funcTable.name[funcIndex];
     const funcName = thread.stringTable.getString(funcStringIndex);
-
-    let displayData;
-    if (callTree) {
-      displayData = callTree.getDisplayData(callNodeIndex);
-    }
 
     let fileName = null;
 

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -20,7 +20,6 @@ import type {
   Thread,
   CategoryList,
   IndexIntoCallNodeTable,
-  CallNodeDisplayData,
   CallNodeInfo,
   WeightType,
   Milliseconds,
@@ -227,11 +226,8 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     return rows;
   }
 
-  _renderCategoryTimings(
-    maybeTimings: ?TimingsForPath,
-    maybeDisplayData: ?CallNodeDisplayData
-  ) {
-    if (!maybeTimings || !maybeDisplayData) {
+  _renderCategoryTimings(maybeTimings: ?TimingsForPath) {
+    if (!maybeTimings) {
       return null;
     }
     const { totalTime, selfTime } = maybeTimings.forPath;
@@ -303,21 +299,15 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     );
   }
 
-  _canRenderImplementationTimings(
-    maybeTimings: ?TimingsForPath,
-    maybeDisplayData: ?CallNodeDisplayData
-  ) {
-    if (!maybeTimings || !maybeDisplayData) {
+  _canRenderImplementationTimings(maybeTimings: ?TimingsForPath) {
+    if (!maybeTimings) {
       return false;
     }
     return Boolean(maybeTimings.forPath.totalTime.breakdownByImplementation);
   }
 
-  _renderImplementationTimings(
-    maybeTimings: ?TimingsForPath,
-    maybeDisplayData: ?CallNodeDisplayData
-  ) {
-    if (!maybeTimings || !maybeDisplayData) {
+  _renderImplementationTimings(maybeTimings: ?TimingsForPath) {
+    if (!maybeTimings) {
       return null;
     }
     const { totalTime, selfTime } = maybeTimings.forPath;
@@ -589,9 +579,9 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           </div>
         </div>
         <div className="tooltipCallNodeDetails">
-          {this._canRenderImplementationTimings(timings, displayData)
-            ? this._renderImplementationTimings(timings, displayData)
-            : this._renderCategoryTimings(timings, displayData)}
+          {this._canRenderImplementationTimings(timings)
+            ? this._renderImplementationTimings(timings)
+            : this._renderCategoryTimings(timings)}
           {callTreeSummaryStrategy !== 'timing' && displayData ? (
             <div className="tooltipDetails tooltipCallNodeDetailsLeft">
               {/* Everything in this div needs to come in pairs of two in order to

--- a/src/test/components/TooltipCallnode.test.js
+++ b/src/test/components/TooltipCallnode.test.js
@@ -27,6 +27,13 @@ describe('TooltipCallNode', function () {
     const { getState, dispatch } = store;
 
     function renderTooltip() {
+      const callTree = selectedThreadSelectors.getCallTree(getState());
+      const callNodeIndex = ensureExists(
+        selectedThreadSelectors.getSelectedCallNodeIndex(getState()),
+        'Unable to find a selected call node index.'
+      );
+      const displayData = callTree.getDisplayData(callNodeIndex);
+
       // This component is not currently connected.
       return render(
         <Provider store={store}>
@@ -36,15 +43,12 @@ describe('TooltipCallNode', function () {
             innerWindowIDToPageMap={ProfileSelectors.getInnerWindowIDToPageMap(
               getState()
             )}
-            callNodeIndex={ensureExists(
-              selectedThreadSelectors.getSelectedCallNodeIndex(getState()),
-              'Unable to find a selected call node index.'
-            )}
+            callNodeIndex={callNodeIndex}
             callNodeInfo={selectedThreadSelectors.getCallNodeInfo(getState())}
+            displayData={displayData}
             categories={ProfileSelectors.getCategories(getState())}
             interval={ProfileSelectors.getProfileInterval(getState())}
             durationText="Fake Duration Text"
-            callTree={selectedThreadSelectors.getCallTree(getState())}
             callTreeSummaryStrategy={selectedThreadSelectors.getCallTreeSummaryStrategy(
               getState()
             )}


### PR DESCRIPTION
Small simplification.

I think this would also make it easier to show a better tooltip in the stack chart, but I'm not changing any behavior here.