### PR TITLE
Add a context menu item to open the JS scripts in DevTools debugger

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -127,6 +127,7 @@ CallNodeContextMenu--searchfox = Look up the function name on Searchfox
 CallNodeContextMenu--copy-function-name = Copy function name
 CallNodeContextMenu--copy-script-url = Copy script URL
 CallNodeContextMenu--copy-stack = Copy stack
+CallNodeContextMenu--show-the-function-in-devtools = Show the function in DevTools
 
 ## CallTree
 ## This is the component for Call Tree panel.

--- a/src/app-logic/web-channel.js
+++ b/src/app-logic/web-channel.js
@@ -29,7 +29,8 @@ export type Request =
   | GetExternalPowerTracksRequest
   | GetSymbolTableRequest
   | QuerySymbolicationApiRequest
-  | GetPageFaviconsRequest;
+  | GetPageFaviconsRequest
+  | OpenScriptInTabDebuggerRequest;
 
 type StatusQueryRequest = {| type: 'STATUS_QUERY' |};
 type EnableMenuButtonRequest = {| type: 'ENABLE_MENU_BUTTON' |};
@@ -57,6 +58,13 @@ type QuerySymbolicationApiRequest = {|
 type GetPageFaviconsRequest = {|
   type: 'GET_PAGE_FAVICONS',
   pageUrls: Array<string>,
+|};
+type OpenScriptInTabDebuggerRequest = {|
+  type: 'OPEN_SCRIPT_IN_DEBUGGER',
+  tabId: number,
+  scriptUrl: string,
+  line: number | null,
+  column: number | null,
 |};
 
 export type MessageFromBrowser<R: ResponseFromBrowser> =
@@ -89,7 +97,8 @@ export type ResponseFromBrowser =
   | GetExternalPowerTracksResponse
   | GetSymbolTableResponse
   | QuerySymbolicationApiResponse
-  | GetPageFaviconsResponse;
+  | GetPageFaviconsResponse
+  | OpenScriptInTabDebuggerResponse;
 
 type StatusQueryResponse = {|
   menuButtonIsEnabled: boolean,
@@ -117,7 +126,10 @@ type StatusQueryResponse = {|
   //   Shipped in Firefox 134.
   //   Adds support for the following message types:
   //    - GET_PAGE_FAVICONS
-
+  // Version 5:
+  //  Shipped in Firefox 136.
+  //  Adds support for showing the JS script in DevTools debugger.
+  //    - OPEN_SCRIPT_IN_DEBUGGER
   version?: number,
 |};
 type EnableMenuButtonResponse = void;
@@ -127,6 +139,7 @@ type GetExternalPowerTracksResponse = MixedObject[];
 type GetSymbolTableResponse = SymbolTableAsTuple;
 type QuerySymbolicationApiResponse = string;
 type GetPageFaviconsResponse = Array<FaviconData | null>;
+type OpenScriptInTabDebuggerResponse = void;
 
 // Manually declare all pairs of request + response for Flow.
 /* eslint-disable no-redeclare */
@@ -154,6 +167,9 @@ declare function _sendMessageWithResponse(
 declare function _sendMessageWithResponse(
   GetPageFaviconsRequest
 ): Promise<GetPageFaviconsResponse>;
+declare function _sendMessageWithResponse(
+  OpenScriptInTabDebuggerRequest
+): Promise<OpenScriptInTabDebuggerResponse>;
 /* eslint-enable no-redeclare */
 
 /**
@@ -248,6 +264,21 @@ export async function getPageFaviconsViaWebChannel(
   return _sendMessageWithResponse({
     type: 'GET_PAGE_FAVICONS',
     pageUrls,
+  });
+}
+
+export async function showFunctionInDevtoolsViaWebChannel(
+  tabId: number,
+  scriptUrl: string,
+  line: number | null,
+  column: number | null
+): Promise<void> {
+  return _sendMessageWithResponse({
+    type: 'OPEN_SCRIPT_IN_DEBUGGER',
+    tabId,
+    scriptUrl,
+    line,
+    column,
   });
 }
 

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -43,7 +43,11 @@ import {
   assertExhaustiveCheck,
 } from 'firefox-profiler/utils/flow';
 
-import { getShouldDisplaySearchfox } from 'firefox-profiler/selectors/profile';
+import {
+  getShouldDisplaySearchfox,
+  getInnerWindowIDToPageMap,
+} from 'firefox-profiler/selectors/profile';
+import { getBrowserConnectionStatus } from 'firefox-profiler/selectors/app';
 
 import type {
   TransformType,
@@ -54,10 +58,13 @@ import type {
   Thread,
   ThreadsKey,
   CategoryList,
+  InnerWindowID,
+  Page,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from 'firefox-profiler/app-logic/tabs-handling';
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+import type { BrowserConnectionStatus } from 'firefox-profiler/app-logic/browser-connection';
 
 type StateProps = {|
   +thread: Thread | null,
@@ -70,6 +77,8 @@ type StateProps = {|
   +inverted: boolean,
   +selectedTab: TabSlug,
   +displaySearchfox: boolean,
+  +browserConnectionStatus: BrowserConnectionStatus,
+  +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
 |};
 
 type DispatchProps = {|
@@ -185,6 +194,28 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
     return stringTable.getString(stringIndex);
   }
 
+  _getFileLineColumn() {
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
+
+    if (rightClickedCallNodeInfo === null) {
+      throw new Error(
+        "The context menu assumes there is a selected call node and there wasn't one."
+      );
+    }
+
+    const {
+      callNodeIndex,
+      thread: { funcTable },
+      callNodeInfo,
+    } = rightClickedCallNodeInfo;
+
+    const callNodeTable = callNodeInfo.getCallNodeTable();
+    const funcIndex = callNodeTable.func[callNodeIndex];
+    const line = funcTable.lineNumber[funcIndex];
+    const column = funcTable.columnNumber[funcIndex];
+    return { line, column };
+  }
+
   showFile(): void {
     const { updateBottomBoxContentsAndMaybeOpen, selectedTab } = this.props;
 
@@ -279,6 +310,9 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
         break;
       case 'expand-all':
         this.expandAll();
+        break;
+      case 'show-function-in-devtools':
+        this.showFunctionInDevtools();
         break;
       default:
         throw new Error(`Unknown type ${type}`);
@@ -403,6 +437,61 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
     expandAllCallNodeDescendants(threadsKey, callNodeIndex, callNodeInfo);
   }
 
+  /**
+   * Get the tab id of the right clicked call node index.
+   */
+  _getTabID() {
+    const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
+    if (rightClickedCallNodeInfo === null) {
+      throw new Error(
+        "The context menu assumes there is a selected call node and there wasn't one."
+      );
+    }
+
+    const { callNodeInfo, callNodeIndex } = rightClickedCallNodeInfo;
+    const { innerWindowIDToPageMap } = this.props;
+
+    const callNodeTable = callNodeInfo.getCallNodeTable();
+    const innerWindowID = callNodeTable.innerWindowID[callNodeIndex];
+
+    if (innerWindowID && innerWindowIDToPageMap) {
+      const page = innerWindowIDToPageMap.get(innerWindowID);
+      if (page) {
+        // Note that pages that belong to an iframe also share the same tabID,
+        // so we don't have to look for the topmost page here.
+        return page.tabID;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Show the right clicked JS function in DevTools debugger if the browser
+   * connection and the tab that function belongs are still present.
+   * This should not be called for non-JS functions.
+   */
+  showFunctionInDevtools() {
+    const { browserConnectionStatus } = this.props;
+    if (browserConnectionStatus.status !== 'ESTABLISHED') {
+      return;
+    }
+
+    const tabID = this._getTabID();
+    const filePath = this._getFilePath();
+    const { line, column } = this._getFileLineColumn();
+
+    if (!tabID || !filePath || filePath === 'self-hosted') {
+      // Don't do anything if we fail to find tab id or file path. 'self-hosted'
+      // means that it's a function provided by the JS engine itself. Therefore
+      // it won't have any source available in the debugger.
+      return;
+    }
+
+    const { browserConnection } = browserConnectionStatus;
+    browserConnection.showFunctionInDevtools(tabID, filePath, line, column);
+  }
+
   getNameForSelectedResource(): string | null {
     const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
@@ -472,7 +561,13 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
   }
 
   renderContextMenuContents() {
-    const { inverted, selectedTab, displaySearchfox, categories } = this.props;
+    const {
+      inverted,
+      selectedTab,
+      displaySearchfox,
+      categories,
+      browserConnectionStatus,
+    } = this.props;
     const rightClickedCallNodeInfo = this.getRightClickedCallNodeInfo();
 
     if (rightClickedCallNodeInfo === null) {
@@ -504,6 +599,14 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
     const fileName =
       filePath &&
       parseFileNameFromSymbolication(filePath).path.match(/[^\\/]+$/)?.[0];
+    const showOpenDebuggerItem =
+      isJS &&
+      filePath &&
+      // 'self-hosted' means that it's a function provided by the JS engine
+      // itself. Debugger won't have any source code available for that.
+      filePath !== 'self-hosted' &&
+      browserConnectionStatus.status === 'ESTABLISHED' &&
+      this._getTabID();
     return (
       <>
         {fileName ? (
@@ -687,6 +790,16 @@ class CallNodeContextMenuImpl extends React.PureComponent<Props> {
             Copy stack
           </MenuItem>
         </Localized>
+        {showOpenDebuggerItem ? (
+          <Localized id="CallNodeContextMenu--show-the-function-in-devtools">
+            <MenuItem
+              onClick={this._handleClick}
+              data={{ type: 'show-function-in-devtools' }}
+            >
+              Show the function in DevTools
+            </MenuItem>
+          </Localized>
+        ) : null}
       </>
     );
   }
@@ -798,6 +911,8 @@ export const CallNodeContextMenu = explicitConnect<
       inverted: getInvertCallstack(state),
       selectedTab: getSelectedTab(state),
       displaySearchfox: getShouldDisplaySearchfox(state),
+      browserConnectionStatus: getBrowserConnectionStatus(state),
+      innerWindowIDToPageMap: getInnerWindowIDToPageMap(state),
     };
   },
   mapDispatchToProps: {

--- a/src/test/components/CallNodeContextMenu.test.js
+++ b/src/test/components/CallNodeContextMenu.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import copy from 'copy-to-clipboard';
 
-import { render } from 'firefox-profiler/test/fixtures/testing-library';
+import { render, screen } from 'firefox-profiler/test/fixtures/testing-library';
 import { CallNodeContextMenu } from '../../components/shared/CallNodeContextMenu';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
@@ -130,8 +130,8 @@ describe('calltree/CallNodeContextMenu', function () {
 
     fixtures.forEach(({ matcher, type }) => {
       it(`adds a transform for "${type}"`, function () {
-        const { getState, getByText } = setup();
-        fireFullClick(getByText(matcher));
+        const { getState } = setup();
+        fireFullClick(screen.getByText(matcher));
         expect(
           selectedThreadSelectors.getTransformStack(getState())[0].type
         ).toBe(type);
@@ -149,20 +149,20 @@ describe('calltree/CallNodeContextMenu', function () {
       } = getProfileFromTextSamples(`A[file:${sourceViewFile}]`);
       const store = storeWithProfile(profile);
       store.dispatch(changeRightClickedCallNode(0, [A]));
-      const { getByText, getState } = setup(store);
+      const { getState } = setup(store);
 
       expect(getSourceViewFile(getState())).toBeNull();
-      fireFullClick(getByText(/Show/));
+      fireFullClick(screen.getByText(/Show/));
       expect(getSourceViewFile(getState())).toBe(sourceViewFile);
     });
 
     it('can expand all call nodes in the call tree', function () {
-      const { getState, getByText } = setup();
+      const { getState } = setup();
       expect(
         selectedThreadSelectors.getExpandedCallNodeIndexes(getState())
       ).toHaveLength(1);
 
-      fireFullClick(getByText('Expand all'));
+      fireFullClick(screen.getByText('Expand all'));
 
       // This test only asserts that a bunch of call nodes were actually expanded.
       expect(
@@ -171,9 +171,9 @@ describe('calltree/CallNodeContextMenu', function () {
     });
 
     it('can look up functions on SearchFox', function () {
-      const { getByText } = setup();
+      setup();
       jest.spyOn(window, 'open').mockImplementation(() => {});
-      fireFullClick(getByText(/Searchfox/));
+      fireFullClick(screen.getByText(/Searchfox/));
       expect(window.open).toHaveBeenCalledWith(
         'https://searchfox.org/mozilla-central/search?q=B',
         '_blank'
@@ -181,23 +181,23 @@ describe('calltree/CallNodeContextMenu', function () {
     });
 
     it('can copy a function name', function () {
-      const { getByText } = setup();
+      setup();
       // Copy is a mocked module, clear it both before and after.
-      fireFullClick(getByText('Copy function name'));
+      fireFullClick(screen.getByText('Copy function name'));
       expect(copy).toHaveBeenCalledWith('B');
     });
 
     it('can copy a script URL', function () {
-      const { getByText } = setup(createStoreWithJsCallStack());
+      setup(createStoreWithJsCallStack());
       // Copy is a mocked module, clear it both before and after.
-      fireFullClick(getByText('Copy script URL'));
+      fireFullClick(screen.getByText('Copy script URL'));
       expect(copy).toHaveBeenCalledWith('https://example.com/script.js');
     });
 
     it('can copy a stack', function () {
-      const { getByText } = setup(createStoreWithJsCallStack());
+      setup(createStoreWithJsCallStack());
       // Copy is a mocked module, clear it both before and after.
-      fireFullClick(getByText('Copy stack'));
+      fireFullClick(screen.getByText('Copy stack'));
       expect(copy).toHaveBeenCalledWith(
         `B.js [https://example.com/script.js:2:222]\nA.js [https://example.com/script.js:1:111]`
       );

--- a/src/test/fixtures/mocks/web-channel.js
+++ b/src/test/fixtures/mocks/web-channel.js
@@ -148,7 +148,7 @@ export function simulateWebChannel(
           requestId: message.requestId,
           response: {
             menuButtonIsEnabled: true,
-            version: 4,
+            version: 5,
           },
         });
         break;
@@ -207,6 +207,15 @@ export function simulateWebChannel(
         });
         break;
       }
+      case 'OPEN_SCRIPT_IN_DEBUGGER': {
+        triggerResponse({
+          type: 'SUCCESS_RESPONSE',
+          requestId: message.requestId,
+          response: undefined,
+        });
+        break;
+      }
+
       default: {
         triggerResponse({
           type: 'ERROR_RESPONSE',

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -250,7 +250,7 @@ export function createGeckoProfile(): GeckoProfile {
   const parentProcessPages = [
     {
       tabID: tabID,
-      innerWindowID: 111111,
+      innerWindowID: 1,
       url: 'https://mozilla.org/',
       embedderInnerWindowID: 0,
     },
@@ -994,8 +994,8 @@ function _createGeckoThreadWithJsTimings(name: string): GeckoThread {
         [1, false, 0, null, null, null, null, null], // 1: 0x100000f84
         [2, false, 0, null, null, null, null, null], // 2: 0x100001a45
         [3, false, 0, null, 4391, null, 0, 0], // 3: Startup::XRE_Main, line 4391, category 16
-        [7, false, 0, 6, 1, null, null, null], // 4: javascriptOne, implementation 'baseline', line 1
-        [8, false, 0, 6, 2, null, null, null], // 5: javascriptTwo, implementation 'baseline', line 2
+        [7, false, 1, 6, 1, null, null, null], // 4: javascriptOne, implementation 'baseline', line 1
+        [8, false, 1, 6, 2, null, null, null], // 5: javascriptTwo, implementation 'baseline', line 2
         [9, false, 0, null, null, null, null, null], // 6: 0x10000f0f0
         [10, false, 0, null, null, null, null, null], // 7: 0x100fefefe
         [11, false, 0, null, 3, null, null, null], // 8: javascriptThree, implementation null, line 3
@@ -1011,7 +1011,7 @@ function _createGeckoThreadWithJsTimings(name: string): GeckoThread {
       'Reflow', // 5
       'baseline', // 6
       'javascriptOne (http://js.com/foobar:1:1)', // 7
-      'javascriptTwo (http://js.com/foobar:2:2)', // 8
+      'javascriptTwo (self-hosted:2:2)', // 8
       '0x10000f0f0', // 9
       '0x100fefefe', // 10
       'javascriptThree (http://js.com/foobar:3:3)', // 11


### PR DESCRIPTION
This is a deploy preview for [Bug 1925391](https://bugzilla.mozilla.org/show_bug.cgi?id=1925391).


It adds a context menu item for call node context menu to open the JS source code in the devtools debugger directly if the tab and browser connection still exists.

Unfortunately it's not possible to simply give a deploy preview. It needs to be a newly captured profile since it relies on the browser web channel connection to be alive.

The recent Firefox Nightly should have the web channel now. So you use any nightly version that includes the patch from [Bug 1925391](https://bugzilla.mozilla.org/show_bug.cgi?id=1925391). Here's how to test it locally:

- Go to `about:config`, change `devtools.performance.recording.ui-base-url` to `https://deploy-preview-5295--perf-html.netlify.app`.
- Go to `about:profiling` and enable the `JS Execution Tracing` feature.
- Start the profiler using profiler popup.
- Go to any website, e.g. https://en.wikipedia.org/wiki/Main_Page
- Capture the profile.
- Go to flame graph in the opened profile and right click any JS frame.
- Click `Show the function in DevTools`. 