### PR TITLE
When popping a committed range, make it the current preview selection.

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -6,6 +6,7 @@
 import { oneLine } from 'common-tags';
 import { getLastVisibleThreadTabSlug } from 'firefox-profiler/selectors/app';
 import {
+  getCommittedRange,
   getCounterSelectors,
   getGlobalTracks,
   getGlobalTrackAndIndexByPid,
@@ -25,6 +26,7 @@ import {
   selectedThreadSelectors,
 } from 'firefox-profiler/selectors/per-thread';
 import {
+  getAllCommittedRanges,
   getImplementationFilter,
   getSelectedThreadIndexes,
   getSelectedThreadsKey,
@@ -1844,10 +1846,19 @@ export function commitRange(start: number, end: number): Action {
   };
 }
 
-export function popCommittedRanges(firstPoppedFilterIndex: number): Action {
-  return {
-    type: 'POP_COMMITTED_RANGES',
-    firstPoppedFilterIndex,
+export function popCommittedRanges(
+  firstPoppedFilterIndex: number
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    dispatch({
+      type: 'POP_COMMITTED_RANGES',
+      firstPoppedFilterIndex,
+      // If the clicked range is not the last one, make the current committed
+      // range the new preview selection, otherwise clear the selection.
+      committedRange:
+        getAllCommittedRanges(getState()).length !== firstPoppedFilterIndex &&
+        getCommittedRange(getState()),
+    });
   };
 }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -545,8 +545,17 @@ const previewSelection: Reducer<PreviewSelection> = (
     case 'UPDATE_PREVIEW_SELECTION':
       return action.previewSelection;
     case 'COMMIT_RANGE':
-    case 'POP_COMMITTED_RANGES':
       return { hasSelection: false, isModifying: false };
+    case 'POP_COMMITTED_RANGES':
+      if (!action.committedRange) {
+        return { hasSelection: false, isModifying: false };
+      }
+      return {
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: action.committedRange.start,
+        selectionEnd: action.committedRange.end,
+      };
     default:
       return state;
   }

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1498,7 +1498,7 @@ describe('actions/ProfileView', function () {
       ]);
     });
 
-    it('pops a committed range and unsets the selection', function () {
+    it('pops a committed range and sets the selection', function () {
       const { getState, dispatch } = setupStore();
       dispatch(
         ProfileView.updatePreviewSelection({
@@ -1526,6 +1526,36 @@ describe('actions/ProfileView', function () {
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 3,
+        selectionEnd: 7,
+      });
+    });
+
+    it('unsets the selection when popping the current committed range', function () {
+      const { getState, dispatch } = setupStore();
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+        { start: 0, end: 10 },
+        { start: 1, end: 9 },
+        { start: 2, end: 8 },
+        { start: 3, end: 7 },
+      ]);
+
+      dispatch(ProfileView.popCommittedRanges(2));
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
+        { start: 0, end: 10 },
+        { start: 1, end: 9 },
+      ]);
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 3,
+        selectionEnd: 7,
+      });
+
+      dispatch(ProfileView.popCommittedRanges(2));
       expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
         hasSelection: false,
         isModifying: false,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -457,7 +457,11 @@ type UrlStateAction =
     |}
   | {| +type: 'CHANGE_SELECTED_TAB', +selectedTab: TabSlug |}
   | {| +type: 'COMMIT_RANGE', +start: number, +end: number |}
-  | {| +type: 'POP_COMMITTED_RANGES', +firstPoppedFilterIndex: number |}
+  | {|
+      +type: 'POP_COMMITTED_RANGES',
+      +firstPoppedFilterIndex: number,
+      +committedRange: StartEndRange | false,
+    |}
   | {|
       +type: 'CHANGE_SELECTED_THREAD',
       +selectedThreadIndexes: Set<ThreadIndex>,


### PR DESCRIPTION
Randell suggested this idea during the performance work week, and I liked it.

[Deploy preview](https://deploy-preview-4970--perf-html.netlify.app/public/64cc55wt9e5b80ypceh7ynepj8p7fztsbah5pwr/flame-graph/?globalTrackOrder=0wc&hiddenGlobalTracks=1wb&hiddenLocalTracksByPid=838689-0wxc~839138-0~839000-0~1391547-0~1396265-0~839185-0~926752-0~839072-0~1363875-0~1396099-0~1392079-0~839052-0&thread=xp&v=10)