### PR TITLE
Rename UniqueStringArray to StringTable.

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -33,7 +33,7 @@ import type {
   ExtraProfileInfoSection,
 } from 'firefox-profiler/types';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
-import { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
+import { StringTable } from 'firefox-profiler/utils/string-table';
 
 import './MetaInfo.css';
 
@@ -153,7 +153,7 @@ class MetaInfoPanelImpl extends React.PureComponent<Props, State> {
                     'moreInfo',
                     format,
                     value,
-                    new UniqueStringArray()
+                    new StringTable()
                   )}
                 </div>
               </div>

--- a/src/components/js-tracer/Chart.js
+++ b/src/components/js-tracer/Chart.js
@@ -21,7 +21,7 @@ import { getSelectedThreadsKey } from 'firefox-profiler/selectors/url-state';
 import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
 import { ensureExists } from 'firefox-profiler/utils/flow';
 
-import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
+import type { StringTable } from 'firefox-profiler/utils/string-table';
 import type {
   JsTracerTable,
   ThreadsKey,
@@ -51,7 +51,7 @@ type DispatchProps = {|
 
 type StateProps = {|
   +jsTracerTimingRows: JsTracerTiming[],
-  +stringTable: UniqueStringArray,
+  +stringTable: StringTable,
   +timeRange: StartEndRange,
   +threadsKey: ThreadsKey,
   +previewSelection: PreviewSelection,

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { UniqueStringArray } from '../utils/unique-string-array';
+import { StringTable } from '../utils/string-table';
 import {
   GECKO_PROFILE_VERSION,
   PROCESSED_PROFILE_VERSION,
@@ -372,7 +372,7 @@ export function getEmptyThread(overrides?: $Shape<Thread>): Thread {
     markers: getEmptyRawMarkerTable(),
     stackTable: getEmptyStackTable(),
     frameTable: getEmptyFrameTable(),
-    stringTable: new UniqueStringArray(),
+    stringTable: new StringTable(),
     funcTable: getEmptyFuncTable(),
     resourceTable: getEmptyResourceTable(),
     nativeSymbols: getEmptyNativeSymbolTable(),

--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -9,7 +9,7 @@ import type {
   FuncTable,
   IndexIntoCallNodeTable,
 } from 'firefox-profiler/types';
-import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
+import type { StringTable } from 'firefox-profiler/utils/string-table';
 import type { CallTreeTimings } from './call-tree';
 
 import { bisectionRightByStrKey } from 'firefox-profiler/utils/bisect';
@@ -86,7 +86,7 @@ export type FlameGraphRows = IndexIntoCallNodeTable[][];
 export function computeFlameGraphRows(
   callNodeTable: CallNodeTable,
   funcTable: FuncTable,
-  stringTable: UniqueStringArray
+  stringTable: StringTable
 ): FlameGraphRows {
   if (callNodeTable.length === 0) {
     return [[]];

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -14,7 +14,7 @@
  * `docs-developer/CHANGELOG-formats.md`.
  */
 
-import { UniqueStringArray } from '../utils/unique-string-array';
+import { StringTable } from '../utils/string-table';
 import { GECKO_PROFILE_VERSION } from '../app-logic/constants';
 
 // Gecko profiles before version 1 did not have a profile.meta.version field.
@@ -204,7 +204,7 @@ const _upgraders = {
     // The type field for DOMEventMarkerPayload was renamed to eventType.
     function convertToVersionSevenRecursive(p) {
       for (const thread of p.threads) {
-        const stringTable = new UniqueStringArray(thread.stringTable);
+        const stringTable = new StringTable(thread.stringTable);
         const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {
@@ -328,7 +328,7 @@ const _upgraders = {
 
     function convertToVersionNineRecursive(p) {
       for (const thread of p.threads) {
-        //const stringTable = new UniqueStringArray(thread.stringTable);
+        //const stringTable = new StringTable(thread.stringTable);
         //const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {
@@ -363,7 +363,7 @@ const _upgraders = {
     function convertToVersionTenRecursive(p) {
       for (const thread of p.threads) {
         const { markers } = thread;
-        const stringTable = new UniqueStringArray(thread.stringTable);
+        const stringTable = new StringTable(thread.stringTable);
         const nameIndex = markers.schema.name;
         const dataIndex = markers.schema.data;
         const timeIndex = markers.schema.time;
@@ -541,7 +541,7 @@ const _upgraders = {
     // a type field to Screenshot marker payload.
     function convertToVersionThirteenRecursive(p) {
       for (const thread of p.threads) {
-        const stringTable = new UniqueStringArray(thread.stringTable);
+        const stringTable = new StringTable(thread.stringTable);
         const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {
@@ -594,7 +594,7 @@ const _upgraders = {
         };
         const locationIndex = thread.frameTable.schema.location;
         const relevantForJSIndex = thread.frameTable.schema.relevantForJS;
-        const stringTable = new UniqueStringArray(thread.stringTable);
+        const stringTable = new StringTable(thread.stringTable);
         for (let i = 0; i < thread.frameTable.data.length; i++) {
           const frameData = thread.frameTable.data[i];
           frameData.splice(relevantForJSIndex, 0, false);

--- a/src/profile-logic/import/dhat.js
+++ b/src/profile-logic/import/dhat.js
@@ -15,7 +15,7 @@ import {
   getEmptyThread,
   getEmptyUnbalancedNativeAllocationsTable,
 } from 'firefox-profiler/profile-logic/data-structures';
-import { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
+import { StringTable } from 'firefox-profiler/utils/string-table';
 
 import { coerce, ensureExists } from 'firefox-profiler/utils/flow';
 
@@ -376,7 +376,7 @@ export function attemptToConvertDhat(json: mixed): Profile | null {
     thread.pid = dhat.pid;
     thread.tid = i;
     thread.name = name;
-    thread.stringTable = new UniqueStringArray(stringTable.serializeToArray());
+    thread.stringTable = new StringTable(stringTable.serializeToArray());
 
     thread.funcTable.name = funcTable.name.slice();
     thread.funcTable.isJS = funcTable.isJS.slice();

--- a/src/profile-logic/js-tracer.js
+++ b/src/profile-logic/js-tracer.js
@@ -23,7 +23,7 @@ import type {
   Microseconds,
 } from 'firefox-profiler/types';
 
-import type { UniqueStringArray } from '../utils/unique-string-array';
+import type { StringTable } from '../utils/string-table';
 import type { JsImplementation } from '../profile-logic/profile-data';
 
 // See the function below for more information.
@@ -184,7 +184,7 @@ export function getJsTracerTiming(
  */
 export function getJsTracerLeafTiming(
   jsTracer: JsTracerTable,
-  stringTable: UniqueStringArray
+  stringTable: StringTable
 ): JsTracerTiming[] {
   // Each event type will have it's own timing information, later collapse these into
   // a single array.

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -45,7 +45,7 @@ import type {
   Tid,
 } from 'firefox-profiler/types';
 
-import type { UniqueStringArray } from '../utils/unique-string-array';
+import type { StringTable } from '../utils/string-table';
 
 /**
  * Jank instances are created from responsiveness values. Responsiveness is a profiler
@@ -120,7 +120,7 @@ export function getSearchFilteredMarkerIndexes(
   markerIndexes: MarkerIndex[],
   markerSchemaByName: MarkerSchemaByName,
   searchRegExps: MarkerRegExps | null,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   categoryList: CategoryList
 ): MarkerIndex[] {
   if (!searchRegExps) {
@@ -178,7 +178,7 @@ function positiveFilterMarker(
   marker: Marker,
   markerSchemaByName: MarkerSchemaByName,
   searchRegExps: MarkerRegExps,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   categoryList: CategoryList
 ): boolean {
   // Need to assign it to a constant variable so Flow doesn't complain about
@@ -246,7 +246,7 @@ function negativeFilterMarker(
   marker: Marker,
   markerSchemaByName: MarkerSchemaByName,
   searchRegExps: MarkerRegExps,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   categoryList: CategoryList
 ): boolean {
   // Need to assign it to a constant variable so Flow doesn't complain about
@@ -600,7 +600,7 @@ export function correlateIPCMarkers(threads: Thread[]): IPCMarkerCorrelations {
  */
 export function deriveMarkersFromRawMarkerTable(
   rawMarkers: RawMarkerTable,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   threadId: Tid,
   threadRange: StartEndRange,
   ipcCorrelations: IPCMarkerCorrelations

--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -26,7 +26,7 @@ import type {
   Tid,
   Pid,
 } from 'firefox-profiler/types';
-import type { UniqueStringArray } from '../utils/unique-string-array';
+import type { StringTable } from '../utils/string-table';
 
 /**
  * The marker schema comes from Gecko, and is embedded in the profile. However,
@@ -144,7 +144,7 @@ export function getSchemaFromMarker(
 export function parseLabel(
   markerSchema: MarkerSchema,
   categories: CategoryList,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   label: string
 ): (Marker) => string {
   // Split the label on the "{key}" capture groups.
@@ -337,7 +337,7 @@ export function getLabelGetter(
   markerSchemaList: MarkerSchema[],
   markerSchemaByName: MarkerSchemaByName,
   categoryList: CategoryList,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   labelKey: LabelKey
 ): (MarkerIndex) => string {
   // Build up a list of label functions, that are tied to the schema name.
@@ -415,7 +415,7 @@ export function formatFromMarkerSchema(
   markerType: string,
   format: MarkerFormatType,
   value: any,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   threadIdToNameMap?: Map<Tid, string>,
   processIdToNameMap?: Map<Pid, string>
 ): string {
@@ -538,7 +538,7 @@ export function formatMarkupFromMarkerSchema(
   markerType: string,
   format: MarkerFormatType,
   value: any,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   threadIdToNameMap?: Map<Tid, string>,
   processIdToNameMap?: Map<Pid, string>
 ): React.Element<any> | string {
@@ -661,7 +661,7 @@ export function formatMarkupFromMarkerSchema(
 export function markerPayloadMatchesSearch(
   markerSchema: MarkerSchema,
   marker: Marker,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   testFun: (string, string) => boolean
 ): boolean {
   const { data } = marker;

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -34,7 +34,7 @@ import {
   deriveMarkersFromRawMarkerTable,
   correlateIPCMarkers,
 } from './marker-data';
-import { UniqueStringArray } from '../utils/unique-string-array';
+import { StringTable } from '../utils/string-table';
 import { ensureExists, getFirstItemFromSet } from '../utils/flow';
 
 import type {
@@ -518,7 +518,7 @@ function mergeLibs(libsPerProfile: Lib[][]): {
  * functions.
  */
 function combineResourceTables(
-  newStringTable: UniqueStringArray,
+  newStringTable: StringTable,
   threads: $ReadOnlyArray<Thread>
 ): {
   resourceTable: ResourceTable,
@@ -573,7 +573,7 @@ function combineResourceTables(
  * This combines the nativeSymbols tables for the threads.
  */
 function combineNativeSymbolTables(
-  newStringTable: UniqueStringArray,
+  newStringTable: StringTable,
   threads: $ReadOnlyArray<Thread>
 ): {
   nativeSymbols: NativeSymbolTable,
@@ -628,7 +628,7 @@ function combineNativeSymbolTables(
  */
 function combineFuncTables(
   translationMapsForResources: TranslationMapForResources[],
-  newStringTable: UniqueStringArray,
+  newStringTable: StringTable,
   threads: $ReadOnlyArray<Thread>
 ): { funcTable: FuncTable, translationMaps: TranslationMapForFuncs[] } {
   const mapOfInsertedFuncs: Map<string, IndexIntoFuncTable> = new Map();
@@ -706,7 +706,7 @@ function combineFuncTables(
 function combineFrameTables(
   translationMapsForFuncs: TranslationMapForFuncs[],
   translationMapsForNativeSymbols: TranslationMapForNativeSymbols[],
-  newStringTable: UniqueStringArray,
+  newStringTable: StringTable,
   threads: $ReadOnlyArray<Thread>
 ): { frameTable: FrameTable, translationMaps: TranslationMapForFrames[] } {
   const translationMaps = [];
@@ -950,7 +950,7 @@ function getComparisonThread(
     ThreadAndWeightMultiplier,
   ]
 ): Thread {
-  const newStringTable = new UniqueStringArray();
+  const newStringTable = new StringTable();
 
   const threads = threadsAndWeightMultipliers.map((item) => item.thread);
 
@@ -1024,7 +1024,7 @@ function getComparisonThread(
  * TODO: Overlapping threads will not look great due to #2783.
  */
 export function mergeThreads(threads: Thread[]): Thread {
-  const newStringTable = new UniqueStringArray();
+  const newStringTable = new StringTable();
 
   // Combine the table we would need.
   const {
@@ -1205,7 +1205,7 @@ type TranslationMapForMarkers = Map<MarkerIndex, MarkerIndex>;
  */
 function mergeMarkers(
   translationMapsForStacks: TranslationMapForStacks[],
-  newStringTable: UniqueStringArray,
+  newStringTable: StringTable,
   threads: Thread[]
 ): {
   markerTable: RawMarkerTable,

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -6,7 +6,7 @@
 import { attemptToConvertChromeProfile } from './import/chrome';
 import { attemptToConvertDhat } from './import/dhat';
 import { AddressLocator } from './address-locator';
-import { UniqueStringArray } from '../utils/unique-string-array';
+import { StringTable } from '../utils/string-table';
 import {
   resourceTypes,
   getEmptyExtensions,
@@ -217,7 +217,7 @@ export class GlobalDataCollector {
 type ExtractionInfo = {
   funcTable: FuncTable,
   resourceTable: ResourceTable,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   addressLocator: AddressLocator,
   libToResourceIndex: Map<IndexIntoLibs, IndexIntoResourceTable>,
   originToResourceIndex: Map<string, IndexIntoResourceTable>,
@@ -240,7 +240,7 @@ type ExtractionInfo = {
 export function extractFuncsAndResourcesFromFrameLocations(
   frameLocations: IndexIntoStringTable[],
   relevantForJSPerFrame: boolean[],
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   libs: LibMapping[],
   extensions: ExtensionTable = getEmptyExtensions(),
   globalDataCollector: GlobalDataCollector
@@ -1128,7 +1128,7 @@ function _processThread(
   const { libs, pausedRanges, meta } = processProfile;
   const { categories, shutdownTime } = meta;
 
-  const stringTable = new UniqueStringArray(thread.stringTable);
+  const stringTable = new StringTable(thread.stringTable);
   const { funcTable, resourceTable, frameFuncs, frameAddresses } =
     extractFuncsAndResourcesFromFrameLocations(
       geckoFrameStruct.location,
@@ -1745,7 +1745,7 @@ function _unserializeSamples({ timeDeltas, time, ...restOfSamples }): any {
 }
 
 /**
- * The UniqueStringArray is a class, and is not serializable. This function turns
+ * The StringTable is a class, and is not serializable. This function turns
  * a profile into the serializable variant.
  */
 export function makeProfileSerializable({
@@ -1806,7 +1806,7 @@ function _unserializeProfile({
       return {
         ...restOfThread,
         samples: _unserializeSamples(samples),
-        stringTable: new UniqueStringArray(stringArray),
+        stringTable: new StringTable(stringArray),
       };
     }),
   };

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -17,7 +17,7 @@
 
 import { sortDataTable } from '../utils/data-table-utils';
 import { resourceTypes } from './data-structures';
-import { UniqueStringArray } from '../utils/unique-string-array';
+import { StringTable } from '../utils/string-table';
 import { timeCode } from '../utils/time-code';
 import { PROCESSED_PROFILE_VERSION } from '../app-logic/constants';
 import { coerce } from '../utils/flow';
@@ -305,7 +305,7 @@ const _upgraders = {
   [4]: (profile) => {
     profile.threads.forEach((thread) => {
       const { funcTable, stringArray, resourceTable } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
 
       // resourceTable gains a new field ("host") and a new resourceType:
       // "webhost". Resources from http and https URLs are now grouped by
@@ -439,7 +439,7 @@ const _upgraders = {
     // The type field for DOMEventMarkerPayload was renamed to eventType.
     for (const thread of profile.threads) {
       const { stringArray, markers } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       const newDataArray = [];
       for (let i = 0; i < markers.length; i++) {
         const name = stringTable.getString(markers.name[i]);
@@ -499,7 +499,7 @@ const _upgraders = {
         continue;
       }
       const { stringArray, markers } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       const newDataArray = [];
       for (let i = 0; i < markers.length; i++) {
         const name = stringTable.getString(markers.name[i]);
@@ -681,7 +681,7 @@ const _upgraders = {
         continue;
       }
 
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       const extraMarkers = [];
       for (let i = 0; i < markers.length; i++) {
         const name = stringTable.getString(markers.name[i]);
@@ -906,7 +906,7 @@ const _upgraders = {
     // the categories by looking at the function names.
     for (const thread of profile.threads) {
       const { frameTable, funcTable, stringArray } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       for (let i = 0; i < frameTable.length; i++) {
         const funcIndex = frameTable.func[i];
         const funcName = stringTable.getString(funcTable.name[funcIndex]);
@@ -992,7 +992,7 @@ const _upgraders = {
     // Old profiles might still have this property.
     for (const thread of profile.threads) {
       const { stringArray, markers } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       const newDataArray = [];
       for (let i = 0; i < markers.length; i++) {
         const name = stringTable.getString(markers.name[i]);
@@ -1047,7 +1047,7 @@ const _upgraders = {
     const domCallRegex = /^(get |set )?\w+(\.\w+| constructor)$/;
     for (const thread of profile.threads) {
       const { funcTable, stringArray } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       funcTable.relevantForJS = new Array(funcTable.length);
       for (let i = 0; i < funcTable.length; i++) {
         const location = stringTable.getString(funcTable.name[i]);
@@ -1071,7 +1071,7 @@ const _upgraders = {
     // We update the func table with right values of 'fileName', 'lineNumber' and 'columnNumber'.
     for (const thread of profile.threads) {
       const { funcTable, stringArray } = thread;
-      const stringTable = new UniqueStringArray(stringArray);
+      const stringTable = new StringTable(stringArray);
       funcTable.columnNumber = [];
       for (
         let funcIndex = 0;

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -86,7 +86,7 @@ import type {
   ThreadWithReservedFunctions,
   TabID,
 } from 'firefox-profiler/types';
-import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
+import type { StringTable } from 'firefox-profiler/utils/string-table';
 
 /**
  * Various helpers for dealing with the profile as a data structure.
@@ -2497,7 +2497,7 @@ export function getOriginAnnotationForFunc(
   funcIndex: IndexIntoFuncTable,
   funcTable: FuncTable,
   resourceTable: ResourceTable,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   frameLineNumber: number | null = null,
   frameColumnNumber: number | null = null
 ): string {
@@ -3031,7 +3031,7 @@ export function extractProfileFilterPageData(
 export function getOrCreateURIResource(
   scriptURI: string,
   resourceTable: ResourceTable,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   originToResourceIndex: Map<string, IndexIntoResourceTable>
 ): IndexIntoResourceTable {
   // Figure out the origin and host.
@@ -3608,7 +3608,7 @@ export function getNativeSymbolInfo(
   nativeSymbol: IndexIntoNativeSymbolTable,
   nativeSymbols: NativeSymbolTable,
   frameTable: FrameTable,
-  stringTable: UniqueStringArray
+  stringTable: StringTable
 ): NativeSymbolInfo {
   const functionSizeOrNull = nativeSymbols.functionSize[nativeSymbol];
   const functionSize =

--- a/src/profile-logic/sanitize.js
+++ b/src/profile-logic/sanitize.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import { UniqueStringArray } from '../utils/unique-string-array';
+import { StringTable } from '../utils/string-table';
 import {
   getEmptyExtensions,
   shallowCloneRawMarkerTable,
@@ -267,7 +267,7 @@ function sanitizeThreadPII(
     return null;
   }
 
-  // We need to update the stringTable. It's not possible with UniqueStringArray.
+  // We need to update the stringTable. It's not possible with StringTable.
   const stringArray = thread.stringTable.serializeToArray();
   let markerTable = shallowCloneRawMarkerTable(thread.markers);
 
@@ -664,7 +664,7 @@ function sanitizeThreadPII(
 
   // Remove the old stringTable and markerTable and replace it
   // with new updated ones.
-  newThread.stringTable = new UniqueStringArray(stringArray);
+  newThread.stringTable = new StringTable(stringArray);
   newThread.markers = markerTable;
 
   // Have we removed everything from this thread?

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -49,7 +49,7 @@ import type {
   CategoryList,
   Milliseconds,
 } from 'firefox-profiler/types';
-import type { UniqueStringArray } from 'firefox-profiler/utils/unique-string-array';
+import type { StringTable } from 'firefox-profiler/utils/string-table';
 
 /**
  * This file contains the functions and logic for working with and applying transforms
@@ -1634,7 +1634,7 @@ function _findRangesByMarkerFilter(
   getMarker: (MarkerIndex) => Marker,
   markerIndexes: MarkerIndex[],
   markerSchemaByName: MarkerSchemaByName,
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   categoryList: CategoryList,
   filter: string
 ): StartEndRange[] {

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -45,7 +45,7 @@ import type {
   IndexIntoFuncTable,
 } from 'firefox-profiler/types';
 
-import type { UniqueStringArray } from '../../utils/unique-string-array';
+import type { StringTable } from '../../utils/string-table';
 import type { TransformLabeL10nIds } from 'firefox-profiler/profile-logic/transforms';
 import type { MarkerSelectorsPerThread } from './markers';
 
@@ -91,7 +91,7 @@ export function getBasicThreadSelectorsPerThread(
           ensureExists(getFirstItemFromSet(threadIndexes))
         ]
       : getMergedThread(state);
-  const getStringTable: Selector<UniqueStringArray> = (state) =>
+  const getStringTable: Selector<StringTable> = (state) =>
     getThread(state).stringTable;
   const getSamplesTable: Selector<SamplesTable> = (state) =>
     getThread(state).samples;

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -14,7 +14,7 @@ import {
 } from '../../../profile-logic/data-structures';
 import { mergeProfilesForDiffing } from '../../../profile-logic/merge-compare';
 import { stateFromLocation } from '../../../app-logic/url-handling';
-import { UniqueStringArray } from '../../../utils/unique-string-array';
+import { StringTable } from '../../../utils/string-table';
 import { ensureExists } from '../../../utils/flow';
 import {
   INTERVAL,
@@ -126,7 +126,7 @@ export function addRawMarkersToThread(
 function _replaceUniqueStringFieldValuesWithStringIndexesInMarkerPayload(
   payload: MixedObject | null,
   markerSchemas: MarkerSchema[],
-  stringTable: UniqueStringArray
+  stringTable: StringTable
 ) {
   if (payload === null) {
     return;
@@ -1439,7 +1439,7 @@ export function getVisualProgressTrackProfile(profileString: string): Profile {
 }
 
 export function getJsTracerTable(
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   events: TestDefinedJsTracerEvent[]
 ): JsTracerTable {
   const jsTracer = getEmptyJsTracerTable();

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -930,7 +930,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "A",
           "B",
@@ -1127,7 +1127,7 @@ Object {
         "prefix": Array [],
         "subcategory": Array [],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "A",
           "B",
@@ -1612,7 +1612,7 @@ Array [
         0,
       ],
     },
-    "stringTable": UniqueStringArray {
+    "stringTable": StringTable {
       "_array": Array [
         "A",
         "B",
@@ -1809,7 +1809,7 @@ Array [
       "prefix": Array [],
       "subcategory": Array [],
     },
-    "stringTable": UniqueStringArray {
+    "stringTable": StringTable {
       "_array": Array [
         "A",
         "B",
@@ -3523,7 +3523,7 @@ CallTree {
         0,
       ],
     },
-    "stringTable": UniqueStringArray {
+    "stringTable": StringTable {
       "_array": Array [
         "A",
         "B",
@@ -3850,7 +3850,7 @@ Object {
       0,
     ],
   },
-  "stringTable": UniqueStringArray {
+  "stringTable": StringTable {
     "_array": Array [
       "A",
       "B",
@@ -4249,7 +4249,7 @@ Object {
       0,
     ],
   },
-  "stringTable": UniqueStringArray {
+  "stringTable": StringTable {
     "_array": Array [
       "A",
       "B",
@@ -4574,7 +4574,7 @@ Object {
       0,
     ],
   },
-  "stringTable": UniqueStringArray {
+  "stringTable": StringTable {
     "_array": Array [
       "A",
       "B",
@@ -4899,7 +4899,7 @@ Object {
       0,
     ],
   },
-  "stringTable": UniqueStringArray {
+  "stringTable": StringTable {
     "_array": Array [
       "A",
       "B",
@@ -5383,7 +5383,7 @@ Object {
       0,
     ],
   },
-  "stringTable": UniqueStringArray {
+  "stringTable": StringTable {
     "_array": Array [
       "A",
       "B",

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -380,7 +380,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "_start (in /usr/lib64/ld-2.25.so)",
           "native_irq_return_iret (in [kernel.kallsyms])",
@@ -616,7 +616,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "_dl_init (in /usr/lib64/ld-2.25.so)",
           "syscall (in /usr/lib64/libc-2.25.so)",
@@ -830,7 +830,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "mozilla::TimeStamp::ComputeProcessUptime (in /home/jesup/src/mozilla/head/obj-opt2/dist/bin/firefox)",
           "__clone (in /usr/lib64/libc-2.25.so)",
@@ -1294,7 +1294,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "__libc_start_main (in /usr/lib64/libc-2.25.so)",
           "main (in /home/jesup/src/mozilla/head/obj-opt2/dist/bin/firefox)",
@@ -1587,7 +1587,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__clone (in /usr/lib64/libc-2.25.so)",
@@ -1920,7 +1920,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "[unknown] (in /usr/lib64/libgio-2.0.so.0.5200.3)",
@@ -2125,7 +2125,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "__clone (in /usr/lib64/libc-2.25.so)",
           "native_irq_return_iret (in [kernel.kallsyms])",
@@ -2333,7 +2333,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__clone (in /usr/lib64/libc-2.25.so)",
@@ -2549,7 +2549,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__clone (in /usr/lib64/libc-2.25.so)",
@@ -2761,7 +2761,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__clone (in /usr/lib64/libc-2.25.so)",
@@ -3026,7 +3026,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__clone (in /usr/lib64/libc-2.25.so)",
@@ -3869,7 +3869,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__libc_start_main (in /usr/lib64/libc-2.25.so)",
@@ -4826,7 +4826,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__libc_start_main (in /usr/lib64/libc-2.25.so)",
@@ -5787,7 +5787,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__libc_start_main (in /usr/lib64/libc-2.25.so)",
@@ -6748,7 +6748,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__libc_start_main (in /usr/lib64/libc-2.25.so)",
@@ -7428,7 +7428,7 @@ Object {
           0,
         ],
       },
-      "stringTable": UniqueStringArray {
+      "stringTable": StringTable {
         "_array": Array [
           "[unknown] (in [unknown])",
           "__libc_recvmsg (in /lib/x86_64-linux-gnu/libpthread-2.27.so)",

--- a/src/test/unit/marker-schema.test.js
+++ b/src/test/unit/marker-schema.test.js
@@ -14,7 +14,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { getMarkerSchema } from '../../selectors/profile';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { markerSchemaForTests } from '../fixtures/profiles/marker-schema';
-import { UniqueStringArray } from '../../utils/unique-string-array';
+import { StringTable } from '../../utils/string-table';
 
 /**
  * Generally, higher level type of testing is preferred to detailed unit tests of
@@ -36,10 +36,7 @@ describe('marker schema labels', function () {
   function applyLabel(options: LabelOptions): string {
     const { schemaData, label, payload } = options;
     const categories = getDefaultCategories();
-    const stringTable = new UniqueStringArray([
-      'IPC Message',
-      'MouseDown Event',
-    ]);
+    const stringTable = new StringTable(['IPC Message', 'MouseDown Event']);
 
     const schema = {
       name: 'TestDefinedMarker',
@@ -290,7 +287,7 @@ describe('marker schema formatting', function () {
             'none',
             format,
             value,
-            new UniqueStringArray(['IPC Message', 'MouseDown Event'])
+            new StringTable(['IPC Message', 'MouseDown Event'])
           )
       )
     ).toMatchInlineSnapshot(`
@@ -416,13 +413,8 @@ describe('marker schema formatting', function () {
       entries.map(([format, value]) => [
         format,
         value,
-        formatMarkupFromMarkerSchema(
-          'none',
-          format,
-          value,
-          new UniqueStringArray()
-        ),
-        formatFromMarkerSchema('none', format, value, new UniqueStringArray()),
+        formatMarkupFromMarkerSchema('none', format, value, new StringTable()),
+        formatFromMarkerSchema('none', format, value, new StringTable()),
       ])
     ).toMatchSnapshot();
   });

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -10,7 +10,7 @@ import {
   unserializeProfileOfArbitraryFormat,
   GlobalDataCollector,
 } from '../../profile-logic/process-profile';
-import { UniqueStringArray } from '../../utils/unique-string-array';
+import { StringTable } from '../../utils/string-table';
 import {
   createGeckoProfile,
   createGeckoCounter,
@@ -83,7 +83,7 @@ describe('extract functions and resource from location strings', function () {
       breakpadId: '',
     },
   ];
-  const stringTable = new UniqueStringArray();
+  const stringTable = new StringTable();
   const locationIndexes = locations.map((location) =>
     stringTable.indexForString(location)
   );

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -32,7 +32,7 @@ import {
   createGeckoProfileWithJsTimings,
   createGeckoSubprocessProfile,
 } from '.././fixtures/profiles/gecko-profile';
-import { UniqueStringArray } from '../../utils/unique-string-array';
+import { StringTable } from '../../utils/string-table';
 import { FakeSymbolStore } from '../fixtures/fake-symbol-store';
 import { sortDataTable } from '../../utils/data-table-utils';
 import { ensureExists } from '../../utils/flow';
@@ -48,8 +48,8 @@ import {
 
 import type { Thread, IndexIntoStackTable } from 'firefox-profiler/types';
 
-describe('unique-string-array', function () {
-  const u = new UniqueStringArray(['foo', 'bar', 'baz']);
+describe('string-table', function () {
+  const u = new StringTable(['foo', 'bar', 'baz']);
 
   it('should return the right strings', function () {
     expect(u.getString(0)).toEqual('foo');
@@ -321,7 +321,7 @@ describe('process-profile', function () {
         // from the parent process.
         const geckoSubprocess = createGeckoSubprocessProfile(geckoProfile);
         const childProcessThread = geckoSubprocess.threads[0];
-        const stringTable = new UniqueStringArray();
+        const stringTable = new StringTable();
         const jsTracer = getJsTracerTable(stringTable, [
           ['jsTracerA', 0, 10],
           ['jsTracerB', 1, 9],

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -30,7 +30,7 @@ export type MarkerFormatType =
   // sanitized. Please be careful with including other types of PII here as well.
   // e.g. "Label: Some String"
   | 'string'
-  /// An index into a (currently) thread-local string table, aka UniqueStringArray
+  /// An index into a (currently) thread-local string table, aka StringTable
   /// This is effectively an integer, so wherever we need to display this value, we
   /// must first perform a lookup into the appropriate string table.
   | 'unique-string'

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -5,7 +5,7 @@
 // @flow
 
 import type { Milliseconds, Address, Microseconds, Bytes } from './units';
-import type { UniqueStringArray } from '../utils/unique-string-array';
+import type { StringTable } from '../utils/string-table';
 import type { MarkerPayload, MarkerSchema, MarkerFormatType } from './markers';
 import type { MarkerPhase, ProfilingLog } from './gecko-profile';
 
@@ -664,7 +664,7 @@ export type Thread = {|
   frameTable: FrameTable,
   // Strings for profiles are collected into a single table, and are referred to by
   // their index by other tables.
-  stringTable: UniqueStringArray,
+  stringTable: StringTable,
   funcTable: FuncTable,
   resourceTable: ResourceTable,
   nativeSymbols: NativeSymbolTable,
@@ -947,7 +947,7 @@ export type Profile = {|
 |};
 
 type SerializableThread = {|
-  ...$Diff<Thread, { stringTable: UniqueStringArray, samples: SamplesTable }>,
+  ...$Diff<Thread, { stringTable: StringTable, samples: SamplesTable }>,
   stringArray: string[],
   samples: SerializableSamplesTable,
 |};
@@ -975,7 +975,7 @@ export type SerializableCounter = {|
 |};
 
 /**
- * The UniqueStringArray is a class, and is not serializable to JSON. This profile
+ * The StringTable is a class, and is not serializable to JSON. This profile
  * variant is able to be based into JSON.stringify.
  */
 export type SerializableProfile = {|

--- a/src/utils/string-table.js
+++ b/src/utils/string-table.js
@@ -5,7 +5,7 @@
 // @flow
 import type { IndexIntoStringTable } from 'firefox-profiler/types';
 
-export class UniqueStringArray {
+export class StringTable {
   _array: string[];
   _stringToIndex: Map<string, IndexIntoStringTable>;
 
@@ -20,10 +20,10 @@ export class UniqueStringArray {
   getString(index: IndexIntoStringTable, els: ?string): string {
     if (!this.hasIndex(index)) {
       if (els) {
-        console.warn(`index ${index} not in UniqueStringArray`);
+        console.warn(`index ${index} not in StringTable`);
         return els;
       }
-      throw new Error(`index ${index} not in UniqueStringArray`);
+      throw new Error(`index ${index} not in StringTable`);
     }
     return this._array[index];
   }


### PR DESCRIPTION
The name "UniqueStringArray" is a holdover from a very early version of this code. Let's rename the class so that it feels a bit more cohesive.