### PR TITLE
Add a "Sample timestamp" field to the sample tooltip in timeline

### DIFF
--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -56,6 +56,7 @@ export type Props = {|
   +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
   +timelineType: TimelineType,
+  +zeroAt: Milliseconds,
   ...SizeProps,
 |};
 
@@ -170,6 +171,7 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
       width,
       height,
       timelineType,
+      zeroAt,
     } = this.props;
     const { hoveredPixelState, mouseX, mouseY } = this.state;
     return (
@@ -213,6 +215,8 @@ class ThreadActivityGraphImpl extends React.PureComponent<Props, State> {
               rangeFilteredThread={rangeFilteredThread}
               categories={categories}
               implementationFilter={implementationFilter}
+              zeroAt={zeroAt}
+              interval={interval}
             />
           </Tooltip>
         )}

--- a/src/components/shared/thread/SampleGraph.js
+++ b/src/components/shared/thread/SampleGraph.js
@@ -52,6 +52,7 @@ type Props = {|
   +trackName: string,
   +timelineType: TimelineType,
   +implementationFilter: ImplementationFilter,
+  +zeroAt: Milliseconds,
   ...SizeProps,
 |};
 
@@ -343,6 +344,7 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
       samplesSelectedStates,
       width,
       height,
+      zeroAt,
     } = this.props;
     const { hoveredPixelState, mouseX, mouseY } = this.state;
 
@@ -378,6 +380,8 @@ export class ThreadSampleGraphImpl extends PureComponent<Props, State> {
               rangeFilteredThread={thread}
               categories={categories}
               implementationFilter={implementationFilter}
+              zeroAt={zeroAt}
+              interval={interval}
             />
           </Tooltip>
         )}

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -26,6 +26,7 @@ import {
   getMaxThreadCPUDeltaPerMs,
   getIsExperimentalCPUGraphsEnabled,
   getImplementationFilter,
+  getZeroAt,
 } from 'firefox-profiler/selectors';
 import {
   TimelineMarkersJank,
@@ -94,6 +95,7 @@ type StateProps = {|
   +maxThreadCPUDeltaPerMs: number,
   +implementationFilter: ImplementationFilter,
   +callTreeVisible: boolean,
+  +zeroAt: Milliseconds,
 |};
 
 type DispatchProps = {|
@@ -195,6 +197,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
       maxThreadCPUDeltaPerMs,
       isExperimentalCPUGraphsEnabled,
       implementationFilter,
+      zeroAt,
     } = this.props;
 
     const processType = filteredThread.processType;
@@ -265,6 +268,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
               maxThreadCPUDeltaPerMs={maxThreadCPUDeltaPerMs}
               implementationFilter={implementationFilter}
               timelineType={timelineType}
+              zeroAt={zeroAt}
             />
             {trackType === 'expanded' ? (
               <ThreadSampleGraph
@@ -279,6 +283,7 @@ class TimelineTrackThreadImpl extends PureComponent<Props> {
                 onSampleClick={this._onSampleClick}
                 timelineType={timelineType}
                 implementationFilter={implementationFilter}
+                zeroAt={zeroAt}
               />
             ) : null}
             {isExperimentalCPUGraphsEnabled &&
@@ -370,6 +375,7 @@ export const TimelineTrackThread = explicitConnect<
       maxThreadCPUDeltaPerMs: getMaxThreadCPUDeltaPerMs(state),
       implementationFilter: getImplementationFilter(state),
       callTreeVisible: selectors.getUsefulTabs(state).includes('calltree'),
+      zeroAt: getZeroAt(state),
     };
   },
   mapDispatchToProps: {

--- a/src/test/components/__snapshots__/SampleGraph.test.js.snap
+++ b/src/test/components/__snapshots__/SampleGraph.test.js.snap
@@ -12,6 +12,18 @@ exports[`SampleGraph ThreadSampleGraph shows the correct tooltip when hovered 1`
     <div
       class="tooltipLabel"
     >
+      Sampled at:
+    </div>
+    <div>
+      1ms
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
       Category:
     </div>
     <div>

--- a/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/SampleTooltipContents.test.js.snap
@@ -33,6 +33,18 @@ exports[`SampleTooltipContents renders the sample tooltip properly 1`] = `
     <div
       class="tooltipLabel"
     >
+      Sampled at:
+    </div>
+    <div>
+      0s
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
       Category:
     </div>
     <div>
@@ -314,6 +326,18 @@ exports[`SampleTooltipContents renders the sample with "variable CPU cycles" CPU
     <div
       class="tooltipLabel"
     >
+      Sampled at:
+    </div>
+    <div>
+      1ms
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
       CPU:
     </div>
     <div>
@@ -426,6 +450,18 @@ exports[`SampleTooltipContents renders the sample with ns CPU usage information 
     <div
       class="tooltipLabel"
     >
+      Sampled at:
+    </div>
+    <div>
+      1ms
+    </div>
+  </div>
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
       CPU:
     </div>
     <div>
@@ -532,6 +568,18 @@ exports[`SampleTooltipContents renders the sample with µs CPU usage information
   data-testid="tooltip"
   style="left: 11px; top: 10px;"
 >
+  <div
+    class="tooltipDetails"
+  >
+    <div
+      class="tooltipLabel"
+    >
+      Sampled at:
+    </div>
+    <div>
+      1ms
+    </div>
+  </div>
   <div
     class="tooltipDetails"
   >


### PR DESCRIPTION
Fixes #5319.

This also came up from a review comment here: https://github.com/firefox-devtools/profiler/pull/5298#issuecomment-2580970102

It sounds like a good idea to add the sample time to the sample tooltips. So 1) it will be more explicit that this is indeed a single sample. 2) It could be useful to know the precise time of a sample, so we can potentially compare different samples.

Apparently this component wasn't localized. So I filed #5321 for that. I'm not so sure if we should really localize it right now, because I think last time we discussed, we were saying that if we have `<label>: <value>` data in a view and value itself is not localized, maybe we shouldn't localize the label either. But I'm open to suggestions. I think this can be done outside of this PR.

[Deploy preview](https://deploy-preview-5322--perf-html.netlify.app/public/64bs9a4538n6pvj0bgzz4rnqmt1sek5ns64c44r/calltree/?globalTrackOrder=0wn&hiddenGlobalTracks=1wm&hiddenLocalTracksByPid=29676-1w4dfg~29682-0~29679-0~29709-0~29708-0~29720-0~29701-0~29706-0~29700-0~29719-0~29721-0~29722-0~29680-0~29681-0~29684-0~29718-0~29702-0~29703-0~29741-0~29734-0~29723-0~29743-0~29736-0&range=2963m1214~3386m68~3406m20&thread=6&v=10) / [production](https://share.firefox.dev/3Prsty3)

Example screenshot:
<img width="703" alt="Screenshot 2025-01-17 at 11 42 29 AM" src="https://github.com/user-attachments/assets/be5aebf1-0679-428d-a6bd-a169cdde4119" />

