### PR TITLE
Retrieve the page favicons from the browser and display it on the tab selector

### DIFF
--- a/src/actions/icons.js
+++ b/src/actions/icons.js
@@ -83,6 +83,37 @@ export function iconStartLoading(icon: string): ThunkAction<Promise<void>> {
 }
 
 /**
+ * Batch load the data url icons.
+ *
+ * We don't need to check if they are valid images or not, so we can omit doing
+ * this extra work for these icons. Just add them directly to our cache and state.
+ */
+export function batchLoadDataUrlIcons(
+  iconsToAdd: Array<string | null>
+): ThunkAction<void> {
+  return (dispatch) => {
+    const newIcons = [];
+    for (const icon of iconsToAdd) {
+      if (!icon || icons.has(icon)) {
+        continue;
+      }
+
+      icons.add(icon);
+
+      // New class name for an icon. They are guaranteed to be unique, that's why
+      // just increment the icon counter and return that string.
+      const className = `favicon-${++iconCounter}`;
+      newIcons.push({ icon, className });
+    }
+
+    dispatch({
+      type: 'ICON_BATCH_ADD',
+      icons: newIcons,
+    });
+  };
+}
+
+/**
  * Only use it in tests!
  */
 export function _resetIconCounter() {

--- a/src/actions/icons.js
+++ b/src/actions/icons.js
@@ -3,10 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Action, ThunkAction } from 'firefox-profiler/types';
+import type {
+  Action,
+  ThunkAction,
+  IconWithClassName,
+} from 'firefox-profiler/types';
 import sha1 from 'firefox-profiler/utils/sha1';
 
