### PR TITLE
Show Chrome extension instructions in the homepage if visited from Chromium browsers

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -365,6 +365,14 @@ Home--load-files-from-other-tools2 =
     Format</traceevent>. <write>Learn how to write your
     own importer</write>.
 
+Home--install-chrome-extension = Install the Chrome extension
+Home--chrome-extension-instructions = Use the <a>{ -profiler-brand-name } extension for Chrome</a>
+    to capture performance profiles in Chrome and analyze them in the
+    { -profiler-brand-name }. Install the extension from the Chrome Web Store.
+Home--chrome-extension-recording-instructions = Once installed, use the extension’s
+    toolbar icon or the shortcuts to start and stop profiling. You can also
+    export profiles and load them here for detailed analysis.
+
 ## IdleSearchField
 ## The component that is used for all the search inputs in the application.
 

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -225,6 +225,7 @@ type PopupInstallPhase =
   | 'popup-enabled'
   | 'suggest-enable-popup'
   // Other browsers:
+  | 'suggest-chrome-extension'
   | 'other-browser';
 
 class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
@@ -249,6 +250,10 @@ class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
           this.setState({ popupInstallPhase: 'webchannel-unavailable' });
         }
       );
+    } else if (_isChromium()) {
+      popupInstallPhase = 'suggest-chrome-extension';
+      // TODO: Check if the extension is installed and show the recording
+      // instructions. But we need to check if extension is there to do that.
     }
 
     this.state = {
@@ -266,6 +271,8 @@ class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
         return this._renderEnablePopupInstructions(false);
       case 'popup-enabled':
         return this._renderRecordInstructions(FirefoxPopupScreenshot);
+      case 'suggest-chrome-extension':
+        return this._renderChromeInstructions();
       case 'other-browser':
         return this._renderOtherBrowserInstructions();
       default:
@@ -369,6 +376,69 @@ class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
                 <a>Profiling Firefox for Android directly on device</a>.
               </p>
             </Localized>
+          </div>
+          {/* end of grid container */}
+        </div>
+      </InstructionTransition>
+    );
+  }
+
+  _renderChromeInstructions() {
+    const chromeExtensionUrl =
+      'https://chromewebstore.google.com/detail/firefox-profiler/ljmahpnflmbkgaipnfbpgjipcnahlghn';
+    return (
+      <InstructionTransition key={0}>
+        <div
+          className="homeInstructions"
+          data-testid="home-enable-popup-instructions"
+        >
+          {/* Grid container: homeInstructions */}
+          {/* Left column: img */}
+          <img
+            className="homeSectionScreenshot"
+            src={PerfScreenshot}
+            alt="screenshot of profiler.firefox.com"
+          />
+          {/* Right column: instructions */}
+          <div>
+            <a
+              className="homeSectionButton"
+              href={chromeExtensionUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <span className="homeSectionPlus">+</span>
+              <Localized id="Home--install-chrome-extension">
+                Install the Chrome extension
+              </Localized>
+            </a>
+            <DocsButton />
+            <Localized
+              id="Home--chrome-extension-instructions"
+              elems={{
+                a: (
+                  <a
+                    href={chromeExtensionUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                ),
+              }}
+            >
+              <p>
+                Use the <a>Firefox Profiler extension for Chrome</a> to capture
+                performance profiles in Chrome and analyze them in the Firefox
+                Profiler. Install the extension from the Chrome Web Store.
+              </p>
+            </Localized>
+            <Localized id="Home--chrome-extension-recording-instructions">
+              <p>
+                Once installed, use the extension’s toolbar icon or the
+                shortcuts to start and stop profiling. You can also export
+                profiles and load them here for detailed analysis.
+              </p>
+            </Localized>
+            {this._renderShortcuts()}
           </div>
           {/* end of grid container */}
         </div>
@@ -625,6 +695,10 @@ class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
 
 function _isFirefox(): boolean {
   return Boolean(navigator.userAgent.match(/Firefox\/\d+\.\d+/));
+}
+
+function _isChromium(): boolean {
+  return Boolean(navigator.userAgent.match(/Chrome\/\d+\.\d+/));
 }
 
 export const Home = explicitConnect<

--- a/src/test/components/Home.test.js
+++ b/src/test/components/Home.test.js
@@ -24,6 +24,8 @@ const FIREFOX =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
 const SAFARI =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8';
+const CHROME =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 let userAgent;
 
 // Flow doesn't understand Object.defineProperty. Use the "any" type to use it anyway.
@@ -45,6 +47,11 @@ describe('app/Home', function () {
 
   it('renders a button to enable the popup in Firefox', () => {
     const { container } = setup(FIREFOX);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders the Chrome extension instructions for Chromium based browsers', () => {
+    const { container } = setup(CHROME);
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -248,6 +248,273 @@ you can go to
 </p>
 `;
 
+exports[`app/Home renders the Chrome extension instructions for Chromium based browsers 1`] = `
+<div
+  class="home"
+>
+  <main
+    class="homeSection"
+  >
+    <header>
+      <h1
+        class="appHeader"
+      >
+        <span
+          class="appHeaderSlogan"
+        >
+          <a
+            class="appHeaderLink"
+            href="/"
+          >
+            ⁨Firefox Profiler⁩
+          </a>
+           — 
+          <span
+            class="appHeaderSubtext"
+          >
+            Web app for ⁨Firefox⁩ performance analysis
+          </span>
+        </span>
+        <a
+          class="appHeaderGithubIcon"
+          href="https://github.com/firefox-devtools/profiler"
+          rel="noopener noreferrer"
+          target="_blank"
+          title="Go to our Git repository (this opens in a new window)"
+        >
+          <svg
+            aria-label="github"
+            class="octicon octicon-mark-github"
+            height="22"
+            version="1.1"
+            viewBox="0 0 16 16"
+            width="22"
+          >
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </a>
+      </h1>
+    </header>
+    <div
+      class="homeSpecialMessage"
+    >
+      This is a special message
+    </div>
+    <p>
+      Capture a performance profile. Analyze it. Share it. Make the web faster.
+    </p>
+    <div
+      class="homeInstructionsTransitionGroup"
+    >
+      <div
+        class="homeInstructions"
+        data-testid="home-enable-popup-instructions"
+      >
+        <img
+          alt="screenshot of profiler.firefox.com"
+          class="homeSectionScreenshot"
+          src="test-file-stub"
+        />
+        <div>
+          <a
+            class="homeSectionButton"
+            href="https://chromewebstore.google.com/detail/firefox-profiler/ljmahpnflmbkgaipnfbpgjipcnahlghn"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <span
+              class="homeSectionPlus"
+            >
+              +
+            </span>
+            Install the Chrome extension
+          </a>
+          <a
+            class="homeSectionButton"
+            href="/docs/"
+          >
+            <span
+              class="homeSectionDocsIcon"
+            />
+            Documentation
+          </a>
+          <p>
+            Use the 
+            <a
+              href="https://chromewebstore.google.com/detail/firefox-profiler/ljmahpnflmbkgaipnfbpgjipcnahlghn"
+              rel="noreferrer"
+              target="_blank"
+            >
+              ⁨Firefox Profiler⁩ extension for Chrome
+            </a>
+            
+to capture performance profiles in Chrome and analyze them in the
+⁨Firefox Profiler⁩. Install the extension from the Chrome Web Store.
+          </p>
+          <p>
+            Once installed, use the extension’s
+toolbar icon or the shortcuts to start and stop profiling. You can also
+export profiles and load them here for detailed analysis.
+          </p>
+          <div>
+            <p>
+              <kbd>
+                Ctrl
+              </kbd>
+              +
+              <kbd>
+                Shift
+              </kbd>
+              +
+              <kbd>
+                1
+              </kbd>
+               
+              Stop and start profiling
+            </p>
+            <p>
+              <kbd>
+                Ctrl
+              </kbd>
+              +
+              <kbd>
+                Shift
+              </kbd>
+              +
+              <kbd>
+                2
+              </kbd>
+               
+              Capture and load profile
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <section
+      class="homeAdditionalContent"
+    >
+      <h2
+        class="homeAdditionalContentTitle protocol-display-xs"
+      >
+        Load existing profiles
+      </h2>
+      <section
+        class="homeActions"
+      >
+        <p>
+          You can 
+          <strong>
+            drag and drop
+          </strong>
+           a profile file here to load it, or:
+        </p>
+        <div
+          class="homeSectionLoadProfile"
+        >
+          <div
+            class="homeSectionActionButtons"
+          >
+            <input
+              class="homeSectionUploadFromFileInput"
+              type="file"
+            />
+            <button
+              class="homeSectionButton"
+              type="button"
+            >
+              Load a profile from file
+            </button>
+            <button
+              aria-expanded="false"
+              class="homeSectionButton"
+              type="button"
+            >
+              Load a profile from a URL
+            </button>
+          </div>
+        </div>
+        <p>
+          The ⁨Firefox Profiler⁩ can also import profiles from other profilers, such as
+
+          <a
+            href="https://profiler.firefox.com/docs/#/./guide-perf-profiling"
+          >
+            Linux perf
+          </a>
+          , 
+          <a
+            href="https://profiler.firefox.com/docs/#/./guide-android-profiling"
+          >
+            Android SimplePerf
+          </a>
+          , the
+Chrome performance panel, 
+          <a
+            href="https://developer.android.com/studio/profile/cpu-profiler"
+          >
+            Android Studio
+          </a>
+          , or
+any file using the 
+          <a
+            href="https://valgrind.org/docs/manual/dh-manual.html"
+          >
+            dhat format
+          </a>
+           or 
+          <a
+            href="https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview"
+          >
+            Google’s Trace Event
+Format
+          </a>
+          . 
+          <a
+            href="https://github.com/firefox-devtools/profiler/blob/main/docs-developer/custom-importer.md"
+          >
+            Learn how to write your
+own importer
+          </a>
+          .
+        </p>
+        <p>
+          You can also compare recordings. 
+          <a
+            href="/compare/"
+          >
+            Open the comparing interface.
+          </a>
+        </p>
+      </section>
+      <section>
+        <h2
+          class="homeRecentUploadedRecordingsTitle protocol-display-xxs"
+        >
+          Your recent uploaded recordings
+        </h2>
+        <list-of-published-profiles
+          limit="3"
+          withactionbuttons="false"
+        />
+      </section>
+    </section>
+    <div
+      class="dragAndDropOverlayWrapper"
+    >
+      <div
+        class="dragAndDropOverlay"
+      >
+        Drop a saved profile here
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`app/Home renders the information screen for other browsers 1`] = `
 <div
   class="home"


### PR DESCRIPTION
Now that we have [a Chrome extension](https://github.com/firefox-devtools/firefox-profiler-for-chrome), let's show an instruction to install it in the profiler home page if it's visited from Chromium based browsers.

I was also thinking about showing the recording instructions if we detect that the chrome extension is already installed, but I don't think we have to have that for the first iteration as this is a clear improvement to the previous version. I would prefer to implement that as a follow-up, as it will require changes in the extension code and we will have to publish that new extension version.

Screenshot:

<img width="1238" alt="Screenshot 2024-12-09 at 12 59 06 PM" src="https://github.com/user-attachments/assets/8dd92fb9-312c-45cd-a253-cab5b19d3a5d">

