### PR TITLE
Change the implementation filter to 'js' if the if a tab is selected in the tab selector

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -1911,6 +1911,9 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
       }
     }
 
+    // Change the implementation filter to 'js' if a new tab filter is selected.
+    const implementationFilter = tabID !== null ? 'js' : 'combined';
+
     dispatch({
       type: 'CHANGE_TAB_FILTER',
       tabID,
@@ -1921,6 +1924,7 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
       localTracksByPid,
       localTrackOrderByPid,
       ...hiddenTracks,
+      implementationFilter,
     });
   };
 }

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -267,6 +267,8 @@ const implementation: Reducer<ImplementationFilter> = (
       return action.implementationFilter || state;
     case 'CHANGE_IMPLEMENTATION_FILTER':
       return action.implementation;
+    case 'CHANGE_TAB_FILTER':
+      return action.implementationFilter;
     default:
       return state;
   }

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -17,7 +17,10 @@ import {
 } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
-import { getTabFilter } from '../../selectors/url-state';
+import {
+  getTabFilter,
+  getImplementationFilter,
+} from '../../selectors/url-state';
 import { ensureExists } from 'firefox-profiler/utils/flow';
 
 describe('app/TabSelectorMenu', () => {
@@ -176,5 +179,32 @@ describe('app/TabSelectorMenu', () => {
     expect(profilerTab.compareDocumentPosition(mozillaTab)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
+  });
+
+  it('should change the implementation filter to js after a tab switch', () => {
+    const { getState, secondTabTabID } = setup();
+
+    // Check that there is no tab filter at first.
+    expect(getTabFilter(getState())).toBe(null);
+    // Also make sure that the implementation filter is 'combined' right now.j
+    expect(getImplementationFilter(getState())).toEqual('combined');
+
+    // Change the tab filter by clicking on the menu item.
+    const profilerTab = screen.getByText('profiler.firefox.com');
+    fireFullClick(profilerTab);
+
+    // Check the tab filter again, it should match the second tab in the profile.
+    expect(getTabFilter(getState())).toBe(secondTabTabID);
+    // Make sure that the implementation filter is switched to 'js'.
+    expect(getImplementationFilter(getState())).toEqual('js');
+
+    // Change the tab filter back to full profile.
+    const allTabs = screen.getByText('All tabs and windows');
+    fireFullClick(allTabs);
+
+    // Check the tab filter again, it should match the first tab in the profile.
+    expect(getTabFilter(getState())).toBe(null);
+    // Make sure that the implementation filter is switched to 'combined' again.
+    expect(getImplementationFilter(getState())).toEqual('combined');
   });
 });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -574,6 +574,7 @@ type UrlStateAction =
       +hiddenLocalTracksByPid: Map<Pid, Set<TrackIndex>>,
       +localTrackOrderByPid: Map<Pid, TrackIndex[]>,
       +selectedTab: TabSlug,
+      +implementationFilter: ImplementationFilter,
     |};
 
 export type IconWithClassName = {| +icon: string, +className: string |};


### PR DESCRIPTION
This also came up while I was working on my talk. I noticed that it's an extra click all the time for web developers when they need to investigate their issues. I think also we discussed about implementing this in the past but never did it. So I think it'll be a lot better for the web developers to have this.

One thing that I'm not so sure about is to whether change it back to `'combined'` once the user selects the `All tabs and windows`. I could leave it as `js`, but felt like switching back to combined made more sense for the users. So I went with that. Let me know what you think!

[Example profile](https://deploy-preview-5199--perf-html.netlify.app/public/z1r4vb03p3deqgkrtcnnysm44521vjcdzw4dcq0)