### PR TITLE
Return early if Firefox doesn't provide any external markers

### DIFF
--- a/src/app-logic/web-channel.js
+++ b/src/app-logic/web-channel.js
@@ -4,7 +4,11 @@
 // @flow
 
 import type { SymbolTableAsTuple } from '../profile-logic/symbol-store-db';
-import type { Milliseconds, MixedObject } from 'firefox-profiler/types';
+import type {
+  Milliseconds,
+  MixedObject,
+  ExternalMarkersData,
+} from 'firefox-profiler/types';
 
 /**
  * This file is in charge of handling the message managing between profiler.firefox.com
@@ -106,7 +110,7 @@ type StatusQueryResponse = {|
 |};
 type EnableMenuButtonResponse = void;
 type GetProfileResponse = ArrayBuffer | MixedObject;
-type GetExternalMarkersResponse = MixedObject[];
+type GetExternalMarkersResponse = ExternalMarkersData;
 type GetExternalPowerTracksResponse = MixedObject[];
 type GetSymbolTableResponse = SymbolTableAsTuple;
 type QuerySymbolicationApiResponse = string;
@@ -192,7 +196,7 @@ export async function getProfileViaWebChannel(): Promise<
 export async function getExternalMarkersViaWebChannel(
   startTime: Milliseconds,
   endTime: Milliseconds
-): Promise<MixedObject[]> {
+): Promise<ExternalMarkersData> {
   return _sendMessageWithResponse({
     type: 'GET_EXTERNAL_MARKERS',
     startTime,

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1385,6 +1385,15 @@ export function insertExternalMarkersIntoProfile(
   externalMarkers: ExternalMarkersData,
   geckoProfile: GeckoProfile
 ): void {
+  if (
+    !externalMarkers.markerSchema ||
+    !externalMarkers.categories ||
+    !externalMarkers.markers
+  ) {
+    // No data provided by Firefox.
+    return;
+  }
+
   for (const schema of externalMarkers.markerSchema) {
     const existingSchema = geckoProfile.meta.markerSchema.find(
       (s) => s.name === schema.name

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -74,11 +74,13 @@ export type ExternalMarkers = {
   data: Array<ExternalMarkerTuple>,
 };
 
-export type ExternalMarkersData = {|
-  markerSchema: MarkerSchema[],
-  categories: CategoryList,
-  markers: ExternalMarkers,
-|};
+export type ExternalMarkersData =
+  | {|
+      markerSchema: MarkerSchema[],
+      categories: CategoryList,
+      markers: ExternalMarkers,
+    |}
+  | {||};
 
 /**
  * These structs aren't very DRY, but it is a simple and complete approach.


### PR DESCRIPTION
It was failing to capture power data before because it was returning an error while trying to get the external markers. Firefox returns an empty array right now, but we should also change it to an empty object. This code works for both options.