### PR TITLE
Remove the console warnings that are happening while computing the tab to thread indexes map

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -3747,9 +3747,6 @@ export function computeTabToThreadIndexesMap(
       if (tabID === undefined) {
         // We couldn't find the tab of this innerWindowID, this should
         // never happen, it might indicate a bug in Firefox.
-        console.warn(
-          `Failed to find the tabID of innerWindowID ${innerWindowID}`
-        );
         continue;
       }
 
@@ -3780,9 +3777,6 @@ export function computeTabToThreadIndexesMap(
         if (tabID === undefined) {
           // We couldn't find the tab of this innerWindowID, this should
           // never happen, it might indicate a bug in Firefox.
-          console.warn(
-            `Failed to find the tabID of innerWindowID ${innerWindowID}`
-          );
           continue;
         }
 


### PR DESCRIPTION
I added these console.warns while working on the tab selector, thinking that it shouldn't happen frequently. But it looks like we always see some console warnings now when we capture a new profile. This is either happening when we reopen an old Firefox session, or there is some other bug where we don't properly register the pages.

I filed a bug to investigate this issue: [Bug 1924681](https://bugzilla.mozilla.org/show_bug.cgi?id=1924681)

Let's remove these currently so we don't pollute the console.