### PR TITLE
Fix some test and non-test warnings

### DIFF
--- a/src/test/components/ProfileName.test.js
+++ b/src/test/components/ProfileName.test.js
@@ -75,7 +75,7 @@ describe('ProfileName', function () {
     expect(getProfileNameFromUrl(getState())).toBe(null);
 
     // Click the button to activate it.
-    button.click();
+    fireEvent.click(button);
     const input = getByDisplayValue(defaultName);
 
     expect(queryByText('Custom name')).not.toBeInTheDocument();
@@ -92,7 +92,7 @@ describe('ProfileName', function () {
     withAnalyticsMock(() => {
       const { getByText, getByDisplayValue } = setup();
       const button = getByText(defaultName);
-      button.click();
+      fireEvent.click(button);
       const input = getByDisplayValue(defaultName);
       fireEvent.change(input, { target: { value: 'Custom name' } });
       fireEvent.blur(input);


### PR DESCRIPTION
This fixes 2 warnings:
1. When running ProfileName.test. Here the problem was that we were calling `button.click` instead of `fireEvent.click`. The former isn't wrapped by `act` while the latter is.
2. When running MenuButtons.test. Here the problem was the change in the order of the state changes apply (redux vs react components); see the comment in the component for more information.