### PR TITLE
 Do not include the profile startTime in window title if it's zero

### DIFF
--- a/src/components/app/WindowTitle.js
+++ b/src/components/app/WindowTitle.js
@@ -70,16 +70,25 @@ class WindowTitleImpl extends PureComponent<Props> {
           const { meta } = profile;
           let title = '';
           if (formattedMetaInfoString) {
-            title += formattedMetaInfoString + SEPARATOR;
+            title += formattedMetaInfoString;
           }
-          title += _formatDateTime(
-            meta.startTime + (meta.profilingStartTime || 0)
-          );
+
+          // Print the startTime only if it's provided.
+          if (meta.startTime > 0) {
+            title +=
+              SEPARATOR +
+              _formatDateTime(meta.startTime + (meta.profilingStartTime || 0));
+          }
+
           if (dataSource === 'public') {
             title += ` (${dataSource})`;
           }
 
-          title += SEPARATOR + PRODUCT;
+          if (title !== '') {
+            // Add the separator only if we added some information before.
+            title += SEPARATOR;
+          }
+          title += PRODUCT;
 
           // Prepend the name of the file if from a zip file.
           if (fileNameInZipFilePath) {

--- a/src/test/components/WindowTitle.test.js
+++ b/src/test/components/WindowTitle.test.js
@@ -34,9 +34,7 @@ describe('WindowTitle', () => {
       </Provider>
     );
 
-    expect(document.title).toBe(
-      'Firefox – 1/1/1970, 12:00:00 AM UTC – Firefox Profiler'
-    );
+    expect(document.title).toBe('Firefox – Firefox Profiler');
   });
 
   it('shows platform details in the window title if it is available', () => {
@@ -55,9 +53,7 @@ describe('WindowTitle', () => {
       </Provider>
     );
 
-    expect(document.title).toBe(
-      'Firefox – macOS 10.14 – 1/1/1970, 12:00:00 AM UTC – Firefox Profiler'
-    );
+    expect(document.title).toBe('Firefox – macOS 10.14 – Firefox Profiler');
   });
 
   it('shows profile name in the window title if it is available', () => {
@@ -102,7 +98,7 @@ describe('WindowTitle', () => {
       </Provider>
     );
 
-    expect(document.title).toBe('1/1/1970, 12:00:00 AM UTC – Firefox Profiler');
+    expect(document.title).toBe('Firefox Profiler');
   });
 
   it('shows the correct title for uploaded recordings', () => {
@@ -173,7 +169,7 @@ describe('WindowTitle', () => {
     );
 
     expect(document.title).toBe(
-      'bar/profile1.json – Firefox – 1/1/1970, 12:00:00 AM UTC – Firefox Profiler'
+      'bar/profile1.json – Firefox – Firefox Profiler'
     );
   });
 });

--- a/src/test/components/WindowTitle.test.js
+++ b/src/test/components/WindowTitle.test.js
@@ -37,6 +37,58 @@ describe('WindowTitle', () => {
     expect(document.title).toBe('Firefox – Firefox Profiler');
   });
 
+  it('shows the profiler startTime in the window title if it is available', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    Object.assign(profile.meta, {
+      startTime: new Date('5 Nov 2024 13:00 UTC').getTime(),
+    });
+    const store = storeWithProfile(profile);
+    store.dispatch(setDataSource('from-url'));
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe(
+      'Firefox – 11/5/2024, 1:00:00 PM UTC – Firefox Profiler'
+    );
+  });
+
+  it('shows the profiler startTime with public annotation in the window title if it is available', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    Object.assign(profile.meta, {
+      startTime: new Date('5 Nov 2024 13:00 UTC').getTime(),
+    });
+    const store = storeWithProfile(profile);
+    store.dispatch(setDataSource('public'));
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe(
+      'Firefox – 11/5/2024, 1:00:00 PM UTC (public) – Firefox Profiler'
+    );
+  });
+
+  it('shows the public annotation without startTime in the window title', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    const store = storeWithProfile(profile);
+    store.dispatch(setDataSource('public'));
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe('Firefox (public) – Firefox Profiler');
+  });
+
   it('shows platform details in the window title if it is available', () => {
     const profile = getEmptyProfile();
     profile.threads.push(getEmptyThread());
@@ -54,6 +106,28 @@ describe('WindowTitle', () => {
     );
 
     expect(document.title).toBe('Firefox – macOS 10.14 – Firefox Profiler');
+  });
+
+  it('shows platform details with the start time in the window title if it is available', () => {
+    const profile = getEmptyProfile();
+    profile.threads.push(getEmptyThread());
+    Object.assign(profile.meta, {
+      oscpu: 'Intel Mac OS X 10.14',
+      platform: 'Macintosh',
+      toolkit: 'cocoa',
+      startTime: new Date('5 Nov 2024 13:00 UTC').getTime(),
+    });
+    const store = storeWithProfile(profile);
+    store.dispatch(setDataSource('from-url'));
+    render(
+      <Provider store={store}>
+        <WindowTitle />
+      </Provider>
+    );
+
+    expect(document.title).toBe(
+      'Firefox – macOS 10.14 – 11/5/2024, 1:00:00 PM UTC – Firefox Profiler'
+    );
   });
 
   it('shows profile name in the window title if it is available', () => {


### PR DESCRIPTION
Previously we were always including the profile `startTime` in the title even when it was zero. It was resulting in a title that includes `1/1/1970, 12:00:00 AM UTC`, which is not useful for anyone. This was more visible in the Chrome profiles especially since they don't have a metadata.

This patch changes this title algorithm to make sure that we don't print the profile time when the profile `startTime` is zero. It also makes sure that `(public)` annotation is properly added as well as all the separators.

Example profile:
[Before](https://share.firefox.dev/3YBKJIV): "Chrome Trace – 1/11/1970, 9:14:08 AM UTC (public) – Firefox Profiler" 
[After](https://deploy-preview-5188--perf-html.netlify.app/public/wsqr4xqz36r33w2fzecc3fbbh2ehxsasq0b22k8/calltree/?globalTrackOrder=40w3&hiddenGlobalTracks=1w3&hiddenLocalTracksByPid=6258-0w7~2844-0w9~2864-0w3~0-0&thread=0&timelineType=category&v=10): "Chrome Trace (public) – Firefox Profiler"