-export function iconHasLoaded(iconWithClassName: [string, string]): Action {
+export function iconHasLoaded(iconWithClassName: {|
+  +icon: string,
+  +className: string,
+|}): Action {
   return {
     type: 'ICON_HAS_LOADED',
     iconWithClassName,
@@ -24,7 +31,10 @@ const icons: Set<string> = new Set();
 
 type IconRequestResult =
   | {| type: 'error' | 'cached' |}
-  | {| type: 'loaded', iconWithClassName: [string, string] |};
+  | {|
+      type: 'loaded',
+      iconWithClassName: IconWithClassName,
+    |};
 
 async function _getIcon(icon: string): Promise<IconRequestResult> {
   if (icons.has(icon)) {
@@ -39,7 +49,7 @@ async function _getIcon(icon: string): Promise<IconRequestResult> {
     image.src = icon;
     image.referrerPolicy = 'no-referrer';
     image.onload = () => {
-      resolve({ type: 'loaded', iconWithClassName: [icon, className] });
+      resolve({ type: 'loaded', iconWithClassName: { icon, className } });
     };
     image.onerror = () => {
       resolve({ type: 'error' });

--- a/src/actions/icons.js
+++ b/src/actions/icons.js
@@ -8,7 +8,6 @@ import type {
   ThunkAction,
   IconWithClassName,
 } from 'firefox-profiler/types';
-import sha1 from 'firefox-profiler/utils/sha1';
 
 export function iconHasLoaded(iconWithClassName: {|
   +icon: string,
@@ -28,6 +27,7 @@ export function iconIsInError(icon: string): Action {
 }
 
 const icons: Set<string> = new Set();
+let iconCounter = 0;
 
 type IconRequestResult =
   | {| type: 'error' | 'cached' |}
@@ -42,7 +42,10 @@ async function _getIcon(icon: string): Promise<IconRequestResult> {
   }
 
   icons.add(icon);
-  const className = await _classNameFromUrl(icon);
+
+  // New class name for an icon. They are guaranteed to be unique, that's why
+  // just increment the icon counter and return that string.
+  const className = `favicon-${++iconCounter}`;
 
   const result = new Promise((resolve) => {
     const image = new Image();
@@ -80,10 +83,8 @@ export function iconStartLoading(icon: string): ThunkAction<Promise<void>> {
 }
 
 /**
- * Transforms a URL into a valid CSS class name.
+ * Only use it in tests!
  */
-async function _classNameFromUrl(url): Promise<string> {
-  return url.startsWith('data:image/')
-    ? 'dataUrl' + (await sha1(url))
-    : url.replace(/[/:.+>< ~()#,]/g, '_');
+export function _resetIconCounter() {
+  iconCounter = 0;
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -267,9 +267,19 @@ export function finalizeProfileView(
         );
     }
 
+    let faviconsPromise = null;
+    if (browserConnection && pages && pages.length > 0) {
+      faviconsPromise = retrievePageFaviconsFromBrowser(
+        dispatch,
+        pages,
+        browserConnection
+      );
+    }
+
     // Note we kick off symbolication only for the profiles we know for sure
     // that they weren't symbolicated.
     // We can skip the symbolication in tests if needed.
+    let symbolicationPromise = null;
     if (!skipSymbolication && profile.meta.symbolicated === false) {
       const symbolStore = getSymbolStore(
         dispatch,
@@ -279,13 +289,15 @@ export function finalizeProfileView(
       if (symbolStore) {
         // Only symbolicate if a symbol store is available. In tests we may not
         // have access to IndexedDB.
-        await doSymbolicateProfile(dispatch, profile, symbolStore);
+        symbolicationPromise = doSymbolicateProfile(
+          dispatch,
+          profile,
+          symbolStore
+        );
       }
     }
 
-    if (browserConnection && pages && pages.length > 0) {
-      await retrievePageFaviconsFromBrowser(dispatch, pages, browserConnection);
-    }
+    await Promise.all([faviconsPromise, symbolicationPromise]);
   };
 }
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1029,22 +1029,24 @@ export async function retrievePageFaviconsFromBrowser(
 ) {
   const newPages = [...pages];
 
-  await browserConnection
-    .getPageFavicons(newPages.map((p) => p.url))
-    .then((favicons) => {
-      if (newPages.length !== favicons.length) {
-        // It appears that an error occurred since the pages and favicons arrays
-        // have different lengths. Return early without doing anything.
-        return;
-      }
+  const favicons = await browserConnection.getPageFavicons(
+    newPages.map((p) => p.url)
+  );
 
-      for (let index = 0; index < favicons.length; index++) {
-        newPages[index] = {
-          ...newPages[index],
-          favicon: favicons[index],
-        };
-      }
-    });
+  if (newPages.length !== favicons.length) {
+    // It appears that an error occurred since the pages and favicons arrays
+    // have different lengths. Return early without doing anything.
+    return;
+  }
+
+  for (let index = 0; index < favicons.length; index++) {
+    if (favicons[index]) {
+      newPages[index] = {
+        ...newPages[index],
+        favicon: favicons[index],
+      };
+    }
+  }
 
   dispatch({
     type: 'UPDATE_PAGES',

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1037,7 +1037,8 @@ export async function retrievePageFaviconsFromBrowser(
 
   if (newPages.length !== favicons.length) {
     // It appears that an error occurred since the pages and favicons arrays
-    // have different lengths. Return early without doing anything.
+    // have different lengths. Return early without doing anything. The favicons
+    // array will be empty if Firefox doesn't support this webchannel request.
     return;
   }
 

--- a/src/app-logic/browser-connection.js
+++ b/src/app-logic/browser-connection.js
@@ -190,7 +190,7 @@ class BrowserConnectionImpl implements BrowserConnection {
   async getPageFavicons(
     pageUrls: Array<string>
   ): Promise<Array<FaviconData | null>> {
-    // This is added in Firefox 133.
+    // This is added in Firefox 134.
     if (this._webChannelSupportsGetPageFavicons) {
       return getPageFaviconsViaWebChannel(pageUrls);
     }

--- a/src/app-logic/browser-connection.js
+++ b/src/app-logic/browser-connection.js
@@ -13,7 +13,7 @@ import {
   querySymbolicationApiViaWebChannel,
   getPageFaviconsViaWebChannel,
 } from './web-channel';
-import type { Milliseconds } from 'firefox-profiler/types';
+import type { Milliseconds, FaviconData } from 'firefox-profiler/types';
 
 /**
  * This file manages the communication between the profiler and the browser.
@@ -70,7 +70,7 @@ export interface BrowserConnection {
     breakpadId: string
   ): Promise<SymbolTableAsTuple>;
 
-  getPageFavicons(pageUrls: Array<string>): Promise<Array<string | null>>;
+  getPageFavicons(pageUrls: Array<string>): Promise<Array<FaviconData | null>>;
 }
 
 /**
@@ -189,7 +189,7 @@ class BrowserConnectionImpl implements BrowserConnection {
 
   async getPageFavicons(
     pageUrls: Array<string>
-  ): Promise<Array<string | null>> {
+  ): Promise<Array<FaviconData | null>> {
     // This is added in Firefox 133.
     if (this._webChannelSupportsGetPageFavicons) {
       return getPageFaviconsViaWebChannel(pageUrls);

--- a/src/app-logic/web-channel.js
+++ b/src/app-logic/web-channel.js
@@ -8,6 +8,7 @@ import type {
   Milliseconds,
   MixedObject,
   ExternalMarkersData,
+  FaviconData,
 } from 'firefox-profiler/types';
 
 /**
@@ -120,7 +121,7 @@ type GetExternalMarkersResponse = ExternalMarkersData;
 type GetExternalPowerTracksResponse = MixedObject[];
 type GetSymbolTableResponse = SymbolTableAsTuple;
 type QuerySymbolicationApiResponse = string;
-type GetPageFaviconsResponse = Array<string | null>;
+type GetPageFaviconsResponse = Array<FaviconData | null>;
 
 // Manually declare all pairs of request + response for Flow.
 /* eslint-disable no-redeclare */

--- a/src/app-logic/web-channel.js
+++ b/src/app-logic/web-channel.js
@@ -113,6 +113,11 @@ type StatusQueryResponse = {|
   //   Shipped in Firefox 125.
   //   Adds support for the following message types:
   //    - GET_EXTERNAL_MARKERS
+  // Version 4:
+  //   Shipped in Firefox 134.
+  //   Adds support for the following message types:
+  //    - GET_PAGE_FAVICONS
+
   version?: number,
 |};
 type EnableMenuButtonResponse = void;

--- a/src/app-logic/web-channel.js
+++ b/src/app-logic/web-channel.js
@@ -27,7 +27,8 @@ export type Request =
   | GetExternalMarkersRequest
   | GetExternalPowerTracksRequest
   | GetSymbolTableRequest
-  | QuerySymbolicationApiRequest;
+  | QuerySymbolicationApiRequest
+  | GetPageFaviconsRequest;
 
 type StatusQueryRequest = {| type: 'STATUS_QUERY' |};
 type EnableMenuButtonRequest = {| type: 'ENABLE_MENU_BUTTON' |};
@@ -51,6 +52,10 @@ type QuerySymbolicationApiRequest = {|
   type: 'QUERY_SYMBOLICATION_API',
   path: string,
   requestJson: string,
+|};
+type GetPageFaviconsRequest = {|
+  type: 'GET_PAGE_FAVICONS',
+  pageUrls: Array<string>,
 |};
 
 export type MessageFromBrowser<R: ResponseFromBrowser> =
@@ -82,7 +87,8 @@ export type ResponseFromBrowser =
   | GetExternalMarkersResponse
   | GetExternalPowerTracksResponse
   | GetSymbolTableResponse
-  | QuerySymbolicationApiResponse;
+  | QuerySymbolicationApiResponse
+  | GetPageFaviconsResponse;
 
 type StatusQueryResponse = {|
   menuButtonIsEnabled: boolean,
@@ -114,6 +120,7 @@ type GetExternalMarkersResponse = ExternalMarkersData;
 type GetExternalPowerTracksResponse = MixedObject[];
 type GetSymbolTableResponse = SymbolTableAsTuple;
 type QuerySymbolicationApiResponse = string;
+type GetPageFaviconsResponse = Array<string | null>;
 
 // Manually declare all pairs of request + response for Flow.
 /* eslint-disable no-redeclare */
@@ -138,6 +145,9 @@ declare function _sendMessageWithResponse(
 declare function _sendMessageWithResponse(
   QuerySymbolicationApiRequest
 ): Promise<QuerySymbolicationApiResponse>;
+declare function _sendMessageWithResponse(
+  GetPageFaviconsRequest
+): Promise<GetPageFaviconsResponse>;
 /* eslint-enable no-redeclare */
 
 /**
@@ -223,6 +233,15 @@ export async function querySymbolicationApiViaWebChannel(
     type: 'QUERY_SYMBOLICATION_API',
     path,
     requestJson,
+  });
+}
+
+export async function getPageFaviconsViaWebChannel(
+  pageUrls: Array<string>
+): Promise<GetPageFaviconsResponse> {
+  return _sendMessageWithResponse({
+    type: 'GET_PAGE_FAVICONS',
+    pageUrls,
   });
 }
 

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -38,7 +38,7 @@ import { BackgroundImageStyleDef } from 'firefox-profiler/components/shared/Styl
 import classNames from 'classnames';
 import { DebugWarning } from 'firefox-profiler/components/app/DebugWarning';
 
-import type { CssPixels, IconWithClassName } from 'firefox-profiler/types';
+import type { CssPixels, IconsWithClassNames } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import './ProfileViewer.css';
@@ -50,7 +50,7 @@ type StateProps = {|
   +isUploading: boolean,
   +isHidingStaleProfile: boolean,
   +hasSanitizedProfile: boolean,
-  +icons: IconWithClassName[],
+  +icons: IconsWithClassNames,
   +isBottomBoxOpen: boolean,
 |};
 
@@ -83,7 +83,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
           profileViewerWrapperBackground: hasSanitizedProfile,
         })}
       >
-        {icons.map(({ className, icon }) => (
+        {[...icons].map(([icon, className]) => (
           <BackgroundImageStyleDef
             className={className}
             url={icon}

--- a/src/components/shared/TabSelectorMenu.css
+++ b/src/components/shared/TabSelectorMenu.css
@@ -17,3 +17,7 @@
   /* Move the checkmark to inline-start instead of right, as it's logically better. */
   inset-inline: 8px 0;
 }
+
+.tabSelectorMenuItem .nodeIcon {
+  margin-inline-end: 10px;
+}

--- a/src/components/shared/TabSelectorMenu.js
+++ b/src/components/shared/TabSelectorMenu.js
@@ -13,6 +13,7 @@ import explicitConnect from 'firefox-profiler/utils/connect';
 import { changeTabFilter } from 'firefox-profiler/actions/receive-profile';
 import { getTabFilter } from '../../selectors/url-state';
 import { getProfileFilterSortedPageData } from 'firefox-profiler/selectors/profile';
+import { Icon } from 'firefox-profiler/components/shared/Icon';
 
 import type { TabID, SortedTabPageData } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
@@ -40,6 +41,10 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
     if (!sortedPageData || sortedPageData.length === 0) {
       return null;
     }
+
+    const hasSomeIcons = sortedPageData.some(
+      ({ pageData }) => !!pageData.favicon
+    );
 
     return (
       <>
@@ -71,6 +76,7 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
               'aria-checked': tabFilter === tabID ? 'false' : 'true',
             }}
           >
+            {hasSomeIcons ? <Icon iconUrl={pageData.favicon} /> : null}
             {pageData.hostname}
           </MenuItem>
         ))}

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2963,7 +2963,8 @@ export function extractProfileFilterPageData(
     }
 
     // The last page is the one we care about.
-    const pageUrl = topMostPages[topMostPages.length - 1].url;
+    const currentPage = topMostPages[topMostPages.length - 1];
+    const pageUrl = currentPage.url;
     if (pageUrl.startsWith('about:')) {
       // If we only have an `about:*` page, we should return early with a friendly
       // origin and hostname. Otherwise the try block will always fail.
@@ -2986,7 +2987,7 @@ export function extractProfileFilterPageData(
     const pageData: ProfileFilterPageData = {
       origin: '',
       hostname: '',
-      favicon: null,
+      favicon: currentPage.favicon ?? null,
     };
 
     try {
@@ -3005,15 +3006,8 @@ export function extractProfileFilterPageData(
             ) ?? '')
           : page.hostname;
 
-      // FIXME(Bug 1620546): This is not ideal and we should get the favicon
-      // either during profile capture or profile pre-process.
       pageData.origin = page.origin;
-      const favicon = new URL('/favicon.ico', page.origin);
-      if (favicon.protocol === 'http:') {
-        // Upgrade http requests.
-        favicon.protocol = 'https:';
-      }
-      pageData.favicon = favicon.href;
+      pageData.favicon = currentPage.favicon ?? null;
     } catch (e) {
       console.warn(
         'Error while extracing the hostname and favicon from the page url',

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -3007,7 +3007,6 @@ export function extractProfileFilterPageData(
           : page.hostname;
 
       pageData.origin = page.origin;
-      pageData.favicon = currentPage.favicon ?? null;
     } catch (e) {
       console.warn(
         'Error while extracing the hostname and favicon from the page url',

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -120,6 +120,8 @@ export function sanitizePII(
       pages = pages.map((page, pageIndex) => ({
         ...page,
         url: removeURLs(page.url, `<Page #${pageIndex}>`),
+        // Remove the favicon data as it could reveal the url.
+        favicon: null,
       }));
     }
   }

--- a/src/reducers/icons.js
+++ b/src/reducers/icons.js
@@ -11,6 +11,14 @@ const favicons: Reducer<IconsWithClassNames> = (state = new Map(), action) => {
       const { icon, className } = action.iconWithClassName;
       return new Map([...state.entries(), [icon, className]]);
     }
+    case 'ICON_BATCH_ADD': {
+      const newState = new Map([...state.entries()]);
+      for (const { icon, className } of action.icons) {
+        newState.set(icon, className);
+      }
+
+      return newState;
+    }
     case 'ICON_IN_ERROR': // nothing to do
     default:
       return state;

--- a/src/reducers/icons.js
+++ b/src/reducers/icons.js
@@ -7,8 +7,10 @@ import type { Reducer, IconsWithClassNames } from 'firefox-profiler/types';
 
 const favicons: Reducer<IconsWithClassNames> = (state = new Map(), action) => {
   switch (action.type) {
-    case 'ICON_HAS_LOADED':
-      return new Map([...state.entries(), action.iconWithClassName]);
+    case 'ICON_HAS_LOADED': {
+      const { icon, className } = action.iconWithClassName;
+      return new Map([...state.entries(), [icon, className]]);
+    }
     case 'ICON_IN_ERROR': // nothing to do
     default:
       return state;

--- a/src/reducers/icons.js
+++ b/src/reducers/icons.js
@@ -5,10 +5,10 @@
 // @flow
 import type { Reducer } from 'firefox-profiler/types';
 
-const favicons: Reducer<Set<string>> = (state = new Set(), action) => {
+const favicons: Reducer<Map<string, string>> = (state = new Map(), action) => {
   switch (action.type) {
     case 'ICON_HAS_LOADED':
-      return new Set([...state, action.icon]);
+      return new Map([...state.entries(), action.iconWithClassName]);
     case 'ICON_IN_ERROR': // nothing to do
     default:
       return state;

--- a/src/reducers/icons.js
+++ b/src/reducers/icons.js
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Reducer } from 'firefox-profiler/types';
+import type { Reducer, IconsWithClassNames } from 'firefox-profiler/types';
 
-const favicons: Reducer<Map<string, string>> = (state = new Map(), action) => {
+const favicons: Reducer<IconsWithClassNames> = (state = new Map(), action) => {
   switch (action.type) {
     case 'ICON_HAS_LOADED':
       return new Map([...state.entries(), action.iconWithClassName]);

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -75,7 +75,7 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
     case 'UPDATE_PAGES': {
       if (state === null) {
         throw new Error(
-          `Assumed that a profile would be loaded by the time for the pages update`
+          `We tried to update the pages information for a non-existent profile.`
         );
       }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -72,6 +72,16 @@ const profile: Reducer<Profile | null> = (state = null, action) => {
         },
       };
     }
+    case 'UPDATE_PAGES': {
+      if (state === null) {
+        throw new Error(
+          `Assumed that a profile would be loaded by the time for the pages update`
+        );
+      }
+
+      const { newPages } = action;
+      return { ...state, pages: newPages };
+    }
     default:
       return state;
   }

--- a/src/selectors/icons.js
+++ b/src/selectors/icons.js
@@ -3,9 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { createSelector } from 'reselect';
 import type {
-  IconWithClassName,
   IconState,
   Selector,
   DangerousSelectorWithArguments,
@@ -13,8 +11,10 @@ import type {
 
 /**
  * A simple selector into the icon state.
+ * It returns a map that matches icon to the icon class name.
  */
-export const getIcons: Selector<IconState> = (state) => state.icons;
+export const getIconsWithClassNames: Selector<IconState> = (state) =>
+  state.icons;
 
 /**
  * In order to load icons without multiple requests, icons are created through
@@ -26,21 +26,9 @@ export const getIconClassName: DangerousSelectorWithArguments<
   string,
   string | null,
 > = (state, icon) => {
-  const icons = getIcons(state);
-  return icon !== null && icons.has(icon) ? _classNameFromUrl(icon) : '';
+  if (icon === null) {
+    return '';
+  }
+  const icons = getIconsWithClassNames(state);
+  return icons.get(icon) ?? '';
 };
-
-/**
- * This functions returns an object with both the icon URL and the class name.
- */
-export const getIconsWithClassNames: Selector<IconWithClassName[]> =
-  createSelector(getIcons, (icons) =>
-    [...icons].map((icon) => ({ icon, className: _classNameFromUrl(icon) }))
-  );
-
-/**
- * Transforms a URL into a valid CSS class name.
- */
-function _classNameFromUrl(url): string {
-  return url.replace(/[/:.+>< ~()#,]/g, '_');
-}

--- a/src/selectors/icons.js
+++ b/src/selectors/icons.js
@@ -4,7 +4,7 @@
 
 // @flow
 import type {
-  IconState,
+  IconsWithClassNames,
   Selector,
   DangerousSelectorWithArguments,
 } from 'firefox-profiler/types';
@@ -13,7 +13,7 @@ import type {
  * A simple selector into the icon state.
  * It returns a map that matches icon to the icon class name.
  */
-export const getIconsWithClassNames: Selector<IconState> = (state) =>
+export const getIconsWithClassNames: Selector<IconsWithClassNames> = (state) =>
   state.icons;
 
 /**

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -18,22 +18,9 @@ import {
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
 import { getTabFilter } from '../../selectors/url-state';
-import { createImageMock } from '../fixtures/mocks/image';
 import { ensureExists } from 'firefox-profiler/utils/flow';
 
 describe('app/TabSelectorMenu', () => {
-  beforeAll(() => {
-    const mock = createImageMock();
-    (window: any).Image = mock.Image;
-  });
-
-  afterAll(() => {
-    // Let all the async favicons finish creating the images.
-    requestAnimationFrame(() => {
-      delete (window: any).Image;
-    });
-  });
-
   function setup() {
     const { profile, ...extraPageData } = addActiveTabInformationToProfile(
       getProfileWithNiceTracks()

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -18,12 +18,28 @@ import {
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
 import { getTabFilter } from '../../selectors/url-state';
+import { createImageMock } from '../fixtures/mocks/image';
+import { ensureExists } from 'firefox-profiler/utils/flow';
 
 describe('app/TabSelectorMenu', () => {
+  beforeAll(() => {
+    const mock = createImageMock();
+    (window: any).Image = mock.Image;
+  });
+
+  afterAll(() => {
+    // Let all the async favicons finish creating the images.
+    requestAnimationFrame(() => {
+      delete (window: any).Image;
+    });
+  });
+
   function setup() {
     const { profile, ...extraPageData } = addActiveTabInformationToProfile(
       getProfileWithNiceTracks()
     );
+    ensureExists(profile.pages)[3].favicon =
+      'data:image/png;base64,test-png-favicon-data-for-profiler.firefox.com';
 
     // This is needed for the thread activity score calculation.
     profile.meta.sampleUnits = {

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -89,9 +89,6 @@ exports[`app/ProfileFilterNavigator renders the site hostname as its first eleme
     <span
       class="filterNavigatorBarItemContent"
     >
-      <div
-        class="nodeIcon "
-      />
       <span
         title="https://developer.mozilla.org"
       >

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
@@ -40,6 +40,9 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
         role="menuitem"
         tabindex="-1"
       >
+        <div
+          class="nodeIcon "
+        />
         profiler.firefox.com
       </div>
       <div
@@ -49,6 +52,9 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
         role="menuitem"
         tabindex="-1"
       >
+        <div
+          class="nodeIcon "
+        />
         mozilla.org
       </div>
     </nav>

--- a/src/test/fixtures/mocks/web-channel.js
+++ b/src/test/fixtures/mocks/web-channel.js
@@ -8,6 +8,7 @@ import type {
   MessageFromBrowser,
   MessageToBrowser,
 } from '../../../app-logic/web-channel';
+import type { FaviconData } from 'firefox-profiler/types';
 
 /**
  * Mock out the WebChannel, a Firefox internal mechanism that allows us to
@@ -144,7 +145,7 @@ export function simulateWebChannel(profileGetter: () => mixed) {
           requestId: message.requestId,
           response: {
             menuButtonIsEnabled: true,
-            version: 1,
+            version: 4,
           },
         });
         break;
@@ -176,6 +177,31 @@ export function simulateWebChannel(profileGetter: () => mixed) {
         });
         break;
       }
+      case 'GET_EXTERNAL_MARKERS': {
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: {},
+        });
+        break;
+      }
+      case 'GET_EXTERNAL_POWER_TRACKS': {
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: ([]: MixedObject[]),
+        });
+        break;
+      }
+      case 'GET_PAGE_FAVICONS': {
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: ([]: Array<FaviconData | null>),
+        });
+        break;
+      }
+
       default: {
         triggerResponse({
           type: 'ERROR_RESPONSE',

--- a/src/test/fixtures/mocks/web-channel.js
+++ b/src/test/fixtures/mocks/web-channel.js
@@ -133,7 +133,10 @@ export function simulateOldWebChannelAndFrameScript(
   return webChannel;
 }
 
-export function simulateWebChannel(profileGetter: () => mixed) {
+export function simulateWebChannel(
+  profileGetter: () => mixed,
+  faviconsGetter?: () => Promise<Array<FaviconData | null>>
+) {
   const webChannel = mockWebChannel();
 
   const { registerMessageToChromeListener, triggerResponse } = webChannel;
@@ -194,14 +197,16 @@ export function simulateWebChannel(profileGetter: () => mixed) {
         break;
       }
       case 'GET_PAGE_FAVICONS': {
+        const favicons: Array<FaviconData | null> = faviconsGetter
+          ? await faviconsGetter()
+          : [];
         triggerResponse({
           type: 'SUCCESS_RESPONSE',
           requestId: message.requestId,
-          response: ([]: Array<FaviconData | null>),
+          response: favicons,
         });
         break;
       }
-
       default: {
         triggerResponse({
           type: 'ERROR_RESPONSE',

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -251,7 +251,7 @@ export function createGeckoProfile(): GeckoProfile {
     {
       tabID: tabID,
       innerWindowID: 111111,
-      url: 'URL',
+      url: 'https://mozilla.org/',
       embedderInnerWindowID: 0,
     },
   ];

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -10,6 +10,7 @@ import '@testing-library/jest-dom';
 import fetchMock from 'fetch-mock-jest';
 import { Headers, Request, Response } from 'node-fetch';
 import { TextDecoder, TextEncoder } from 'util';
+import crypto from 'crypto';
 
 jest.mock('../utils/worker-factory');
 import * as WorkerFactory from '../utils/worker-factory';
@@ -85,5 +86,12 @@ expect.extend({
         `expected element to have class ${className}, current classes are ${received.className}`,
       pass: false,
     };
+  },
+});
+
+Object.defineProperty(global.self, 'crypto', {
+  value: {
+    // $FlowExpectError This flow version doesn't know about webcrypto
+    subtle: crypto.webcrypto.subtle,
   },
 });

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -15,10 +15,7 @@ describe('actions/icons', function () {
     'https://valid.icon1.example.org/favicon.ico',
     'https://valid.icon2.example.org/favicon.ico',
   ];
-  const expectedClasses = [
-    'https___valid_icon1_example_org_favicon_ico',
-    'https___valid_icon2_example_org_favicon_ico',
-  ];
+  const expectedClasses = ['favicon-1', 'favicon-2'];
   const invalidIcon = 'https://invalid.icon.example.org/favicon.ico';
 
   let imageInstances: Image[] = [];
@@ -32,6 +29,7 @@ describe('actions/icons', function () {
   afterEach(() => {
     delete (window: any).Image;
     imageInstances = [];
+    iconsActions._resetIconCounter();
   });
 
   function _createCallNodeWithIcon(icon: string): CallNodeDisplayData {

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -56,9 +56,10 @@ describe('actions/icons', function () {
       return blankStore().getState();
     }
 
-    it('getIcons return an empty set', function () {
-      const initialState = iconsAccessors.getIcons(getInitialState());
-      expect(initialState).toBeInstanceOf(Set);
+    it('getIconsWithClassNames return an empty map', function () {
+      const initialState =
+        iconsAccessors.getIconsWithClassNames(getInitialState());
+      expect(initialState).toBeInstanceOf(Map);
       expect(initialState.size).toEqual(0);
     });
 
@@ -68,11 +69,6 @@ describe('actions/icons', function () {
         _createCallNodeWithIcon(validIcons[0]).icon
       );
       expect(subject).toBe('');
-    });
-
-    it('getIconsWithClassNames returns an empty array', function () {
-      const subject = iconsAccessors.getIconsWithClassNames(getInitialState());
-      expect(subject).toEqual([]);
     });
   });
 
@@ -87,6 +83,11 @@ describe('actions/icons', function () {
         dispatch(iconsActions.iconStartLoading(validIcons[1])),
       ];
 
+      // Let the event loop go around for iconStartLoading. Note that we don't
+      // want to await for the promises yet, since we would like to mock them.
+      // We will await them later.
+      await new Promise((res) => requestAnimationFrame(res));
+
       // Only 2 requests because only 2 different icons
       expect(imageInstances.length).toBe(2);
       imageInstances.forEach((instance, i) => {
@@ -97,12 +98,9 @@ describe('actions/icons', function () {
       await Promise.all(promises);
 
       const state = getState();
-      let subject = iconsAccessors.getIcons(state);
-      expect([...subject]).toEqual(validIcons);
-
-      subject = iconsAccessors.getIconsWithClassNames(state);
-      expect(subject).toEqual(
-        validIcons.map((icon, i) => ({ icon, className: expectedClasses[i] }))
+      let subject = iconsAccessors.getIconsWithClassNames(state);
+      expect([...subject]).toEqual(
+        validIcons.map((icon, i) => [icon, expectedClasses[i]])
       );
 
       validIcons.forEach((icon, i) => {
@@ -121,13 +119,17 @@ describe('actions/icons', function () {
       const actionPromise = dispatch(
         iconsActions.iconStartLoading(invalidIcon)
       );
+      // Let the event loop go around for iconStartLoading. Note that we don't
+      // want to await for the promises yet, since we would like to mock them.
+      // We will await them later.
+      await new Promise((res) => requestAnimationFrame(res));
       expect(imageInstances.length).toBe(1);
       (imageInstances[0]: any).onerror();
 
       await actionPromise;
 
       const state = getState();
-      let subject = iconsAccessors.getIcons(state);
+      let subject = iconsAccessors.getIconsWithClassNames(state);
       expect([...subject]).toEqual([]);
 
       subject = iconsAccessors.getIconClassName(
@@ -135,9 +137,6 @@ describe('actions/icons', function () {
         _createCallNodeWithIcon(invalidIcon).icon
       );
       expect(subject).toBe('');
-
-      subject = iconsAccessors.getIconsWithClassNames(state);
-      expect(subject).toEqual([]);
     });
   });
 });

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -8,6 +8,7 @@ import { blankStore } from '../fixtures/stores';
 import * as iconsAccessors from '../../selectors/icons';
 import * as iconsActions from '../../actions/icons';
 import type { CallNodeDisplayData } from 'firefox-profiler/types';
+import { waitFor } from 'firefox-profiler/test/fixtures/testing-library';
 
 describe('actions/icons', function () {
   const validIcons = [
@@ -56,7 +57,7 @@ describe('actions/icons', function () {
       return blankStore().getState();
     }
 
-    it('getIconsWithClassNames return an empty map', function () {
+    it('getIconsWithClassNames returns an empty map', function () {
       const initialState =
         iconsAccessors.getIconsWithClassNames(getInitialState());
       expect(initialState).toBeInstanceOf(Map);
@@ -83,10 +84,8 @@ describe('actions/icons', function () {
         dispatch(iconsActions.iconStartLoading(validIcons[1])),
       ];
 
-      // Let the event loop go around for iconStartLoading. Note that we don't
-      // want to await for the promises yet, since we would like to mock them.
-      // We will await them later.
-      await new Promise((res) => requestAnimationFrame(res));
+      // Wait until we have 2 image instances after calling iconStartLoading.
+      await waitFor(() => expect(imageInstances.length).toBe(2));
 
       // Only 2 requests because only 2 different icons
       expect(imageInstances.length).toBe(2);
@@ -119,10 +118,8 @@ describe('actions/icons', function () {
       const actionPromise = dispatch(
         iconsActions.iconStartLoading(invalidIcon)
       );
-      // Let the event loop go around for iconStartLoading. Note that we don't
-      // want to await for the promises yet, since we would like to mock them.
-      // We will await them later.
-      await new Promise((res) => requestAnimationFrame(res));
+      // Wait until we have 2 image instances after calling iconStartLoading.
+      await waitFor(() => expect(imageInstances.length).toBe(1));
       expect(imageInstances.length).toBe(1);
       (imageInstances[0]: any).onerror();
 

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -1137,18 +1137,22 @@ describe('extractProfileFilterPageData', function () {
       innerWindowID: 1,
       url: 'https://www.mozilla.org',
       embedderInnerWindowID: 0,
+      favicon: 'data:image/png;base64,test-png-favicon-data-for-mozilla.org',
     },
     aboutBlank: {
       tabID: 2222,
       innerWindowID: 2,
       url: 'about:blank',
       embedderInnerWindowID: 0,
+      favicon: null,
     },
     profiler: {
       tabID: 2222,
       innerWindowID: 3,
       url: 'https://profiler.firefox.com/public/xyz',
       embedderInnerWindowID: 0,
+      favicon:
+        'data:image/png;base64,test-png-favicon-data-for-profiler.firefox.com',
     },
     exampleSubFrame: {
       tabID: 2222,
@@ -1156,12 +1160,14 @@ describe('extractProfileFilterPageData', function () {
       url: 'https://example.com/subframe',
       // This is a subframe of the page above.
       embedderInnerWindowID: 3,
+      favicon: 'data:image/png;base64,test-png-favicon-data-for-example.com',
     },
     exampleTopFrame: {
       tabID: 2222,
       innerWindowID: 5,
       url: 'https://example.com',
       embedderInnerWindowID: 0,
+      favicon: 'data:image/png;base64,test-png-favicon-data-for-example.com',
     },
   };
 
@@ -1175,7 +1181,8 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'https://www.mozilla.org',
           hostname: 'www.mozilla.org',
-          favicon: 'https://www.mozilla.org/favicon.ico',
+          favicon:
+            'data:image/png;base64,test-png-favicon-data-for-mozilla.org',
         },
       ],
     ]);
@@ -1193,7 +1200,8 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'https://profiler.firefox.com',
           hostname: 'profiler.firefox.com',
-          favicon: 'https://profiler.firefox.com/favicon.ico',
+          favicon:
+            'data:image/png;base64,test-png-favicon-data-for-profiler.firefox.com',
         },
       ],
     ]);
@@ -1211,7 +1219,8 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'https://profiler.firefox.com',
           hostname: 'profiler.firefox.com',
-          favicon: 'https://profiler.firefox.com/favicon.ico',
+          favicon:
+            'data:image/png;base64,test-png-favicon-data-for-profiler.firefox.com',
         },
       ],
     ]);
@@ -1257,7 +1266,8 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'https://example.com',
           hostname: 'example.com',
-          favicon: 'https://example.com/favicon.ico',
+          favicon:
+            'data:image/png;base64,test-png-favicon-data-for-example.com',
         },
       ],
     ]);
@@ -1275,7 +1285,8 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'https://www.mozilla.org',
           hostname: 'www.mozilla.org',
-          favicon: 'https://www.mozilla.org/favicon.ico',
+          favicon:
+            'data:image/png;base64,test-png-favicon-data-for-mozilla.org',
         },
       ],
       [
@@ -1283,7 +1294,8 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'https://profiler.firefox.com',
           hostname: 'profiler.firefox.com',
-          favicon: 'https://profiler.firefox.com/favicon.ico',
+          favicon:
+            'data:image/png;base64,test-png-favicon-data-for-profiler.firefox.com',
         },
       ],
     ]);

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -448,6 +448,32 @@ describe('sanitizePII', function () {
     expect(includesChromeUrl).toBe(true);
   });
 
+  it('should sanitize the favicons in the pages information', function () {
+    const profile = processGeckoProfile(createGeckoProfile());
+    // Add some favicons to check later
+    ensureExists(profile.pages)[1].favicon =
+      'data:image/png;base64,mock-base64-image-data';
+
+    const { originalProfile, sanitizedProfile } = setup(
+      { shouldRemoveUrls: true },
+      profile
+    );
+
+    // Checking to make sure that we have favicons in the original profile pages array.
+    const pageUrl = ensureExists(originalProfile.pages).find(
+      (page) => page.favicon
+    );
+    if (pageUrl === undefined) {
+      throw new Error(
+        "There should be a favicon in the 'pages' array in this profile."
+      );
+    }
+
+    for (const page of ensureExists(sanitizedProfile.pages)) {
+      expect(page.favicon).toBe(null);
+    }
+  });
+
   it('should sanitize all the URLs inside network markers', function () {
     const { sanitizedProfile } = setup({
       shouldRemoveUrls: true,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -582,7 +582,8 @@ type IconsAction =
       +type: 'ICON_HAS_LOADED',
       +iconWithClassName: IconWithClassName,
     |}
-  | {| +type: 'ICON_IN_ERROR', +icon: string |};
+  | {| +type: 'ICON_IN_ERROR', +icon: string |}
+  | {| +type: 'ICON_BATCH_ADD', icons: IconWithClassName[] |};
 
 type SidebarAction = {|
   +type: 'CHANGE_SIDEBAR_OPEN_STATE',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -577,7 +577,7 @@ type UrlStateAction =
     |};
 
 type IconsAction =
-  | {| +type: 'ICON_HAS_LOADED', +icon: string |}
+  | {| +type: 'ICON_HAS_LOADED', +iconWithClassName: [string, string] |}
   | {| +type: 'ICON_IN_ERROR', +icon: string |};
 
 type SidebarAction = {|

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -576,8 +576,12 @@ type UrlStateAction =
       +selectedTab: TabSlug,
     |};
 
+export type IconWithClassName = {| +icon: string, +className: string |};
 type IconsAction =
-  | {| +type: 'ICON_HAS_LOADED', +iconWithClassName: [string, string] |}
+  | {|
+      +type: 'ICON_HAS_LOADED',
+      +iconWithClassName: IconWithClassName,
+    |}
   | {| +type: 'ICON_IN_ERROR', +icon: string |};
 
 type SidebarAction = {|

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -13,6 +13,7 @@ import type {
   TabID,
   IndexIntoCategoryList,
   IndexIntoLibs,
+  PageList,
 } from './profile';
 import type {
   CallNodePath,
@@ -442,7 +443,11 @@ type ReceiveProfileAction =
   | {| +type: 'WAITING_FOR_PROFILE_FROM_BROWSER' |}
   | {| +type: 'WAITING_FOR_PROFILE_FROM_STORE' |}
   | {| +type: 'WAITING_FOR_PROFILE_FROM_URL', +profileUrl: ?string |}
-  | {| +type: 'TRIGGER_LOADING_FROM_URL', +profileUrl: string |};
+  | {| +type: 'TRIGGER_LOADING_FROM_URL', +profileUrl: string |}
+  | {|
+      +type: 'UPDATE_PAGES',
+      +newPages: PageList,
+    |};
 
 type UrlEnhancerAction =
   | {| +type: 'START_FETCHING_PROFILES' |}

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -745,6 +745,6 @@ export type BottomBoxInfo = {|
  * Favicon data that is retrieved from the browser connection.
  */
 export type FaviconData = {|
-  +data: Uint8Array,
+  +data: ArrayBuffer,
   +mimeType: string,
 |};

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -740,3 +740,11 @@ export type BottomBoxInfo = {|
   sourceFile: string | null,
   nativeSymbols: NativeSymbolInfo[],
 |};
+
+/**
+ * Favicon data that is retrieved from the browser connection.
+ */
+export type FaviconData = {|
+  +data: Uint8Array,
+  +mimeType: string,
+|};

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -479,6 +479,11 @@ export type Page = {|
   // capturing was disabled when a private browsing window was open.
   // The property is always present in Firefox 98+.
   isPrivateBrowsing?: boolean,
+  // Favicon data of the page if it was successfully retrieved from Firefox.
+  // It's a base64 encoded URI string when available.
+  // It's null when Firefox can't get the favicon.
+  // This is added in Firefox 133, earlier profiles will not have it.
+  favicon?: string | null,
 |};
 
 export type PageList = Array<Page>;

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -482,7 +482,7 @@ export type Page = {|
   // Favicon data of the page if it was successfully retrieved from Firefox.
   // It's a base64 encoded URI string when available.
   // It's null when Firefox can't get the favicon.
-  // This is added in Firefox 133, earlier profiles will not have it.
+  // This is added in Firefox 134, earlier profiles will not have it.
   favicon?: string | null,
 |};
 

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -423,7 +423,7 @@ export type L10nState = {|
   +direction: 'ltr' | 'rtl',
 |};
 
-export type IconState = Set<string>;
+export type IconState = Map<string, string>;
 
 export type CodeState = {|
   +sourceCodeCache: Map<string, SourceCodeStatus>,
@@ -441,7 +441,7 @@ export type State = {|
   +code: CodeState,
 |};
 
-export type IconWithClassName = {|
-  +icon: string,
-  +className: string,
-|};
+/**
+ * Map of icons to their class names
+ */
+export type IconsWithClassNames = Map<string, string>;

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -423,7 +423,10 @@ export type L10nState = {|
   +direction: 'ltr' | 'rtl',
 |};
 
-export type IconState = Map<string, string>;
+/**
+ * Map of icons to their class names
+ */
+export type IconsWithClassNames = Map<string, string>;
 
 export type CodeState = {|
   +sourceCodeCache: Map<string, SourceCodeStatus>,
@@ -434,14 +437,9 @@ export type State = {|
   +app: AppState,
   +profileView: ProfileViewState,
   +urlState: UrlState,
-  +icons: IconState,
+  +icons: IconsWithClassNames,
   +zippedProfiles: ZippedProfilesState,
   +publish: PublishState,
   +l10n: L10nState,
   +code: CodeState,
 |};
-
-/**
- * Map of icons to their class names
- */
-export type IconsWithClassNames = Map<string, string>;

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -4,10 +4,10 @@
 // @flow
 
 /**
- * Encode the bytes Uint8Array into a base64 data url.
+ * Encode the ArrayBuffer{,View} bytes into a base64 data url.
  */
 export async function bytesToBase64DataUrl(
-  bytes: Uint8Array,
+  bytes: $ArrayBufferView | ArrayBuffer,
   type: string = 'application/octet-stream'
 ): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -15,14 +15,14 @@ export async function bytesToBase64DataUrl(
       onload: () => resolve((reader.result: any)),
       onerror: () => reject(reader.error),
     });
-    reader.readAsDataURL(new File([bytes], '', { type }));
+    reader.readAsDataURL(new Blob([bytes], { type }));
   });
 }
 
 /**
  * Decode the encoded base64 data url into bytes array.
  */
-export async function dataUrlToBytes(dataUrl: string): Promise<Uint8Array> {
+export async function dataUrlToBytes(dataUrl: string): Promise<ArrayBuffer> {
   const res = await fetch(dataUrl);
-  return new Uint8Array(await res.arrayBuffer());
+  return res.arrayBuffer();
 }

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+/**
+ * Encode the bytes Uint8Array into a base64 data url.
+ */
+export async function bytesToBase64DataUrl(
+  bytes: Uint8Array,
+  type: string = 'application/octet-stream'
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = Object.assign(new FileReader(), {
+      onload: () => resolve((reader.result: any)),
+      onerror: () => reject(reader.error),
+    });
+    reader.readAsDataURL(new File([bytes], '', { type }));
+  });
+}
+
+/**
+ * Decode the encoded base64 data url into bytes array.
+ */
+export async function dataUrlToBytes(dataUrl: string): Promise<Uint8Array> {
+  const res = await fetch(dataUrl);
+  return new Uint8Array(await res.arrayBuffer());
+}


### PR DESCRIPTION
This requires changes from [Bug 1921778](https://bugzilla.mozilla.org/show_bug.cgi?id=1921778) since it adds the webchannel changes in the backend.

This PR adds the ability to retrieve the favicons for pages as a data url, so we can display them easily in the frontend without needing to fetch them from their url every time we open a profile.

This also changes how we use the `Icon` component and how we compute the css class names for them. Let me know what you think!

Note that this doesn't change the other icons that we have in places like call tree. I would prefer to do it as a followup as there are some questions to answer there.

[Deploy preview with the page data retrieved already](https://deploy-preview-5166--perf-html.netlify.app/public/z1r4vb03p3deqgkrtcnnysm44521vjcdzw4dcq0)
