### PR TITLE
Make the call tree sidebar localizable

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -189,6 +189,24 @@ CallTree--inlining-badge = (inlined)
 ## This is the sidebar component that is used in Call Tree and Flame Graph panels.
 
 CallTreeSidebar--select-a-node = Select a node to display information about it.
+CallTreeSidebar--call-node-details = Call node details
+
+CallTreeSidebar--traced-running-time =
+    .label = Traced running time
+CallTreeSidebar--traced-self-time =
+    .label = Traced self time
+CallTreeSidebar--running-time =
+    .label = Running time
+CallTreeSidebar--self-time =
+    .label = Self time
+CallTreeSidebar--running-samples =
+    .label = Running samples
+CallTreeSidebar--self-samples =
+    .label = Self samples
+CallTreeSidebar--running-size =
+    .label = Running size
+CallTreeSidebar--self-size =
+    .label = Self size
 
 ## CompareHome
 ## This is used in the page to compare two profiles.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -208,6 +208,17 @@ CallTreeSidebar--running-size =
 CallTreeSidebar--self-size =
     .label = Self size
 
+CallTreeSidebar--categories = Categories
+CallTreeSidebar--implementation = Implementation
+
+CallTreeSidebar--running-milliseconds = Running milliseconds
+CallTreeSidebar--running-sample-count = Running sample count
+CallTreeSidebar--running-bytes = Running bytes
+
+CallTreeSidebar--self-milliseconds = Self milliseconds
+CallTreeSidebar--self-sample-count = Self sample count
+CallTreeSidebar--self-bytes = Self bytes
+
 ## CompareHome
 ## This is used in the page to compare two profiles.
 ## See: https://profiler.firefox.com/compare/

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -191,6 +191,20 @@ CallTree--inlining-badge = (inlined)
 CallTreeSidebar--select-a-node = Select a node to display information about it.
 CallTreeSidebar--call-node-details = Call node details
 
+## CallTreeSidebar timing information
+##
+## Firefox Profiler stops the execution of the program every 1ms to record the
+## stack. Only thing we know for sure is the stack at that point of time when
+## the stack is taken. We try to estimate the time spent in each function and
+## translate it to a duration. That's why we use the "traced" word here.
+## There is actually no difference between "Traced running time" and "Running
+## time" in the context of the profiler. We use "Traced" to emphasize that this
+## is an estimation where we have more space in the UI.
+##
+## "Self time" is the time spent in the function itself, excluding the time spent
+## in the functions it called. "Running time" is the time spent in the function
+## itself, including the time spent in the functions it called.
+
 CallTreeSidebar--traced-running-time =
     .label = Traced running time
 CallTreeSidebar--traced-self-time =

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -302,14 +302,27 @@ type WeightDetails = {|
   +number: (n: number) => string,
 |};
 
