### PR TITLE
Provide an option to display stacks all with the same widths in the stack chart

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -811,6 +811,7 @@ StackSettings--call-tree-strategy-native-deallocations-sites = Deallocation Site
 StackSettings--invert-call-stack = Invert call stack
     .title = Sort by the time spent in a call node, ignoring its children.
 StackSettings--show-user-timing = Show user timing
+StackSettings--use-stack-chart-same-widths = Use the same width for each stack
 
 StackSettings--panel-search =
     .label = Filter stacks:

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -1689,6 +1689,22 @@ export function changeShowUserTimings(
   };
 }
 
+export function changeStackChartSameWidths(
+  stackChartSameWidths: boolean
+): ThunkAction<void> {
+  return (dispatch) => {
+    sendAnalytics({
+      hitType: 'event',
+      eventCategory: 'profile',
+      eventAction: 'toggle stack chart same widths',
+    });
+    dispatch({
+      type: 'CHANGE_STACK_CHART_SAME_WIDTHS',
+      stackChartSameWidths,
+    });
+  };
+}
+
 /**
  * This action toggles changes between using a summary view that shows only self time
  * for the JS tracer data, and a stack-based view (similar to the stack chart) for the

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -196,6 +196,7 @@ type StackChartQuery = {|
   search: string, // "js::RunScript"
   invertCallstack: null | void,
   showUserTimings: null | void,
+  sameWidths: null | void,
   ctSummary: string,
 |};
 
@@ -305,10 +306,13 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
   const selectedTab = urlState.selectedTab;
   switch (selectedTab) {
     case 'stack-chart':
-      // Stack chart uses all of the CallTree's query strings but also has an
-      // additional query string.
+      // Stack chart uses all of the CallTree's query strings but also has
+      // additional query strings.
       query = (baseQuery: StackChartQueryShape);
       query.showUserTimings = urlState.profileSpecific.showUserTimings
+        ? null
+        : undefined;
+      query.sameWidths = urlState.profileSpecific.stackChartSameWidths
         ? null
         : undefined;
     /* fallsthrough */
@@ -542,6 +546,7 @@ export function stateFromLocation(
       ),
       invertCallstack: query.invertCallstack === undefined ? false : true,
       showUserTimings: query.showUserTimings === undefined ? false : true,
+      stackChartSameWidths: query.sameWidths === undefined ? false : true,
       committedRanges: query.range ? parseCommittedRanges(query.range) : [],
       selectedThreads,
       callTreeSearchString: query.search || '',

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -305,18 +305,16 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
   const selectedTab = urlState.selectedTab;
   switch (selectedTab) {
     case 'stack-chart':
+      // Stack chart uses all of the CallTree's query strings but also has an
+      // additional query string.
+      query = (baseQuery: StackChartQueryShape);
+      query.showUserTimings = urlState.profileSpecific.showUserTimings
+        ? null
+        : undefined;
+    /* fallsthrough */
     case 'flame-graph':
     case 'calltree': {
-      if (selectedTab === 'stack-chart') {
-        // Stack chart uses all of the CallTree's query strings but also has an
-        // additional query string.
-        query = (baseQuery: StackChartQueryShape);
-        query.showUserTimings = urlState.profileSpecific.showUserTimings
-          ? null
-          : undefined;
-      } else {
-        query = (baseQuery: CallTreeQueryShape);
-      }
+      query = (baseQuery: CallTreeQueryShape);
 
       query.search = urlState.profileSpecific.callTreeSearchString || undefined;
       query.invertCallstack = urlState.profileSpecific.invertCallstack

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -11,11 +11,13 @@ import {
   changeInvertCallstack,
   changeCallTreeSearchString,
   changeShowUserTimings,
+  changeStackChartSameWidths,
 } from 'firefox-profiler/actions/profile-view';
 import {
   getInvertCallstack,
   getSelectedTab,
   getShowUserTimings,
+  getStackChartSameWidths,
   getCurrentSearchString,
 } from 'firefox-profiler/selectors/url-state';
 import { getProfileUsesMultipleStackTypes } from 'firefox-profiler/selectors/profile';
@@ -40,6 +42,7 @@ type StateProps = {|
   +allowSwitchingStackType: boolean,
   +invertCallstack: boolean,
   +showUserTimings: boolean,
+  +stackChartSameWidths: boolean,
   +currentSearchString: string,
   +hasUsefulJsAllocations: boolean,
   +hasUsefulNativeAllocations: boolean,
@@ -49,6 +52,7 @@ type DispatchProps = {|
   +changeInvertCallstack: typeof changeInvertCallstack,
   +changeShowUserTimings: typeof changeShowUserTimings,
   +changeCallTreeSearchString: typeof changeCallTreeSearchString,
+  +changeStackChartSameWidths: typeof changeStackChartSameWidths,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -62,6 +66,10 @@ class StackSettingsImpl extends PureComponent<Props> {
     this.props.changeShowUserTimings(e.currentTarget.checked);
   };
 
+  _onUseStackChartSameWidths = (e: SyntheticEvent<HTMLInputElement>) => {
+    this.props.changeStackChartSameWidths(e.currentTarget.checked);
+  };
+
   _onSearch = (value: string) => {
     this.props.changeCallTreeSearchString(value);
   };
@@ -72,6 +80,7 @@ class StackSettingsImpl extends PureComponent<Props> {
       invertCallstack,
       selectedTab,
       showUserTimings,
+      stackChartSameWidths,
       hideInvertCallstack,
       currentSearchString,
       hasUsefulJsAllocations,
@@ -112,17 +121,30 @@ class StackSettingsImpl extends PureComponent<Props> {
                 </label>
               )}
               {selectedTab !== 'stack-chart' ? null : (
-                <label className="photon-label photon-label-micro photon-label-horiz-padding">
-                  <input
-                    type="checkbox"
-                    className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
-                    onChange={this._onShowUserTimingsClick}
-                    checked={showUserTimings}
-                  />
-                  <Localized id="StackSettings--show-user-timing">
-                    Show user timing
-                  </Localized>
-                </label>
+                <>
+                  <label className="photon-label photon-label-micro photon-label-horiz-padding">
+                    <input
+                      type="checkbox"
+                      className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                      onChange={this._onShowUserTimingsClick}
+                      checked={showUserTimings}
+                    />
+                    <Localized id="StackSettings--show-user-timing">
+                      Show user timing
+                    </Localized>
+                  </label>
+                  <label className="photon-label photon-label-micro photon-label-horiz-padding">
+                    <input
+                      type="checkbox"
+                      className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                      onChange={this._onUseStackChartSameWidths}
+                      checked={stackChartSameWidths}
+                    />
+                    <Localized id="StackSettings--use-stack-chart-same-widths">
+                      Use the same width for each stack
+                    </Localized>
+                  </label>
+                </>
               )}
             </li>
           )}
@@ -154,6 +176,7 @@ export const StackSettings = explicitConnect<
     invertCallstack: getInvertCallstack(state),
     selectedTab: getSelectedTab(state),
     showUserTimings: getShowUserTimings(state),
+    stackChartSameWidths: getStackChartSameWidths(state),
     currentSearchString: getCurrentSearchString(state),
     hasUsefulJsAllocations:
       selectedThreadSelectors.getHasUsefulJsAllocations(state),
@@ -164,6 +187,7 @@ export const StackSettings = explicitConnect<
     changeInvertCallstack,
     changeCallTreeSearchString,
     changeShowUserTimings,
+    changeStackChartSameWidths,
   },
   component: StackSettingsImpl,
 });

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -229,13 +229,16 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
     const timePerCssPixel = viewportRangeLength / innerContainerWidth;
 
     // Compute the time range that's displayed on the canvas, including in the
