### PR TITLE
Show sample tooltips on sample graph hover

### DIFF
--- a/src/components/shared/thread/SampleGraph.js
+++ b/src/components/shared/thread/SampleGraph.js
@@ -288,6 +288,10 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
     const x = event.nativeEvent.offsetX;
     const time = rangeStart + (x / r.width) * (rangeEnd - rangeStart);
 
+    // These values are copied from the `drawCanvas` method to compute the
+    // `drawnSampleWidth` instead of extracting into a new function. Extracting
+    // into a new function is not really idea for performance reasons since we
+    // need these values for other values in `drawCanvas`.
     const rangeLength = rangeEnd - rangeStart;
     const xPixelsPerMs = r.width / rangeLength;
     const trueIntervalPixelWidth = interval * xPixelsPerMs;

--- a/src/components/shared/thread/SampleGraph.js
+++ b/src/components/shared/thread/SampleGraph.js
@@ -51,7 +51,7 @@ type Props = {|
   ) => void,
   +trackName: string,
   +timelineType: TimelineType,
-  implementationFilter: ImplementationFilter,
+  +implementationFilter: ImplementationFilter,
   ...SizeProps,
 |};
 
@@ -130,8 +130,7 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
     canvas.width = Math.round(width * devicePixelRatio);
     canvas.height = Math.round(height * devicePixelRatio);
     const ctx = canvas.getContext('2d');
-    const range = [rangeStart, rangeEnd];
-    const rangeLength = range[1] - range[0];
+    const rangeLength = rangeEnd - rangeStart;
     const xPixelsPerMs = canvas.width / rangeLength;
     const trueIntervalPixelWidth = interval * xPixelsPerMs;
     const multiplier = trueIntervalPixelWidth < 2.0 ? 1.2 : 1.0;
@@ -141,8 +140,8 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
     );
     const drawnSampleWidth = Math.min(drawnIntervalWidth, 10);
 
-    const firstDrawnSampleTime = range[0] - drawnIntervalWidth / xPixelsPerMs;
-    const lastDrawnSampleTime = range[1];
+    const firstDrawnSampleTime = rangeStart - drawnIntervalWidth / xPixelsPerMs;
+    const lastDrawnSampleTime = rangeEnd;
 
     const firstDrawnSampleIndex = bisectionRight(
       thread.samples.time,
@@ -172,7 +171,7 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
         continue;
       }
       const xPos =
-        (sampleTime - range[0]) * xPixelsPerMs - drawnSampleWidth / 2;
+        (sampleTime - rangeStart) * xPixelsPerMs - drawnSampleWidth / 2;
       let samplesBucket;
       if (
         samplesSelectedStates !== null &&
@@ -247,11 +246,10 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
     const { rangeStart, rangeEnd, thread, interval } = this.props;
     const r = canvas.getBoundingClientRect();
 
-    const x = event.pageX - r.left;
+    const x = event.nativeEvent.offsetX;
     const time = rangeStart + (x / r.width) * (rangeEnd - rangeStart);
 
-    const range = [rangeStart, rangeEnd];
-    const rangeLength = range[1] - range[0];
+    const rangeLength = rangeEnd - rangeStart;
     const xPixelsPerMs = canvas.width / rangeLength;
     const trueIntervalPixelWidth = interval * xPixelsPerMs;
     const multiplier = trueIntervalPixelWidth < 2.0 ? 1.2 : 1.0;
@@ -261,8 +259,7 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
     );
     const drawnSampleWidth = Math.min(drawnIntervalWidth, 10) / 2;
 
