### PR TITLE
Don't pass the preview filtered thread to getTimingsForPath/CallNodeIndex.

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -432,7 +432,6 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
                 callNodeIndex,
                 callNodeInfo,
                 interval,
-                thread,
                 unfilteredThread,
                 sampleIndexOffset,
                 categories,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -789,7 +789,6 @@ export function getTimingsForPath(
   needlePath: CallNodePath,
   callNodeInfo: CallNodeInfo,
   interval: Milliseconds,
-  thread: Thread,
   unfilteredThread: Thread,
   sampleIndexOffset: number,
   categories: CategoryList,
@@ -801,7 +800,6 @@ export function getTimingsForPath(
     callNodeInfo.getCallNodeIndexFromPath(needlePath),
     callNodeInfo,
     interval,
-    thread,
     unfilteredThread,
     sampleIndexOffset,
     categories,
@@ -823,7 +821,6 @@ export function getTimingsForCallNodeIndex(
   needleNodeIndex: IndexIntoCallNodeTable | null,
   callNodeInfo: CallNodeInfo,
   interval: Milliseconds,
-  thread: Thread,
   unfilteredThread: Thread,
   sampleIndexOffset: number,
   categories: CategoryList,
@@ -833,9 +830,6 @@ export function getTimingsForCallNodeIndex(
 ): TimingsForPath {
   /* ------------ Variables definitions ------------*/
 
-  // This is the data from the filtered thread that we'll loop over.
-  const { stringTable } = thread;
-
   // This is the data from the unfiltered thread that we'll use to gather
   // category and JS implementation information. Note that samples are offset by
   // `sampleIndexOffset` because of range filtering.
@@ -843,6 +837,7 @@ export function getTimingsForCallNodeIndex(
     stackTable: unfilteredStackTable,
     funcTable: unfilteredFuncTable,
     frameTable: unfilteredFrameTable,
+    stringTable,
   } = unfilteredThread;
 
   // This holds the category index for the JavaScript category, so that we can

--- a/src/selectors/per-thread/index.js
+++ b/src/selectors/per-thread/index.js
@@ -263,7 +263,6 @@ export const selectedNodeSelectors: NodeSelectors = (() => {
     selectedThreadSelectors.getSelectedCallNodePath,
     selectedThreadSelectors.getCallNodeInfo,
     ProfileSelectors.getProfileInterval,
-    selectedThreadSelectors.getPreviewFilteredThread,
     selectedThreadSelectors.getThread,
     selectedThreadSelectors.getSampleIndexOffsetFromPreviewRange,
     ProfileSelectors.getCategories,


### PR DESCRIPTION
It was only using it for the stringTable, and only looking up string indexes found on the unfiltered thread, so it might as well use the unfiltered thread's stringTable.

It's getting the filtered samples through a separate argument.

I wrote this patch yesterday, and today @julienw pointed out the same thing in #5328. :)