-    // margins around the viewport.
+    // margins around the viewport. This means we're displaying more than the
+    // range when doing a preview selection.
+    const timeAtViewportStart: Milliseconds =
+      rangeStart + rangeLength * viewportLeft;
     const timeAtStart: Milliseconds =
-      rangeStart + rangeLength * viewportLeft - timePerCssPixel * marginLeft;
+      timeAtViewportStart - marginLeft * timePerCssPixel;
+    const timeAtViewportEnd: Milliseconds =
+      rangeStart + rangeLength * viewportRight;
     const timeAtEnd: Milliseconds =
-      rangeStart +
-      rangeLength * viewportRight +
-      timePerCssPixel * TIMELINE_MARGIN_RIGHT;
+      timeAtViewportEnd + TIMELINE_MARGIN_RIGHT * timePerCssPixel;
 
     const pixelAtViewportPosition = (
       viewportPosition: UnitIntervalOfProfileRange
@@ -559,14 +562,13 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       viewport: { viewportLeft, viewportRight, viewportTop, containerWidth },
     } = this.props;
 
-    const innerDevicePixelsWidth =
+    const innerContainerWidth =
       containerWidth - marginLeft - TIMELINE_MARGIN_RIGHT;
     const rangeLength: Milliseconds = rangeEnd - rangeStart;
     const viewportLength: UnitIntervalOfProfileRange =
       viewportRight - viewportLeft;
     const unitIntervalTime: UnitIntervalOfProfileRange =
-      viewportLeft +
-      viewportLength * ((x - marginLeft) / innerDevicePixelsWidth);
+      viewportLeft + viewportLength * ((x - marginLeft) / innerContainerWidth);
     const time: Milliseconds = rangeStart + unitIntervalTime * rangeLength;
     const depth = Math.floor((y + viewportTop) / ROW_CSS_PIXELS_HEIGHT);
     const stackTiming = combinedTimingRows[depth];

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -20,11 +20,13 @@ import {
   getInnerWindowIDToPageMap,
   getProfileUsesMultipleStackTypes,
 } from '../../selectors/profile';
-import { selectedThreadSelectors } from '../../selectors/per-thread';
 import {
+  getStackChartSameWidths,
   getShowUserTimings,
   getSelectedThreadsKey,
-} from '../../selectors/url-state';
+} from 'firefox-profiler/selectors/url-state';
+import type { SameWidthsIndexToTimestampMap } from 'firefox-profiler/profile-logic/stack-timing';
+import { selectedThreadSelectors } from '../../selectors/per-thread';
 import { StackChartEmptyReasons } from './StackChartEmptyReasons';
 import { ContextMenuTrigger } from '../shared/ContextMenuTrigger';
 import { StackSettings } from '../shared/StackSettings';
@@ -69,6 +71,7 @@ type StateProps = {|
   +weightType: WeightType,
   +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
   +combinedTimingRows: CombinedTimingRows,
+  +sameWidthsIndexToTimestampMap: SameWidthsIndexToTimestampMap,
   +timeRange: StartEndRange,
   +interval: Milliseconds,
   +previewSelection: PreviewSelection,
@@ -82,6 +85,7 @@ type StateProps = {|
   +userTimings: MarkerIndex[],
   +displayStackType: boolean,
   +hasFilteredCtssSamples: boolean,
+  +useStackChartSameWidths: boolean,
 |};
 
 type DispatchProps = {|
@@ -202,6 +206,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       thread,
       threadsKey,
       combinedTimingRows,
+      sameWidthsIndexToTimestampMap,
       timeRange,
       interval,
       previewSelection,
@@ -217,6 +222,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       weightType,
       displayStackType,
       hasFilteredCtssSamples,
+      useStackChartSameWidths,
     } = this.props;
 
     const maxViewportHeight = combinedTimingRows.length * STACK_FRAME_HEIGHT;
@@ -258,6 +264,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   innerWindowIDToPageMap,
                   threadsKey,
                   combinedTimingRows,
+                  sameWidthsIndexToTimestampMap,
                   getMarker,
                   // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
                   updatePreviewSelection,
@@ -275,6 +282,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   scrollToSelectionGeneration,
                   marginLeft: TIMELINE_MARGIN_LEFT,
                   displayStackType: displayStackType,
+                  useStackChartSameWidths,
                 }}
               />
             </div>
@@ -297,6 +305,8 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       // Use the raw WeightType here, as the stack chart does not use the call tree
       weightType: selectedThreadSelectors.getSamplesWeightType(state),
       combinedTimingRows,
+      sameWidthsIndexToTimestampMap:
+        selectedThreadSelectors.getSameWidthsIndexToTimestampMap(state),
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       previewSelection: getPreviewSelection(state),
@@ -314,6 +324,7 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       displayStackType: getProfileUsesMultipleStackTypes(state),
       hasFilteredCtssSamples:
         selectedThreadSelectors.getHasFilteredCtssSamples(state),
