### PR TITLE
Do not crash on timeline hover/selection when a profile doesn't have any samples or markers

### DIFF
--- a/src/components/app/ListOfPublishedProfiles.js
+++ b/src/components/app/ListOfPublishedProfiles.js
@@ -26,6 +26,11 @@ import './ListOfPublishedProfiles.css';
 // them by clicking on them, or delete them.
 
 function _formatRange(range: StartEndRange): string {
+  if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+    // Do not attempt to show if the range is NaN or Infinity, which happens
+    // if a profile doesn't have any samples or markers.
+    return '';
+  }
   return formatSeconds(range.end - range.start, 3, 1);
 }
 

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -347,6 +347,13 @@ class TimelineRulerAndSelection extends React.PureComponent<Props> {
     const { committedRange, width } = this.props;
     const { selectionStart, selectionEnd } = previewSelection;
 
+    if (!Number.isFinite(selectionStart) || !Number.isFinite(selectionEnd)) {
+      // Do not render the selection overlay if there is no data to display in
+      // the timeline. This prevents a crash on range selection if the profile
+      // is completely empty.
+      return null;
+    }
+
     const beforeWidth =
       ((selectionStart - committedRange.start) /
         (committedRange.end - committedRange.start)) *
@@ -429,6 +436,17 @@ class TimelineRulerAndSelection extends React.PureComponent<Props> {
         (committedRange.end - committedRange.start);
     }
 
+    let mousePosTimestamp = null;
+    if (mouseTimePosition !== null && Number.isFinite(mouseTimePosition)) {
+      // Only compute and display the timestamp when there is a mouse position
+      // and the position is not NaN or Infinity which is the case when there
+      // is no data in the timeline.
+      mousePosTimestamp = getFormattedTimeLength(
+        mouseTimePosition - zeroAt,
+        (committedRange.end - committedRange.start) / width
+      );
+    }
+
     return (
       <div
         className={classNames('timelineSelection', className)}
@@ -445,19 +463,16 @@ class TimelineRulerAndSelection extends React.PureComponent<Props> {
           className="timelineSelectionHoverLine"
           style={{
             visibility:
-              previewSelection.isModifying || hoverLocation === null
+              previewSelection.isModifying ||
+              hoverLocation === null ||
+              isNaN(hoverLocation)
                 ? 'hidden'
                 : undefined,
             left: hoverLocation === null ? '0' : `${hoverLocation}px`,
           }}
         >
           <span className="timelineSelectionOverlayTime">
-            {mouseTimePosition !== null
-              ? getFormattedTimeLength(
-                  mouseTimePosition - zeroAt,
-                  (committedRange.end - committedRange.start) / width
-                )
-              : null}
+            {mousePosTimestamp}
           </span>
         </div>
       </div>

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -1,5 +1,278 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TimelineSelection does not crash when there are no samples or markers 1`] = `
+<body>
+  <div>
+    <div
+      class="timelineSelection"
+    >
+      <div
+        class="timelineHeader"
+      >
+        <button
+          class="timelineSettingsHiddenTracks"
+          type="button"
+        >
+          <span
+            class="timelineSettingsHiddenTracksNumber"
+          >
+            ⁨2⁩
+          </span>
+           / 
+          <span
+            class="timelineSettingsHiddenTracksNumber"
+          >
+            ⁨2⁩
+          </span>
+           tracks
+        </button>
+        <div
+          class="timelineRuler"
+          style="--timeline-ruler-height: 20px;"
+        >
+          <ol
+            class="timelineRulerContainer"
+          />
+        </div>
+      </div>
+      <div
+        class="overflowEdgeIndicator tracksContainer timelineOverflowEdgeIndicator"
+      >
+        <div
+          class="overflowEdgeIndicatorEdge topEdge"
+        />
+        <div
+          class="overflowEdgeIndicatorEdge rightEdge"
+        />
+        <div
+          class="overflowEdgeIndicatorEdge bottomEdge"
+        />
+        <div
+          class="overflowEdgeIndicatorEdge leftEdge"
+        />
+        <div
+          class="overflowEdgeIndicatorScrollbox tracksContainer timelineOverflowEdgeIndicatorScrollbox"
+        >
+          <div
+            class="overflowEdgeIndicatorContentsWrapper"
+          >
+            <ol
+              class="timelineThreadList"
+            >
+              <li
+                class="timelineTrack"
+              >
+                <div
+                  class="timelineTrackRow timelineTrackGlobalRow"
+                >
+                  <div
+                    class="react-contextmenu-wrapper timelineTrackLabel timelineTrackGlobalGrippy"
+                  >
+                    <button
+                      class="timelineTrackNameButton"
+                      type="button"
+                    >
+                      Process 0
+                    </button>
+                    <button
+                      class="timelineTrackCloseButton"
+                      title="Hide process"
+                      type="button"
+                    />
+                  </div>
+                  <div
+                    class="timelineTrackTrack"
+                  >
+                    <div
+                      class="timelineTrackThreadBlank"
+                      style="--timeline-track-thread-blank-height: 30px;"
+                    />
+                  </div>
+                </div>
+                <ol
+                  class="timelineTrackLocalTracks"
+                >
+                  <li
+                    class="timelineTrack timelineTrackLocal"
+                  >
+                    <div
+                      class="timelineTrackRow timelineTrackLocalRow selected"
+                    >
+                      <div
+                        class="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
+                        title="Empty
+Thread: \\"Empty\\" (0)
+Process: \\"default\\" (0)"
+                      >
+                        <button
+                          class="timelineTrackNameButton"
+                          type="button"
+                        >
+                          Empty
+                        </button>
+                        <button
+                          class="timelineTrackCloseButton"
+                          title="Hide track"
+                          type="button"
+                        />
+                      </div>
+                      <div
+                        class="timelineTrackTrack"
+                      >
+                        <div
+                          class="timelineTrackThread expanded"
+                        >
+                          <div
+                            class="timelineMarkers selected"
+                            data-testid="TimelineMarkersJank"
+                          >
+                            <div
+                              class="react-contextmenu-wrapper"
+                            >
+                              <div>
+                                <canvas
+                                  class="timelineMarkersCanvas"
+                                  height="50"
+                                  width="400"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="threadActivityGraph"
+                          >
+                            <div>
+                              <canvas
+                                class="threadActivityGraphCanvas threadActivityGraphCanvas"
+                                height="50"
+                                width="400"
+                              >
+                                <h2>
+                                  Activity Graph for 
+                                  Empty
+                                </h2>
+                                <p>
+                                  This graph shows a visual chart of thread activity.
+                                </p>
+                              </canvas>
+                            </div>
+                          </div>
+                          <div
+                            class="threadSampleGraph"
+                          >
+                            <div>
+                              <canvas
+                                class="threadSampleGraphCanvas threadSampleGraphCanvas"
+                                height="50"
+                                width="400"
+                              >
+                                <h2>
+                                  Stack Graph for 
+                                  Empty
+                                </h2>
+                                <p>
+                                  This graph charts the stack height of each sample.
+                                </p>
+                              </canvas>
+                            </div>
+                          </div>
+                          <div
+                            class="timelineEmptyThreadIndicator"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+      <div
+        class="timelineSelectionHoverLine"
+        style="visibility: hidden; left: 0px;"
+      >
+        <span
+          class="timelineSelectionOverlayTime"
+        />
+      </div>
+    </div>
+    <nav
+      class="react-contextmenu timelineTrackContextMenu"
+      role="menu"
+      style="position: fixed; opacity: 0; pointer-events: none;"
+      tabindex="-1"
+    >
+      <form
+        class="trackSearchField trackContextMenuSearchField"
+      >
+        <input
+          autocomplete="off"
+          class="trackSearchFieldInput photon-input"
+          name="search"
+          placeholder="Enter filter terms"
+          required=""
+          title="Only display tracks that match a certain text"
+          type="search"
+          value=""
+        />
+        <input
+          class="trackSearchFieldButton"
+          tabindex="-1"
+          type="reset"
+        />
+      </form>
+      <div
+        class="react-contextmenu-separator"
+      />
+      <div
+        aria-disabled="true"
+        class="react-contextmenu-item react-contextmenu-item--disabled"
+        role="menuitem"
+        tabindex="-1"
+      >
+        Show all tracks
+      </div>
+      <div
+        class="react-contextmenu-separator"
+      />
+      <div
+        aria-checked="true"
+        aria-disabled="false"
+        class="react-contextmenu-item timelineTrackContextMenuItem checkable checked"
+        role="menuitemcheckbox"
+        tabindex="-1"
+        title="Process 0 (Process ID: 0)"
+      >
+        <span>
+          Process 0
+        </span>
+        <span
+          class="timelineTrackContextMenuSpacer"
+        />
+        <span
+          class="timelineTrackContextMenuPid"
+        >
+          (
+          0
+          )
+        </span>
+      </div>
+      <div
+        aria-checked="true"
+        aria-disabled="false"
+        class="react-contextmenu-item checkable indented checked"
+        role="menuitemcheckbox"
+        tabindex="-1"
+      >
+        Empty
+      </div>
+    </nav>
+  </div>
+</body>
+`;
+
 exports[`TimelineSelection renders the vertical line indicating the time position from the mouse cursor 1`] = `
 <body>
   <div>


### PR DESCRIPTION
This fixes #5037.

It was happening because we were trying to find the timestamp of the hovered mouse location. Also I noticed that the same thing happens when we try to select a time range in an empty timeline. This should fix both of the issues.

Right before I was publishing this PR, I also noticed that when you upload an empty profile the home page also crashes because it tries to calculate the range too in the published profiles list. So I fixed that one as well.


[Deploy preview](https://deploy-preview-5086--perf-html.netlify.app/public/d36dswgwppe2vh5h08w8f70jfqpe13wgpxbzcj0/marker-chart/?globalTrackOrder=0&hiddenLocalTracksByPid=8924-ewn&thread=0&v=10) / [Production](https://share.firefox.dev/3YMJQir)