### PR TITLE
Return null instead of throwing an error if it fails to get the resource name in active tab view

### DIFF
--- a/src/test/fixtures/profiles/tracks.js
+++ b/src/test/fixtures/profiles/tracks.js
@@ -337,6 +337,7 @@ export function getStoreWithMemoryTrack(pid: Pid = '222') {
  */
 export function getHumanReadableActiveTabTracks(state: State): string[] {
   const globalTracks = profileViewSelectors.getActiveTabGlobalTracks(state);
+  const resourceTracks = profileViewSelectors.getActiveTabResourceTracks(state);
   const selectedThreadIndexes =
     urlStateSelectors.getSelectedThreadIndexes(state);
   const text: string[] = [];
@@ -365,6 +366,22 @@ export function getHumanReadableActiveTabTracks(state: State): string[] {
         throw assertExhaustiveCheck(
           globalTrack,
           'Unhandled ActiveTabGlobalTrack.'
+        );
+    }
+  }
+
+  for (const resourceTrack of resourceTracks) {
+    switch (resourceTrack.type) {
+      case 'sub-frame':
+        text.push(`  - iframe: ${resourceTrack.name}`);
+        break;
+      case 'thread':
+        text.push(`  - ${resourceTrack.name}`);
+        break;
+      default:
+        throw assertExhaustiveCheck(
+          resourceTrack,
+          'Unhandled ActiveTabResourceTrack.'
         );
     }
   }

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -165,6 +165,7 @@ describe('ActiveTab', function () {
       const { getState } = setup(profile, false);
       expect(getHumanReadableActiveTabTracks(getState())).toEqual([
         'main track [tab] SELECTED',
+        '  - iframe: Page #2',
       ]);
     });
   });


### PR DESCRIPTION
This fixes #4834.

Previously if it was failing to find a resource name, it was throwing an error. This was happening because we are explicitly excluding the `about:blank` and `about:newtab` pages. They are excluded so we can find the correct page name.

Deploy previews:
[Before](https://profiler.firefox.com/public/g19gpwmd1a6bq66yxmfs051aez947ck9p8qkytr/calltree/?implementation=js&thread=p&v=10&view=active-tab) / [After](https://deploy-preview-4905--perf-html.netlify.app/public/g19gpwmd1a6bq66yxmfs051aez947ck9p8qkytr/calltree/?implementation=js&thread=p&v=10&view=active-tab)
[Before](http://profiler.firefox.com/public/jwzm6vnapdjj2p8f4w6nbm8806dm91q9czz3g0g/marker-chart/?view=active-tab) / [After](https://deploy-preview-4905--perf-html.netlify.app/public/jwzm6vnapdjj2p8f4w6nbm8806dm91q9czz3g0g/marker-chart/?view=active-tab)

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/FP-38)
