### PR TITLE
Support 'pid' and 'tid' formats in marker schemas.

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -216,7 +216,7 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
     // This is the common case.
 
     return [
-      <TooltipDetail label="Thread" key="thread">
+      <TooltipDetail label="Track" key="thread">
         {threadName}
       </TooltipDetail>,
     ];

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -19,6 +19,7 @@ import {
   getInnerWindowIDToPageMap,
   getZeroAt,
   getThreadIdToNameMap,
+  getProcessIdToNameMap,
   getThreadSelectorsFromThreadsKey,
 } from 'firefox-profiler/selectors';
 
@@ -52,6 +53,7 @@ import type {
   MarkerIndex,
   InnerWindowID,
   Page,
+  Pid,
   Tid,
 } from 'firefox-profiler/types';
 
@@ -93,6 +95,7 @@ type StateProps = {|
   +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +zeroAt: Milliseconds,
   +threadIdToNameMap: Map<Tid, string>,
+  +processIdToNameMap: Map<Pid, string>,
   +markerSchemaByName: MarkerSchemaByName,
   +getMarkerLabel: (MarkerIndex) => string,
   +categories: CategoryList,
@@ -224,7 +227,13 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
    * properties that are difficult to represent with the Schema.
    */
   _renderMarkerDetails(): TooltipDetailComponent[] {
-    const { marker, markerSchemaByName, thread } = this.props;
+    const {
+      marker,
+      markerSchemaByName,
+      thread,
+      threadIdToNameMap,
+      processIdToNameMap,
+    } = this.props;
     const data = marker.data;
     const details: TooltipDetailComponent[] = [];
 
@@ -255,7 +264,9 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
                       schema.name,
                       format,
                       value,
-                      thread.stringTable
+                      thread.stringTable,
+                      threadIdToNameMap,
+                      processIdToNameMap
                     )}
                   </TooltipDetail>
                 );
