### PR TITLE
Fix sidebar-toggle in High Contrast Mode.

### DIFF
--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -176,6 +176,9 @@
   border-inline-start-color: currentcolor;
   border-inline-start-width: 8px;
   content: '';
+
+  /* Make sure the arrow is visible in High Contrast Mode */
+  forced-color-adjust: none;
   margin-inline-start: -11px;
 }
 
@@ -189,4 +192,16 @@
   border-color: currentcolor transparent transparent;
   margin-top: 3px;
   margin-inline-start: -12px;
+}
+
+@media (forced-colors: active) {
+  .sidebar-toggle,
+  .sidebar-toggle::before {
+    color: ButtonText;
+  }
+
+  .sidebar-label:hover .sidebar-toggle,
+  .sidebar-label:hover .sidebar-toggle::before {
+    color: SelectedItem;
+  }
 }


### PR DESCRIPTION
Make sure the arrow is visible, and fix the hover style

| dark | light |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/dfc96d19-6884-4489-ae23-f25b302f7909)  | ![image](https://github.com/user-attachments/assets/6770cefd-bbb0-4ed1-890b-8e04829c9ea2) |