### PR TITLE
Adapt Tracks to High Contrast Mode.

### DIFF
--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -168,3 +168,55 @@
   /* We want the width to look like it's 150px, but need to substract the 3px padding/margin and the 1px border */
   width: calc(135px - var(--selected-left-border-width) - 1px);
 }
+
+@media (forced-colors: active) {
+  .timelineTrackRow {
+    /* In regular mode, the left border is drawn with a box-shadow which is not visible in HCM,
+       and would make the selected track look misaligned.
+       Since we're rendering the track with a completely different color, we can avoid setting this
+       border, setting it to 0px so the computation made to account for it handle everything fine */
+    --selected-left-border-width: 0px;
+  }
+
+  .timelineTrackRow.selected .timelineTrackLabel {
+    border-color: CanvasText;
+    background-color: SelectedItem;
+    color: SelectedItemText;
+  }
+
+  .timelineTrackRow.selected .timelineTrackLabel button {
+    color: inherit;
+  }
+
+  .timelineTrackRow:not(.selected):hover .timelineTrackLabel {
+    background-color: SelectedItemText;
+    color: SelectedItem;
+  }
+
+  .timelineTrackRow:not(.selected):hover .timelineTrackLabel button {
+    color: inherit;
+  }
+
+  /* In regular mode, there's an inset box-shadow, which we don't see in HCM.
+     Add a solid border so we do have a separation between a parent and a local track */
+  .timelineTrackLocalTracks::before {
+    border-top: 1px solid;
+  }
+
+  .timelineTrackCloseButton {
+    border: 1px solid ButtonText;
+    background-color: ButtonFace;
+  }
+
+  .timelineTrackCloseButton:hover {
+    border-color: SelectedItem;
+    background-color: ButtonFace;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    /* We need to adapt the cross icon in dark mode so it still visible */
+    .timelineTrackCloseButton {
+      background-image: url(../../../res/img/svg/close-light.svg);
+    }
+  }
+}


### PR DESCRIPTION
This patch makes the selected track use system colors for selected and hovered style.
It also switches from using a box-shadow to a before pseudo element to draw the left selected indicator so it's easier to handle.
We also add a few CSS variables simplify computation.

Here Screenshots track is hovered, GPU Process is selected

|  | Dark | Light |
| --- | --- | --- |
| before | ![image](https://github.com/user-attachments/assets/4a4df741-07ee-488e-93c1-aa314b0004b6) | ![image](https://github.com/user-attachments/assets/727e25da-bd0d-492c-93a1-22c93ccac02b) |
| after | ![image](https://github.com/user-attachments/assets/23c835a3-7a28-484e-a8b9-6c974edcca11) | ![image](https://github.com/user-attachments/assets/85dc16c0-3a03-40bc-94b5-2ae6a8e04503) |