-    const maxTimeDistance =
-      (drawnSampleWidth / 2 / r.width) * (rangeEnd - rangeStart);
+    const maxTimeDistance = (drawnSampleWidth / 2 / r.width) * rangeLength;
 
     const sampleIndex = getSampleIndexClosestToCenteredTime(
       thread.samples,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -277,6 +277,8 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
                 samplesSelectedStates={samplesSelectedStates}
                 categories={categories}
                 onSampleClick={this._onSampleClick}
+                timelineType={timelineType}
+                implementationFilter={implementationFilter}
               />
             ) : null}
             {isExperimentalCPUGraphsEnabled &&

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2325,41 +2325,51 @@ export function getSampleIndexClosestToStartTime(
  * uses the adjusted time. In this context, adjusted time means that `time` array
  * represent the "center" of the sample, and raw values represent the "start" of
  * the sample.
+ *
+ * Additionally it also checks for a maxTimeDistance threshold. If the time to
+ * sample distance is higher than that, it just returns null, which indicates
+ * no sample found.
  */
 export function getSampleIndexClosestToCenteredTime(
   samples: SamplesTable,
-  time: number
-): IndexIntoSamplesTable {
+  time: number,
+  maxTimeDistance: number
+): IndexIntoSamplesTable | null {
+  // Helper function to compute the "center" of a sample
+  const getCenterTime = (index: number): number => {
+    if (samples.weight) {
+      return samples.time[index] + Math.abs(samples.weight[index]) / 2;
+    }
+    return samples.time[index];
+  };
+
   // Bisect to find the index of the first sample after the provided time.
   const index = bisectionRight(samples.time, time);
 
   if (index === 0) {
-    return 0;
+    // Time is before the first sample
+    return maxTimeDistance >= Math.abs(getCenterTime(0) - time) ? 0 : null;
   }
 
-  if (index === samples.length) {
-    return samples.length - 1;
+  if (index === samples.time.length) {
+    // Time is after the last sample
+    const lastIndex = samples.time.length - 1;
+    return maxTimeDistance >= Math.abs(getCenterTime(lastIndex) - time)
+      ? lastIndex
+      : null;
   }
 
-  // Check the distance between the provided time and the center of the bisected sample
-  // and its predecessor.
-  const previousIndex = index - 1;
-  let distanceToThis;
-  let distanceToLast;
+  // Calculate distances to the centered time for both the current and previous samples
+  const distanceToNext = Math.abs(getCenterTime(index) - time);
+  const distanceToPrevious = Math.abs(getCenterTime(index - 1) - time);
 
-  if (samples.weight) {
-    const samplesWeight = samples.weight;
-    const weight = Math.abs(samplesWeight[index]);
-    const previousWeight = Math.abs(samplesWeight[previousIndex]);
-
-    distanceToThis = samples.time[index] + weight / 2 - time;
-    distanceToLast = time - (samples.time[previousIndex] + previousWeight / 2);
-  } else {
-    distanceToThis = samples.time[index] - time;
-    distanceToLast = time - samples.time[previousIndex];
+  if (distanceToNext <= distanceToPrevious) {
+    // If `distanceToNext` is closer but exceeds `maxTimeDistance`, return null.
+    return distanceToNext <= maxTimeDistance ? index : null;
   }
 
-  return distanceToThis < distanceToLast ? index : index - 1;
+  // Otherwise, `distanceToPrevious` is closer. Again check if it exceeds `maxTimeDistance`.
+  return distanceToPrevious <= maxTimeDistance ? index - 1 : null;
 }
 
 export function getFriendlyThreadName(

--- a/src/test/components/SampleGraph.test.js
+++ b/src/test/components/SampleGraph.test.js
@@ -104,6 +104,7 @@ describe('SampleGraph', function () {
     function clickSampleGraph(index: IndexIntoSamplesTable) {
       fireFullClick(sampleGraphCanvas, {
         pageX: getSamplesPixelPosition(index),
+        offsetX: getSamplesPixelPosition(index),
         pageY: GRAPH_HEIGHT / 2,
       });
     }
@@ -114,6 +115,7 @@ describe('SampleGraph', function () {
         sampleGraphCanvas,
         getMouseEvent('mousemove', {
           pageX: getSamplesPixelPosition(index),
+          offsetX: getSamplesPixelPosition(index),
           pageY: GRAPH_HEIGHT / 2,
         })
       );
@@ -195,6 +197,7 @@ describe('SampleGraph', function () {
       // Now we are selecting outside of the sample, which should remove the selection.
       fireFullClick(sampleGraphCanvas, {
         pageX: getSamplesPixelPosition(1) + PIXELS_PER_SAMPLE / 2,
+        offsetX: getSamplesPixelPosition(1) + PIXELS_PER_SAMPLE / 2,
         pageY: GRAPH_HEIGHT / 2,
       });
       expect(getCallNodePath()).toEqual([]);
@@ -238,6 +241,7 @@ describe('SampleGraph', function () {
         sampleGraphCanvas,
         getMouseEvent('mousemove', {
           pageX: getSamplesPixelPosition(1) + PIXELS_PER_SAMPLE / 2,
+          offsetX: getSamplesPixelPosition(1) + PIXELS_PER_SAMPLE / 2,
           pageY: GRAPH_HEIGHT / 2,
         })
       );

--- a/src/test/components/SampleGraph.test.js
+++ b/src/test/components/SampleGraph.test.js
@@ -49,8 +49,8 @@ const GRAPH_HEIGHT = 10;
 function getSamplesPixelPosition(
   sampleIndex: IndexIntoSamplesTable
 ): CssPixels {
-  // Compute the pixel position of the center of a given sample.
-  return sampleIndex * PIXELS_PER_SAMPLE + PIXELS_PER_SAMPLE * 0.5;
+  // Compute the pixel position of the exact sample.
+  return sampleIndex * PIXELS_PER_SAMPLE;
 }
 
 function getSamplesProfile() {

--- a/src/test/components/__snapshots__/SampleGraph.test.js.snap
+++ b/src/test/components/__snapshots__/SampleGraph.test.js.snap
@@ -1,5 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SampleGraph ThreadSampleGraph shows the correct tooltip when hovered 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 21px; top: 10px;"
+>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Category:
+    </div>
+    <div>
+      <span
+        class="colored-square category-color-green"
+      />
+      Graphics
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Stack:
+    </div>
+  </div>
+  <ul
+    class="backtrace"
+  >
+    <li
+      class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+    >
+      <span
+        class="colored-border category-color-green"
+        title="Graphics"
+      />
+      G
+      <em
+        class="backtraceStackFrameOrigin"
+      />
+    </li>
+    <li
+      class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+    >
+      <span
+        class="colored-border category-color-green"
+        title="Graphics"
+      />
+      F
+      <em
+        class="backtraceStackFrameOrigin"
+      />
+    </li>
+    <li
+      class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+    >
+      <span
+        class="colored-border category-color-blue"
+        title="DOM"
+      />
+      C
+      <em
+        class="backtraceStackFrameOrigin"
+      />
+    </li>
+    <li
+      class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+    >
+      <span
+        class="colored-border category-color-blue"
+        title="DOM"
+      />
+      B
+      <em
+        class="backtraceStackFrameOrigin"
+      />
+    </li>
+    <li
+      class="backtraceStackFrame backtraceStackFrame_isFrameLabel"
+    >
+      <span
+        class="colored-border category-color-blue"
+        title="DOM"
+      />
+      A
+      <em
+        class="backtraceStackFrameOrigin"
+      />
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`SampleGraph matches the 2d canvas draw snapshot 1`] = `
 Array [
   Array [


### PR DESCRIPTION
Fixes #3363.

This was requested by multiple people because sometimes it's not clear to users what the squares in the sample graph are. For example latest feedback we got was in #5278. They also said that a tooltip would've helped.

[Deploy preview](https://deploy-preview-5298--perf-html.netlify.app/public/64bs9a4538n6pvj0bgzz4rnqmt1sek5ns64c44r/calltree/?globalTrackOrder=0wn&hiddenGlobalTracks=1wm&hiddenLocalTracksByPid=29676-1w4dfg~29682-0~29679-0~29709-0~29708-0~29720-0~29701-0~29706-0~29700-0~29719-0~29721-0~29722-0~29680-0~29681-0~29684-0~29718-0~29702-0~29703-0~29741-0~29734-0~29723-0~29743-0~29736-0&range=2963m1214~3386m68~3406m20&thread=6&v=10) / [Production](https://share.firefox.dev/3Prsty3)