### PR TITLE
Correctly declare imported simpleperf trace profiles to be of the current version

### DIFF
--- a/src/profile-logic/import/simpleperf.js
+++ b/src/profile-logic/import/simpleperf.js
@@ -2,6 +2,7 @@
 
 import { simpleperf_report_proto as report } from './proto/simpleperf_report';
 
+import { PROCESSED_PROFILE_VERSION } from 'firefox-profiler/app-logic/constants';
 import type { Milliseconds } from 'firefox-profiler/types/units';
 import type {
   CategoryList,
@@ -381,7 +382,7 @@ class FirefoxProfile {
       // from the browser.)
       version: 30,
       // This is the processed profile format version.
-      preprocessedProfileVersion: 50,
+      preprocessedProfileVersion: PROCESSED_PROFILE_VERSION,
 
       symbolicationNotSupported: true,
       markerSchema: [],


### PR DESCRIPTION
This importer uses the Profile type, so it must be maintained to comply with the types of the latest version.
But if the self-declared version is set to 50, it will go through the upgraders, which will not work if the profile is already using the current version.