### PR TITLE
Allow resizing the selected range past the other bound of the current selected range

### DIFF
--- a/src/components/shared/Draggable.js
+++ b/src/components/shared/Draggable.js
@@ -15,7 +15,10 @@ export type OnMove = (
 ) => void;
 
 type Props = {
-  value: { +selectionStart: Milliseconds, +selectionEnd: Milliseconds },
+  value: {
+    +selectionStart: Milliseconds,
+    +selectionEnd: Milliseconds,
+  },
   onMove: OnMove,
   className: string,
   children?: React.Node,

--- a/src/components/timeline/Selection.css
+++ b/src/components/timeline/Selection.css
@@ -86,10 +86,19 @@
   cursor: ew-resize;
 }
 
+/* The :not() selectors are to handle the edge case where the mouse is pressed
+ * on a grippy, then the pointer is moved down (above the first track) but not
+ * moved horizontally.
+ * In that case, because selectionDeltas are 0, the draggingStart/draggingEnd
+ * classes are not set, and the grippy is not hovered, so it would be light
+ * grey until the mouse is moved horizontally. */
 .timelineSelectionGrippyRangeStart:hover,
-.timelineSelectionGrippyRangeStart.dragging,
+.draggingStart > .timelineSelectionGrippyRangeStart,
+:not(.draggingStart, .draggingEnd)
+  > .timelineSelectionGrippyRangeStart.dragging,
 .timelineSelectionGrippyRangeEnd:hover,
-.timelineSelectionGrippyRangeEnd.dragging {
+.draggingEnd > .timelineSelectionGrippyRangeEnd,
+:not(.draggingStart, .draggingEnd) > .timelineSelectionGrippyRangeEnd.dragging {
   background: #888;
 }
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -93,6 +93,8 @@ export type PreviewSelection =
       +isModifying: boolean,
       +selectionStart: number,
       +selectionEnd: number,
+      +draggingStart?: boolean,
+      +draggingEnd?: boolean,
     |};
 
 /**


### PR DESCRIPTION
[Production](https://share.firefox.dev/45rP84q) | [Deploy preview](https://deploy-preview-5031--perf-html.netlify.app/public/3gg2fk69mjmhtzvdhfhvrckwghvs5sachz13x7g/calltree/?globalTrackOrder=0&thread=0&v=10)

Currently when a profile has a selected range, dragging timelineSelectionGrippyRangeStart / timelineSelectionGrippyRangeEnd to adjust the start/end of the selected range has these behaviors that I find unpleasant:
- dragging the end into the start results in a 1ns selected range at the position of the current selected range's start.
- dragging the start into the end also results in a 1ns selected range, but pushed to the new position timelineSelectionGrippyRangeStart was moved to.

The PR I'm submitting changes the behavior so that the start can be dragged past the current end and the end can be dragged past the current start. In these cases, the start/end are swapped so that the new selected range still has a start time < its end time.

For context, the use case I had was trying to slice a profile in two subprofiles. I first selected one half of the profile, committed the range, and shared a short url. Then I uncommited the range, which resulted in the previously committed range becoming the selected range. At that point, I wanted to select a new range where the start of the selected range would be the start of the profile, and the new end of the selected range would be the start of the previously selected range. I couldn't find a way to do it, and ended up doing a new selection, with an approximate end time. This PR makes this use case easy, without IMHO regressing anything useful (I can't think of a case where the existing behaviors would be more useful).

I expected to need to adjust tests for this new behavior, but nothing failed. I'm afraid this part of the code has very little test coverage, if any.