### PR TITLE
 Correctly match strings in unique-string marker fields

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -120,6 +120,7 @@ export function getSearchFilteredMarkerIndexes(
   markerIndexes: MarkerIndex[],
   markerSchemaByName: MarkerSchemaByName,
   searchRegExps: MarkerRegExps | null,
+  stringTable: UniqueStringArray,
   categoryList: CategoryList
 ): MarkerIndex[] {
   if (!searchRegExps) {
@@ -146,6 +147,7 @@ export function getSearchFilteredMarkerIndexes(
         marker,
         markerSchemaByName,
         searchRegExps,
+        stringTable,
         categoryList
       );
     }
@@ -159,6 +161,7 @@ export function getSearchFilteredMarkerIndexes(
         marker,
         markerSchemaByName,
         searchRegExps,
+        stringTable,
         categoryList
       );
     }
@@ -175,6 +178,7 @@ function positiveFilterMarker(
   marker: Marker,
   markerSchemaByName: MarkerSchemaByName,
   searchRegExps: MarkerRegExps,
+  stringTable: UniqueStringArray,
   categoryList: CategoryList
 ): boolean {
   // Need to assign it to a constant variable so Flow doesn't complain about
@@ -229,7 +233,7 @@ function positiveFilterMarker(
     );
     if (
       markerSchema &&
-      markerPayloadMatchesSearch(markerSchema, marker, test)
+      markerPayloadMatchesSearch(markerSchema, marker, stringTable, test)
     ) {
       return true;
     }
@@ -242,6 +246,7 @@ function negativeFilterMarker(
   marker: Marker,
   markerSchemaByName: MarkerSchemaByName,
   searchRegExps: MarkerRegExps,
+  stringTable: UniqueStringArray,
   categoryList: CategoryList
 ): boolean {
   // Need to assign it to a constant variable so Flow doesn't complain about
@@ -295,7 +300,7 @@ function negativeFilterMarker(
 
     if (
       markerSchema &&
-      markerPayloadMatchesSearch(markerSchema, marker, test)
+      markerPayloadMatchesSearch(markerSchema, marker, stringTable, test)
     ) {
       // Found the field in the negative filters, do not include it.
       return false;

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -92,30 +92,30 @@ export function getMarkerSchemaName(
   markerName: string,
   markerData: MarkerPayload | null
 ): string {
-  if (markerData) {
-    const { type } = markerData;
-    if (type === 'tracing' && markerData.category) {
-      // TODO - Tracing markers have a duplicate "category" field.
-      // See issue #2749
-
-      // Does a marker schema for the "category" exist?
-      return markerSchemaByName[markerData.category] === undefined
-        ? // If not, default back to tracing
-          'tracing'
-        : // If so, use the category as the schema name.
-          markerData.category;
-    }
-    if (type === 'Text') {
-      // Text markers are a cheap and easy way to create markers with
-      // a category. Check for schema if it exists, if not, fallback to
-      // a Text type marker.
-      return markerSchemaByName[markerName] === undefined ? 'Text' : markerName;
-    }
-    return markerData.type;
+  if (!markerData) {
+    // Fall back to using the name if no payload exists.
+    return markerName;
   }
 
-  // Fall back to using the name if no payload exists.
-  return markerName;
+  const { type } = markerData;
+  if (type === 'tracing' && markerData.category) {
+    // TODO - Tracing markers have a duplicate "category" field.
+    // See issue #2749
+
+    // Does a marker schema for the "category" exist?
+    return markerSchemaByName[markerData.category] === undefined
+      ? // If not, default back to tracing
+        'tracing'
+      : // If so, use the category as the schema name.
+        markerData.category;
+  }
+  if (type === 'Text') {
+    // Text markers are a cheap and easy way to create markers with
+    // a category. Check for schema if it exists, if not, fallback to
+    // a Text type marker.
+    return markerSchemaByName[markerName] === undefined ? 'Text' : markerName;
+  }
+  return type;
 }
 
 /**

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -659,6 +659,7 @@ export function formatMarkupFromMarkerSchema(
 export function markerPayloadMatchesSearch(
   markerSchema: MarkerSchema,
   marker: Marker,
+  stringTable: UniqueStringArray,
   testFun: (string, string) => boolean
 ): boolean {
   const { data } = marker;
@@ -669,7 +670,10 @@ export function markerPayloadMatchesSearch(
   // Check if searchable fields match the search regular expression.
   for (const payloadField of markerSchema.data) {
     if (payloadField.searchable) {
-      const value = data[payloadField.key];
+      let value = data[payloadField.key];
+      if (payloadField.format === 'unique-string') {
+        value = stringTable.getString(value);
+      }
       if (value === undefined || value === null || value === '') {
         continue;
       }

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -49,6 +49,7 @@ import type {
   CategoryList,
   Milliseconds,
 } from 'firefox-profiler/types';
+import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
 
 /**
  * This file contains the functions and logic for working with and applying transforms
@@ -1633,6 +1634,7 @@ function _findRangesByMarkerFilter(
   getMarker: (MarkerIndex) => Marker,
   markerIndexes: MarkerIndex[],
   markerSchemaByName: MarkerSchemaByName,
+  stringTable: UniqueStringArray,
   categoryList: CategoryList,
   filter: string
 ): StartEndRange[] {
@@ -1644,6 +1646,7 @@ function _findRangesByMarkerFilter(
     markerIndexes,
     markerSchemaByName,
     searchRegExps,
+    stringTable,
     categoryList
   );
 
@@ -1682,6 +1685,7 @@ export function filterSamples(
             getMarker,
             markerIndexes,
             markerSchemaByName,
+            thread.stringTable,
             categoryList,
             filter
           );

--- a/src/selectors/per-thread/markers.js
+++ b/src/selectors/per-thread/markers.js
@@ -296,6 +296,7 @@ export function getMarkerSelectorsPerThread(
       getCommittedRangeAndTabFilteredMarkerIndexes,
       ProfileSelectors.getMarkerSchemaByName,
       UrlState.getMarkersSearchStringsAsRegExp,
+      threadSelectors.getStringTable,
       ProfileSelectors.getCategories,
       MarkerData.getSearchFilteredMarkerIndexes
     );
@@ -354,6 +355,7 @@ export function getMarkerSelectorsPerThread(
       getNetworkMarkerIndexes,
       ProfileSelectors.getMarkerSchemaByName,
       UrlState.getNetworkSearchStringsAsRegExp,
+      threadSelectors.getStringTable,
       ProfileSelectors.getCategories,
       MarkerData.getSearchFilteredMarkerIndexes
     );

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -2211,7 +2211,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
           class="menuButtonsDownloadSize"
         >
           (
-          1.57 kB
+          1.65 kB
           )
         </span>
       </a>
@@ -2329,7 +2329,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          1.55 kB
+          1.63 kB
           )
         </span>
       </a>
@@ -2442,7 +2442,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          1.57 kB
+          1.65 kB
           )
         </span>
       </a>

--- a/src/test/fixtures/profiles/marker-schema.js
+++ b/src/test/fixtures/profiles/marker-schema.js
@@ -196,4 +196,34 @@ export const markerSchemaForTests: MarkerSchema[] = [
       },
     ],
   },
+  {
+    name: 'StringTesting',
+    display: ['marker-chart', 'marker-table', 'timeline-overview'],
+    data: [
+      {
+        key: 'searchableString',
+        label: 'Searchable string field',
+        format: 'string',
+        searchable: true,
+      },
+      {
+        key: 'searchableUniqueString',
+        label: 'Searchable unique string field',
+        format: 'unique-string',
+        searchable: true,
+      },
+      {
+        key: 'nonSearchableString',
+        label: 'Non-searchable string field',
+        format: 'string',
+        searchable: false,
+      },
+      {
+        key: 'nonSearchableUniqueString',
+        label: 'Non-searchable unique string field',
+        format: 'unique-string',
+        searchable: false,
+      },
+    ],
+  },
 ];

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -418,6 +418,40 @@ Object {
         ],
         "name": "RefreshDriverTick",
       },
+      Object {
+        "data": Array [
+          Object {
+            "format": "string",
+            "key": "searchableString",
+            "label": "Searchable string field",
+            "searchable": true,
+          },
+          Object {
+            "format": "unique-string",
+            "key": "searchableUniqueString",
+            "label": "Searchable unique string field",
+            "searchable": true,
+          },
+          Object {
+            "format": "string",
+            "key": "nonSearchableString",
+            "label": "Non-searchable string field",
+            "searchable": false,
+          },
+          Object {
+            "format": "unique-string",
+            "key": "nonSearchableUniqueString",
+            "label": "Non-searchable unique string field",
+            "searchable": false,
+          },
+        ],
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "name": "StringTesting",
+      },
     ],
     "misc": "",
     "oscpu": "",

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -429,13 +429,11 @@ describe('Marker schema filtering', function () {
     // prettier-ignore
     const profile = getProfileWithMarkers([
       ['no payload',        0, null, null],
-      // $FlowExpectError - Invalid payload by our type system.
       ['payload no schema', 0, null, { type: 'no schema marker' }],
       ['RefreshDriverTick', 0, null, { type: 'Text', name: 'RefreshDriverTick' }],
       ['UserTiming',        5, 6,    { type: 'UserTiming', name: 'name', entryType: 'mark' }],
       // The following is a tracing marker without a schema attached, this was a
       // regression reported in Bug 1678698.
-      // $FlowExpectError - Invalid payload by our type system.
       ['RandomTracingMarker', 7, 8,  { type: 'tracing', category: 'RandomTracingMarker' }],
       ...getNetworkMarkers(),
     ]);

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -127,9 +127,7 @@ describe('ordering and hiding', function () {
 
   function getProfileWithCustomMarkerTracks() {
     const profile = getProfileWithMarkers([
-      // $FlowExpectError Our flow type system doesn't know about this non-existant marker type.
       ['Marker', 1, 2, { type: 'Marker', first: 5 }],
-      // $FlowExpectError Our flow type system doesn't know about this non-existant marker type.
       ['NoGraphMarker', 3, 4, { type: 'NoGraphMarker', first: 6 }],
     ]);
 


### PR DESCRIPTION
[Production](https://share.firefox.dev/4c0pupM) | [Deploy preview](https://deploy-preview-5036--perf-html.netlify.app/public/w3xpzd4fg3r8wwsjprm6zvb51enjjhg5qdrrrq0/marker-chart/?globalTrackOrder=01&markerSearch=-async%2C-sync&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F1bnavsk3d8qw4w17q19bxk4841v7cwcf23dzggs&thread=1&v=10)

Fixes #5034.