### PR TITLE
Adapt Tree row toggle button to High Contrast Mode.

### DIFF
--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -3,12 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .treeView {
+  --tree-row-toggle-button-color: #888;
+  --tree-row-toggle-button-active-color: var(--grey-60);
+  --selected-tree-row-toggle-button-color: #fff;
+  --selected-tree-row-toggle-button-active-color: rgb(255 255 255 / 0.7);
+
   display: flex;
   flex: 1;
   flex-flow: column nowrap;
   border-top: 1px solid var(--grey-30);
   cursor: default;
   user-select: none;
+}
+
+@media (forced-colors: active) {
+  .treeView {
+    --tree-row-toggle-button-color: ButtonText;
+    --tree-row-toggle-button-active-color: SelectedItem;
+    --selected-tree-row-toggle-button-color: SelectedItemText;
+    --selected-tree-row-toggle-button-active-color: ButtonText;
+  }
 }
 
 .treeViewRow,
@@ -202,7 +216,10 @@
   border-bottom: 5px solid transparent;
   border-left: 8px solid;
   margin-left: 8px;
-  color: #888;
+  color: var(--tree-row-toggle-button-color);
+
+  /* Opt-out of forced colors so the transparent borders aren't turned into opaque ones */
+  forced-color-adjust: none;
 }
 
 .treeRowToggleButton.expanded {
@@ -216,17 +233,17 @@
 }
 
 .treeRowToggleButton:active:hover {
-  color: var(--grey-60);
+  color: var(--tree-row-toggle-button-active-color);
 }
 
 .treeViewBody:focus .treeViewRow.isSelected > .treeRowToggleButton {
-  color: #fff;
+  color: var(--selected-tree-row-toggle-button-color);
 }
 
 .treeViewBody:focus
   .treeViewRow.isSelected
   > .treeRowToggleButton:active:hover {
-  color: rgb(255 255 255 / 0.7);
+  color: var(--selected-tree-row-toggle-button-active-color);
 }
 
 .treeRowToggleButton.leaf {


### PR DESCRIPTION
Use CSS variable to manage the colors of the arrow in its differents states, and override the variable in forced-colors with system colors.

On regular and selected node:
Dark HCM: ![image](https://github.com/user-attachments/assets/7561b48e-8c30-4142-a81d-e00ca9f60817)
Light HCM: ![image](https://github.com/user-attachments/assets/a77301bd-7f6e-4603-97e4-2dda4a27ae61)

Active on regular and selected node
![image](https://github.com/user-attachments/assets/5734d729-7467-4411-9f71-428764ae3021)
![image](https://github.com/user-attachments/assets/5d8074e1-52c7-4f39-bc24-d2a1f032898e)
![image](https://github.com/user-attachments/assets/c5731e2c-7109-424c-9e56-894b78d69aae)
![image](https://github.com/user-attachments/assets/39988f00-f294-4f28-9bae-dc42483ee150)

