### PR TITLE
Do not clip the favicons in call tree

### DIFF
--- a/src/components/calltree/CallTree.css
+++ b/src/components/calltree/CallTree.css
@@ -18,6 +18,7 @@
 
 .treeViewFixedColumn.icon {
   display: flex;
+  overflow: visible;
   flex-flow: column nowrap;
   align-items: center;
 }


### PR DESCRIPTION
Fixes #4532.

I'm not a fan of this solution, but I'm also not a fan of our current way of handling this column. The icon itself is 14px but the parent div's width is 10px. So I would prefer to change the parent's width to 14px too, but this parent itself is not really responsible of paddings arond this. It's the adjacent separator divs who are responsible. So this other solution will be a lot more difficult to handle gracefully.