### PR TITLE
Remove "Recording started" line from Profile Info if startTime is 0

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -224,7 +224,7 @@ class MetaInfoPanelImpl extends React.PureComponent<Props, State> {
     return (
       <>
         <div className="metaInfoSection">
-          {meta.profilingStartTime !== undefined ? (
+          {meta.profilingStartTime !== undefined && meta.startTime ? (
             <div className="metaInfoRow">
               <span className="metaInfoLabel">
                 <Localized id="MenuButtons--metaInfo--profiling-started">


### PR DESCRIPTION
This PR is a follow-on from https://github.com/firefox-devtools/profiler/pull/5188 that removes the "Recording started:" line from the Profile Info popup if profile startTime is 0, as illustrated below:

| Before | After |
| ------------- | ------------- |
| ![Profile_Info_no_Recording_started_before](https://github.com/user-attachments/assets/5a46a3db-1c2e-47ee-aca4-9d7a9bea1324) | ![Profile_Info_no_Recording_started_after](https://github.com/user-attachments/assets/12d6762a-760f-4dfd-ac76-6449f4a3c367) |