### PR TITLE
Do no persist the tooltips in flame graph and stack chart

### DIFF
--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -939,6 +939,7 @@ class MarkerChartCanvasImpl extends React.PureComponent<Props> {
         hitTest={this.hitTest}
         onMouseMove={this.onMouseMove}
         onMouseLeave={this.onMouseLeave}
+        stickyTooltips={true}
       />
     );
   }

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -33,6 +33,8 @@ type Props<Item> = {|
 
   +onMouseMove?: (e: { nativeEvent: MouseEvent }) => mixed,
   +onMouseLeave?: (e: { nativeEvent: MouseEvent }) => mixed,
+  // Defaults to false. Set to true if the chart should persist the tooltips on click.
+  +stickyTooltips?: boolean,
 |};
 
 // The naming of the X and Y coordinates here correspond to the ones
@@ -224,11 +226,13 @@ export class ChartCanvas<Item> extends React.Component<
     const { onSelectItem } = this.props;
     if (e.button === 0 && onSelectItem) {
       // Left button is a selection action
-      this.setState((state) => ({
-        selectedItem: state.hoveredItem,
-        pageX: e.pageX,
-        pageY: e.pageY,
-      }));
+      if (this.props.stickyTooltips) {
+        this.setState((state) => ({
+          selectedItem: state.hoveredItem,
+          pageX: e.pageX,
+          pageY: e.pageY,
+        }));
+      }
 
       onSelectItem(this.state.hoveredItem);
     }

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -88,7 +88,7 @@ describe('FlameGraph', function () {
     expect(getTooltip()).toBeTruthy();
   });
 
-  it('persists the selected frame tooltips properly', () => {
+  it('should not persist the selected frame tooltips', () => {
     const { getTooltip, moveMouse, findFillTextPosition, leftClick } =
       setupFlameGraph();
     // No tooltip displayed yet.
@@ -102,51 +102,8 @@ describe('FlameGraph', function () {
     // Move the mouse outside of the frame.
     moveMouse({ x: 0, y: 0 });
 
-    // Make sure that we have the tooltip persisted.
-    expect(getTooltip()).toBeTruthy();
-
-    // Click outside of the marker.
-    leftClick({ x: 0, y: 0 });
-
-    // Now the tooltip should not be displayed.
+    // Make sure that we don't have a persisted tooltip.
     expect(getTooltip()).toBeFalsy();
-  });
-
-  it('tooltip should not persist if the flame graph gets changed', () => {
-    const {
-      getContentDiv,
-      getTooltip,
-      moveMouse,
-      findFillTextPosition,
-      leftClick,
-    } = setupFlameGraph();
-    const div = getContentDiv();
-    // No tooltip displayed yet.
-    expect(getTooltip()).toBe(null);
-
-    leftClick(findFillTextPosition('A'));
-
-    // The tooltip should be displayed.
-    expect(getTooltip()).toBeTruthy();
-
-    // Move the mouse outside of the frame.
-    moveMouse({ x: 0, y: 0 });
-
-    // Make sure that we have the tooltip persisted.
-    expect(getTooltip()).toBeTruthy();
-
-    // Flush the draw log to make sure we properly draw the graph later.
-    flushDrawLog();
-
-    // Do something that updates the flame graph component.
-    fireEvent.keyDown(div, { key: 'Enter' });
-
-    // Now the tooltip should not be displayed because it could show invalid data.
-    expect(getTooltip()).toBeFalsy();
-
-    // Make sure that the graph is rendered properly.
-    const drawCalls = flushDrawLog();
-    expect(drawCalls.length).toBeGreaterThan(0);
   });
 
   it('has a tooltip that matches the snapshot with categories', () => {


### PR DESCRIPTION
Fixes #5140.

Let's move on with disabling it as a first step and then we can discuss a more elegant way to persist it.

[Deploy preview](https://deploy-preview-5147--perf-html.netlify.app/public/28p7jvd50ycpf740a3y7cqqfp8mqp6671fzwt58/flame-graph/?globalTrackOrder=0wxt&hiddenGlobalTracks=1wxt&hiddenLocalTracksByPid=62037-1w3~64317-0~64319-0~64247-0~62826-0~64259-0~64270-0~62750-01~63028-0~62986-01~63847-0~63181-0~63837-0~63574-0~62570-0~63612-0~62790-0~62722-01~63042-0~63635-0~62955-0~62930-0~62582-01~62576-0~63512-0~62921-0~63148-0~63213-0~62806-0~63352-0~63268-0~62464-0~63092-0~62630-0~62862-0~63450-0~62610-0~63416-01~63207-01~62910-0~62666-0~62458-0~63165-0~62890-0~62672-0~63832-0~62267-0&thread=0&v=10)