@@ -524,6 +535,7 @@ export const TooltipMarker = explicitConnect<OwnProps, StateProps, {||}>({
       innerWindowIDToPageMap: getInnerWindowIDToPageMap(state),
       zeroAt: getZeroAt(state),
       threadIdToNameMap: getThreadIdToNameMap(state),
+      processIdToNameMap: getProcessIdToNameMap(state),
       markerSchemaByName: getMarkerSchemaByName(state),
       getMarkerLabel: selectors.getMarkerTooltipLabelGetter(state),
       categories: getCategories(state),

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -23,6 +23,8 @@ import type {
   Marker,
   MarkerIndex,
   MarkerPayload,
+  Tid,
+  Pid,
 } from 'firefox-profiler/types';
 import type { UniqueStringArray } from '../utils/unique-string-array';
 
@@ -64,7 +66,7 @@ export const markerSchemaFrontEndOnly: MarkerSchema[] = [
       {
         key: 'otherPid',
         label: 'Other Pid',
-        format: 'string',
+        format: 'pid',
         searchable: true,
       },
     ],
@@ -413,7 +415,9 @@ export function formatFromMarkerSchema(
   markerType: string,
   format: MarkerFormatType,
   value: any,
-  stringTable: UniqueStringArray
+  stringTable: UniqueStringArray,
+  threadIdToNameMap?: Map<Tid, string>,
+  processIdToNameMap?: Map<Pid, string>
 ): string {
   if (value === undefined || value === null) {
     console.warn(
@@ -450,7 +454,9 @@ export function formatFromMarkerSchema(
               markerType,
               format || 'string',
               cell,
-              stringTable
+              stringTable,
+              threadIdToNameMap,
+              processIdToNameMap
             );
           });
         });
@@ -490,6 +496,14 @@ export function formatFromMarkerSchema(
       return formatNumber(value);
     case 'percentage':
       return formatPercent(value);
+    case 'pid':
+      return processIdToNameMap && processIdToNameMap.has(value)
+        ? `${ensureExists(processIdToNameMap.get(value))} (${value})`
+        : `PID: ${value}`;
+    case 'tid':
+      return threadIdToNameMap && threadIdToNameMap.has(value)
+        ? `${ensureExists(threadIdToNameMap.get(value))} (${value})`
+        : `TID: ${value}`;
     case 'list':
       if (!(value instanceof Array)) {
         throw new Error('Expected an array for list format');
@@ -521,14 +535,23 @@ export function formatMarkupFromMarkerSchema(
   markerType: string,
   format: MarkerFormatType,
   value: any,
-  stringTable: UniqueStringArray
+  stringTable: UniqueStringArray,
+  threadIdToNameMap?: Map<Tid, string>,
+  processIdToNameMap?: Map<Pid, string>
 ): React.Element<any> | string {
   if (value === undefined || value === null) {
     console.warn(`Formatting ${value} for ${JSON.stringify(markerType)}`);
     return '(empty)';
   }
   if (format !== 'url' && typeof format !== 'object' && format !== 'list') {
-    return formatFromMarkerSchema(markerType, format, value, stringTable);
+    return formatFromMarkerSchema(
+      markerType,
+      format,
+      value,
+      stringTable,
+      threadIdToNameMap,
+      processIdToNameMap
+    );
   }
   if (typeof format === 'object') {
     switch (format.type) {
@@ -569,7 +592,9 @@ export function formatMarkupFromMarkerSchema(
                             markerType,
                             columns[i].type || 'string',
                             cell,
-                            stringTable
+                            stringTable,
+                            threadIdToNameMap,
+                            processIdToNameMap
                           )}
                         </td>
                       );

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -864,6 +864,23 @@ export const getThreadIdToNameMap: Selector<Map<Tid, string>> = createSelector(
   }
 );
 
+export const getProcessIdToNameMap: Selector<Map<Pid, string>> = createSelector(
+  getThreads,
+  (threads) => {
+    const processIdToNameMap = new Map();
+    for (const thread of threads) {
+      if (!thread.isMainThread || !thread.pid) {
+        continue;
+      }
+      processIdToNameMap.set(
+        thread.pid,
+        getFriendlyThreadName(threads, thread)
+      );
+    }
+    return processIdToNameMap;
+  }
+);
+
 // Gets whether this profile contains private information.
 export const getContainsPrivateBrowsingInformation: Selector<boolean> =
   createSelector(getProfile, (profile) => {

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -1097,8 +1097,8 @@ describe('TooltipMarker', function () {
         />
       </Provider>
     );
-    const threadTitle = screen.getByText('Thread:');
-    const threadInfo = threadTitle.nextSibling;
-    expect(threadInfo).toHaveTextContent(tab2Domain);
+    const trackTitle = screen.getByText('Track:');
+    const trackInfo = trackTitle.nextSibling;
+    expect(trackInfo).toHaveTextContent(tab2Domain);
   });
 });

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -343,7 +343,7 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
       <div
         class="tooltipLabel"
       >
-        Thread
+        Track
         :
       </div>
       Empty
@@ -1353,7 +1353,7 @@ exports[`MarkerChart with active tab renders the hovered marker properly 2`] = `
       <div
         class="tooltipLabel"
       >
-        Thread
+        Track
         :
       </div>
       Empty

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -90,7 +90,7 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
         <div
           class="tooltipLabel"
         >
-          Thread
+          Track
           :
         </div>
         Empty

--- a/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerSidebar.test.js.snap
@@ -58,7 +58,7 @@ exports[`MarkerSidebar matches the snapshots when displaying data about the curr
           Other Pid
           :
         </div>
-        2222
+        PID: 2222
         <div
           class="tooltipLabel"
         >

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -887,7 +887,7 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
       <div
         class="tooltipLabel"
       >
-        Thread
+        Track
         :
       </div>
       Empty

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -221,7 +221,7 @@ exports[`TooltipMarker renders properly network markers that were aborted 1`] = 
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -316,7 +316,7 @@ exports[`TooltipMarker renders properly network markers where content type is bl
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -502,7 +502,7 @@ exports[`TooltipMarker renders properly network markers where content type is mi
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -698,7 +698,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part 2
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -958,7 +958,7 @@ exports[`TooltipMarker renders properly network markers with a preconnect part c
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1144,7 +1144,7 @@ exports[`TooltipMarker renders properly normal network markers 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1401,7 +1401,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Internal 
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1514,7 +1514,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Permanent
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1627,7 +1627,7 @@ exports[`TooltipMarker renders properly redirect network markers for a Temporary
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1740,7 +1740,7 @@ exports[`TooltipMarker renders properly redirect network markers for an internal
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1846,7 +1846,7 @@ exports[`TooltipMarker renders properly redirect network markers without additio
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -1918,7 +1918,7 @@ exports[`TooltipMarker renders the tooltip of CompositorScreenshotWindowDestroye
         <div
           class="tooltipLabel"
         >
-          Thread
+          Track
           :
         </div>
         Empty
@@ -1951,7 +1951,7 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout_ShapeGuard 
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -1989,7 +1989,7 @@ exports[`TooltipMarker renders tooltips for various markers: Bailout-10 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -2020,7 +2020,7 @@ exports[`TooltipMarker renders tooltips for various markers: BailoutKind::Argume
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -2063,7 +2063,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.5 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -2127,7 +2127,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.6 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -2189,7 +2189,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.7 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -2251,7 +2251,7 @@ exports[`TooltipMarker renders tooltips for various markers: DOMEvent-10.8 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -2658,7 +2658,7 @@ exports[`TooltipMarker renders tooltips for various markers: FileIO-114 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3074,7 +3074,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3196,7 +3196,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCMinor-15.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3269,7 +3269,7 @@ exports[`TooltipMarker renders tooltips for various markers: GCSlice-17.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3361,7 +3361,7 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3392,7 +3392,7 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate http://m
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3430,7 +3430,7 @@ exports[`TooltipMarker renders tooltips for various markers: Invalidate-10 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3475,7 +3475,7 @@ exports[`TooltipMarker renders tooltips for various markers: Log-21.7 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3513,7 +3513,7 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-14.5
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3556,7 +3556,7 @@ exports[`TooltipMarker renders tooltips for various markers: NotifyDidPaint-112.
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3601,7 +3601,7 @@ exports[`TooltipMarker renders tooltips for various markers: PlayAudio-115 1`] =
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3660,7 +3660,7 @@ exports[`TooltipMarker renders tooltips for various markers: PreferenceRead-114.
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -3703,7 +3703,7 @@ exports[`TooltipMarker renders tooltips for various markers: RefreshObserver-122
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -4007,7 +4007,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-18.5 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -4344,7 +4344,7 @@ exports[`TooltipMarker renders tooltips for various markers: Styles-20 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -4648,7 +4648,7 @@ exports[`TooltipMarker renders tooltips for various markers: TimeToFirstInteract
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -4720,7 +4720,7 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Main Thread
@@ -4767,7 +4767,7 @@ exports[`TooltipMarker shows a tooltip for Jank markers 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -4838,7 +4838,7 @@ exports[`TooltipMarker shows image of CompositorScreenshot markers 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty
@@ -4883,7 +4883,7 @@ exports[`TooltipMarker shows the source thread for markers from a merged thread 
         <div
           class="tooltipLabel"
         >
-          Thread
+          Track
           :
         </div>
         https://mozilla.org
@@ -4951,7 +4951,7 @@ exports[`TooltipMarker shows the source thread for markers from a merged thread 
         <div
           class="tooltipLabel"
         >
-          Thread
+          Track
           :
         </div>
         https://letsencrypt.org

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -3329,7 +3329,7 @@ exports[`TooltipMarker renders tooltips for various markers: IPCOut-120 1`] = `
       Other Pid
       :
     </div>
-    2222
+    PID: 2222
     <div
       class="tooltipLabel"
     >

--- a/src/test/components/__snapshots__/TrackCustomMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TrackCustomMarker.test.js.snap
@@ -49,7 +49,7 @@ exports[`TrackCustomMarker has a tooltip that matches the snapshot 1`] = `
     <div
       class="tooltipLabel"
     >
-      Thread
+      Track
       :
     </div>
     Empty

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -105,7 +105,7 @@ exports[`timeline/TrackNetwork draws differently a request and displays a toolti
       <div
         class="tooltipLabel"
       >
-        Thread
+        Track
         :
       </div>
       Empty

--- a/src/test/unit/marker-schema.test.js
+++ b/src/test/unit/marker-schema.test.js
@@ -271,6 +271,8 @@ describe('marker schema formatting', function () {
       ['percentage', 0.123456789],
       ['percentage', 1234.56789],
       ['percentage', 0.000123456],
+      ['pid', '2322'],
+      ['tid', '2427'],
       ['unique-string', 0], // Should be "IPC Message", see "stringTable" in "applyLabel" fn
       ['unique-string', 1], // Should be "MouseDown Event", see "stringTable" in "applyLabel" fn
       ['unique-string', null], // Should be "(empty)"
@@ -357,6 +359,8 @@ describe('marker schema formatting', function () {
         "percentage - 12%",
         "percentage - 123,457%",
         "percentage - 0.0%",
+        "pid - PID: 2322",
+        "tid - TID: 2427",
         "unique-string - IPC Message",
         "unique-string - MouseDown Event",
         "unique-string - (empty)",

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -62,6 +62,8 @@ export type MarkerFormatType =
   // use it for time information.
   // "Label: 52.23, 0.0054, 123,456.78"
   | 'decimal'
+  | 'pid'
+  | 'tid'
   | 'list'
   | {| type: 'table', columns: TableColumnFormat[] |};
 


### PR DESCRIPTION
Example profile using these new types: https://share.firefox.dev/3Vsc6p8, [deploy preview](https://deploy-preview-4941--perf-html.netlify.app/public/4atjf37gg5b04jnqj1jt6peeqmy02hnta6qarxg/marker-chart/?globalTrackOrder=502134&hiddenGlobalTracks=2&hiddenLocalTracksByPid=19665-0wbdwxqxtwy2~19799-013wqswv~25685-0wp~29948-0wnqwu~19746-0wmowq&markerSearch=19665&thread=0&v=10)