### PR TITLE
Make sample indexes compatible between the unfiltered and (preview) filtered call tree summary strategy samples when using an allocation strategy

### DIFF
--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -604,8 +604,8 @@ export function getCallTree(
  * Returns a table with the appropriate data for the call tree summary strategy,
  * for use by the call tree or flame graph.
  *
- * If the strategy is one of the allocation strategies, the returned table will be
- * based on thread.jsAllocations or thread.nativeAllocations, but with a modified
+ * If the strategy is one of the native allocation strategies, the returned table
+ * will be based on thread.nativeAllocations, but with a modified
  * stack column: Some samples will have a null stack, so that they are ignored.
  * For example, the returned table for `native-allocations` will have null stacks
  * for samples which are deallocations.

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -250,7 +250,7 @@ export function getBasicThreadSelectorsPerThread(
   const getUnfilteredCtssSamples: Selector<SamplesLikeTable> = createSelector(
     getThread,
     getCallTreeSummaryStrategy,
-    CallTree.extractSamplesLikeTable
+    CallTree.extractUnfilteredSamplesLikeTable
   );
 
   /**


### PR DESCRIPTION
[Production](https://profiler.firefox.com/public/vh01943rdqy5rpj2q152cgnz9vzff8k4phbdpa8/calltree/?ctSummary=native-retained-allocations&globalTrackOrder=0&thread=0&v=10) | [Deploy preview](https://deploy-preview-5332--perf-html.netlify.app/public/vh01943rdqy5rpj2q152cgnz9vzff8k4phbdpa8/calltree/?ctSummary=native-retained-allocations&globalTrackOrder=0&thread=0&v=10)

Fixes #5331.

Let's say we allocate 100 objects, and then free the first 50 of them. If you look at the entire thread, the `retained-native-allocations` view will show the allocation samples for the second 50 objects (the ones that weren't freed).
If you look at just the part of the thread where you allocated, you will see allocation samples for all 100 objects (because none were freed in that part of the thread).
How do you get the stack category for each of the 100 allocation samples, especially if you've applied transforms or a JS-only filter?

You need to look at the stack of the raw nativeAllocations table.

You cannot look at the `retained-native-allocations` of the entire thread, because that table doesn't have the stacks for the first 50 objects - it removes those samples because it knows that those objects have been deallocated.

This commit makes it so that the unfilteredCtssSamples are just the raw allocation tables, when an allocation-related call tree summary strategy is selected.

And it makes it so that `extractSamplesLikeTable` always returns a table that has compatible indexes to the `extractUnfilteredCtssSamples`, just with some samples having a null stack.

Now the unfilteredCtssSamples can be used to look up the stack, and therefore the original category of a sample, based on the sample index in the filtered (or preview-filtered) CTSS samples table. We should not create a call tree just based on the unfilteredCtssSamples because these samples have not been filtered according to the strategy.