### PR TITLE
[Tab selector 6] Get the real names of the extensions 

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2930,7 +2930,8 @@ export function filterToRetainedAllocations(
  * Returns null if we don't have information about pages (in older profiles).
  */
 export function extractProfileFilterPageData(
-  pagesMapByTabID: Map<TabID, PageList> | null
+  pagesMapByTabID: Map<TabID, PageList> | null,
+  extensionIDToNameMap: Map<string, string> | null
 ): Map<TabID, ProfileFilterPageData> {
   if (pagesMapByTabID === null) {
     // We don't have pages array (which is the case for older profiles). Return early.
@@ -2976,6 +2977,12 @@ export function extractProfileFilterPageData(
 
     try {
       const page = new URL(pageUrl);
+      let extensionName = null;
+      if (extensionIDToNameMap && pageUrl.startsWith('moz-extension://')) {
+        // Find the real name of the extension.
+        extensionName = extensionIDToNameMap.get(page.origin + '/');
+      }
+
       // FIXME(Bug 1620546): This is not ideal and we should get the favicon
       // either during profile capture or profile pre-process.
       const favicon = new URL('/favicon.ico', page.origin);
@@ -2985,7 +2992,7 @@ export function extractProfileFilterPageData(
       }
       pageDataByTabID.set(tabID, {
         origin: page.origin,
-        hostname: page.hostname,
+        hostname: extensionName ?? page.hostname,
         favicon: favicon.href,
       });
     } catch (e) {

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2975,33 +2975,55 @@ export function extractProfileFilterPageData(
       continue;
     }
 
+    // Constructing the page data outside of the try-catch block, and adding it
+    // to the map outside of it as well. This is mostly because some favicon URL
+    // constructions might fail and we don't want to miss them still. We should
+    // always have at least a hostname, which is needed for displaying the tab
+    // name.
+    // The known failing case is when we try to construct a URL with a
+    // moz-extension:// protocol on platforms outside of Firefox. Only Firefox
+    // can parse it properly. Chrome and node will output a URL with no `origin`.
+    const pageData: ProfileFilterPageData = {
+      origin: '',
+      hostname: '',
+      favicon: null,
+    };
+
     try {
       const page = new URL(pageUrl);
-      let extensionName = null;
-      if (extensionIDToNameMap && pageUrl.startsWith('moz-extension://')) {
-        // Find the real name of the extension.
-        extensionName = extensionIDToNameMap.get(page.origin + '/');
-      }
+
+      pageData.hostname =
+        extensionIDToNameMap && pageUrl.startsWith('moz-extension://')
+          ? // Get the real extension name if it's an extension.
+            (extensionIDToNameMap.get(
+              'moz-extension://' +
+                // For non-Firefox browsers, we can't construct a URL object
+                // with the 'moz-extension://' protocol properly. So we have to
+                // have a fallback that uses simple string split.
+                (page.hostname ? page.hostname : pageUrl.split('/')[2]) +
+                '/'
+            ) ?? '')
+          : page.hostname;
 
       // FIXME(Bug 1620546): This is not ideal and we should get the favicon
       // either during profile capture or profile pre-process.
+      pageData.origin = page.origin;
       const favicon = new URL('/favicon.ico', page.origin);
       if (favicon.protocol === 'http:') {
         // Upgrade http requests.
         favicon.protocol = 'https:';
       }
-      pageDataByTabID.set(tabID, {
-        origin: page.origin,
-        hostname: extensionName ?? page.hostname,
-        favicon: favicon.href,
-      });
+      pageData.favicon = favicon.href;
     } catch (e) {
-      console.error(
+      console.warn(
         'Error while extracing the hostname and favicon from the page url',
         pageUrl
       );
-      continue;
     }
+
+    // Adding it to the map outside of the try-catch block, just in case something
+    // might fail.
+    pageDataByTabID.set(tabID, pageData);
   }
 
   return pageDataByTabID;

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -79,6 +79,7 @@ import type {
   IndexIntoSamplesTable,
   ExtraProfileInfoSection,
   TableViewOptions,
+  ExtensionTable,
 } from 'firefox-profiler/types';
 
 export const getProfileView: Selector<ProfileViewState> = (state) =>
@@ -212,6 +213,10 @@ const getMarkerSchemaGecko: Selector<MarkerSchema[]> = (state) =>
 // See SampleUnits type definition for more information.
 export const getSampleUnits: Selector<SampleUnits | void> = (state) =>
   getMeta(state).sampleUnits;
+
+// Get all extensions in the profile metadata.
+export const getExtensionTable: Selector<ExtensionTable | void> = (state) =>
+  getMeta(state).extensions;
 
 /**
  * Firefox profiles will always have categories. However, imported profiles may not
@@ -869,6 +874,19 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
   }
 );
 
+export const getExtensionIdToNameMap: Selector<Map<string, string> | null> =
+  createSelector(getExtensionTable, (extensions) => {
+    if (!extensions) {
+      return null;
+    }
+
+    const extensionIDtoNameMap = new Map();
+    for (let i = 0; i < extensions.length; i++) {
+      extensionIDtoNameMap.set(extensions.baseURL[i], extensions.name[i]);
+    }
+    return extensionIDtoNameMap;
+  });
+
 /**
  * Extract the hostname and favicon from the last page if we are in single tab
  * Extract the hostname and favicon from the last page for all tab ids. we
@@ -879,7 +897,11 @@ export const getRelevantInnerWindowIDsForCurrentTab: Selector<
  */
 export const getProfileFilterPageDataByTabID: Selector<
   Map<TabID, ProfileFilterPageData>,
-> = createSelector(getPagesMap, extractProfileFilterPageData);
+> = createSelector(
+  getPagesMap,
+  getExtensionIdToNameMap,
+  extractProfileFilterPageData
+);
 
 /**
  * This returns the hostname and favicon information for the current tab id.

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -1168,7 +1168,7 @@ describe('extractProfileFilterPageData', function () {
   it('extracts the page data when there is only one relevant page', function () {
     // Adding only the https://www.mozilla.org page.
     const pagesMap = new Map([[pages.mozilla.tabID, [pages.mozilla]]]);
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.mozilla.tabID,
@@ -1186,7 +1186,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.profiler.tabID, [pages.profiler, pages.exampleSubFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.profiler.tabID,
@@ -1204,7 +1204,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.profiler.tabID, [pages.aboutBlank, pages.profiler]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.profiler.tabID,
@@ -1220,7 +1220,7 @@ describe('extractProfileFilterPageData', function () {
   it('extracts the page data when there is only about:blank as relevant page', function () {
     const pagesMap = new Map([[pages.aboutBlank.tabID, [pages.aboutBlank]]]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.aboutBlank.tabID,
@@ -1240,7 +1240,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.exampleSubFrame.tabID, [pages.exampleSubFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([]);
     expect(console.error).toHaveBeenCalled();
   });
@@ -1250,7 +1250,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.profiler.tabID, [pages.profiler, pages.exampleTopFrame]],
     ]);
 
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.profiler.tabID,
@@ -1268,7 +1268,7 @@ describe('extractProfileFilterPageData', function () {
       [pages.mozilla.tabID, [pages.mozilla]],
       [pages.profiler.tabID, [pages.profiler, pages.exampleSubFrame]],
     ]);
-    const pageData = extractProfileFilterPageData(pagesMap);
+    const pageData = extractProfileFilterPageData(pagesMap, null);
     expect([...pageData]).toEqual([
       [
         pages.mozilla.tabID,


### PR DESCRIPTION
Previously it was not possible to see the real extension names and they were always written like "UUID" because of it. With this PR, we get the correct extension names from the `profile.extensions` array and display them properly.

It also had a bug previously. When we try to construct a URL object with `moz-extension://` protocol, it was failing outside of Firefox, it was returning `'null'` for the origin and hostname, which was crashing in the code since we were trying to use it for something else afterwards. This PR makes sure that it doesn't crash on non-Firefox browsers and always return the proper name for the extensions.

[Deploy preview](https://deploy-preview-5132--perf-html.netlify.app/public/h3p4hx4kec9vwjxjeb0383pn6h2fxngx90e8ep8/calltree/?globalTrackOrder=l0wk&hiddenGlobalTracks=1wbdwfh&hiddenLocalTracksByPid=22330-2w5~36664-01~37313-0~22358-0~37310-0~35696-0~22340-0~36652-0~22347-0~22357-0~36662-0~22344-0~37312-0~22343-0w2~22342-01~18289-0w3~37000-0&thread=i&v=10)