### PR TITLE
[deploy preview] Display traced values in Stack Chart view

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "babel-loader": "^9.2.1",
     "babel-plugin-module-resolver": "^5.0.2",
     "browserslist": "^4.24.3",
-    "caniuse-lite": "^1.0.30001690",
     "circular-dependency-plugin": "^5.2.1",
     "codecov": "^3.8.3",
     "copy-webpack-plugin": "^12.0.2",

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -20,6 +20,7 @@ import {
   typeof changeMouseTimePosition as ChangeMouseTimePosition,
 } from '../../actions/profile-view';
 import { mapCategoryColorNameToStackChartStyles } from '../../utils/colors';
+import { getArgvSummaries } from '../../utils/value-summaries';
 import { TooltipCallNode } from '../tooltip/CallNode';
 import { TooltipMarker } from '../tooltip/Marker';
 
@@ -96,6 +97,7 @@ const TEXT_CSS_PIXELS_OFFSET_START = 3;
 const TEXT_CSS_PIXELS_OFFSET_TOP = 11;
 const FONT_SIZE = 10;
 const BORDER_OPACITY = 0.4;
+
 
 class StackChartCanvasImpl extends React.PureComponent<Props> {
   _textMeasurement: null | TextMeasurement;
@@ -467,12 +469,18 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       );
     }
 
+
     const callNodeIndex = timing.callNode[stackTimingIndex];
     if (callNodeIndex === undefined) {
       return null;
     }
     const duration =
       timing.end[stackTimingIndex] - timing.start[stackTimingIndex];
+    const argv = timing.argv[stackTimingIndex];
+    let argvSummaries = undefined;
+    if (argv != -1) {
+      argvSummaries = getArgvSummaries(thread, argv);
+    }
 
     return (
       <TooltipCallNode
@@ -487,6 +495,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
         callTreeSummaryStrategy="timing"
         durationText={formatMilliseconds(duration)}
         displayStackType={displayStackType}
+        argv={JSON.stringify(argvSummaries, null, 2) || null}
       />
     );
   };

