### PR TITLE
[Tab selector #1] Add a redux state for the tab filter

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -50,6 +50,7 @@ import type {
   UrlState,
   UploadedProfileInformation,
   IndexIntoCategoryList,
+  TabID,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type {
@@ -426,5 +427,18 @@ export function toggleOpenCategoryInSidebar(
     type: 'TOGGLE_SIDEBAR_OPEN_CATEGORY',
     kind,
     category,
+  };
+}
+
+/**
+ * Change the selected browser tab filter for the profile.
+ * TabID here means the unique ID for a give browser tab and corresponds to
+ * multiple pages in the `profile.pages` array.
+ * If it's null it will undo the filter and will show the full profile.
+ */
+export function changeTabFilter(tabID: TabID | null): Action {
+  return {
+    type: 'CHANGE_TAB_FILTER',
+    tabID,
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -153,6 +153,7 @@ type FullProfileSpecificBaseQuery = {|
   hiddenGlobalTracks: string, // "01"
   hiddenLocalTracksByPid: string, // "1549-0w8~1593-23~1598-01~1602-02~1607-1"
   localTrackOrderByPid: string, // "1549-780w6~1560-01"
+  tabID: TabID,
   // The following values are legacy, and will be converted to track-based values. These
   // value can't be upgraded using the typical URL upgrading process, as the full profile
   // must be fetched to compute the tracks.
@@ -328,6 +329,7 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
         urlState.profileSpecific.full.localTrackOrderByPid,
         urlState.profileSpecific.full.localTrackOrderChangedPids
       );
+      baseQuery.tabID = urlState.profileSpecific.full.tabFilter ?? undefined;
 
       break;
     }
@@ -581,9 +583,17 @@ export function stateFromLocation(
     transforms[selectedThreadsKey] = parseTransforms(query.transforms);
   }
 
-  let tabID = null;
+  // oldTabID is used for the old active tab view that we had. We will remove
+  // it in the end, but have to keep this while we have the view.
+  let oldTabID = null;
   if (query.ctxId && Number.isInteger(Number(query.ctxId))) {
-    tabID = Number(query.ctxId);
+    oldTabID = Number(query.ctxId);
+  }
+
+  // tabID is used for the tab selector that we have in our full view.
+  let tabID = null;
+  if (query.tabID && Number.isInteger(Number(query.tabID))) {
+    tabID = Number(query.tabID);
   }
 
   const selectedTab =
@@ -631,7 +641,7 @@ export function stateFromLocation(
     symbolServerUrl: query.symbolServer || null,
     timelineTrackOrganization: validateTimelineTrackOrganization(
       query.view,
-      tabID
+      oldTabID
     ),
     profileSpecific: {
       implementation,
@@ -663,6 +673,7 @@ export function stateFromLocation(
         ),
         localTrackOrderByPid,
         localTrackOrderChangedPids,
+        tabFilter: tabID,
         legacyThreadOrder: query.threadOrder
           ? query.threadOrder.split('-').map((index) => Number(index))
           : null,

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -1358,8 +1358,8 @@ function validateTimelineTrackOrganization(
  * provided or something else is provided for some reason.
  */
 function validateTimelineType(type: ?string): TimelineType {
-  // Pretend this is a TimelineTrackOrganization so that we can exhaustively
-  // go through each option.
+  // Pretend this is a TimelineType so that we can exhaustively go through
+  // each option.
   const timelineType: TimelineType = (type: any);
   switch (timelineType) {
     case 'stack':

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -140,6 +140,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'TOGGLE_RESOURCES_PANEL':
     case 'ENABLE_EXPERIMENTAL_CPU_GRAPHS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'CHANGE_TAB_FILTER':
     // Committed range changes: (fallthrough)
     case 'COMMIT_RANGE':
     case 'POP_COMMITTED_RANGES':

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -24,6 +24,7 @@ import type {
   SourceViewState,
   AssemblyViewState,
   IsOpenPerPanelState,
+  TabID,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -508,6 +509,19 @@ const localTrackOrderChangedPids: Reducer<Set<Pid>> = (
   }
 };
 
+/**
+ * This state controls whether or not we are filtering the full view for a
+ * specific Firefox tab.
+ */
+const tabFilter: Reducer<TabID | null> = (state = null, action) => {
+  switch (action.type) {
+    case 'CHANGE_TAB_FILTER':
+      return action.tabID;
+    default:
+      return state;
+  }
+};
+
 // If you update this reducer, please don't forget to update the profileName
 // reducer below as well.
 const pathInZipFile: Reducer<string | null> = (state = null, action) => {
@@ -671,6 +685,7 @@ const fullProfileSpecific = combineReducers({
   localTrackOrderByPid,
   localTrackOrderChangedPids,
   showJsTracerSummary,
+  tabFilter,
   // The timeline tracks used to be hidden and sorted by thread indexes, rather than
   // track indexes. The only way to migrate this information to tracks-based data is to
   // first retrieve the profile, so they can't be upgraded by the normal url upgrading

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -34,6 +34,7 @@ import type {
   FullProfileSpecificUrlState,
   ActiveTabSpecificProfileUrlState,
   NativeSymbolInfo,
+  TabID,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -154,6 +155,10 @@ export const getHiddenLocalTracksByPid: Selector<Map<Pid, Set<TrackIndex>>> = (
 export const getLocalTrackOrderByPid: Selector<Map<Pid, TrackIndex[]>> = (
   state
 ) => getFullProfileSpecificState(state).localTrackOrderByPid;
+export const getTabFilter: Selector<TabID | null> = (state) =>
+  getFullProfileSpecificState(state).tabFilter;
+export const hasTabFilter: Selector<boolean> = (state) =>
+  getTabFilter(state) !== null;
 
 /**
  * This selector does a simple lookup in the set of hidden tracks for a PID, and ensures

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -557,6 +557,10 @@ type UrlStateAction =
       +type: 'TOGGLE_SIDEBAR_OPEN_CATEGORY',
       +kind: string,
       +category: IndexIntoCategoryList,
+    |}
+  | {|
+      +type: 'CHANGE_TAB_FILTER',
+      +tabID: TabID | null,
     |};
 
 type IconsAction =

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -355,6 +355,7 @@ export type FullProfileSpecificUrlState = {|
   localTrackOrderByPid: Map<Pid, TrackIndex[]>,
   localTrackOrderChangedPids: Set<Pid>,
   showJsTracerSummary: boolean,
+  tabFilter: TabID | null,
   legacyThreadOrder: ThreadIndex[] | null,
   legacyHiddenThreads: ThreadIndex[] | null,
 |};


### PR DESCRIPTION
This is the first PR from #5068.

It adds the basic redux state and adds some tests for this behavior. It doesn't change anything related to user visible behavior yet.

I don't think it needs a deploy preview as it doesn't change anything, but let me know if you think otherwise.