### PR TITLE
Remove "Back to home" link on import errors when not loading from file

### DIFF
--- a/src/components/app/AppViewRouter.js
+++ b/src/components/app/AppViewRouter.js
@@ -100,6 +100,8 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
           }
         }
 
+        const showBackHomeLink = dataSource === 'from-file';
+
         return (
           <Localized
             id={message}
@@ -118,7 +120,7 @@ class AppViewRouterImpl extends PureComponent<AppViewRouterProps> {
             <ProfileRootMessage
               additionalMessage={additionalMessage}
               showLoader={false}
-              showBackHomeLink={true}
+              showBackHomeLink={showBackHomeLink}
             >{`missing translation for ${message}`}</ProfileRootMessage>
           </Localized>
         );

--- a/src/components/app/ProfileLoaderAnimation.js
+++ b/src/components/app/ProfileLoaderAnimation.js
@@ -61,7 +61,9 @@ class ProfileLoaderAnimationImpl extends PureComponent<ProfileLoaderAnimationPro
       : 'ProfileLoaderAnimation--loading-view-not-found';
     const showLoader = Boolean(loadingMessage);
     const showBackHomeLink = Boolean(
-      view.additionalData && view.additionalData.message
+      view.additionalData &&
+        view.additionalData.message &&
+        dataSource === 'from-file'
     );
 
     return (

--- a/src/test/components/Root.test.js
+++ b/src/test/components/Root.test.js
@@ -138,17 +138,30 @@ describe('app/AppViewRouter', function () {
     const {
       container,
       dispatch,
-      navigateToStoreLoadingPage,
+      navigateToFromFileProfileLoadingPage,
       navigateBackToHome,
     } = setup();
 
-    navigateToStoreLoadingPage();
+    navigateToFromFileProfileLoadingPage();
     dispatch(fatalError(new Error('Error while loading profile')));
     expect(container.firstChild).toMatchSnapshot();
     expect(console.error).toHaveBeenCalled();
 
     navigateBackToHome();
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('does not render back home link when not opened with from-file', function () {
+    const {
+      container,
+      dispatch,
+      navigateToStoreLoadingPage,
+    } = setup();
+
+    navigateToStoreLoadingPage();
+    dispatch(fatalError(new Error('Error while loading profile')));
+    expect(container.firstChild).toMatchSnapshot();
+    expect(console.error).toHaveBeenCalled();
   });
 
   it('renders a compare home when navigating to /compare/, then loads when changing profiles', () => {
@@ -214,6 +227,15 @@ function setup() {
     actAndDispatch(updateUrlState(newUrlState));
   }
 
+  function navigateToFromFileProfileLoadingPage() {
+    const newUrlState = stateFromLocation({
+      pathname: '/from-file/calltree',
+      search: '',
+      hash: '',
+    });
+    actAndDispatch(updateUrlState(newUrlState));
+  }
+
   function navigateBackToHome() {
     const newUrlState = stateFromLocation({
       pathname: '/',
@@ -246,6 +268,7 @@ function setup() {
     dispatch: actAndDispatch,
     navigateToStoreLoadingPage,
     navigateToFromBrowserProfileLoadingPage,
+    navigateToFromFileProfileLoadingPage,
     navigateBackToHome,
     navigateToCompareHome,
     navigateToMyProfiles,

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`app/AppViewRouter does not render back home link when not opened with from-file 1`] = `
+<div
+  class="rootMessageContainer"
+>
+  <div
+    class="rootMessage"
+  >
+    <h1
+      class="rootMessageTitle"
+    >
+      Firefox Profiler
+    </h1>
+    <div
+      class="rootMessageText"
+    >
+      <p>
+        Could not download the profile.
+      </p>
+    </div>
+    <div
+      class="rootMessageAdditional"
+    >
+      <p>
+        Error: Error while loading profile
+      </p>
+      <p>
+        The full stack has been written to the Web Console.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`app/AppViewRouter does not try to retrieve a profile when moving from from-browser to public 1`] = `<profile-viewer />`;
 
 exports[`app/AppViewRouter renders an home when the user pressed back after an error 1`] = `
@@ -18,7 +51,7 @@ exports[`app/AppViewRouter renders an home when the user pressed back after an e
       class="rootMessageText"
     >
       <p>
-        Could not download the profile.
+        Couldn’t read the file or parse the profile in it.
       </p>
     </div>
     <div
@@ -76,15 +109,6 @@ exports[`app/AppViewRouter renders temporary errors 1`] = `
       <p>
         Tried 3 times out of 10.
       </p>
-    </div>
-    <div
-      class="rootBackHomeLink"
-    >
-      <a
-        href="/"
-      >
-        Back to home
-      </a>
     </div>
     <div
       class="loading"


### PR DESCRIPTION
Fix #5222.

"Back to home" button is not much useful when not loading profile from the home page. Remove the "Back to home" button when not loading the profile using the 'from-file' datasource.