### PR TITLE
[Tab selector 4] Add a getTabToThreadIndexesMap selector to get relevant threads per tab 

### DIFF
--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -375,37 +375,19 @@ export const getInnerWindowIDToPageMap: Selector<Map<
 export const getInnerWindowIDToTabMap: Selector<Map<
   InnerWindowID,
   TabID,
-> | null> = createSelector(
-  getPageList,
-  getInnerWindowIDToPageMap,
-  (pages, innerWindowIDToPageMap) => {
-    if (!pages || innerWindowIDToPageMap === null) {
-      // Return null if there are no pages.
-      return null;
-    }
-
-    const innerWindowIDToTabMap: Map<InnerWindowID, TabID> = new Map();
-    const getTopMostParent = (page) => {
-      if (page.embedderInnerWindowID === 0) {
-        return page;
-      }
-
-      // We are using a Map to make this more performant.
-      // It should be 1-2 loop iteration in 99% of the cases.
-      const parent = innerWindowIDToPageMap.get(page.embedderInnerWindowID);
-      if (parent !== undefined) {
-        return getTopMostParent(parent);
-      }
-      return page;
-    };
-    for (const page of pages) {
-      const topMostParent = getTopMostParent(page);
-      innerWindowIDToTabMap.set(page.innerWindowID, topMostParent.tabID);
-    }
-
-    return innerWindowIDToTabMap;
+> | null> = createSelector(getPageList, (pages) => {
+  if (!pages) {
+    // Return null if there are no pages.
+    return null;
   }
-);
+
+  const innerWindowIDToTabMap: Map<InnerWindowID, TabID> = new Map();
+  for (const page of pages) {
+    innerWindowIDToTabMap.set(page.innerWindowID, page.tabID);
+  }
+
+  return innerWindowIDToTabMap;
+});
 
 /**
  * Return a map of tab to thread indexes map. This is useful for learning which

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -14,6 +14,7 @@ import {
   getFriendlyThreadName,
   processCounter,
   getInclusiveSampleIndexRangeForSelection,
+  computeTabToThreadIndexesMap,
 } from '../profile-logic/profile-data';
 import {
   IPCMarkerCorrelations,
@@ -398,80 +399,8 @@ export const getTabToThreadIndexesMap: Selector<Map<TabID, Set<ThreadIndex>>> =
   createSelector(
     getThreads,
     getInnerWindowIDToTabMap,
-    (threads, innerWindowIDToTabMap) => {
-      const tabToThreadIndexesMap = new Map();
-      if (!innerWindowIDToTabMap) {
-        // There is no pages information in the profile, return an empty map.
-        return tabToThreadIndexesMap;
-      }
-
-      // We need to iterate over all the samples and markers once to figure out
-      // which innerWindowIDs are present in each thread. This is probably not
-      // very cheap, but it'll allow us to not compute this information every
-      // time when we need it.
-      for (let threadIdx = 0; threadIdx < threads.length; threadIdx++) {
-        const thread = threads[threadIdx];
-
-        // First go over the innerWindowIDs of the samples.
-        for (let i = 0; i < thread.frameTable.length; i++) {
-          const innerWindowID = thread.frameTable.innerWindowID[i];
-          if (innerWindowID === null) {
-            continue;
-          }
-
-          const tabID = innerWindowIDToTabMap.get(innerWindowID);
-          if (tabID === undefined) {
-            // We couldn't find the tab of this innerWindowID, this should
-            // never happen, it might indicate a bug in Firefox.
-            console.warn(
-              `Failed to find the tabID of innerWindowID ${innerWindowID}`
-            );
-            continue;
-          }
-
-          let threadIndexes = tabToThreadIndexesMap.get(tabID);
-          if (!threadIndexes) {
-            threadIndexes = new Set();
-            tabToThreadIndexesMap.set(tabID, threadIndexes);
-          }
-          threadIndexes.add(threadIdx);
-        }
-
-        // Then go over the markers to find their innerWindowIDs.
-        for (let i = 0; i < thread.markers.length; i++) {
-          const markerData = thread.markers.data[i];
-
-          if (!markerData) {
-            continue;
-          }
-
-          if (
-            markerData.innerWindowID !== null &&
-            markerData.innerWindowID !== undefined
-          ) {
-            const innerWindowID = markerData.innerWindowID;
-            const tabID = innerWindowIDToTabMap.get(innerWindowID);
-            if (tabID === undefined) {
-              // We couldn't find the tab of this innerWindowID, this should
-              // never happen, it might indicate a bug in Firefox.
-              console.warn(
-                `Failed to find the tabID of innerWindowID ${innerWindowID}`
-              );
-              continue;
-            }
-
-            let threadIndexes = tabToThreadIndexesMap.get(tabID);
-            if (!threadIndexes) {
-              threadIndexes = new Set();
-              tabToThreadIndexesMap.set(tabID, threadIndexes);
-            }
-            threadIndexes.add(threadIdx);
-          }
-        }
-      }
-
-      return tabToThreadIndexesMap;
-    }
+    (threads, innerWindowIDToTabMap) =>
+      computeTabToThreadIndexesMap(threads, innerWindowIDToTabMap)
   );
 
 /**

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -348,6 +348,151 @@ export const getIPCMarkerCorrelations: Selector<IPCMarkerCorrelations> =
   createSelector(getThreads, correlateIPCMarkers);
 
 /**
+ * Returns an InnerWindowID -> Page map, so we can look up the page from inner
+ * window id quickly. Returns null if there are no pages in the profile.
+ */
+export const getInnerWindowIDToPageMap: Selector<Map<
+  InnerWindowID,
+  Page,
+> | null> = createSelector(getPageList, (pages) => {
+  if (!pages) {
+    // Return null if there are no pages.
+    return null;
+  }
+
+  const innerWindowIDToPageMap: Map<InnerWindowID, Page> = new Map();
+  for (const page of pages) {
+    innerWindowIDToPageMap.set(page.innerWindowID, page);
+  }
+
+  return innerWindowIDToPageMap;
+});
+
+/**
+ * Returns an InnerWindowID -> TabID map, so we can find the TabID of a given
+ * innerWindowID quickly. Returns null if there are no pages in the profile.
+ */
+export const getInnerWindowIDToTabMap: Selector<Map<
+  InnerWindowID,
+  TabID,
+> | null> = createSelector(
+  getPageList,
+  getInnerWindowIDToPageMap,
+  (pages, innerWindowIDToPageMap) => {
+    if (!pages || innerWindowIDToPageMap === null) {
+      // Return null if there are no pages.
+      return null;
+    }
+
+    const innerWindowIDToTabMap: Map<InnerWindowID, TabID> = new Map();
+    const getTopMostParent = (page) => {
+      if (page.embedderInnerWindowID === 0) {
+        return page;
+      }
+
+      // We are using a Map to make this more performant.
+      // It should be 1-2 loop iteration in 99% of the cases.
+      const parent = innerWindowIDToPageMap.get(page.embedderInnerWindowID);
+      if (parent !== undefined) {
+        return getTopMostParent(parent);
+      }
+      return page;
+    };
+    for (const page of pages) {
+      const topMostParent = getTopMostParent(page);
+      innerWindowIDToTabMap.set(page.innerWindowID, topMostParent.tabID);
+    }
+
+    return innerWindowIDToTabMap;
+  }
+);
+
+/**
+ * Return a map of tab to thread indexes map. This is useful for learning which
+ * threads are involved for tabs. This is mainly used for the tab selector on
+ * the top left corner.
+ */
+export const getTabToThreadIndexesMap: Selector<Map<TabID, Set<ThreadIndex>>> =
+  createSelector(
+    getThreads,
+    getInnerWindowIDToTabMap,
+    (threads, innerWindowIDToTabMap) => {
+      const tabToThreadIndexesMap = new Map();
+      if (!innerWindowIDToTabMap) {
+        // There is no pages information in the profile, return an empty map.
+        return tabToThreadIndexesMap;
+      }
+
+      // We need to iterate over all the samples and markers once to figure out
+      // which innerWindowIDs are present in each thread. This is probably not
+      // very cheap, but it'll allow us to not compute this information every
+      // time when we need it.
+      for (let threadIdx = 0; threadIdx < threads.length; threadIdx++) {
+        const thread = threads[threadIdx];
+
+        // First go over the innerWindowIDs of the samples.
+        for (let i = 0; i < thread.frameTable.length; i++) {
+          const innerWindowID = thread.frameTable.innerWindowID[i];
+          if (innerWindowID === null) {
+            continue;
+          }
+
+          const tabID = innerWindowIDToTabMap.get(innerWindowID);
+          if (tabID === undefined) {
+            // We couldn't find the tab of this innerWindowID, this should
+            // never happen, it might indicate a bug in Firefox.
+            console.warn(
+              `Failed to find the tabID of innerWindowID ${innerWindowID}`
+            );
+            continue;
+          }
+
+          let threadIndexes = tabToThreadIndexesMap.get(tabID);
+          if (!threadIndexes) {
+            threadIndexes = new Set();
+            tabToThreadIndexesMap.set(tabID, threadIndexes);
+          }
+          threadIndexes.add(threadIdx);
+        }
+
+        // Then go over the markers to find their innerWindowIDs.
+        for (let i = 0; i < thread.markers.length; i++) {
+          const markerData = thread.markers.data[i];
+
+          if (!markerData) {
+            continue;
+          }
+
+          if (
+            markerData.innerWindowID !== null &&
+            markerData.innerWindowID !== undefined
+          ) {
+            const innerWindowID = markerData.innerWindowID;
+            const tabID = innerWindowIDToTabMap.get(innerWindowID);
+            if (tabID === undefined) {
+              // We couldn't find the tab of this innerWindowID, this should
+              // never happen, it might indicate a bug in Firefox.
+              console.warn(
+                `Failed to find the tabID of innerWindowID ${innerWindowID}`
+              );
+              continue;
+            }
+
+            let threadIndexes = tabToThreadIndexesMap.get(tabID);
+            if (!threadIndexes) {
+              threadIndexes = new Set();
+              tabToThreadIndexesMap.set(tabID, threadIndexes);
+            }
+            threadIndexes.add(threadIdx);
+          }
+        }
+      }
+
+      return tabToThreadIndexesMap;
+    }
+  );
+
+/**
  * Tracks
  *
  * Tracks come in two flavors: global tracks and local tracks.
@@ -652,27 +797,6 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
     return { hidden, total };
   }
 );
-
-/**
- * Returns an InnerWindowID -> Page map, so we can look up the page from inner
- * window id quickly. Returns null if there are no pages in the profile.
- */
-export const getInnerWindowIDToPageMap: Selector<Map<
-  InnerWindowID,
-  Page,
-> | null> = createSelector(getPageList, (pages) => {
-  if (!pages) {
-    // Return null if there are no pages.
-    return null;
-  }
-
-  const innerWindowIDToPageMap: Map<InnerWindowID, Page> = new Map();
-  for (const page of pages) {
-    innerWindowIDToPageMap.set(page.innerWindowID, page);
-  }
-
-  return innerWindowIDToPageMap;
-});
 
 /**
  * Get the pages array and construct a Map of pages that we can use to get the


### PR DESCRIPTION
This is the fourth PR of #5068.

This PR creates a `getTabToThreadIndexesMap` selector to be used in the next patches. It is useful to quickly get which tab uses which threads in the timeline, as well as gathering the CPU activity scores per tab to be able to sort the tab selector list. Also added some tests to check the behavior.
