### PR TITLE
Fix the marker chart/flame graph/stack chart rendering issue when the tooltip is persisted

### DIFF
--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -368,10 +368,11 @@ export class ChartCanvas<Item> extends React.Component<
         // selected item can get out of sync. Invalidate it to make sure that
         // it's always fresh. This setState will cause a rerender, but we have
         // to do it to prevent any crashes or incorrect tooltip positions.
+        // This is okay to do it because the main `prevProps !== this.props`
+        // check above will return false and will not schedule additional drawing.
         this.setState({ selectedItem: null });
-      } else {
-        this._scheduleDraw();
       }
+      this._scheduleDraw();
     } else if (
       !hoveredItemsAreEqual(prevState.hoveredItem, this.state.hoveredItem)
     ) {

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -135,11 +135,18 @@ describe('FlameGraph', function () {
     // Make sure that we have the tooltip persisted.
     expect(getTooltip()).toBeTruthy();
 
+    // Flush the draw log to make sure we properly draw the graph later.
+    flushDrawLog();
+
     // Do something that updates the flame graph component.
     fireEvent.keyDown(div, { key: 'Enter' });
 
     // Now the tooltip should not be displayed because it could show invalid data.
     expect(getTooltip()).toBeFalsy();
+
+    // Make sure that the graph is rendered properly.
+    const drawCalls = flushDrawLog();
+    expect(drawCalls.length).toBeGreaterThan(0);
   });
 
   it('has a tooltip that matches the snapshot with categories', () => {


### PR DESCRIPTION
Fixes #5056.
Fixes #5057.

This was happening because of an incorrect assumption inside the shared component's `componentDidUpdate` method.

Marker chart: [production](https://share.firefox.dev/3VPhXDo) / [deploy preview](https://deploy-preview-5058--perf-html.netlify.app/public/wkp24zrht6yhkdz7kwnnp3akcfnas1q9ayjtqm8/marker-chart/?globalTrackOrder=b0wa&hiddenGlobalTracks=1w7&hiddenLocalTracksByPid=684-23~693-01~685-0~691-0~695-0~699-0~702-0~689-0~687-0&thread=1&v=10)
Flame graph: [production](https://share.firefox.dev/3VXT0G5) / [deploy preview](https://deploy-preview-5058--perf-html.netlify.app/public/ret2m65ys95h1qdd6ra9px92m4fcpmvn3eq88v0/flame-graph/?globalTrackOrder=0&thread=0&timelineType=category&v=10)