### PR TITLE
Do not compile png files on our user docs to fix the image links

### DIFF
--- a/docs-user/js/init.js
+++ b/docs-user/js/init.js
@@ -7,5 +7,5 @@ window.$docsify = {
   subMaxLevel: 2,
   // Photon blue-50
   themeColor: '#0a84ff',
-  noCompileLinks: ['.*\\.svg'],
+  noCompileLinks: ['.*\\.svg', '.*\\.png'],
 };


### PR DESCRIPTION
This fixes the image links that don't work in https://profiler.firefox.com/docs/#/./guide-profiling-android-directly-on-device?id=enable-secret-settings-on-the-mobile-device

Click on any links in that page and see that it can't find the image links.

[Deploy preview](https://deploy-preview-4939--perf-html.netlify.app/docs/#/./guide-profiling-android-directly-on-device)