### PR TITLE
Persist tooltips when the items (marker, frame) are selected

### DIFF
--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -10,23 +10,23 @@ import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
 
 import type { CssPixels, DevicePixels } from 'firefox-profiler/types';
 
-type Props<HoveredItem> = {|
+type Props<Item> = {|
   +containerWidth: CssPixels,
   +containerHeight: CssPixels,
   +className: string,
-  +onSelectItem?: (HoveredItem | null) => void,
-  +onRightClick?: (HoveredItem | null) => void,
-  +onDoubleClickItem: (HoveredItem | null) => void,
-  +getHoveredItemInfo: (HoveredItem) => React.Node,
+  +onSelectItem?: (Item | null) => void,
+  +onRightClick?: (Item | null) => void,
+  +onDoubleClickItem: (Item | null) => void,
+  +getHoveredItemInfo: (Item) => React.Node,
   +drawCanvas: (
     CanvasRenderingContext2D,
     ChartCanvasScale: ChartCanvasScale,
-    ChartCanvasHoverInfo: ChartCanvasHoverInfo<HoveredItem>
+    ChartCanvasHoverInfo: ChartCanvasHoverInfo<Item>
   ) => void,
   +isDragging: boolean,
   // Applies ctx.scale() to the canvas to draw using CssPixels rather than DevicePixels.
   +scaleCtxToCssPixels: boolean,
-  +hitTest: (x: CssPixels, y: CssPixels) => HoveredItem | null,
+  +hitTest: (x: CssPixels, y: CssPixels) => Item | null,
   // Default to true. Set to false if the chart should be redrawn right away after
   // rerender.
   +drawCanvasAfterRaf?: boolean,
@@ -37,9 +37,9 @@ type Props<HoveredItem> = {|
 
 // The naming of the X and Y coordinates here correspond to the ones
 // found on the MouseEvent interface.
-type State<HoveredItem> = {
-  hoveredItem: HoveredItem | null,
-  selectedItem: HoveredItem | null,
+type State<Item> = {
+  hoveredItem: Item | null,
+  selectedItem: Item | null,
   pageX: CssPixels,
   pageY: CssPixels,
 };
@@ -51,9 +51,9 @@ export type ChartCanvasScale = {
   cssToUserScale: number,
 };
 
-export type ChartCanvasHoverInfo<HoveredItem> = {
-  hoveredItem: HoveredItem | null,
-  prevHoveredItem: HoveredItem | null,
+export type ChartCanvasHoverInfo<Item> = {
+  hoveredItem: Item | null,
+  prevHoveredItem: Item | null,
   isHoveredOnlyDifferent: boolean,
 };
 
@@ -72,9 +72,9 @@ const MOUSE_CLICK_MAX_MOVEMENT_DELTA: CssPixels = 5;
 
 // This isn't a PureComponent on purpose: we always want to update if the parent updates
 // But we still conditionally update the canvas itself, see componentDidUpdate.
-export class ChartCanvas<HoveredItem> extends React.Component<
-  Props<HoveredItem>,
-  State<HoveredItem>,
+export class ChartCanvas<Item> extends React.Component<
+  Props<Item>,
+  State<Item>,
 > {
   _devicePixelRatio: number = 1;
   // The current mouse position. Needs to be stored for tooltip
@@ -93,7 +93,7 @@ export class ChartCanvas<HoveredItem> extends React.Component<
   _canvas: HTMLCanvasElement | null = null;
   _isDrawScheduled: boolean = false;
 
-  state: State<HoveredItem> = {
+  state: State<Item> = {
     hoveredItem: null,
     selectedItem: null,
     pageX: 0,
@@ -102,7 +102,7 @@ export class ChartCanvas<HoveredItem> extends React.Component<
 
   _scheduleDraw(
     isHoveredOnlyDifferent: boolean = false,
-    prevHoveredItem: HoveredItem | null = null
+    prevHoveredItem: Item | null = null
   ) {
     const { drawCanvasAfterRaf } = this.props;
     if (drawCanvasAfterRaf === false) {
@@ -175,7 +175,7 @@ export class ChartCanvas<HoveredItem> extends React.Component<
 
   _doDrawCanvas(
     isHoveredOnlyDifferent: boolean = false,
-    prevHoveredItem: HoveredItem | null = null
+    prevHoveredItem: Item | null = null
   ) {
     const { className, drawCanvas, scaleCtxToCssPixels } = this.props;
     const { hoveredItem } = this.state;
@@ -353,10 +353,7 @@ export class ChartCanvas<HoveredItem> extends React.Component<
     }
   }
 
-  componentDidUpdate(
-    prevProps: Props<HoveredItem>,
-    prevState: State<HoveredItem>
-  ) {
+  componentDidUpdate(prevProps: Props<Item>, prevState: State<Item>) {
     if (prevProps !== this.props) {
       this._scheduleDraw();
     } else if (

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -389,7 +389,13 @@ export class ChartCanvas<Item> extends React.Component<
           onDoubleClick={this._onDoubleClick}
         />
         {!isDragging && tooltipContents ? (
-          <Tooltip mouseX={pageX} mouseY={pageY}>
+          <Tooltip
+            mouseX={pageX}
+            mouseY={pageY}
+            className={classNames({
+              clickable: this.state.selectedItem !== null,
+            })}
+          >
             {tooltipContents}
           </Tooltip>
         ) : null}

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -278,7 +278,10 @@ export class ChartCanvas<Item> extends React.Component<
     const maybeHoveredItem = this.props.hitTest(this._offsetX, this._offsetY);
     if (maybeHoveredItem !== null) {
       if (this.state.selectedItem === null) {
-        // Update both the hovered item and the position of the tooltip.
+        // Update both the hovered item and the pageX and pageY values. The
+        // pageX and pageY values are used to change the position of the tooltip
+        // and if there is no selected item, it means that we can update this
+        // position freely.
         this.setState({
           hoveredItem: maybeHoveredItem,
           pageX: event.pageX,
@@ -287,6 +290,8 @@ export class ChartCanvas<Item> extends React.Component<
       } else {
         // If there is a selected item, only update the hoveredItem and not the
         // pageX and pageY values which is used for the position of the tooltip.
+        // By keeping the x and y values the same, we make sure that the tooltip
+        // stays in its initial position where it's clicked.
         this.setState({
           hoveredItem: maybeHoveredItem,
         });

--- a/src/components/tooltip/Tooltip.css
+++ b/src/components/tooltip/Tooltip.css
@@ -14,6 +14,11 @@
   transition: opacity 250ms;
 }
 
+.tooltip.clickable {
+  /* Make sure that the pointer events are properly triggered if it's clickable */
+  pointer-events: auto;
+}
+
 .tooltipTiming {
   padding-right: 0.5em;
   color: #666;

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -5,6 +5,7 @@
 // @flow
 import * as React from 'react';
 import ReactDOM from 'react-dom';
+import classNames from 'classnames';
 import type { CssPixels } from 'firefox-profiler/types';
 
 import {
@@ -21,6 +22,7 @@ type Props = {|
   +mouseX: CssPixels,
   +mouseY: CssPixels,
   +children: React.Node,
+  +className?: string,
 |};
 
 // These types represent the tooltip's position. They will be used when storing
@@ -159,10 +161,17 @@ export class Tooltip extends React.PureComponent<Props> {
     this.setPositioningStyle();
   }
 
+  _mouseDownListener = (event: SyntheticMouseEvent<>) => {
+    // Prevent the canvas element to handle the mouse down event. Otherwise
+    // drag and drop events closes the tooltip.
+    event.stopPropagation();
+  };
+
   render() {
     return ReactDOM.createPortal(
       <div
-        className="tooltip"
+        className={classNames('tooltip', this.props.className)}
+        onMouseDown={this._mouseDownListener}
         data-testid="tooltip"
         // This will be overridden in setPositioningStyle, but they are
         // necessary so that the measurements are correct.

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -158,6 +158,84 @@ exports[`MarkerChart context menus displays when right clicking on a marker 1`] 
 </nav>
 `;
 
+exports[`MarkerChart persists the selected marker tooltips properly 1`] = `
+<div
+  class="tooltip clickable"
+  data-testid="tooltip"
+  style="left: 186px; top: 150px;"
+>
+  <div
+    class="tooltipMarker"
+  >
+    <div
+      class="tooltipHeader"
+    >
+      <div
+        class="tooltipOneLine"
+      >
+        <div
+          class="tooltipTiming"
+        >
+          6ms
+        </div>
+        <div
+          class="tooltipTitle"
+        >
+          Marker B
+        </div>
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Name
+        :
+      </div>
+      Marker B
+      <div
+        class="tooltipLabel"
+      >
+        Marker
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Entry Type
+        :
+      </div>
+      measure
+      <div
+        class="tooltipLabel"
+      >
+        Description
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Track
+        :
+      </div>
+      Empty
+    </div>
+  </div>
+</div>
+`;
+
 exports[`MarkerChart renders the hoveredItem markers properly 1`] = `
 Array [
   Array [


### PR DESCRIPTION
With this PR, after you click on a marker or a frame, it should persist the tooltip until somewhere else closed so we can click on links or copy text easily.

Profile with markers that have a url: [Before](https://share.firefox.dev/4eCrrKF) / [After](https://deploy-preview-5039--perf-html.netlify.app/public/bc0vtnnr7175fffmyp0x70dq9j4pb1z7sk6pzf8/marker-chart/?globalTrackOrder=91w708&hiddenGlobalTracks=1w7&hiddenLocalTracksByPid=7045-0w2~7164-0~7124-0~7220-0~7353-0~7251-0~7136-0~7237-0&markerSearch=ChannelMarker&profileName=speedometer3-benchmark%2Fiteration-1.json.gz&range=9603m12481~9957m12126&thread=0&v=10)