### PR TITLE
Change StringTable API a bit.

### DIFF
--- a/src/components/app/MenuButtons/MetaInfo.js
+++ b/src/components/app/MenuButtons/MetaInfo.js
@@ -153,7 +153,7 @@ class MetaInfoPanelImpl extends React.PureComponent<Props, State> {
                     'moreInfo',
                     format,
                     value,
-                    new StringTable()
+                    StringTable.withBackingArray([])
                   )}
                 </div>
               </div>

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -386,7 +386,7 @@ export function getEmptyThread(overrides?: $Shape<Thread>): Thread {
     markers: getEmptyRawMarkerTable(),
     stackTable: getEmptyStackTable(),
     frameTable: getEmptyFrameTable(),
-    stringTable: new StringTable(),
+    stringTable: StringTable.withBackingArray([]),
     funcTable: getEmptyFuncTable(),
     resourceTable: getEmptyResourceTable(),
     nativeSymbols: getEmptyNativeSymbolTable(),

--- a/src/profile-logic/gecko-profile-versioning.js
+++ b/src/profile-logic/gecko-profile-versioning.js
@@ -204,11 +204,10 @@ const _upgraders = {
     // The type field for DOMEventMarkerPayload was renamed to eventType.
     function convertToVersionSevenRecursive(p) {
       for (const thread of p.threads) {
-        const stringTable = new StringTable(thread.stringTable);
         const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {
-          const name = stringTable.getString(thread.markers.data[i][nameIndex]);
+          const name = thread.stringTable[thread.markers.data[i][nameIndex]];
           if (name === 'DOMEvent') {
             const data = thread.markers.data[i][dataIndex];
             data.eventType = data.type;
@@ -328,8 +327,6 @@ const _upgraders = {
 
     function convertToVersionNineRecursive(p) {
       for (const thread of p.threads) {
-        //const stringTable = new StringTable(thread.stringTable);
-        //const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {
           let marker = thread.markers.data[i][dataIndex];
@@ -363,14 +360,13 @@ const _upgraders = {
     function convertToVersionTenRecursive(p) {
       for (const thread of p.threads) {
         const { markers } = thread;
-        const stringTable = new StringTable(thread.stringTable);
         const nameIndex = markers.schema.name;
         const dataIndex = markers.schema.data;
         const timeIndex = markers.schema.time;
         const extraMarkers = [];
         for (let i = 0; i < markers.data.length; i++) {
           const marker = markers.data[i];
-          const name = stringTable.getString(marker[nameIndex]);
+          const name = thread.stringTable[marker[nameIndex]];
           const data = marker[dataIndex];
           if (name === 'DOMEvent' && data.type !== 'tracing') {
             const endMarker = [];
@@ -541,11 +537,10 @@ const _upgraders = {
     // a type field to Screenshot marker payload.
     function convertToVersionThirteenRecursive(p) {
       for (const thread of p.threads) {
-        const stringTable = new StringTable(thread.stringTable);
         const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {
-          const name = stringTable.getString(thread.markers.data[i][nameIndex]);
+          const name = thread.stringTable[thread.markers.data[i][nameIndex]];
           const data = thread.markers.data[i][dataIndex];
           switch (name) {
             case 'VsyncTimestamp':
@@ -594,7 +589,7 @@ const _upgraders = {
         };
         const locationIndex = thread.frameTable.schema.location;
         const relevantForJSIndex = thread.frameTable.schema.relevantForJS;
-        const stringTable = new StringTable(thread.stringTable);
+        const stringTable = StringTable.withBackingArray(thread.stringTable);
         for (let i = 0; i < thread.frameTable.data.length; i++) {
           const frameData = thread.frameTable.data[i];
           frameData.splice(relevantForJSIndex, 0, false);
@@ -609,7 +604,6 @@ const _upgraders = {
             frameData[relevantForJSIndex] = domCallRegex.test(location);
           }
         }
-        thread.stringTable = stringTable.serializeToArray();
       }
       for (const subprocessProfile of p.processes) {
         convertToVersionFourteenRecursive(subprocessProfile);
@@ -621,17 +615,13 @@ const _upgraders = {
     // The type field for DOMEventMarkerPayload was renamed to eventType.
     function convertToVersion15Recursive(p) {
       for (const thread of p.threads) {
-        if (thread.stringTable.indexOf('DiskIO') === -1) {
+        const stringTable = StringTable.withBackingArray(thread.stringTable);
+        if (!stringTable.hasString('DiskIO')) {
           // There are no DiskIO markers.
           continue;
         }
 
-        let fileIoStringIndex = thread.stringTable.indexOf('FileIO');
-        if (fileIoStringIndex === -1) {
-          fileIoStringIndex = thread.stringTable.length;
-          thread.stringTable.push('FileIO');
-        }
-
+        const fileIoStringIndex = stringTable.indexForString('FileIO');
         const nameIndex = thread.markers.schema.name;
         const dataIndex = thread.markers.schema.data;
         for (let i = 0; i < thread.markers.data.length; i++) {

--- a/src/profile-logic/import/dhat.js
+++ b/src/profile-logic/import/dhat.js
@@ -15,7 +15,6 @@ import {
   getEmptyThread,
   getEmptyUnbalancedNativeAllocationsTable,
 } from 'firefox-profiler/profile-logic/data-structures';
-import { StringTable } from 'firefox-profiler/utils/string-table';
 
 import { coerce, ensureExists } from 'firefox-profiler/utils/flow';
 
@@ -376,7 +375,7 @@ export function attemptToConvertDhat(json: mixed): Profile | null {
     thread.pid = dhat.pid;
     thread.tid = i;
     thread.name = name;
-    thread.stringTable = new StringTable(stringTable.serializeToArray());
+    thread.stringTable = stringTable;
 
     thread.funcTable.name = funcTable.name.slice();
     thread.funcTable.isJS = funcTable.isJS.slice();

--- a/src/profile-logic/import/simpleperf.js
+++ b/src/profile-logic/import/simpleperf.js
@@ -221,7 +221,8 @@ class FirefoxThread {
   tid: number;
   pid: number;
 
-  strings = new StringTable();
+  stringArray = [];
+  strings = StringTable.withBackingArray(this.stringArray);
 
   sampleTable: SamplesTable = getEmptySamplesTable();
 

--- a/src/profile-logic/merge-compare.js
+++ b/src/profile-logic/merge-compare.js
@@ -950,7 +950,7 @@ function getComparisonThread(
     ThreadAndWeightMultiplier,
   ]
 ): Thread {
-  const newStringTable = new StringTable();
+  const newStringTable = StringTable.withBackingArray([]);
 
   const threads = threadsAndWeightMultipliers.map((item) => item.thread);
 
@@ -1024,7 +1024,7 @@ function getComparisonThread(
  * TODO: Overlapping threads will not look great due to #2783.
  */
 export function mergeThreads(threads: Thread[]): Thread {
-  const newStringTable = new StringTable();
+  const newStringTable = StringTable.withBackingArray([]);
 
   // Combine the table we would need.
   const {

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -1129,7 +1129,7 @@ function _processThread(
   const { libs, pausedRanges, meta } = processProfile;
   const { categories, shutdownTime } = meta;
 
-  const stringTable = new StringTable(thread.stringTable);
+  const stringTable = StringTable.withBackingArray(thread.stringTable);
   const { funcTable, resourceTable, frameFuncs, frameAddresses } =
     extractFuncsAndResourcesFromFrameLocations(
       geckoFrameStruct.location,
@@ -1768,7 +1768,7 @@ export function makeProfileSerializable({
       return {
         ...restOfThread,
         samples: _serializeSamples(samples),
-        stringArray: stringTable.serializeToArray(),
+        stringArray: stringTable.getBackingArray(),
       };
     }),
   };
@@ -1807,7 +1807,7 @@ function _unserializeProfile({
       return {
         ...restOfThread,
         samples: _unserializeSamples(samples),
-        stringTable: new StringTable(stringArray),
+        stringTable: StringTable.withBackingArray(stringArray),
       };
     }),
   };

--- a/src/test/unit/marker-schema.test.js
+++ b/src/test/unit/marker-schema.test.js
@@ -36,7 +36,10 @@ describe('marker schema labels', function () {
   function applyLabel(options: LabelOptions): string {
     const { schemaData, label, payload } = options;
     const categories = getDefaultCategories();
-    const stringTable = new StringTable(['IPC Message', 'MouseDown Event']);
+    const stringTable = StringTable.withBackingArray([
+      'IPC Message',
+      'MouseDown Event',
+    ]);
 
     const schema = {
       name: 'TestDefinedMarker',
@@ -287,7 +290,7 @@ describe('marker schema formatting', function () {
             'none',
             format,
             value,
-            new StringTable(['IPC Message', 'MouseDown Event'])
+            StringTable.withBackingArray(['IPC Message', 'MouseDown Event'])
           )
       )
     ).toMatchInlineSnapshot(`
@@ -409,12 +412,13 @@ describe('marker schema formatting', function () {
       ['list', []],
       ['list', ['a', 'b']],
     ];
+    const stringTable = StringTable.withBackingArray([]);
     expect(
       entries.map(([format, value]) => [
         format,
         value,
-        formatMarkupFromMarkerSchema('none', format, value, new StringTable()),
-        formatFromMarkerSchema('none', format, value, new StringTable()),
+        formatMarkupFromMarkerSchema('none', format, value, stringTable),
+        formatFromMarkerSchema('none', format, value, stringTable),
       ])
     ).toMatchSnapshot();
   });

--- a/src/test/unit/merge-compare.test.js
+++ b/src/test/unit/merge-compare.test.js
@@ -368,7 +368,7 @@ describe('mergeThreads function', function () {
     const mergedMarkers = mergedThread.markers;
     const mergedStringTable = mergedThread.stringTable;
     expect(mergedMarkers).toHaveLength(6);
-    expect(mergedStringTable.serializeToArray()).toHaveLength(6);
+    expect(mergedStringTable.getBackingArray()).toHaveLength(6);
 
     const markerNames = [];
     const markerStartTimes = [];

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -83,7 +83,7 @@ describe('extract functions and resource from location strings', function () {
       breakpadId: '',
     },
   ];
-  const stringTable = new StringTable();
+  const stringTable = StringTable.withBackingArray([]);
   const locationIndexes = locations.map((location) =>
     stringTable.indexForString(location)
   );

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -49,7 +49,7 @@ import {
 import type { Thread, IndexIntoStackTable } from 'firefox-profiler/types';
 
 describe('string-table', function () {
-  const u = new StringTable(['foo', 'bar', 'baz']);
+  const u = StringTable.withBackingArray(['foo', 'bar', 'baz']);
 
   it('should return the right strings', function () {
     expect(u.getString(0)).toEqual('foo');
@@ -321,7 +321,7 @@ describe('process-profile', function () {
         // from the parent process.
         const geckoSubprocess = createGeckoSubprocessProfile(geckoProfile);
         const childProcessThread = geckoSubprocess.threads[0];
-        const stringTable = new StringTable();
+        const stringTable = StringTable.withBackingArray([]);
         const jsTracer = getJsTracerTable(stringTable, [
           ['jsTracerA', 0, 10],
           ['jsTracerB', 1, 9],

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -480,7 +480,7 @@ describe('sanitizePII', function () {
     });
 
     for (const thread of sanitizedProfile.threads) {
-      const stringArray = thread.stringTable.serializeToArray();
+      const stringArray = thread.stringTable.getBackingArray();
       for (let i = 0; i < thread.markers.length; i++) {
         const currentMarker = thread.markers.data[i];
         if (
@@ -533,7 +533,7 @@ describe('sanitizePII', function () {
     });
 
     for (const thread of sanitizedProfile.threads) {
-      const stringArray = thread.stringTable.serializeToArray();
+      const stringArray = thread.stringTable.getBackingArray();
       for (const string of stringArray) {
         // We are keeping the http(s) and removing the rest.
         // That's why we can't test it with `includes('http')`.


### PR DESCRIPTION
This avoids copies of the underlying array.

It also provides a new "constructor" (StringTable.withBackingArray) which avoids recreating the map when we need a StringTable for the same array in different places.