### PR TITLE
Remove some code that uses the preview filtered thread

### DIFF
--- a/src/components/flame-graph/MaybeFlameGraph.js
+++ b/src/components/flame-graph/MaybeFlameGraph.js
@@ -76,9 +76,7 @@ export const MaybeFlameGraph = explicitConnect<{||}, StateProps, DispatchProps>(
       return {
         invertCallstack: getInvertCallstack(state),
         isPreviewSelectionEmpty:
-          selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
-            state
-          ) === 0,
+          !selectedThreadSelectors.getHasPreviewFilteredCtssSamples(state),
       };
     },
     mapDispatchToProps: {

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -69,7 +69,6 @@ type StateProps = {|
   +thread: Thread,
   +weightType: WeightType,
   +innerWindowIDToPageMap: Map<InnerWindowID, Page> | null,
-  +maxStackDepthPlusOne: number,
   +combinedTimingRows: CombinedTimingRows,
   +timeRange: StartEndRange,
   +interval: Milliseconds,
@@ -205,7 +204,6 @@ class StackChartImpl extends React.PureComponent<Props> {
     const {
       thread,
       threadsKey,
-      maxStackDepthPlusOne,
       combinedTimingRows,
       timeRange,
       interval,
@@ -225,7 +223,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       hasFilteredCtssSamples,
     } = this.props;
 
-    const maxViewportHeight = maxStackDepthPlusOne * STACK_FRAME_HEIGHT;
+    const maxViewportHeight = combinedTimingRows.length * STACK_FRAME_HEIGHT;
 
     return (
       <div
@@ -302,8 +300,6 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       thread: selectedThreadSelectors.getFilteredThread(state),
       // Use the raw WeightType here, as the stack chart does not use the call tree
       weightType: selectedThreadSelectors.getSamplesWeightType(state),
-      maxStackDepthPlusOne:
-        selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(state),
       combinedTimingRows,
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -84,6 +84,7 @@ type StateProps = {|
   +userTimings: MarkerIndex[],
   +timelineMarginLeft: CssPixels,
   +displayStackType: boolean,
+  +hasFilteredCtssSamples: boolean,
 |};
 
 type DispatchProps = {|
@@ -221,6 +222,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       weightType,
       timelineMarginLeft,
       displayStackType,
+      hasFilteredCtssSamples,
     } = this.props;
 
     const maxViewportHeight = maxStackDepthPlusOne * STACK_FRAME_HEIGHT;
@@ -234,7 +236,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       >
         <StackSettings hideInvertCallstack={true} />
         <TransformNavigator />
-        {maxStackDepthPlusOne === 0 && userTimings.length === 0 ? (
+        {!hasFilteredCtssSamples && userTimings.length === 0 ? (
           <StackChartEmptyReasons />
         ) : (
           <ContextMenuTrigger
@@ -319,6 +321,8 @@ export const StackChart = explicitConnect<{||}, StateProps, DispatchProps>({
       userTimings: selectedThreadSelectors.getUserTimingMarkerIndexes(state),
       timelineMarginLeft: getTimelineMarginLeft(state),
       displayStackType: getProfileUsesMultipleStackTypes(state),
+      hasFilteredCtssSamples:
+        selectedThreadSelectors.getHasFilteredCtssSamples(state),
     };
   },
   mapDispatchToProps: {

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -309,13 +309,6 @@ export function getStackAndSampleSelectorsPerThread(
     ProfileData.computeCallNodeMaxDepthPlusOne
   );
 
-  const getPreviewFilteredCallNodeMaxDepthPlusOne: Selector<number> =
-    createSelector(
-      threadSelectors.getPreviewFilteredCtssSamples,
-      getCallNodeInfo,
-      ProfileData.computeCallNodeMaxDepthPlusOne
-    );
-
   /**
    * When computing the call tree, a "samples" table is used, which
    * can represent a variety of formats with different weight types.
@@ -471,7 +464,6 @@ export function getStackAndSampleSelectorsPerThread(
     getTracedSelfAndTotalForSelectedCallNode,
     getStackTimingByDepth,
     getFilteredCallNodeMaxDepthPlusOne,
-    getPreviewFilteredCallNodeMaxDepthPlusOne,
     getFlameGraphTiming,
     getRightClickedCallNodeIndex,
   };

--- a/src/selectors/per-thread/stack-sample.js
+++ b/src/selectors/per-thread/stack-sample.js
@@ -339,7 +339,7 @@ export function getStackAndSampleSelectorsPerThread(
   );
 
   const getCallTree: Selector<CallTree.CallTree> = createSelector(
-    threadSelectors.getPreviewFilteredThread,
+    threadSelectors.getFilteredThread,
     getCallNodeInfo,
     ProfileSelectors.getCategories,
     getCallTreeTimings,

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -510,12 +510,24 @@ export function getThreadSelectorsWithMarkersPerThread(
     CallTree.extractSamplesLikeTable
   );
 
+  const getHasFilteredCtssSamples: Selector<boolean> = createSelector(
+    getFilteredCtssSamples,
+    (samples: SamplesLikeTable) =>
+      samples.length !== 0 && samples.stack.some((s) => s !== null)
+  );
+
   const getPreviewFilteredCtssSamples: Selector<SamplesLikeTable> =
     createSelector(
       getPreviewFilteredThread,
       threadSelectors.getCallTreeSummaryStrategy,
       CallTree.extractSamplesLikeTable
     );
+
+  const getHasPreviewFilteredCtssSamples: Selector<boolean> = createSelector(
+    getPreviewFilteredCtssSamples,
+    (samples: SamplesLikeTable) =>
+      samples.length !== 0 && samples.stack.some((s) => s !== null)
+  );
 
   /**
    * This selector returns the offset to add to a sampleIndex when accessing the
@@ -571,6 +583,8 @@ export function getThreadSelectorsWithMarkersPerThread(
     getFilteredCtssSamples,
     getPreviewFilteredCtssSamples,
     getPreviewFilteredCtssSampleIndexOffset,
+    getHasFilteredCtssSamples,
+    getHasPreviewFilteredCtssSamples,
     getTransformLabelL10nIds,
     getLocalizedTransformLabels,
   };

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -3463,15 +3463,21 @@ CallTree {
       "eventDelay": Array [
         0,
         0,
+        0,
+        0,
       ],
-      "length": 2,
+      "length": 4,
       "stack": Array [
         6,
         6,
+        6,
+        8,
       ],
       "time": Array [
+        3,
         4,
         5,
+        6,
       ],
       "weight": null,
       "weightType": "samples",

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -239,7 +239,7 @@ describe('selectors/getCallNodeMaxDepthPlusOneForFlameGraph', function () {
 
     const store = storeWithProfile(profile);
     const allSamplesMaxDepth =
-      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
+      selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(
         store.getState()
       );
     expect(allSamplesMaxDepth).toEqual(4);
@@ -249,7 +249,7 @@ describe('selectors/getCallNodeMaxDepthPlusOneForFlameGraph', function () {
     const { profile } = getProfileFromTextSamples(` `);
     const store = storeWithProfile(profile);
     const allSamplesMaxDepth =
-      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
+      selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(
         store.getState()
       );
     expect(allSamplesMaxDepth).toEqual(0);

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -256,6 +256,48 @@ describe('selectors/getCallNodeMaxDepthPlusOneForFlameGraph', function () {
   });
 });
 
+describe('selectors/getHasPreviewFilteredCtssSamples', function () {
+  it('returns true if there are samples', function () {
+    const { profile } = getProfileFromTextSamples(`
+      A  A  A
+      B  B  B
+      C  C
+      D
+    `);
+
+    const store = storeWithProfile(profile);
+    const hasSamples = selectedThreadSelectors.getHasPreviewFilteredCtssSamples(
+      store.getState()
+    );
+    expect(hasSamples).toEqual(true);
+  });
+
+  it('returns false if the preview selection filters out all samples', function () {
+    const { profile } = getProfileFromTextSamples(`
+      A  A  A
+      B  B  B
+      C  C
+      D
+    `);
+
+    const store = storeWithProfile(profile);
+
+    store.dispatch(
+      updatePreviewSelection({
+        hasSelection: true,
+        isModifying: false,
+        selectionStart: 1.1,
+        selectionEnd: 1.7,
+      })
+    );
+
+    const hasSamples = selectedThreadSelectors.getHasPreviewFilteredCtssSamples(
+      store.getState()
+    );
+    expect(hasSamples).toEqual(false);
+  });
+});
+
 describe('actions/changeImplementationFilter', function () {
   const store = storeWithProfile();
 

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -2034,15 +2034,6 @@ describe('snapshots of selectors/profile', function () {
     ).toEqual(4);
   });
 
-  it('matches the last stored run of selectedThreadSelector.getPreviewFilteredCallNodeMaxDepthPlusOne', function () {
-    const { getState } = setupStore();
-    expect(
-      selectedThreadSelectors.getPreviewFilteredCallNodeMaxDepthPlusOne(
-        getState()
-      )
-    ).toEqual(4);
-  });
-
   it('matches the last stored run of selectedThreadSelector.getSelectedCallNodePath', function () {
     const { getState, A, B } = setupStore();
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -34,7 +34,7 @@ export function addDataToWindowObject(
   defineProperty(target, 'filteredThread', {
     enumerable: true,
     get() {
-      return selectorsForConsole.selectedThread.getPreviewFilteredThread(
+      return selectorsForConsole.selectedThread.getFilteredThread(
         getState()
       );
     },

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -34,9 +34,7 @@ export function addDataToWindowObject(
   defineProperty(target, 'filteredThread', {
     enumerable: true,
     get() {
-      return selectorsForConsole.selectedThread.getFilteredThread(
-        getState()
-      );
+      return selectorsForConsole.selectedThread.getFilteredThread(getState());
     },
   });
 


### PR DESCRIPTION
I haven't seen it show up as a performance problem, but it's a bit silly that we create a new samples table every time the preview selection changes. It should be possible to just ignore samples outside the range.

This PR doesn't actually get rid of the preview filtered thread, but it moves some things around so that such a change would be easier to make in the future.