### PR TITLE
Pass the correct sample index offset to getTimingsForCallNodeIndex for the flame graph tooltip.

### DIFF
--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -419,7 +419,7 @@ export const FlameGraph = explicitConnect<{||}, StateProps, DispatchProps>({
     unfilteredThread: selectedThreadSelectors.getThread(state),
     weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),
     sampleIndexOffset:
-      selectedThreadSelectors.getSampleIndexOffsetFromCommittedRange(state),
+      selectedThreadSelectors.getSampleIndexOffsetFromPreviewRange(state),
     // Use the filtered call node max depth, rather than the preview filtered one, so
     // that the viewport height is stable across preview selections.
     maxStackDepthPlusOne:

--- a/src/test/components/FlameGraph.test.js
+++ b/src/test/components/FlameGraph.test.js
@@ -220,6 +220,24 @@ describe('FlameGraph', function () {
     expect(copy).toHaveBeenLastCalledWith('B');
   });
 
+  it('has a tooltip that matches the snapshot with categories when a preview selection is applied', () => {
+    const { getTooltip, moveMouse, findFillTextPosition, dispatch } =
+      setupFlameGraph();
+    flushDrawLog();
+    act(() => {
+      dispatch(
+        updatePreviewSelection({
+          hasSelection: true,
+          isModifying: false,
+          selectionStart: 1.3,
+          selectionEnd: 5,
+        })
+      );
+    });
+    moveMouse(findFillTextPosition('A'));
+    expect(getTooltip()).toMatchSnapshot();
+  });
+
   describe('EmptyReasons', () => {
     it('matches the snapshot when a profile has no samples', () => {
       const profile = getEmptyProfile();

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -228,6 +228,177 @@ exports[`FlameGraph has a tooltip that matches the snapshot with categories 1`] 
 </div>
 `;
 
+exports[`FlameGraph has a tooltip that matches the snapshot with categories when a preview selection is applied 1`] = `
+<div
+  class="tooltip"
+  data-testid="tooltip"
+  style="left: 14px; top: 306px;"
+>
+  <div
+    class="tooltipCallNode"
+  >
+    <div
+      class="tooltipOneLine tooltipHeader"
+    >
+      <div
+        class="tooltipTiming"
+      >
+        1.0ms (100%)
+      </div>
+      <div
+        class="tooltipTitle"
+      >
+        A
+      </div>
+      <div
+        class="tooltipIcon"
+      />
+    </div>
+    <div
+      class="tooltipCallNodeDetails"
+    >
+      <div
+        class="tooltipDetails tooltipCallNodeDetailsLeft"
+      >
+        <div
+          class="tooltipLabel"
+        >
+          Stack Type:
+        </div>
+        <div>
+          Native
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          Category:
+        </div>
+        <div>
+          <span
+            class="colored-square category-color-blue"
+          />
+          DOM
+        </div>
+        <div
+          class="tooltipLabel"
+        >
+          File:
+        </div>
+        <div
+          class="tooltipDetailsUrl"
+        >
+          path/to/file:10:100
+        </div>
+      </div>
+      <div
+        class="tooltipCallNodeCategory"
+      >
+        <div />
+        <div
+          class="tooltipCallNodeHeader"
+        />
+        <div
+          class="tooltipCallNodeHeader"
+        >
+          <span
+            class="tooltipCallNodeHeaderSwatchRunning"
+          />
+          Running
+        </div>
+        <div
+          class="tooltipCallNodeHeader"
+        >
+          <span
+            class="tooltipCallNodeHeaderSwatchSelf"
+          />
+          Self
+        </div>
+        <div
+          class="tooltipLabel tooltipCategoryLabel tooltipCategoryRowHeader"
+        >
+          Overall
+        </div>
+        <div
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
+        >
+          <div
+            aria-label="Total samples overall"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
+          <div
+            aria-label="Self samples overall"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
+        >
+          1 sample
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRow tooltipCategoryRowHeader"
+        >
+          —
+        </div>
+        <div
+          class="tooltipCallNodeName tooltipLabel tooltipCategoryRowHeader"
+        >
+          Network
+        </div>
+        <div
+          class="tooltipCallNodeGraph tooltipCategoryRowHeader"
+        >
+          <div
+            aria-label="Total samples for Network"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="1"
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterTotal"
+            role="meter"
+          >
+            <div
+              class="tooltipCallNodeGraphMeterBar"
+              style="width: 100%;"
+            />
+          </div>
+          <div
+            aria-label="Self samples for Network"
+            aria-valuemax="1"
+            aria-valuemin="0"
+            aria-valuenow="0"
+            class="tooltipCallNodeGraphMeter tooltipCallNodeGraphMeterSelf"
+            role="meter"
+          />
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
+        >
+          1 sample
+        </div>
+        <div
+          class="tooltipCallNodeTiming tooltipCategoryRowHeader"
+        >
+          —
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`FlameGraph has a tooltip that matches the snapshot with implementation 1`] = `
 <div
   class="tooltip"


### PR DESCRIPTION
Fixes #5323.

The other caller of getTimingsForCallNodeIndex is the getTimingsForSidebar selector, which already passes the right offset.