### PR TITLE
[Tab selector 3] Generate page information for all tabs

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -82,6 +82,7 @@ import type {
   BottomBoxInfo,
   Bytes,
   ThreadWithReservedFunctions,
+  TabID,
 } from 'firefox-profiler/types';
 import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
 
@@ -2924,74 +2925,79 @@ export function filterToRetainedAllocations(
 }
 
 /**
- * Extract the hostname and favicon from the last page given the relative pages
- * to a tab. We assume that the user wants to know about the last loaded page
- * in this tab.
+ * Extract the hostname and favicon from the last page for all tab ids. we
+ * assume that the user wants to know about the last loaded page in this tab.
+ * returns null if we don't have information about pages (in older profiles).
  */
 export function extractProfileFilterPageData(
-  pages: PageList | null,
-  relevantPages: Set<InnerWindowID>
-): ProfileFilterPageData | null {
-  if (pages === null) {
-    // We don't have pages array (which is the case for older profiles).
-    // Return early.
-    return null;
+  pagesMapByTabID: Map<TabID, PageList> | null
+): Map<TabID, ProfileFilterPageData> {
+  if (pagesMapByTabID === null) {
+    // We don't have pages array (which is the case for older profiles). Return early.
+    return new Map();
   }
 
-  // Getting the pages that are relevant and a top-most frame.
-  let filteredPages = pages.filter(
-    (page) =>
-      // It's the top-most frame if `embedderInnerWindowID` is zero.
-      page.embedderInnerWindowID === 0 && relevantPages.has(page.innerWindowID)
-  );
-
-  if (filteredPages.length > 1) {
-    // If there are more than one top-most page, it's also good to filter out the
-    // `about:` pages so user can see their url they are actually profiling.
-    filteredPages = filteredPages.filter(
-      (page) => !page.url.startsWith('about:')
+  const pageDataByTabID = new Map();
+  for (const [tabID, pages] of pagesMapByTabID) {
+    let topMostPages = pages.filter(
+      (page) =>
+        // It's the top-most frame if `embedderInnerWindowID` is zero.
+        page.embedderInnerWindowID === 0
     );
-  }
 
-  if (filteredPages.length === 0) {
-    // There should be at least one relevant page.
-    console.error(`Expected a relevant page but couldn't find it.`);
-    return null;
-  }
-
-  const pageUrl = filteredPages[filteredPages.length - 1].url;
-
-  if (pageUrl.startsWith('about:')) {
-    // If we only have an `about:*` page, we should return early with a friendly
-    // origin and hostname. Otherwise the try block will fail.
-    return {
-      origin: pageUrl,
-      hostname: pageUrl,
-      favicon: null,
-    };
-  }
-
-  try {
-    const page = new URL(pageUrl);
-    // FIXME(Bug 1620546): This is not ideal and we should get the favicon
-    // either during profile capture or profile pre-process.
-    const favicon = new URL('/favicon.ico', page.origin);
-    if (favicon.protocol === 'http:') {
-      // Upgrade http requests.
-      favicon.protocol = 'https:';
+    if (topMostPages.length > 1) {
+      // If there are more than one top-most page, it's also good to filter out the
+      // `about:` pages so user can see their url they are actually profiling.
+      topMostPages = topMostPages.filter(
+        (page) => !page.url.startsWith('about:')
+      );
     }
-    return {
-      origin: page.origin,
-      hostname: page.hostname,
-      favicon: favicon.href,
-    };
-  } catch (e) {
-    console.error(
-      'Error while extracing the hostname and favicon from the page url',
-      pageUrl
-    );
-    return null;
+
+    if (topMostPages.length === 0) {
+      // There should be at least one relevant page.
+      console.error(
+        `Expected a relevant page for tabID ${tabID} but couldn't find it.`
+      );
+      continue;
+    }
+
+    // The last page is the one we care about.
+    const pageUrl = topMostPages[topMostPages.length - 1].url;
+    if (pageUrl.startsWith('about:')) {
+      // If we only have an `about:*` page, we should return early with a friendly
+      // origin and hostname. Otherwise the try block will always fail.
+      pageDataByTabID.set(tabID, {
+        origin: pageUrl,
+        hostname: pageUrl,
+        favicon: null,
+      });
+      continue;
+    }
+
+    try {
+      const page = new URL(pageUrl);
+      // FIXME(Bug 1620546): This is not ideal and we should get the favicon
+      // either during profile capture or profile pre-process.
+      const favicon = new URL('/favicon.ico', page.origin);
+      if (favicon.protocol === 'http:') {
+        // Upgrade http requests.
+        favicon.protocol = 'https:';
+      }
+      pageDataByTabID.set(tabID, {
+        origin: page.origin,
+        hostname: page.hostname,
+        favicon: favicon.href,
+      });
+    } catch (e) {
+      console.error(
+        'Error while extracing the hostname and favicon from the page url',
+        pageUrl
+      );
+      continue;
+    }
   }
+
+  return pageDataByTabID;
 }
 
 // Returns the resource index for a "url" or "webhost" resource which is created

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2954,9 +2954,9 @@ export function extractProfileFilterPageData(
     }
 
     if (topMostPages.length === 0) {
-      // There should be at least one relevant page.
+      // There should be at least one topmost page.
       console.error(
-        `Expected a relevant page for tabID ${tabID} but couldn't find it.`
+        `Expected at least one topmost page for tabID ${tabID} but couldn't find it.`
       );
       continue;
     }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2927,7 +2927,7 @@ export function filterToRetainedAllocations(
 /**
  * Extract the hostname and favicon from the last page for all tab ids. we
  * assume that the user wants to know about the last loaded page in this tab.
- * returns null if we don't have information about pages (in older profiles).
+ * Returns null if we don't have information about pages (in older profiles).
  */
 export function extractProfileFilterPageData(
   pagesMapByTabID: Map<TabID, PageList> | null

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -1131,134 +1131,162 @@ describe('getSamplesSelectedStates', function () {
 });
 
 describe('extractProfileFilterPageData', function () {
-  const innerWindowIds = {
-    mozilla: 1,
-    aboutBlank: 2,
-    profiler: 3,
-    exampleSubFrame: 4,
-    exampleTopFrame: 5,
-    unknown: 6,
-  };
-  // This is the `profile.pages` array.
-  const pages = [
-    {
+  const pages = {
+    mozilla: {
       tabID: 1111,
-      innerWindowID: innerWindowIds.mozilla,
+      innerWindowID: 1,
       url: 'https://www.mozilla.org',
       embedderInnerWindowID: 0,
     },
-    {
+    aboutBlank: {
       tabID: 2222,
-      innerWindowID: innerWindowIds.aboutBlank,
+      innerWindowID: 2,
       url: 'about:blank',
       embedderInnerWindowID: 0,
     },
-    {
+    profiler: {
       tabID: 2222,
-      innerWindowID: innerWindowIds.profiler,
+      innerWindowID: 3,
       url: 'https://profiler.firefox.com/public/xyz',
       embedderInnerWindowID: 0,
     },
-    {
+    exampleSubFrame: {
       tabID: 2222,
-      innerWindowID: innerWindowIds.exampleSubFrame,
+      innerWindowID: 4,
       url: 'https://example.com/subframe',
       // This is a subframe of the page above.
-      embedderInnerWindowID: innerWindowIds.profiler,
+      embedderInnerWindowID: 3,
     },
-    {
+    exampleTopFrame: {
       tabID: 2222,
-      innerWindowID: innerWindowIds.exampleTopFrame,
+      innerWindowID: 5,
       url: 'https://example.com',
       embedderInnerWindowID: 0,
     },
-  ];
+  };
 
   it('extracts the page data when there is only one relevant page', function () {
     // Adding only the https://www.mozilla.org page.
-    const relevantPages = new Set([innerWindowIds.mozilla]);
-
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-    expect(pageData).toEqual({
-      origin: 'https://www.mozilla.org',
-      hostname: 'www.mozilla.org',
-      favicon: 'https://www.mozilla.org/favicon.ico',
-    });
+    const pagesMap = new Map([[pages.mozilla.tabID, [pages.mozilla]]]);
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([
+      [
+        pages.mozilla.tabID,
+        {
+          origin: 'https://www.mozilla.org',
+          hostname: 'www.mozilla.org',
+          favicon: 'https://www.mozilla.org/favicon.ico',
+        },
+      ],
+    ]);
   });
 
   it('extracts the page data when there are multiple relevant page', function () {
-    const relevantPages = new Set([
-      innerWindowIds.profiler,
-      innerWindowIds.exampleSubFrame,
+    const pagesMap = new Map([
+      [pages.profiler.tabID, [pages.profiler, pages.exampleSubFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-    expect(pageData).toEqual({
-      origin: 'https://profiler.firefox.com',
-      hostname: 'profiler.firefox.com',
-      favicon: 'https://profiler.firefox.com/favicon.ico',
-    });
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([
+      [
+        pages.profiler.tabID,
+        {
+          origin: 'https://profiler.firefox.com',
+          hostname: 'profiler.firefox.com',
+          favicon: 'https://profiler.firefox.com/favicon.ico',
+        },
+      ],
+    ]);
   });
 
   it('extracts the page data when there are multiple relevant page with about:blank', function () {
-    const relevantPages = new Set([
-      innerWindowIds.aboutBlank,
-      innerWindowIds.profiler,
+    const pagesMap = new Map([
+      [pages.profiler.tabID, [pages.aboutBlank, pages.profiler]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-    expect(pageData).toEqual({
-      origin: 'https://profiler.firefox.com',
-      hostname: 'profiler.firefox.com',
-      favicon: 'https://profiler.firefox.com/favicon.ico',
-    });
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([
+      [
+        pages.profiler.tabID,
+        {
+          origin: 'https://profiler.firefox.com',
+          hostname: 'profiler.firefox.com',
+          favicon: 'https://profiler.firefox.com/favicon.ico',
+        },
+      ],
+    ]);
   });
 
   it('extracts the page data when there is only about:blank as relevant page', function () {
-    const relevantPages = new Set([innerWindowIds.aboutBlank]);
+    const pagesMap = new Map([[pages.aboutBlank.tabID, [pages.aboutBlank]]]);
 
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-    expect(pageData).toEqual({
-      origin: 'about:blank',
-      hostname: 'about:blank',
-      favicon: null,
-    });
-  });
-
-  it('fails to extract the page data when there is no profile data in common', function () {
-    // Ignore the error we output when it fails.
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    const relevantPages = new Set([innerWindowIds.unknown]);
-
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-
-    expect(pageData).toEqual(null);
-    expect(console.error).toHaveBeenCalled();
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([
+      [
+        pages.aboutBlank.tabID,
+        {
+          origin: 'about:blank',
+          hostname: 'about:blank',
+          favicon: null,
+        },
+      ],
+    ]);
   });
 
   it('fails to extract the page data when there is only a sub frame', function () {
     // Ignore the error we output when it fails.
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    const relevantPages = new Set([innerWindowIds.exampleSubFrame]);
+    const pagesMap = new Map([
+      [pages.exampleSubFrame.tabID, [pages.exampleSubFrame]],
+    ]);
 
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-
-    expect(pageData).toEqual(null);
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([]);
     expect(console.error).toHaveBeenCalled();
   });
 
   it('extracts the page data of the last frame when there are multiple relevant pages', function () {
-    const relevantPages = new Set([
-      innerWindowIds.profiler,
-      innerWindowIds.exampleTopFrame,
+    const pagesMap = new Map([
+      [pages.profiler.tabID, [pages.profiler, pages.exampleTopFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pages, relevantPages);
-    expect(pageData).toEqual({
-      origin: 'https://example.com',
-      hostname: 'example.com',
-      favicon: 'https://example.com/favicon.ico',
-    });
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([
+      [
+        pages.profiler.tabID,
+        {
+          origin: 'https://example.com',
+          hostname: 'example.com',
+          favicon: 'https://example.com/favicon.ico',
+        },
+      ],
+    ]);
+  });
+
+  it('can extract the data of several tabs', function () {
+    const pagesMap = new Map([
+      [pages.mozilla.tabID, [pages.mozilla]],
+      [pages.profiler.tabID, [pages.profiler, pages.exampleSubFrame]],
+    ]);
+    const pageData = extractProfileFilterPageData(pagesMap);
+    expect([...pageData]).toEqual([
+      [
+        pages.mozilla.tabID,
+        {
+          origin: 'https://www.mozilla.org',
+          hostname: 'www.mozilla.org',
+          favicon: 'https://www.mozilla.org/favicon.ico',
+        },
+      ],
+      [
+        pages.profiler.tabID,
+        {
+          origin: 'https://profiler.firefox.com',
+          hostname: 'profiler.firefox.com',
+          favicon: 'https://profiler.firefox.com/favicon.ico',
+        },
+      ],
+    ]);
   });
 });
 


### PR DESCRIPTION
This is the third PR of #5068.

Previously we were only generating page information for the selected/active tab. But for the tab selector to work, we need page information of all tabs. So this PR makes sure that we extract the data for all of them.
Again, this is not a user visible change.