### PR TITLE
[deploy preview] Add a tab selector

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -50,6 +50,7 @@ import type {
   UrlState,
   UploadedProfileInformation,
   IndexIntoCategoryList,
+  TabID,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type {
@@ -426,5 +427,12 @@ export function toggleOpenCategoryInSidebar(
     type: 'TOGGLE_SIDEBAR_OPEN_CATEGORY',
     kind,
     category,
+  };
+}
+
+export function changeTabFilter(tabID: TabID | null): Action {
+  return {
+    type: 'CHANGE_TAB_FILTER',
+    tabID,
   };
 }

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -50,7 +50,6 @@ import type {
   UrlState,
   UploadedProfileInformation,
   IndexIntoCategoryList,
-  TabID,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type {
@@ -427,12 +426,5 @@ export function toggleOpenCategoryInSidebar(
     type: 'TOGGLE_SIDEBAR_OPEN_CATEGORY',
     kind,
     category,
-  };
-}
-
-export function changeTabFilter(tabID: TabID | null): Action {
-  return {
-    type: 'CHANGE_TAB_FILTER',
-    tabID,
   };
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -40,7 +40,11 @@ import {
   getActiveTabID,
   getMarkerSchemaByName,
 } from 'firefox-profiler/selectors';
-import { getSelectedTab } from 'firefox-profiler/selectors/url-state';
+import {
+  getSelectedTab,
+  getTabFilter,
+} from 'firefox-profiler/selectors/url-state';
+import { getTabToThreadIndexesMap } from 'firefox-profiler/selectors/profile';
 import {
   withHistoryReplaceStateAsync,
   withHistoryReplaceStateSync,
@@ -288,9 +292,15 @@ export function finalizeFullProfileView(
   return (dispatch, getState) => {
     const hasUrlInfo = maybeSelectedThreadIndexes !== null;
 
-    const globalTracks = computeGlobalTracks(profile);
+    const tabToThreadIndexesMap = getTabToThreadIndexesMap(getState());
+    const globalTracks = computeGlobalTracks(
+      profile,
+      hasUrlInfo ? getTabFilter(getState()) : null,
+      tabToThreadIndexesMap
+    );
     const localTracksByPid = computeLocalTracksByPid(
       profile,
+      globalTracks,
       getMarkerSchemaByName(getState())
     );
 
@@ -1718,5 +1728,112 @@ export function retrieveProfileForRawUrl(
 
     // Profile may be null if the response was a zip file.
     return getProfileOrNull(getState());
+  };
+}
+
+/**
+ * Change the selected browser tab filter for the profile.
+ * TabID here means the unique ID for a give browser tab and corresponds to
+ * multiple pages in the `profile.pages` array.
+ */
+export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const profile = getProfile(getState());
+    const tabToThreadIndexesMap = getTabToThreadIndexesMap(getState());
+    const globalTracks = computeGlobalTracks(
+      profile,
+      tabID,
+      tabToThreadIndexesMap
+    );
+    const localTracksByPid = computeLocalTracksByPid(
+      profile,
+      globalTracks,
+      getMarkerSchemaByName(getState())
+    );
+
+    const legacyThreadOrder = getLegacyThreadOrder(getState());
+    const globalTrackOrder = initializeGlobalTrackOrder(
+      globalTracks,
+      null,
+      legacyThreadOrder
+    );
+    const localTrackOrderByPid = initializeLocalTrackOrderByPid(
+      null,
+      localTracksByPid,
+      legacyThreadOrder,
+      profile
+    );
+
+    const tracksWithOrder = {
+      globalTracks,
+      globalTrackOrder,
+      localTracksByPid,
+      localTrackOrderByPid,
+    };
+
+    let hiddenTracks = null;
+
+    // For non-initial profile loads, initialize the set of hidden tracks from
+    // information in the URL.
+    const legacyHiddenThreads = getLegacyHiddenThreads(getState());
+    if (legacyHiddenThreads !== null) {
+      hiddenTracks = tryInitializeHiddenTracksLegacy(
+        tracksWithOrder,
+        legacyHiddenThreads,
+        profile
+      );
+    }
+    if (hiddenTracks === null) {
+      // Compute a default set of hidden tracks.
+      // This is the case for the initial profile load.
+      // We also get here if the URL info was ignored, for example if
+      // respecting it would have caused all threads to become hidden.
+      hiddenTracks = computeDefaultHiddenTracks(tracksWithOrder, profile);
+    }
+
+    console.log(
+      'canova trackswithorder',
+      tracksWithOrder,
+      hiddenTracks
+      // getVisibleThreads(tracksWithOrder, hiddenTracks)
+    );
+    const selectedThreadIndexes = initializeSelectedThreadIndex(
+      null, // maybeSelectedThreadIndexes
+      getVisibleThreads(tracksWithOrder, hiddenTracks),
+      profile
+    );
+
+    // If the currently selected tab is only visible when the selected track
+    // has samples, verify that the selected track has samples, and if not
+    // select the marker chart.
+    let selectedTab = getSelectedTab(getState());
+    if (tabsShowingSampleData.includes(selectedTab)) {
+      let hasSamples = false;
+      for (const threadIndex of selectedThreadIndexes) {
+        const thread = profile.threads[threadIndex];
+        const { samples, jsAllocations, nativeAllocations } = thread;
+        hasSamples = [samples, jsAllocations, nativeAllocations].some((table) =>
+          hasUsefulSamples(table, thread)
+        );
+        if (hasSamples) {
+          break;
+        }
+      }
+      if (!hasSamples) {
+        selectedTab = 'marker-chart';
+      }
+    }
+
+    dispatch({
+      type: 'CHANGE_TAB_FILTER',
+      tabID,
+      selectedThreadIndexes,
+      selectedTab,
+      globalTracks,
+      globalTrackOrder,
+      localTracksByPid,
+      localTrackOrderByPid,
+      ...hiddenTracks,
+    });
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -1355,8 +1355,8 @@ function validateTimelineTrackOrganization(
  * provided or something else is provided for some reason.
  */
 function validateTimelineType(type: ?string): TimelineType {
-  // Pretend this is a TimelineTrackOrganization so that we can exhaustively
-  // go through each option.
+  // Pretend this is a TimelineType so that we can exhaustively go through
+  // each option.
   const timelineType: TimelineType = (type: any);
   switch (timelineType) {
     case 'stack':

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -153,6 +153,7 @@ type FullProfileSpecificBaseQuery = {|
   hiddenGlobalTracks: string, // "01"
   hiddenLocalTracksByPid: string, // "1549-0w8~1593-23~1598-01~1602-02~1607-1"
   localTrackOrderByPid: string, // "1549-780w6~1560-01"
+  tabID: TabID,
   // The following values are legacy, and will be converted to track-based values. These
   // value can't be upgraded using the typical URL upgrading process, as the full profile
   // must be fetched to compute the tracks.
@@ -328,6 +329,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
         urlState.profileSpecific.full.localTrackOrderByPid,
         urlState.profileSpecific.full.localTrackOrderChangedPids
       );
+      baseQuery.tabID = urlState.profileSpecific.full.tabFilter || undefined;
 
       break;
     }
@@ -581,9 +583,14 @@ export function stateFromLocation(
     transforms[selectedThreadsKey] = parseTransforms(query.transforms);
   }
 
-  let tabID = null;
+  let oldTabID = null;
   if (query.ctxId && Number.isInteger(Number(query.ctxId))) {
-    tabID = Number(query.ctxId);
+    oldTabID = Number(query.ctxId);
+  }
+
+  let tabID = null;
+  if (query.tabID && Number.isInteger(Number(query.tabID))) {
+    tabID = Number(query.tabID);
   }
 
   const selectedTab =
@@ -631,7 +638,7 @@ export function stateFromLocation(
     symbolServerUrl: query.symbolServer || null,
     timelineTrackOrganization: validateTimelineTrackOrganization(
       query.view,
-      tabID
+      oldTabID
     ),
     profileSpecific: {
       implementation,
@@ -663,6 +670,7 @@ export function stateFromLocation(
         ),
         localTrackOrderByPid,
         localTrackOrderChangedPids,
+        tabFilter: tabID,
         legacyThreadOrder: query.threadOrder
           ? query.threadOrder.split('-').map((index) => Number(index))
           : null,

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -9,6 +9,10 @@
   column-gap: 5px;
 }
 
+.profileFilterNavigator--tab-selector:not(.disabled) {
+  cursor: pointer;
+}
+
 /* This is the dropdown arrow on the left of the button. */
 .profileFilterNavigator--tab-selector::before {
   position: absolute;

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -25,7 +25,7 @@
   margin-top: 5px;
   margin-right: 5px;
   margin-left: 5px;
-  color: var(--grey-60);
+  color: var(--internal-selected-color);
   content: '';
 }
 

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.profileFilterNavigator--tab-selector {
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
+  column-gap: 5px;
+}
+
+/* This is the dropdown arrow on the left of the button. */
+.profileFilterNavigator--tab-selector::before {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  border-top: 6px solid;
+  border-right: 4px solid transparent;
+  border-bottom: 0 solid transparent;
+  border-left: 4px solid transparent;
+  margin-top: 5px;
+  margin-right: 5px;
+  margin-left: 5px;
+  color: var(--grey-60);
+  content: '';
+}
+
+.profileFilterNavigator--tab-selector.disabled::before {
+  color: var(--grey-30);
+}

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -4,37 +4,53 @@
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import memoize from 'memoize-immutable';
 import { Localized } from '@fluent/react';
+import { showMenu } from '@firefox-devtools/react-contextmenu';
+import classNames from 'classnames';
 
-import explicitConnect from 'firefox-profiler/utils/connect';
+import explicitConnect, {
+  type ConnectedProps,
+} from 'firefox-profiler/utils/connect';
 import { popCommittedRanges } from 'firefox-profiler/actions/profile-view';
+import { changeTabFilter } from 'firefox-profiler/actions/app';
 import {
   getPreviewSelection,
-  getProfileFilterPageData,
+  getProfileFilterPageDataByTabID,
   getProfileRootRange,
 } from 'firefox-profiler/selectors/profile';
-import { getCommittedRangeLabels } from 'firefox-profiler/selectors/url-state';
+import {
+  getCommittedRangeLabels,
+  getTabFilter,
+} from 'firefox-profiler/selectors/url-state';
 import { getFormattedTimeLength } from 'firefox-profiler/profile-logic/committed-ranges';
 import { FilterNavigatorBar } from 'firefox-profiler/components/shared/FilterNavigatorBar';
 import { Icon } from 'firefox-profiler/components/shared/Icon';
+import { TabContextMenu } from '../shared/TabContextMenu';
 
-import type { ElementProps } from 'react';
 import type {
   ProfileFilterPageData,
   StartEndRange,
+  TabID,
 } from 'firefox-profiler/types';
 
-type Props = {|
-  +filterPageData: ProfileFilterPageData | null,
-  +rootRange: StartEndRange,
-  ...ElementProps<typeof FilterNavigatorBar>,
-|};
+import './ProfileFilterNavigator.css';
+
 type DispatchProps = {|
   +onPop: $PropertyType<Props, 'onPop'>,
+  +changeTabFilter: typeof changeTabFilter,
 |};
-type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
+type StateProps = {|
+  +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
+  +tabFilter: TabID | null,
+  +rootRange: StartEndRange,
+  +className: string,
+  +items: $ReadOnlyArray<React.Node | string>,
+  +selectedItem: number,
+  +uncommittedItem?: string,
+|};
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
   _getItemsWithFirstElement = memoize(
@@ -44,6 +60,19 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
     }
   );
 
+  _showMenu = (event: SyntheticMouseEvent<HTMLElement>) => {
+    if (this.props.items.length > 0) {
+      return;
+    }
+    const rect = event.currentTarget.getBoundingClientRect();
+    showMenu({
+      data: null,
+      id: 'TabContextMenu',
+      position: { x: rect.left, y: rect.bottom },
+      target: event.target,
+    });
+  };
+
   render() {
     const {
       className,
@@ -51,23 +80,53 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
       selectedItem,
       uncommittedItem,
       onPop,
-      filterPageData,
       rootRange,
+      pageDataByTabID,
+      tabFilter,
     } = this.props;
 
     let firstItem;
-    if (filterPageData) {
-      firstItem = (
-        <>
-          {filterPageData.favicon ? (
-            <Icon iconUrl={filterPageData.favicon} />
-          ) : null}
-          <span title={filterPageData.origin}>
-            {filterPageData.hostname} (
-            {getFormattedTimeLength(rootRange.end - rootRange.start)})
+    if (pageDataByTabID) {
+      const pageData =
+        tabFilter !== null ? pageDataByTabID.get(tabFilter) : null;
+
+      if (pageData) {
+        firstItem = (
+          <span
+            onClick={this._showMenu}
+            className={classNames('profileFilterNavigator--tab-selector', {
+              disabled: items.length > 0,
+            })}
+          >
+            {pageData.favicon ? <Icon iconUrl={pageData.favicon} /> : null}
+            <span title={pageData.origin}>
+              {pageData?.hostname} (
+              {getFormattedTimeLength(rootRange.end - rootRange.start)})
+            </span>
           </span>
-        </>
-      );
+        );
+      } else {
+        // FIXME: Remove the duplication later.
+        firstItem = (
+          <span
+            onClick={this._showMenu}
+            className={classNames('profileFilterNavigator--tab-selector', {
+              disabled: items.length > 0,
+            })}
+          >
+            <Localized
+              id="ProfileFilterNavigator--full-range-with-duration"
+              vars={{
+                fullRangeDuration: getFormattedTimeLength(
+                  rootRange.end - rootRange.start
+                ),
+              }}
+            >
+              Full Range
+            </Localized>
+          </span>
+        );
+      }
     } else {
       firstItem = (
         <Localized
@@ -88,13 +147,16 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
       items
     );
     return (
-      <FilterNavigatorBar
-        className={className}
-        items={itemsWithFirstElement}
-        selectedItem={selectedItem}
-        uncommittedItem={uncommittedItem}
-        onPop={onPop}
-      />
+      <>
+        <FilterNavigatorBar
+          className={className}
+          items={itemsWithFirstElement}
+          selectedItem={selectedItem}
+          uncommittedItem={uncommittedItem}
+          onPop={onPop}
+        />
+        <TabContextMenu />
+      </>
     );
   }
 }
@@ -112,7 +174,8 @@ export const ProfileFilterNavigator = explicitConnect<
           previewSelection.selectionEnd - previewSelection.selectionStart
         )
       : undefined;
-    const filterPageData = getProfileFilterPageData(state);
+    const pageDataByTabID = getProfileFilterPageDataByTabID(state);
+    const tabFilter = getTabFilter(state);
     const rootRange = getProfileRootRange(state);
     return {
       className: 'profileFilterNavigator',
@@ -121,12 +184,14 @@ export const ProfileFilterNavigator = explicitConnect<
       // array's length by adding the first element.
       selectedItem: items.length,
       uncommittedItem,
-      filterPageData,
+      pageDataByTabID,
+      tabFilter,
       rootRange,
     };
   },
   mapDispatchToProps: {
     onPop: popCommittedRanges,
+    changeTabFilter,
   },
   component: ProfileFilterNavigatorBarImpl,
 });

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -14,7 +14,7 @@ import explicitConnect, {
   type ConnectedProps,
 } from 'firefox-profiler/utils/connect';
 import { popCommittedRanges } from 'firefox-profiler/actions/profile-view';
-import { changeTabFilter } from 'firefox-profiler/actions/app';
+import { changeTabFilter } from 'firefox-profiler/actions/receive-profile';
 import {
   getPreviewSelection,
   getProfileFilterPageDataByTabID,

--- a/src/components/shared/TabContextMenu.css
+++ b/src/components/shared/TabContextMenu.css
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.tabContextMenuItem.checkable {
+  padding-right: 0;
+  padding-left: 21px;
+}
+
+.react-contextmenu-item.tabContextMenuItem.checked:not(
+    .react-contextmenu-item--disabled
+  )::before {
+  left: 8px;
+}

--- a/src/components/shared/TabContextMenu.css
+++ b/src/components/shared/TabContextMenu.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .tabContextMenuItem.checkable {
-  padding-right: 0;
+  padding-right: 10px;
   padding-left: 21px;
 }
 

--- a/src/components/shared/TabContextMenu.js
+++ b/src/components/shared/TabContextMenu.js
@@ -11,15 +11,16 @@ import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { changeTabFilter } from 'firefox-profiler/actions/receive-profile';
 import { getTabFilter } from '../../selectors/url-state';
-import { getProfileFilterPageDataByTabID } from 'firefox-profiler/selectors/profile';
+import { getProfileFilterSortedPageData } from 'firefox-profiler/selectors/profile';
 
-import type { TabID, ProfileFilterPageData } from 'firefox-profiler/types';
+import type { TabID } from 'firefox-profiler/types';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+import type { SortedTabPageData } from 'firefox-profiler/selectors/profile';
 
 type StateProps = {|
   +tabFilter: TabID | null,
-  +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
+  +sortedPageData: SortedTabPageData | null,
 |};
 
 type DispatchProps = {|
@@ -36,8 +37,8 @@ class TabContextMenuImpl extends React.PureComponent<Props> {
   };
 
   renderContextMenuContents() {
-    const { pageDataByTabID, tabFilter } = this.props;
-    if (!pageDataByTabID) {
+    const { sortedPageData, tabFilter } = this.props;
+    if (!sortedPageData) {
       return null;
     }
 
@@ -57,7 +58,7 @@ class TabContextMenuImpl extends React.PureComponent<Props> {
         >
           Full Profile
         </MenuItem>
-        {[...pageDataByTabID].map(([tabID, pageData]) => (
+        {sortedPageData.map(({ tabID, pageData }) => (
           <MenuItem
             key={tabID}
             onClick={this._handleClick}
@@ -89,10 +90,10 @@ class TabContextMenuImpl extends React.PureComponent<Props> {
 export const TabContextMenu = explicitConnect<{||}, StateProps, DispatchProps>({
   mapStateToProps: (state) => {
     const tabFilter = getTabFilter(state);
-    const pageDataByTabID = getProfileFilterPageDataByTabID(state);
+    const sortedPageData = getProfileFilterSortedPageData(state);
     return {
       tabFilter,
-      pageDataByTabID,
+      sortedPageData,
     };
   },
   mapDispatchToProps: {

--- a/src/components/shared/TabContextMenu.js
+++ b/src/components/shared/TabContextMenu.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 
 import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
-import { changeTabFilter } from 'firefox-profiler/actions/app';
+import { changeTabFilter } from 'firefox-profiler/actions/receive-profile';
 import { getTabFilter } from '../../selectors/url-state';
 import { getProfileFilterPageDataByTabID } from 'firefox-profiler/selectors/profile';
 

--- a/src/components/shared/TabContextMenu.js
+++ b/src/components/shared/TabContextMenu.js
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { MenuItem } from '@firefox-devtools/react-contextmenu';
+import classNames from 'classnames';
+
+import { ContextMenu } from './ContextMenu';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { changeTabFilter } from 'firefox-profiler/actions/app';
+import { getTabFilter } from '../../selectors/url-state';
+import { getProfileFilterPageDataByTabID } from 'firefox-profiler/selectors/profile';
+
+import type { TabID, ProfileFilterPageData } from 'firefox-profiler/types';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type StateProps = {|
+  +tabFilter: TabID | null,
+  +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
+|};
+
+type DispatchProps = {|
+  +changeTabFilter: typeof changeTabFilter,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+import './TabContextMenu.css';
+
+class TabContextMenuImpl extends React.PureComponent<Props> {
+  _handleClick = (event: SyntheticEvent<>, data: { id: TabID }): void => {
+    this.props.changeTabFilter(data.id);
+  };
+
+  renderContextMenuContents() {
+    const { pageDataByTabID, tabFilter } = this.props;
+    if (!pageDataByTabID) {
+      return null;
+    }
+
+    return (
+      <>
+        <MenuItem
+          key={0}
+          onClick={this._handleClick}
+          data={{ id: null }}
+          attributes={{
+            className: classNames('tabContextMenuItem', {
+              checkable: true,
+              checked: tabFilter === null,
+            }),
+            'aria-checked': tabFilter === null ? 'false' : 'true',
+          }}
+        >
+          Full Profile
+        </MenuItem>
+        {[...pageDataByTabID].map(([tabID, pageData]) => (
+          <MenuItem
+            key={tabID}
+            onClick={this._handleClick}
+            data={{ id: tabID }}
+            attributes={{
+              className: classNames('tabContextMenuItem', {
+                checkable: true,
+                checked: tabFilter === tabID,
+              }),
+              'aria-checked': tabFilter === tabID ? 'false' : 'true',
+            }}
+          >
+            {pageData.hostname}
+          </MenuItem>
+        ))}
+      </>
+    );
+  }
+
+  render() {
+    return (
+      <ContextMenu id="TabContextMenu" className="TabContextMenu">
+        {this.renderContextMenuContents()}
+      </ContextMenu>
+    );
+  }
+}
+
+export const TabContextMenu = explicitConnect<{||}, StateProps, DispatchProps>({
+  mapStateToProps: (state) => {
+    const tabFilter = getTabFilter(state);
+    const pageDataByTabID = getProfileFilterPageDataByTabID(state);
+    return {
+      tabFilter,
+      pageDataByTabID,
+    };
+  },
+  mapDispatchToProps: {
+    changeTabFilter,
+  },
+  component: TabContextMenuImpl,
+});

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -82,6 +82,7 @@ import type {
   BottomBoxInfo,
   Bytes,
   ThreadWithReservedFunctions,
+  TabID,
 } from 'firefox-profiler/types';
 import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
 
@@ -2924,74 +2925,79 @@ export function filterToRetainedAllocations(
 }
 
 /**
- * Extract the hostname and favicon from the last page given the relative pages
- * to a tab. We assume that the user wants to know about the last loaded page
- * in this tab.
+ * Extract the hostname and favicon from the last page for all tab ids. we
+ * assume that the user wants to know about the last loaded page in this tab.
+ * returns null if we don't have information about pages (in older profiles).
  */
 export function extractProfileFilterPageData(
-  pages: PageList | null,
-  relevantPages: Set<InnerWindowID>
-): ProfileFilterPageData | null {
-  if (pages === null) {
-    // We don't have pages array (which is the case for older profiles).
-    // Return early.
-    return null;
+  pagesMapByTabID: Map<TabID, PageList> | null
+): Map<TabID, ProfileFilterPageData> {
+  if (pagesMapByTabID === null) {
+    // We don't have pages array (which is the case for older profiles). Return early.
+    return new Map();
   }
 
-  // Getting the pages that are relevant and a top-most frame.
-  let filteredPages = pages.filter(
-    (page) =>
-      // It's the top-most frame if `embedderInnerWindowID` is zero.
-      page.embedderInnerWindowID === 0 && relevantPages.has(page.innerWindowID)
-  );
-
-  if (filteredPages.length > 1) {
-    // If there are more than one top-most page, it's also good to filter out the
-    // `about:` pages so user can see their url they are actually profiling.
-    filteredPages = filteredPages.filter(
-      (page) => !page.url.startsWith('about:')
+  const pageDataByTabID = new Map();
+  for (const [tabID, pages] of pagesMapByTabID) {
+    let topMostPages = pages.filter(
+      (page) =>
+        // It's the top-most frame if `embedderInnerWindowID` is zero.
+        page.embedderInnerWindowID === 0
     );
-  }
 
-  if (filteredPages.length === 0) {
-    // There should be at least one relevant page.
-    console.error(`Expected a relevant page but couldn't find it.`);
-    return null;
-  }
-
-  const pageUrl = filteredPages[filteredPages.length - 1].url;
-
-  if (pageUrl.startsWith('about:')) {
-    // If we only have an `about:*` page, we should return early with a friendly
-    // origin and hostname. Otherwise the try block will fail.
-    return {
-      origin: pageUrl,
-      hostname: pageUrl,
-      favicon: null,
-    };
-  }
-
-  try {
-    const page = new URL(pageUrl);
-    // FIXME(Bug 1620546): This is not ideal and we should get the favicon
-    // either during profile capture or profile pre-process.
-    const favicon = new URL('/favicon.ico', page.origin);
-    if (favicon.protocol === 'http:') {
-      // Upgrade http requests.
-      favicon.protocol = 'https:';
+    if (topMostPages.length > 1) {
+      // If there are more than one top-most page, it's also good to filter out the
+      // `about:` pages so user can see their url they are actually profiling.
+      topMostPages = topMostPages.filter(
+        (page) => !page.url.startsWith('about:')
+      );
     }
-    return {
-      origin: page.origin,
-      hostname: page.hostname,
-      favicon: favicon.href,
-    };
-  } catch (e) {
-    console.error(
-      'Error while extracing the hostname and favicon from the page url',
-      pageUrl
-    );
-    return null;
+
+    if (topMostPages.length === 0) {
+      // There should be at least one relevant page.
+      console.error(
+        `Expected a relevant page for tabID ${tabID} but couldn't find it.`
+      );
+      continue;
+    }
+
+    // The last page is the one we care about.
+    const pageUrl = topMostPages[topMostPages.length - 1].url;
+    if (pageUrl.startsWith('about:')) {
+      // If we only have an `about:*` page, we should return early with a friendly
+      // origin and hostname. Otherwise the try block will always fail.
+      pageDataByTabID.set(tabID, {
+        origin: pageUrl,
+        hostname: pageUrl,
+        favicon: null,
+      });
+      continue;
+    }
+
+    try {
+      const page = new URL(pageUrl);
+      // FIXME(Bug 1620546): This is not ideal and we should get the favicon
+      // either during profile capture or profile pre-process.
+      const favicon = new URL('/favicon.ico', page.origin);
+      if (favicon.protocol === 'http:') {
+        // Upgrade http requests.
+        favicon.protocol = 'https:';
+      }
+      pageDataByTabID.set(tabID, {
+        origin: page.origin,
+        hostname: page.hostname,
+        favicon: favicon.href,
+      });
+    } catch (e) {
+      console.error(
+        'Error while extracing the hostname and favicon from the page url',
+        pageUrl
+      );
+      continue;
+    }
   }
+
+  return pageDataByTabID;
 }
 
 // Returns the resource index for a "url" or "webhost" resource which is created

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2930,7 +2930,8 @@ export function filterToRetainedAllocations(
  * returns null if we don't have information about pages (in older profiles).
  */
 export function extractProfileFilterPageData(
-  pagesMapByTabID: Map<TabID, PageList> | null
+  pagesMapByTabID: Map<TabID, PageList> | null,
+  extensionIDToNameMap: Map<string, string> | null
 ): Map<TabID, ProfileFilterPageData> {
   if (pagesMapByTabID === null) {
     // We don't have pages array (which is the case for older profiles). Return early.
@@ -2976,6 +2977,12 @@ export function extractProfileFilterPageData(
 
     try {
       const page = new URL(pageUrl);
+      let extensionName = null;
+      if (extensionIDToNameMap && pageUrl.startsWith('moz-extension://')) {
+        // Find the real name of the extension.
+        extensionName = extensionIDToNameMap.get(page.origin + '/');
+      }
+
       // FIXME(Bug 1620546): This is not ideal and we should get the favicon
       // either during profile capture or profile pre-process.
       const favicon = new URL('/favicon.ico', page.origin);
@@ -2985,7 +2992,7 @@ export function extractProfileFilterPageData(
       }
       pageDataByTabID.set(tabID, {
         origin: page.origin,
-        hostname: page.hostname,
+        hostname: extensionName ?? page.hostname,
         favicon: favicon.href,
       });
     } catch (e) {

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2924,19 +2924,17 @@ export function filterToRetainedAllocations(
 }
 
 /**
- * Extract the hostname and favicon from the first page if we are in single tab
- * view. Currently we assume that we don't change the origin of webpages while
- * profiling in web developer preset. That's why we are simply getting the first
- * page we find that belongs to the active tab. Returns null if profiler is not
- * in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page given the relative pages
+ * to a tab. We assume that the user wants to know about the last loaded page
+ * in this tab.
  */
 export function extractProfileFilterPageData(
   pages: PageList | null,
   relevantPages: Set<InnerWindowID>
 ): ProfileFilterPageData | null {
-  if (relevantPages.size === 0 || pages === null) {
-    // Either we are not in single tab view, or we don't have pages array(which
-    // is the case for older profiles). Return early.
+  if (pages === null) {
+    // We don't have pages array (which is the case for older profiles).
+    // Return early.
     return null;
   }
 
@@ -2961,7 +2959,7 @@ export function extractProfileFilterPageData(
     return null;
   }
 
-  const pageUrl = filteredPages[0].url;
+  const pageUrl = filteredPages[filteredPages.length - 1].url;
 
   if (pageUrl.startsWith('about:')) {
     // If we only have an `about:*` page, we should return early with a friendly

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -1051,7 +1051,7 @@ export function computeDefaultVisibleThreads(
   // First, compute a score for every thread.
   const maxCpuDeltaPerInterval = computeMaxCPUDeltaPerInterval(profile);
   let scores = threads.map((thread, threadIndex) => {
-    const score = _computeThreadDefaultVisibilityScore(
+    const score = computeThreadDefaultVisibilityScore(
       profile,
       thread,
       maxCpuDeltaPerInterval
@@ -1099,7 +1099,7 @@ export function computeDefaultVisibleThreads(
   return new Set(finalList.map(({ threadIndex }) => threadIndex));
 }
 
-type DefaultVisibilityScore = {|
+export type DefaultVisibilityScore = {|
   // Whether this thread is one of the essential threads that
   // should always be kept (unless there's too many of them).
   isEssentialFirefoxThread: boolean,
@@ -1123,7 +1123,7 @@ const AUDIO_THREAD_SAMPLE_SCORE_BOOST_FACTOR = 40;
 // See the DefaultVisibilityScore type for details.
 // If we have too many threads, we use this score to compare between
 // "interesting" threads to make sure we keep the most interesting ones.
-function _computeThreadDefaultVisibilityScore(
+export function computeThreadDefaultVisibilityScore(
   profile: Profile,
   thread: Thread,
   maxCpuDeltaPerInterval: number | null

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -52,6 +52,7 @@ const view: Reducer<AppViewState> = (
     case 'VIEW_FULL_PROFILE':
     case 'VIEW_ORIGINS_PROFILE':
     case 'VIEW_ACTIVE_TAB_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return { phase: 'DATA_LOADED' };
     default:
       return state;
@@ -146,6 +147,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     // Bottom box: (fallthrough)
     case 'UPDATE_BOTTOM_BOX':
     case 'CLOSE_BOTTOM_BOX_FOR_TAB':
+      // case 'CHANGE_TAB_FILTER':
       return state + 1;
     default:
       return state;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -85,6 +85,7 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
 const globalTracks: Reducer<GlobalTrack[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return action.globalTracks;
     default:
       return state;
@@ -103,6 +104,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'CHANGE_TAB_FILTER':
       return action.localTracksByPid;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -24,6 +24,7 @@ import type {
   SourceViewState,
   AssemblyViewState,
   IsOpenPerPanelState,
+  TabID,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -508,6 +509,19 @@ const localTrackOrderChangedPids: Reducer<Set<Pid>> = (
   }
 };
 
+/**
+ * This state controls whether or not we are filtering the full view for a
+ * specific Firefox tab.
+ */
+const tabFilter: Reducer<TabID | null> = (state = null, action) => {
+  switch (action.type) {
+    case 'CHANGE_TAB_FILTER':
+      return action.tabID;
+    default:
+      return state;
+  }
+};
+
 // If you update this reducer, please don't forget to update the profileName
 // reducer below as well.
 const pathInZipFile: Reducer<string | null> = (state = null, action) => {
@@ -671,6 +685,7 @@ const fullProfileSpecific = combineReducers({
   localTrackOrderByPid,
   localTrackOrderChangedPids,
   showJsTracerSummary,
+  tabFilter,
   // The timeline tracks used to be hidden and sorted by thread indexes, rather than
   // track indexes. The only way to migrate this information to tracks-based data is to
   // first retrieve the profile, so they can't be upgraded by the normal url upgrading

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -97,6 +97,7 @@ const selectedTab: Reducer<TabSlug> = (state = 'calltree', action) => {
     case 'CHANGE_SELECTED_TAB':
     case 'SELECT_TRACK':
     case 'VIEW_FULL_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return action.selectedTab;
     case 'FOCUS_CALL_TREE':
       return 'calltree';
@@ -138,6 +139,7 @@ const selectedThreads: Reducer<Set<ThreadIndex> | null> = (
     case 'HIDE_PROVIDED_TRACKS':
     case 'ISOLATE_LOCAL_TRACK':
     case 'TOGGLE_RESOURCES_PANEL':
+    case 'CHANGE_TAB_FILTER':
       // Only switch to non-null selected threads.
       return (action.selectedThreadIndexes: Set<ThreadIndex>);
     case 'SANITIZED_PROFILE_PUBLISHED': {
@@ -325,6 +327,7 @@ const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
+    case 'CHANGE_TAB_FILTER':
       return action.globalTrackOrder;
     case 'SANITIZED_PROFILE_PUBLISHED':
       // If some threads were removed, do not even attempt to figure this out. It's
@@ -345,6 +348,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'ISOLATE_SCREENSHOT_TRACK':
+    case 'CHANGE_TAB_FILTER':
       return action.hiddenGlobalTracks;
     case 'HIDE_GLOBAL_TRACK': {
       const hiddenGlobalTracks = new Set(state);
@@ -389,6 +393,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return action.hiddenLocalTracksByPid;
     case 'HIDE_LOCAL_TRACK': {
       const hiddenLocalTracksByPid = new Map(state);
@@ -475,6 +480,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'CHANGE_TAB_FILTER':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -348,6 +348,27 @@ export const getIPCMarkerCorrelations: Selector<IPCMarkerCorrelations> =
   createSelector(getThreads, correlateIPCMarkers);
 
 /**
+ * Returns an InnerWindowID -> Page map, so we can look up the page from inner
+ * window id quickly. Returns null if there are no pages in the profile.
+ */
+export const getInnerWindowIDToPageMap: Selector<Map<
+  InnerWindowID,
+  Page,
+> | null> = createSelector(getPageList, (pages) => {
+  if (!pages) {
+    // Return null if there are no pages.
+    return null;
+  }
+
+  const innerWindowIDToPageMap: Map<InnerWindowID, Page> = new Map();
+  for (const page of pages) {
+    innerWindowIDToPageMap.set(page.innerWindowID, page);
+  }
+
+  return innerWindowIDToPageMap;
+});
+
+/**
  * Returns an InnerWindowID -> TabID map, so we can find the TabID of a given
  * innerWindowID quickly. Returns null if there are no pages in the profile.
  */
@@ -760,27 +781,6 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
     return { hidden, total };
   }
 );
-
-/**
- * Returns an InnerWindowID -> Page map, so we can look up the page from inner
- * window id quickly. Returns null if there are no pages in the profile.
- */
-export const getInnerWindowIDToPageMap: Selector<Map<
-  InnerWindowID,
-  Page,
-> | null> = createSelector(getPageList, (pages) => {
-  if (!pages) {
-    // Return null if there are no pages.
-    return null;
-  }
-
-  const innerWindowIDToPageMap: Map<InnerWindowID, Page> = new Map();
-  for (const page of pages) {
-    innerWindowIDToPageMap.set(page.innerWindowID, page);
-  }
-
-  return innerWindowIDToPageMap;
-});
 
 /**
  * Get the pages array and construct a Map of pages that we can use to get the

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -78,6 +78,7 @@ import type {
   IndexIntoSamplesTable,
   ExtraProfileInfoSection,
   TableViewOptions,
+  ExtensionTable,
 } from 'firefox-profiler/types';
 
 export const getProfileView: Selector<ProfileViewState> = (state) =>
@@ -211,6 +212,10 @@ const getMarkerSchemaGecko: Selector<MarkerSchema[]> = (state) =>
 // See SampleUnits type definition for more information.
 export const getSampleUnits: Selector<SampleUnits | void> = (state) =>
   getMeta(state).sampleUnits;
+
+// Get all extensions in the profile metadata.
+export const getExtensionTable: Selector<ExtensionTable | void> = (state) =>
+  getMeta(state).extensions;
 
 /**
  * Firefox profiles will always have categories. However, imported profiles may not
@@ -942,6 +947,19 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
   }
 );
 
+export const getExtensionIDToNameMap: Selector<Map<string, string> | null> =
+  createSelector(getExtensionTable, (extensions) => {
+    if (!extensions) {
+      return null;
+    }
+
+    const extensionIDtoNameMap = new Map();
+    for (let i = 0; i < extensions.length; i++) {
+      extensionIDtoNameMap.set(extensions.baseURL[i], extensions.name[i]);
+    }
+    return extensionIDtoNameMap;
+  });
+
 /**
  * Extract the hostname and favicon from the last page if we are in single tab
  * Extract the hostname and favicon from the last page for all tab ids. we
@@ -952,7 +970,11 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
  */
 export const getProfileFilterPageDataByTabID: Selector<
   Map<TabID, ProfileFilterPageData>,
-> = createSelector(getPagesMap, extractProfileFilterPageData);
+> = createSelector(
+  getPagesMap,
+  getExtensionIDToNameMap,
+  extractProfileFilterPageData
+);
 
 /**
  * This returns the hostname and favicon information for the current tab id.

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -837,17 +837,21 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
 );
 
 /**
- * Extracts the data of the first page on the tab filtered profile.
- * Currently we assume that we don't change the origin of webpages while
- * profiling in web developer preset. That's why we are simply getting the
- * first page we find that belongs to the active tab. Returns null if profiler
- * is not in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page if we are in single tab
+ * view. We assume that the user wants to know about the last loaded page in
+ * this tab.
+ * Returns null if profiler is not in the single tab view at the moment.
  */
 export const getProfileFilterPageData: Selector<ProfileFilterPageData | null> =
   createSelector(
     getPageList,
     getRelevantInnerWindowIDsForCurrentTab,
-    extractProfileFilterPageData
+    (pageList, relevantPages) => {
+      if (relevantPages.size === 0) {
+        return null;
+      }
+      return extractProfileFilterPageData(pageList, relevantPages);
+    }
   );
 
 /**

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -34,6 +34,7 @@ import type {
   FullProfileSpecificUrlState,
   ActiveTabSpecificProfileUrlState,
   NativeSymbolInfo,
+  TabID,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -154,6 +155,10 @@ export const getHiddenLocalTracksByPid: Selector<Map<Pid, Set<TrackIndex>>> = (
 export const getLocalTrackOrderByPid: Selector<Map<Pid, TrackIndex[]>> = (
   state
 ) => getFullProfileSpecificState(state).localTrackOrderByPid;
+export const getTabFilter: Selector<TabID | null> = (state) =>
+  getFullProfileSpecificState(state).tabFilter;
+export const hasTabFilter: Selector<boolean> = (state) =>
+  getTabFilter(state) !== null;
 
 /**
  * This selector does a simple lookup in the set of hidden tracks for a PID, and ensures

--- a/src/test/components/FilterNavigatorBar.test.js
+++ b/src/test/components/FilterNavigatorBar.test.js
@@ -146,19 +146,4 @@ describe('app/ProfileFilterNavigator', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
-
-  it('displays the site hostname as its first element in the single tab view', () => {
-    const { dispatch, queryByText, getByText } = setup();
-    act(() => {
-      dispatch(
-        ReceiveProfile.changeTimelineTrackOrganization({
-          type: 'active-tab',
-          tabID,
-        })
-      );
-    });
-    expect(queryByText(/Full Range/)).not.toBeInTheDocument();
-    // Using regexp because searching for a partial text.
-    expect(getByText(/developer\.mozilla\.org/)).toBeInTheDocument();
-  });
 });

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -10,7 +10,11 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 1`] 
     <span
       class="filterNavigatorBarItemContent"
     >
-      Full Range (⁨51ms⁩)
+      <span
+        class="profileFilterNavigator--tab-selector"
+      >
+        Full Range (⁨51ms⁩)
+      </span>
     </span>
   </li>
 </ol>
@@ -27,7 +31,11 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] 
       class="filterNavigatorBarItemContent"
       type="button"
     >
-      Full Range (⁨51ms⁩)
+      <span
+        class="profileFilterNavigator--tab-selector disabled"
+      >
+        Full Range (⁨51ms⁩)
+      </span>
     </button>
   </li>
   <li
@@ -53,7 +61,11 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] 
       class="filterNavigatorBarItemContent"
       type="button"
     >
-      Full Range (⁨51ms⁩)
+      <span
+        class="profileFilterNavigator--tab-selector disabled"
+      >
+        Full Range (⁨51ms⁩)
+      </span>
     </button>
   </li>
   <li
@@ -89,16 +101,10 @@ exports[`app/ProfileFilterNavigator renders the site hostname as its first eleme
     <span
       class="filterNavigatorBarItemContent"
     >
-      <div
-        class="nodeIcon "
-      />
       <span
-        title="https://developer.mozilla.org"
+        class="profileFilterNavigator--tab-selector"
       >
-        developer.mozilla.org
-         (
-        51ms
-        )
+        Full Range (⁨51ms⁩)
       </span>
     </span>
   </li>

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -990,7 +990,7 @@ describe('extractProfileFilterPageData', function () {
   it('extracts the page data when there is only one relevant page', function () {
     // Adding only the https://www.mozilla.org page.
     const pagesMap = new Map([[pages.mozilla.tabID, [pages.mozilla]]]);
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.mozilla.tabID,
@@ -1008,7 +1008,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.profiler.tabID, [pages.profiler, pages.exampleSubFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.profiler.tabID,
@@ -1026,7 +1026,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.profiler.tabID, [pages.aboutBlank, pages.profiler]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.profiler.tabID,
@@ -1042,7 +1042,7 @@ describe('extractProfileFilterPageData', function () {
   it('extracts the page data when there is only about:blank as relevant page', function () {
     const pagesMap = new Map([[pages.aboutBlank.tabID, [pages.aboutBlank]]]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.aboutBlank.tabID,
@@ -1062,7 +1062,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.exampleSubFrame.tabID, [pages.exampleSubFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([]);
     expect(console.error).toHaveBeenCalled();
   });
@@ -1072,7 +1072,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.mozilla.tabID, [pages.mozilla]],
       [pages.profiler.tabID, [pages.profiler, pages.exampleSubFrame]],
     ]);
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.mozilla.tabID,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -557,6 +557,10 @@ type UrlStateAction =
       +type: 'TOGGLE_SIDEBAR_OPEN_CATEGORY',
       +kind: string,
       +category: IndexIntoCategoryList,
+    |}
+  | {|
+      +type: 'CHANGE_TAB_FILTER',
+      +tabID: TabID | null,
     |};
 
 type IconsAction =

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -561,6 +561,14 @@ type UrlStateAction =
   | {|
       +type: 'CHANGE_TAB_FILTER',
       +tabID: TabID | null,
+      +selectedThreadIndexes: Set<ThreadIndex>,
+      +globalTracks: GlobalTrack[],
+      +globalTrackOrder: TrackIndex[],
+      +hiddenGlobalTracks: Set<TrackIndex>,
+      +localTracksByPid: Map<Pid, LocalTrack[]>,
+      +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
+      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+      +selectedTab: TabSlug,
     |};
 
 type IconsAction =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -355,6 +355,7 @@ export type FullProfileSpecificUrlState = {|
   localTrackOrderByPid: Map<Pid, TrackIndex[]>,
   localTrackOrderChangedPids: Set<Pid>,
   showJsTracerSummary: boolean,
+  tabFilter: TabID | null,
   legacyThreadOrder: ThreadIndex[] | null,
   legacyHiddenThreads: ThreadIndex[] | null,
 |};


### PR DESCRIPTION
This PR adds a tab selector on the top left corner, inside the "Full Range" breadcrumbs root. By clicking that, you can select a different tab and this will change the amount of global tracks and local tracks you'll get. Allowing web developers to see only the tracks that they are interested in. Note that this doesn't filter the samples or markers, it filters only the tracks.

There are few things I would like to fix still but I'm happy to get feedback on the UX and the UI. Please let me know what you think!

[Deploy preview](https://deploy-preview-5068--perf-html.netlify.app/public/vk6etp8gknwtezq5eketjzxnyx7hgnr34mqf3mr/calltree/?globalTrackOrder=c0wb&hiddenGlobalTracks=1w46wa&hiddenLocalTracksByPid=73101-23~73880-01~73879-01~73876-01~73107-01~73875-01~73874-01~73878-01~73740-01~73871-01~73870-01&tabID=19&thread=u&v=10)

cc @julienw @AdamBrouwersHarries @mstange @fqueze 
