### PR TITLE
Fix test debugging in VS Code.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,8 @@
     {
       "name": "Run Jest",
       "type": "node",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["test"],
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
       "args": ["--runInBand", "${file}"],
       "cwd": "${workspaceFolder}",


### PR DESCRIPTION
Without these environment variables, choosing "Run -> Start Debugging" on a test file in VS Code would run into the assertion added by #5167:

```
Jest must be run from `yarn test`
```