### PR TITLE
[Tab selector 5] Add a tab selector component and implement tab switching

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -807,6 +807,13 @@ TabBar--marker-table-tab = Marker Table
 TabBar--network-tab = Network
 TabBar--js-tracer-tab = JS Tracer
 
+## TabSelectorMenu
+## This component is a context menu that's opened when you click on the root
+## range at the top left corner for profiler analysis view. It's used to switch
+## between tabs that were captured in the profile.
+
+TabSelectorMenu--full-profile = Full Profile
+
 ## TrackContextMenu
 ## This is used as a context menu for timeline to organize the tracks in the
 ## analysis UI.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -812,7 +812,7 @@ TabBar--js-tracer-tab = JS Tracer
 ## range at the top left corner for profiler analysis view. It's used to switch
 ## between tabs that were captured in the profile.
 
-TabSelectorMenu--full-profile = Full Profile
+TabSelectorMenu--all-tabs-and-windows = All tabs and windows
 
 ## TrackContextMenu
 ## This is used as a context menu for timeline to organize the tracks in the

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -50,7 +50,6 @@ import type {
   UrlState,
   UploadedProfileInformation,
   IndexIntoCategoryList,
-  TabID,
 } from 'firefox-profiler/types';
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type {
@@ -427,18 +426,5 @@ export function toggleOpenCategoryInSidebar(
     type: 'TOGGLE_SIDEBAR_OPEN_CATEGORY',
     kind,
     category,
-  };
-}
-
-/**
- * Change the selected browser tab filter for the profile.
- * TabID here means the unique ID for a give browser tab and corresponds to
- * multiple pages in the `profile.pages` array.
- * If it's null it will undo the filter and will show the full profile.
- */
-export function changeTabFilter(tabID: TabID | null): Action {
-  return {
-    type: 'CHANGE_TAB_FILTER',
-    tabID,
   };
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1761,7 +1761,6 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
       tabID,
       tabToThreadIndexesMap
     );
-    // Passing the global tracks to see which ones we have.
     const localTracksByPid = computeLocalTracksByPid(
       profile,
       globalTracks,

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -5,30 +5,24 @@
 .profileFilterNavigator--tab-selector {
   display: flex;
   align-items: center;
+  column-gap: 5px;
 
   /* Padding for the arrow on the left side. */
-  padding-left: 20px;
-  column-gap: 5px;
-}
-
-.profileFilterNavigator--tab-selector:not(.disabled) {
-  cursor: pointer;
+  padding-inline-start: 20px;
 }
 
 /* This is the dropdown arrow on the left of the button. */
 .profileFilterNavigator--tab-selector::before {
   position: absolute;
-  top: 4px;
-  left: 4px;
   border-top: 6px solid;
   border-right: 4px solid transparent;
   border-bottom: 0 solid transparent;
   border-left: 4px solid transparent;
-  margin-top: 5px;
-  margin-right: 5px;
-  margin-left: 5px;
+  margin: 5px 5px 0;
   color: var(--internal-selected-color);
   content: '';
+  inset-block-start: 4px;
+  inset-inline-start: 4px;
 }
 
 .profileFilterNavigator--tab-selector.disabled::before {

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -11,6 +11,10 @@
   column-gap: 5px;
 }
 
+.profileFilterNavigator--tab-selector:not(.disabled) {
+  cursor: pointer;
+}
+
 /* This is the dropdown arrow on the left of the button. */
 .profileFilterNavigator--tab-selector::before {
   position: absolute;

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -7,8 +7,8 @@
   align-items: center;
   column-gap: 5px;
 
-  /* Padding for the arrow on the left side. */
-  padding-inline-start: 20px;
+  /* Padding for the arrow on the left side and a bit on the other for hover. */
+  padding-inline: 20px 5px;
 }
 
 /* This is the dropdown arrow on the left of the button. */
@@ -25,7 +25,7 @@
   inset-inline-start: 4px;
 }
 
-.profileFilterNavigator--tab-selector.disabled::before {
+span.profileFilterNavigator--tab-selector::before {
   /* Disabled tab selector indicates this with a grayed out arrow. */
   color: var(--grey-30);
 }

--- a/src/components/app/ProfileFilterNavigator.css
+++ b/src/components/app/ProfileFilterNavigator.css
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.profileFilterNavigator--tab-selector {
+  display: flex;
+  align-items: center;
+
+  /* Padding for the arrow on the left side. */
+  padding-left: 20px;
+  column-gap: 5px;
+}
+
+/* This is the dropdown arrow on the left of the button. */
+.profileFilterNavigator--tab-selector::before {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  border-top: 6px solid;
+  border-right: 4px solid transparent;
+  border-bottom: 0 solid transparent;
+  border-left: 4px solid transparent;
+  margin-top: 5px;
+  margin-right: 5px;
+  margin-left: 5px;
+  color: var(--internal-selected-color);
+  content: '';
+}
+
+.profileFilterNavigator--tab-selector.disabled::before {
+  /* Disabled tab selector indicates this with a grayed out arrow. */
+  color: var(--grey-30);
+}

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -7,33 +7,47 @@
 import React from 'react';
 import memoize from 'memoize-immutable';
 import { Localized } from '@fluent/react';
+import { showMenu } from '@firefox-devtools/react-contextmenu';
+import classNames from 'classnames';
 
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { popCommittedRanges } from 'firefox-profiler/actions/profile-view';
 import {
   getPreviewSelection,
   getProfileFilterPageData,
+  getProfileFilterPageDataByTabID,
   getProfileRootRange,
 } from 'firefox-profiler/selectors/profile';
-import { getCommittedRangeLabels } from 'firefox-profiler/selectors/url-state';
+import {
+  getCommittedRangeLabels,
+  getTabFilter,
+} from 'firefox-profiler/selectors/url-state';
 import { getFormattedTimeLength } from 'firefox-profiler/profile-logic/committed-ranges';
 import { FilterNavigatorBar } from 'firefox-profiler/components/shared/FilterNavigatorBar';
 import { Icon } from 'firefox-profiler/components/shared/Icon';
+import { TabSelectorMenu } from '../shared/TabSelectorMenu';
 
 import type { ElementProps } from 'react';
 import type {
   ProfileFilterPageData,
   StartEndRange,
+  TabID,
 } from 'firefox-profiler/types';
 
+import './ProfileFilterNavigator.css';
+
 type Props = {|
-  +filterPageData: ProfileFilterPageData | null,
+  +filterPageDataForActiveTab: ProfileFilterPageData | null,
+  +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
+  +tabFilter: TabID | null,
   +rootRange: StartEndRange,
   ...ElementProps<typeof FilterNavigatorBar>,
 |};
+
 type DispatchProps = {|
   +onPop: $PropertyType<Props, 'onPop'>,
 |};
+
 type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
 
 class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
@@ -44,6 +58,22 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
     }
   );
 
