### PR TITLE
Change the 'test-build-coverage' script to use `yarn test` instead of `jest` directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "node bin/output-fixing-commands.js cross-env LC_ALL=C TZ=UTC NODE_ENV=test jest",
     "test-all": "run-p --max-parallel 4 flow license-check lint test test-alex test-lockfile",
     "test-all:ci": "run-p --max-parallel 4 flow:ci license-check lint test test-alex test-lockfile",
-    "test-build-coverage": "jest --coverage --coverageReporters=html",
+    "test-build-coverage": "yarn test --coverage --coverageReporters=html",
     "test-serve-coverage": "ws -d coverage/ -p 4343",
     "test-coverage": "run-s test-build-coverage test-serve-coverage",
     "test-alex": "alex ./docs-* *.md",


### PR DESCRIPTION
Since it was using the jest directly without setting the important environment variables, `test-build-coverage` script was failing. If you were to run `test-coverage`, because the first one was failing, it was always stopping early without serving the files.