-function getWeightTypeLabel(weightType: WeightType): string {
+function getRunningWeightTypeLabelL10nId(weightType: WeightType): string {
   switch (weightType) {
     case 'tracing-ms':
-      return `milliseconds`;
+      return 'CallTreeSidebar--running-milliseconds';
     case 'samples':
-      return 'sample count';
+      return 'CallTreeSidebar--running-sample-count';
     case 'bytes':
-      return 'bytes';
+      return 'CallTreeSidebar--running-bytes';
+    default:
+      throw assertExhaustiveCheck(weightType, 'Unhandled WeightType.');
+  }
+}
+
+function getSelfWeightTypeLabelL10nId(weightType: WeightType): string {
+  switch (weightType) {
+    case 'tracing-ms':
+      return 'CallTreeSidebar--self-milliseconds';
+    case 'samples':
+      return 'CallTreeSidebar--self-sample-count';
+    case 'bytes':
+      return 'CallTreeSidebar--self-bytes';
     default:
       throw assertExhaustiveCheck(weightType, 'Unhandled WeightType.');
   }
@@ -458,10 +471,12 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
           {totalTimeBreakdownByCategory ? (
             <>
               <h4 className="sidebar-title3 sidebar-title-label">
-                <div className="sidebar-title-label-left">Categories</div>
-                <div className="sidebar-title-label-right">
-                  Running {getWeightTypeLabel(weightType)}
-                </div>
+                <Localized id="CallTreeSidebar--categories">
+                  <div className="sidebar-title-label-left">Categories</div>
+                </Localized>
+                <Localized id={getRunningWeightTypeLabelL10nId(weightType)}>
+                  <div className="sidebar-title-label-right"></div>
+                </Localized>
               </h4>
               <CategoryBreakdown
                 kind="total"
@@ -474,10 +489,12 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
           {selfTimeBreakdownByCategory ? (
             <>
               <h4 className="sidebar-title3 sidebar-title-label">
-                <div className="sidebar-title-label-left">Categories</div>
-                <div className="sidebar-title-label-right">
-                  Self {getWeightTypeLabel(weightType)}
-                </div>
+                <Localized id="CallTreeSidebar--categories">
+                  <div className="sidebar-title-label-left">Categories</div>
+                </Localized>
+                <Localized id={getSelfWeightTypeLabelL10nId(weightType)}>
+                  <div className="sidebar-title-label-right"></div>
+                </Localized>
               </h4>
               <CategoryBreakdown
                 kind="self"
@@ -490,8 +507,12 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
           {totalTimeBreakdownByImplementation && totalTime.value ? (
             <React.Fragment>
               <h4 className="sidebar-title3 sidebar-title-label">
-                <div>Implementation</div>
-                <div>Running {getWeightTypeLabel(weightType)}</div>
+                <Localized id="CallTreeSidebar--implementation">
+                  <div>Implementation</div>
+                </Localized>
+                <Localized id={getRunningWeightTypeLabelL10nId(weightType)}>
+                  <div></div>
+                </Localized>
               </h4>
               <ImplementationBreakdown
                 breakdown={totalTimeBreakdownByImplementation}
@@ -502,8 +523,12 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
           {selfTimeBreakdownByImplementation && selfTime.value ? (
             <React.Fragment>
               <h4 className="sidebar-title3 sidebar-title-label">
-                <div>Implementation</div>
-                <div>Self {getWeightTypeLabel(weightType)}</div>
+                <Localized id="CallTreeSidebar--implementation">
+                  <div>Implementation</div>
+                </Localized>
+                <Localized id={getSelfWeightTypeLabelL10nId(weightType)}>
+                  <div></div>
+                </Localized>
               </h4>
               <ImplementationBreakdown
                 breakdown={selfTimeBreakdownByImplementation}

--- a/src/components/sidebar/CallTreeSidebar.js
+++ b/src/components/sidebar/CallTreeSidebar.js
@@ -297,8 +297,8 @@ type StateProps = {|
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 
 type WeightDetails = {|
-  +running: string,
-  +self: string,
+  +runningL10nId: string,
+  +selfL10nId: string,
   +number: (n: number) => string,
 |};
 
@@ -321,20 +321,20 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
       switch (weightType) {
         case 'tracing-ms':
           return {
-            running: 'Running time',
-            self: 'Self time',
+            runningL10nId: 'CallTreeSidebar--running-time',
+            selfL10nId: 'CallTreeSidebar--self-time',
             number: (n) => formatMilliseconds(n, 3, 1),
           };
         case 'samples':
           return {
-            running: 'Running samples',
-            self: 'Self samples',
+            runningL10nId: 'CallTreeSidebar--running-samples',
+            selfL10nId: 'CallTreeSidebar--self-samples',
             number: (n) => formatNumber(n, 0),
           };
         case 'bytes':
           return {
-            running: 'Running size',
-            self: 'Self size',
+            runningL10nId: 'CallTreeSidebar--running-size',
+            selfL10nId: 'CallTreeSidebar--self-size',
             number: (n) => formatBytes(n),
           };
         default:
@@ -371,7 +371,8 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
       );
     }
 
-    const { number, running, self } = this._getWeightTypeDetails(weightType);
+    const { number, runningL10nId, selfL10nId } =
+      this._getWeightTypeDetails(weightType);
 
     const totalTimePercent = Math.round((totalTime.value / rootTime) * 100);
     const selfTimePercent = Math.round((selfTime.value / rootTime) * 100);
@@ -400,42 +401,60 @@ class CallTreeSidebarImpl extends React.PureComponent<Props> {
             ) : null}
           </header>
           <h4 className="sidebar-title3">
-            <div>Call node details</div>
+            <Localized id="CallTreeSidebar--call-node-details">
+              <div>Call node details</div>
+            </Localized>
           </h4>
           {selectedNodeTracedSelfAndTotal ? (
-            <SidebarDetail
-              label="Traced running time"
-              value={formatMilliseconds(
-                selectedNodeTracedSelfAndTotal.total,
-                3,
-                1
-              )}
-            ></SidebarDetail>
+            <Localized
+              id="CallTreeSidebar--traced-running-time"
+              attrs={{ label: true }}
+            >
+              <SidebarDetail
+                label="Traced running time"
+                value={formatMilliseconds(
+                  selectedNodeTracedSelfAndTotal.total,
+                  3,
+                  1
+                )}
+              ></SidebarDetail>
+            </Localized>
           ) : null}
           {selectedNodeTracedSelfAndTotal ? (
-            <SidebarDetail
-              label="Traced self time"
-              value={
-                selectedNodeTracedSelfAndTotal.self === 0
-                  ? '—'
-                  : formatMilliseconds(
-                      selectedNodeTracedSelfAndTotal.self,
-                      3,
-                      1
-                    )
-              }
-            />
+            <Localized
+              id="CallTreeSidebar--traced-self-time"
+              attrs={{ label: true }}
+            >
+              <SidebarDetail
+                label="Traced self time"
+                value={
+                  selectedNodeTracedSelfAndTotal.self === 0
+                    ? '—'
+                    : formatMilliseconds(
+                        selectedNodeTracedSelfAndTotal.self,
+                        3,
+                        1
+                      )
+                }
+              />
+            </Localized>
           ) : null}
-          <SidebarDetail
-            label={running}
-            value={totalTime.value ? `${number(totalTime.value)}` : '—'}
-            percentage={totalTimePercent ? totalTimePercent + '%' : '—'}
-          />
-          <SidebarDetail
-            label={self}
-            value={selfTime.value ? `${number(selfTime.value)}` : '—'}
-            percentage={selfTimePercent ? selfTimePercent + '%' : '—'}
-          />
+          <Localized id={runningL10nId} attrs={{ label: true }}>
+            <SidebarDetail
+              // The value for the label following will be replaced
+              label=""
+              value={totalTime.value ? `${number(totalTime.value)}` : '—'}
+              percentage={totalTimePercent ? totalTimePercent + '%' : '—'}
+            />
+          </Localized>
+          <Localized id={selfL10nId} attrs={{ label: true }}>
+            <SidebarDetail
+              // The value for the label following will be replaced
+              label=""
+              value={selfTime.value ? `${number(selfTime.value)}` : '—'}
+              percentage={selfTimePercent ? selfTimePercent + '%' : '—'}
+            />
+          </Localized>
           {totalTimeBreakdownByCategory ? (
             <>
               <h4 className="sidebar-title3 sidebar-title-label">

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -57,7 +57,7 @@
 
 .sidebar-title-label > :nth-child(2) {
   color: var(--grey-50);
-  text-align: right;
+  text-align: end;
 }
 
 .sidebar-titlegroup {
@@ -120,7 +120,7 @@
 
 .sidebar-value,
 .sidebar-percentage {
-  text-align: right;
+  text-align: end;
   white-space: nowrap;
 }
 
@@ -167,11 +167,14 @@
   position: absolute;
   width: 0;
   height: 0;
-  border-width: 5px 4px 5px 8px;
   border-style: solid;
-  border-color: transparent transparent transparent currentcolor;
+  border-color: transparent;
   margin-top: 1px;
   background: none;
+  border-block-width: 5px;
+  border-inline-end-width: 4px;
+  border-inline-start-color: currentcolor;
+  border-inline-start-width: 8px;
   content: '';
   margin-inline-start: -11px;
 }

--- a/src/test/components/CallTreeSidebar.test.js
+++ b/src/test/components/CallTreeSidebar.test.js
@@ -130,6 +130,25 @@ describe('CallTreeSidebar', function () {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('matches the snapshots when displaying bytes data', () => {
+    const profileWithDicts = getProfileWithCategories();
+    // Create a weighted samples table with bytes.
+    const [{ samples }] = profileWithDicts.profile.threads;
+    samples.weightType = 'bytes';
+    samples.weight = samples.time.map((i) => i);
+
+    const {
+      selectNode,
+      funcNamesDict: { A, B, Cjs },
+      container,
+    } = setup(profileWithDicts);
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    selectNode([A, B, Cjs]);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it('matches the snapshots when displaying data about the currently selected node in an inverted tree', () => {
     const {
       selectNode,

--- a/src/test/components/__snapshots__/CallTreeSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/CallTreeSidebar.test.js.snap
@@ -96,8 +96,7 @@ exports[`CallTreeSidebar can expand subcategories 1`] = `
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -140,8 +139,7 @@ exports[`CallTreeSidebar can expand subcategories 1`] = `
       <div
         class="sidebar-title-label-right"
       >
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -180,8 +178,7 @@ exports[`CallTreeSidebar can expand subcategories 1`] = `
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -214,8 +211,7 @@ exports[`CallTreeSidebar can expand subcategories 1`] = `
         Implementation
       </div>
       <div>
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -341,8 +337,7 @@ exports[`CallTreeSidebar can expand subcategories 2`] = `
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -415,8 +410,7 @@ exports[`CallTreeSidebar can expand subcategories 2`] = `
       <div
         class="sidebar-title-label-right"
       >
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -455,8 +449,7 @@ exports[`CallTreeSidebar can expand subcategories 2`] = `
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -489,8 +482,7 @@ exports[`CallTreeSidebar can expand subcategories 2`] = `
         Implementation
       </div>
       <div>
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -628,8 +620,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -662,8 +653,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -789,8 +779,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -823,8 +812,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -950,8 +938,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1011,8 +998,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -1045,8 +1031,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1079,8 +1064,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -1206,8 +1190,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1244,8 +1227,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -1278,8 +1260,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1312,8 +1293,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Self 
-        sample count
+        Self sample count
       </div>
     </h4>
     <div
@@ -1451,8 +1431,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1485,8 +1464,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1612,8 +1590,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1646,8 +1623,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1773,8 +1749,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1807,8 +1782,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1934,8 +1908,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
       <div
         class="sidebar-title-label-right"
       >
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div
@@ -1968,8 +1941,7 @@ exports[`CallTreeSidebar matches the snapshots when displaying data about the cu
         Implementation
       </div>
       <div>
-        Running 
-        sample count
+        Running sample count
       </div>
     </h4>
     <div

--- a/src/test/components/__snapshots__/CallTreeSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/CallTreeSidebar.test.js.snap
@@ -512,6 +512,151 @@ exports[`CallTreeSidebar can expand subcategories 2`] = `
 </aside>
 `;
 
+exports[`CallTreeSidebar matches the snapshots when displaying bytes data 1`] = `
+<div
+  class="sidebar sidebar-calltree"
+>
+  <div
+    class="sidebar-contents-wrapper"
+  >
+    Select a node to display information about it.
+  </div>
+</div>
+`;
+
+exports[`CallTreeSidebar matches the snapshots when displaying bytes data 2`] = `
+<aside
+  class="sidebar sidebar-calltree"
+>
+  <div
+    class="sidebar-contents-wrapper"
+  >
+    <header
+      class="sidebar-titlegroup"
+    >
+      <h2
+        class="sidebar-title can-select-content"
+        title="Cjs
+(click to select)"
+      >
+        <input
+          class="can-select-content-input"
+          readonly=""
+          value="Cjs"
+        />
+      </h2>
+    </header>
+    <h4
+      class="sidebar-title3"
+    >
+      <div>
+        Call node details
+      </div>
+    </h4>
+    <div
+      class="sidebar-label"
+    >
+      Running size
+    </div>
+    <div
+      class="sidebar-percentage"
+    >
+      17%
+    </div>
+    <div
+      class="sidebar-value"
+    >
+      1B
+    </div>
+    <div
+      class="sidebar-label"
+    >
+      Self size
+    </div>
+    <div
+      class="sidebar-percentage"
+    >
+      —
+    </div>
+    <div
+      class="sidebar-value"
+    >
+      —
+    </div>
+    <h4
+      class="sidebar-title3 sidebar-title-label"
+    >
+      <div
+        class="sidebar-title-label-left"
+      >
+        Categories
+      </div>
+      <div
+        class="sidebar-title-label-right"
+      >
+        Running bytes
+      </div>
+    </h4>
+    <div
+      class="sidebar-label"
+    >
+      JavaScript
+    </div>
+    <div
+      class="sidebar-percentage"
+    >
+      100%
+    </div>
+    <div
+      class="sidebar-value"
+    >
+      1B
+    </div>
+    <div
+      class="sidebar-histogram-bar"
+    >
+      <div
+        class="sidebar-histogram-bar-color category-color-yellow"
+        style="width: 100.0000%;"
+      />
+    </div>
+    <h4
+      class="sidebar-title3 sidebar-title-label"
+    >
+      <div>
+        Implementation
+      </div>
+      <div>
+        Running bytes
+      </div>
+    </h4>
+    <div
+      class="sidebar-label"
+    >
+      JS interpreter
+    </div>
+    <div
+      class="sidebar-percentage"
+    >
+      100%
+    </div>
+    <div
+      class="sidebar-value"
+    >
+      1B
+    </div>
+    <div
+      class="sidebar-histogram-bar"
+    >
+      <div
+        class="sidebar-histogram-bar-color"
+        style="width: 100.0000%;"
+      />
+    </div>
+  </div>
+</aside>
+`;
+
 exports[`CallTreeSidebar matches the snapshots when displaying data about the currently selected node 1`] = `
 <div
   class="sidebar sidebar-calltree"


### PR DESCRIPTION
This fixes #4917.

It looks like we forgot to make this sidebar localizable before. Let's fix it.

Profiles to test: 
[Before](https://share.firefox.dev/42LSePe) / [After (with samples and memory allocations)](https://deploy-preview-4920--perf-html.netlify.app/public/8gj6d7vamdwdh6xwaqjj5vh47tb0k50dhahwdm8/calltree/?globalTrackOrder=x10wx0&hiddenGlobalTracks=1wv&hiddenLocalTracksByPid=169055-1wg~192517-0~169132-0~169369-0~169194-0~1300387-01~1286775-01~191935-0~1300252-0~169809-0~169462-0~1301183-0~169373-0~192005-0~1300460-0~1672761-0~1300318-01~1675551-0~1300463-0~1300408-01~1301186-0~1300531-0~1672801-0~1300313-01~192077-0w2~1672868-0~1300210-01~169249-0&localTrackOrderByPid=169055-hi0wg~192517-0~169132-0~169369-0~169194-0~1300387-01~1286775-01~191935-0~1300252-0~169809-0~169462-0~1301183-0~169373-0~192005-0~1300460-0~1672761-0~1300318-01~1675551-0~1300463-0~1300408-01~1301186-0~1300531-0~1672801-0~1300313-01~192077-120~1672868-0~1300210-01~169249-0~1675555-0&thread=xi&v=10)


It also fixes some rtl issues with the sidebar. Previously the texts that were aligned to the right side with `text-align: right;`, now that's changed to `end`. And also the category/implementation toggle triangle was not rtl friendly. Fixed that as well. We still have lots of rtl issues on the profiler though... Especially call tree is completely useless, but let's think about it on another issue. 

Before             |  After
:-------------------------:|:-------------------------:
<img width="353" alt="Screenshot 2024-02-21 at 1 10 33 PM" src="https://github.com/firefox-devtools/profiler/assets/466239/acfe5305-c1fe-49d5-a461-076c106db7fd"> | <img width="359" alt="Screenshot 2024-02-21 at 1 09 47 PM" src="https://github.com/firefox-devtools/profiler/assets/466239/12fc96d1-60b7-4fe7-89e7-19ae05729db0">