+  _showTabSelectorMenu = (event: SyntheticMouseEvent<HTMLElement>) => {
+    if (this.props.items.length > 0) {
+      // Do nothing if there are committed ranges. We only allow users to change
+      // the tab if they are on root range.
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    showMenu({
+      data: null,
+      id: 'TabSelectorMenu',
+      position: { x: rect.left, y: rect.bottom },
+      target: event.target,
+    });
+  };
+
   render() {
     const {
       className,
@@ -51,36 +81,76 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
       selectedItem,
       uncommittedItem,
       onPop,
-      filterPageData,
       rootRange,
+      filterPageDataForActiveTab,
+      pageDataByTabID,
+      tabFilter,
     } = this.props;
 
     let firstItem;
-    if (filterPageData) {
+    if (filterPageDataForActiveTab) {
+      // TODO: Remove this once we ship the tab selector and remove the active tab view.
       firstItem = (
         <>
-          {filterPageData.favicon ? (
-            <Icon iconUrl={filterPageData.favicon} />
+          {filterPageDataForActiveTab.favicon ? (
+            <Icon iconUrl={filterPageDataForActiveTab.favicon} />
           ) : null}
-          <span title={filterPageData.origin}>
-            {filterPageData.hostname} (
+          <span title={filterPageDataForActiveTab.origin}>
+            {filterPageDataForActiveTab.hostname} (
             {getFormattedTimeLength(rootRange.end - rootRange.start)})
           </span>
         </>
       );
     } else {
-      firstItem = (
-        <Localized
-          id="ProfileFilterNavigator--full-range-with-duration"
-          vars={{
-            fullRangeDuration: getFormattedTimeLength(
-              rootRange.end - rootRange.start
-            ),
-          }}
-        >
-          Full Range
-        </Localized>
-      );
+      // This is for the tab selector.
+      if (pageDataByTabID && pageDataByTabID.size > 0) {
+        const pageData =
+          tabFilter !== null ? pageDataByTabID.get(tabFilter) : null;
+
+        firstItem = (
+          <span
+            onClick={this._showTabSelectorMenu}
+            className={classNames('profileFilterNavigator--tab-selector', {
+              disabled: items.length > 0,
+            })}
+          >
+            {/* Show the page data if the profile is filtered by tab */}
+            {pageData ? (
+              <>
+                {pageData.favicon ? <Icon iconUrl={pageData.favicon} /> : null}
+                <span title={pageData.origin}>
+                  {pageData?.hostname} (
+                  {getFormattedTimeLength(rootRange.end - rootRange.start)})
+                </span>
+              </>
+            ) : (
+              <Localized
+                id="ProfileFilterNavigator--full-range-with-duration"
+                vars={{
+                  fullRangeDuration: getFormattedTimeLength(
+                    rootRange.end - rootRange.start
+                  ),
+                }}
+              >
+                Full Range
+              </Localized>
+            )}
+          </span>
+        );
+      } else {
+        firstItem = (
+          <Localized
+            id="ProfileFilterNavigator--full-range-with-duration"
+            vars={{
+              fullRangeDuration: getFormattedTimeLength(
+                rootRange.end - rootRange.start
+              ),
+            }}
+          >
+            Full Range
+          </Localized>
+        );
+      }
     }
 
     const itemsWithFirstElement = this._getItemsWithFirstElement(
@@ -88,13 +158,18 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
       items
     );
     return (
-      <FilterNavigatorBar
-        className={className}
-        items={itemsWithFirstElement}
-        selectedItem={selectedItem}
-        uncommittedItem={uncommittedItem}
-        onPop={onPop}
-      />
+      <>
+        <FilterNavigatorBar
+          className={className}
+          items={itemsWithFirstElement}
+          selectedItem={selectedItem}
+          uncommittedItem={uncommittedItem}
+          onPop={onPop}
+        />
+        {pageDataByTabID && pageDataByTabID.size > 0 ? (
+          <TabSelectorMenu />
+        ) : null}
+      </>
     );
   }
 }
@@ -112,7 +187,11 @@ export const ProfileFilterNavigator = explicitConnect<
           previewSelection.selectionEnd - previewSelection.selectionStart
         )
       : undefined;
-    const filterPageData = getProfileFilterPageData(state);
+
+    // TODO: Remove this once we ship the tab selector and remove the active tab view.
+    const filterPageDataForActiveTab = getProfileFilterPageData(state);
+    const pageDataByTabID = getProfileFilterPageDataByTabID(state);
+    const tabFilter = getTabFilter(state);
     const rootRange = getProfileRootRange(state);
     return {
       className: 'profileFilterNavigator',
@@ -121,7 +200,9 @@ export const ProfileFilterNavigator = explicitConnect<
       // array's length by adding the first element.
       selectedItem: items.length,
       uncommittedItem,
-      filterPageData,
+      filterPageDataForActiveTab,
+      pageDataByTabID,
+      tabFilter,
       rootRange,
     };
   },

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -59,7 +59,7 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
   );
 
   _showTabSelectorMenu = (event: SyntheticMouseEvent<HTMLElement>) => {
-    if (this.props.items.length > 0) {
+    if (this.props.items.length > 0 || this.props.uncommittedItem) {
       // Do nothing if there are committed ranges. We only allow users to change
       // the tab if they are on root range.
       return;
@@ -110,36 +110,56 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
         const pageData =
           tabFilter !== null ? pageDataByTabID.get(tabFilter) : null;
 
-        firstItem = (
-          <span
-            onClick={this._showTabSelectorMenu}
-            className={classNames('profileFilterNavigator--tab-selector', {
-              disabled: items.length > 0,
-            })}
-          >
+        const itemContents = pageData ? (
+          <>
             {/* Show the page data if the profile is filtered by tab */}
-            {pageData ? (
-              <>
-                {pageData.favicon ? <Icon iconUrl={pageData.favicon} /> : null}
-                <span title={pageData.origin}>
-                  {pageData.hostname} (
-                  {getFormattedTimeLength(rootRange.end - rootRange.start)})
-                </span>
-              </>
-            ) : (
-              <Localized
-                id="ProfileFilterNavigator--full-range-with-duration"
-                vars={{
-                  fullRangeDuration: getFormattedTimeLength(
-                    rootRange.end - rootRange.start
-                  ),
-                }}
-              >
-                Full Range
-              </Localized>
-            )}
-          </span>
+            {pageData.favicon ? <Icon iconUrl={pageData.favicon} /> : null}
+            <span title={pageData.origin}>
+              {pageData.hostname} (
+              {getFormattedTimeLength(rootRange.end - rootRange.start)})
+            </span>
+          </>
+        ) : (
+          <Localized
+            id="ProfileFilterNavigator--full-range-with-duration"
+            vars={{
+              fullRangeDuration: getFormattedTimeLength(
+                rootRange.end - rootRange.start
+              ),
+            }}
+          >
+            Full Range
+          </Localized>
         );
+
+        if (items.length === 0 && !uncommittedItem) {
+          // It should be a clickable button if there are no committed ranges.
+          firstItem = (
+            <button
+              type="button"
+              onClick={this._showTabSelectorMenu}
+              className={classNames(
+                'filterNavigatorBarItemContent',
+                'profileFilterNavigator--tab-selector'
+              )}
+            >
+              {itemContents}
+            </button>
+          );
+        } else {
+          // There are committed ranges, don't make it button because this will
+          // be wrapped with a button.
+          firstItem = (
+            <span
+              className={classNames(
+                'filterNavigatorBarItemContent',
+                'profileFilterNavigator--tab-selector'
+              )}
+            >
+              {itemContents}
+            </span>
+          );
+        }
       } else {
         firstItem = (
           <Localized

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -102,7 +102,10 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
         </>
       );
     } else {
-      // This is for the tab selector.
+      // pageDataByTabID will be empty if there is no page information in the
+      // profile or when the page information is empty. This could happen for
+      // older profiles and profiles from external importers that don't have
+      // this information.
       if (pageDataByTabID && pageDataByTabID.size > 0) {
         const pageData =
           tabFilter !== null ? pageDataByTabID.get(tabFilter) : null;
@@ -119,7 +122,7 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
               <>
                 {pageData.favicon ? <Icon iconUrl={pageData.favicon} /> : null}
                 <span title={pageData.origin}>
-                  {pageData?.hostname} (
+                  {pageData.hostname} (
                   {getFormattedTimeLength(rootRange.end - rootRange.start)})
                 </span>
               </>

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -106,7 +106,8 @@ class ProfileFilterNavigatorBarImpl extends React.PureComponent<Props> {
       // profile or when the page information is empty. This could happen for
       // older profiles and profiles from external importers that don't have
       // this information.
-      if (pageDataByTabID && pageDataByTabID.size > 0) {
+      // eslint-disable-next-line no-constant-condition
+      if (false && pageDataByTabID && pageDataByTabID.size > 0) {
         const pageData =
           tabFilter !== null ? pageDataByTabID.get(tabFilter) : null;
 

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -108,7 +108,8 @@
   color: var(--internal-selected-color);
 }
 
-.filterNavigatorBarItem:not(.filterNavigatorBarLeafItem):hover {
+.filterNavigatorBarItem:not(.filterNavigatorBarLeafItem):hover,
+.filterNavigatorBarItem:has(button.profileFilterNavigator--tab-selector):hover {
   background-color: rgb(0 0 0 / 0.1);
 }
 

--- a/src/components/shared/TabSelectorMenu.css
+++ b/src/components/shared/TabSelectorMenu.css
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.tabSelectorMenuItem.checkable {
+  padding-right: 10px;
+  padding-left: 20px;
+}
+
+.react-contextmenu-item.tabSelectorMenuItem.checked:not(
+    .react-contextmenu-item--disabled
+  )::before {
+  /* Move the checkmark to the left instead of right, as it's logically better. */
+  left: 8px;
+}

--- a/src/components/shared/TabSelectorMenu.css
+++ b/src/components/shared/TabSelectorMenu.css
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+.TabSelectorMenu {
+  /* Make it scrollable if the tab list is too long. */
+  overflow-y: auto;
+}
+
 .tabSelectorMenuItem.checkable {
   padding-right: 10px;
   padding-left: 20px;

--- a/src/components/shared/TabSelectorMenu.css
+++ b/src/components/shared/TabSelectorMenu.css
@@ -15,5 +15,5 @@
     .react-contextmenu-item--disabled
   )::before {
   /* Move the checkmark to inline-start instead of right, as it's logically better. */
-  inset-inline-start: 8px;
+  inset-inline: 8px 0;
 }

--- a/src/components/shared/TabSelectorMenu.css
+++ b/src/components/shared/TabSelectorMenu.css
@@ -8,13 +8,12 @@
 }
 
 .tabSelectorMenuItem.checkable {
-  padding-right: 10px;
-  padding-left: 20px;
+  padding-inline: 20px 10px;
 }
 
 .react-contextmenu-item.tabSelectorMenuItem.checked:not(
     .react-contextmenu-item--disabled
   )::before {
-  /* Move the checkmark to the left instead of right, as it's logically better. */
-  left: 8px;
+  /* Move the checkmark to inline-start instead of right, as it's logically better. */
+  inset-inline-start: 8px;
 }

--- a/src/components/shared/TabSelectorMenu.js
+++ b/src/components/shared/TabSelectorMenu.js
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 
 import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
+import { changeTabFilter } from 'firefox-profiler/actions/receive-profile';
 import { getTabFilter } from '../../selectors/url-state';
 import { getProfileFilterPageDataByTabID } from 'firefox-profiler/selectors/profile';
 
@@ -21,15 +22,17 @@ type StateProps = {|
   +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
 |};
 
-type DispatchProps = {||};
+type DispatchProps = {|
+  +changeTabFilter: typeof changeTabFilter,
+|};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 import './TabSelectorMenu.css';
 
 class TabSelectorMenuImpl extends React.PureComponent<Props> {
-  _handleClick = (_event: SyntheticEvent<>, _data: {| id: TabID |}): void => {
-    // FIXME: Implement tab switching.
+  _handleClick = (_event: SyntheticEvent<>, data: {| id: TabID |}): void => {
+    this.props.changeTabFilter(data.id);
   };
 
   renderTabSelectorMenuContents() {
@@ -90,6 +93,9 @@ export const TabSelectorMenu = explicitConnect<{||}, StateProps, DispatchProps>(
       tabFilter: getTabFilter(state),
       pageDataByTabID: getProfileFilterPageDataByTabID(state),
     }),
+    mapDispatchToProps: {
+      changeTabFilter,
+    },
     component: TabSelectorMenuImpl,
   }
 );

--- a/src/components/shared/TabSelectorMenu.js
+++ b/src/components/shared/TabSelectorMenu.js
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { MenuItem } from '@firefox-devtools/react-contextmenu';
+import { Localized } from '@fluent/react';
+import classNames from 'classnames';
+
+import { ContextMenu } from './ContextMenu';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { getTabFilter } from '../../selectors/url-state';
+import { getProfileFilterPageDataByTabID } from 'firefox-profiler/selectors/profile';
+
+import type { TabID, ProfileFilterPageData } from 'firefox-profiler/types';
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type StateProps = {|
+  +tabFilter: TabID | null,
+  +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
+|};
+
+type DispatchProps = {||};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+import './TabSelectorMenu.css';
+
+class TabSelectorMenuImpl extends React.PureComponent<Props> {
+  _handleClick = (_event: SyntheticEvent<>, _data: {| id: TabID |}): void => {
+    // FIXME: Implement tab switching.
+  };
+
+  renderTabSelectorMenuContents() {
+    const { pageDataByTabID, tabFilter } = this.props;
+    if (!pageDataByTabID || pageDataByTabID.size === 0) {
+      // There is no page data, return early.
+      return null;
+    }
+
+    return (
+      <>
+        <MenuItem
+          key={0}
+          onClick={this._handleClick}
+          data={{ id: null }}
+          attributes={{
+            className: classNames('tabSelectorMenuItem', {
+              checkable: true,
+              checked: tabFilter === null,
+            }),
+            'aria-checked': tabFilter === null ? 'false' : 'true',
+          }}
+        >
+          <Localized id="TabSelectorMenu--full-profile">Full Profile</Localized>
+        </MenuItem>
+        {[...pageDataByTabID].map(([tabID, pageData]) => (
+          <MenuItem
+            key={tabID}
+            onClick={this._handleClick}
+            data={{ id: tabID }}
+            attributes={{
+              className: classNames('tabSelectorMenuItem', {
+                checkable: true,
+                checked: tabFilter === tabID,
+              }),
+              'aria-checked': tabFilter === tabID ? 'false' : 'true',
+            }}
+          >
+            {pageData.hostname}
+          </MenuItem>
+        ))}
+      </>
+    );
+  }
+
+  render() {
+    return (
+      <ContextMenu id="TabSelectorMenu" className="TabSelectorMenu">
+        {this.renderTabSelectorMenuContents()}
+      </ContextMenu>
+    );
+  }
+}
+
+export const TabSelectorMenu = explicitConnect<{||}, StateProps, DispatchProps>(
+  {
+    mapStateToProps: (state) => ({
+      tabFilter: getTabFilter(state),
+      pageDataByTabID: getProfileFilterPageDataByTabID(state),
+    }),
+    component: TabSelectorMenuImpl,
+  }
+);

--- a/src/components/shared/TabSelectorMenu.js
+++ b/src/components/shared/TabSelectorMenu.js
@@ -45,7 +45,6 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
     return (
       <>
         <MenuItem
-          key={0}
           onClick={this._handleClick}
           data={{ id: null }}
           attributes={{
@@ -56,7 +55,9 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
             'aria-checked': tabFilter === null ? 'false' : 'true',
           }}
         >
-          <Localized id="TabSelectorMenu--full-profile">Full Profile</Localized>
+          <Localized id="TabSelectorMenu--all-tabs-and-windows">
+            All tabs and windows
+          </Localized>
         </MenuItem>
         {[...pageDataByTabID].map(([tabID, pageData]) => (
           <MenuItem

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -3709,7 +3709,8 @@ export function computeTabToThreadIndexesMap(
     // First go over the innerWindowIDs of the samples.
     for (let i = 0; i < thread.frameTable.length; i++) {
       const innerWindowID = thread.frameTable.innerWindowID[i];
-      if (innerWindowID === null) {
+      if (innerWindowID === null || innerWindowID === 0) {
+        // Zero value also means null for innerWindowID.
         continue;
       }
 
@@ -3741,7 +3742,9 @@ export function computeTabToThreadIndexesMap(
 
       if (
         markerData.innerWindowID !== null &&
-        markerData.innerWindowID !== undefined
+        markerData.innerWindowID !== undefined &&
+        // Zero value also means null for innerWindowID.
+        markerData.innerWindowID !== 0
       ) {
         const innerWindowID = markerData.innerWindowID;
         const tabID = innerWindowIDToTabMap.get(innerWindowID);

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -476,7 +476,7 @@ export function computeGlobalTracks(
     mainThreadIndex: number | null,
   };
   const globalTracksByPid: Map<Pid, ProcessTrack> = new Map();
-  const globalTracks: GlobalTrack[] = [];
+  let globalTracks: GlobalTrack[] = [];
 
   // Create the global tracks.
   for (
@@ -553,6 +553,14 @@ export function computeGlobalTracks(
     }
   }
 
+  // Filter the global tracks by current tab.
+  globalTracks = filterGlobalTracksByTab(
+    globalTracks,
+    profile,
+    tabID,
+    tabToThreadIndexesMap
+  );
+
   // When adding a new track type, this sort ensures that the newer tracks are added
   // at the end so that the global track indexes are stable and backwards compatible.
   globalTracks.sort(
@@ -561,13 +569,7 @@ export function computeGlobalTracks(
       GLOBAL_TRACK_INDEX_ORDER[a.type] - GLOBAL_TRACK_INDEX_ORDER[b.type]
   );
 
-  // At the end, we need to filter global tracks by current tab.
-  return filterGlobalTracksByTab(
-    globalTracks,
-    profile,
-    tabID,
-    tabToThreadIndexesMap
-  );
+  return globalTracks;
 }
 
 /**

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -254,8 +254,8 @@ export function initializeLocalTrackOrderByPid(
 /**
  * Take a profile and figure out all of the local tracks, and organize them by PID.
  * availableGlobalTracks is being sent by the caller to see which globalTracks
- * are present. They could have been filtered out by the tab selector so we
- * should ignore them.
+ * are present. The ones that have been filtered out by the tab selector
+ * should be ignored.
  */
 export function computeLocalTracksByPid(
   profile: Profile,
@@ -264,7 +264,7 @@ export function computeLocalTracksByPid(
 ): Map<Pid, LocalTrack[]> {
   const localTracksByPid = new Map();
 
-  // Create a new set of avaiable pids, so we can filter out the local tracks
+  // Create a new set of available pids, so we can filter out the local tracks
   // if their globalTracks are also filtered out by the tab selector.
   const availablePids = new Set();
   for (const globalTrack of availableGlobalTracks) {
@@ -586,6 +586,9 @@ function filterGlobalTracksByTab(
 
   const threadIndexes = tabToThreadIndexesMap.get(tabID);
   if (!threadIndexes) {
+    // This is not really a possible path. It might indicate a bug on the frontend
+    // or backend.
+    console.warn(`Failed to find the thread indexes for given tab ${tabID}`);
     return globalTracks;
   }
 
@@ -596,7 +599,7 @@ function filterGlobalTracksByTab(
       case 'process': {
         const { mainThreadIndex } = globalTrack;
         if (mainThreadIndex === null) {
-          // Do not incldue the global track if it doesn't have any main thread
+          // Do not include the global track if it doesn't have any main thread
           // index.
           continue;
         }

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -16,6 +16,7 @@ import type {
   Tid,
   TrackReference,
   MarkerSchemaByName,
+  TabID,
 } from 'firefox-profiler/types';
 
 import { defaultThreadOrder, getFriendlyThreadName } from './profile-data';
@@ -252,12 +253,25 @@ export function initializeLocalTrackOrderByPid(
 
 /**
  * Take a profile and figure out all of the local tracks, and organize them by PID.
+ * availableGlobalTracks is being sent by the caller to see which globalTracks
+ * are present. They could have been filtered out by the tab selector so we
+ * should ignore them.
  */
 export function computeLocalTracksByPid(
   profile: Profile,
+  availableGlobalTracks: GlobalTrack[],
   markerSchemaByName: MarkerSchemaByName
 ): Map<Pid, LocalTrack[]> {
   const localTracksByPid = new Map();
+
+  // Create a new set of avaiable pids, so we can filter out the local tracks
+  // if their globalTracks are also filtered out by the tab selector.
+  const availablePids = new Set();
+  for (const globalTrack of availableGlobalTracks) {
+    if (globalTrack.type === 'process') {
+      availablePids.add(globalTrack.pid);
+    }
+  }
 
   // find markers that might have their own track.
   const markerSchemasWithGraphs = (profile.meta.markerSchema || []).filter(
@@ -271,6 +285,10 @@ export function computeLocalTracksByPid(
   ) {
     const thread = profile.threads[threadIndex];
     const { pid, markers } = thread;
+    if (!availablePids.has(pid)) {
+      // If the global track is filtered out ignore it here too.
+      continue;
+    }
     // Get or create the tracks and trackOrder.
     let tracks = localTracksByPid.get(pid);
     if (tracks === undefined) {
@@ -339,6 +357,11 @@ export function computeLocalTracksByPid(
   if (counters) {
     for (let counterIndex = 0; counterIndex < counters.length; counterIndex++) {
       const { pid, category, samples } = counters[counterIndex];
+      if (!availablePids.has(pid)) {
+        // If the global track is filtered out ignore it here too.
+        continue;
+      }
+
       if (['Memory', 'power', 'Bandwidth'].includes(category)) {
         if (category === 'power' && samples.length <= 2) {
           // If we have only 2 samples, they are likely both 0 and we don't have a real counter.
@@ -439,7 +462,11 @@ export function addProcessCPUTracksForProcess(
 /**
  * Take a profile and figure out what GlobalTracks it contains.
  */
-export function computeGlobalTracks(profile: Profile): GlobalTrack[] {
+export function computeGlobalTracks(
+  profile: Profile,
+  tabID: TabID | null = null,
+  tabToThreadIndexesMap: Map<ThreadIndex, Set<TabID>>
+): GlobalTrack[] {
   // Defining this ProcessTrack type here helps flow understand the intent of
   // the internals of this function, otherwise each GlobalTrack usage would need
   // to check that it's a process type.
@@ -534,7 +561,71 @@ export function computeGlobalTracks(profile: Profile): GlobalTrack[] {
       GLOBAL_TRACK_INDEX_ORDER[a.type] - GLOBAL_TRACK_INDEX_ORDER[b.type]
   );
 
-  return globalTracks;
+  // At the end, we need to filter global tracks by current tab.
+  return filterGlobalTracksByTab(
+    globalTracks,
+    profile,
+    tabID,
+    tabToThreadIndexesMap
+  );
+}
+
+/**
+ * Filter the global tracks by the current selected tab if it's specified.
+ */
+function filterGlobalTracksByTab(
+  globalTracks: GlobalTrack[],
+  profile: Profile,
+  tabID: TabID | null,
+  tabToThreadIndexesMap: Map<ThreadIndex, Set<TabID>>
+): GlobalTrack[] {
+  if (tabID === null) {
+    // Return the global tracks if there is no tab filter.
+    return globalTracks;
+  }
+
+  const threadIndexes = tabToThreadIndexesMap.get(tabID);
+  if (!threadIndexes) {
+    return globalTracks;
+  }
+
+  // Filter the tracks by the tab filter.
+  const newGlobalTracks = [];
+  for (const globalTrack of globalTracks) {
+    switch (globalTrack.type) {
+      case 'process': {
+        const { mainThreadIndex } = globalTrack;
+        if (mainThreadIndex === null) {
+          // Do not incldue the global track if it doesn't have any main thread
+          // index.
+          continue;
+        }
+
+        const thread = profile.threads[mainThreadIndex];
+        if (
+          // Always add the parent process main thread.
+          (thread.isMainThread && thread.processType === 'default') ||
+          threadIndexes.has(mainThreadIndex)
+        ) {
+          newGlobalTracks.push(globalTrack);
+        }
+        break;
+      }
+      // Always include the screenshots.
+      case 'screenshots':
+      // Also always add the visual progress tracks without looking at the tab
+      // filter. (fallthrough)
+      case 'visual-progress':
+      case 'perceptual-visual-progress':
+      case 'contentful-visual-progress':
+        newGlobalTracks.push(globalTrack);
+        break;
+      default:
+        throw new Error('Unhandled globalTack type.');
+    }
+  }
+
+  return newGlobalTracks;
 }
 
 /**
@@ -726,7 +817,7 @@ export function computeDefaultHiddenTracks(
 ): HiddenTracks {
   return _computeHiddenTracksForVisibleThreads(
     profile,
-    computeDefaultVisibleThreads(profile),
+    computeDefaultVisibleThreads(profile, tracksWithOrder),
     tracksWithOrder
   );
 }
@@ -917,7 +1008,8 @@ const IDLE_THRESHOLD_FRACTION = 0.05;
 
 // Return a non-empty set of threads that should be shown by default.
 export function computeDefaultVisibleThreads(
-  profile: Profile
+  profile: Profile,
+  tracksWithOrder: TracksWithOrder
 ): Set<ThreadIndex> {
   const threads = profile.threads;
   if (threads.length === 0) {
@@ -932,9 +1024,36 @@ export function computeDefaultVisibleThreads(
     return new Set(profile.meta.initialVisibleThreads);
   }
 
+  const allTrackThreads = new Set();
+  for (const globalTrack of tracksWithOrder.globalTracks) {
+    switch (globalTrack.type) {
+      case 'process':
+        if (globalTrack.mainThreadIndex !== null) {
+          allTrackThreads.add(globalTrack.mainThreadIndex);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  // $FlowExpectError Flow doesn't know about Array.prototype.flat.
+  const localTracks = Array.from(
+    tracksWithOrder.localTracksByPid.values()
+  ).flat();
+  for (const localTrack of localTracks) {
+    switch (localTrack.type) {
+      case 'thread':
+        allTrackThreads.add(localTrack.threadIndex);
+        break;
+      default:
+        break;
+    }
+  }
+
   // First, compute a score for every thread.
   const maxCpuDeltaPerInterval = computeMaxCPUDeltaPerInterval(profile);
-  const scores = threads.map((thread, threadIndex) => {
+  let scores = threads.map((thread, threadIndex) => {
     const score = _computeThreadDefaultVisibilityScore(
       profile,
       thread,
@@ -942,6 +1061,9 @@ export function computeDefaultVisibleThreads(
     );
     return { threadIndex, score };
   });
+
+  // Next, filter the tracks by the tab selector threads.
+  scores = scores.filter(({ threadIndex }) => allTrackThreads.has(threadIndex));
 
   // Next, sort the threads by score.
   scores.sort(({ score: a }, { score: b }) => {

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -148,7 +148,6 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     // Bottom box: (fallthrough)
     case 'UPDATE_BOTTOM_BOX':
     case 'CLOSE_BOTTOM_BOX_FOR_TAB':
-      // case 'CHANGE_TAB_FILTER':
       return state + 1;
     default:
       return state;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -52,6 +52,7 @@ const view: Reducer<AppViewState> = (
     case 'VIEW_FULL_PROFILE':
     case 'VIEW_ORIGINS_PROFILE':
     case 'VIEW_ACTIVE_TAB_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return { phase: 'DATA_LOADED' };
     default:
       return state;
@@ -147,6 +148,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     // Bottom box: (fallthrough)
     case 'UPDATE_BOTTOM_BOX':
     case 'CLOSE_BOTTOM_BOX_FOR_TAB':
+      // case 'CHANGE_TAB_FILTER':
       return state + 1;
     default:
       return state;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -85,6 +85,7 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
 const globalTracks: Reducer<GlobalTrack[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return action.globalTracks;
     default:
       return state;
@@ -103,6 +104,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'CHANGE_TAB_FILTER':
       return action.localTracksByPid;
     default:
       return state;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -97,6 +97,7 @@ const selectedTab: Reducer<TabSlug> = (state = 'calltree', action) => {
     case 'CHANGE_SELECTED_TAB':
     case 'SELECT_TRACK':
     case 'VIEW_FULL_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return action.selectedTab;
     case 'FOCUS_CALL_TREE':
       return 'calltree';
@@ -138,6 +139,7 @@ const selectedThreads: Reducer<Set<ThreadIndex> | null> = (
     case 'HIDE_PROVIDED_TRACKS':
     case 'ISOLATE_LOCAL_TRACK':
     case 'TOGGLE_RESOURCES_PANEL':
+    case 'CHANGE_TAB_FILTER':
       // Only switch to non-null selected threads.
       return (action.selectedThreadIndexes: Set<ThreadIndex>);
     case 'SANITIZED_PROFILE_PUBLISHED': {
@@ -325,6 +327,7 @@ const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
+    case 'CHANGE_TAB_FILTER':
       return action.globalTrackOrder;
     case 'SANITIZED_PROFILE_PUBLISHED':
       // If some threads were removed, do not even attempt to figure this out. It's
@@ -345,6 +348,7 @@ const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'ISOLATE_SCREENSHOT_TRACK':
+    case 'CHANGE_TAB_FILTER':
       return action.hiddenGlobalTracks;
     case 'HIDE_GLOBAL_TRACK': {
       const hiddenGlobalTracks = new Set(state);
@@ -389,6 +393,7 @@ const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
 ) => {
   switch (action.type) {
     case 'VIEW_FULL_PROFILE':
+    case 'CHANGE_TAB_FILTER':
       return action.hiddenLocalTracksByPid;
     case 'HIDE_LOCAL_TRACK': {
       const hiddenLocalTracksByPid = new Map(state);
@@ -475,6 +480,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'CHANGE_TAB_FILTER':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {
       const localTrackOrderByPid = new Map(state);

--- a/src/test/components/FilterNavigatorBar.test.js
+++ b/src/test/components/FilterNavigatorBar.test.js
@@ -159,6 +159,6 @@ describe('app/ProfileFilterNavigator', () => {
     });
     expect(queryByText(/Full Range/)).not.toBeInTheDocument();
     // Using regexp because searching for a partial text.
-    expect(getByText(/developer\.mozilla\.org/)).toBeInTheDocument();
+    expect(getByText(/developer\.mozilla\.org \(/)).toBeInTheDocument();
   });
 });

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
+import { screen } from '@testing-library/react';
 
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { TabSelectorMenu } from 'firefox-profiler/components/shared/TabSelectorMenu';
@@ -38,7 +39,7 @@ describe('app/TabSelectorMenu', () => {
     profile.threads[1].frameTable.length++;
 
     const store = storeWithProfile(profile);
-    const renderResults = render(
+    render(
       <Provider store={store}>
         <TabSelectorMenu />
       </Provider>
@@ -46,49 +47,48 @@ describe('app/TabSelectorMenu', () => {
 
     return {
       profile,
-      ...renderResults,
       ...extraPageData,
       ...store,
     };
   }
 
   it('should render properly', () => {
-    const { container } = setup();
-    expect(container.firstChild).toMatchSnapshot();
+    setup();
+    expect(document.body).toMatchSnapshot();
   });
 
   it('should not render when the profile does not contain any page data', () => {
     const store = storeWithProfile(getProfileWithNiceTracks());
-    const { container } = render(
+    render(
       <Provider store={store}>
         <TabSelectorMenu />
       </Provider>
     );
-    expect(container.firstChild).toMatchSnapshot();
+    expect(document.body).toMatchSnapshot();
   });
 
   it('should switch tabs properly', () => {
-    const { getState, getByText, firstTabTabID, secondTabTabID } = setup();
+    const { getState, firstTabTabID, secondTabTabID } = setup();
 
     // Check that there is no tab filter at first.
     expect(getTabFilter(getState())).toBe(null);
 
     // Change the tab filter by clicking on the menu item.
-    const mozillaTab = getByText('mozilla.org');
+    const mozillaTab = screen.getByText('mozilla.org');
     fireFullClick(mozillaTab);
 
     // Check the tab filter again, it should match the first tab in the profile.
     expect(getTabFilter(getState())).toBe(firstTabTabID);
 
     // Change the tab filter again.
-    const profilerTab = getByText('profiler.firefox.com');
+    const profilerTab = screen.getByText('profiler.firefox.com');
     fireFullClick(profilerTab);
 
     // Check the tab filter again, it should match the second tab in the profile.
     expect(getTabFilter(getState())).toBe(secondTabTabID);
 
     // Change the tab filter to all tabs and windows
-    const allTabs = getByText('All tabs and windows');
+    const allTabs = screen.getByText('All tabs and windows');
     fireFullClick(allTabs);
 
     // Check the tab filter again, it should be null, meaning all tabs and windows.
@@ -96,7 +96,7 @@ describe('app/TabSelectorMenu', () => {
   });
 
   it('should display the relevant threads after tab switch', () => {
-    const { getState, getByText, firstTabTabID, secondTabTabID } = setup();
+    const { getState, firstTabTabID, secondTabTabID } = setup();
 
     // Check that there is no tab filter at first.
     expect(getTabFilter(getState())).toBe(null);
@@ -109,7 +109,7 @@ describe('app/TabSelectorMenu', () => {
     ]);
 
     // Change the tab filter by clicking on the menu item.
-    const profilerTab = getByText('profiler.firefox.com');
+    const profilerTab = screen.getByText('profiler.firefox.com');
     fireFullClick(profilerTab);
 
     // Check the tab filter again, it should match the second tab in the profile.
@@ -125,7 +125,7 @@ describe('app/TabSelectorMenu', () => {
     ]);
 
     // Change the tab filter again.
-    const mozillaTab = getByText('mozilla.org');
+    const mozillaTab = screen.getByText('mozilla.org');
     fireFullClick(mozillaTab);
 
     // Check the tab filter again, it should match the first tab in the profile.
@@ -136,7 +136,7 @@ describe('app/TabSelectorMenu', () => {
     ]);
 
     // Change the tab filter to all tabs and windows.
-    const allTabs = getByText('All tabs and windows');
+    const allTabs = screen.getByText('All tabs and windows');
     fireFullClick(allTabs);
 
     // Check the tab filter again, it should be null, meaning full profile.

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { render } from 'firefox-profiler/test/fixtures/testing-library';
+import { TabSelectorMenu } from 'firefox-profiler/components/shared/TabSelectorMenu';
+import { addActiveTabInformationToProfile } from '../fixtures/profiles/processed-profile';
+import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
+import { storeWithProfile } from '../fixtures/stores';
+
+describe('app/TabSelectorMenu', () => {
+  function setup() {
+    const { profile, ...extraPageData } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+
+    const store = storeWithProfile(profile);
+    const renderResults = render(
+      <Provider store={store}>
+        <TabSelectorMenu />
+      </Provider>
+    );
+
+    return {
+      profile,
+      ...renderResults,
+      ...extraPageData,
+      ...store,
+    };
+  }
+
+  it('should render properly', () => {
+    const { container } = setup();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should not render when the profile does not contain any page data', () => {
+    const store = storeWithProfile(getProfileWithNiceTracks());
+    const { container } = render(
+      <Provider store={store}>
+        <TabSelectorMenu />
+      </Provider>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -87,11 +87,11 @@ describe('app/TabSelectorMenu', () => {
     // Check the tab filter again, it should match the second tab in the profile.
     expect(getTabFilter(getState())).toBe(secondTabTabID);
 
-    // Change the tab filter to the full profile.
-    const fullProfile = getByText('Full Profile');
-    fireFullClick(fullProfile);
+    // Change the tab filter to all tabs and windows
+    const allTabs = getByText('All tabs and windows');
+    fireFullClick(allTabs);
 
-    // Check the tab filter again, it should be null, meaning full profile.
+    // Check the tab filter again, it should be null, meaning all tabs and windows.
     expect(getTabFilter(getState())).toBe(null);
   });
 
@@ -135,9 +135,9 @@ describe('app/TabSelectorMenu', () => {
       'show [thread GeckoMain default] SELECTED',
     ]);
 
-    // Change the tab filter to the full profile.
-    const fullProfile = getByText('Full Profile');
-    fireFullClick(fullProfile);
+    // Change the tab filter to all tabs and windows.
+    const allTabs = getByText('All tabs and windows');
+    fireFullClick(allTabs);
 
     // Check the tab filter again, it should be null, meaning full profile.
     expect(getTabFilter(getState())).toBe(null);

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -10,14 +10,32 @@ import { Provider } from 'react-redux';
 import { render } from 'firefox-profiler/test/fixtures/testing-library';
 import { TabSelectorMenu } from 'firefox-profiler/components/shared/TabSelectorMenu';
 import { addActiveTabInformationToProfile } from '../fixtures/profiles/processed-profile';
-import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
+import {
+  getProfileWithNiceTracks,
+  getHumanReadableTracks,
+} from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
+import { fireFullClick } from '../fixtures/utils';
+import { getTabFilter } from '../../selectors/url-state';
 
 describe('app/TabSelectorMenu', () => {
   function setup() {
     const { profile, ...extraPageData } = addActiveTabInformationToProfile(
       getProfileWithNiceTracks()
     );
+
+    // Add some frames with innerWindowIDs now. Note that we only expand the
+    // innerWindowID array and not the others as we don't check them at all.
+    //
+    // Thread 0 will be present in firstTabTabID.
+    // Thread 1 be present in secondTabTabID.
+    profile.threads[0].frameTable.innerWindowID[0] =
+      extraPageData.parentInnerWindowIDsWithChildren;
+    profile.threads[0].frameTable.length++;
+
+    profile.threads[1].frameTable.innerWindowID[0] =
+      extraPageData.secondTabInnerWindowIDs[0];
+    profile.threads[1].frameTable.length++;
 
     const store = storeWithProfile(profile);
     const renderResults = render(
@@ -47,5 +65,88 @@ describe('app/TabSelectorMenu', () => {
       </Provider>
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should switch tabs properly', () => {
+    const { getState, getByText, firstTabTabID, secondTabTabID } = setup();
+
+    // Check that there is no tab filter at first.
+    expect(getTabFilter(getState())).toBe(null);
+
+    // Change the tab filter by clicking on the menu item.
+    const mozillaTab = getByText('mozilla.org');
+    fireFullClick(mozillaTab);
+
+    // Check the tab filter again, it should match the first tab in the profile.
+    expect(getTabFilter(getState())).toBe(firstTabTabID);
+
+    // Change the tab filter again.
+    const profilerTab = getByText('profiler.firefox.com');
+    fireFullClick(profilerTab);
+
+    // Check the tab filter again, it should match the second tab in the profile.
+    expect(getTabFilter(getState())).toBe(secondTabTabID);
+
+    // Change the tab filter to the full profile.
+    const fullProfile = getByText('Full Profile');
+    fireFullClick(fullProfile);
+
+    // Check the tab filter again, it should be null, meaning full profile.
+    expect(getTabFilter(getState())).toBe(null);
+  });
+
+  it('should display the relevant threads after tab switch', () => {
+    const { getState, getByText, firstTabTabID, secondTabTabID } = setup();
+
+    // Check that there is no tab filter at first.
+    expect(getTabFilter(getState())).toBe(null);
+    // Also make sure that we have all the threads currently.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain default]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    // Change the tab filter by clicking on the menu item.
+    const profilerTab = getByText('profiler.firefox.com');
+    fireFullClick(profilerTab);
+
+    // Check the tab filter again, it should match the second tab in the profile.
+    expect(getTabFilter(getState())).toBe(secondTabTabID);
+    // Make sure that the second process group is visible.
+    // Note that the first thread will be visible too, because it's the parent
+    // process which we always include.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain default]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
+
+    // Change the tab filter again.
+    const mozillaTab = getByText('mozilla.org');
+    fireFullClick(mozillaTab);
+
+    // Check the tab filter again, it should match the first tab in the profile.
+    expect(getTabFilter(getState())).toBe(firstTabTabID);
+    // Also make sure that the first process is visible.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain default] SELECTED',
+    ]);
+
+    // Change the tab filter to the full profile.
+    const fullProfile = getByText('Full Profile');
+    fireFullClick(fullProfile);
+
+    // Check the tab filter again, it should be null, meaning full profile.
+    expect(getTabFilter(getState())).toBe(null);
+    // It should show the full thread list again.
+    expect(getHumanReadableTracks(getState())).toEqual([
+      'show [thread GeckoMain default]',
+      'show [thread GeckoMain tab] SELECTED',
+      '  - show [thread DOM Worker]',
+      '  - show [thread Style]',
+    ]);
   });
 });

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -673,7 +673,7 @@ describe('TooltipMarker', function () {
       })
     );
 
-    expect(getValueForProperty('Page')).toBe('Page #1');
+    expect(getValueForProperty('Page')).toBe('https://www.cnn.com/');
   });
 
   it('renders page information for private pages in network markers', () => {
@@ -696,7 +696,7 @@ describe('TooltipMarker', function () {
     );
 
     expect(getValueForProperty('Page')).toBe(
-      'Page #4 (id: 11111111114) (private)'
+      'https://profiler.firefox.com/ (private)'
     );
     expect(getValueForProperty('Private Browsing')).toBe('Yes');
   });

--- a/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
+++ b/src/test/components/__snapshots__/ActiveTabTimeline.test.js.snap
@@ -106,7 +106,7 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
         IFrame:
       </span>
        
-      Page #3
+      https://www.google.com/
     </div>
     <div
       class="timelineTrackTrack"
@@ -141,7 +141,7 @@ exports[`ActiveTabTimeline ActiveTabResourceTrack with a thread/sub-frame track 
             >
               <h2>
                 Activity Graph for 
-                Page #3
+                https://www.google.com/
               </h2>
               <p>
                 This graph shows a visual chart of thread activity.
@@ -285,7 +285,7 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
             IFrame:
           </span>
            
-          Page #2
+          https://www.youtube.com/
         </div>
         <div
           class="timelineTrackTrack"
@@ -320,7 +320,7 @@ exports[`ActiveTabTimeline ActiveTabResourcesPanel matches the snapshot of a res
                 >
                   <h2>
                     Activity Graph for 
-                    Page #2
+                    https://www.youtube.com/
                   </h2>
                   <p>
                     This graph shows a visual chart of thread activity.

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -10,12 +10,7 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 1`] 
     <span
       class="filterNavigatorBarItemContent"
     >
-      <button
-        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
-        type="button"
-      >
-        Full Range (⁨51ms⁩)
-      </button>
+      Full Range (⁨51ms⁩)
     </span>
   </li>
 </ol>
@@ -32,11 +27,7 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] 
       class="filterNavigatorBarItemContent"
       type="button"
     >
-      <span
-        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
-      >
-        Full Range (⁨51ms⁩)
-      </span>
+      Full Range (⁨51ms⁩)
     </button>
   </li>
   <li
@@ -62,11 +53,7 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] 
       class="filterNavigatorBarItemContent"
       type="button"
     >
-      <span
-        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
-      >
-        Full Range (⁨51ms⁩)
-      </span>
+      Full Range (⁨51ms⁩)
     </button>
   </li>
   <li

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -10,11 +10,12 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 1`] 
     <span
       class="filterNavigatorBarItemContent"
     >
-      <span
-        class="profileFilterNavigator--tab-selector"
+      <button
+        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
+        type="button"
       >
         Full Range (⁨51ms⁩)
-      </span>
+      </button>
     </span>
   </li>
 </ol>
@@ -32,7 +33,7 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] 
       type="button"
     >
       <span
-        class="profileFilterNavigator--tab-selector disabled"
+        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
       >
         Full Range (⁨51ms⁩)
       </span>
@@ -62,7 +63,7 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] 
       type="button"
     >
       <span
-        class="profileFilterNavigator--tab-selector disabled"
+        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
       >
         Full Range (⁨51ms⁩)
       </span>

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -10,7 +10,11 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 1`] 
     <span
       class="filterNavigatorBarItemContent"
     >
-      Full Range (⁨51ms⁩)
+      <span
+        class="profileFilterNavigator--tab-selector"
+      >
+        Full Range (⁨51ms⁩)
+      </span>
     </span>
   </li>
 </ol>
@@ -27,7 +31,11 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] 
       class="filterNavigatorBarItemContent"
       type="button"
     >
-      Full Range (⁨51ms⁩)
+      <span
+        class="profileFilterNavigator--tab-selector disabled"
+      >
+        Full Range (⁨51ms⁩)
+      </span>
     </button>
   </li>
   <li
@@ -53,7 +61,11 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] 
       class="filterNavigatorBarItemContent"
       type="button"
     >
-      Full Range (⁨51ms⁩)
+      <span
+        class="profileFilterNavigator--tab-selector disabled"
+      >
+        Full Range (⁨51ms⁩)
+      </span>
     </button>
   </li>
   <li

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -1441,7 +1441,21 @@ exports[`MarkerChart with active tab renders the hovered marker properly 2`] = `
         Page
         :
       </div>
-      Page #1
+      <div
+        class="tooltipDetailsUrl"
+      >
+        <span
+          class="tooltipDetailsDim"
+        >
+          https://
+        </span>
+        www.cnn.com
+        <span
+          class="tooltipDetailsDim"
+        >
+          /
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
@@ -1,49 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app/TabSelectorMenu should not render when the profile does not contain any page data 1`] = `
-<nav
-  class="react-contextmenu TabSelectorMenu"
-  role="menu"
-  style="position: fixed; opacity: 0; pointer-events: none;"
-  tabindex="-1"
->
-  <div />
-</nav>
+<body>
+  <div>
+    <nav
+      class="react-contextmenu TabSelectorMenu"
+      role="menu"
+      style="position: fixed; opacity: 0; pointer-events: none;"
+      tabindex="-1"
+    >
+      <div />
+    </nav>
+  </div>
+</body>
 `;
 
 exports[`app/TabSelectorMenu should render properly 1`] = `
-<nav
-  class="react-contextmenu TabSelectorMenu"
-  role="menu"
-  style="position: fixed; opacity: 0; pointer-events: none;"
-  tabindex="-1"
->
-  <div
-    aria-checked="false"
-    aria-disabled="false"
-    class="react-contextmenu-item tabSelectorMenuItem checkable checked"
-    role="menuitem"
-    tabindex="-1"
-  >
-    All tabs and windows
+<body>
+  <div>
+    <nav
+      class="react-contextmenu TabSelectorMenu"
+      role="menu"
+      style="position: fixed; opacity: 0; pointer-events: none;"
+      tabindex="-1"
+    >
+      <div
+        aria-checked="false"
+        aria-disabled="false"
+        class="react-contextmenu-item tabSelectorMenuItem checkable checked"
+        role="menuitem"
+        tabindex="-1"
+      >
+        All tabs and windows
+      </div>
+      <div
+        aria-checked="true"
+        aria-disabled="false"
+        class="react-contextmenu-item tabSelectorMenuItem checkable"
+        role="menuitem"
+        tabindex="-1"
+      >
+        mozilla.org
+      </div>
+      <div
+        aria-checked="true"
+        aria-disabled="false"
+        class="react-contextmenu-item tabSelectorMenuItem checkable"
+        role="menuitem"
+        tabindex="-1"
+      >
+        profiler.firefox.com
+      </div>
+    </nav>
   </div>
-  <div
-    aria-checked="true"
-    aria-disabled="false"
-    class="react-contextmenu-item tabSelectorMenuItem checkable"
-    role="menuitem"
-    tabindex="-1"
-  >
-    mozilla.org
-  </div>
-  <div
-    aria-checked="true"
-    aria-disabled="false"
-    class="react-contextmenu-item tabSelectorMenuItem checkable"
-    role="menuitem"
-    tabindex="-1"
-  >
-    profiler.firefox.com
-  </div>
-</nav>
+</body>
 `;

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
@@ -25,7 +25,7 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
     role="menuitem"
     tabindex="-1"
   >
-    Full Profile
+    All tabs and windows
   </div>
   <div
     aria-checked="true"

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app/TabSelectorMenu should not render when the profile does not contain any page data 1`] = `
+<nav
+  class="react-contextmenu TabSelectorMenu"
+  role="menu"
+  style="position: fixed; opacity: 0; pointer-events: none;"
+  tabindex="-1"
+>
+  <div />
+</nav>
+`;
+
+exports[`app/TabSelectorMenu should render properly 1`] = `
+<nav
+  class="react-contextmenu TabSelectorMenu"
+  role="menu"
+  style="position: fixed; opacity: 0; pointer-events: none;"
+  tabindex="-1"
+>
+  <div
+    aria-checked="false"
+    aria-disabled="false"
+    class="react-contextmenu-item tabSelectorMenuItem checkable checked"
+    role="menuitem"
+    tabindex="-1"
+  >
+    Full Profile
+  </div>
+  <div
+    aria-checked="true"
+    aria-disabled="false"
+    class="react-contextmenu-item tabSelectorMenuItem checkable"
+    role="menuitem"
+    tabindex="-1"
+  >
+    mozilla.org
+  </div>
+  <div
+    aria-checked="true"
+    aria-disabled="false"
+    class="react-contextmenu-item tabSelectorMenuItem checkable"
+    role="menuitem"
+    tabindex="-1"
+  >
+    profiler.firefox.com
+  </div>
+</nav>
+`;

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1828,11 +1828,11 @@ export function getProfileWithBalancedNativeAllocations() {
  * Pages array has the following relationship:
  * Tab #1                           Tab #2
  * --------------                --------------
- * Page #1                        Page #4
- * |- Page #2                     |
- * |  |- Page #3                  Page #6
+ * cnn.com                        profiler.firefox.com
+ * |- youtube.com                 |
+ * |  |- google.com               google.com
  * |
- * Page #5
+ * mozilla.org
  */
 export function addActiveTabInformationToProfile(
   profile: Profile,
@@ -1859,28 +1859,28 @@ export function addActiveTabInformationToProfile(
     {
       tabID: firstTabTabID,
       innerWindowID: parentInnerWindowIDsWithChildren,
-      url: 'Page #1',
+      url: 'https://www.cnn.com/',
       embedderInnerWindowID: 0,
     },
     // An iframe page inside the previous page
     {
       tabID: firstTabTabID,
       innerWindowID: iframeInnerWindowIDsWithChild,
-      url: 'Page #2',
+      url: 'https://www.youtube.com/',
       embedderInnerWindowID: parentInnerWindowIDsWithChildren,
     },
     // Another iframe page inside the previous iframe
     {
       tabID: firstTabTabID,
       innerWindowID: firstTabInnerWindowIDs[2],
-      url: 'Page #3',
+      url: 'https://www.google.com/',
       embedderInnerWindowID: iframeInnerWindowIDsWithChild,
     },
     // A top most frame from the second tab
     {
       tabID: secondTabTabID,
       innerWindowID: secondTabInnerWindowIDs[0],
-      url: 'Page #4',
+      url: 'https://profiler.firefox.com/',
       embedderInnerWindowID: 0,
     },
     // Another top most frame from the first tab
@@ -1888,15 +1888,15 @@ export function addActiveTabInformationToProfile(
     {
       tabID: firstTabTabID,
       innerWindowID: firstTabInnerWindowIDs[3],
-      url: 'Page #5',
+      url: 'https://mozilla.org/',
       embedderInnerWindowID: 0,
     },
     // Another top most frame from the second tab
     {
       tabID: secondTabTabID,
       innerWindowID: secondTabInnerWindowIDs[1],
-      url: 'Page #4',
-      embedderInnerWindowID: 0,
+      url: 'https://www.google.com/',
+      embedderInnerWindowID: secondTabInnerWindowIDs[0],
     },
   ];
 

--- a/src/test/store/active-tab.test.js
+++ b/src/test/store/active-tab.test.js
@@ -174,7 +174,7 @@ describe('ActiveTab', function () {
       const { getState } = setup(profile, false);
       expect(getHumanReadableActiveTabTracks(getState())).toEqual([
         'main track [tab] SELECTED',
-        '  - iframe: Page #2',
+        '  - iframe: https://www.youtube.com/',
       ]);
     });
 

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -596,7 +596,7 @@ describe('ctxId', function () {
     const resourceTracks = getActiveTabResourceTracks(getState());
     expect(resourceTracks).toEqual([
       {
-        name: 'Page #2',
+        name: 'https://www.youtube.com/',
         type: 'sub-frame',
         threadIndex: 1,
       },

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -21,11 +21,7 @@ import {
   updateBottomBoxContentsAndMaybeOpen,
   closeBottomBox,
 } from '../actions/profile-view';
-import {
-  changeSelectedTab,
-  changeProfilesToCompare,
-  changeTabFilter,
-} from '../actions/app';
+import { changeSelectedTab, changeProfilesToCompare } from '../actions/app';
 import {
   stateFromLocation,
   getQueryStringFromUrlState,
@@ -38,6 +34,7 @@ import { blankStore } from './fixtures/stores';
 import {
   viewProfile,
   changeTimelineTrackOrganization,
+  changeTabFilter,
 } from '../actions/receive-profile';
 import type {
   Profile,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -561,6 +561,14 @@ type UrlStateAction =
   | {|
       +type: 'CHANGE_TAB_FILTER',
       +tabID: TabID | null,
+      +selectedThreadIndexes: Set<ThreadIndex>,
+      +globalTracks: GlobalTrack[],
+      +globalTrackOrder: TrackIndex[],
+      +hiddenGlobalTracks: Set<TrackIndex>,
+      +localTracksByPid: Map<Pid, LocalTrack[]>,
+      +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
+      +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
+      +selectedTab: TabSlug,
     |};
 
 type IconsAction =


### PR DESCRIPTION
This PR implements the basic tab selector component and makes it possible to switch between tabs.

Currently there are 3 main things missing, I will follow-up with these PRs after this one.
- Sort the tab selector list by their thread activity.
- Get the real names of web extensions.
- Add icons of the domains inside the tab selector.

And then, I would like to sort the threads in the timeline differently if it's filtered by tab. Currently the parent process is always at the top. I would like to put the most active content process to the top if a tab is selected.

[Deploy preview](https://deploy-preview-5093--perf-html.netlify.app/public/h3p4hx4kec9vwjxjeb0383pn6h2fxngx90e8ep8)
