### PR TITLE
Support absolute memory counters

### DIFF
--- a/docs-developer/CHANGELOG-formats.md
+++ b/docs-developer/CHANGELOG-formats.md
@@ -6,6 +6,12 @@ Note that this is not an exhaustive list. Processed profile format upgraders can
 
 ## Processed profile format
 
+### Version 52
+
+Counters contain a new boolean field `relative`. It is true of the samples
+in the counter are relative measuments to the previous count, the first
+sample is 0, the absolute value is unknown.
+
 ### Version 51
 
 Two new marker schema field format types have been added: `flow-id` and `terminating-flow-id`, with string index values (like `unique-string`).
@@ -82,6 +88,11 @@ We've also cleaned up the ResourceTable format:
 Older versions are not documented in this changelog but can be found in [processed-profile-versioning.js](../src/profile-logic/processed-profile-versioning.js).
 
 ## Gecko profile format
+
+### Version 32
+
+The memory counters are now named "malloc-relative" or "malloc-absolute"
+rather than "malloc" (which were all previously relative)
 
 ### Version 31
 

--- a/docs-user/memory-allocations.md
+++ b/docs-user/memory-allocations.md
@@ -10,9 +10,9 @@ The Firefox Profiler supports three different types of memory profiling
 
 ![A screenshot showing the memory track in the timeline.](images/allocation-track.png)
 
-The memory track graphs overall allocation and deallocation numbers over time for a single process. It is enabled only in Nightly. It works by tracking every allocation and deallocation, and occasionally sampling what that summed number is. The track also collects the markers related to garbage collection and cycle collection. Mouse over the graph to see all of the numbers.
+The memory track graphs overall allocation and deallocation numbers over time for a single process. It counts every allocation and deallocation in Firefox's main memory allocator, mozjemalloc. It does not include the JS heap or other custom allocators such as LifoAlloc.  The total bytes allocated is sampled and plotted on the memory track.  The track also collects the markers related to garbage collection and cycle collection. Mouse over the graph to see all of the numbers.
 
-The graph visualization tracks the relative memory usage over the committed range of time. It's important to note that this is not absolute memory usage. The graph and numbers will change when committing a range selection.
+The graph visualization tracks the memory usage over the committed range of time. Depending on the version of Firefox used this may be either relative or absolute bytes allocated.  In either case the graph will change when committing a range selection so that small differences can be made clear.  If the memory counter is relative then the numbers will also change when committing to a range.
 
 ## Native Memory Allocations (experimental)
 

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -9,12 +9,12 @@ import type { MarkerPhase } from 'firefox-profiler/types';
 // The current version of the Gecko profile format.
 // Please don't forget to update the gecko profile format changelog in
 // `docs-developer/CHANGELOG-formats.md`.
-export const GECKO_PROFILE_VERSION = 31;
+export const GECKO_PROFILE_VERSION = 32;
 
 // The current version of the "processed" profile format.
 // Please don't forget to update the processed profile format changelog in
 // `docs-developer/CHANGELOG-formats.md`.
-export const PROCESSED_PROFILE_VERSION = 51;
+export const PROCESSED_PROFILE_VERSION = 52;
 
 // The following are the margin sizes for the left and right of the timeline. Independent
 // components need to share these values.

