### PR TITLE
[Tab selector #2] Extract the page data in the full view

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2924,19 +2924,17 @@ export function filterToRetainedAllocations(
 }
 
 /**
- * Extract the hostname and favicon from the first page if we are in single tab
- * view. Currently we assume that we don't change the origin of webpages while
- * profiling in web developer preset. That's why we are simply getting the first
- * page we find that belongs to the active tab. Returns null if profiler is not
- * in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page given the relative pages
+ * to a tab. We assume that the user wants to know about the last loaded page
+ * in this tab.
  */
 export function extractProfileFilterPageData(
   pages: PageList | null,
   relevantPages: Set<InnerWindowID>
 ): ProfileFilterPageData | null {
-  if (relevantPages.size === 0 || pages === null) {
-    // Either we are not in single tab view, or we don't have pages array(which
-    // is the case for older profiles). Return early.
+  if (pages === null) {
+    // We don't have pages array (which is the case for older profiles).
+    // Return early.
     return null;
   }
 
@@ -2961,7 +2959,7 @@ export function extractProfileFilterPageData(
     return null;
   }
 
-  const pageUrl = filteredPages[0].url;
+  const pageUrl = filteredPages[filteredPages.length - 1].url;
 
   if (pageUrl.startsWith('about:')) {
     // If we only have an `about:*` page, we should return early with a friendly

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -696,35 +696,33 @@ export const getPagesMap: Selector<Map<TabID, Page[]> | null> = createSelector(
 
     // Construction of TabID to Page array map.
     const pageMap: Map<TabID, Page[]> = new Map();
-    const appendPageMap = (tabID, page) => {
+
+    for (const page of pageList) {
+      // If this is an iframe, we recursively visit its parent.
+      const getTopMostParent = (item) => {
+        if (item.embedderInnerWindowID === 0) {
+          return item;
+        }
+
+        // We are using a Map to make this more performant.
+        // It should be 1-2 loop iteration in 99% of the cases.
+        const parent = innerWindowIDToPageMap.get(item.embedderInnerWindowID);
+        if (parent !== undefined) {
+          return getTopMostParent(parent);
+        }
+        // This is very unlikely to happen.
+        return item;
+      };
+
+      const topMostParent = getTopMostParent(page);
+
+      // Now we have the top most parent. We can append the pageMap.
+      const { tabID } = topMostParent;
       const tabEntry = pageMap.get(tabID);
       if (tabEntry === undefined) {
         pageMap.set(tabID, [page]);
       } else {
         tabEntry.push(page);
-      }
-    };
-
-    for (const page of pageList) {
-      if (page.embedderInnerWindowID === undefined) {
-        // This is the top most page, which means the web page itself.
-        appendPageMap(page.tabID, page);
-      } else {
-        // This is an iframe, we should find its parent to see find top most
-        // TabID, which is the tab ID for our case.
-        const getTopMostParent = (item) => {
-          // We are using a Map to make this more performant.
-          // It should be 1-2 loop iteration in 99% of the cases.
-          const parent = innerWindowIDToPageMap.get(item.embedderInnerWindowID);
-          if (parent !== undefined) {
-            return getTopMostParent(parent);
-          }
-          return item;
-        };
-
-        const parent = getTopMostParent(page);
-        // Now we have the top most parent. We can append the pageMap.
-        appendPageMap(parent.tabID, page);
       }
     }
 

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -837,17 +837,21 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
 );
 
 /**
- * Extracts the data of the first page on the tab filtered profile.
- * Currently we assume that we don't change the origin of webpages while
- * profiling in web developer preset. That's why we are simply getting the
- * first page we find that belongs to the active tab. Returns null if profiler
- * is not in the single tab view at the moment.
+ * Extract the hostname and favicon from the last page if we are in single tab
+ * view. We assume that the user wants to know about the last loaded page in
+ * this tab.
+ * Returns null if profiler is not in the single tab view at the moment.
  */
 export const getProfileFilterPageData: Selector<ProfileFilterPageData | null> =
   createSelector(
     getPageList,
     getRelevantInnerWindowIDsForCurrentTab,
-    extractProfileFilterPageData
+    (pageList, relevantPages) => {
+      if (relevantPages.size === 0) {
+        return null;
+      }
+      return extractProfileFilterPageData(pageList, relevantPages);
+    }
   );
 
 /**

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -1136,7 +1136,8 @@ describe('extractProfileFilterPageData', function () {
     aboutBlank: 2,
     profiler: 3,
     exampleSubFrame: 4,
-    unknown: 5,
+    exampleTopFrame: 5,
+    unknown: 6,
   };
   // This is the `profile.pages` array.
   const pages = [
@@ -1164,6 +1165,12 @@ describe('extractProfileFilterPageData', function () {
       url: 'https://example.com/subframe',
       // This is a subframe of the page above.
       embedderInnerWindowID: innerWindowIds.profiler,
+    },
+    {
+      tabID: 2222,
+      innerWindowID: innerWindowIds.exampleTopFrame,
+      url: 'https://example.com',
+      embedderInnerWindowID: 0,
     },
   ];
 
@@ -1238,6 +1245,20 @@ describe('extractProfileFilterPageData', function () {
 
     expect(pageData).toEqual(null);
     expect(console.error).toHaveBeenCalled();
+  });
+
+  it('extracts the page data of the last frame when there are multiple relevant pages', function () {
+    const relevantPages = new Set([
+      innerWindowIds.profiler,
+      innerWindowIds.exampleTopFrame,
+    ]);
+
+    const pageData = extractProfileFilterPageData(pages, relevantPages);
+    expect(pageData).toEqual({
+      origin: 'https://example.com',
+      hostname: 'example.com',
+      favicon: 'https://example.com/favicon.ico',
+    });
   });
 });
 


### PR DESCRIPTION
This is the second PR of #5068. 

It doesn't depend on the first PR, so you can review it independently. Also it's some refactoring and minor code changes without visible UI/UX changes. Previous and new tests should cover all the behaviors.

Previously `extractProfileFilterPageData` was only working on the active tab view and was returning early for the full view, with this change it should be possible to run it in the full view as well.

Similarly, I don't think it needs a deploy preview as it doesn't change anything, but let me know if you think otherwise.