+      useStackChartSameWidths: getStackChartSameWidths(state),
     };
   },
   mapDispatchToProps: {

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -27,21 +27,44 @@ import type { CallNodeInfo } from './call-node-info';
  * depth. Each object is a table that contains the the start time and end time in
  * milliseconds, and the stack index that points into the stack table.
  *
+ * Here is a tree example:
+ *
+ * This table shows off how a stack chart gets filtered to JS only, where the number is
+ * the stack index, and P is platform code, and J javascript.
+ *
+ *   0-10-20-30-40-50-60-70-80-90-91 <- Timing (ms)
+ *    0-----1--2--3--4--5--6--7--8   <- same width indexes
+ *  ================================
+ *     0P 0P 0P 0P 0P 0P 0P 0P 0P  |
+ *     1P 1P 1P    1P 1P 1P 1P 1P  |
+ *     2P 2P 3P       4J 4J 4J 4J  |
+ *                       5J 5J     |
+ *                          6P     |
+ *                          7P     |
+ *                          8J     |
+ *
+ * Note that stacks 10 and 20 in the unfiltered tree are the same, therefore
+ * they'll form just one "same width" stack.
+ * It's easier to think of the "same widths" indexes as the space between each
+ * new stack.
+ *
  * stackTimingByDepth Example:
  * [
  *   // This first object represents the first box at the base of the chart. It only
  *   // contains a single stack frame to draw, starting at 10ms, ending at 100ms. It
  *   // points to the stackIndex 0.
  *
- *   {start: [10], end: [100], stack: [0]}
+ *   {start: [10], end: [91], sameWidthsStart: [0], sameWidthsEnd: [8], stack: [0], length: 1},
  *
- *   // This next object represents 3 boxes to draw, the first box being stack 1 in the
- *   // stack table, and it starts at 20ms, and ends at 40ms.
+ *   // This next object represents 2 boxes to draw, the first box being stack 1 in the
+ *   // stack table, and it starts at 10ms, and ends at 40ms.
+ *   {start: [10, 50], end: [40, 91], sameWidthsStart: [0, 3], sameWidthsEnd: [2, 8], stack: [1, 1], length: 2},
  *
- *   {start: [20, 40, 60], end: [40, 60, 80], stack: [1, 2, 3]}
- *   {start: [20, 40, 60], end: [40, 60, 80], stack: [34, 59, 72]}
+ *   // This next object represents 3 boxes to draw, the first box being stack 2 in the
+ *   // stack table, and it starts at 10ms, and ends at 30ms.
+ *   {start: [10, 30, 60], end: [30, 40, 91], sameWidthsStart: [0, 1, 4], sameWidthsEnd: [1, 2, 8], stack: [2, 3, 4], length: 3},
+ *   {start: [70], end: [90], sameWidthsStart: [5], sameWidthsEnd: [7], stack: [5], length: 1},
  *   ...
- *   {start: [25, 45], end: [35, 55], stack: [123, 159]}
  * ]
  */
 
@@ -51,6 +74,12 @@ export type IndexIntoStackTiming = number;
 export type StackTiming = {|
   start: Milliseconds[],
   end: Milliseconds[],
+  // These 2 properties sameWidthsStart and sameWidthsEnd increments at each
+  // "tick", that is at each stack change. They'll make it possible to draw a
+  // stack chart where each different stack has the same width, and can better
+  // show very short changes.
+  sameWidthsStart: number[],
+  sameWidthsEnd: number[],
   callNode: IndexIntoCallNodeTable[],
   length: number,
 |};
@@ -76,6 +105,8 @@ export function getStackTimingByDepth(
   const stackTimingByDepth = Array.from({ length: maxDepthPlusOne }, () => ({
     start: [],
     end: [],
+    sameWidthsStart: [],
+    sameWidthsEnd: [],
     callNode: [],
     length: 0,
   }));
@@ -106,13 +137,16 @@ export function getStackTimingByDepth(
   let deepestOpenBoxCallNodeIndex = -1;
   let deepestOpenBoxDepth = -1;
   const openBoxStartTimeByDepth = new Float64Array(maxDepthPlusOne);
+  const openBoxStartTickByDepth = new Float64Array(maxDepthPlusOne);
 
+  let currentStackTick = 0;
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
-    const sampleTime = samples.time[sampleIndex];
     const thisCallNodeIndex = sampleCallNodes[sampleIndex] ?? -1;
     if (thisCallNodeIndex === deepestOpenBoxCallNodeIndex) {
       continue;
     }
+
+    const sampleTime = samples.time[sampleIndex];
 
     // Phase 1: Commit open boxes which are not shared by the current call node,
     // i.e. any boxes whose call nodes are not ancestors of the current call node.
@@ -135,10 +169,13 @@ export function getStackTimingByDepth(
       // deepestOpenBoxCallNodeIndex is *not* an ancestors of thisCallNodeIndex.
       // Commit this box.
       const start = openBoxStartTimeByDepth[deepestOpenBoxDepth];
+      const startStackTick = openBoxStartTickByDepth[deepestOpenBoxDepth];
       const stackTimingForThisDepth = stackTimingByDepth[deepestOpenBoxDepth];
       const index = stackTimingForThisDepth.length++;
       stackTimingForThisDepth.start[index] = start;
       stackTimingForThisDepth.end[index] = sampleTime;
+      stackTimingForThisDepth.sameWidthsStart[index] = startStackTick;
+      stackTimingForThisDepth.sameWidthsEnd[index] = currentStackTick;
       stackTimingForThisDepth.callNode[index] = deepestOpenBoxCallNodeIndex;
       deepestOpenBoxCallNodeIndex =
         callNodeTablePrefixColumn[deepestOpenBoxCallNodeIndex];
@@ -154,10 +191,12 @@ export function getStackTimingByDepth(
       while (deepestOpenBoxDepth < thisCallNodeDepth) {
         deepestOpenBoxDepth++;
         openBoxStartTimeByDepth[deepestOpenBoxDepth] = sampleTime;
+        openBoxStartTickByDepth[deepestOpenBoxDepth] = currentStackTick;
       }
     }
 
     deepestOpenBoxCallNodeIndex = thisCallNodeIndex;
+    currentStackTick++;
   }
 
   // We've processed all samples.
@@ -167,8 +206,11 @@ export function getStackTimingByDepth(
     const stackTimingForThisDepth = stackTimingByDepth[deepestOpenBoxDepth];
     const index = stackTimingForThisDepth.length++;
     const start = openBoxStartTimeByDepth[deepestOpenBoxDepth];
+    const startStackTick = openBoxStartTickByDepth[deepestOpenBoxDepth];
     stackTimingForThisDepth.start[index] = start;
     stackTimingForThisDepth.end[index] = endTime;
+    stackTimingForThisDepth.sameWidthsStart[index] = startStackTick;
+    stackTimingForThisDepth.sameWidthsEnd[index] = currentStackTick;
     stackTimingForThisDepth.callNode[index] = deepestOpenBoxCallNodeIndex;
     deepestOpenBoxCallNodeIndex =
       callNodeTablePrefixColumn[deepestOpenBoxCallNodeIndex];

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -306,6 +306,15 @@ const showUserTimings: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+const stackChartSameWidths: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'CHANGE_STACK_CHART_SAME_WIDTHS':
+      return action.stackChartSameWidths;
+    default:
+      return state;
+  }
+};
+
 /**
  * This state controls whether or not to show a summary view of self time, or the full
  * stack-based view of the JS tracer data.
@@ -651,6 +660,7 @@ const profileSpecific = combineReducers({
   lastSelectedCallTreeSummaryStrategy,
   invertCallstack,
   showUserTimings,
+  stackChartSameWidths,
   committedRanges,
   callTreeSearchString,
   markersSearchString,

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -385,7 +385,7 @@ export function getStackAndSampleSelectorsPerThread(
       }
     );
 
-  const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> =
+  const _getStackTimingByDepthWithMap: Selector<StackTiming.StackTimingByDepthWithMap> =
     createSelector(
       threadSelectors.getFilteredCtssSamples,
       _getSampleIndexToNonInvertedCallNodeIndexForFilteredCtssThread,
@@ -394,6 +394,13 @@ export function getStackAndSampleSelectorsPerThread(
       ProfileSelectors.getProfileInterval,
       StackTiming.getStackTimingByDepth
     );
+  const getStackTimingByDepth: Selector<StackTiming.StackTimingByDepth> = (
+    state
+  ) => _getStackTimingByDepthWithMap(state).timings;
+  const getSameWidthsIndexToTimestampMap: Selector<
+    StackTiming.SameWidthsIndexToTimestampMap,
+  > = (state) =>
+    _getStackTimingByDepthWithMap(state).sameWidthsIndexToTimestampMap;
 
   const getFlameGraphRows: Selector<FlameGraph.FlameGraphRows> = createSelector(
     (state) => getCallNodeInfo(state).getNonInvertedCallNodeTable(),
@@ -448,6 +455,7 @@ export function getStackAndSampleSelectorsPerThread(
     getTracedTiming,
     getTracedSelfAndTotalForSelectedCallNode,
     getStackTimingByDepth,
+    getSameWidthsIndexToTimestampMap,
     getFilteredCallNodeMaxDepthPlusOne,
     getFlameGraphTiming,
     getRightClickedCallNodeIndex,

--- a/src/selectors/url-state.js
+++ b/src/selectors/url-state.js
@@ -68,6 +68,8 @@ export const getLastSelectedCallTreeSummaryStrategy: Selector<
   getProfileSpecificState(state).lastSelectedCallTreeSummaryStrategy;
 export const getShowUserTimings: Selector<boolean> = (state) =>
   getProfileSpecificState(state).showUserTimings;
+export const getStackChartSameWidths: Selector<boolean> = (state) =>
+  getProfileSpecificState(state).stackChartSameWidths;
 export const getSourceViewFile: Selector<string | null> = (state) =>
   getProfileSpecificState(state).sourceView.sourceFile;
 export const getSourceViewScrollGeneration: Selector<number> = (state) =>

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -132,8 +132,8 @@ describe('StackChart', function () {
         updatePreviewSelection({
           hasSelection: true,
           isModifying: false,
-          selectionStart: 2.1,
-          selectionEnd: 3.1,
+          selectionStart: 3.1,
+          selectionEnd: 3.4,
         })
       )
     );

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -11,6 +11,7 @@ import {
   fireEvent,
   screen,
   act,
+  within,
 } from 'firefox-profiler/test/fixtures/testing-library';
 import * as UrlStateSelectors from '../../selectors/url-state';
 
@@ -32,6 +33,7 @@ import {
   commitRange,
   changeImplementationFilter,
   changeCallTreeSummaryStrategy,
+  updatePreviewSelection,
 } from '../../actions/profile-view';
 import { changeSelectedTab } from '../../actions/app';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
@@ -87,6 +89,72 @@ describe('StackChart', function () {
     moveMouse(findFillTextPositionFromDrawLog(drawCalls, 'B'));
     expect(getTooltip()).toBeTruthy();
     expect(getTooltip()).toMatchSnapshot('tooltip');
+  });
+
+  it('matches the snapshot and can display a tooltip with the same widths option', () => {
+    const samples = `
+      A[cat:DOM]       A[cat:DOM]       A[cat:DOM]       A[cat:DOM]
+      B[cat:DOM]       B[cat:DOM]       B[cat:DOM]       B[cat:DOM]
+      C[cat:Graphics]  C[cat:Graphics]  C[cat:Graphics]  H[cat:Network]
+      D[cat:Graphics]  F[cat:Graphics]  F[cat:Graphics]  I[cat:Network]
+      E[cat:Graphics]  G[cat:Graphics]  G[cat:Graphics]
+    `;
+    const { getTooltip, moveMouse, flushRafCalls, dispatch } =
+      setupSamples(samples);
+    useSameWidthsStackChart({ flushRafCalls });
+
+    let drawCalls = flushDrawLog();
+    expect(document.body).toMatchSnapshot('dom');
+    expect(getDrawnFrames(drawCalls)).toEqual([
+      'A',
+      'B',
+      'C',
+      'H',
+      'D',
+      'F',
+      'I',
+      'E',
+      'G',
+    ]);
+    expect(drawCalls).toMatchSnapshot('draw calls');
+
+    // It can also display a tooltip when hovering a stack.
+    expect(getTooltip()).toBe(null);
+
+    moveMouse(findFillTextPositionFromDrawLog(drawCalls, 'I'));
+    expect(getTooltip()).toBeTruthy();
+    expect(getTooltip()).toMatchSnapshot('tooltip');
+
+    // Let's add a preview selection and do it again.
+    flushDrawLog();
+    act(() =>
+      dispatch(
+        updatePreviewSelection({
+          hasSelection: true,
+          isModifying: false,
+          selectionStart: 2.1,
+          selectionEnd: 3.1,
+        })
+      )
+    );
+
+    flushRafCalls();
+    drawCalls = flushDrawLog();
+    expect(getDrawnFrames(drawCalls)).toEqual([
+      'A',
+      'B',
+      'C',
+      'H',
+      'F',
+      'I',
+      'G',
+    ]);
+    expect(drawCalls).toMatchSnapshot('draw calls for preview selection');
+
+    // It can also display a tooltip when hovering a new stack.
+    moveMouse(findFillTextPositionFromDrawLog(drawCalls, 'H'));
+    expect(getTooltip()).toBeTruthy();
+    expect(getTooltip()).toMatchSnapshot('tooltip after preview selection');
   });
 
   it('can select a call node when clicking the chart', function () {
@@ -162,11 +230,6 @@ describe('StackChart', function () {
     clickMenuItem('Copy function name');
     expect(copy).toHaveBeenLastCalledWith('B');
   });
-
-  function getDrawnFrames() {
-    const drawCalls = flushDrawLog();
-    return drawCalls.filter(([fn]) => fn === 'fillText').map(([, arg]) => arg);
-  }
 
   it('can scroll into view when selecting a node', function () {
     // Create a stack deep enough to not have all its rendered frames
@@ -284,15 +347,28 @@ describe('MarkerChart', function () {
   it.todo('can right click a marker and show a context menu');
 
   it('shows a tooltip when hovering', () => {
-    const { getTooltip, moveMouse, findFillTextPosition } = setupUserTimings({
-      isShowUserTimingsClicked: true,
-    });
+    const { getTooltip, moveMouse, findFillTextPosition, flushRafCalls } =
+      setupUserTimings({
+        isShowUserTimingsClicked: true,
+      });
 
     expect(getTooltip()).toBe(null);
 
     moveMouse(findFillTextPosition('componentB'));
-    expect(getTooltip()).toBeTruthy();
-    expect(getTooltip()).toMatchSnapshot();
+    let tooltip = getTooltip();
+    expect(
+      within(ensureExists(tooltip)).getByText('componentB')
+    ).toBeInTheDocument();
+    expect(tooltip).toMatchSnapshot();
+
+    // This still matches markers with the same widths option
+    useSameWidthsStackChart({ flushRafCalls });
+    moveMouse(findFillTextPosition('componentA'));
+    tooltip = getTooltip();
+    expect(
+      within(ensureExists(tooltip)).getByText('componentA')
+    ).toBeInTheDocument();
+    expect(tooltip).toMatchSnapshot();
   });
 });
 
@@ -310,6 +386,17 @@ function showUserTimings({ getByLabelText, flushRafCalls }) {
   const checkbox = getByLabelText('Show user timing');
   fireFullClick(checkbox);
   flushRafCalls();
+}
+
+function useSameWidthsStackChart({ flushRafCalls }) {
+  flushDrawLog();
+  const checkbox = screen.getByLabelText('Use the same width for each stack');
+  fireFullClick(checkbox);
+  flushRafCalls();
+}
+
+function getDrawnFrames(drawCalls = flushDrawLog()) {
+  return drawCalls.filter(([fn]) => fn === 'fillText').map(([, arg]) => arg);
 }
 
 function setupCombinedTimings() {
@@ -467,6 +554,7 @@ function setup(store, funcNames: string[] = []) {
 
   function moveMouse(where) {
     fireMouseEvent('mousemove', getPositioningOptions(where));
+    flushRafCalls();
   }
 
   // Context menu tools

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -75,11 +75,18 @@ beforeEach(addRootOverlayElement);
 afterEach(removeRootOverlayElement);
 
 describe('StackChart', function () {
-  it('matches the snapshot', () => {
-    const { container } = setupSamples();
+  it('matches the snapshot and can display a tooltip', () => {
+    const { container, getTooltip, moveMouse } = setupSamples();
     const drawCalls = flushDrawLog();
-    expect(container.firstChild).toMatchSnapshot();
-    expect(drawCalls).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot('dom');
+    expect(drawCalls).toMatchSnapshot('draw calls');
+
+    // It can also display a tooltip when hovering a stack.
+    expect(getTooltip()).toBe(null);
+
+    moveMouse(findFillTextPositionFromDrawLog(drawCalls, 'B'));
+    expect(getTooltip()).toBeTruthy();
+    expect(getTooltip()).toMatchSnapshot('tooltip');
   });
 
   it('can select a call node when clicking the chart', function () {

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -954,7 +954,7 @@ exports[`StackChart EmptyReasons shows reasons when samples have been completely
 </div>
 `;
 
-exports[`StackChart matches the snapshot 1`] = `
+exports[`StackChart matches the snapshot and can display a tooltip: dom 1`] = `
 <div
   aria-labelledby="stack-chart-tab-button"
   class="stackChart"
@@ -1123,7 +1123,7 @@ exports[`StackChart matches the snapshot 1`] = `
 </div>
 `;
 
-exports[`StackChart matches the snapshot 2`] = `
+exports[`StackChart matches the snapshot and can display a tooltip: draw calls 1`] = `
 Array [
   Array [
     "set font",
@@ -1392,6 +1392,63 @@ Array [
     300,
   ],
 ]
+`;
+
+exports[`StackChart matches the snapshot and can display a tooltip: tooltip 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 164px; top: 38px;"
+>
+  <div
+    class="tooltipCallNode"
+  >
+    <div
+      class="tooltipOneLine tooltipHeader"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        3.0ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        B
+      </div>
+      <div
+        class="tooltipIcon"
+      />
+    </div>
+    <div
+      class="tooltipCallNodeDetails"
+    >
+      <div
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          Native
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-blue"
+          />
+          DOM
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`StackChart works when the user selects the JS allocations option 1`] = `

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CombinedChart renders combined stack chart 1`] = `
 <div
@@ -71,6 +71,15 @@ exports[`CombinedChart renders combined stack chart 1`] = `
             type="checkbox"
           />
           Show user timing
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          Use the same width for each stack
         </label>
       </li>
     </ul>
@@ -559,6 +568,15 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
           />
           Show user timing
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          Use the same width for each stack
+        </label>
       </li>
     </ul>
     <div
@@ -1007,6 +1025,15 @@ exports[`StackChart matches the snapshot 1`] = `
             type="checkbox"
           />
           Show user timing
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          Use the same width for each stack
         </label>
       </li>
     </ul>
@@ -1467,6 +1494,15 @@ exports[`StackChart works when the user selects the JS allocations option 1`] = 
                 type="checkbox"
               />
               Show user timing
+            </label>
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+            >
+              <input
+                class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                type="checkbox"
+              />
+              Use the same width for each stack
             </label>
           </li>
         </ul>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -903,6 +903,73 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
 </div>
 `;
 
+exports[`MarkerChart shows a tooltip when hovering 2`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 182.1818181818182px; top: 38px;"
+>
+  <div
+    class="tooltipMarker"
+  >
+    <div
+      class="tooltipHeader"
+    >
+      <div
+        class="tooltipOneLine"
+      >
+        <div
+          class="tooltipTiming"
+        >
+          8ms
+        </div>
+        <div
+          class="tooltipTitle"
+        >
+          componentA
+        </div>
+      </div>
+    </div>
+    <div
+      class="tooltipDetails"
+    >
+      <div
+        class="tooltipLabel"
+      >
+        Name
+        :
+      </div>
+      componentA
+      <div
+        class="tooltipLabel"
+      >
+        Entry Type
+        :
+      </div>
+      measure
+      <div
+        class="tooltipLabel"
+      >
+        Description
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
+      <div
+        class="tooltipLabel"
+      >
+        Track
+        :
+      </div>
+      Empty
+    </div>
+  </div>
+</div>
+`;
+
 exports[`StackChart EmptyReasons shows reasons when a profile has no samples 1`] = `
 <div
   class="EmptyReasons"
@@ -951,6 +1018,708 @@ exports[`StackChart EmptyReasons shows reasons when samples have been completely
   <p>
     Try broadening the selected range, removing search terms, or call tree transforms to view samples.
   </p>
+</div>
+`;
+
+exports[`StackChart matches the snapshot and can display a tooltip with the same widths option: dom 1`] = `
+<body>
+  <div
+    id="root-overlay"
+  />
+  <div>
+    <div
+      aria-labelledby="stack-chart-tab-button"
+      class="stackChart"
+      id="stack-chart-tab"
+      role="tabpanel"
+    >
+      <div
+        class="stackSettings"
+      >
+        <ul
+          class="panelSettingsList"
+        >
+          <li
+            class="panelSettingsListItem"
+          >
+            <input
+              checked=""
+              class="photon-radio photon-radio-micro"
+              id="implementation-radio-combined"
+              title="Do not filter the stack frames"
+              type="radio"
+              value="combined"
+            />
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+              for="implementation-radio-combined"
+              title="Do not filter the stack frames"
+            >
+              All frames
+            </label>
+            <input
+              class="photon-radio photon-radio-micro"
+              id="implementation-radio-js"
+              title="Show only the stack frames related to JavaScript execution"
+              type="radio"
+              value="js"
+            />
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+              for="implementation-radio-js"
+              title="Show only the stack frames related to JavaScript execution"
+            >
+              JavaScript
+            </label>
+            <input
+              class="photon-radio photon-radio-micro"
+              id="implementation-radio-cpp"
+              title="Show only the stack frames for native code"
+              type="radio"
+              value="cpp"
+            />
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+              for="implementation-radio-cpp"
+              title="Show only the stack frames for native code"
+            >
+              Native
+            </label>
+          </li>
+          <li
+            class="panelSettingsListItem"
+          >
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+            >
+              <input
+                class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                type="checkbox"
+              />
+              Show user timing
+            </label>
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+            >
+              <input
+                class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                type="checkbox"
+              />
+              Use the same width for each stack
+            </label>
+          </li>
+        </ul>
+        <div
+          class="panelSearchField stackSettingsSearchField"
+        >
+          <label
+            class="panelSearchFieldLabel"
+          >
+            Filter stacks: 
+            <form
+              class="idleSearchField panelSearchFieldInput"
+            >
+              <input
+                class="idleSearchFieldInput photon-input"
+                name="search"
+                placeholder="Enter filter terms"
+                required=""
+                title="Only display stacks which contain a function whose name matches this substring"
+                type="search"
+                value=""
+              />
+              <input
+                class="idleSearchFieldButton"
+                tabindex="-1"
+                type="reset"
+              />
+            </form>
+          </label>
+          <div
+            class="panelSearchFieldIntroduction isHidden"
+          >
+            Did you know you can use the comma (,) to search using several terms?
+          </div>
+        </div>
+      </div>
+      <ol
+        class="filterNavigatorBar calltreeTransformNavigator"
+      >
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+        >
+          <span
+            class="filterNavigatorBarItemContent"
+          >
+            Complete “⁨Empty⁩”
+          </span>
+        </li>
+      </ol>
+      <div
+        class="react-contextmenu-wrapper treeViewContextMenu"
+      >
+        <div
+          class="stackChartContent"
+        >
+          <div
+            class="chartViewport"
+            tabindex="0"
+          >
+            <div>
+              <canvas
+                class="chartCanvas stackChartCanvas"
+                height="300"
+                style="width: 365px; height: 300px;"
+                width="365"
+              />
+            </div>
+            <div
+              class="chartViewportScroll hidden"
+            >
+              Zoom Chart:
+              <kbd
+                class="chartViewportScrollKbd"
+              >
+                Ctrl + Scroll
+              </kbd>
+              or
+              <kbd
+                class="chartViewportScrollKbd"
+              >
+                Shift + Scroll
+              </kbd>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`StackChart matches the snapshot and can display a tooltip with the same widths option: draw calls 1`] = `
+Array [
+  Array [
+    "set font",
+    "10px sans-serif",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "fillRect",
+    150,
+    0,
+    199.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "A",
+    153,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "fillRect",
+    150,
+    16,
+    199.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "B",
+    153,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    32,
+    133.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "C",
+    153,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "fillRect",
+    284,
+    32,
+    66.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "H",
+    286.33333333333337,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    48,
+    66.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "D",
+    153,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    217,
+    48,
+    66.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "F",
+    219.66666666666669,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "fillRect",
+    284,
+    48,
+    66.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "I",
+    286.33333333333337,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    64,
+    66.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "E",
+    153,
+    75,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    217,
+    64,
+    66.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "G",
+    219.66666666666669,
+    75,
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "fillRect",
+    150,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    350,
+    0,
+    1,
+    300,
+  ],
+]
+`;
+
+exports[`StackChart matches the snapshot and can display a tooltip with the same widths option: draw calls for preview selection 1`] = `
+Array [
+  Array [
+    "set font",
+    "10px sans-serif",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    365,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "fillRect",
+    50,
+    0,
+    299.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "A",
+    53,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "fillRect",
+    50,
+    16,
+    299.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "B",
+    53,
+    27,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    50,
+    32,
+    199.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "C",
+    53,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "fillRect",
+    250,
+    32,
+    99.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "H",
+    253,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    48,
+    99.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "F",
+    153,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    250,
+    48,
+    99.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000",
+  ],
+  Array [
+    "fillText",
+    "I",
+    253,
+    59,
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "fillRect",
+    150,
+    64,
+    99.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "G",
+    153,
+    75,
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "fillRect",
+    -270,
+    0,
+    1,
+    300,
+  ],
+  Array [
+    "fillRect",
+    530,
+    0,
+    1,
+    300,
+  ],
+]
+`;
+
+exports[`StackChart matches the snapshot and can display a tooltip with the same widths option: tooltip 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 297.33333333333337px; top: 70px;"
+>
+  <div
+    class="tooltipCallNode"
+  >
+    <div
+      class="tooltipOneLine tooltipHeader"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1.0ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        I
+      </div>
+      <div
+        class="tooltipIcon"
+      />
+    </div>
+    <div
+      class="tooltipCallNodeDetails"
+    >
+      <div
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          Native
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-lightblue"
+          />
+          Network
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StackChart matches the snapshot and can display a tooltip with the same widths option: tooltip after preview selection 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 264px; top: 54px;"
+>
+  <div
+    class="tooltipCallNode"
+  >
+    <div
+      class="tooltipOneLine tooltipHeader"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1.0ms
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        H
+      </div>
+      <div
+        class="tooltipIcon"
+      />
+    </div>
+    <div
+      class="tooltipCallNodeDetails"
+    >
+      <div
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          Native
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-lightblue"
+          />
+          Network
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -1447,9 +1447,9 @@ Array [
   ],
   Array [
     "fillRect",
-    50,
     0,
-    299.4,
+    0,
+    349.4,
     15,
   ],
   Array [
@@ -1459,7 +1459,7 @@ Array [
   Array [
     "fillText",
     "A",
-    53,
+    3,
     11,
   ],
   Array [
@@ -1468,9 +1468,9 @@ Array [
   ],
   Array [
     "fillRect",
-    50,
+    0,
     16,
-    299.4,
+    349.4,
     15,
   ],
   Array [
@@ -1480,7 +1480,7 @@ Array [
   Array [
     "fillText",
     "B",
-    53,
+    3,
     27,
   ],
   Array [
@@ -1489,7 +1489,28 @@ Array [
   ],
   Array [
     "fillRect",
-    50,
+    0,
+    32,
+    149.4,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "C",
+    3,
+    43,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff60",
+  ],
+  Array [
+    "fillRect",
+    150,
     32,
     199.4,
     15,
@@ -1500,29 +1521,8 @@ Array [
   ],
   Array [
     "fillText",
-    "C",
-    53,
-    43,
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff60",
-  ],
-  Array [
-    "fillRect",
-    250,
-    32,
-    99.4,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#000000",
-  ],
-  Array [
-    "fillText",
     "H",
-    253,
+    153,
     43,
   ],
   Array [
@@ -1531,9 +1531,9 @@ Array [
   ],
   Array [
     "fillRect",
-    150,
+    0,
     48,
-    99.4,
+    149.4,
     15,
   ],
   Array [
@@ -1543,7 +1543,7 @@ Array [
   Array [
     "fillText",
     "F",
-    153,
+    3,
     59,
   ],
   Array [
@@ -1552,9 +1552,9 @@ Array [
   ],
   Array [
     "fillRect",
-    250,
+    150,
     48,
-    99.4,
+    199.4,
     15,
   ],
   Array [
@@ -1564,7 +1564,7 @@ Array [
   Array [
     "fillText",
     "I",
-    253,
+    153,
     59,
   ],
   Array [
@@ -1573,9 +1573,9 @@ Array [
   ],
   Array [
     "fillRect",
-    150,
+    0,
     64,
-    99.4,
+    149.4,
     15,
   ],
   Array [
@@ -1585,7 +1585,7 @@ Array [
   Array [
     "fillText",
     "G",
-    153,
+    3,
     75,
   ],
   Array [
@@ -1594,14 +1594,14 @@ Array [
   ],
   Array [
     "fillRect",
-    -270,
+    -1916.6666666666679,
     0,
     1,
     300,
   ],
   Array [
     "fillRect",
-    530,
+    750.0000000000002,
     0,
     1,
     300,
@@ -1670,7 +1670,7 @@ exports[`StackChart matches the snapshot and can display a tooltip with the same
 <div
   class="tooltip"
   data-testid="tooltip"
-  style="left: 264px; top: 54px;"
+  style="left: 164px; top: 54px;"
 >
   <div
     class="tooltipCallNode"

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -36,6 +36,7 @@ describe('selectors/getStackTimingByDepth', function () {
    *
    *            Unfiltered             ->             JS Only
    *   0-10-20-30-40-50-60-70-80-90-91      0-10-20-30-40-50-60-70-80-90-91 <- Timing (ms)
+   * 0--1-----2--3--4--5--6--7--8--9      0-----------------1--2--3--4--5   <- same width indexes
    *  ================================     ================================
    *  0P 0P 0P 0P 0P 0P 0P 0P 0P 0P  |     0P 0P 0P 0P 0P 0P 0P 0P 0P 0P  |
    *  1P 1P 1P 1P    1P 1P 1P 1P 1P  |                       1J 1J 1J 1J  |
@@ -44,6 +45,13 @@ describe('selectors/getStackTimingByDepth', function () {
    *                          6P     |                             4J     |
    *                          7P     |
    *                          8J     |
+   *
+   * Note that stacks 10 and 20 in the unfiltered tree are the same, therefore
+   * they'll form just one "same width" stack.
+   * Similarly in the JS Only tree, stacks 0 to 50 are the same one and will form
+   * one "same width" stack.
+   * It's easier to think of the "same widths" indexes as the space between each
+   * new stack.
    */
 
   it('computes unfiltered stack timing by depth', function () {
@@ -52,18 +60,62 @@ describe('selectors/getStackTimingByDepth', function () {
       store.getState()
     );
     expect(stackTimingByDepth).toEqual([
-      { start: [0], end: [91], callNode: [0], length: 1 },
-      { start: [0, 50], end: [40, 91], callNode: [1, 1], length: 2 },
+      {
+        start: [0],
+        end: [91],
+        sameWidthsStart: [0],
+        sameWidthsEnd: [9],
+        callNode: [0],
+        length: 1,
+      },
+      {
+        start: [0, 50],
+        end: [40, 91],
+        sameWidthsStart: [0, 4],
+        sameWidthsEnd: [3, 9],
+        callNode: [1, 1],
+        length: 2,
+      },
       {
         start: [10, 30, 60],
         end: [30, 40, 91],
+        sameWidthsStart: [1, 2, 5],
+        sameWidthsEnd: [2, 3, 9],
         callNode: [2, 3, 4],
         length: 3,
       },
-      { start: [70], end: [90], callNode: [5], length: 1 },
-      { start: [80], end: [90], callNode: [6], length: 1 },
-      { start: [80], end: [90], callNode: [7], length: 1 },
-      { start: [80], end: [90], callNode: [8], length: 1 },
+      {
+        start: [70],
+        end: [90],
+        sameWidthsStart: [6],
+        sameWidthsEnd: [8],
+        callNode: [5],
+        length: 1,
+      },
+      {
+        start: [80],
+        end: [90],
+        sameWidthsStart: [7],
+        sameWidthsEnd: [8],
+        callNode: [6],
+        length: 1,
+      },
+      {
+        start: [80],
+        end: [90],
+        sameWidthsStart: [7],
+        sameWidthsEnd: [8],
+        callNode: [7],
+        length: 1,
+      },
+      {
+        start: [80],
+        end: [90],
+        sameWidthsStart: [7],
+        sameWidthsEnd: [8],
+        callNode: [8],
+        length: 1,
+      },
     ]);
   });
 
@@ -74,13 +126,62 @@ describe('selectors/getStackTimingByDepth', function () {
       store.getState()
     );
     expect(stackTimingByDepth).toEqual([
-      { start: [60], end: [91], callNode: [0], length: 1 },
-      { start: [60], end: [91], callNode: [1], length: 1 },
-      { start: [60], end: [91], callNode: [4], length: 1 },
-      { start: [70], end: [90], callNode: [5], length: 1 },
-      { start: [80], end: [90], callNode: [6], length: 1 },
-      { start: [80], end: [90], callNode: [7], length: 1 },
-      { start: [80], end: [90], callNode: [8], length: 1 },
+      {
+        start: [60],
+        end: [91],
+        sameWidthsStart: [0],
+        sameWidthsEnd: [4],
+        callNode: [0],
+        length: 1,
+      },
+      {
+        start: [60],
+        end: [91],
+        sameWidthsStart: [0],
+        sameWidthsEnd: [4],
+        callNode: [1],
+        length: 1,
+      },
+      {
+        start: [60],
+        end: [91],
+        sameWidthsStart: [0],
+        sameWidthsEnd: [4],
+        callNode: [4],
+        length: 1,
+      },
+      {
+        start: [70],
+        end: [90],
+        sameWidthsStart: [1],
+        sameWidthsEnd: [3],
+        callNode: [5],
+        length: 1,
+      },
+      {
+        start: [80],
+        end: [90],
+        sameWidthsStart: [2],
+        sameWidthsEnd: [3],
+        callNode: [6],
+        length: 1,
+      },
+      {
+        start: [80],
+        end: [90],
+        sameWidthsStart: [2],
+        sameWidthsEnd: [3],
+        callNode: [7],
+        length: 1,
+      },
+      {
+        start: [80],
+        end: [90],
+        sameWidthsStart: [2],
+        sameWidthsEnd: [3],
+        callNode: [8],
+        length: 1,
+      },
     ]);
   });
 });
