### PR TITLE
Prevent any crashes or incorrect tooltip positions when the chart gets updated

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -382,7 +382,14 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
     }
 
     const stackTiming = flameGraphTiming[depth];
+    if (!stackTiming) {
+      return null;
+    }
     const callNodeIndex = stackTiming.callNode[flameGraphTimingIndex];
+    if (callNodeIndex === undefined) {
+      return null;
+    }
+
     const ratio =
       stackTiming.end[flameGraphTimingIndex] -
       stackTiming.start[flameGraphTimingIndex];

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -360,7 +360,18 @@ export class ChartCanvas<Item> extends React.Component<
 
   componentDidUpdate(prevProps: Props<Item>, prevState: State<Item>) {
     if (prevProps !== this.props) {
-      this._scheduleDraw();
+      if (
+        this.state.selectedItem !== null &&
+        prevState.selectedItem === this.state.selectedItem
+      ) {
+        // The props have changed but not the selectedItem. This mean that the
+        // selected item can get out of sync. Invalidate it to make sure that
+        // it's always fresh. This setState will cause a rerender, but we have
+        // to do it to prevent any crashes or incorrect tooltip positions.
+        this.setState({ selectedItem: null });
+      } else {
+        this._scheduleDraw();
+      }
     } else if (
       !hoveredItemsAreEqual(prevState.hoveredItem, this.state.hoveredItem)
     ) {

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -450,6 +450,9 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
     }
 
     const timing = combinedTimingRows[depth];
+    if (!timing) {
+      return null;
+    }
 
     if (timing.index) {
       const markerIndex = timing.index[stackTimingIndex];
@@ -465,6 +468,9 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
     }
 
     const callNodeIndex = timing.callNode[stackTimingIndex];
+    if (callNodeIndex === undefined) {
+      return null;
+    }
     const duration =
       timing.end[stackTimingIndex] - timing.start[stackTimingIndex];
 


### PR DESCRIPTION
Fixes #5047.

This PR fixes the crash that happens when the selected frame doesn't match properly after updating the flame graph / stack chart. This is because selectedItem is dependent on the current filtered call tree. This should also fix where the tooltips were being persistent when we select a different range etc. that makes the selected frame outside of the range.

[Example profile](https://deploy-preview-5048--perf-html.netlify.app/public/64bs9a4538n6pvj0bgzz4rnqmt1sek5ns64c44r/flame-graph/?globalTrackOrder=0wn&hiddenGlobalTracks=1wm&hiddenLocalTracksByPid=29676-1w4dfg~29682-0~29679-0~29709-0~29708-0~29720-0~29701-0~29706-0~29700-0~29719-0~29721-0~29722-0~29680-0~29681-0~29684-0~29718-0~29702-0~29703-0~29741-0~29734-0~29723-0~29743-0~29736-0&thread=x9&v=10)
