### PR TITLE
Adapt time-slice selection in High Contrast Mode. 

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -39,6 +39,19 @@ body {
   color: var(--grey-90);
 }
 
+@media (forced-colors: active) {
+  :root {
+    /* The following properties are retrieved in index.js to create SVG filters that
+    * we can apply on icons to control their color.
+    * These variable can be declared in any rule, as long as their value is still
+    * a valid color (which means we can use `light-dark()` or any other color functions).
+    * The colors can be applied on SVG icons with `filter: url(#--var-name)` */
+    --button-icon-color: ButtonText;
+    --button-icon-hover-color: SelectedItem;
+    --button-icon-active-color: SelectedItem;
+  }
+}
+
 .profileFilterNavigator {
   height: 24px;
   flex-shrink: 1;
@@ -48,4 +61,12 @@ body {
   display: flex;
   flex: 1;
   flex-flow: column nowrap;
+}
+
+#svg-filters {
+  position: absolute;
+  overflow: hidden;
+  width: 0;
+  height: 0;
+  inset-inline-start: -1000vw;
 }

--- a/res/index.html
+++ b/res/index.html
@@ -10,6 +10,7 @@
     <link rel="preload" href="locales/en-US/app.ftl" as="fetch" />
   </head>
   <body style="background-color: #363959; /* ink-70 */">
+    <svg id="svg-filters"></svg>
     <div id="root"></div>
     <div id="root-overlay"></div>
   </body>

--- a/src/components/timeline/Selection.css
+++ b/src/components/timeline/Selection.css
@@ -9,6 +9,10 @@
     100vw - var(--thread-label-column-width) -
       var(--vertical-scrollbar-reserved-width)
   );
+  --grippy-range-background-color: #aaa;
+  --grippy-range-border-color: white;
+  --grippy-range-hover-background-color: #888;
+  --selection-outbound-opacity: 0.1;
 
   position: relative;
   display: flex;
@@ -54,7 +58,8 @@
 .timelineSelectionDimmerBefore,
 .timelineSelectionDimmerAfter {
   flex-shrink: 0;
-  background: rgb(12 12 13 / 0.1);
+  background: rgb(12 12 13 / var(--selection-outbound-opacity));
+  forced-color-adjust: none;
 }
 
 .timelineSelectionDimmerAfter {
@@ -79,10 +84,10 @@
   z-index: 3;
   width: 0;
   padding: 3px;
-  border: 1px solid white;
+  border: 1px solid var(--grippy-range-border-color);
   border-radius: 5px;
   margin: 0 -4px;
-  background: #aaa;
+  background: var(--grippy-range-background-color);
   cursor: ew-resize;
 }
 
@@ -99,7 +104,7 @@
 .timelineSelectionGrippyRangeEnd:hover,
 .draggingEnd > .timelineSelectionGrippyRangeEnd,
 :not(.draggingStart, .draggingEnd) > .timelineSelectionGrippyRangeEnd.dragging {
-  background: #888;
+  background: var(--grippy-range-hover-background-color);
 }
 
 .timelineSelectionGrippyMoveRange {
@@ -153,6 +158,14 @@
   will-change: opacity;
 }
 
+.timelineSelectionOverlayZoomButton::before {
+  position: absolute;
+  display: grid;
+  content: url(../../../res/img/svg/zoom-icon.svg);
+  inset: 0;
+  place-content: center;
+}
+
 .timelineSelectionOverlayZoomButton.hidden {
   opacity: 0 !important;
   pointer-events: none;
@@ -180,5 +193,35 @@
 
   .timelineSelectionHoverLine {
     background-color: CanvasText;
+  }
+
+  .timelineSelection {
+    --grippy-range-background-color: ButtonText;
+    --grippy-range-border-color: ButtonBorder;
+    --grippy-range-hover-background-color: SelectedItem;
+    --selection-outbound-opacity: 0.6;
+  }
+
+  .timelineSelectionDimmerBefore {
+    border-inline-end: 1px solid CanvasText;
+  }
+
+  .timelineSelectionDimmerAfter {
+    border-inline-start: 1px solid CanvasText;
+  }
+
+  .timelineSelectionOverlayZoomButton {
+    border-color: ButtonText;
+    background-color: ButtonFace;
+    opacity: 1;
+  }
+
+  .timelineSelectionOverlayZoomButton:hover {
+    background-color: SelectedItem;
+  }
+
+  .timelineSelectionOverlayZoomButton:active:hover {
+    border-color: SelectedItem;
+    background-color: ButtonFace;
   }
 }