@@ -534,11 +635,48 @@ describe('selectors/getCombinedTimingRows', function () {
         start: [3],
         instantOnly: false,
       },
-      { start: [0], end: [3], callNode: [0], length: 1 },
-      { start: [0], end: [3], callNode: [1], length: 1 },
-      { start: [0, 2], end: [2, 3], callNode: [2, 7], length: 2 },
-      { start: [0, 1, 2], end: [1, 2, 3], callNode: [3, 5, 8], length: 3 },
-      { start: [0, 1], end: [1, 2], callNode: [4, 6], length: 2 },
+      // Note that every sample has a different stack, therefore `sameWidthsStart`
+      // and `sameWidthsEnd` have the same data as `start` and `end`.
+      {
+        start: [0],
+        end: [3],
+        sameWidthsStart: [0],
+        sameWidthsEnd: [3],
+        callNode: [0],
+        length: 1,
+      },
+      {
+        start: [0],
+        end: [3],
+        sameWidthsStart: [0],
+        sameWidthsEnd: [3],
+        callNode: [1],
+        length: 1,
+      },
+      {
+        start: [0, 2],
+        end: [2, 3],
+        sameWidthsStart: [0, 2],
+        sameWidthsEnd: [2, 3],
+        callNode: [2, 7],
+        length: 2,
+      },
+      {
+        start: [0, 1, 2],
+        end: [1, 2, 3],
+        sameWidthsStart: [0, 1, 2],
+        sameWidthsEnd: [1, 2, 3],
+        callNode: [3, 5, 8],
+        length: 3,
+      },
+      {
+        start: [0, 1],
+        end: [1, 2],
+        sameWidthsStart: [0, 1],
+        sameWidthsEnd: [1, 2],
+        callNode: [4, 6],
+        length: 2,
+      },
     ]);
   });
 });

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -117,6 +117,11 @@ describe('selectors/getStackTimingByDepth', function () {
         length: 1,
       },
     ]);
