### PR TITLE
Simplify some code related to thread CPU deltas

### DIFF
--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -74,10 +74,10 @@ function _computeMaxVariableCPUCyclesPerMs(
  *    Returns 1234567 * 3, i.e. "3703701 cycles per sample if each sample ticks at
  *    the declared 3ms interval and the CPU usage is at the observed maximum".
  */
-export function computeMaxCPUDeltaPerInterval(profile: Profile): number | null {
+export function computeMaxCPUDeltaPerMs(profile: Profile): number {
   const sampleUnits = profile.meta.sampleUnits;
   if (!sampleUnits) {
-    return null;
+    return 1;
   }
 
   const interval = profile.meta.interval;
@@ -86,21 +86,20 @@ export function computeMaxCPUDeltaPerInterval(profile: Profile): number | null {
   switch (threadCPUDeltaUnit) {
     case 'µs':
     case 'ns': {
-      const cpuDeltaTimeUnitMultiplier =
-        getCpuDeltaTimeUnitMultiplier(threadCPUDeltaUnit);
-      return cpuDeltaTimeUnitMultiplier * interval;
+      const deltaUnitPerMs = getCpuDeltaTimeUnitMultiplier(threadCPUDeltaUnit);
+      return deltaUnitPerMs;
     }
     case 'variable CPU cycles': {
       const maxThreadCPUDeltaPerMs = _computeMaxVariableCPUCyclesPerMs(
         profile.threads,
         interval
       );
-      return maxThreadCPUDeltaPerMs * interval;
+      return maxThreadCPUDeltaPerMs;
     }
     default:
       throw assertExhaustiveCheck(
         threadCPUDeltaUnit,
-        'Unhandled threadCPUDelta unit in computeMaxCPUDeltaPerInterval.'
+        'Unhandled threadCPUDelta unit in computeMaxCPUDeltaPerMs.'
       );
   }
 }

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -15,10 +15,14 @@ import type {
 } from 'firefox-profiler/types';
 
 /**
- * Compute the max CPU delta value per ms for that thread. It computes the
- * max value after the threadCPUDelta processing.
+ * Compute the max CPU cycles per ms for the thread. Should only be called when
+ * the cpu delta unit is 'variable CPU cycles'.
+ * This computes the max value before the threadCPUDelta processing -
+ * the threadCPUDelta processing wouldn't do anything other than remove nulls
+ * anyway, because if the unit is 'variable CPU cycles' then we don't do any
+ * clamping.
  */
-export function computeMaxThreadCPUDeltaPerMs(
+function _computeMaxVariableCPUCyclesPerMs(
   threads: Thread[],
   profileInterval: Milliseconds
 ): number {
@@ -87,7 +91,7 @@ export function computeMaxCPUDeltaPerInterval(profile: Profile): number | null {
       return cpuDeltaTimeUnitMultiplier * interval;
     }
     case 'variable CPU cycles': {
-      const maxThreadCPUDeltaPerMs = computeMaxThreadCPUDeltaPerMs(
+      const maxThreadCPUDeltaPerMs = _computeMaxVariableCPUCyclesPerMs(
         profile.threads,
         interval
       );

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -22,10 +22,7 @@ import type {
  * anyway, because if the unit is 'variable CPU cycles' then we don't do any
  * clamping.
  */
-function _computeMaxVariableCPUCyclesPerMs(
-  threads: Thread[],
-  profileInterval: Milliseconds
-): number {
+function _computeMaxVariableCPUCyclesPerMs(threads: Thread[]): number {
   let maxThreadCPUDeltaPerMs = 0;
   for (let threadIndex = 0; threadIndex < threads.length; threadIndex++) {
     const { samples } = threads[threadIndex];
@@ -37,11 +34,10 @@ function _computeMaxVariableCPUCyclesPerMs(
       continue;
     }
 
-    // First element of CPU delta is always null because back-end doesn't know
-    // the delta since there is no previous sample.
+    // Ignore the first CPU delta value; it's meaningless because there is no
+    // previous sample.
     for (let i = 1; i < samples.length; i++) {
-      const sampleTimeDeltaInMs =
-        i === 0 ? profileInterval : samples.time[i] - samples.time[i - 1];
+      const sampleTimeDeltaInMs = samples.time[i] - samples.time[i - 1];
       if (sampleTimeDeltaInMs !== 0) {
         const cpuDeltaPerMs = (threadCPUDelta[i] || 0) / sampleTimeDeltaInMs;
         maxThreadCPUDeltaPerMs = Math.max(
@@ -80,7 +76,6 @@ export function computeMaxCPUDeltaPerMs(profile: Profile): number {
     return 1;
   }
 
-  const interval = profile.meta.interval;
   const threadCPUDeltaUnit = sampleUnits.threadCPUDelta;
 
   switch (threadCPUDeltaUnit) {
@@ -91,8 +86,7 @@ export function computeMaxCPUDeltaPerMs(profile: Profile): number {
     }
     case 'variable CPU cycles': {
       const maxThreadCPUDeltaPerMs = _computeMaxVariableCPUCyclesPerMs(
-        profile.threads,
-        interval
+        profile.threads
       );
       return maxThreadCPUDeltaPerMs;
     }

--- a/src/selectors/cpu.js
+++ b/src/selectors/cpu.js
@@ -6,21 +6,20 @@
 import { createSelector } from 'reselect';
 
 import {
+  getProfile,
   getThreads,
-  getProfileInterval,
   getSampleUnits,
   getMeta,
   getCounter,
 } from './profile';
-import { getThreadSelectors } from './per-thread';
-import { computeMaxThreadCPUDeltaPerMs } from 'firefox-profiler/profile-logic/cpu';
+import { computeMaxCPUDeltaPerInterval } from 'firefox-profiler/profile-logic/cpu';
 
-import type { Selector, State, Thread } from 'firefox-profiler/types';
+import type { Selector } from 'firefox-profiler/types';
 
 export const getIsCPUUtilizationProvided: Selector<boolean> = createSelector(
   getSampleUnits,
   getMeta,
-  getCPUProcessedThreads,
+  getThreads,
   (sampleUnits, meta, threads) => {
     return (
       sampleUnits !== undefined &&
@@ -45,31 +44,8 @@ export const getAreThereAnyProcessCPUCounters: Selector<boolean> =
       counters.some((counter) => counter.category === 'CPU')
   );
 
-/**
- * This function returns the list of all threads after the CPU values have been
- * processed. This uses a selector from the per-thread selectors. Because we'll
- * use this selector for every thread, and also need the full state for this call,
- * we can't use the simple memoization from `createSelector`, and instead we
- * need to implement our own simple memoization.
- */
-let _threads = null;
-let _cpuProcessedThreads = null;
-function getCPUProcessedThreads(state: State): Thread[] {
-  const threads = getThreads(state);
-
-  if (_threads !== threads || _cpuProcessedThreads === null) {
-    // Storing the threads makes it possible to invalidate the memoized value at
-    // the right moment.
-    _threads = threads;
-    _cpuProcessedThreads = threads.map((thread, threadIndex) =>
-      getThreadSelectors(threadIndex).getCPUProcessedThread(state)
-    );
-  }
-  return _cpuProcessedThreads;
-}
-
 export const getMaxThreadCPUDeltaPerMs: Selector<number> = createSelector(
-  getCPUProcessedThreads,
-  getProfileInterval,
-  computeMaxThreadCPUDeltaPerMs
+  getProfile,
+  (profile) =>
+    (computeMaxCPUDeltaPerInterval(profile) ?? 0) * profile.meta.interval
 );

--- a/src/selectors/cpu.js
+++ b/src/selectors/cpu.js
@@ -5,14 +5,7 @@
 
 import { createSelector } from 'reselect';
 
-import {
-  getProfile,
-  getThreads,
-  getSampleUnits,
-  getMeta,
-  getCounter,
-} from './profile';
-import { computeMaxCPUDeltaPerInterval } from 'firefox-profiler/profile-logic/cpu';
+import { getThreads, getSampleUnits, getMeta, getCounter } from './profile';
 
 import type { Selector } from 'firefox-profiler/types';
 
@@ -43,9 +36,3 @@ export const getAreThereAnyProcessCPUCounters: Selector<boolean> =
       counters !== null &&
       counters.some((counter) => counter.category === 'CPU')
   );
-
-export const getMaxThreadCPUDeltaPerMs: Selector<number> = createSelector(
-  getProfile,
-  (profile) =>
-    (computeMaxCPUDeltaPerInterval(profile) ?? 0) * profile.meta.interval
-);

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -718,22 +718,20 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
   }
 );
 
-export const getMaxCPUDeltaPerInterval: Selector<number | null> =
-  createSelector(getProfile, CPU.computeMaxCPUDeltaPerInterval);
+export const getMaxThreadCPUDeltaPerMs: Selector<number> = createSelector(
+  getProfile,
+  CPU.computeMaxCPUDeltaPerMs
+);
 
 export const getThreadActivityScores: Selector<Array<ThreadActivityScore>> =
   createSelector(
     getProfile,
-    getMaxCPUDeltaPerInterval,
-    (profile, maxCpuDeltaPerInterval) => {
+    getMaxThreadCPUDeltaPerMs,
+    (profile, maxCpuDeltaPerMs) => {
       const { threads } = profile;
 
       return threads.map((thread) =>
-        Tracks.computeThreadActivityScore(
-          profile,
-          thread,
-          maxCpuDeltaPerInterval
-        )
+        Tracks.computeThreadActivityScore(profile, thread, maxCpuDeltaPerMs)
       );
     }
   );


### PR DESCRIPTION
There was a mismatch in whether `computeMaxThreadCPUDeltaPerMs` was called before or after thread CPU delta processing. It didn't make a difference in practice, but it's better to just always call it with the unprocessed values. This will avoid problems if we end up giving the processed values a different type.