--- a/src/components/tooltip/CallNode.js
+++ b/src/components/tooltip/CallNode.js
@@ -129,6 +129,7 @@ type Props = {|
   +timings?: TimingsForPath,
   +callTreeSummaryStrategy: CallTreeSummaryStrategy,
   +displayStackType: boolean,
+  +argv?: string | null,
 |};
 
 /**
@@ -358,6 +359,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
       thread,
       durationText,
       categories,
+      argv,
       displayData,
       timings,
       callTreeSummaryStrategy,
@@ -422,6 +424,18 @@ export class TooltipCallNode extends React.PureComponent<Props> {
         </div>,
         thread.stringTable.getString(resourceNameIndex),
       ];
+    }
+
+    let argvEl = null;
+    if (argv) {
+      argvEl = [
+        <div className="tooltipLabel" key="resource">
+          Arguments:
+        </div>,
+      ];
+      for (let line of argv.split("\n")) {
+        argvEl.push(line);
+      }
     }
 
     // Finding current frame and parent frame URL(if there is).
@@ -538,6 +552,7 @@ export class TooltipCallNode extends React.PureComponent<Props> {
             {pageAndParentPageURL}
             {fileName}
             {resource}
+            {argvEl}
           </div>
           {this._renderCategoryTimings(timings)}
         </div>

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -89,6 +89,7 @@ export function getEmptySamplesTableWithEventDelay(): RawSamplesTable {
     eventDelay: [],
     stack: [],
     time: [],
+    argv: [],
     length: 0,
   };
 }
@@ -109,6 +110,7 @@ export function getEmptySamplesTableWithResponsiveness(): SamplesTable {
     responsiveness: [],
     stack: [],
     time: [],
+    argv: [],
     length: 0,
   };
 }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -19,6 +19,7 @@ import {
 } from './data-structures';
 import { immutableUpdate, ensureExists, coerce } from '../utils/flow';
 import { verifyMagic, SIMPLEPERF as SIMPLEPERF_MAGIC } from '../utils/magic';
+import { base64StringToArrayBuffer } from '../utils/value-summaries';
 import { attemptToUpgradeProcessedProfileThroughMutation } from './processed-profile-versioning';
 import { upgradeGeckoProfileToCurrentVersion } from './gecko-profile-versioning';
 import {
@@ -967,6 +968,10 @@ function _processSamples(geckoSamples: GeckoSampleStruct): RawSamplesTable {
     }
   }
 
+  if (geckoSamples.argv) {
+    samples.argv = geckoSamples.argv;
+  }
+
   if (geckoSamples.eventDelay) {
     samples.eventDelay = geckoSamples.eventDelay;
   } else if (geckoSamples.responsiveness) {
@@ -1202,6 +1207,17 @@ function _processThread(
   if (nativeAllocations) {
     // Only add the Native allocations if they exist.
     newThread.nativeAllocations = nativeAllocations;
+  }
+
+  if (thread.values) {
+    var buffer = base64StringToArrayBuffer(thread.values);
+    if (buffer) {
+      newThread.argvBuffer = buffer;
+    }
+  }
+
+  if (thread.shapes) {
+    newThread.shapes = thread.shapes;
   }
 
   function processJsTracer() {

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1673,6 +1673,13 @@ export function filterThreadSamplesToRange(
     );
   }
 
+  if (samples.argv) {
+    newSamples.argv = samples.argv.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+  }
+
   if (samples.threadId) {
     newSamples.threadId = samples.threadId.slice(
       beginSampleIndex,
@@ -1799,6 +1806,13 @@ export function filterRawThreadSamplesToRange(
     );
   }
 
+  if (samples.argv) {
+    newSamples.argv = samples.argv.slice(
+      beginSampleIndex,
+      endSampleIndex
+    );
+  }
+
   if (samples.threadId) {
     newSamples.threadId = samples.threadId.slice(
       beginSampleIndex,
@@ -1906,6 +1920,10 @@ export function filterCounterSamplesToRange(
       ? samples.number.slice(beginSampleIndex, endSampleIndex)
       : undefined,
   };
+
+  if (samples.argv) {
+    newCounter.argv = samples.argv.slice(beginSampleIndex, endSampleIndex);
+  }
 
   return newCounter;
 }
@@ -2345,6 +2363,7 @@ export function computeSamplesTableFromRawSamplesTable(
   const {
     responsiveness,
     eventDelay,
+    argv,
     stack,
     weight,
     weightType,
@@ -2371,6 +2390,7 @@ export function computeSamplesTableFromRawSamplesTable(
     // These fields are copied from the raw samples table:
     responsiveness,
     eventDelay,
+    argv,
     stack,
     weight,
     weightType,
@@ -2417,6 +2437,8 @@ export function createThreadFromDerivedTables(
     jsTracer,
     isPrivateBrowsing,
     userContextId,
+    argvBuffer,
+    shapes,
   } = rawThread;
 
   const thread: Thread = {
@@ -2445,6 +2467,8 @@ export function createThreadFromDerivedTables(
     jsTracer,
     isPrivateBrowsing,
     userContextId,
+    argvBuffer,
+    shapes,
 
     // These fields are derived:
     samples,

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -2117,6 +2117,9 @@ export function addInnerWindowIdToStacks(
       if (samples.responsiveness) {
         samples.responsiveness.push(samples.responsiveness[sampleIndex]);
       }
+      if (samples.argv) {
+        samples.argv.push(samples.argv[sampleIndex]);
+      }
       if (samples.threadCPUDelta) {
         samples.threadCPUDelta.push(samples.threadCPUDelta[sampleIndex]);
       }

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -120,6 +120,7 @@ export type GeckoSamples = {|
         stack: 0,
         time: 1,
         eventDelay: 2,
+        argv?: 3,
         threadCPUDelta?: 3,
       |},
   data: Array<
@@ -154,6 +155,7 @@ export type GeckoSampleStructWithResponsiveness = {|
   // versions may not have it or that feature could be disabled. No upgrader was
   // written for this change because it's a completely new data source.
   threadCPUDelta?: Array<number | null>,
+  argv?: Array<number | null>,
   length: number,
 |};
 
@@ -168,6 +170,7 @@ export type GeckoSampleStructWithEventDelay = {|
   // versions may not have it or that feature could be disabled. No upgrader was
   // written for this change because it's a completely new data source.
   threadCPUDelta?: Array<number | null>,
+  argv?: Array<number | null>,
   length: number,
 |};
 
@@ -276,6 +279,8 @@ export type GeckoThread = {|
   stackTable: GeckoStackTable,
   stringTable: string[],
   jsTracerEvents?: JsTracerTable,
+  values?: string,
+  shapes?: Array<?Array<string>>,
 |};
 
 export type GeckoExtensionMeta = {|

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -132,6 +132,7 @@ export type SamplesTable = {|
   // This property isn't present in normal threads. However it's present for
   // merged threads, so that we know the origin thread for these samples.
   threadId?: Tid[],
+  argv?: Array<number | null>,
   length: number,
 |};
 

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -118,6 +118,7 @@ export type RawSamplesTable = {|
   time?: Milliseconds[],
   // If the `time` column is not present, then the `timeDeltas` column must be present.
   timeDeltas?: Milliseconds[],
+  argv?: Array<number | null>,
   // An optional weight array. If not present, then the weight is assumed to be 1.
   // See the WeightType type for more information.
   weight: null | number[],
@@ -133,6 +134,7 @@ export type RawSamplesTable = {|
   // This property isn't present in normal threads. However it's present for
   // merged threads, so that we know the origin thread for these samples.
   threadId?: Tid[],
+  argv?: Array<number | null>,
   length: number,
 |};
 
@@ -636,7 +638,9 @@ export type RawThread = {|
   // It's absent in Firefox 97 and before, or in Firefox 98+ when this thread
   // had no extra attribute at all.
   userContextId?: number,
-|};
+  argvBuffer?: ArrayBuffer,
+  shapes?: Array<?Array<string>>,
+  |};
 
 export type ExtensionTable = {|
   baseURL: string[],

--- a/src/utils/value-summaries.js
+++ b/src/utils/value-summaries.js
@@ -1,0 +1,333 @@
+
+const JSVAL_TYPE_DOUBLE = 0x00;
+const JSVAL_TYPE_INT32 = 0x01;
+const JSVAL_TYPE_BOOLEAN = 0x02;
+const JSVAL_TYPE_UNDEFINED = 0x03;
+const JSVAL_TYPE_NULL = 0x04;
+const JSVAL_TYPE_MAGIC = 0x05;
+const JSVAL_TYPE_STRING = 0x06;
+const JSVAL_TYPE_SYMBOL = 0x07;
+const JSVAL_TYPE_PRIVATE_GCTHING = 0x08;
+const JSVAL_TYPE_BIGINT = 0x09;
+const JSVAL_TYPE_EXTENDED_PRIMITIVE = 0x0b;
+const JSVAL_TYPE_OBJECT = 0x0c;
+
+const GETTER_SETTER_MAGIC = 0xf;
+
+const OBJECT_IS_INDEXED_FLAG = 1;
+const OBJECT_IS_EXTENSIBLE_FLAG = 2;
+const OBJECT_IS_SEALED_FLAG = 4;
+const OBJECT_IS_FROZEN_FLAG = 8;
+
+const NUMBER_IS_OUT_OF_LINE_MAGIC = 0xf;
+const MIN_INLINE_INT = -1;
+const MAX_INLINE_INT = 13;
+
+const STRING_TOO_LONG_FLAG = 1;
+
+const STRING_ENCODING_LATIN1 = 0;
+const STRING_ENCODING_TWO_BYTE = 1;
+const STRING_ENCODING_UTF8 = 2;
+
+const OBJECT_KIND_NATIVE_OBJECT = 42 + 0;
+const OBJECT_KIND_ARRAY_LIKE = 42 + 1;
+const OBJECT_KIND_MAP_LIKE = 42 + 2;
+const OBJECT_KIND_ERROR = 42 + 3;
+const OBJECT_KIND_FUNCTION = 42 + 4;
+const OBJECT_KIND_EXTERNAL = 42 + 5;
+const OBJECT_KIND_NOT_IMPLEMENTED = 42 + 6;
+
+const EXTERNAL_SUMMARY_KIND_UNKNOWN = 0;
+const EXTERNAL_SUMMARY_KIND_ELEMENT = 1;
+const EXTERNAL_SUMMARY_KIND_OTHER_NODE = 2;
+
+class BufferReader {
+  #view;
+  #index;
+
+  constructor(buffer, index = 0) {
+    this.#view = new DataView(buffer);
+    this.#index = index;
+  }
+
+  peekUint8() {
+    return this.#view.getUint8(this.#index);
+  }
+
+  readUint8() {
+    let result = this.#view.getUint8(this.#index);
+    this.#index += 1;
+    return result;
+  }
+
+  readUint16() {
+    let result = this.#view.getUint16(this.#index, true);
+    this.#index += 2;
+    return result;
+  }
+
+  readUint32() {
+    let result = this.#view.getUint32(this.#index, true);
+    this.#index += 4;
+    return result;
+  }
+
+  readInt8() {
+    let result = this.#view.getInt8(this.#index);
+    this.#index += 1;
+    return result;
+  }
+
+  readInt16() {
+    let result = this.#view.getInt16(this.#index, true);
+    this.#index += 2;
+    return result;
+  }
+
+  readInt32() {
+    let result = this.#view.getInt32(this.#index, true);
+    this.#index += 4;
+    return result;
+  }
+
+  readFloat32() {
+    let result = this.#view.getFloat32(this.#index, true);
+    this.#index += 4;
+    return result;
+  }
+
+  readFloat64() {
+    let result = this.#view.getFloat64(this.#index, true);
+    this.#index += 8;
+    return result;
+  }
+
+  readString() {
+    let encoding = this.readUint8();
+    let length = this.readUint32();
+    if (length == 0) {
+      return "";
+    }
+    let result = "";
+    if (encoding == STRING_ENCODING_LATIN1) {
+      let decoder = new TextDecoder("latin1");
+      result = decoder.decode(this.#view.buffer.slice(this.#index, this.#index + length));
+      this.#index += length;
+    } else if (encoding == STRING_ENCODING_UTF8) {
+      let decoder = new TextDecoder("utf-8");
+      result = decoder.decode(this.#view.buffer.slice(this.#index, this.#index + length));
+      this.#index += length;
+    } else if (encoding == STRING_ENCODING_TWO_BYTE) {
+      let decoder = new TextDecoder("utf-16"); // this isn't quite right, is it? ugh.
+      let size = length * 2;
+      result = decoder.decode(this.#view.buffer.slice(this.#index, this.#index + size));
+      this.#index += size;
+    }
+    return result;
+  }
+}
+
+function readNativeObjectSummary(result, reader, flags, depth, shapes) {
+  if (depth > 1) {
+    return;
+  }
+
+  let preview = {};
+
+  preview.kind = "Object";
+
+  let shapeId = reader.readUint32();
+  let shape = shapes[shapeId];
+
+  if (!shape) {
+    return;
+  }
+
+  let indexed = !!(flags & OBJECT_IS_INDEXED_FLAG);
+  let ownProperties = {};
+  let ownPropertyLength = 0;
+
+  if (indexed) {
+    let elementsLength = reader.readUint32();
+    for (let i = 0; i < elementsLength; i++) {
+      ownPropertyLength++;
+      let nestedSummary = readValueSummary(reader, depth, shapes);
+      ownProperties[i] = {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: nestedSummary,
+      };
+    }
+  }
+
+  result.class = shape[0];
+  for (let i = 1; i < shape.length; i++) {
+    ownPropertyLength++;
+    let header = reader.peekUint8();
+    let id = shape[i];
+    let desc = {
+      configurable: true,
+      enumerable: true,
+      get: undefined,
+      set: undefined,
+    };
+    if ((header & 0xf) == GETTER_SETTER_MAGIC) {
+      reader.readUint8();
+      desc.get = readValueSummary(reader, depth, shapes);
+      desc.set = readValueSummary(reader, depth, shapes);
+    } else {
+      let nestedSummary = readValueSummary(reader, depth, shapes);
+      desc.writable = true;
+      desc.value = nestedSummary;
+    }
+    ownProperties[id] = desc;
+  }
+
+  preview.ownProperties = ownProperties;
+
+  result.preview = preview;
+}
+
+function readExternalObjectSummary(result, reader, flags, depth, shapes) {
+  let preview = {};
+  
+  result.class = reader.readString();
+  let kind = reader.readUint8();
+
+  if (kind == EXTERNAL_SUMMARY_KIND_UNKNOWN) {
+    return;
+  }
+
+  let isConnected = !!reader.readUint8();
+  let nodeType = reader.readUint16();
+  preview.kind = "DOMNode";
+  preview.isConnected = isConnected;
+  preview.nodeType = nodeType;
+  
+  if (kind == EXTERNAL_SUMMARY_KIND_ELEMENT) {
+    preview.nodeName = reader.readString();
+    let numAttributes = reader.readUint32();
+    preview.attributes = {};
+    preview.attributesLength = numAttributes;
+    for (let i = 0; i < numAttributes; i++) {
+      let attrName = reader.readString();
+      let attrVal = reader.readString();
+      preview.attributes[attrName] = attrVal;      
+    }
+  }
+
+  result.preview = preview;
+}
+
+function readObjectSummary(reader, flags, depth, shapes) {
+  let extensible = !!(flags & OBJECT_IS_EXTENSIBLE_FLAG);
+  let frozen = !!(flags & OBJECT_IS_FROZEN_FLAG);
+  let sealed = !!(flags & OBJECT_IS_SEALED_FLAG);
+
+  let result = {
+    type: "object",
+    class: undefined,
+    ownPropertyLength: 0,
+    isError: false,
+    extensible,
+    sealed,
+    frozen,
+  };
+
+  let kind = reader.readUint8();
+  switch (kind) {
+    case OBJECT_KIND_ARRAY_LIKE:
+      result.class = "Array";
+      break;
+    case OBJECT_KIND_MAP_LIKE:
+      result.class = "Map";
+      break;
+    case OBJECT_KIND_ERROR:
+      result.class = "Error";
+      break;
+    case OBJECT_KIND_FUNCTION:
+      result.class = "Function";
+      break;
+    case OBJECT_KIND_EXTERNAL:
+      readExternalObjectSummary(result, reader, flags, depth + 1, shapes);
+      break;
+    case OBJECT_KIND_NOT_IMPLEMENTED:
+      result.class = reader.readString();
+      break;
+    case OBJECT_KIND_NATIVE_OBJECT: {
+      readNativeObjectSummary(result, reader, flags, depth + 1, shapes);
+      break;
+    }
+    default:
+      throw new Error("Bad object kind");
+  }
+
+  return result;
+}
+
+function readValueSummary(reader, depth, shapes) {
+  let header = reader.readUint8();
+  let type = header & 0x0f;
+  let flags = (header & 0xf0) >> 4;
+  switch (type) {
+    case JSVAL_TYPE_DOUBLE:
+      if (flags == NUMBER_IS_OUT_OF_LINE_MAGIC) {
+        return reader.readFloat64();
+      } else {
+        return 0;
+      }
+    case JSVAL_TYPE_INT32:
+      if (flags == NUMBER_IS_OUT_OF_LINE_MAGIC) {
+        return reader.readInt32();
+      } else {
+        return flags + MIN_INLINE_INT;
+      }
+    case JSVAL_TYPE_BOOLEAN:
+      return !!flags;
+    case JSVAL_TYPE_NULL:
+      return null;
+    case JSVAL_TYPE_UNDEFINED:
+    case JSVAL_TYPE_MAGIC:
+    case JSVAL_TYPE_PRIVATE_GCTHING:
+    case JSVAL_TYPE_SYMBOL:
+    case JSVAL_TYPE_BIGINT:
+    case JSVAL_TYPE_EXTENDED_PRIMITIVE:
+      return undefined;
+    case JSVAL_TYPE_STRING: {
+      if (flags & STRING_TOO_LONG_FLAG) {
+        return "<string_too_long>"
+      } else {
+        return reader.readString();
+      }
+    }
+    case JSVAL_TYPE_OBJECT: {
+      return readObjectSummary(reader, flags, depth, shapes);
+    }
+    default:
+      throw new Error("Bad value type");
+  }
+}
+
+export function getArgvSummaries(thread, argvIndex) {
+  if (argvIndex == -2) {
+    return [];
+  }
+  if (argvIndex == -1) {
+    return "<missing>";
+  }
+  let reader = new BufferReader(thread.argvBuffer, argvIndex);
+  let argc = reader.readUint32();
+  let args = new Array(argc);
+  for (let i = 0; i < argc; i++) {
+    args[i] = readValueSummary(reader, 0, thread.shapes);
+  }
+  return args;
+}
+
+export function base64StringToArrayBuffer(str) {
+    if (Uint8Array.fromBase64) {
+        return Uint8Array.fromBase64(str).buffer;
+    }
+    return null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,10 +3512,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688, caniuse-lite@^1.0.30001690:
-  version "1.0.30001690"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz#f2d15e3aaf8e18f76b2b8c1481abde063b8104c8"
-  integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001688:
+  version "1.0.30001698"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001698.tgz"
+  integrity sha512-xJ3km2oiG/MbNU8G6zIq6XRZ6HtAOVXsbOrP/blGazi52kc5Yy7b6sDA5O+FbROzRrV7BSTllLHuNvmawYUJjw==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -12057,7 +12057,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12074,6 +12074,15 @@ string-width@^3.0.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -12179,7 +12188,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12199,6 +12208,13 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13817,7 +13833,7 @@ workbox-window@7.3.0, workbox-window@^7.3.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.3.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13830,6 +13846,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This is a rough draft of adding in the support for displaying traced values (from the JS Execution Tracing option) in the Stack Chart view. This currently requires the work in https://phabricator.services.mozilla.com/D236936 to function.