### PR TITLE
Adapt Keyboard shortcut dialog in High Contrast Mode.

### DIFF
--- a/src/components/app/KeyboardShortcut.css
+++ b/src/components/app/KeyboardShortcut.css
@@ -126,3 +126,27 @@
     animation: none;
   }
 }
+
+@media (forced-colors: active) {
+  .appKeyboardShortcutsBox {
+    border: 1px solid CanvasText;
+  }
+
+  .appKeyboardShortcutsHeaderClose {
+    border: 1px solid ButtonText;
+    background-color: ButtonFace;
+    color: ButtonText;
+  }
+
+  .appKeyboardShortcutsHeaderClose:hover {
+    border-color: SelectedItem;
+    background-color: SelectedItemText;
+    color: SelectedItem;
+  }
+
+  .appKeyboardShortcutsShortcut {
+    background: SelectedItemText;
+    color: SelectedItem;
+    outline: 1px solid CanvasText;
+  }
+}


### PR DESCRIPTION
Make sure the dialog has a border, that kbd elements have a distinct style and that the close button follows the Firefox HCM guidelines.

|  | HCM Dark | HCM Light|
| --- | --- |  --- |
|dialog | ![image](https://github.com/user-attachments/assets/3c4b4c67-fe1d-46f8-8434-83a87b65415f) | ![image](https://github.com/user-attachments/assets/6f21711a-3366-4a8c-8881-6da13ab22b3e) |
| close button hover |  ![image](https://github.com/user-attachments/assets/9b004963-ea13-4071-a8d2-3ac7c52fca71) |  ![image](https://github.com/user-attachments/assets/7f159ee7-09a9-469f-9917-5e4bbeff0001) |
