### PR TITLE
[Tab selector 7] Sort the tabs by their thread activity scores

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -44,7 +44,10 @@ import {
   getSelectedTab,
   getTabFilter,
 } from 'firefox-profiler/selectors/url-state';
-import { getTabToThreadIndexesMap } from 'firefox-profiler/selectors/profile';
+import {
+  getTabToThreadIndexesMap,
+  getThreadActivityScores,
+} from 'firefox-profiler/selectors/profile';
 import {
   withHistoryReplaceStateAsync,
   withHistoryReplaceStateSync,
@@ -348,7 +351,11 @@ export function finalizeFullProfileView(
       // This is the case for the initial profile load.
       // We also get here if the URL info was ignored, for example if
       // respecting it would have caused all threads to become hidden.
-      hiddenTracks = computeDefaultHiddenTracks(tracksWithOrder, profile);
+      hiddenTracks = computeDefaultHiddenTracks(
+        tracksWithOrder,
+        profile,
+        getThreadActivityScores(getState())
+      );
     }
 
     const selectedThreadIndexes = initializeSelectedThreadIndex(
@@ -1804,7 +1811,11 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
       // This is the case for the initial profile load.
       // We also get here if the URL info was ignored, for example if
       // respecting it would have caused all threads to become hidden.
-      hiddenTracks = computeDefaultHiddenTracks(tracksWithOrder, profile);
+      hiddenTracks = computeDefaultHiddenTracks(
+        tracksWithOrder,
+        profile,
+        getThreadActivityScores(getState())
+      );
     }
 
     const selectedThreadIndexes = initializeSelectedThreadIndex(

--- a/src/components/shared/TabSelectorMenu.js
+++ b/src/components/shared/TabSelectorMenu.js
@@ -12,14 +12,14 @@ import { ContextMenu } from './ContextMenu';
 import explicitConnect from 'firefox-profiler/utils/connect';
 import { changeTabFilter } from 'firefox-profiler/actions/receive-profile';
 import { getTabFilter } from '../../selectors/url-state';
-import { getProfileFilterPageDataByTabID } from 'firefox-profiler/selectors/profile';
+import { getProfileFilterSortedPageData } from 'firefox-profiler/selectors/profile';
 
-import type { TabID, ProfileFilterPageData } from 'firefox-profiler/types';
+import type { TabID, SortedTabPageData } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 type StateProps = {|
   +tabFilter: TabID | null,
-  +pageDataByTabID: Map<TabID, ProfileFilterPageData> | null,
+  +sortedPageData: SortedTabPageData | null,
 |};
 
 type DispatchProps = {|
@@ -36,9 +36,8 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
   };
 
   renderTabSelectorMenuContents() {
-    const { pageDataByTabID, tabFilter } = this.props;
-    if (!pageDataByTabID || pageDataByTabID.size === 0) {
-      // There is no page data, return early.
+    const { sortedPageData, tabFilter } = this.props;
+    if (!sortedPageData || sortedPageData.length === 0) {
       return null;
     }
 
@@ -59,7 +58,7 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
             All tabs and windows
           </Localized>
         </MenuItem>
-        {[...pageDataByTabID].map(([tabID, pageData]) => (
+        {sortedPageData.map(({ tabID, pageData }) => (
           <MenuItem
             key={tabID}
             onClick={this._handleClick}
@@ -92,7 +91,7 @@ export const TabSelectorMenu = explicitConnect<{||}, StateProps, DispatchProps>(
   {
     mapStateToProps: (state) => ({
       tabFilter: getTabFilter(state),
-      pageDataByTabID: getProfileFilterPageDataByTabID(state),
+      sortedPageData: getProfileFilterSortedPageData(state),
     }),
     mapDispatchToProps: {
       changeTabFilter,

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -20,7 +20,6 @@ import type {
 } from 'firefox-profiler/types';
 
 import { defaultThreadOrder, getFriendlyThreadName } from './profile-data';
-import { computeMaxCPUDeltaPerInterval } from './cpu';
 import { intersectSets, subtractSets } from '../utils/set';
 import { splitSearchString, stringsToRegExp } from '../utils/string';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
@@ -818,11 +817,16 @@ export function tryInitializeHiddenTracksFromUrl(
 // The result is guaranteed to have a non-empty number of visible threads.
 export function computeDefaultHiddenTracks(
   tracksWithOrder: TracksWithOrder,
-  profile: Profile
+  profile: Profile,
+  threadActivityScores: Array<DefaultVisibilityScore>
 ): HiddenTracks {
   return _computeHiddenTracksForVisibleThreads(
     profile,
-    computeDefaultVisibleThreads(profile, tracksWithOrder),
+    computeDefaultVisibleThreads(
+      profile,
+      tracksWithOrder,
+      threadActivityScores
+    ),
     tracksWithOrder
   );
 }
@@ -1049,7 +1053,8 @@ const IDLE_THRESHOLD_FRACTION = 0.05;
 // Return a non-empty set of threads that should be shown by default.
 export function computeDefaultVisibleThreads(
   profile: Profile,
-  tracksWithOrder: TracksWithOrder
+  tracksWithOrder: TracksWithOrder,
+  threadActivityScores: Array<DefaultVisibilityScore>
 ): Set<ThreadIndex> {
   const threads = profile.threads;
   if (threads.length === 0) {
@@ -1067,15 +1072,10 @@ export function computeDefaultVisibleThreads(
   const allTrackThreads = computeAllTrackThreads(tracksWithOrder);
 
   // First, compute a score for every thread.
-  const maxCpuDeltaPerInterval = computeMaxCPUDeltaPerInterval(profile);
-  let scores = threads.map((thread, threadIndex) => {
-    const score = computeThreadDefaultVisibilityScore(
-      profile,
-      thread,
-      maxCpuDeltaPerInterval
-    );
-    return { threadIndex, score };
-  });
+  let scores = threadActivityScores.map((score, threadIndex) => ({
+    threadIndex,
+    score,
+  }));
 
   // Next, filter the tracks by the tab selector threads.
   scores = scores.filter(({ threadIndex }) => allTrackThreads.has(threadIndex));

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -1069,7 +1069,7 @@ export function computeDefaultVisibleThreads(
   // First, compute a score for every thread.
   const maxCpuDeltaPerInterval = computeMaxCPUDeltaPerInterval(profile);
   let scores = threads.map((thread, threadIndex) => {
-    const score = _computeThreadDefaultVisibilityScore(
+    const score = computeThreadDefaultVisibilityScore(
       profile,
       thread,
       maxCpuDeltaPerInterval
@@ -1116,7 +1116,7 @@ export function computeDefaultVisibleThreads(
   return new Set(finalList.map(({ threadIndex }) => threadIndex));
 }
 
-type DefaultVisibilityScore = {|
+export type DefaultVisibilityScore = {|
   // Whether this thread is one of the essential threads that
   // should always be kept (unless there's too many of them).
   isEssentialFirefoxThread: boolean,
@@ -1140,7 +1140,7 @@ const AUDIO_THREAD_SAMPLE_SCORE_BOOST_FACTOR = 40;
 // See the DefaultVisibilityScore type for details.
 // If we have too many threads, we use this score to compare between
 // "interesting" threads to make sure we keep the most interesting ones.
-function _computeThreadDefaultVisibilityScore(
+export function computeThreadDefaultVisibilityScore(
   profile: Profile,
   thread: Thread,
   maxCpuDeltaPerInterval: number | null

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -818,7 +818,7 @@ export function tryInitializeHiddenTracksFromUrl(
 export function computeDefaultHiddenTracks(
   tracksWithOrder: TracksWithOrder,
   profile: Profile,
-  threadActivityScores: Array<DefaultVisibilityScore>
+  threadActivityScores: Array<ThreadActivityScore>
 ): HiddenTracks {
   return _computeHiddenTracksForVisibleThreads(
     profile,
@@ -1054,7 +1054,7 @@ const IDLE_THRESHOLD_FRACTION = 0.05;
 export function computeDefaultVisibleThreads(
   profile: Profile,
   tracksWithOrder: TracksWithOrder,
-  threadActivityScores: Array<DefaultVisibilityScore>
+  threadActivityScores: Array<ThreadActivityScore>
 ): Set<ThreadIndex> {
   const threads = profile.threads;
   if (threads.length === 0) {
@@ -1116,7 +1116,7 @@ export function computeDefaultVisibleThreads(
   return new Set(finalList.map(({ threadIndex }) => threadIndex));
 }
 
-export type DefaultVisibilityScore = {|
+export type ThreadActivityScore = {|
   // Whether this thread is one of the essential threads that
   // should always be kept (unless there's too many of them).
   isEssentialFirefoxThread: boolean,
@@ -1140,11 +1140,11 @@ const AUDIO_THREAD_SAMPLE_SCORE_BOOST_FACTOR = 40;
 // See the DefaultVisibilityScore type for details.
 // If we have too many threads, we use this score to compare between
 // "interesting" threads to make sure we keep the most interesting ones.
-export function computeThreadDefaultVisibilityScore(
+export function computeThreadActivityScore(
   profile: Profile,
   thread: Thread,
   maxCpuDeltaPerInterval: number | null
-): DefaultVisibilityScore {
+): ThreadActivityScore {
   const isEssentialFirefoxThread = _isEssentialFirefoxThread(thread);
   const isInterestingEvenWithMinimalActivity =
     _isFirefoxMediaThreadWhichIsUsuallyIdle(thread);

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -84,7 +84,7 @@ import type {
   SortedTabPageData,
 } from 'firefox-profiler/types';
 
-import type { DefaultVisibilityScore } from '../profile-logic/tracks';
+import type { ThreadActivityScore } from '../profile-logic/tracks';
 
 export const getProfileView: Selector<ProfileViewState> = (state) =>
   state.profileView;
@@ -721,7 +721,7 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
 export const getMaxCPUDeltaPerInterval: Selector<number | null> =
   createSelector(getProfile, CPU.computeMaxCPUDeltaPerInterval);
 
-export const getThreadActivityScores: Selector<Array<DefaultVisibilityScore>> =
+export const getThreadActivityScores: Selector<Array<ThreadActivityScore>> =
   createSelector(
     getProfile,
     getMaxCPUDeltaPerInterval,
@@ -729,7 +729,7 @@ export const getThreadActivityScores: Selector<Array<DefaultVisibilityScore>> =
       const { threads } = profile;
 
       return threads.map((thread) =>
-        Tracks.computeThreadDefaultVisibilityScore(
+        Tracks.computeThreadActivityScore(
           profile,
           thread,
           maxCpuDeltaPerInterval

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
@@ -40,7 +40,7 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
         role="menuitem"
         tabindex="-1"
       >
-        mozilla.org
+        profiler.firefox.com
       </div>
       <div
         aria-checked="true"
@@ -49,7 +49,7 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
         role="menuitem"
         tabindex="-1"
       >
-        profiler.firefox.com
+        mozilla.org
       </div>
     </nav>
   </div>

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -663,6 +663,16 @@ export type ProfileFilterPageData = {|
   favicon: string | null,
 |};
 
+/**
+ * Information about the Tab selector state that is sorted by their tab activity
+ * scores.
+ */
+export type SortedTabPageData = Array<{|
+  tabID: TabID,
+  tabScore: number,
+  pageData: ProfileFilterPageData,
+|}>;
+
 export type CallNodeLeafAndSummary = {|
   // This property stores the amount of unit (time, bytes, count, etc.) spent in the
   // stacks' leaf nodes.


### PR DESCRIPTION
This PR sorts the tabs by their thread activity scores. Previously it was kinda random and it wasn't easy to find the most active one. With this the most active tab should appear at the top.

[Example profile](https://deploy-preview-5142--perf-html.netlify.app/public/h3p4hx4kec9vwjxjeb0383pn6h2fxngx90e8ep8/)