### PR TITLE
Fix two confused upgraders which didn't expect to be run on the serialized format.

### DIFF
--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2062,7 +2062,7 @@ const _upgraders = {
         libs: threadLibs,
         resourceTable,
         nativeSymbols,
-        stringTable,
+        stringArray,
       } = thread;
       const threadLibIndexToGlobalLibIndex = new Map();
       delete thread.libs;
@@ -2106,8 +2106,12 @@ const _upgraders = {
           nameStringIndex === undefined ||
           nameStringIndex === null
         ) {
-          resourceTable.name[resourceIndex] =
-            stringTable.indexForString('<unnamed resource>');
+          let stringIndex = stringArray.indexOf('<unnamed resource>');
+          if (stringIndex === -1) {
+            stringIndex = stringArray.length;
+            stringArray.push('<unnamed resource>');
+          }
+          resourceTable.name[resourceIndex] = stringIndex;
         }
         const hostStringIndex = resourceTable.host[resourceIndex];
         if (hostStringIndex === -1 || hostStringIndex === undefined) {

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2270,8 +2270,6 @@ const _upgraders = {
   [50]: (_) => {
     // The serialized format can now optionally store sample and counter sample
     // times as time deltas instead of absolute timestamps to reduce the JSON size.
-    // The unserialized version is unchanged, and because the upgraders run
-    // after unserialization they see no difference.
   },
   [51]: (_) => {
     // This version bump added two new form types for new marker schema field:


### PR DESCRIPTION
The upgrader for version 50 had a misleading comment, and the upgrader for version 41 had broken code in a code path that's never taken.