### PR TITLE
Display malloc heap size data in GCMajor markers

### DIFF
--- a/src/components/tooltip/GCMarker.js
+++ b/src/components/tooltip/GCMarker.js
@@ -249,8 +249,8 @@ export function getGCMajorDetails(
       if (post_heap_size !== undefined) {
         gcsize = (
           <TooltipDetail
-            label="Heap size (pre - post)"
-            key="GMajor-Heap size (pre - post)"
+            label="GC heap size (pre - post)"
+            key="GMajor-GC heap size (pre - post)"
           >
             {formatBytes(timings.allocated_bytes) +
               ' - ' +
@@ -259,7 +259,10 @@ export function getGCMajorDetails(
         );
       } else {
         gcsize = (
-          <TooltipDetail label="Heap size (pre)" key="GMajor-Heap size (pre)">
+          <TooltipDetail
+            label="GC heap size (pre)"
+            key="GMajor-GC heap size (pre)"
+          >
             {formatBytes(timings.allocated_bytes)}
           </TooltipDetail>
         );
@@ -283,7 +286,26 @@ export function getGCMajorDetails(
             /* maxFractionalDigits */ 2
           )}
         </TooltipDetail>,
-        gcsize,
+        gcsize
+      );
+      const pre_malloc_heap_size = timings.pre_malloc_heap_size;
+      const post_malloc_heap_size = timings.post_malloc_heap_size;
+      if (
+        pre_malloc_heap_size !== undefined &&
+        post_malloc_heap_size !== undefined
+      ) {
+        details.push(
+          <TooltipDetail
+            label="Malloc heap size (pre - post)"
+            key="GMajor-Malloc heap size (pre - post)"
+          >
+            {formatBytes(pre_malloc_heap_size) +
+              ' - ' +
+              formatBytes(post_malloc_heap_size)}
+          </TooltipDetail>
+        );
+      }
+      details.push(
         <TooltipDetail label="MMU 20ms" key="GMajor-MMU 20ms">
           {formatPercent(timings.mmu_20ms)}
         </TooltipDetail>,

--- a/src/test/components/TooltipMarker.test.js
+++ b/src/test/components/TooltipMarker.test.js
@@ -210,6 +210,8 @@ describe('TooltipMarker', function () {
             added_chunks: 50,
             allocated_bytes: 48377856,
             post_heap_size: 38051840,
+            pre_malloc_heap_size: 24188928,
+            post_malloc_heap_size: 12683946,
             major_gc_number: 1,
             max_pause: 74.026,
             minor_gc_number: 16,

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -2983,10 +2983,17 @@ exports[`TooltipMarker renders tooltips for various markers: GCMajor-16.5 1`] = 
     <div
       class="tooltipLabel"
     >
-      Heap size (pre - post)
+      GC heap size (pre - post)
       :
     </div>
     46.1MB - 36.3MB
+    <div
+      class="tooltipLabel"
+    >
+      Malloc heap size (pre - post)
+      :
+    </div>
+    23.1MB - 12.1MB
     <div
       class="tooltipLabel"
     >

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -330,9 +330,14 @@ type GCMajorCompleted_Shared = {|
   // 'None' as a reason.
   nonincremental_reason?: 'None' | string,
 
-  // The allocated space for the whole heap before the GC started.
+  // The total size of GC things before and after the GC.
   allocated_bytes: number,
   post_heap_size?: number,
+
+  // The total size of malloc data owned by GC things before and after the GC.
+  // Added in Firefox v135 (Bug 1933205).
+  pre_malloc_heap_size?: number,
+  post_malloc_heap_size?: number,
 
   // Only present if non-zero.
   added_chunks?: number,


### PR DESCRIPTION
In the context of the SpiderMonkey GC, malloc heap data is malloced data owned by GC things.

This displays the total size of malloc heap data added to the profile data in Firefox bug-1933205.