### PR TITLE
Fix the network bars not being properly positioned in Chrome

### DIFF
--- a/src/components/network-chart/index.css
+++ b/src/components/network-chart/index.css
@@ -20,6 +20,7 @@
 }
 
 .networkChartRowItem {
+  position: relative;
   display: block;
   width: 100%;
   height: 16px;
@@ -51,6 +52,7 @@
 
 .networkChartRowItemBar {
   position: absolute; /* The bar will be positioned in JS. */
+  top: 0;
   display: inline-block;
   overflow: hidden; /* This clips this element's children using its border-radius */
   height: 14px;


### PR DESCRIPTION
Fixes #5196

[Deploy preview](https://deploy-preview-5209--perf-html.netlify.app/public/a607mdt6zyazhnay7kvreccrybzg11y3nzapw1r/network-chart/?globalTrackOrder=b0wa&hiddenGlobalTracks=0w9&hiddenLocalTracksByPid=843-13~846-0&range=9256m2911~10000m420&thread=f&v=10) / [Production](https://profiler.firefox.com/public/a607mdt6zyazhnay7kvreccrybzg11y3nzapw1r/network-chart/?globalTrackOrder=b0wa&hiddenGlobalTracks=0w9&hiddenLocalTracksByPid=843-13~846-0&range=9256m2911~10000m420&thread=f&v=10)