### PR TITLE
Improve the precision of getFittedText

### DIFF
--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -618,6 +618,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
         textMeasurement.getFittedText(
           name,
           TIMELINE_MARGIN_LEFT -
+            LABEL_PADDING -
             (countString ? textMeasurement.getTextWidth(countString) : 0)
         ) + countString;
 

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -1010,6 +1010,10 @@ Array [
     "Non-interval marker F without data",
   ],
   Array [
+    "measureText",
+    "Non-interval marker F withou",
+  ],
+  Array [
     "fillText",
     "Non-interval marker F withou…",
     5,
@@ -1028,6 +1032,10 @@ Array [
   Array [
     "measureText",
     "Very very very very very very Very very very very very very Very very very very very very Very very very very very very Very very very very very very long Marker D",
+  ],
+  Array [
+    "measureText",
+    "Very very very very very ver",
   ],
   Array [
     "fillText",

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -755,6 +755,14 @@ Array [
     "componentD",
   ],
   Array [
+    "measureText",
+    "c",
+  ],
+  Array [
+    "measureText",
+    "co",
+  ],
+  Array [
     "set fillStyle",
     "#000000",
   ],


### PR DESCRIPTION
The "Show marker count next to the marker name in the marker chart when a marker is hovered." commit was already in a separate PR (#4892), but the 2 patches would conflict.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-24)