+
+    const timingMap = selectedThreadSelectors.getSameWidthsIndexToTimestampMap(
+      store.getState()
+    );
+    expect(timingMap).toEqual([0, 10, 30, 40, 50, 60, 70, 80, 90, 91]);
   });
 
   it('uses search strings', function () {

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -20,6 +20,8 @@ import {
   setDataSource,
   updateBottomBoxContentsAndMaybeOpen,
   closeBottomBox,
+  changeShowUserTimings,
+  changeStackChartSameWidths,
 } from '../actions/profile-view';
 import { changeSelectedTab, changeProfilesToCompare } from '../actions/app';
 import {
@@ -430,16 +432,6 @@ describe('search strings', function () {
     expect(urlStateSelectors.getMarkersSearchString(getState())).toBe(
       'otherString'
     );
-  });
-
-  it('properly handles showUserTimings strings', function () {
-    const { getState } = _getStoreWithURL({ search: '' });
-    expect(urlStateSelectors.getShowUserTimings(getState())).toBe(false);
-  });
-
-  it('defaults to not showing user timings', function () {
-    const { getState } = _getStoreWithURL();
-    expect(urlStateSelectors.getShowUserTimings(getState())).toBe(false);
   });
 
   it('serializes the call tree search strings in the URL', function () {
@@ -1609,6 +1601,46 @@ describe('last requested call tree summary strategy', function () {
     expect(getLastSelectedCallTreeSummaryStrategy(getState())).toEqual(
       'timing'
     );
+  });
+});
+
+describe('stack chart specific queries', function () {
+  it('persists the "show user timings" setting to the URL', function () {
+    const { getState, dispatch } = _getStoreWithURL({
+      pathname: '/public/1ecd7a421948995171a4bb483b7bcc8e1868cc57/stack-chart/',
+    });
+
+    const expectedQueryString = 'showUserTimings';
+    expect(getQueryStringFromState(getState())).not.toContain(
+      expectedQueryString
+    );
+    dispatch(changeShowUserTimings(true));
+    expect(getQueryStringFromState(getState())).toContain(expectedQueryString);
+
+    const storeAfterReload = _getStoreFromStateAfterUrlRoundtrip(getState());
+
+    expect(
+      urlStateSelectors.getShowUserTimings(storeAfterReload.getState())
+    ).toBe(true);
+  });
+
+  it('persists the "use same widths" setting to the URL', function () {
+    const { getState, dispatch } = _getStoreWithURL({
+      pathname: '/public/1ecd7a421948995171a4bb483b7bcc8e1868cc57/stack-chart/',
+    });
+
+    const expectedQueryString = 'sameWidths';
+    expect(getQueryStringFromState(getState())).not.toContain(
+      expectedQueryString
+    );
+    dispatch(changeStackChartSameWidths(true));
+    expect(getQueryStringFromState(getState())).toContain(expectedQueryString);
+
+    const storeAfterReload = _getStoreFromStateAfterUrlRoundtrip(getState());
+
+    expect(
+      urlStateSelectors.getStackChartSameWidths(storeAfterReload.getState())
+    ).toBe(true);
   });
 });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -493,6 +493,10 @@ type UrlStateAction =
       +showUserTimings: boolean,
     |}
   | {|
+      +type: 'CHANGE_STACK_CHART_SAME_WIDTHS',
+      +stackChartSameWidths: boolean,
+    |}
+  | {|
       +type: 'CHANGE_SHOW_JS_TRACER_SUMMARY',
       +showSummary: boolean,
     |}

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -324,6 +324,7 @@ export type ProfileSpecificUrlState = {|
   lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy,
   invertCallstack: boolean,
   showUserTimings: boolean,
+  stackChartSameWidths: boolean,
   committedRanges: StartEndRange[],
   callTreeSearchString: string,
   markersSearchString: string,


### PR DESCRIPTION
The goal for this patch is to make shorter behaviors much easier to see. This is useful especially for debugging (and especially when used with the jstracer) rather than for profiling.

It's probably easier to look at this commit by commit, and hiding whitespace changes.
Tell me what you think! Especially please tell me if this needs some comments, now that the logic is fresh in my mind.

[deploy preview](https://deploy-preview-5195--perf-html.netlify.app/public/tmq90ah2r3ry01zw8w650wxkx27vd44kraqqe6r/stack-chart/?globalTrackOrder=b0wa&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=232138-1w3~422462-0~232410-0~232367-0~232615-0~420959-0~232739-0~232557-0~232696-0~232658-0&sameWidths&showUserTimings&thread=e&v=11)

Here is the stack chart without the option checked:
<img width="2144" height="991" alt="image" src="https://github.com/user-attachments/assets/dc34105a-af15-4e8d-a632-00ab44654529" />

and the same stack chart with the option:
<img width="2144" height="991" alt="image" src="https://github.com/user-attachments/assets/1b52830c-30bf-4145-bfd7-ab776cff8467" />

and especially the central part, when scrolled down:
without the option:
<img width="307" height="446" alt="image" src="https://github.com/user-attachments/assets/bab2fe3c-1a59-498b-95a6-665e330d2082" />

With the option:
<img width="1492" height="446" alt="image" src="https://github.com/user-attachments/assets/c127cbbc-6de4-4561-bc65-f093ec856789" />

