### PR TITLE
Use the new API of react

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import '../res/css/network.css';
 import 'react-splitter-layout/lib/index.css';
 
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Root } from './components/app/Root';
 import createStore from './app-logic/create-store';
 import {
@@ -45,17 +45,13 @@ window.geckoProfilerPromise = new Promise(function (resolve) {
 });
 
 const store = createStore();
-
-// This uses the React 17 API despite that we use React 18. When moving to the
-// newer API, don't forget to update the tests in
-// src/test/fixtures/testing-library.js.
-render(
-  <Root store={store} />,
+const root = createRoot(
   ensureExists(
     document.getElementById('root'),
     'Unable to find the DOM element to attach the React element to.'
   )
 );
+root.render(<Root store={store} />);
 
 addDataToWindowObject(store.getState, store.dispatch);
 if (process.env.NODE_ENV === 'production') {

--- a/src/test/components/ButtonWithPanel.test.js
+++ b/src/test/components/ButtonWithPanel.test.js
@@ -6,7 +6,11 @@
 import * as React from 'react';
 import { fireEvent } from '@testing-library/react';
 
-import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
+import {
+  render,
+  screen,
+  act,
+} from 'firefox-profiler/test/fixtures/testing-library';
 import { ButtonWithPanel } from '../../components/shared/ButtonWithPanel';
 import { ensureExists } from '../../utils/flow';
 import { fireFullClick } from '../fixtures/utils';
@@ -82,7 +86,9 @@ describe('shared/ButtonWithPanel', () => {
     const button = screen.getByText('My Button');
     expect(button.title).toBe('Click here to open the panel');
     fireFullClick(button);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(button.title).toBe('');
   });
 
@@ -90,7 +96,9 @@ describe('shared/ButtonWithPanel', () => {
     const { container } = setup();
 
     fireFullClick(screen.getByText('My Button'));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(container.firstChild).toMatchSnapshot();
 
     //it closes the panel when Esc key is pressed
@@ -99,7 +107,9 @@ describe('shared/ButtonWithPanel', () => {
       keyCode: 27,
       which: 27,
     });
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -107,7 +117,9 @@ describe('shared/ButtonWithPanel', () => {
     const { container } = setup();
 
     fireFullClick(screen.getByText('My Button'));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(container.firstChild).toMatchSnapshot();
 
     // it closes the panel when clicking outside the panel
@@ -116,7 +128,9 @@ describe('shared/ButtonWithPanel', () => {
     );
     fireFullClick(newDiv);
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(container.firstChild).toMatchSnapshot();
   });
 
@@ -124,12 +138,16 @@ describe('shared/ButtonWithPanel', () => {
     const { container } = setup();
 
     fireFullClick(screen.getByText('My Button'));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     ensureExists(container.querySelector('.arrowPanel.open'));
 
     fireFullClick(screen.getByText('My Button'));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(container.querySelector('.arrowPanel.open')).toBe(null);
   });
@@ -138,17 +156,23 @@ describe('shared/ButtonWithPanel', () => {
     const { container } = setup();
 
     fireFullClick(screen.getByText('My Button'));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     ensureExists(container.querySelector('.arrowPanel.open'));
 
     // Clicking on the panel doesn't hide the popup.
     fireFullClick(screen.getByText('Panel content'));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     ensureExists(container.querySelector('.arrowPanel.open'));
 
     // But clicking on the arrow area does.
     fireFullClick(ensureExists(container.querySelector('.arrowPanelArrow')));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(container.querySelector('.arrowPanel.open')).toBe(null);
   });
 });

--- a/src/test/components/MenuButtonsPermalinks.test.js
+++ b/src/test/components/MenuButtonsPermalinks.test.js
@@ -6,7 +6,11 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
+import {
+  render,
+  screen,
+  act,
+} from 'firefox-profiler/test/fixtures/testing-library';
 import { MenuButtons } from '../../components/app/MenuButtons';
 import { storeWithProfile } from '../fixtures/stores';
 import { stateFromLocation } from '../../app-logic/url-handling';
@@ -45,7 +49,9 @@ describe('<Permalink>', function () {
     const queryInput = () => screen.queryByTestId('MenuButtonsPermalink-input');
     const clickAndRunTimers = (where) => {
       fireFullClick(where);
-      jest.runAllTimers();
+      act(() => {
+        jest.runAllTimers();
+      });
     };
 
     return {
@@ -75,7 +81,7 @@ describe('<Permalink>', function () {
       clickAndRunTimers,
     } = setup();
     clickAndRunTimers(getPermalinkButton());
-    await shortUrlPromise;
+    await act(() => shortUrlPromise);
     const input = ensureExists(
       queryInput(),
       'Unable to find the permalink input text field'

--- a/src/test/components/Root-history.test.js
+++ b/src/test/components/Root-history.test.js
@@ -14,6 +14,7 @@ import {
 } from 'firefox-profiler/test/fixtures/testing-library';
 import { Root } from '../../components/app/Root';
 import { autoMockCanvasContext } from '../fixtures/mocks/canvas-context';
+import { fireFullClick } from '../fixtures/utils';
 import { getProfileUrlForHash } from '../../actions/receive-profile';
 import { blankStore } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
@@ -130,7 +131,7 @@ describe('Root with history', function () {
       name: 'Marker Chart',
       selected: false,
     });
-    markerChart.click();
+    fireFullClick(markerChart);
 
     await waitForTab({ name: 'Call Tree', selected: false });
     await waitForTab({ name: 'Marker Chart', selected: true });
@@ -168,7 +169,7 @@ describe('Root with history', function () {
       name: 'Marker Chart',
       selected: false,
     });
-    markerChart.click();
+    fireFullClick(markerChart);
 
     await waitForTab({ name: 'Call Tree', selected: false });
     await waitForTab({ name: 'Marker Chart', selected: true });

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -40,7 +40,7 @@ jest.mock('../../components/app/ListOfPublishedProfiles', () => ({
 import * as React from 'react';
 import { Provider } from 'react-redux';
 
-import { render } from 'firefox-profiler/test/fixtures/testing-library';
+import { render, act } from 'firefox-profiler/test/fixtures/testing-library';
 import { AppViewRouter } from '../../components/app/AppViewRouter';
 import { ProfileLoader } from '../../components/app/ProfileLoader';
 import { updateUrlState, changeProfilesToCompare } from '../../actions/app';
@@ -190,13 +190,19 @@ function setup() {
     </Provider>
   );
 
+  function actAndDispatch(what) {
+    act(() => {
+      store.dispatch(what);
+    });
+  }
+
   function navigateToStoreLoadingPage() {
     const newUrlState = stateFromLocation({
       pathname: '/public/ThisIsAFakeHash/calltree',
       search: '',
       hash: '',
     });
-    store.dispatch(updateUrlState(newUrlState));
+    actAndDispatch(updateUrlState(newUrlState));
   }
 
   function navigateToFromBrowserProfileLoadingPage() {
@@ -205,7 +211,7 @@ function setup() {
       search: '',
       hash: '',
     });
-    store.dispatch(updateUrlState(newUrlState));
+    actAndDispatch(updateUrlState(newUrlState));
   }
 
   function navigateBackToHome() {
@@ -214,7 +220,7 @@ function setup() {
       hash: '',
       search: '',
     });
-    store.dispatch(updateUrlState(newUrlState));
+    actAndDispatch(updateUrlState(newUrlState));
   }
 
   function navigateToCompareHome() {
@@ -223,7 +229,7 @@ function setup() {
       hash: '',
       search: '',
     });
-    store.dispatch(updateUrlState(newUrlState));
+    actAndDispatch(updateUrlState(newUrlState));
   }
 
   function navigateToMyProfiles() {
@@ -232,12 +238,12 @@ function setup() {
       hash: '',
       search: '',
     });
-    store.dispatch(updateUrlState(newUrlState));
+    actAndDispatch(updateUrlState(newUrlState));
   }
 
   return {
     ...renderResult,
-    dispatch: store.dispatch,
+    dispatch: actAndDispatch,
     navigateToStoreLoadingPage,
     navigateToFromBrowserProfileLoadingPage,
     navigateBackToHome,

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -92,7 +92,9 @@ describe('app/ServiceWorkerManager', () => {
         dispatchEvent: (eventName) => {
           const listeners = listenersMap.get(eventName) ?? new Set();
           for (const listener of listeners) {
-            listener();
+            act(() => {
+              listener();
+            });
           }
         },
       };

--- a/src/test/components/TrackContextMenu.test.js
+++ b/src/test/components/TrackContextMenu.test.js
@@ -115,10 +115,12 @@ describe('timeline/TrackContextMenu', function () {
     };
 
     const showContextMenu = () => {
-      showMenu({
-        data: null,
-        id: 'TimelineTrackContextMenu',
-        position: { x: 0, y: 0 },
+      act(() => {
+        showMenu({
+          data: null,
+          id: 'TimelineTrackContextMenu',
+          position: { x: 0, y: 0 },
+        });
       });
     };
 

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -134,9 +134,7 @@ describe('UrlManager', function () {
     await waitUntilUrlSetupPhase('done');
     expect(getDataSource(getState())).toMatch('from-browser');
 
-    // This is called by React 18 until we move to the createRoot API.
-    //expect(console.error).not.toHaveBeenCalled();
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('redirects from-file back to no data source', async function () {

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -124,7 +124,9 @@ describe('Viewport', function () {
       expect(isTimerVisible()).toBe(true);
 
       // Run the setTimeout, the menu should disappear.
-      jest.runAllTimers();
+      act(() => {
+        jest.runAllTimers();
+      });
       expect(isTimerVisible()).toBe(false);
     });
 

--- a/src/test/fixtures/mocks/request-animation-frame.js
+++ b/src/test/fixtures/mocks/request-animation-frame.js
@@ -12,6 +12,7 @@
  */
 
 import { stripIndent } from 'common-tags';
+import { act } from 'firefox-profiler/test/fixtures/testing-library';
 
 function stripThisFileFromErrorStack(error: Error): string[] {
   const stacks = error.stack.split('\n');
@@ -92,7 +93,9 @@ export function mockRaf() {
       while (oldrequests.length) {
         const request = oldrequests.shift();
         const arg = timestamps.shift();
-        request.func.call(null, arg);
+        act(() => {
+          request.func.call(null, arg);
+        });
       }
     }
 

--- a/src/test/fixtures/mocks/resize-observer.js
+++ b/src/test/fixtures/mocks/resize-observer.js
@@ -4,6 +4,8 @@
 
 // @flow
 
+import { act } from 'firefox-profiler/test/fixtures/testing-library';
+
 /**
  * Creating a mock resize observer type because Flow's ResizeObserver
  * type is a bit obsolete.
@@ -127,7 +129,9 @@ function triggerSingleObserver(
   }
 
   // Trigger the ResizeObserver callback with all the entries.
-  item.callback(entries, observer);
+  act(() => {
+    item.callback(entries, observer);
+  });
 }
 
 /**

--- a/src/test/fixtures/testing-library.js
+++ b/src/test/fixtures/testing-library.js
@@ -15,26 +15,9 @@ function customRender(children: React$Element<any>, ...args: any) {
   const bundles = lazilyParsedBundles([['en-US', messages]]);
   const localization = new ReactLocalization(bundles);
 
-  // Silence React 18 errors as it's too noisy in the test output. Don't forget
-  // to remove it when removing legacyRoot below!
-  // Other files such as src/test/components/UrlManager.test.js also mock
-  // console.error and might need to be changed in the same time.
-  if (!console.error._isMockFunction) {
-    const originalConsoleError = console.error.bind(console);
-    jest.spyOn(console, 'error').mockImplementation((...args) => {
-      if (/ReactDOM.render is no longer supported in React 18/.test(args[0])) {
-        return;
-      }
-      originalConsoleError(...args);
-    });
-  }
-
   const renderResult = render(
     <LocalizationProvider l10n={localization}>{children}</LocalizationProvider>,
     {
-      // Stick to the React 17 behavior for now. Don't forget to remove the
-      // mock for console.error above when removing this!
-      legacyRoot: true,
       ...args,
     }
   );

--- a/src/types/libdef/npm/react-dom_vx.x.x.js
+++ b/src/types/libdef/npm/react-dom_vx.x.x.js
@@ -17,6 +17,10 @@ declare module 'react-dom' {
   declare module.exports: any;
 }
 
+declare module 'react-dom/client' {
+  declare module.exports: any;
+}
+
 /**
  * We include stubs for each file inside this npm package in case you need to
  * require those files directly. Feel free to delete any files that aren't


### PR DESCRIPTION
This switches to the new API and fixes the tests around it (mostly adding `act` everywhere it was missing before).

I couldn't find problems in the app itself, but please test carefully on your side.

Deploy previews:
[home page](https://deploy-preview-5139--perf-html.netlify.app/)
[a complex website](https://deploy-preview-5139--perf-html.netlify.app/public/3hrdgjakmcn01fhtvbebyp04r716sa5p8dstmdg/marker-table/?globalTrackOrder=0wf&hiddenGlobalTracks=1w8abde&hiddenLocalTracksByPid=165422-136wdgwl~517143-0w5~516996-0w7~518980-0w5~518975-0w7~165714-0w2~519144-0w5~170378-0w4~519148-0w5~518997-249a~166471-0w3~170218-0w3~165893-1wdhi~519068-0w5~165799-0w5~165767-0w24&thread=0&v=10)