### PR TITLE
Support profiling from the toolbox in Thunderbird Release

### DIFF
--- a/src/app-logic/browser-connection.js
+++ b/src/app-logic/browser-connection.js
@@ -183,8 +183,19 @@ class BrowserConnectionImpl implements BrowserConnection {
   }
 }
 
+// Should work with:
+// Firefox Desktop: "Mozilla/5.0 (X11; Linux x86_64; rv:132.0) Gecko/20100101 Firefox/132.0"
+// Thunderbird: "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Thunderbird/128.2.3"
+// Firefox Android: "Mozilla/5.0 (Android 12; Mobile; rv:132.0) Gecko/132.0 Firefox/132.0"
+// Should not work with:
+// Chrome: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36'
+// Safari: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1'
+//
+// We could match for Gecko/ but do all Gecko-based browsers support the
+// WebChannel? Probably not. Therefore specifically Firefox and Thunderbird are
+// looked for, until we find that we need a broader net.
 function _isFirefox(userAgent: string): boolean {
-  return Boolean(userAgent.match(/Firefox\/\d+\.\d+/));
+  return userAgent.includes('Firefox/') || userAgent.includes('Thunderbird/');
 }
 
 class TimeoutError extends Error {


### PR DESCRIPTION
Thunderbird Releases doesn't include the Firefox/ string in its userAgent, therefore we neeed to match Thunderbird/ as well.

See also the discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1920387.

Fixes #5134

I checked locally that Thunderbird was working properly after this change.

For reference here is how I tried it:
1. Open the browser toolbox in Thunderbird.
2. Open the browser toolbox for the browser toolbox (ctrl shift alt + i)
3. type `openLinkIn("about:config")` in the console
4. change the preference `devtools.performance.recording.ui-base-url` to point to the local development server