### PR TITLE
Compute cpuRatio values when computing the derived thread

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -53,7 +53,6 @@ export type Props = {|
     IndexIntoSamplesTable
   ) => number,
   +enableCPUUsage: boolean,
-  +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
   +timelineType: TimelineType,
   +zeroAt: Milliseconds,
@@ -165,7 +164,6 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
       sampleIndexOffset,
       samplesSelectedStates,
       treeOrderSampleComparator,
-      maxThreadCPUDeltaPerMs,
       enableCPUUsage,
       implementationFilter,
       width,
@@ -199,7 +197,6 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
           passFillsQuerier={this._setFillsQuerier}
           onClick={this._onClick}
           enableCPUUsage={enableCPUUsage}
-          maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
           width={width}
           height={height}
         />

--- a/src/components/shared/thread/ActivityGraphCanvas.js
+++ b/src/components/shared/thread/ActivityGraphCanvas.js
@@ -42,7 +42,6 @@ type CanvasProps = {|
   +passFillsQuerier: (ActivityFillGraphQuerier) => void,
   +onClick: (SyntheticMouseEvent<HTMLCanvasElement>) => void,
   +enableCPUUsage: boolean,
-  +maxThreadCPUDeltaPerMs: number,
   ...SizeProps,
 |};
 
@@ -128,7 +127,6 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       treeOrderSampleComparator,
       categories,
       enableCPUUsage,
-      maxThreadCPUDeltaPerMs,
       width,
       height,
     } = this.props;