--- a/src/components/timeline/TrackBandwidthGraph.js
+++ b/src/components/timeline/TrackBandwidthGraph.js
@@ -42,7 +42,7 @@ import type {
   Counter,
   Thread,
   ThreadIndex,
-  AccumulatedCounterSamples,
+  CounterSummary,
   Milliseconds,
   PreviewSelection,
   CssPixels,
@@ -63,7 +63,7 @@ type CanvasProps = {|
   +rangeEnd: Milliseconds,
   +counter: Counter,
   +counterSampleRange: [IndexIntoSamplesTable, IndexIntoSamplesTable],
-  +accumulatedSamples: AccumulatedCounterSamples,
+  +counterSummary: CounterSummary,
   +maxCounterSampleCountPerMs: number,
   +interval: Milliseconds,
   +width: CssPixels,
@@ -309,7 +309,7 @@ type StateProps = {|
   +rangeEnd: Milliseconds,
   +counter: Counter,
   +counterSampleRange: [IndexIntoSamplesTable, IndexIntoSamplesTable],
-  +accumulatedSamples: AccumulatedCounterSamples,
+  +counterSummary: CounterSummary,
   +maxCounterSampleCountPerMs: number,
   +interval: Milliseconds,
   +filteredThread: Thread,
@@ -472,7 +472,7 @@ class TrackBandwidthGraphImpl extends React.PureComponent<Props, State> {
 
   _renderTooltip(counterIndex: number): React.Node {
     const {
-      accumulatedSamples,
+      counterSummary,
       counter,
       rangeStart,
       rangeEnd,
@@ -496,8 +496,10 @@ class TrackBandwidthGraphImpl extends React.PureComponent<Props, State> {
       return null;
     }
 
-    const { minCount, countRange, accumulatedCounts } = accumulatedSamples;
-    const bytes = accumulatedCounts[counterIndex] - minCount;
+    const { minCount, countRange, accumulatedCounts } = counterSummary;
+    const bytes = accumulatedCounts
+      ? accumulatedCounts[counterIndex] - minCount
+      : null;
     const operations =
       samples.number !== undefined ? samples.number[counterIndex] : null;
 
@@ -547,10 +549,12 @@ class TrackBandwidthGraphImpl extends React.PureComponent<Props, State> {
               </Localized>
             ) : null}
             <TooltipDetailSeparator />
-            {this._formatDataTransferValue(
-              bytes,
-              'TrackBandwidthGraph--cumulative-bandwidth-at-this-time'
-            )}
+            {bytes
+              ? this._formatDataTransferValue(
+                  bytes,
+                  'TrackBandwidthGraph--cumulative-bandwidth-at-this-time'
+                )
+              : null}
             {this._formatDataTransferValue(
               countRange,
               'TrackBandwidthGraph--total-bandwidth-in-graph'
@@ -637,7 +641,7 @@ class TrackBandwidthGraphImpl extends React.PureComponent<Props, State> {
       graphHeight,
       width,
       lineWidth,
-      accumulatedSamples,
+      counterSummary,
       maxCounterSampleCountPerMs,
     } = this.props;
 
@@ -656,7 +660,7 @@ class TrackBandwidthGraphImpl extends React.PureComponent<Props, State> {
           width={width}
           lineWidth={lineWidth}
           interval={interval}
-          accumulatedSamples={accumulatedSamples}
+          counterSummary={counterSummary}
           maxCounterSampleCountPerMs={maxCounterSampleCountPerMs}
         />
         {hoveredCounter === null ? null : (
@@ -695,7 +699,7 @@ export const TrackBandwidthGraph = explicitConnect<
       threadIndex: counter.mainThreadIndex,
       maxCounterSampleCountPerMs:
         counterSelectors.getMaxRangeCounterSampleCountPerMs(state),
-      accumulatedSamples: counterSelectors.getAccumulateCounterSamples(state),
+      counterSummary: counterSelectors.getCounterSummary(state),
       rangeStart: start,
       rangeEnd: end,
       counterSampleRange,

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -1490,6 +1490,23 @@ const _upgraders = {
     // frontend to display older formats.
   },
 
+  [32]: (profile) => {
+    function convertToVersion32Recursive(p) {
+      if (p.counters) {
+        for (const c of p.counters) {
+          if (c.name === 'malloc') {
+            c.name = 'malloc-relative';
+          }
+        }
+      }
+
+      for (const subprocessProfile of p.processes) {
+        convertToVersion32Recursive(subprocessProfile);
+      }
+    }
+    convertToVersion32Recursive(profile);
+  },
+
   // If you add a new upgrader here, please document the change in
   // `docs-developer/CHANGELOG-formats.md`.
 };

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1030,26 +1030,68 @@ function _processCounters(
     );
   }
 
-  return geckoCounters.reduce(
-    (result, { name, category, description, samples }) => {
-      if (samples.data.length === 0) {
-        // It's possible that no sample has been collected during our capture
-        // session, ignore this counter if that's the case.
-        return result;
-      }
+  /**
+   * Process the samples in the counter.
+   */
+  function processCounter(gecko_counter: GeckoCounter): Counter {
+    const { name, category, description } = gecko_counter;
 
-      result.push({
-        name,
-        category,
-        description,
-        pid: mainThreadPid,
-        mainThreadIndex,
-        samples: adjustTableTimestamps(_toStructOfArrays(samples), delta),
-      });
+    const relative = name === 'malloc-relative';
+    const samples = adjustTableTimestamps(
+      _toStructOfArrays(gecko_counter.samples),
+      delta
+    );
+
+    const count = samples.count.slice();
+    const number =
+      samples.number !== undefined ? samples.number.slice() : undefined;
+
+    if (relative) {
+      // These lines zero out the first values of the relative memory
+      // counters, as they are unreliable. In addition, there are probably
+      // some missed counts in the memory counters, so the first memory number
+      // slowly creeps up over time, and becomes very unrealistic.  In order
+      // to not be affected by these platform limitations, zero out the first
+      // counter values.
+      //
+      // "Memory counter in Gecko Profiler isn't cleared when starting a new
+      // capture"
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1520587
+      count[0] = 0;
+      if (number !== undefined) {
+        number[0] = 0;
+      }
+    } else if (name === 'malloc-absolute') {
+      // Absolute memory counter samples are relative to the previous one,
+      // it's just that the first sample is absolute.  To make this more
+      // consistent with other counters we transform it to absolute here.
+      var accumulated = count[0];
+      for (var i = 1; i < count.length; i++) {
+        accumulated += count[i];
+        count[i] = accumulated;
+      }
+    }
+
+    return {
+      name,
+      category,
+      description,
+      pid: mainThreadPid,
+      mainThreadIndex,
+      samples: { ...samples, number, count },
+      relative,
+    };
+  }
+
+  return geckoCounters.reduce((result, gecko_counter) => {
+    if (gecko_counter.samples.data.length === 0) {
+      // It's possible that no sample has been collected during our capture
+      // session, ignore this counter if that's the case.
       return result;
-    },
-    []
-  );
+    }
+    result.push(processCounter(gecko_counter));
+    return result;
+  }, []);
 }
 
 /**

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1065,8 +1065,8 @@ function _processCounters(
       // Absolute memory counter samples are relative to the previous one,
       // it's just that the first sample is absolute.  To make this more
       // consistent with other counters we transform it to absolute here.
-      var accumulated = count[0];
-      for (var i = 1; i < count.length; i++) {
+      let accumulated = count[0];
+      for (let i = 1; i < count.length; i++) {
         accumulated += count[i];
         count[i] = accumulated;
       }

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2282,6 +2282,17 @@ const _upgraders = {
     // marker data with the new field types data, and no modification is needed in the
     // frontend to display older formats.
   },
+  [52]: (profile) => {
+    if (profile.counters && profile.counters.length > 0) {
+      for (const counter of profile.counters) {
+        counter.relative = counter.name in ['malloc', "bandwidth"];
+        if (counter.name === "malloc") {
+          counter.name = 'malloc.relative';
+        }
+      }
+    }
+  },
+
   // If you add a new upgrader here, please document the change in
   // `docs-developer/CHANGELOG-formats.md`.
 };

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2285,8 +2285,8 @@ const _upgraders = {
   [52]: (profile) => {
     if (profile.counters && profile.counters.length > 0) {
       for (const counter of profile.counters) {
-        counter.relative = counter.name in ['malloc', "bandwidth"];
-        if (counter.name === "malloc") {
+        counter.relative = counter.name in ['malloc', 'bandwidth'];
+        if (counter.name === 'malloc') {
           counter.name = 'malloc.relative';
         }
       }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -64,8 +64,8 @@ import type {
   CallNodeTable,
   CallNodePath,
   CallNodeAndCategoryPath,
+  CounterSummary,
   IndexIntoCallNodeTable,
-  AccumulatedCounterSamples,
   SamplesLikeTable,
   SelectedState,
   ProfileFilterPageData,
@@ -1721,61 +1721,43 @@ export function filterCounterSamplesToRange(
 }
 
 /**
- * Process the samples in the counter.
+ * The memory counter sometimes contains relative offsets of memory. In
+ * order to draw an interesting graph, take the memory counts, and find the
+ * minimum and maximum values, accumulating them if necessary. Then, map
+ * those values to the accumulatedCounts array.
  */
-export function processCounter(counter: Counter): Counter {
-  const { samples } = counter;
-  const count = samples.count.slice();
-  const number =
-    samples.number !== undefined ? samples.number.slice() : undefined;
-
-  // These lines zero out the first values of the counters, as they are unreliable. In
-  // addition, there are probably some missed counts in the memory counters, so the
-  // first memory number slowly creeps up over time, and becomes very unrealistic.
-  // In order to not be affected by these platform limitations, zero out the first
-  // counter values.
-  //
-  // "Memory counter in Gecko Profiler isn't cleared when starting a new capture"
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1520587
-  count[0] = 0;
-  if (number !== undefined) {
-    number[0] = 0;
-  }
-
-  return {
-    ...counter,
-    samples: {
-      ...samples,
-      number,
-      count,
-    },
-  };
-}
-
-/**
- * The memory counter contains relative offsets of memory. In order to draw an interesting
- * graph, take the memory counts, and find the minimum and maximum values, by
- * accumulating them over the entire profile range. Then, map those values to the
- * accumulatedCounts array.
- */
-export function accumulateCounterSamples(
+export function summariseCounterSamples(
   samples: CounterSamplesTable,
+  relative: boolean,
   sampleRange?: [IndexIntoSamplesTable, IndexIntoSamplesTable]
-): AccumulatedCounterSamples {
-  let minCount = 0;
-  let maxCount = 0;
-  let accumulated = 0;
-  const accumulatedCounts = Array(samples.length).fill(0);
-  // If a range is provided, use it instead. This will also include the
-  // samples right before and after the range.
+): CounterSummary {
+  // If a range is provided, use it. This will also include the samples
+  // right before and after the range.
   const startSampleIndex = sampleRange ? sampleRange[0] : 0;
   const endSampleIndex = sampleRange ? sampleRange[1] : samples.length;
+  const numSamples = endSampleIndex - startSampleIndex;
+  var accumulatedCounts;
+  var getSample;
+
+  if (relative) {
+    accumulatedCounts = Array(numSamples);
+    let accumulated = 0;
+    for (let i = 0; i < numSamples; i++) {
+      accumulated += samples.count[startSampleIndex + i];
+      accumulatedCounts[i] = accumulated;
+    }
+
+    getSample = (i) => accumulatedCounts[i - startSampleIndex];
+  } else {
+    getSample = (i) => samples.count[i];
+  }
+
+  let minCount = getSample(startSampleIndex);
+  let maxCount = getSample(startSampleIndex);
 
   for (let i = startSampleIndex; i < endSampleIndex; i++) {
-    accumulated += samples.count[i];
-    minCount = Math.min(accumulated, minCount);
-    maxCount = Math.max(accumulated, maxCount);
-    accumulatedCounts[i] = accumulated;
+    minCount = Math.min(getSample(i), minCount);
+    maxCount = Math.max(getSample(i), maxCount);
   }
   const countRange = maxCount - minCount;
 

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1736,8 +1736,8 @@ export function summariseCounterSamples(
   const startSampleIndex = sampleRange ? sampleRange[0] : 0;
   const endSampleIndex = sampleRange ? sampleRange[1] : samples.length;
   const numSamples = endSampleIndex - startSampleIndex;
-  var accumulatedCounts;
-  var getSample;
+  let accumulatedCounts;
+  let getSample;
 
   if (relative) {
     accumulatedCounts = Array(numSamples);

--- a/src/test/components/TrackBandwidth.test.js
+++ b/src/test/components/TrackBandwidth.test.js
@@ -77,11 +77,12 @@ describe('TrackBandwidth', function () {
           time: thread.samples.time.slice(),
           // Bandwidth usage numbers. They are bytes.
           count: [
-            10000, 40000, 50000, 100000, 2000000, 5000000, 30000, 1000000,
+            0, 40000, 50000, 100000, 2000000, 5000000, 30000, 1000000,
             20000, 1, 12000, 100000,
           ],
           length: SAMPLE_COUNT,
         },
+        true,
         'SystemBandwidth',
         'bandwidth'
       ),

--- a/src/test/components/TrackBandwidth.test.js
+++ b/src/test/components/TrackBandwidth.test.js
@@ -77,8 +77,8 @@ describe('TrackBandwidth', function () {
           time: thread.samples.time.slice(),
           // Bandwidth usage numbers. They are bytes.
           count: [
-            0, 40000, 50000, 100000, 2000000, 5000000, 30000, 1000000,
-            20000, 1, 12000, 100000,
+            0, 40000, 50000, 100000, 2000000, 5000000, 30000, 1000000, 20000, 1,
+            12000, 100000,
           ],
           length: SAMPLE_COUNT,
         },

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -28,6 +28,8 @@ import {
 import {
   getProfileFromTextSamples,
   getCounterForThread,
+  getCounterForThreadWithSamples,
+  makeSamples,
 } from '../fixtures/profiles/processed-profile';
 import {
   autoMockElementSize,
@@ -67,8 +69,24 @@ describe('TrackMemory', function () {
     );
     const threadIndex = 0;
     const thread = profile.threads[threadIndex];
+
+    // Relative samples,
+    const samplesA = makeSamples(
+      (i) => i == 0 ? 0 : Math.sin(i),
+      thread,
+      counterConfig
+    );
+    // Absolute samples,
+    const samplesB = makeSamples(
+      (i) => Math.sin(i) + 10,
+      thread,
+      counterConfig
+    );
     profile.counters = [
-      getCounterForThread(thread, threadIndex, counterConfig),
+      getCounterForThreadWithSamples(thread, threadIndex,
+        samplesA, true),
+      getCounterForThreadWithSamples(thread, threadIndex,
+        samplesB, false),
     ];
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -72,7 +72,7 @@ describe('TrackMemory', function () {
 
     // Relative samples,
     const samplesA = makeSamples(
-      (i) => i == 0 ? 0 : Math.sin(i),
+      (i) => (i === 0 ? 0 : Math.sin(i)),
       thread,
       counterConfig
     );
@@ -83,10 +83,8 @@ describe('TrackMemory', function () {
       counterConfig
     );
     profile.counters = [
-      getCounterForThreadWithSamples(thread, threadIndex,
-        samplesA, true),
-      getCounterForThreadWithSamples(thread, threadIndex,
-        samplesB, false),
+      getCounterForThreadWithSamples(thread, threadIndex, samplesA, true),
+      getCounterForThreadWithSamples(thread, threadIndex, samplesB, false),
     ];
     const store = storeWithProfile(profile);
     const { getState, dispatch } = store;

--- a/src/test/components/TrackPower.test.js
+++ b/src/test/components/TrackPower.test.js
@@ -78,6 +78,7 @@ describe('TrackPower', function () {
           ],
           length: SAMPLE_COUNT,
         },
+        false,
         'SystemPower',
         'power'
       ),

--- a/src/test/components/TrackProcessCPU.test.js
+++ b/src/test/components/TrackProcessCPU.test.js
@@ -68,6 +68,7 @@ describe('TrackProcessCPU', function () {
           count: [100, 400, 500, 1000, 200, 500, 300, 100],
           length: SAMPLE_COUNT,
         },
+        false,
         'processCPU',
         'CPU'
       ),

--- a/src/test/components/__snapshots__/TrackMemory.test.js.snap
+++ b/src/test/components/__snapshots__/TrackMemory.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TrackMemory draws a dot that matches the snapshot 1`] = `
 <div
   class="timelineTrackMemoryGraphDot"
-  style="left: 20px; top: 2.697563250235465px; background-color: rgb(215, 110, 0);"
+  style="left: 20px; top: 3.9396262364054238px; background-color: rgb(215, 110, 0);"
 />
 `;
 
@@ -67,6 +67,16 @@ exports[`TrackMemory has a tooltip that matches the snapshot for counts equallin
       2B
     </span>
     memory range in graph
+  </div>
+  <div
+    class="timelineTrackMemoryTooltipLine"
+  >
+    <span
+      class="timelineTrackMemoryTooltipNumber"
+    >
+      0
+    </span>
+    allocations and deallocations since the previous sample
   </div>
 </div>
 `;

--- a/src/test/components/__snapshots__/TrackPower.test.js.snap
+++ b/src/test/components/__snapshots__/TrackPower.test.js.snap
@@ -63,7 +63,7 @@ Array [
   Array [
     "moveTo",
     0,
-    26,
+    24,
   ],
   Array [
     "lineTo",

--- a/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
+++ b/src/test/components/__snapshots__/TrackProcessCPU.test.js.snap
@@ -56,7 +56,7 @@ Array [
   Array [
     "moveTo",
     0,
-    24,
+    21.7,
   ],
   Array [
     "lineTo",

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1517,16 +1517,8 @@ export function getCounterForThread(
     description: 'My Description',
     pid: thread.pid,
     mainThreadIndex,
-    samples: {
-      time: thread.samples.time.slice(),
-      // Create some arbitrary (positive integer) values for the number.
-      number: config.hasCountNumber
-        ? thread.samples.time.map((_, i) => Math.floor(50 * Math.sin(i) + 50))
-        : undefined,
-      // Create some arbitrary values for the count.
-      count: thread.samples.time.map((_, i) => Math.sin(i)),
-      length: thread.samples.length,
-    },
+    relative: false,
+    samples: makeSamples(Math.sin, thread, config),
   };
   return counter;
 }
@@ -1543,6 +1535,7 @@ export function getCounterForThreadWithSamples(
     count?: number[],
     length: number,
   },
+  relative: boolean,
   name?: string,
   category?: string
 ): Counter {
@@ -1564,8 +1557,28 @@ export function getCounterForThreadWithSamples(
     pid: thread.pid,
     mainThreadIndex,
     samples: newSamples,
+    relative: relative,
   };
   return counter;
+}
+
+/**
+ * Given a function to generate the counts make a samples
+ * structure.
+ */
+export function makeSamples(fn: (number) => number,
+  thread: Thread,
+  config: { hasCountNumber: boolean } = {}
+) {
+  return {time: thread.samples.time.slice(),
+      // Create some arbitrary (positive integer) values for the number.
+      number: config.hasCountNumber
+        ? thread.samples.time.map((_, i) => Math.floor(50 * Math.sin(i) + 50))
+        : undefined,
+      // Create some arbitrary values for the count.
+      count: thread.samples.time.map((_, i) => fn(i)),
+      length: thread.samples.length,
+    };
 }
 
 /**

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -1566,19 +1566,21 @@ export function getCounterForThreadWithSamples(
  * Given a function to generate the counts make a samples
  * structure.
  */
-export function makeSamples(fn: (number) => number,
+export function makeSamples(
+  fn: (number) => number,
   thread: Thread,
   config: { hasCountNumber: boolean } = {}
 ) {
-  return {time: thread.samples.time.slice(),
-      // Create some arbitrary (positive integer) values for the number.
-      number: config.hasCountNumber
-        ? thread.samples.time.map((_, i) => Math.floor(50 * Math.sin(i) + 50))
-        : undefined,
-      // Create some arbitrary values for the count.
-      count: thread.samples.time.map((_, i) => fn(i)),
-      length: thread.samples.length,
-    };
+  return {
+    time: thread.samples.time.slice(),
+    // Create some arbitrary (positive integer) values for the number.
+    number: config.hasCountNumber
+      ? thread.samples.time.map((_, i) => Math.floor(50 * Math.sin(i) + 50))
+      : undefined,
+    // Create some arbitrary values for the count.
+    count: thread.samples.time.map((_, i) => fn(i)),
+    length: thread.samples.length,
+  };
 }
 
 /**

--- a/src/test/integration/symbolicator-cli/symbolicated.json
+++ b/src/test/integration/symbolicator-cli/symbolicated.json
@@ -7,7 +7,7 @@
     "debug": false,
     "extensions": { "baseURL": [], "id": [], "length": 0, "name": [] },
     "interval": 1,
-    "preprocessedProfileVersion": 51,
+    "preprocessedProfileVersion": 52,
     "processType": 0,
     "product": "a.out",
     "oscpu": "macOS 14.6.1",

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -457,7 +457,7 @@ Object {
     "oscpu": "",
     "physicalCPUs": 0,
     "platform": "",
-    "preprocessedProfileVersion": 51,
+    "preprocessedProfileVersion": 52,
     "processType": 0,
     "product": "Firefox",
     "sourceURL": "",
@@ -465,7 +465,7 @@ Object {
     "startTime": 0,
     "symbolicated": true,
     "toolkit": "",
-    "version": 31,
+    "version": 32,
   },
   "pages": Array [
     Object {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -3222,9 +3222,7 @@ describe('counter selectors', function () {
   it('can summarise absolute samples', function () {
     const { getState, counterA } = setup();
     counterA.relative = false;
-    counterA.samples.count = [
-      100, 125, 90, 111, 112, 113, 120, 98, 99, 100,
-    ];
+    counterA.samples.count = [100, 125, 90, 111, 112, 113, 120, 98, 99, 100];
     expect(getCounterSelectors(0).getCounterSummary(getState())).toEqual({
       accumulatedCounts: undefined,
       countRange: 35,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -48,10 +48,7 @@ import {
   getThreadSelectors,
 } from '../../selectors/per-thread';
 import { ensureExists } from '../../utils/flow';
-import {
-  processCounter,
-  type BreakdownByCategory,
-} from '../../profile-logic/profile-data';
+import { type BreakdownByCategory } from '../../profile-logic/profile-data';
 
 import type {
   TrackReference,
@@ -3182,25 +3179,17 @@ describe('counter selectors', function () {
     const counterB = getCounterForThread(thread, threadIndex);
     profile.counters = [counterA, counterB];
     const { getState, dispatch } = storeWithProfile(profile);
-    const processedCounterA = processCounter(counterA);
-    const processedCounterB = processCounter(counterB);
     return {
       getState,
       dispatch,
       counterA,
-      processedCounterA,
-      processedCounterB,
     };
   }
 
   it('can get the counters', function () {
-    const { processedCounterA, processedCounterB, getState } = setup();
-    expect(getCounterSelectors(0).getCounter(getState())).toStrictEqual(
-      processedCounterA
-    );
-    expect(getCounterSelectors(1).getCounter(getState())).toStrictEqual(
-      processedCounterB
-    );
+    const { getState } = setup();
+    expect(getCounterSelectors(0).getCounter(getState())).toBeDefined();
+    expect(getCounterSelectors(1).getCounter(getState())).toBeDefined();
   });
 
   it('can get the counter description', function () {
@@ -3215,22 +3204,32 @@ describe('counter selectors', function () {
     expect(getCounterSelectors(0).getPid(getState())).toBe('0');
   });
 
-  it('can accumulate samples', function () {
+  it('can accumulate relative samples', function () {
     const { getState, counterA } = setup();
+    counterA.relative = true;
     counterA.samples.count = [
-      // The first value gets zeroed out due to a work-around for Bug 1520587. It
-      // can be much larger than all the rest of the values, as it doesn't ever
-      // get reset.
-      10000,
-      -2, 3, -5, 7, -11, 13, -17, 19, 23,
+      // The first value is expected to be zero after importing the profile.
+      0, -2, 3, -5, 7, -11, 13, -17, 19, 23,
     ];
-    expect(
-      getCounterSelectors(0).getAccumulateCounterSamples(getState())
-    ).toEqual({
+    expect(getCounterSelectors(0).getCounterSummary(getState())).toEqual({
       accumulatedCounts: [0, -2, 1, -4, 3, -8, 5, -12, 7, 30],
       countRange: 42,
       maxCount: 30,
       minCount: -12,
+    });
+  });
+
+  it('can summarise absolute samples', function () {
+    const { getState, counterA } = setup();
+    counterA.relative = false;
+    counterA.samples.count = [
+      100, 125, 90, 111, 112, 113, 120, 98, 99, 100,
+    ];
+    expect(getCounterSelectors(0).getCounterSummary(getState())).toEqual({
+      accumulatedCounts: undefined,
+      countRange: 35,
+      maxCount: 125,
+      minCount: 90,
     });
   });
 });

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -40,7 +40,7 @@ Object {
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,
-    "preprocessedProfileVersion": 51,
+    "preprocessedProfileVersion": 52,
     "processType": 0,
     "product": "Firefox",
     "sampleUnits": undefined,
@@ -50,7 +50,7 @@ Object {
     "symbolicated": true,
     "toolkit": undefined,
     "updateChannel": undefined,
-    "version": 31,
+    "version": 32,
     "visualMetrics": undefined,
   },
   "pages": Array [],
@@ -7975,7 +7975,7 @@ Object {
     "stackwalk": 1,
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
-    "version": 31,
+    "version": 32,
   },
   "pausedRanges": Array [],
   "processes": Array [
@@ -8936,7 +8936,7 @@ Object {
     Object {
       "category": "Memory",
       "description": "Amount of allocated memory",
-      "name": "malloc",
+      "name": "malloc-relative",
       "samples": Object {
         "data": Array [
           Array [
@@ -9431,7 +9431,7 @@ Object {
     "stackwalk": 1,
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
-    "version": 31,
+    "version": 32,
   },
   "pages": Array [
     Object {
@@ -10971,7 +10971,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 51,
+    "preprocessedProfileVersion": 52,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -12625,7 +12625,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 51,
+    "preprocessedProfileVersion": 52,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -13958,8 +13958,9 @@ Object {
       "category": "Memory",
       "description": "Amount of allocated memory",
       "mainThreadIndex": 0,
-      "name": "malloc",
+      "name": "malloc.relative",
       "pid": "11111",
+      "relative": false,
       "samples": Object {
         "count": Array [
           1,
@@ -14422,7 +14423,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 51,
+    "preprocessedProfileVersion": 52,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -442,17 +442,18 @@ export type JsTracerTiming = {
 };
 
 /**
- * The memory counter contains relative offsets of memory. This type provides a data
- * structure that can be used to see the total range of change over all the samples.
+ * The memory counter sometimes contains relative offsets of memory. This type provides a data
+ * structure that can be used to see the total range of change over all the samples,
  */
-export type AccumulatedCounterSamples = {|
+export type CounterSummary = {|
   +minCount: number,
   +maxCount: number,
   +countRange: number,
-  // This value holds the accumulation of all the previous counts in the Counter samples.
-  // For a memory counter, this gives the relative offset of bytes in that range
-  // selection. The array will share the indexes of the range filtered counter samples.
-  +accumulatedCounts: number[],
+  // If present this value holds the accumulation of all the previous counts
+  // in the Counter samples.  For a relative memory counter, this gives the
+  // relative offset of bytes in that range selection. The array will share
+  // the indexes of the range filtered counter samples.
+  +accumulatedCounts: ?(number[]),
 |};
 
 /**

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -538,6 +538,7 @@ export type Counter = {|
   color?: GraphColor,
   pid: Pid,
   mainThreadIndex: ThreadIndex,
+  relative: boolean,
   samples: CounterSamplesTable,
 |};
 


### PR DESCRIPTION
Support absolute in addition to relative memory counters and render them correctly.  This involves incrementing the profiler versions.

The corresponding gecko code change is [1806054](https://bugzilla.mozilla.org/show_bug.cgi?id=1806054) (https://bugzilla.mozilla.org/show_bug.cgi?id=1806054): Memory profiling uses the expensive malloc_usable_size function.