### PR TITLE
Adapt context menu to High Contrast Mode

### DIFF
--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -44,3 +44,11 @@
   color: #000;
   margin-inline-start: 12px;
 }
+
+@media (forced-colors: active) {
+  .callNodeContextMenuShortcut {
+    background: SelectedItemText;
+    color: SelectedItem;
+    outline: 1px solid CanvasText;
+  }
+}

--- a/src/components/shared/ContextMenu.css
+++ b/src/components/shared/ContextMenu.css
@@ -148,3 +148,19 @@
 .react-contextmenu-item--selected > strong {
   color: #fff;
 }
+
+@media (forced-colors: active) {
+  .react-contextmenu {
+    border: 1px solid CanvasText;
+  }
+
+  .react-contextmenu-item:not(.react-contextmenu-item--disabled):hover {
+    background-color: SelectedItem;
+    color: SelectedItemText;
+  }
+
+  .react-contextmenu-item.react-contextmenu-item--disabled,
+  .react-contextmenu-item.react-contextmenu-item--disabled:hover {
+    color: GrayText;
+  }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f410a8fe-2b23-4b75-9ef9-d3164c2039ae)
![image](https://github.com/user-attachments/assets/9b1af861-26a7-49b2-be21-77e7e6414b17)
![image](https://github.com/user-attachments/assets/bceda55d-c97d-459b-bfac-3d5b5b791c02)
![image](https://github.com/user-attachments/assets/4b988c2a-bd40-49e7-851a-964e09b3fca1)

Note: I'll handle the call tree node context menu icons in a dedicated PR (they aren't visible in dark mode and don't look great when the item is hovered)