@@ -150,7 +148,6 @@ export class ActivityGraphCanvas extends React.PureComponent<CanvasProps> {
       sampleIndexOffset,
       samplesSelectedStates,
       enableCPUUsage,
-      maxThreadCPUDeltaPerMs,
       xPixelsPerMs: canvasPixelWidth / (rangeEnd - rangeStart),
       treeOrderSampleComparator,
       greyCategoryIndex: categories.findIndex((c) => c.color === 'grey') || 0,

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -40,7 +40,6 @@ type RenderedComponentSettings = {|
   +sampleIndexOffset: number,
   +xPixelsPerMs: number,
   +enableCPUUsage: boolean,
-  +maxThreadCPUDeltaPerMs: number,
   +treeOrderSampleComparator: ?(
     IndexIntoSamplesTable,
     IndexIntoSamplesTable
@@ -240,7 +239,7 @@ export class ActivityGraphFillComputer {
     }
 
     // Go through the samples and accumulate the category into the percentageBuffers.
-    const { threadCPUDelta } = samples;
+    const { threadCPURatio } = samples;
     for (let i = 0; i < samples.length - 1; i++) {
       const nextSampleTime = samples.time[i + 1];
       const stackIndex = samples.stack[i];
@@ -249,13 +248,11 @@ export class ActivityGraphFillComputer {
           ? greyCategoryIndex
           : stackTable.category[stackIndex];
 
-      let cpuBeforeSample = null;
-      let cpuAfterSample = null;
-      if (enableCPUUsage && threadCPUDelta) {
-        // It must be non-null because we are checking this in the processing
-        // step and eliminating all the null values.
-        cpuBeforeSample = ensureExists(threadCPUDelta[i]);
-        cpuAfterSample = ensureExists(threadCPUDelta[i + 1]);
+      let beforeSampleCpuRatio = 1;
+      let afterSampleCpuRatio = 1;
+      if (enableCPUUsage && threadCPURatio) {
+        beforeSampleCpuRatio = threadCPURatio[i];
+        afterSampleCpuRatio = threadCPURatio[i + 1];
       }
 
       // Mutate the percentage buffers.
@@ -265,8 +262,8 @@ export class ActivityGraphFillComputer {
         prevSampleTime,
         sampleTime,
         nextSampleTime,
-        cpuBeforeSample,
-        cpuAfterSample
+        beforeSampleCpuRatio,
+        afterSampleCpuRatio
       );
 
       prevSampleTime = sampleTime;
@@ -281,23 +278,23 @@ export class ActivityGraphFillComputer {
         ? stackTable.category[lastSampleStack]
         : greyCategoryIndex;
 
-    let cpuBeforeSample = null;
-    let cpuAfterSample = null;
-    if (enableCPUUsage && threadCPUDelta) {
-      cpuBeforeSample = ensureExists(threadCPUDelta[lastIdx]);
+    let beforeSampleCpuRatio = 1;
+    let afterSampleCpuRatio = 1;
+    if (enableCPUUsage && threadCPURatio) {
+      beforeSampleCpuRatio = threadCPURatio[lastIdx];
 
       const nextIdxInFullThread = sampleIndexOffset + lastIdx + 1;
       if (nextIdxInFullThread < fullThread.samples.length) {
         // Since we are zoomed in the timeline, rangeFilteredThread will not
         // have the information of the next sample. So we need to get that
         // information from the full thread.
-        cpuAfterSample = ensureExists(
-          ensureExists(fullThread.samples.threadCPUDelta)[nextIdxInFullThread]
-        );
+        afterSampleCpuRatio = ensureExists(fullThread.samples.threadCPURatio)[
+          nextIdxInFullThread
+        ];
       } else {
         // If we don't have this information in the full thread, simply use the
-        // previous CPU delta.
-        cpuAfterSample = cpuBeforeSample;
+        // previous CPU ratio.
+        afterSampleCpuRatio = beforeSampleCpuRatio;
       }
     }
 
@@ -307,8 +304,8 @@ export class ActivityGraphFillComputer {
       prevSampleTime,
       sampleTime,
       sampleTime + interval,
-      cpuBeforeSample,
-      cpuAfterSample
+      beforeSampleCpuRatio,
+      afterSampleCpuRatio
     );
   }
 
@@ -322,8 +319,8 @@ export class ActivityGraphFillComputer {
     prevSampleTime: Milliseconds,
     sampleTime: Milliseconds,
     nextSampleTime: Milliseconds,
-    cpuBeforeSample: number | null,
-    cpuAfterSample: number | null
+    beforeSampleCpuRatio: number,
+    afterSampleCpuRatio: number
   ) {
     const { rangeEnd, rangeStart, categoryDrawStyles } =
       this.renderedComponentSettings;
@@ -349,8 +346,8 @@ export class ActivityGraphFillComputer {
       prevSampleTime,
       sampleTime,
       nextSampleTime,
-      cpuBeforeSample,
-      cpuAfterSample,
+      beforeSampleCpuRatio,
+      afterSampleCpuRatio,
       rangeStart
     );
   }
@@ -512,9 +509,9 @@ export class ActivityFillGraphQuerier {
       return null;
     }
 
-    const threadCPUDelta = samples.threadCPUDelta;
-    if (!threadCPUDelta) {
-      // There is no threadCPUDelta information in the array. Return null.
+    const threadCPURatio = samples.threadCPURatio;
+    if (!threadCPURatio) {
+      // There is no threadCPURatio information in the array. Return null.
       return null;
     }
 
@@ -700,33 +697,32 @@ export class ActivityFillGraphQuerier {
         ? fullThread.samples.time[fullThreadSample + 1]
         : sampleTime + interval;
 
-    let cpuDeltaBeforeSample = null;
-    let cpuDeltaAfterSample = null;
-    const { threadCPUDelta } = samples;
-    if (enableCPUUsage && threadCPUDelta) {
-      // It must be non-null because we are checking this in the processing
-      // step and eliminating all the null values.
-      cpuDeltaBeforeSample = ensureExists(threadCPUDelta[sample]);
+    let beforeSampleCpuRatio = 1;
+    let afterSampleCpuRatio = 1;
+    const { threadCPURatio } = samples;
+    if (enableCPUUsage && threadCPURatio) {
+      beforeSampleCpuRatio = threadCPURatio[sample];
       // Use the fullThread here to properly get the next in case zoomed in.
-      cpuDeltaAfterSample = ensureExists(fullThread.samples.threadCPUDelta)[
-        fullThreadSample + 1
-      ];
-      cpuDeltaAfterSample =
-        // It can be undefined if this is the last sample in the profile.
-        cpuDeltaAfterSample !== undefined && cpuDeltaAfterSample !== null
-          ? cpuDeltaAfterSample
-          : cpuDeltaBeforeSample;
+      const fullThreadSamplesCPURatio = ensureExists(
+        fullThread.samples.threadCPURatio
+      );
+      if (fullThreadSample + 1 < fullThreadSamplesCPURatio.length) {
+        afterSampleCpuRatio = fullThreadSamplesCPURatio[fullThreadSample + 1];
+      } else {
+        afterSampleCpuRatio = beforeSampleCpuRatio;
+      }
     }
 
     const kernelRangeStartTime = rangeStart + kernelPos / xPixelsPerMs;
+
     _accumulateInBuffer(
       pixelsAroundX,
       this.renderedComponentSettings,
       prevSampleTime,
       sampleTime,
       nextSampleTime,
-      cpuDeltaBeforeSample,
-      cpuDeltaAfterSample,
+      beforeSampleCpuRatio,
+      afterSampleCpuRatio,
       kernelRangeStartTime
     );
 
@@ -852,11 +848,11 @@ function _accumulateInBuffer(
   prevSampleTime: Milliseconds,
   sampleTime: Milliseconds,
   nextSampleTime: Milliseconds,
-  cpuDeltaBeforeSample: number | null,
-  cpuDeltaAfterSample: number | null,
+  beforeSampleCpuRatio: number,
+  afterSampleCpuRatio: number,
   bufferTimeRangeStart: Milliseconds
 ) {
-  const { xPixelsPerMs, maxThreadCPUDeltaPerMs } = renderedComponentSettings;
+  const { xPixelsPerMs } = renderedComponentSettings;
   const sampleCategoryStartTime = (prevSampleTime + sampleTime) / 2;
   const sampleCategoryEndTime = (sampleTime + nextSampleTime) / 2;
   let sampleCategoryStartPixel =
@@ -873,8 +869,6 @@ function _accumulateInBuffer(
   const intCategoryStartPixel = sampleCategoryStartPixel | 0;
   const intCategoryEndPixel = sampleCategoryEndPixel | 0;
   const intSamplePixel = samplePixel | 0;
-  const sampleTimeDeltaBefore = sampleTime - prevSampleTime;
-  const sampleTimeDeltaAfter = nextSampleTime - sampleTime;
 
   // Every sample has two parts because of different CPU usage values.
   // For every sample part, we have a fractional interval of this sample part's
@@ -899,17 +893,6 @@ function _accumulateInBuffer(
   // |       |       |       |///////////////////////|       |       |
   // |       |       +-------+///////////////////////|       |       |
   // +-------+-------+///////////////////////////////+-------+-------+
-
-  // A number between 0 and 1 for sample ratio. It changes depending on
-  // the CPU usage per ms if it's given. If not, it uses 1 directly.
-  const beforeSampleCpuRatio =
-    cpuDeltaBeforeSample === null || sampleTimeDeltaBefore === 0
-      ? 1
-      : cpuDeltaBeforeSample / sampleTimeDeltaBefore / maxThreadCPUDeltaPerMs;
-  const afterSampleCpuRatio =
-    cpuDeltaAfterSample === null || sampleTimeDeltaAfter === 0
-      ? 1
-      : cpuDeltaAfterSample / sampleTimeDeltaAfter / maxThreadCPUDeltaPerMs;
 
   // Samples have two parts to be able to present the different CPU usages properly.
   // This is because CPU usage number of a sample represents the CPU usage

--- a/src/components/shared/thread/CPUGraph.js
+++ b/src/components/shared/thread/CPUGraph.js
@@ -33,7 +33,6 @@ type Props = {|
   // Decide which way the stacks grow up from the floor, or down from the ceiling.
   +stacksGrowFromCeiling?: boolean,
   +trackName: string,
-  +maxThreadCPUDeltaPerMs: number,
 |};
 
 export class ThreadCPUGraph extends PureComponent<Props> {
@@ -47,10 +46,7 @@ export class ThreadCPUGraph extends PureComponent<Props> {
     if (sampleIndex >= samples.length - 1) {
       return 0;
     }
-    const cpuDelta = ensureExists(samples.threadCPUDelta)[sampleIndex + 1] || 0;
-    const interval = samples.time[sampleIndex + 1] - samples.time[sampleIndex];
-    const currentCPUPerMs = cpuDelta / interval;
-    return currentCPUPerMs;
+    return ensureExists(samples.threadCPURatio)[sampleIndex + 1] || 0;
   };
 
   render() {
@@ -63,7 +59,6 @@ export class ThreadCPUGraph extends PureComponent<Props> {
       rangeEnd,
       categories,
       trackName,
-      maxThreadCPUDeltaPerMs,
       onSampleClick,
     } = this.props;
 
@@ -73,7 +68,7 @@ export class ThreadCPUGraph extends PureComponent<Props> {
     return (
       <ThreadHeightGraph
         heightFunc={this._heightFunction}
-        maxValue={maxThreadCPUDeltaPerMs}
+        maxValue={1}
         className={className}
         trackName={trackName}
         interval={interval}

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -23,7 +23,6 @@ import {
   getSelectedThreadIndexes,
   getTimelineType,
   getThreadSelectorsFromThreadsKey,
-  getMaxThreadCPUDeltaPerMs,
   getIsExperimentalCPUGraphsEnabled,
   getImplementationFilter,
   getZeroAt,
@@ -92,7 +91,6 @@ type StateProps = {|
   +selectedThreadIndexes: Set<ThreadIndex>,
   +enableCPUUsage: boolean,
   +isExperimentalCPUGraphsEnabled: boolean,
-  +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
   +callTreeVisible: boolean,
   +zeroAt: Milliseconds,
@@ -194,7 +192,6 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       trackType,
       trackName,
       enableCPUUsage,
-      maxThreadCPUDeltaPerMs,
       isExperimentalCPUGraphsEnabled,
       implementationFilter,
       zeroAt,
@@ -265,7 +262,6 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               samplesSelectedStates={samplesSelectedStates}
               treeOrderSampleComparator={treeOrderSampleComparator}
               enableCPUUsage={enableCPUUsage}
-              maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
               implementationFilter={implementationFilter}
               timelineType={timelineType}
               zeroAt={zeroAt}
@@ -287,7 +283,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               />
             ) : null}
             {isExperimentalCPUGraphsEnabled &&
-            rangeFilteredThread.samples.threadCPUDelta !== undefined ? (
+            rangeFilteredThread.samples.threadCPURatio !== undefined ? (
               <ThreadCPUGraph
                 className="threadCPUGraph"
                 trackName={trackName}
@@ -299,7 +295,6 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
                 samplesSelectedStates={samplesSelectedStates}
                 categories={categories}
                 onSampleClick={this._onSampleClick}
-                maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
               />
             ) : null}
           </>
@@ -340,11 +335,11 @@ export const TimelineTrackThread = explicitConnect<
     const selectors = getThreadSelectorsFromThreadsKey(threadsKey);
     const selectedThreadIndexes = getSelectedThreadIndexes(state);
     const committedRange = getCommittedRange(state);
-    const fullThread = selectors.getCPUProcessedThread(state);
+    const fullThread = selectors.getThread(state);
     const timelineType = getTimelineType(state);
     const enableCPUUsage =
       timelineType === 'cpu-category' &&
-      fullThread.samples.threadCPUDelta !== undefined;
+      fullThread.samples.threadCPURatio !== undefined;
 
     return {
       fullThread,
@@ -371,7 +366,6 @@ export const TimelineTrackThread = explicitConnect<
       selectedThreadIndexes,
       enableCPUUsage,
       isExperimentalCPUGraphsEnabled: getIsExperimentalCPUGraphsEnabled(state),
-      maxThreadCPUDeltaPerMs: getMaxThreadCPUDeltaPerMs(state),
       implementationFilter: getImplementationFilter(state),
       callTreeVisible: selectors.getUsefulTabs(state).includes('calltree'),
       zeroAt: getZeroAt(state),

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -13,7 +13,6 @@ import { numberSeriesToDeltas } from 'firefox-profiler/utils/number-series';
 import type {
   RawThread,
   SampleUnits,
-  ThreadCPUDeltaUnit,
   Profile,
   RawSamplesTable,
 } from 'firefox-profiler/types';
@@ -79,19 +78,15 @@ export function computeMaxCPUDeltaPerMs(profile: Profile): number {
   }
 
   const threadCPUDeltaUnit = sampleUnits.threadCPUDelta;
-
   switch (threadCPUDeltaUnit) {
     case 'µs':
-    case 'ns': {
-      const deltaUnitPerMs = getCpuDeltaTimeUnitMultiplier(threadCPUDeltaUnit);
-      return deltaUnitPerMs;
-    }
-    case 'variable CPU cycles': {
-      const maxThreadCPUDeltaPerMs = _computeMaxVariableCPUCyclesPerMs(
-        profile.threads
-      );
-      return maxThreadCPUDeltaPerMs;
-    }
+      // ms to µs multiplier
+      return 1000;
+    case 'ns':
+      // ms to ns multiplier
+      return 1000000;
+    case 'variable CPU cycles':
+      return _computeMaxVariableCPUCyclesPerMs(profile.threads);
     default:
       throw assertExhaustiveCheck(
         threadCPUDeltaUnit,
@@ -150,27 +145,4 @@ export function computeThreadCPURatio(
   }
 
   return threadCPURatio;
-}
-
-/**
- * A helper function that is used to convert ms time units to threadCPUDelta units.
- * Returns 1 for 'variable CPU cycles' as it's not a time unit.
- */
-function getCpuDeltaTimeUnitMultiplier(unit: ThreadCPUDeltaUnit): number {
-  switch (unit) {
-    case 'µs':
-      // ms to µs multiplier
-      return 1000;
-    case 'ns':
-      // ms to ns multiplier
-      return 1000000;
-    case 'variable CPU cycles':
-      // We can't convert the CPU cycle unit to any time units
-      return 1;
-    default:
-      throw assertExhaustiveCheck(
-        unit,
-        'Unhandled threadCPUDelta unit in the processing.'
-      );
-  }
 }

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -62,23 +62,16 @@ function _computeMaxVariableCPUCyclesPerMs(threads: RawThread[]): number {
 }
 
 /**
- * Returns the expected cpu delta per sample if cpu is at 100% and
- * sampling happens at the declared interval.
+ * Returns the expected cpu delta per millisecond if cpu is at 100%.
  *
- * Returns null if the profile does not use cpu deltas.
- * Otherwise, returns a ratio that can be used to compare activity
- * between threads with cpu deltas and threads without cpu deltas.
+ * Returns 1 if the profile does not use cpu deltas.
  *
- * Examples:
- *  - interval: 2 (ms), sampleUnits: undefined
- *    Returns null.
- *  - interval: 5 (ms), sampleUnits.threadCPUDelta: "µs"
- *    Returns 5000, i.e. "5000µs cpu delta per sample if each sample ticks at
- *    the declared 5ms interval and the CPU usage is at 100%".
- *  - interval: 3 (ms), sampleUnits.threadCPUDelta: "variable CPU cycles",
- *    max_{sample}(sample.cpuDelta / sample.timeDelta) == 1234567 cycles per ms
- *    Returns 1234567 * 3, i.e. "3703701 cycles per sample if each sample ticks at
- *    the declared 3ms interval and the CPU usage is at the observed maximum".
+ * If the profile uses CPU deltas given in 'variable CPU cycles', then we check
+ * all threads and return the maximum observed cpu delta per millisecond value,
+ * which becomes the reference for 100% CPU.
+ *
+ * If the profile uses CPU deltas in microseconds or nanoseconds, the we return
+ * the conversion factor to milliseconds.
  */
 export function computeMaxCPUDeltaPerMs(profile: Profile): number {
   const sampleUnits = profile.meta.sampleUnits;

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -8,7 +8,7 @@ import {
   ensureExists,
   assertExhaustiveCheck,
 } from 'firefox-profiler/utils/flow';
-import { timeColumnToTimeDeltas } from 'firefox-profiler/profile-logic/process-profile';
+import { numberSeriesToDeltas } from 'firefox-profiler/utils/number-series';
 
 import type {
   RawThread,
@@ -41,7 +41,7 @@ function _computeMaxVariableCPUCyclesPerMs(threads: RawThread[]): number {
 
     const timeDeltas =
       samples.time !== undefined
-        ? timeColumnToTimeDeltas(samples.time)
+        ? numberSeriesToDeltas(samples.time)
         : ensureExists(samples.timeDeltas);
 
     // Ignore the first CPU delta value; it's meaningless because there is no

--- a/src/profile-logic/cpu.js
+++ b/src/profile-logic/cpu.js
@@ -12,11 +12,10 @@ import { numberSeriesToDeltas } from 'firefox-profiler/utils/number-series';
 
 import type {
   RawThread,
-  Thread,
-  Milliseconds,
   SampleUnits,
   ThreadCPUDeltaUnit,
   Profile,
+  RawSamplesTable,
 } from 'firefox-profiler/types';
 
 /**
@@ -102,93 +101,55 @@ export function computeMaxCPUDeltaPerMs(profile: Profile): number {
 }
 
 /**
- * Process the CPU delta values of that thread. It will throw an error if it
- * fails to find threadCPUDelta array.
- * It does two different processing:
+ * Computes the threadCPURatio column for the SamplesTable.
  *
- * 1. For the threadCPUDelta values with timing units, it limits these values
- * to the interval. This is mostly a bug on macOS platform (with µs values)
- * because we could only detect these values in that platform so far. But to be
- * safe, we are also doing this processing for Linux platform (ns values).
- * 2. We are checking for null values and converting them to non-null values if
- * there are any by getting the closest threadCPUDelta value.
+ * The CPU ratio is a number between 0 and 1, and describes the CPU use between
+ * the previous sample time and the current sample time. It is the ratio of cpu
+ * time to elapsed wall clock time.
+ *
+ * This function returns undefined if `samples` does not have a `threadCPUDelta`
+ * column.
  */
-export function processThreadCPUDelta(
-  thread: Thread,
+export function computeThreadCPURatio(
+  samples: RawSamplesTable,
   sampleUnits: SampleUnits,
-  profileInterval: Milliseconds
-): Thread {
-  const { samples } = thread;
+  timeDeltas: number[],
+  maxThreadCPUDeltaPerMs: number
+): Float64Array | void {
   const { threadCPUDelta } = samples;
 
   if (!threadCPUDelta) {
-    throw new Error(
-      "processThreadCPUDelta should not be called for the profiles that don't include threadCPUDelta."
-    );
-  }
-  // A helper function to shallow clone the thread with different threadCPUDelta values.
-  function _newThreadWithNewThreadCPUDelta(
-    threadCPUDelta: Array<number | null> | void
-  ): Thread {
-    const newSamples = {
-      ...samples,
-      threadCPUDelta,
-    };
-
-    const newThread = {
-      ...thread,
-      samples: newSamples,
-    };
-
-    return newThread;
+    return undefined;
   }
 
-  const newThreadCPUDelta: Array<number | null> = new Array(samples.length);
-  const cpuDeltaTimeUnitMultiplier = getCpuDeltaTimeUnitMultiplier(
-    sampleUnits.threadCPUDelta
-  );
+  const threadCPURatio: Float64Array = new Float64Array(threadCPUDelta.length);
 
-  for (let i = 0; i < samples.length; i++) {
-    // Ideally there shouldn't be any null values but that can happen if the
-    // back-end fails to get the CPU usage numbers from the operation system.
-    // In that case, try to find the closest number and use it to mitigate the
-    // weird graph renderings.
-    const threadCPUDeltaValue = findClosestNonNullValueToIdx(threadCPUDelta, i);
+  // Ignore threadCPUDelta[0] and set threadCPURatio[0] to zero - there is no
+  // previous sample so there is no meaningful value we could compute here.
+  threadCPURatio[0] = 0;
 
-    const threadCPUDeltaUnit = sampleUnits.threadCPUDelta;
-    switch (threadCPUDeltaUnit) {
-      // Check if the threadCPUDelta is more than the interval time and limit
-      // that number to the interval if it's bigger than that. This is mostly
-      // either a bug on the back-end or a bug on the operation system level.
-      // This happens mostly with µs values which is coming from macOS. We can
-      // remove that processing once we are sure that these numbers are reliable
-      // and this issue doesn't occur.
-      case 'µs':
-      case 'ns': {
-        const intervalInThreadCPUDeltaUnit =
-          i === 0
-            ? profileInterval * cpuDeltaTimeUnitMultiplier
-            : (samples.time[i] - samples.time[i - 1]) *
-              cpuDeltaTimeUnitMultiplier;
-        if (threadCPUDeltaValue > intervalInThreadCPUDeltaUnit) {
-          newThreadCPUDelta[i] = intervalInThreadCPUDeltaUnit;
-        } else {
-          newThreadCPUDelta[i] = threadCPUDeltaValue;
-        }
-        break;
-      }
-      case 'variable CPU cycles':
-        newThreadCPUDelta[i] = threadCPUDeltaValue;
-        break;
-      default:
-        throw assertExhaustiveCheck(
-          threadCPUDeltaUnit,
-          'Unhandled threadCPUDelta unit in the processing.'
-        );
+  // For the rest of the samples, compute the ratio based on the CPU delta and
+  // on the elapsed time between samples (timeDeltas[i]).
+  for (let i = 1; i < threadCPUDelta.length; i++) {
+    const referenceCpuDelta = maxThreadCPUDeltaPerMs * timeDeltas[i];
+    const cpuDelta = threadCPUDelta[i];
+    if (cpuDelta === null || referenceCpuDelta === 0) {
+      // Default to 100% CPU if the CPU delta isn't known or if no time has
+      // elapsed between samples.
+      // In profiles from Firefox, values at the beginning of threadCPUDelta can
+      // be null if the samples at the beginning were collected by the base
+      // profiler, which doesn't support collecting CPU delta information yet,
+      // see bug 1756519.
+      threadCPURatio[i] = 1;
+      continue;
     }
+
+    // Limit values to 1.0.
+    threadCPURatio[i] =
+      cpuDelta <= referenceCpuDelta ? cpuDelta / referenceCpuDelta : 1;
   }
 
-  return _newThreadWithNewThreadCPUDelta(newThreadCPUDelta);
+  return threadCPURatio;
 }
 
 /**
@@ -212,34 +173,4 @@ function getCpuDeltaTimeUnitMultiplier(unit: ThreadCPUDeltaUnit): number {
         'Unhandled threadCPUDelta unit in the processing.'
       );
   }
-}
-
-/**
- * A helper function that finds the closest non-null item in an element to an index.
- * This is useful for finding the non-null threadCPUDelta number to a sample.
- */
-function findClosestNonNullValueToIdx(
-  array: Array<number | null>,
-  idx: number,
-  distance: number = 0
-): number {
-  if (distance >= array.length) {
-    throw new Error('Expected the distance to be less than the array length.');
-  }
-
-  if (idx + distance < array.length) {
-    const itemAfter = array[idx + distance];
-    if (itemAfter !== null) {
-      return itemAfter;
-    }
-  }
-
-  if (idx - distance >= 0) {
-    const itemBefore = array[idx - distance];
-    if (itemBefore !== null) {
-      return itemBefore;
-    }
-  }
-
-  return findClosestNonNullValueToIdx(array, idx, ++distance);
 }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -918,7 +918,7 @@ function _processMarkerPayload(
   }
 }
 
-export function timeColumnToTimeDeltas(time: Milliseconds[]): Milliseconds[] {
+function _timeColumnToCompactTimeDeltas(time: Milliseconds[]): Milliseconds[] {
   const NS_PER_MS = 1000000;
 
   // For each timestamp in the time series, compute the delta to the previous
@@ -947,7 +947,7 @@ export function timeColumnToTimeDeltas(time: Milliseconds[]): Milliseconds[] {
 function _processSamples(geckoSamples: GeckoSampleStruct): RawSamplesTable {
   const samples: RawSamplesTable = {
     stack: geckoSamples.stack,
-    timeDeltas: timeColumnToTimeDeltas(geckoSamples.time),
+    timeDeltas: _timeColumnToCompactTimeDeltas(geckoSamples.time),
     weightType: 'samples',
     weight: null,
     length: geckoSamples.length,
@@ -1054,7 +1054,7 @@ function _processCounterSamples(
   geckoCounterSamples: GeckoCounterSamplesStruct
 ): RawCounterSamplesTable {
   return {
-    timeDeltas: timeColumnToTimeDeltas(geckoCounterSamples.time),
+    timeDeltas: _timeColumnToCompactTimeDeltas(geckoCounterSamples.time),
     number: geckoCounterSamples.number,
     count: geckoCounterSamples.count,
     length: geckoCounterSamples.length,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2340,7 +2340,7 @@ function _computeThreadWithInvertedStackTable(
 export function computeSamplesTableFromRawSamplesTable(
   rawSamples: RawSamplesTable,
   sampleUnits: SampleUnits | void,
-  maxThreadCPUDeltaPerMs: number
+  referenceCPUDeltaPerMs: number
 ): SamplesTable {
   const {
     responsiveness,
@@ -2362,7 +2362,7 @@ export function computeSamplesTableFromRawSamplesTable(
           rawSamples,
           sampleUnits,
           timeDeltas,
-          maxThreadCPUDeltaPerMs
+          referenceCPUDeltaPerMs
         )
       : undefined;
   const time = computeTimeColumnForRawSamplesTable(rawSamples);

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -30,6 +30,7 @@ import {
   ensureExists,
   getFirstItemFromSet,
 } from 'firefox-profiler/utils/flow';
+import { numberSeriesFromDeltas } from 'firefox-profiler/utils/number-series';
 import ExtensionFavicon from '../../res/img/svg/extension-outline.svg';
 import DefaultLinkFavicon from '../../res/img/svg/globe.svg';
 
@@ -1510,19 +1511,11 @@ export function filterThreadByTab(
   });
 }
 
-export function computeTimeColumnFromTimeDeltas(timeDelta: number[]): number[] {
-  let prevTime = 0;
-  return timeDelta.map((delta) => {
-    prevTime = prevTime + delta;
-    return prevTime;
-  });
-}
-
 export function computeTimeColumnForRawSamplesTable(
   samples: RawSamplesTable | RawCounterSamplesTable
 ): number[] {
   const { time, timeDeltas } = samples;
-  return time ?? computeTimeColumnFromTimeDeltas(ensureExists(timeDeltas));
+  return time ?? numberSeriesFromDeltas(ensureExists(timeDeltas));
 }
 
 /**

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -1174,7 +1174,7 @@ const AUDIO_THREAD_SAMPLE_SCORE_BOOST_FACTOR = 40;
 export function computeThreadActivityScore(
   profile: Profile,
   thread: RawThread,
-  maxCpuDeltaPerMs: number
+  referenceCPUDeltaPerMs: number
 ): ThreadActivityScore {
   const isEssentialFirefoxThread = _isEssentialFirefoxThread(thread);
   const isInParentProcess = thread.processType === 'default';
@@ -1183,7 +1183,7 @@ export function computeThreadActivityScore(
   const sampleScore = _computeThreadSampleScore(
     profile,
     thread,
-    maxCpuDeltaPerMs
+    referenceCPUDeltaPerMs
   );
   const boostedSampleScore = isInterestingEvenWithMinimalActivity
     ? sampleScore * AUDIO_THREAD_SAMPLE_SCORE_BOOST_FACTOR
@@ -1227,7 +1227,7 @@ function _isFirefoxMediaThreadWhichIsUsuallyIdle(thread: RawThread): boolean {
 function _computeThreadSampleScore(
   { meta }: Profile,
   { samples, stackTable, frameTable }: RawThread,
-  maxCpuDeltaPerMs: number
+  referenceCPUDeltaPerMs: number
 ): number {
   if (meta.sampleUnits && samples.threadCPUDelta) {
     // Sum up all CPU deltas in this thread, to compute a total
@@ -1256,8 +1256,8 @@ function _computeThreadSampleScore(
     (stack) =>
       stack !== null && derivedStackTable.category[stack] !== idleCategoryIndex
   ).length;
-  const maxCpuDeltaPerInterval = maxCpuDeltaPerMs * meta.interval;
-  return nonIdleSampleCount * maxCpuDeltaPerInterval;
+  const referenceCPUDeltaPerInterval = referenceCPUDeltaPerMs * meta.interval;
+  return nonIdleSampleCount * referenceCPUDeltaPerInterval;
 }
 
 function _findDefaultThread(threads: RawThread[]): RawThread | null {

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -15,7 +15,6 @@ import * as ProfileData from '../../profile-logic/profile-data';
 import * as CallTree from '../../profile-logic/call-tree';
 import * as ProfileSelectors from '../profile';
 import * as JsTracer from '../../profile-logic/js-tracer';
-import * as Cpu from '../../profile-logic/cpu';
 import { StringTable } from '../../utils/string-table';
 import {
   assertExhaustiveCheck,
@@ -108,6 +107,8 @@ export function getBasicThreadSelectorsPerThread(
     getRawThread(state).samples;
   const getSamplesTable: Selector<SamplesTable> = createSelector(
     getRawSamplesTable,
+    ProfileSelectors.getSampleUnits,
+    ProfileSelectors.getMaxThreadCPUDeltaPerMs,
     ProfileData.computeSamplesTableFromRawSamplesTable
   );
   const getNativeAllocations: Selector<NativeAllocationsTable | void> = (
@@ -160,20 +161,8 @@ export function getBasicThreadSelectorsPerThread(
     ProfileData.createThreadFromDerivedTables
   );
 
-  const getCPUProcessedThread: Selector<Thread> = createSelector(
-    getThread,
-    ProfileSelectors.getSampleUnits,
-    ProfileSelectors.getProfileInterval,
-    (thread, sampleUnits, profileInterval) =>
-      thread.samples === null ||
-      thread.samples.threadCPUDelta === undefined ||
-      !sampleUnits
-        ? thread
-        : Cpu.processThreadCPUDelta(thread, sampleUnits, profileInterval)
-  );
-
   const getThreadWithReservedFunctions: Selector<ThreadWithReservedFunctions> =
-    createSelector(getCPUProcessedThread, ProfileData.reserveFunctionsInThread);
+    createSelector(getThread, ProfileData.reserveFunctionsInThread);
 
   const getFunctionsReservedThread: Selector<Thread> = (state) =>
     getThreadWithReservedFunctions(state).thread;
@@ -449,7 +438,6 @@ export function getBasicThreadSelectorsPerThread(
     getHasUsefulJsAllocations,
     getHasUsefulNativeAllocations,
     getCanShowRetainedMemory,
-    getCPUProcessedThread,
     getFunctionsReservedThread,
     getTabFilteredThread,
     getActiveTabFilteredThread,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -108,7 +108,7 @@ export function getBasicThreadSelectorsPerThread(
   const getSamplesTable: Selector<SamplesTable> = createSelector(
     getRawSamplesTable,
     ProfileSelectors.getSampleUnits,
-    ProfileSelectors.getMaxThreadCPUDeltaPerMs,
+    ProfileSelectors.getReferenceCPUDeltaPerMs,
     ProfileData.computeSamplesTableFromRawSamplesTable
   );
   const getNativeAllocations: Selector<NativeAllocationsTable | void> = (

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -730,20 +730,24 @@ export const getHiddenTrackCount: Selector<HiddenTrackCount> = createSelector(
   }
 );
 
-export const getMaxThreadCPUDeltaPerMs: Selector<number> = createSelector(
+export const getReferenceCPUDeltaPerMs: Selector<number> = createSelector(
   getProfile,
-  CPU.computeMaxCPUDeltaPerMs
+  CPU.computeReferenceCPUDeltaPerMs
 );
 
 export const getThreadActivityScores: Selector<Array<ThreadActivityScore>> =
   createSelector(
     getProfile,
-    getMaxThreadCPUDeltaPerMs,
-    (profile, maxCpuDeltaPerMs) => {
+    getReferenceCPUDeltaPerMs,
+    (profile, referenceCPUDeltaPerMs) => {
       const { threads } = profile;
 
       return threads.map((thread) =>
-        Tracks.computeThreadActivityScore(profile, thread, maxCpuDeltaPerMs)
+        Tracks.computeThreadActivityScore(
+          profile,
+          thread,
+          referenceCPUDeltaPerMs
+        )
       );
     }
   );

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -13,6 +13,7 @@ import {
   getEmptyBalancedNativeAllocationsTable,
 } from '../../../profile-logic/data-structures';
 import { mergeProfilesForDiffing } from '../../../profile-logic/merge-compare';
+import { computeMaxCPUDeltaPerMs } from '../../../profile-logic/cpu';
 import { stateFromLocation } from '../../../app-logic/url-handling';
 import { StringTable } from '../../../utils/string-table';
 import { computeThreadFromRawThread } from '../utils';
@@ -1111,8 +1112,14 @@ export function getProfileWithDicts(profile: Profile): ProfileWithDicts {
     'Expected to find categories'
   ).findIndex((c) => c.name === 'Other');
 
+  const maxThreadCPUDeltaPerMs = computeMaxCPUDeltaPerMs(profile);
   const derivedThreads = profile.threads.map((rawThread) =>
-    computeThreadFromRawThread(rawThread, defaultCategory)
+    computeThreadFromRawThread(
+      rawThread,
+      profile.meta.sampleUnits,
+      maxThreadCPUDeltaPerMs,
+      defaultCategory
+    )
   );
   const funcNameDicts = derivedThreads.map(getFuncNamesDictForThread);
   const funcNamesPerThread = funcNameDicts.map(({ funcNames }) => funcNames);

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -13,7 +13,7 @@ import {
   getEmptyBalancedNativeAllocationsTable,
 } from '../../../profile-logic/data-structures';
 import { mergeProfilesForDiffing } from '../../../profile-logic/merge-compare';
-import { computeMaxCPUDeltaPerMs } from '../../../profile-logic/cpu';
+import { computeReferenceCPUDeltaPerMs } from '../../../profile-logic/cpu';
 import { stateFromLocation } from '../../../app-logic/url-handling';
 import { StringTable } from '../../../utils/string-table';
 import { computeThreadFromRawThread } from '../utils';
@@ -1112,12 +1112,12 @@ export function getProfileWithDicts(profile: Profile): ProfileWithDicts {
     'Expected to find categories'
   ).findIndex((c) => c.name === 'Other');
 
-  const maxThreadCPUDeltaPerMs = computeMaxCPUDeltaPerMs(profile);
+  const referenceCPUDeltaPerMs = computeReferenceCPUDeltaPerMs(profile);
   const derivedThreads = profile.threads.map((rawThread) =>
     computeThreadFromRawThread(
       rawThread,
       profile.meta.sampleUnits,
-      maxThreadCPUDeltaPerMs,
+      referenceCPUDeltaPerMs,
       defaultCategory
     )
   );

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -29,6 +29,7 @@ import type {
   IndexIntoStackTable,
   RawThread,
   IndexIntoCategoryList,
+  SampleUnits,
 } from 'firefox-profiler/types';
 
 import { ensureExists } from 'firefox-profiler/utils/flow';
@@ -120,6 +121,8 @@ export function getMouseEvent(
 
 export function computeThreadFromRawThread(
   rawThread: RawThread,
+  sampleUnits: SampleUnits | void,
+  maxThreadCPUDeltaPerMs: number,
   defaultCategory: IndexIntoCategoryList
 ): Thread {
   const stringTable = StringTable.withBackingArray(rawThread.stringArray);
@@ -128,7 +131,11 @@ export function computeThreadFromRawThread(
     rawThread.frameTable,
     defaultCategory
   );
-  const samples = computeSamplesTableFromRawSamplesTable(rawThread.samples);
+  const samples = computeSamplesTableFromRawSamplesTable(
+    rawThread.samples,
+    sampleUnits,
+    maxThreadCPUDeltaPerMs
+  );
   return createThreadFromDerivedTables(
     rawThread,
     samples,

--- a/src/test/fixtures/utils.js
+++ b/src/test/fixtures/utils.js
@@ -122,7 +122,7 @@ export function getMouseEvent(
 export function computeThreadFromRawThread(
   rawThread: RawThread,
   sampleUnits: SampleUnits | void,
-  maxThreadCPUDeltaPerMs: number,
+  referenceCPUDeltaPerMs: number,
   defaultCategory: IndexIntoCategoryList
 ): Thread {
   const stringTable = StringTable.withBackingArray(rawThread.stringArray);
@@ -134,7 +134,7 @@ export function computeThreadFromRawThread(
   const samples = computeSamplesTableFromRawSamplesTable(
     rawThread.samples,
     sampleUnits,
-    maxThreadCPUDeltaPerMs
+    referenceCPUDeltaPerMs
   );
   return createThreadFromDerivedTables(
     rawThread,

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -5260,7 +5260,7 @@ Object {
       null,
       null,
     ],
-    "threadCPUDelta": undefined,
+    "threadCPURatio": undefined,
     "threadId": undefined,
     "time": Array [
       0,

--- a/src/test/unit/cpu.test.js
+++ b/src/test/unit/cpu.test.js
@@ -4,85 +4,76 @@
 
 // @flow
 
-import { processThreadCPUDelta } from 'firefox-profiler/profile-logic/cpu';
 import {
   getProfileWithThreadCPUDelta,
   getProfileWithDicts,
 } from '../fixtures/profiles/processed-profile';
+import { ensureExists } from '../../utils/flow';
 
 import type { ThreadCPUDeltaUnit, Milliseconds } from 'firefox-profiler/types';
 
 const MS_TO_US_MULTIPLIER = 1000;
 const MS_TO_NS_MULTIPLIER = 1000000;
 
-describe('processThreadCPUDelta', function () {
+describe('computeThreadCPURatio', function () {
   function setup(
-    threadCPUDelta?: Array<number | null>,
+    threadCPURatio?: Array<number | null>,
     unit: ThreadCPUDeltaUnit = 'ns',
     interval: Milliseconds = 1
   ) {
     const profile = getProfileWithThreadCPUDelta(
-      [threadCPUDelta],
+      [threadCPURatio],
       unit,
       interval
     );
     const { derivedThreads } = getProfileWithDicts(profile);
     const [thread] = derivedThreads;
+    const cpuRatio = [...ensureExists(thread.samples.threadCPURatio)];
 
-    if (!profile.meta.sampleUnits) {
-      throw new Error('SampleUnits object could not found in the profile.');
-    }
-
-    const processedThread = processThreadCPUDelta(
-      thread,
-      profile.meta.sampleUnits,
-      profile.meta.interval
-    );
-
-    return { profile, thread, processedThread };
+    return { profile, cpuRatio };
   }
 
-  it('throws if all of its values are null', function () {
-    expect(() => setup([null, null, null, null, null, null])).toThrow();
-  });
-
-  it('throws if there are no threadCPUDelta values', function () {
-    expect(() => setup(undefined)).toThrow();
-  });
-
-  it('removes the null values by finding the closest non-null threadCPUDelta value', function () {
+  it('sets the first value to zero and turns null values into 100% CPU', function () {
     // Testing the case where only the values in the middle are null.
-    const { processedThread: processedThread1 } = setup([
-      0.1,
+    const { cpuRatio: cpuRatio1 } = setup([
+      null,
+      0.1 * MS_TO_NS_MULTIPLIER,
       null,
       null,
       null,
       null,
-      0.2,
+      0.2 * MS_TO_NS_MULTIPLIER,
     ]);
-    expect(processedThread1.samples.threadCPUDelta).toEqual([
-      0.1, 0.1, 0.1, 0.2, 0.2, 0.2,
-    ]);
+    expect(cpuRatio1).toEqual([0, 0.1, 1, 1, 1, 1, 0.2]);
 
     // Testing the case where the values at the start are null.
-    const { processedThread: processedThread2 } = setup([null, null, 0.1]);
-    expect(processedThread2.samples.threadCPUDelta).toEqual([0.1, 0.1, 0.1]);
+    const { cpuRatio: cpuRatio2 } = setup([
+      null,
+      null,
+      null,
+      0.1 * MS_TO_NS_MULTIPLIER,
+    ]);
+    expect(cpuRatio2).toEqual([0, 1, 1, 0.1]);
 
     // Testing the case where the values at the end are null.
-    const { processedThread: processedThread3 } = setup([0.1, null, null]);
-    expect(processedThread3.samples.threadCPUDelta).toEqual([0.1, 0.1, 0.1]);
-
-    // If there are values in either side of a null sample with the same distance,
-    // pick the latter one.
-    const { processedThread: processedThread4 } = setup([0.1, null, 0.2]);
-    expect(processedThread4.samples.threadCPUDelta).toEqual([0.1, 0.2, 0.2]);
+    // This does not happen in profiles from Firefox - Firefox only leaves values
+    // at the start null (the first one is always null, and the 2nd to nth values
+    // may be null for samples collected by the base profiler (bug 1756519)).
+    const { cpuRatio: cpuRatio3 } = setup([
+      0,
+      0.1 * MS_TO_NS_MULTIPLIER,
+      null,
+      null,
+    ]);
+    expect(cpuRatio3).toEqual([0, 0.1, 1, 1]);
   });
 
   it('processes Linux timing values and caps them to 100% if they are more than the interval values', function () {
-    // Interval is in the ms values and Linux uses ns for threadCPUDelta values.
+    // Interval is in the ms values and Linux uses ns for threadCPURatio values.
     const intervalMs = 1;
-    const { processedThread: processedThread1 } = setup(
+    const { cpuRatio: cpuRatio1 } = setup(
       [
+        0,
         0.5 * MS_TO_NS_MULTIPLIER, // <- Less than the interval
         0.7 * MS_TO_NS_MULTIPLIER, // <- Less than the interval
         1 * MS_TO_NS_MULTIPLIER, // <- Equal to the interval, should be fine
@@ -93,20 +84,22 @@ describe('processThreadCPUDelta', function () {
       intervalMs
     );
 
-    expect(processedThread1.samples.threadCPUDelta).toEqual([
-      0.5 * MS_TO_NS_MULTIPLIER, // <- not changed
-      0.7 * MS_TO_NS_MULTIPLIER, // <- not changed
-      1 * MS_TO_NS_MULTIPLIER, // <- not changed
-      1 * MS_TO_NS_MULTIPLIER, // <- capped to 100%
-      1 * MS_TO_NS_MULTIPLIER, // <- capped to 100%
+    expect(cpuRatio1).toEqual([
+      0,
+      0.5, // <- not changed
+      0.7, // <- not changed
+      1, // <- not changed
+      1, // <- capped to 100%
+      1, // <- capped to 100%
     ]);
   });
 
   it('processes macOS timing values and caps them to 100% if they are more than the interval values', function () {
-    // Interval is in the ms values and macOS uses µs for threadCPUDelta values.
+    // Interval is in the ms values and macOS uses µs for threadCPURatio values.
     const intervalMs = 1;
-    const { processedThread: processedThread1 } = setup(
+    const { cpuRatio: cpuRatio1 } = setup(
       [
+        0,
         0.5 * MS_TO_US_MULTIPLIER, // <- Less than the interval
         0.7 * MS_TO_US_MULTIPLIER, // <- Less than the interval
         1 * MS_TO_US_MULTIPLIER, // <- Equal to the interval, should be fine
@@ -117,19 +110,21 @@ describe('processThreadCPUDelta', function () {
       intervalMs
     );
 
-    expect(processedThread1.samples.threadCPUDelta).toEqual([
-      0.5 * MS_TO_US_MULTIPLIER, // <- not changed
-      0.7 * MS_TO_US_MULTIPLIER, // <- not changed
-      1 * MS_TO_US_MULTIPLIER, // <- not changed
-      1 * MS_TO_US_MULTIPLIER, // <- capped to 100%
-      1 * MS_TO_US_MULTIPLIER, // <- capped to 100%
+    expect(cpuRatio1).toEqual([
+      0,
+      0.5, // <- not changed
+      0.7, // <- not changed
+      1, // <- not changed
+      1, // <- capped to 100%
+      1, // <- capped to 100%
     ]);
   });
 
   it('does not process the Windows values for 100% capping because they are not timing values', function () {
     // Use the ns conversion multiplier to imitate the worst case.
     const intervalMs = 1;
-    const threadCPUDelta = [
+    const threadCPURatio = [
+      0,
       0.5 * MS_TO_NS_MULTIPLIER,
       0.7 * MS_TO_NS_MULTIPLIER,
       1 * MS_TO_NS_MULTIPLIER,
@@ -137,28 +132,21 @@ describe('processThreadCPUDelta', function () {
       23 * MS_TO_NS_MULTIPLIER,
       123123 * MS_TO_NS_MULTIPLIER,
     ];
-    const { processedThread: processedThread1 } = setup(
-      threadCPUDelta,
+    const { cpuRatio: cpuRatio1 } = setup(
+      threadCPURatio,
       'variable CPU cycles',
       intervalMs
     );
 
-    // It shouldn't change the values!
-    expect(processedThread1.samples.threadCPUDelta).toEqual(threadCPUDelta);
-  });
-
-  it('processes the timing values and caps the first element correctly if it exceeds the interval', function () {
-    // Testing the case where only the values in the middle are null.
-    const interval = 1;
-    const { processedThread: processedThread1 } = setup(
-      [2 * MS_TO_NS_MULTIPLIER, 0.5 * MS_TO_NS_MULTIPLIER],
-      'ns',
-      interval
-    );
-
-    expect(processedThread1.samples.threadCPUDelta).toEqual([
-      interval * MS_TO_NS_MULTIPLIER,
-      0.5 * MS_TO_NS_MULTIPLIER,
+    // 123123 is the max value, everything should be based on it
+    expect(cpuRatio1).toEqual([
+      0,
+      0.5 / 123123,
+      0.7 / 123123,
+      1 / 123123,
+      1.2 / 123123,
+      23 / 123123,
+      1,
     ]);
   });
 });

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -126,10 +126,9 @@ export type SamplesTable = {|
   // See the WeightType type for more information.
   weight: null | number[],
   weightType: WeightType,
-  // The elapsed CPU delta since the previous sample, in the unit given by
-  // profile.meta.sampleUnits.threadCPUDelta. Absent in profiles without CPU
-  // delta information.
-  threadCPUDelta?: Array<number | null>,
+  // The CPU ratio, between 0 and 1, over the time between the previous sample
+  // and this sample.
+  threadCPURatio?: Float64Array,
   // This property isn't present in normal threads. However it's present for
   // merged threads, so that we know the origin thread for these samples.
   threadId?: Tid[],

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -127,6 +127,8 @@ export type RawSamplesTable = {|
   // It's landed in Firefox 86, and it is optional because older profile
   // versions may not have it or that feature could be disabled. No upgrader was
   // written for this change because it's a completely new data source.
+  // The first value is ignored - it's not meaningful because there is no previous
+  // sample.
   threadCPUDelta?: Array<number | null>,
   // This property isn't present in normal threads. However it's present for
   // merged threads, so that we know the origin thread for these samples.

--- a/src/utils/number-series.js
+++ b/src/utils/number-series.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+export function numberSeriesFromDeltas(deltas: number[]): number[] {
+  const values = new Array(deltas.length);
+  let prev = 0;
+  for (let i = 0; i < deltas.length; i++) {
+    const current = prev + deltas[i];
+    values[i] = current;
+    prev = current;
+  }
+  return values;
+}
+
+export function numberSeriesToDeltas(values: number[]): number[] {
+  const deltas = new Array(values.length);
+  let prev = 0;
+  for (let i = 0; i < values.length; i++) {
+    const current = values[i];
+    deltas[i] = current - prev;
+    prev = current;
+  }
+  return deltas;
+}


### PR DESCRIPTION
[Production](https://share.firefox.dev/4ayKCDQ) | [Deploy preview](https://deploy-preview-5288--perf-html.netlify.app/public/62r9rwwtyrgzj8z3vc40jafaerxcq1gm7zj0y5g/calltree/?globalTrackOrder=80w576&hiddenGlobalTracks=1w46w8&hiddenLocalTracksByPid=1260-0wyb~9280-0w8~10132-0wk~10152-0wk~10120-0wk~8708-0wp~9508-0wx1~9812-0wx4&localTrackOrderByPid=1260-ya0wxgybxiwy9xh~9280-80w7~10132-k0wj~10152-k0wj~10120-k0wj~8708-p0w57wo6~9508-x2x30wx1~9812-x50wx4&range=m1224&thread=0&v=10)

`processThreadCPUDelta` makes it so that the `threadCPUDelta` column doesn't have any null values. However, the type of the `threadCPUDelta` column still looks as if values could be null.
Now that we have a derived `Thread` type, we can change the type so that it expresses that the values can't be null. So we move the call to `processThreadCPUDelta` a bit earlier in the derivation pipeline so that all the types work out.

Even better, we can compute CPU ratios at this point, and not even store the "clamped and non-null cpu delta" values.

And since we're doing that, I'm changing the behavior for null cpu delta values: Rather than using the closest non-null cpu delta and spreading it over a potentially-different sample time delta, just set the cpu ratio to 1. The only known cause of null values (other than the first value, which we ignore) is the base profiler, and we want CPU percentage to be reported as 100% during the base profiler time.

Fixes #4072.