### PR TITLE
WIP: introduce compressedArrayElement for profile data

### DIFF
--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -8,7 +8,7 @@ import { getStackType } from 'firefox-profiler/profile-logic/transforms';
 import { parseFileNameFromSymbolication } from 'firefox-profiler/utils/special-paths';
 import { formatCallNodeNumberWithUnit } from 'firefox-profiler/utils/format-numbers';
 import { Icon } from 'firefox-profiler/components/shared/Icon';
-import { getCategoryPairLabel } from 'firefox-profiler/profile-logic/profile-data';
+import { getCategoryPairLabel, compressedArrayElement } from 'firefox-profiler/profile-logic/profile-data';
 import { countPositiveValues } from 'firefox-profiler/utils';
 
 import type {
@@ -366,17 +366,17 @@ export class TooltipCallNode extends React.PureComponent<Props> {
       displayStackType,
     } = this.props;
     const callNodeTable = callNodeInfo.getCallNodeTable();
-    const categoryIndex = callNodeTable.category[callNodeIndex];
+    const categoryIndex = compressedArrayElement(callNodeTable.category, callNodeIndex);
     const categoryColor = categories[categoryIndex].color;
-    const subcategoryIndex = callNodeTable.subcategory[callNodeIndex];
+    const subcategoryIndex = compressedArrayElement(callNodeTable.subcategory,callNodeIndex);
     const funcIndex = callNodeTable.func[callNodeIndex];
-    const innerWindowID = callNodeTable.innerWindowID[callNodeIndex];
+    const innerWindowID = compressedArrayElement(callNodeTable.innerWindowID, callNodeIndex);
     const funcStringIndex = thread.funcTable.name[funcIndex];
     const funcName = thread.stringTable.getString(funcStringIndex);
 
     let fileName = null;
 
-    const fileNameIndex = thread.funcTable.fileName[funcIndex];
+    const fileNameIndex = compressedArrayElement(thread.funcTable.fileName, funcIndex);
     if (fileNameIndex !== null) {
       let fileNameURL = thread.stringTable.getString(fileNameIndex);
       // fileNameURL could be a path from symbolication (potentially using "special path"
@@ -386,10 +386,10 @@ export class TooltipCallNode extends React.PureComponent<Props> {
 
       // JS functions have information about where the function starts.
       // Add :<line>:<col> to the URL, if known.
-      const lineNumber = thread.funcTable.lineNumber[funcIndex];
+      const lineNumber = compressedArrayElement(thread.funcTable.lineNumber, funcIndex);
       if (lineNumber !== null) {
         fileNameURL += ':' + lineNumber;
-        const columnNumber = thread.funcTable.columnNumber[funcIndex];
+        const columnNumber = compressedArrayElement(thread.funcTable.columnNumber, funcIndex);
         if (columnNumber !== null) {
           fileNameURL += ':' + columnNumber;
         }


### PR DESCRIPTION
Much of the profile json coming from something like `samply` is taken up by arrays containing an identical value. `samply` even has serialization helpers to create arrays of length N with just null, 0, etc. in order to match the profile file format. These values take up a lot of space in the final json; up to 30% in some profiles, and the values are completely unnecessary.

This draft PR shows one approach to how the format could be changed to allow for arrays that all contain the same value to be replaced with just the value itself. In other words:

```
  lineNumber: [null, null, null, .....]
```
becomes:
```
   lineNumber: null
```

I don't actually like this implementation, but opening this PR to get feedback. The problem is that the profiler front end code uses the JSON data format as the in-memory data format directly, so every single location that reads from one of these arrays would need to be replaced with a call to `compressedArrayElement` which is very error prone. I've only captured a few of these locations here.

I think a better approach would be to introduce a type that acts like an array, but contains a `_value` that's either an array or a single value and then as part of parsing the profile, run through the post-`JSON.parse` data structure and convert these, e.g.:

```
  functionTable.lineNumber = new CompressedArray(functionTable.lineNumber);
```

`CompressedArray` would also have a `toJSON` implementation to serialize the value-or-array.
