### PR TITLE
Add Class of Service for a request in the profiler network tab

### DIFF
--- a/src/components/tooltip/NetworkMarker.js
+++ b/src/components/tooltip/NetworkMarker.js
@@ -456,5 +456,13 @@ export function getNetworkMarkerDetails(
     );
   }
 
+  if (payload.classOfService) {
+    details.push(
+      <TooltipDetail label="Class of Service" key="Network-Class of Service">
+        {payload.classOfService}
+      </TooltipDetail>
+    );
+  }
+
   return details;
 }

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -785,6 +785,50 @@ describe('TooltipMarker', function () {
     expect(getValueForProperty('HTTP Version')).toBe('3');
   });
 
+  it('renders page information for pages with one class of service flag', () => {
+    setupWithPayload(
+      getNetworkMarkers({
+        id: 1235,
+        startTime: 19000,
+        fetchStart: 19200.2,
+        endTime: 20433.8,
+        uri: 'https://example.org/index.html',
+        payload: {
+          cache: 'Hit',
+          pri: 8,
+          count: 47027,
+          contentType: 'text/html',
+          classOfService: 'Leader',
+        },
+      })
+    );
+
+    expect(getValueForProperty('Class of Service')).toBe('Leader');
+  });
+
+  it('renders page information for pages with multiple class of service flags', () => {
+    setupWithPayload(
+      getNetworkMarkers({
+        id: 1235,
+        startTime: 19000,
+        fetchStart: 19200.2,
+        endTime: 20433.8,
+        uri: 'https://example.org/index.html',
+        payload: {
+          cache: 'Hit',
+          pri: 8,
+          count: 47027,
+          contentType: 'text/html',
+          classOfService: 'Unblocked | Throttleable | TailForbidden',
+        },
+      })
+    );
+
+    expect(getValueForProperty('Class of Service')).toBe(
+      'Unblocked | Throttleable | TailForbidden'
+    );
+  });
+
   it('renders properly network markers with a preconnect part', () => {
     const { container } = setupWithPayload(
       getNetworkMarkers({

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -523,6 +523,13 @@ export type NetworkPayload = {|
   isPrivateBrowsing?: boolean,
   httpVersion?: NetworkHttpVersion,
 
+  // Used to express class dependencies and characteristics.
+  // Possible flags: Leader, Follower, Speculative, Background, Unblocked,
+  // Throttleable, UrgentStart, DontThrottle, Tail, TailAllowed, and
+  // TailForbidden. Multiple flags can be set, separated by '|',
+  // or we use 'Unset' if no flag is set.
+  classOfService?: string,
+
   // NOTE: the following comments are valid for the merged markers. For the raw
   // markers, startTime and endTime have different meanings. Please look
   // `src/profile-logic/marker-data.js` for more information.


### PR DESCRIPTION
Continuation of [Expose class of service for each request in the profiler network tab](https://bugzilla.mozilla.org/show_bug.cgi?id=1919148)