### PR TITLE
Add default favicons to extensions and pages that don't have nay favicons

### DIFF
--- a/res/img/svg/extension-outline.svg
+++ b/res/img/svg/extension-outline.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.5 3.75a1.75 1.75 0 0 0-1.75 1.75v2.375a.875.875 0 0 1-.875.875H6.5a.75.75 0 0 0-.75.75V11h1.5a3.5 3.5 0 1 1 0 7h-1.5v1.5c0 .414.336.75.75.75h12a.75.75 0 0 0 .75-.75v-10a.75.75 0 0 0-.75-.75h-3.375a.875.875 0 0 1-.875-.875V5.5a1.75 1.75 0 0 0-1.75-1.75zM9 5.5a3.5 3.5 0 1 1 7 0V7h2.5A2.5 2.5 0 0 1 21 9.5v10a2.5 2.5 0 0 1-2.5 2.5h-12A2.5 2.5 0 0 1 4 19.5v-2.375c0-.483.392-.875.875-.875H7.25a1.75 1.75 0 1 0 0-3.5H4.875A.875.875 0 0 1 4 11.875V9.5A2.5 2.5 0 0 1 6.5 7H9V5.5z" fill="#000" />
+</svg>

--- a/res/img/svg/globe.svg
+++ b/res/img/svg/globe.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zM9.731 4.066a8.257 8.257 0 0 0-5.938 7.09h3.266a13.027 13.027 0 0 1 2.672-7.09zm-2.672 8.84h-3.26a8.258 8.258 0 0 0 5.873 7.01 13.025 13.025 0 0 1-2.613-7.01zm4.911 7.01a11.295 11.295 0 0 1-3.157-7.01h6.369a11.296 11.296 0 0 1-3.212 7.01zm-3.157-8.76a11.298 11.298 0 0 1 3.217-7.072 11.299 11.299 0 0 1 3.161 7.072H8.813zm8.132 0a13.027 13.027 0 0 0-2.616-7.073 8.257 8.257 0 0 1 5.878 7.073h-3.262zm-.008 1.75a13.026 13.026 0 0 1-2.669 7.028 8.257 8.257 0 0 0 5.933-7.028h-3.264z" fill="#000" />
+</svg>

--- a/src/components/shared/TabSelectorMenu.js
+++ b/src/components/shared/TabSelectorMenu.js
@@ -42,10 +42,6 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
       return null;
     }
 
-    const hasSomeIcons = sortedPageData.some(
-      ({ pageData }) => !!pageData.favicon
-    );
-
     return (
       <>
         <MenuItem
@@ -76,7 +72,7 @@ class TabSelectorMenuImpl extends React.PureComponent<Props> {
               'aria-checked': tabFilter === tabID ? 'false' : 'true',
             }}
           >
-            {hasSomeIcons ? <Icon iconUrl={pageData.favicon} /> : null}
+            <Icon iconUrl={pageData.favicon} />
             {pageData.hostname}
           </MenuItem>
         ))}

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -31,6 +31,8 @@ import {
   ensureExists,
   getFirstItemFromSet,
 } from 'firefox-profiler/utils/flow';
+import ExtensionFavicon from '../../res/img/svg/extension-outline.svg';
+import DefaultLinkFavicon from '../../res/img/svg/globe.svg';
 
 import type {
   Profile,
@@ -2971,7 +2973,7 @@ export function extractProfileFilterPageData(
       pageDataByTabID.set(tabID, {
         origin: pageUrl,
         hostname: pageUrl,
-        favicon: null,
+        favicon: DefaultLinkFavicon,
       });
       continue;
     }
@@ -2984,17 +2986,19 @@ export function extractProfileFilterPageData(
     // The known failing case is when we try to construct a URL with a
     // moz-extension:// protocol on platforms outside of Firefox. Only Firefox
     // can parse it properly. Chrome and node will output a URL with no `origin`.
+    const isExtension = pageUrl.startsWith('moz-extension://');
+    const defaultFavicon = isExtension ? ExtensionFavicon : DefaultLinkFavicon;
     const pageData: ProfileFilterPageData = {
       origin: '',
       hostname: '',
-      favicon: currentPage.favicon ?? null,
+      favicon: currentPage.favicon ?? defaultFavicon,
     };
 
     try {
       const page = new URL(pageUrl);
 
       pageData.hostname =
-        extensionIDToNameMap && pageUrl.startsWith('moz-extension://')
+        extensionIDToNameMap && isExtension
           ? // Get the real extension name if it's an extension.
             (extensionIDToNameMap.get(
               'moz-extension://' +

--- a/src/symbolicator-cli/webpack.config.js
+++ b/src/symbolicator-cli/webpack.config.js
@@ -19,6 +19,10 @@ module.exports = {
         use: ['babel-loader'],
         include: includes,
       },
+      {
+        test: /\.svg$/,
+        type: 'asset/resource',
+      },
     ],
   },
   experiments: {

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.js.snap
@@ -89,6 +89,9 @@ exports[`app/ProfileFilterNavigator renders the site hostname as its first eleme
     <span
       class="filterNavigatorBarItemContent"
     >
+      <div
+        class="nodeIcon "
+      />
       <span
         title="https://developer.mozilla.org"
       >

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -1236,7 +1236,7 @@ describe('extractProfileFilterPageData', function () {
         {
           origin: 'about:blank',
           hostname: 'about:blank',
-          favicon: null,
+          favicon: 'test-file-stub',
         },
       ],
     ]);

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -660,7 +660,7 @@ export type InitialSelectedTrackReference = HTMLElement;
 export type ProfileFilterPageData = {|
   origin: string,
   hostname: string,
-  favicon: string | null,
+  favicon: string,
 |};
 
 /**


### PR DESCRIPTION
This PR adds default icons for extensions and pages. So if we don't have any favicons for these, these default ones will be used in the tab selector.

[Example profile](https://deploy-preview-5182--perf-html.netlify.app/public/1pv36v8pgyn1sg1pmsry542d5vn3yd1wtygcd8r/calltree/?globalTrackOrder=e0wd&hiddenGlobalTracks=1wb&hiddenLocalTracksByPid=1143648-0w6~1143767-0~1143926-0~1144193-0~1144031-0~1144736-0~1143930-0~1144584-0~1143912-0~1144366-0~1143805-01&thread=k&timelineType=category&v=10)