### PR TITLE
Adjust string index fields in markers when merging threads

### DIFF
--- a/src/profile-logic/marker-schema.js
+++ b/src/profile-logic/marker-schema.js
@@ -667,3 +667,32 @@ export function markerPayloadMatchesSearch(
 
   return false;
 }
+
+/**
+ * Returns a map of marker schema name -> array of field keys, listing any fields
+ * that contain indexes into the string table. If a marker schema has no such
+ * fields, then we don't put an entry for it in the returned map.
+ */
+export function computeStringIndexMarkerFieldsByDataType(
+  markerSchemas: MarkerSchema[]
+): Map<string, string[]> {
+  const stringIndexMarkerFieldsByDataType = new Map();
+
+  // 'CompositorScreenshot' markers currently don't have a schema (#5303),
+  // hardcode the url field (which is a string index) until they do.
+  stringIndexMarkerFieldsByDataType.set('CompositorScreenshot', ['url']);
+
+  for (const schema of markerSchemas) {
+    const { name, data } = schema;
+    const stringIndexFields = [];
+    for (const field of data) {
+      if (field.format === 'unique-string' && field.key) {
+        stringIndexFields.push(field.key);
+      }
+    }
+    if (stringIndexFields.length !== 0) {
+      stringIndexMarkerFieldsByDataType.set(name, stringIndexFields);
+    }
+  }
+  return stringIndexMarkerFieldsByDataType;
+}

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -83,9 +83,11 @@ export function getBasicThreadSelectorsPerThread(
 
   const getMergedRawThread: Selector<RawThread> = createSelector(
     ProfileSelectors.getProfile,
-    (profile) =>
+    ProfileSelectors.getStringIndexMarkerFieldsByDataType,
+    (profile, stringIndexMarkerFieldsByDataType) =>
       mergeThreads(
-        [...threadIndexes].map((threadIndex) => profile.threads[threadIndex])
+        [...threadIndexes].map((threadIndex) => profile.threads[threadIndex]),
+        stringIndexMarkerFieldsByDataType
       )
   );
   /**

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -21,7 +21,10 @@ import {
   IPCMarkerCorrelations,
   correlateIPCMarkers,
 } from '../profile-logic/marker-data';
-import { markerSchemaFrontEndOnly } from '../profile-logic/marker-schema';
+import {
+  markerSchemaFrontEndOnly,
+  computeStringIndexMarkerFieldsByDataType,
+} from '../profile-logic/marker-schema';
 import { getDefaultCategories } from 'firefox-profiler/profile-logic/data-structures';
 import { defaultTableViewOptions } from '../reducers/profile-view';
 import { StringTable } from '../utils/string-table';
@@ -250,6 +253,12 @@ export const getMarkerSchema: Selector<MarkerSchema[]> = createSelector(
       ...markerSchemaFrontEndOnly,
     ];
   }
+);
+
+export const getStringIndexMarkerFieldsByDataType: Selector<
+  Map<string, string[]>,
+> = createSelector(getMarkerSchema, (schemaList) =>
+  computeStringIndexMarkerFieldsByDataType(schemaList)
 );
 
 export const getMarkerSchemaByName: Selector<MarkerSchemaByName> =


### PR DESCRIPTION
[Production](https://share.firefox.dev/4hzflTv) | [Deploy preview](https://deploy-preview-5344--perf-html.netlify.app/public/fpw9sn5h8fffghntpd2yp6xpv1a4s14s72t60c0/marker-chart/?globalTrackOrder=0w2&hiddenGlobalTracks=02&hiddenLocalTracksByPid=20500-0wjlwprwym~20646-0wx4x6wxaxcwxh~20718-0wfhwxaxcwxf&localTrackOrderByPid=20646-03xh12xdwxf4w687ab9dcexgfwx4x6wxaxcx5xb&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F3aqw9lnr1ja32njx7g13sgbxn592wfxdfrfn08z&thread=zuA4&v=10)

Fixes #5098.