### PR TITLE
Use the categories in the flame graph tooltip instead of the old implementation information

### DIFF
--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.tooltipCallNodeImplementation,
 .tooltipCallNodeCategory {
   display: grid;
   padding-bottom: 10px;

--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -46,16 +46,10 @@
 .tooltipCallNodeGraphMeterBar {
   height: 100%;
   box-sizing: border-box;
-}
 
-/* Some colors don't have enough contrast (yellow for JavaScript, white for
- * Idle), therefore adding a border improves accessibility. */
-.tooltipCallNodeGraphMeterTotal > .tooltipCallNodeGraphMeterBar {
-  border-top: 1px solid var(--grey-50);
-}
-
-.tooltipCallNodeGraphMeterSelf > .tooltipCallNodeGraphMeterBar {
-  border-bottom: 1px solid var(--grey-50);
+  /* Some colors don't have enough contrast (yellow for JavaScript, white for
+   * Idle), therefore adding a border improves accessibility. */
+  border-inline-end: 1px solid var(--grey-50);
 }
 
 .tooltipCallNodeCategory .tooltipCategoryRowHeader {

--- a/src/components/tooltip/CallNode.css
+++ b/src/components/tooltip/CallNode.css
@@ -4,9 +4,10 @@
 
 .tooltipCallNodeCategory {
   display: grid;
+  align-items: center;
   padding-bottom: 10px;
   border-bottom: 1px solid var(--grey-30);
-  grid-gap: 2px;
+  grid-gap: 4px;
   grid-template-columns: repeat(4, min-content);
 }
 
@@ -22,33 +23,43 @@
   white-space: nowrap;
 }
 
+/* This contains the 2 meters (self and total sample count values). */
 .tooltipCallNodeGraph {
-  position: relative;
-  width: var(--graph-width);
-  height: var(--graph-height);
-  border-radius: 2px;
-  margin-top: 3px;
-  background-color: var(--grey-30);
+  display: flex;
+  width: 150px;
+  height: 10px;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.tooltipCallNodeGraphRunning {
-  height: calc(var(--graph-height) / 2 - 1px);
-  border-radius: 2px;
-  background-color: var(--blue-40);
+/* This is just one meter (either self or total sample count values). */
+.tooltipCallNodeGraphMeter {
+  /* It's not fully clear why height: 0 is needed here, but otherwise the meter
+   * has a height of 11px despite the parent's 10px height... */
+  height: 0;
+  flex: 1;
+  appearance: none;
+  background: var(--grey-90-a10);
 }
 
-.tooltipCallNodeGraphSelf {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: calc(var(--graph-height) / 2 - 1px);
-  border-radius: 2px;
-  margin-top: calc(var(--graph-height) / 2);
-  background-color: var(--blue-60);
+/* This is the bar inside the meter. */
+.tooltipCallNodeGraphMeterBar {
+  height: 100%;
+  box-sizing: border-box;
+}
+
+/* Some colors don't have enough contrast (yellow for JavaScript, white for
+ * Idle), therefore adding a border improves accessibility. */
+.tooltipCallNodeGraphMeterTotal > .tooltipCallNodeGraphMeterBar {
+  border-top: 1px solid var(--grey-50);
+}
+
+.tooltipCallNodeGraphMeterSelf > .tooltipCallNodeGraphMeterBar {
+  border-bottom: 1px solid var(--grey-50);
 }
 
 .tooltipCallNodeCategory .tooltipCategoryRowHeader {
-  margin-top: 8px;
+  margin-top: 12px;
   font-weight: bold;
 }
 
@@ -85,13 +96,4 @@
   min-width: 150px;
   padding: 10px;
   padding-bottom: 5px;
-}
-
-.tooltipCategoryRowHeader.tooltipCallNodeGraph {
-  /* we have to add 3px to the 8px of category row to realign the callnode graph propertly */
-  margin-top: 11px;
-}
-
-.tooltipCategoryRowHeader.tooltipCategoryName {
-  padding-right: 4px;
 }

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -202,7 +202,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           subCategory,
           selfTimeValue,
           entireCategoryValue,
-          entireCategoryValue,
+          totalTime.value,
           isHighPrecision,
           true
         )
@@ -221,7 +221,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         -1 /* Any number different from a subcategory index */,
         selfTimeValue,
         entireCategoryValue,
-        entireCategoryValue,
+        totalTime.value,
         isHighPrecision,
         true /* isCategoryHeader */
       )

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -46,16 +46,25 @@ function TooltipCallNodeMeter({
   max,
   value,
   color,
+  ariaLabel,
 }: {|
   additionalClassName: string,
   max: number,
   value: number,
   color?: string,
+  ariaLabel: string,
 |}) {
   const widthPercent = (value / max) * 100 + '%';
   const barColor = color ? `var(--category-color-${color})` : 'var(--blue-40)';
   return (
-    <div className={`tooltipCallNodeGraphMeter ${additionalClassName}`}>
+    <div
+      className={`tooltipCallNodeGraphMeter ${additionalClassName}`}
+      role="meter"
+      aria-label={ariaLabel}
+      aria-valuemax={max}
+      aria-valuemin={0}
+      aria-valuenow={value}
+    >
       <div
         className="tooltipCallNodeGraphMeterBar"
         style={{ width: widthPercent, background: barColor }}
@@ -70,12 +79,14 @@ function TooltipCallNodeTotalSelfMeters({
   self,
   total,
   color,
+  labelQualifier,
 }: {|
   isHeader: boolean,
   max: number,
   self: number,
   total: number,
   color?: string,
+  labelQualifier: string,
 |}) {
   return (
     <div
@@ -88,12 +99,14 @@ function TooltipCallNodeTotalSelfMeters({
         max={max}
         value={total}
         color={color}
+        ariaLabel={`Total samples ${labelQualifier}`}
       />
       <TooltipCallNodeMeter
         additionalClassName="tooltipCallNodeGraphMeterSelf"
         max={max}
         value={self}
         color={color}
+        ariaLabel={`Self samples ${labelQualifier}`}
       />
     </div>
   );
@@ -148,6 +161,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           self={selfTime}
           total={totalTime}
           max={overallTotalTime}
+          labelQualifier={`for ${label}`}
           color={color}
           isHeader={isCategoryHeader}
         />
@@ -306,6 +320,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           self={selfTime.value}
           total={totalTime.value}
           max={totalTime.value}
+          labelQualifier="overall"
           isHeader={true}
         />
         <div className="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader">

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -38,6 +38,63 @@ import classNames from 'classnames';
 const GRAPH_WIDTH = 150;
 const GRAPH_HEIGHT = 10;
 
+function TooltipCallNodeMeter({
+  className,
+  max,
+  value,
+  color,
+}: {|
+  className: string,
+  max: number,
+  value: number,
+  color?: string,
+|}) {
+  return (
+    <div
+      className={className}
+      style={{
+        width: (GRAPH_WIDTH * value) / max,
+        backgroundColor: color ? `var(--category-color-${color})` : null,
+      }}
+    />
+  );
+}
+
+function TooltipCallNodeTotalSelfMeters({
+  isHeader,
+  max,
+  self,
+  total,
+  color,
+}: {|
+  isHeader: boolean,
+  max: number,
+  self: number,
+  total: number,
+  color?: string,
+|}) {
+  return (
+    <div
+      className={classNames('tooltipCallNodeGraph', {
+        tooltipCategoryRowHeader: isHeader,
+      })}
+    >
+      <TooltipCallNodeMeter
+        className="tooltipCallNodeGraphRunning"
+        max={max}
+        value={total}
+        color={color}
+      />
+      <TooltipCallNodeMeter
+        className="tooltipCallNodeGraphSelf"
+        max={max}
+        value={self}
+        color={color}
+      />
+    </div>
+  );
+}
+
 type Props = {|
   +thread: Thread,
   +weightType: WeightType,
@@ -83,26 +140,13 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         >
           {label}
         </div>
-        <div
-          className={classNames('tooltipCallNodeGraph ', {
-            tooltipCategoryRowHeader: isCategoryHeader,
-          })}
-        >
-          <div
-            className="tooltipCallNodeGraphRunning"
-            style={{
-              width: (GRAPH_WIDTH * totalTime) / overallTotalTime,
-              backgroundColor: `var(--category-color-${color})`,
-            }}
-          />
-          <div
-            className="tooltipCallNodeGraphSelf"
-            style={{
-              width: (GRAPH_WIDTH * selfTime) / overallTotalTime,
-              backgroundColor: `var(--category-color-${color})`,
-            }}
-          />
-        </div>
+        <TooltipCallNodeTotalSelfMeters
+          self={selfTime}
+          total={totalTime}
+          max={overallTotalTime}
+          color={color}
+          isHeader={isCategoryHeader}
+        />
         <div
           className={classNames({
             tooltipCallNodeTiming: true,
@@ -254,20 +298,12 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         <div className="tooltipLabel tooltipCategoryLabel tooltipCategoryRowHeader">
           Overall
         </div>
-        <div className="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader">
-          <div
-            className="tooltipCallNodeGraphRunning"
-            style={{
-              width: GRAPH_WIDTH,
-            }}
-          />
-          <div
-            className="tooltipCallNodeGraphSelf"
-            style={{
-              width: (GRAPH_WIDTH * selfTime.value) / totalTime.value,
-            }}
-          />
-        </div>
+        <TooltipCallNodeTotalSelfMeters
+          self={selfTime.value}
+          total={totalTime.value}
+          max={totalTime.value}
+          isHeader={true}
+        />
         <div className="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader">
           {formatCallNodeNumberWithUnit(
             weightType,

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -6,13 +6,9 @@ import * as React from 'react';
 
 import { getStackType } from 'firefox-profiler/profile-logic/transforms';
 import { parseFileNameFromSymbolication } from 'firefox-profiler/utils/special-paths';
-import { objectEntries } from 'firefox-profiler/utils/flow';
 import { formatCallNodeNumberWithUnit } from 'firefox-profiler/utils/format-numbers';
 import { Icon } from 'firefox-profiler/components/shared/Icon';
-import {
-  getFriendlyStackTypeName,
-  getCategoryPairLabel,
-} from 'firefox-profiler/profile-logic/profile-data';
+import { getCategoryPairLabel } from 'firefox-profiler/profile-logic/profile-data';
 import { countPositiveValues } from 'firefox-profiler/utils';
 
 import type {
@@ -299,127 +295,6 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     );
   }
 
-  _canRenderImplementationTimings(maybeTimings: ?TimingsForPath) {
-    if (!maybeTimings) {
-      return false;
-    }
-    return maybeTimings.forPath.totalTime.breakdownByImplementation !== null;
-  }
-
-  _renderImplementationTimings(maybeTimings: ?TimingsForPath) {
-    if (!maybeTimings) {
-      return null;
-    }
-    const { totalTime, selfTime } = maybeTimings.forPath;
-    if (!totalTime.breakdownByImplementation) {
-      return null;
-    }
-
-    const sortedTotalBreakdownByImplementation = objectEntries(
-      totalTime.breakdownByImplementation
-    ).sort((a, b) => b[1] - a[1]);
-    const { thread, weightType } = this.props;
-
-    // JS Tracer threads have data relevant to the microsecond level.
-    const isHighPrecision = Boolean(thread.isJsTracer);
-
-    return (
-      <div className="tooltipCallNodeImplementation">
-        {/* grid row -------------------------------------------------- */}
-        <div />
-        <div className="tooltipCallNodeHeader" />
-        <div className="tooltipCallNodeHeader">
-          <span className="tooltipCallNodeHeaderSwatchRunning" />
-          Running
-        </div>
-        <div className="tooltipCallNodeHeader">
-          <span className="tooltipCallNodeHeaderSwatchSelf" />
-          Self
-        </div>
-        {/* grid row -------------------------------------------------- */}
-        <div className="tooltipLabel">Overall</div>
-        <div className="tooltipCallNodeGraph">
-          <div
-            className="tooltipCallNodeGraphRunning"
-            style={{
-              width: GRAPH_WIDTH,
-            }}
-          />
-          <div
-            className="tooltipCallNodeGraphSelf"
-            style={{
-              width: (GRAPH_WIDTH * selfTime.value) / totalTime.value,
-            }}
-          />
-        </div>
-        <div className="tooltipCallNodeTiming">
-          {formatCallNodeNumberWithUnit(
-            weightType,
-            isHighPrecision,
-            totalTime.value
-          )}
-        </div>
-        <div className="tooltipCallNodeTiming">
-          {selfTime.value === 0
-            ? '—'
-            : formatCallNodeNumberWithUnit(
-                weightType,
-                isHighPrecision,
-                selfTime.value
-              )}
-        </div>
-        {/* grid row -------------------------------------------------- */}
-        {sortedTotalBreakdownByImplementation.map(
-          ([implementation, time], index) => {
-            let selfTimeValue = 0;
-            if (selfTime.breakdownByImplementation) {
-              selfTimeValue =
-                selfTime.breakdownByImplementation[implementation] || 0;
-            }
-
-            return (
-              <React.Fragment key={index}>
-                <div className="tooltipCallNodeName tooltipLabel">
-                  {getFriendlyStackTypeName(implementation)}
-                </div>
-                <div className="tooltipCallNodeGraph">
-                  <div
-                    className="tooltipCallNodeGraphRunning"
-                    style={{
-                      width: (GRAPH_WIDTH * time) / totalTime.value,
-                    }}
-                  />
-                  <div
-                    className="tooltipCallNodeGraphSelf"
-                    style={{
-                      width: (GRAPH_WIDTH * selfTimeValue) / totalTime.value,
-                    }}
-                  />
-                </div>
-                <div className="tooltipCallNodeTiming">
-                  {formatCallNodeNumberWithUnit(
-                    weightType,
-                    isHighPrecision,
-                    time
-                  )}
-                </div>
-                <div className="tooltipCallNodeTiming">
-                  {selfTimeValue === 0
-                    ? '—'
-                    : formatCallNodeNumberWithUnit(
-                        weightType,
-                        isHighPrecision,
-                        selfTimeValue
-                      )}
-                </div>
-              </React.Fragment>
-            );
-          }
-        )}
-      </div>
-    );
-  }
-
   render() {
     const {
       callNodeIndex,
@@ -575,9 +450,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           </div>
         </div>
         <div className="tooltipCallNodeDetails">
-          {this._canRenderImplementationTimings(timings)
-            ? this._renderImplementationTimings(timings)
-            : this._renderCategoryTimings(timings)}
+          {this._renderCategoryTimings(timings)}
           {callTreeSummaryStrategy !== 'timing' && displayData ? (
             <div className="tooltipDetails tooltipCallNodeDetailsLeft">
               {/* Everything in this div needs to come in pairs of two in order to

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -35,28 +35,32 @@ import type {
 import './CallNode.css';
 import classNames from 'classnames';
 
-const GRAPH_WIDTH = 150;
-const GRAPH_HEIGHT = 10;
-
+/**
+ * This implements a meter bar, used to display in a visual way the values for
+ * the total and self sample counts.
+ * This component could be implemented using a HTML <meter>, but these ones are
+ * impossible to style in a cross-browser way, notably Chrome and Safari.
+ */
 function TooltipCallNodeMeter({
-  className,
+  additionalClassName,
   max,
   value,
   color,
 }: {|
-  className: string,
+  additionalClassName: string,
   max: number,
   value: number,
   color?: string,
 |}) {
+  const widthPercent = (value / max) * 100 + '%';
+  const barColor = color ? `var(--category-color-${color})` : 'var(--blue-40)';
   return (
-    <div
-      className={className}
-      style={{
-        width: (GRAPH_WIDTH * value) / max,
-        backgroundColor: color ? `var(--category-color-${color})` : null,
-      }}
-    />
+    <div className={`tooltipCallNodeGraphMeter ${additionalClassName}`}>
+      <div
+        className="tooltipCallNodeGraphMeterBar"
+        style={{ width: widthPercent, background: barColor }}
+      ></div>
+    </div>
   );
 }
 
@@ -80,13 +84,13 @@ function TooltipCallNodeTotalSelfMeters({
       })}
     >
       <TooltipCallNodeMeter
-        className="tooltipCallNodeGraphRunning"
+        additionalClassName="tooltipCallNodeGraphMeterTotal"
         max={max}
         value={total}
         color={color}
       />
       <TooltipCallNodeMeter
-        className="tooltipCallNodeGraphSelf"
+        additionalClassName="tooltipCallNodeGraphMeterSelf"
         max={max}
         value={self}
         color={color}
@@ -469,13 +473,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
     }
 
     return (
-      <div
-        className="tooltipCallNode"
-        style={{
-          '--graph-width': GRAPH_WIDTH + 'px',
-          '--graph-height': GRAPH_HEIGHT + 'px',
-        }}
-      >
+      <div className="tooltipCallNode">
         <div className="tooltipOneLine tooltipHeader">
           <div className="tooltipTiming">{durationText}</div>
           <div className="tooltipTitle">{funcName}</div>

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -266,7 +266,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
           subCategory,
           selfTimeValue,
           subCategoryValue,
-          entireCategoryValue,
+          totalTime.value,
           isHighPrecision,
           false /* isCategoryHeader */
         )

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -65,10 +65,12 @@ function TooltipCallNodeMeter({
       aria-valuemin={0}
       aria-valuenow={value}
     >
-      <div
-        className="tooltipCallNodeGraphMeterBar"
-        style={{ width: widthPercent, background: barColor }}
-      ></div>
+      {value > 0 ? (
+        <div
+          className="tooltipCallNodeGraphMeterBar"
+          style={{ width: widthPercent, background: barColor }}
+        ></div>
+      ) : null}
     </div>
   );
 }

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -76,7 +76,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -103,7 +103,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           Network
         </div>
         <div
-          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -130,7 +130,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           Graphics
         </div>
         <div
-          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -249,7 +249,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -276,7 +276,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           Network
         </div>
         <div
-          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -303,7 +303,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           Graphics
         </div>
         <div
-          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -847,7 +847,7 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -874,7 +874,7 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           Graphics
         </div>
         <div
-          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -999,7 +999,7 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -1026,7 +1026,7 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           Graphics
         </div>
         <div
-          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -48,7 +48,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
       class="tooltipCallNodeDetails"
     >
       <div
-        class="tooltipCallNodeImplementation"
+        class="tooltipCallNodeCategory"
       >
         <div />
         <div
@@ -71,12 +71,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           Self
         </div>
         <div
-          class="tooltipLabel"
+          class="tooltipLabel tooltipCategoryLabel tooltipCategoryRowHeader"
         >
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -88,22 +88,22 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           3 samples
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           —
         </div>
         <div
-          class="tooltipCallNodeName tooltipLabel"
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
         >
-          Native code
+          Network
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -115,12 +115,39 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
-          3 samples
+          1 sample
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
+        >
+          —
+        </div>
+        <div
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
+        >
+          Graphics
+        </div>
+        <div
+          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+        >
+          <div
+            class="tooltipCallNodeGraphRunning"
+            style="width: 150px;"
+          />
+          <div
+            class="tooltipCallNodeGraphSelf"
+            style="width: 0px;"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
+        >
+          2 samples
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
           —
         </div>
@@ -194,7 +221,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
       class="tooltipCallNodeDetails"
     >
       <div
-        class="tooltipCallNodeImplementation"
+        class="tooltipCallNodeCategory"
       >
         <div />
         <div
@@ -217,12 +244,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           Self
         </div>
         <div
-          class="tooltipLabel"
+          class="tooltipLabel tooltipCategoryLabel tooltipCategoryRowHeader"
         >
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -234,22 +261,22 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           3 samples
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           —
         </div>
         <div
-          class="tooltipCallNodeName tooltipLabel"
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
         >
-          Native code
+          Network
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -261,12 +288,39 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
-          3 samples
+          1 sample
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
+        >
+          —
+        </div>
+        <div
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
+        >
+          Graphics
+        </div>
+        <div
+          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
+        >
+          <div
+            class="tooltipCallNodeGraphRunning"
+            style="width: 150px;"
+          />
+          <div
+            class="tooltipCallNodeGraphSelf"
+            style="width: 0px;"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
+        >
+          2 samples
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
           —
         </div>
@@ -765,7 +819,7 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
       class="tooltipCallNodeDetails"
     >
       <div
-        class="tooltipCallNodeImplementation"
+        class="tooltipCallNodeCategory"
       >
         <div />
         <div
@@ -788,12 +842,12 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           Self
         </div>
         <div
-          class="tooltipLabel"
+          class="tooltipLabel tooltipCategoryLabel tooltipCategoryRowHeader"
         >
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -805,22 +859,22 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeName tooltipLabel"
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
         >
-          Native code
+          Graphics
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -832,12 +886,12 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
           1 sample
         </div>
@@ -917,7 +971,7 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
       class="tooltipCallNodeDetails"
     >
       <div
-        class="tooltipCallNodeImplementation"
+        class="tooltipCallNodeCategory"
       >
         <div />
         <div
@@ -940,12 +994,12 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           Self
         </div>
         <div
-          class="tooltipLabel"
+          class="tooltipLabel tooltipCategoryLabel tooltipCategoryRowHeader"
         >
           Overall
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph tooltipCategoryRow tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -957,22 +1011,22 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeName tooltipLabel"
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
         >
-          Native code
+          Graphics
         </div>
         <div
-          class="tooltipCallNodeGraph"
+          class="tooltipCallNodeGraph  tooltipCategoryRowHeader"
         >
           <div
             class="tooltipCallNodeGraphRunning"
@@ -984,12 +1038,12 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           />
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
           1 sample
         </div>
         <div
-          class="tooltipCallNodeTiming"
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
         >
           1 sample
         </div>

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -25,7 +25,6 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
 >
   <div
     class="tooltipCallNode"
-    style="--graph-width: 150px; --graph-height: 10px;"
   >
     <div
       class="tooltipOneLine tooltipHeader"
@@ -79,13 +78,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 0px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 0%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
@@ -106,13 +113,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 50px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 33.33333333333333%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 0px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 0%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -133,13 +148,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 100px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 66.66666666666666%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 0px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 0%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -198,7 +221,6 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
 >
   <div
     class="tooltipCallNode"
-    style="--graph-width: 150px; --graph-height: 10px;"
   >
     <div
       class="tooltipOneLine tooltipHeader"
@@ -252,13 +274,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 0px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 0%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
@@ -279,13 +309,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 50px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 33.33333333333333%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 0px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 0%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -306,13 +344,21 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 100px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 66.66666666666666%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 0px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 0%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -796,7 +842,6 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
 >
   <div
     class="tooltipCallNode"
-    style="--graph-width: 150px; --graph-height: 10px;"
   >
     <div
       class="tooltipOneLine tooltipHeader"
@@ -850,13 +895,21 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
@@ -877,13 +930,21 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -948,7 +1009,6 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
 >
   <div
     class="tooltipCallNode"
-    style="--graph-width: 150px; --graph-height: 10px;"
   >
     <div
       class="tooltipOneLine tooltipHeader"
@@ -1002,13 +1062,21 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
@@ -1029,13 +1097,21 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
-            class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
           <div
-            class="tooltipCallNodeGraphSelf"
-            style="width: 150px;"
-          />
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -78,7 +78,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples overall"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="3"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -86,7 +91,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
             />
           </div>
           <div
+            aria-label="Self samples overall"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -113,7 +123,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples for Network"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -121,7 +136,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
             />
           </div>
           <div
+            aria-label="Self samples for Network"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -148,7 +168,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples for Graphics"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="2"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -156,7 +181,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
             />
           </div>
           <div
+            aria-label="Self samples for Graphics"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -274,7 +304,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples overall"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="3"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -282,7 +317,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
             />
           </div>
           <div
+            aria-label="Self samples overall"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -309,7 +349,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples for Network"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -317,7 +362,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
             />
           </div>
           <div
+            aria-label="Self samples for Network"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -344,7 +394,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples for Graphics"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="2"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -352,7 +407,12 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
             />
           </div>
           <div
+            aria-label="Self samples for Graphics"
+            aria-valuemax="3"
+            aria-valuemin="0"
+            aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -895,7 +955,12 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples overall"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -903,7 +968,12 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
             />
           </div>
           <div
+            aria-label="Self samples overall"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -930,7 +1000,12 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples for Graphics"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -938,7 +1013,12 @@ exports[`FlameGraph shows a tooltip with the resource information with categorie
             />
           </div>
           <div
+            aria-label="Self samples for Graphics"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -1062,7 +1142,12 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples overall"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -1070,7 +1155,12 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
             />
           </div>
           <div
+            aria-label="Self samples overall"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -1097,7 +1187,12 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
           class="tooltipCallNodeGraph tooltipCategoryRowHeader"
         >
           <div
+            aria-label="Total samples for Graphics"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"
@@ -1105,7 +1200,12 @@ exports[`FlameGraph shows a tooltip with the resource information with implement
             />
           </div>
           <div
+            aria-label="Self samples for Graphics"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
           >
             <div
               class="tooltipCallNodeGraphMeterBar"

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -97,12 +97,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
             aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
             role="meter"
-          >
-            <div
-              class="tooltipCallNodeGraphMeterBar"
-              style="width: 0%;"
-            />
-          </div>
+          />
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
@@ -142,12 +137,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
             aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
             role="meter"
-          >
-            <div
-              class="tooltipCallNodeGraphMeterBar"
-              style="width: 0%;"
-            />
-          </div>
+          />
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -187,12 +177,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
             aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
             role="meter"
-          >
-            <div
-              class="tooltipCallNodeGraphMeterBar"
-              style="width: 0%;"
-            />
-          </div>
+          />
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -323,12 +308,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
             aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
             role="meter"
-          >
-            <div
-              class="tooltipCallNodeGraphMeterBar"
-              style="width: 0%;"
-            />
-          </div>
+          />
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
@@ -368,12 +348,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
             aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
             role="meter"
-          >
-            <div
-              class="tooltipCallNodeGraphMeterBar"
-              style="width: 0%;"
-            />
-          </div>
+          />
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"
@@ -413,12 +388,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
             aria-valuenow="0"
             class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
             role="meter"
-          >
-            <div
-              class="tooltipCallNodeGraphMeterBar"
-              style="width: 0%;"
-            />
-          </div>
+          />
         </div>
         <div
           class="tooltipCallNodeTiming tooltipCategoryRowHeader"

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -107,7 +107,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
         >
           <div
             class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
+            style="width: 50px;"
           />
           <div
             class="tooltipCallNodeGraphSelf"
@@ -134,7 +134,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
         >
           <div
             class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
+            style="width: 100px;"
           />
           <div
             class="tooltipCallNodeGraphSelf"
@@ -280,7 +280,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
         >
           <div
             class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
+            style="width: 50px;"
           />
           <div
             class="tooltipCallNodeGraphSelf"
@@ -307,7 +307,7 @@ exports[`FlameGraph has a tooltip that matches the snapshot with implementation 
         >
           <div
             class="tooltipCallNodeGraphRunning"
-            style="width: 150px;"
+            style="width: 100px;"
           />
           <div
             class="tooltipCallNodeGraphSelf"

--- a/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipCallnode.test.js.snap
@@ -3,7 +3,6 @@
 exports[`TooltipCallNode handles native allocations 1`] = `
 <div
   class="tooltipCallNode"
-  style="--graph-width: 150px; --graph-height: 10px;"
 >
   <div
     class="tooltipOneLine tooltipHeader"
@@ -75,7 +74,6 @@ exports[`TooltipCallNode handles native allocations 1`] = `
 exports[`TooltipCallNode with page information displays Page URL for iframe pages 1`] = `
 <div
   class="tooltipCallNode"
-  style="--graph-width: 150px; --graph-height: 10px;"
 >
   <div
     class="tooltipOneLine tooltipHeader"
@@ -145,7 +143,6 @@ exports[`TooltipCallNode with page information displays Page URL for iframe page
 exports[`TooltipCallNode with page information displays Page URL for non-iframe pages 1`] = `
 <div
   class="tooltipCallNode"
-  style="--graph-width: 150px; --graph-height: 10px;"
 >
   <div
     class="tooltipOneLine tooltipHeader"


### PR DESCRIPTION
## The changes
As we discussed several times, with this PR we now use the categories information in the flame graph tooltip.

This also changes some logic and CSS.

1. This changes how they're styled, using a flex container instead of absolute positioning. This also adds a subtle border (top or bottom depending on total count / self count) for accessibility reason, so that the less visible category color still has some contrast (especially yellow and white).
2. Meter bars for categories (not subcategories!) now use the overall total time as their denominator, previously this was always taking the full width. Happy to hear feedback about that one.

Here are some more thoughts about point 2:
* without this change, all categories always took the full width. I believe this didn't make it easy to visualize at the first glance what percentage of a node each category take
* however I didn't do the same for the subcategories, because they would usually be very small as a result; instead I kept the denominator to the category value.
* I'm not super happy about the result to be honest: the categories are related to the overall value, while the subcategories are related to their category value. I believe it still makes the most sense, but visually this is a bit confusing at first. Happy to hear ideas!

## Some screenshots
Before: 
![image](https://github.com/firefox-devtools/profiler/assets/454175/8912c8d9-5eb3-4050-8e06-119c4493a5b5)

Without the CSS changes:
![image](https://github.com/firefox-devtools/profiler/assets/454175/d5be0c87-e80d-4c6d-9b70-197b0cbf7cf4)

After, with all CSS changes:
![image](https://github.com/firefox-devtools/profiler/assets/454175/a9de3e2e-37c2-46aa-b7b1-8e23a034886f)

Here is also an example with some self time:
![image](https://github.com/firefox-devtools/profiler/assets/454175/3bf67055-eb0d-418d-812f-fa352bf1bf66)


## Deploy preview
[Deploy preview](https://deploy-preview-4966--perf-html.netlify.app/public/64cc55wt9e5b80ypceh7ynepj8p7fztsbah5pwr/flame-graph/?globalTrackOrder=0wc&hiddenGlobalTracks=1wb&hiddenLocalTracksByPid=838689-0wxc~839138-0~839000-0~1391547-0~1396265-0~839185-0~926752-0~839072-0~1363875-0~1396099-0~1392079-0~839052-0&thread=xp&v=10) / [production](https://profiler.firefox.com/public/64cc55wt9e5b80ypceh7ynepj8p7fztsbah5pwr/flame-graph/?globalTrackOrder=0wc&hiddenGlobalTracks=1wb&hiddenLocalTracksByPid=838689-0wxc~839138-0~839000-0~1391547-0~1396265-0~839185-0~926752-0~839072-0~1363875-0~1396099-0~1392079-0~839052-0&thread=xp&v=10)