### PR TITLE
Fix timestamp issues in local tests

### DIFF
--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -17,6 +17,10 @@ import { autoMockResizeObserver } from './fixtures/mocks/resize-observer';
 
 autoMockResizeObserver();
 
+if (process.env.TZ !== 'UTC') {
+  throw new Error('Jest must be run from `yarn test`');
+}
+
 // Register TextDecoder and TextEncoder with the global scope.
 // These are now available globally in nodejs, but not when running with jsdom
 // in jest apparently.

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -226,7 +226,7 @@ export function addDataToWindowObject(
       // This will be imperfect because of float rounding errors but still better
       // than not having them.
       const ns = Math.trunc((ts - Math.trunc(ts)) * 10 ** 6);
-      return `${d.getFullYear()}-${pad(d.getUTCMonth() + 1, 2)}-${pad(d.getUTCDate(), 2)} ${pad(d.getUTCHours(), 2)}:${pad(d.getUTCMinutes(), 2)}:${pad(d.getUTCSeconds(), 2)}.${pad(d.getUTCMilliseconds(), 3)}${pad(ns, 6)} UTC`;
+      return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1, 2)}-${pad(d.getUTCDate(), 2)} ${pad(d.getUTCHours(), 2)}:${pad(d.getUTCMinutes(), 2)}:${pad(d.getUTCSeconds(), 2)}.${pad(d.getUTCMilliseconds(), 3)}${pad(ns, 6)} UTC`;
     }
 
     const logs = [];


### PR DESCRIPTION
For some reason the tests fail for me locally from what I assume to be timezone issues. The `getUTCFullYear` is a correctness fix, and the one just setting the date string in tests is a workaround. I couldn't get the date to change by setting the `process.env.TZ = 'UTC'`, which the internet says _should_ work.