### PR TITLE
Change the 'is-ready' postMessage pairs to 'ready:request' and 'ready:response' to be more explicit

### DIFF
--- a/docs-developer/loading-in-profiles.md
+++ b/docs-developer/loading-in-profiles.md
@@ -110,7 +110,7 @@ Firefox loads the profiles directly into the front-end through a WebChannel mech
 
 A profile can be injected via another website and the postMessage API.
 
-First wait for the page to be ready. This can be done by posting an `{ name: 'is-ready' }` message and waiting for the response of a similar `{ name: 'is-ready' }`.
+First wait for the page to be ready. This can be done by posting an `{ name: 'ready:request' }` message and waiting for the response of a similar `{ name: 'ready:response' }`.
 
 ```js
 /**
@@ -133,7 +133,7 @@ function openProfile(profile) {
    * @param {MessageEvent} event
    */
   const listener = ({ data }) => {
-    if (data?.name === 'is-ready') {
+    if (data?.name === 'ready:response') {
       console.log('The profiler is ready. Injecting the profile.');
       isReady = true;
       const message = {
@@ -148,7 +148,7 @@ function openProfile(profile) {
   window.addEventListener('message', listener);
   while (!isReady) {
     await new Promise((resolve) => setTimeout(resolve, 100));
-    profilerWindow.postMessage({ name: 'is-ready' }, origin);
+    profilerWindow.postMessage({ name: 'ready:request' }, origin);
   }
 
   window.removeEventListener('message', listener);

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1712,17 +1712,17 @@ export function retrieveProfileForRawUrl(
             case 'inject-profile':
               dispatch(viewProfileFromPostMessage(data.profile));
               break;
-            case 'is-ready': {
+            case 'ready:request': {
               // The "inject-profile" event could be coming from a variety of locations.
               // It could come from a `window.open` call on another page. It could come
               // from an addon. It could come from being embedded in an iframe. In order
               // to generically support these cases allow the opener to poll for the
-              // "is-ready" message.
+              // "ready:response" message.
               console.log(
                 'Responding via postMessage that the profiler is ready.'
               );
               const otherWindow = event.source ?? window;
-              otherWindow.postMessage({ name: 'is-ready' }, '*');
+              otherWindow.postMessage({ name: 'ready:response' }, '*');
               break;
             }
             default:

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -363,13 +363,17 @@ describe('UrlManager', function () {
 
     await new Promise((resolve) => {
       function listener({ data }) {
-        if (data && typeof data === 'object' && data.name === 'is-ready') {
+        if (
+          data &&
+          typeof data === 'object' &&
+          data.name === 'ready:response'
+        ) {
           resolve();
           window.removeEventListener('message', listener);
         }
       }
       window.addEventListener('message', listener);
-      window.postMessage({ name: 'is-ready' }, '*');
+      window.postMessage({ name: 'ready:request' }, '*');
     });
 
     window.postMessage(


### PR DESCRIPTION
Edit after updating the PR:
I have changed the postMessage names directly now to `'ready:request'` and `'ready:response'` to be more explicit.

Before update:
This changes the `is-ready` message handling that comes from `postMessage`. I needed this for a Chrome extension I was working on. But in their extension API you have to be in the same `window` while sending this message. That's why when `is-ready` returns a message with the same name to itself, it creates an infinite loop. I changed the name from `is-ready` to `ready` when notifying the profiler is ready.

@gregtatum I wanted to get your feedback since you implemented this feature initially for your work. I would prefer to always send `ready` instead of `is-ready` but that would probably break your use case. So that's why I went with a non-breaking usage where I check if the windows are the same and if so, send a message with a different name. Let me know what you think!