--- a/src/components/timeline/Selection.css
+++ b/src/components/timeline/Selection.css
@@ -150,8 +150,7 @@
   border: 1px solid rgb(0 0 0 / 0.2);
   border-radius: 100%;
   margin: -15px;
-  background: url(../../../res/img/svg/zoom-icon.svg) center center no-repeat
-    rgb(255 255 255 / 0.6);
+  background-color: rgb(255 255 255 / 0.6);
   opacity: 0.5;
   pointer-events: auto;
   transition: opacity 200ms ease-in-out;
@@ -161,7 +160,7 @@
 .timelineSelectionOverlayZoomButton::before {
   position: absolute;
   display: grid;
-  content: url(../../../res/img/svg/zoom-icon.svg);
+  content: url(firefox-profiler-res/img/svg/zoom-icon.svg);
   inset: 0;
   place-content: center;
 }
@@ -216,12 +215,25 @@
     opacity: 1;
   }
 
+  .timelineSelectionOverlayZoomButton::before {
+    filter: url(#--button-icon-color);
+  }
+
   .timelineSelectionOverlayZoomButton:hover {
-    background-color: SelectedItem;
+    border-color: SelectedItem;
+    background-color: SelectedItemText;
+  }
+
+  .timelineSelectionOverlayZoomButton:hover::before {
+    filter: url(#--button-icon-hover-color);
   }
 
   .timelineSelectionOverlayZoomButton:active:hover {
-    border-color: SelectedItem;
+    border-color: ButtonText;
     background-color: ButtonFace;
+  }
+
+  .timelineSelectionOverlayZoomButton:hover:active::before {
+    filter: url(#--button-icon-active-color);
   }
 }

--- a/src/types/globals/Window.js
+++ b/src/types/globals/Window.js
@@ -90,6 +90,7 @@ declare class Window {
     platform: string,
   };
   postMessage: (message: any, targetOrigin: string) => void;
+  matchMedia: (matchMedia: string) => MediaQueryList;
 }
 
 declare var window: Window;


### PR DESCRIPTION
Make sure the start and end grips look like button, make the
outbound of the selection even dimmer and add border to make
the selection super obvious.

Using registered property we can get the rgb component from
given values that we can then turn into SVG filters that
we can then apply on top of the icon we use, in CSS.
The time-slice zoom icon takes advantage of this new capability
to adapt to High Contrast Mode.

---

| | dark | light |
| --- | --- | --- |
| timeslice selected, end "grip" is hovered  | ![image](https://github.com/user-attachments/assets/556f7aa2-49e1-4424-ae2a-b8c399aab2bb)  | ![image](https://github.com/user-attachments/assets/0db90ff3-7f95-416a-8042-b9e9afcad2b1)   |
| hovered zoom icon  | ![image](https://github.com/user-attachments/assets/379645b3-1efa-465c-a521-a998a946dc7f)  |  ![image](https://github.com/user-attachments/assets/69739612-c2ae-473a-8641-1c7ed8f86439)  |
| active zoom icon  | ![image](https://github.com/user-attachments/assets/60fd6f38-7379-426e-a0a7-eb15cff9107f)  |  ![image](https://github.com/user-attachments/assets/74e75f45-8722-4815-8b17-fece85ebc0a7)  |