### PR TITLE
Properly skip the samples that have different categories on activity graph hit testing

### DIFF
--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -473,11 +473,14 @@ export class ActivityFillGraphQuerier {
         continue;
       }
       const sampleCategory = stackTable.category[stackIndex];
+      if (sampleCategory !== category) {
+        // The sample contribution is already filtered by the category at this
+        // point. So we should skip the samples that have different categories.
+        continue;
+      }
+
       const upperEdgeOfThisSample = upperEdgeOfPreviousSample + contribution;
-      // Checking the sample category here because there are samples with different
-      // categories that has y percentage is lower than the upperEdgeOfThisSample.
-      // It's possible to pick the wrong value otherwise.
-      if (sampleCategory === category && yPercentage <= upperEdgeOfThisSample) {
+      if (yPercentage <= upperEdgeOfThisSample) {
         // We use <= rather than < here so that we don't return null if
         // yPercentage is equal to the upper edge of the last sample.
         return { sample, cpuRatioInTimeRange };


### PR DESCRIPTION
This fixes #4901.

https://github.com/firefox-devtools/profiler/commit/5e15bf75ae6e3914ab2d566dcb0209a2b5b4e047 broke the hit testing of the activity graph. We should skip the samples with different categories on `getSampleAndCpuRatioAtClick` but because of a logic problem it was actually always updating the `upperEdgeOfPreviousSample`. With this PR it now skips the other categories as expected.

Deploy preview: [before](https://share.firefox.dev/3U7VGl7) / [after](https://deploy-preview-4921--perf-html.netlify.app/public/r8tk97av3ed6afzcgf65ha8qrn00mn0tvrbvw0g/calltree/?globalTrackOrder=01&hiddenGlobalTracks=0&hiddenLocalTracksByPid=3939.1-0w8&invertCallstack&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F3mpb967jr35myv99xyl5y8g4s2zpgrv9siy20rr&thread=1&v=10)