### PR TITLE
Add a "Merge unaccounted native frames" transform

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -66,6 +66,12 @@ CallNodeContextMenu--transform-merge-call-node = Merge node only
         function’s node that called it. It only removes the function from that
         specific part of the tree. Any other places the function was called from
         will remain in the profile.
+CallNodeContextMenu--transform-merge-unaccounted-native-functions = Merge unaccounted native frames
+    .title =
+        Removes stack frames such as unsymbolicated JIT frames from the call tree,
+        and make their callers absorb their cost.
+        Specifically, this transform merges any native stack frames which were
+        not accounted to a shared library.
 
 # This is used as the context menu item title for "Focus on function" and "Focus
 # on function (inverted)" transforms.
@@ -1082,6 +1088,12 @@ TransformNavigator--merge-call-node = Merge Node: { $item }
 # Variables:
 #   $item (String) - Name of the function that transform applied to.
 TransformNavigator--merge-function = Merge: { $item }
+
+# "Merge unaccounted native frames" transform.
+# See: https://profiler.firefox.com/docs/#/./guide-filtering-call-trees?id=merge
+# Corresponds to the context menu item with the l10n ID
+# CallNodeContextMenu--transform-merge-unaccounted-native-functions
+TransformNavigator--merge-unaccounted-native-functions = Merge unaccounted native
 
 # "Drop function" transform.
 # See: https://profiler.firefox.com/docs/#/./guide-filtering-call-trees?id=drop

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -2078,6 +2078,13 @@ export function handleCallNodeTransformShortcut(
           })
         );
         break;
+      case 'U':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'merge-unaccounted-native-functions',
+          })
+        );
+        break;
       case 'd':
         dispatch(
           addTransformToStack(threadsKey, {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -1424,13 +1424,13 @@ describe('url upgrading', function () {
 
 describe('URL serialization of the transform stack', function () {
   const transformString =
-    'f-combined-0w2~mcn-combined-2w4~f-js-3w5-i~mf-6~ff-7~fg-42~cr-combined-8-9~' +
+    'f-combined-0w2~mcn-combined-2w4~f-js-3w5-i~mf-6~mu~ff-7~fg-42~cr-combined-8-9~' +
     'drec-combined-10~rec-11~df-12~cfs-13';
   const { getState } = _getStoreWithURL({
     search: '?transforms=' + transformString,
   });
 
-  it('deserializes focus subtree transforms', function () {
+  it('deserializes transforms', function () {
     const transformStack =
       selectedThreadSelectors.getTransformStack(getState());
 
@@ -1456,6 +1456,9 @@ describe('URL serialization of the transform stack', function () {
       {
         type: 'merge-function',
         funcIndex: 6,
+      },
+      {
+        type: 'merge-unaccounted-native-functions',
       },
       {
         type: 'focus-function',
@@ -1491,7 +1494,7 @@ describe('URL serialization of the transform stack', function () {
     ]);
   });
 
-  it('re-serializes the focus subtree transforms', function () {
+  it('re-serializes the transforms', function () {
     const queryString = getQueryStringFromState(getState());
     expect(queryString).toContain(`transforms=${transformString}`);
   });

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -179,7 +179,7 @@ export type TransformDefinitions = {
   |},
 
   /**
-   * The MergeFunctions transform is similar to the MergeCallNode, except it merges a single
+   * The MergeFunction transform is similar to the MergeCallNode, except it merges a single
    * function across the entire call tree, regardless of its location in the tree. It is not
    * depended on any particular CallNodePath.
    *
@@ -200,6 +200,15 @@ export type TransformDefinitions = {
   'merge-function': {|
     +type: 'merge-function',
     +funcIndex: IndexIntoFuncTable,
+  |},
+
+  /**
+   * The MergeUnaccountedNativeFunctions transform is similar to the MergeFunction,
+   * except it merges all functions that look like unsymbolicated JIT functions:
+   * Functions which are of the form 0xhexadress and which don't have a resource.
+   */
+  'merge-unaccounted-native-functions': {|
+    +type: 'merge-unaccounted-native-functions',
   |},
 
   /**

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -85,6 +85,7 @@ export function convertToTransformType(type: string): TransformType | null {
     // we have been exhaustive.
     case 'merge-call-node':
     case 'merge-function':
+    case 'merge-unaccounted-native-functions':
     case 'focus-subtree':
     case 'focus-function':
     case 'focus-category':


### PR DESCRIPTION
[Production](https://share.firefox.dev/47G6fAA) | [Deploy preview](https://deploy-preview-5141--perf-html.netlify.app/public/28p7jvd50ycpf740a3y7cqqfp8mqp6671fzwt58/flame-graph/?globalTrackOrder=0wxt&hiddenGlobalTracks=1wxt&hiddenLocalTracksByPid=62037-1w3~64317-0~64319-0~64247-0~62826-0~64259-0~64270-0~62750-01~63028-0~62986-01~63847-0~63181-0~63837-0~63574-0~62570-0~63612-0~62790-0~62722-01~63042-0~63635-0~62955-0~62930-0~62582-01~62576-0~63512-0~62921-0~63148-0~63213-0~62806-0~63352-0~63268-0~62464-0~63092-0~62630-0~62862-0~63450-0~62610-0~63416-01~63207-01~62910-0~62666-0~62458-0~63165-0~62890-0~62672-0~63832-0~62267-0&thread=0&transforms=f-combined-0gjMkzVrzVszW2zC9wzCbzW3zCdzCezWlwzWoAX1zWpzWrx.8x.awx.cx.hx.ix.kzS1DY6DYaDYbyCpwyCsyD0MFfMFgyD0yEbyEdDYcwDYeDYgySbAYm~ff-15326~munfs&v=10)

This makes it easier to analyze profiles with JIT frames.

This transform gets rid of 0x12345 frames in the call tree - but only those that haven't been accounted to a shared library, i.e. only frames which we consider to be "probably JIT" frames. This transform does not merge unsymbolicated frames for which we know what library they belong to.

Ideally, we wouldn't have those stray hex addresses in the profiles; either Firefox would filter them out during stack merging, or it should give us the correct memory ranges for JIT functions so that we can account these addresses to the right JS function / JIT trampoline etc. But it's not doing that correctly today.

https://bugzilla.mozilla.org/show_bug.cgi?id=1463559 is one of the bugs about this.

For now it seems easier to just offer a transform which gets rid of these stray JIT address frames. This new transform doesn't really clutter anything up; users will only know about it if they right-click such a frame / call node.

Even if Firefox starts giving us better information for JIT frames, this transform can still be useful. For example, you could see this type of stack frame in profiles that are gathered with samply, on applications that use other JITs or applications which don't have Jitdump instrumentation enabled.
Another use case would be if Firefox uses a system library that makes use of jitting, for example a software OpenGL implementation. Those libraries can't be expected to expose their JIT details to our profiler.