### PR TITLE
Use a monospace font in the permalink textbox.

### DIFF
--- a/src/components/app/MenuButtons/Permalink.css
+++ b/src/components/app/MenuButtons/Permalink.css
@@ -14,6 +14,10 @@
 }
 
 .menuButtonsPermalinkTextField {
-  width: 16em;
+  width: 20em;
   height: 19px;
+
+  /* Use a monospace font so that I and l can be differentiated */
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
 }


### PR DESCRIPTION
[Production](https://share.firefox.dev/3OzUweo) | [Deploy preview](https://deploy-preview-4912--perf-html.netlify.app/public/nj4wxh974nwd4j8hxgxdrjmp8m6j7kxbpypxfdg/calltree/?globalTrackOrder=0&thread=0&v=10)

Before:

![Screenshot 2024-02-07 at 3 14 10 PM](https://github.com/firefox-devtools/profiler/assets/961291/516f1c6b-16eb-4227-a03e-d8af278dc5a3)

After:

![Screenshot 2024-02-07 at 3 32 16 PM](https://github.com/firefox-devtools/profiler/assets/961291/e47ed7c5-67a4-4b0b-98d1-fbb0f0c3a875)

Sometimes I transfer profiles from one machine to another by manually typing out the short link. I often run into the problem that I can't differentiate the lowercase L and the uppercase i easily. Using a monospace font should help with that.