### PR TITLE
Bring the max stacking depth limit back for marker timings

### DIFF
--- a/src/profile-logic/marker-timing.js
+++ b/src/profile-logic/marker-timing.js
@@ -10,6 +10,10 @@ import type {
   MarkerTimingAndBuckets,
 } from 'firefox-profiler/types';
 
+// Arbitrarily set an upper limit for adding marker depths, avoiding very long
+// overlapping marker timings.
+const MAX_STACKING_DEPTH = 300;
+
 /**
  * This function computes the timing information for laying out the markers in the
  * MarkerChart component. Each marker is put into a single row based on its name. In
@@ -160,6 +164,12 @@ export function getMarkerTiming(
 
     if (foundMarkerTiming) {
       addCurrentMarkerToMarkerTiming(foundMarkerTiming);
+      continue;
+    }
+
+    if (markerTimingsForName.length >= MAX_STACKING_DEPTH) {
+      // There are too many markers stacked around the same time already, let's
+      // ignore this marker.
       continue;
     }
 


### PR DESCRIPTION
This brings back the `MAX_STACKING_DEPTH` that was removed in https://github.com/firefox-devtools/profiler/pull/3927/commits/6920425f9fc06bee7ef1fbf6756bc8660002a856 to make the marker chart more performant for cases where there are a lot of marker that are stacked on top of each other.

For example: 
[Before](https://share.firefox.dev/4925zF3) / [After](https://deploy-preview-4898--perf-html.netlify.app/public/1y01189smkgcmh64p7x4r7j4qmtddhrge5f849g/calltree/?globalTrackOrder=0w8&hiddenGlobalTracks=0w7&hiddenLocalTracksByPid=5200-0w7&thread=xh&v=10)
[Before](https://share.firefox.dev/3SVYPne) / [After](https://deploy-preview-4898--perf-html.netlify.app/public/720c4azyjfq55thf5x4ak5bwa986098r1x0pbtr/calltree/?globalTrackOrder=x2wx50wx1&hiddenGlobalTracks=0wx0x2wx5&hiddenLocalTracksByPid=19476-0w2~24668-0~16780-01~24504-01~13664-01~15084-0~14792-01~25556-01~17976-01~5244-0~6468-0w2~7736-0~21360-0~21348-0~21320-01~11060-01~20512-02wg&implementation=js&thread=y4&v=10)

Fixes #4808 and one of the profile is from #4894.