### PR TITLE
Change the marker schema to accept a description and get rid of the notion of static fields

### DIFF
--- a/docs-developer/CHANGELOG-formats.md
+++ b/docs-developer/CHANGELOG-formats.md
@@ -6,6 +6,16 @@ Note that this is not an exhaustive list. Processed profile format upgraders can
 
 ## Processed profile format
 
+### Version 55
+
+Changes to the `MarkerSchema` type which is used for the elements of the array at `profile.meta.markerSchema`:
+
+- A new `description` field was added. This field is optional.
+- The `data` property was renamed to `fields`.
+- Every field must have a `key` and a `format` property now. There are no static fields any more.
+
+Concretely, this means that if you have a `{ "label": "Description", value: "..." }` entry in your marker schema's `data` array, this entry needs to be removed and the description needs to be put into the `description` field instead, and the `data` property needs to be renamed to `fields`. If you have any other static fields, i.e. fields with `label` and `value` properties rather than `key` and `format` properties, then they need to be removed without replacement.
+
 ### Version 54
 
 The `implementation` column was removed from the frameTable. Modern profiles from Firefox use subcategories to represent the information about the JIT type of a JS frame.

--- a/src/app-logic/constants.js
+++ b/src/app-logic/constants.js
@@ -14,7 +14,7 @@ export const GECKO_PROFILE_VERSION = 31;
 // The current version of the "processed" profile format.
 // Please don't forget to update the processed profile format changelog in
 // `docs-developer/CHANGELOG-formats.md`.
-export const PROCESSED_PROFILE_VERSION = 54;
+export const PROCESSED_PROFILE_VERSION = 55;
 
 // The following are the margin sizes for the left and right of the timeline. Independent
 // components need to share these values.

--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -241,52 +241,43 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
       // Add the details for the markers based on their Marker schema.
       const schema = getSchemaFromMarker(markerSchemaByName, marker.data);
       if (schema) {
-        for (const schemaData of schema.data) {
-          if (schemaData.hidden) {
-            // Do not include the data field if it's marked as hidden.
+        for (const field of schema.fields) {
+          if (field.hidden) {
+            // Do not include hidden fields.
             continue;
           }
 
-          // Check for a schema that is looking up and formatting a value from
-          // the payload.
-          if (schemaData.value === undefined) {
-            const { key, label, format } = schemaData;
-            if (key in data) {
-              const value = data[key];
+          const { key, label, format } = field;
 
-              // Don't add undefined values, as values are optional.
-              if (value !== undefined && value !== null) {
-                details.push(
-                  <TooltipDetail
-                    key={schema.name + '-' + key}
-                    label={label || key}
-                  >
-                    {formatMarkupFromMarkerSchema(
-                      schema.name,
-                      format,
-                      value,
-                      thread.stringTable,
-                      threadIdToNameMap,
-                      processIdToNameMap
-                    )}
-                  </TooltipDetail>
-                );
-              }
-            }
+          const value = data[key];
+          if (value === undefined || value === null) {
+            // This marker doesn't have a value for this field. Values are optional.
+            continue;
           }
 
-          // Do a check to see if there is no key. This means this is a simple
-          // label that is applied to every marker of this type, with no data
-          // lookup. For some reason Flow as not able to refine this.
-          if (schemaData.key === undefined) {
-            const { label, value } = schemaData;
-            const key = label + '-' + value;
-            details.push(
-              <TooltipDetail key={key} label={label}>
-                <div className="tooltipDetailsDescription">{value}</div>
-              </TooltipDetail>
-            );
-          }
+          details.push(
+            <TooltipDetail key={schema.name + '-' + key} label={label || key}>
+              {formatMarkupFromMarkerSchema(
+                schema.name,
+                format,
+                value,
+                thread.stringTable,
+                threadIdToNameMap,
+                processIdToNameMap
+              )}
+            </TooltipDetail>
+          );
+        }
+
+        if (schema.description) {
+          const key = schema.name + '-description';
+          details.push(
+            <TooltipDetail key={key} label="Description">
+              <div className="tooltipDetailsDescription">
+                {schema.description}
+              </div>
+            </TooltipDetail>
+          );
         }
       }
 

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -939,7 +939,7 @@ function extractMarkers(
       tooltipLabel: '{marker.data.type2} - EventDispatch',
       tableLabel: '{marker.data.type2}',
       display: ['marker-chart', 'marker-table', 'timeline-overview'],
-      data: [
+      fields: [
         {
           // In the original chrome profile, the key is `type`, but we rename it
           // so that it doesn't clash with our internal `type` property.

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -1434,36 +1434,29 @@ export function sanitizeFromMarkerSchema(
   markerSchema: MarkerSchema,
   markerPayload: MarkerPayload
 ): MarkerPayload {
-  for (const propertyDescription of markerSchema.data) {
-    if (
-      propertyDescription.key !== undefined &&
-      propertyDescription.format !== undefined
-    ) {
-      const key = propertyDescription.key;
-      const format = propertyDescription.format;
-      if (!(key in markerPayload)) {
-        continue;
-      }
+  for (const { key, format } of markerSchema.fields) {
+    if (!(key in markerPayload)) {
+      continue;
+    }
 
-      // We're typing the result of the sanitization with `any` because Flow
-      // doesn't like much our enormous enum of non-exact objects that's used as
-      // MarkerPayload type, and this code is too generic for Flow in this context.
-      if (format === 'url') {
-        markerPayload = ({
-          ...markerPayload,
-          [key]: removeURLs(markerPayload[key]),
-        }: any);
-      } else if (format === 'file-path') {
-        markerPayload = ({
-          ...markerPayload,
-          [key]: removeFilePath(markerPayload[key]),
-        }: any);
-      } else if (format === 'sanitized-string') {
-        markerPayload = ({
-          ...markerPayload,
-          [key]: '<sanitized>',
-        }: any);
-      }
+    // We're typing the result of the sanitization with `any` because Flow
+    // doesn't like much our enormous enum of non-exact objects that's used as
+    // MarkerPayload type, and this code is too generic for Flow in this context.
+    if (format === 'url') {
+      markerPayload = ({
+        ...markerPayload,
+        [key]: removeURLs(markerPayload[key]),
+      }: any);
+    } else if (format === 'file-path') {
+      markerPayload = ({
+        ...markerPayload,
+        [key]: removeFilePath(markerPayload[key]),
+      }: any);
+    } else if (format === 'sanitized-string') {
+      markerPayload = ({
+        ...markerPayload,
+        [key]: '<sanitized>',
+      }: any);
     }
   }
 

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -69,6 +69,9 @@ import type {
   GeckoProfile,
   GeckoSubprocessProfile,
   GeckoThread,
+  GeckoMetaMarkerSchema,
+  GeckoStaticFieldSchemaData,
+  GeckoDynamicFieldSchemaData,
   GeckoMarkers,
   GeckoMarkerStruct,
   GeckoMarkerTuple,
@@ -1382,6 +1385,63 @@ export function adjustMarkerTimestamps(
   };
 }
 
+function _convertGeckoMarkerSchema(
+  markerSchema: GeckoMetaMarkerSchema
+): MarkerSchema {
+  const {
+    name,
+    tooltipLabel,
+    tableLabel,
+    chartLabel,
+    display,
+    data,
+    graphs,
+    isStackBased,
+  } = markerSchema;
+
+  const fields: GeckoDynamicFieldSchemaData[] = [];
+  const staticFields: GeckoStaticFieldSchemaData[] = [];
+  for (const f of data) {
+    if (f.value === undefined) {
+      fields.push(f);
+    } else if (f.key === undefined) {
+      // extra check to placate Flow
+      staticFields.push(f);
+    }
+  }
+
+  let description = undefined;
+  if (staticFields.length !== 0) {
+    let staticDescriptionFieldIndex = staticFields.findIndex(
+      (f) => f.label === 'Description'
+    );
+    if (staticDescriptionFieldIndex === -1) {
+      staticDescriptionFieldIndex = 0;
+    }
+    const discardedFields = staticFields.filter(
+      (_f, i) => i !== staticDescriptionFieldIndex
+    );
+    if (discardedFields.length !== 0) {
+      console.warn(
+        `Discarding the following static fields from marker schema "${name}": ${discardedFields.join(', ')}`
+      );
+    }
+    description = staticFields[staticDescriptionFieldIndex].value;
+  }
+
+  return {
+    name,
+    tooltipLabel,
+    tableLabel,
+    chartLabel,
+    display,
+    fields,
+    description,
+    graphs,
+    isStackBased,
+  };
+}
+
 /**
  * Marker schemas are only emitted for markers that are used. Each subprocess
  * can have a different list, as the processes are not coordinating with each
@@ -1389,16 +1449,16 @@ export function adjustMarkerTimestamps(
  * primary list that is stored on the processed profile's meta object.
  */
 function processMarkerSchema(geckoProfile: GeckoProfile): MarkerSchema[] {
-  const combinedSchemas: MarkerSchema[] = geckoProfile.meta.markerSchema;
-  const names: Set<string> = new Set(
-    geckoProfile.meta.markerSchema.map(({ name }) => name)
+  const combinedSchemas: MarkerSchema[] = geckoProfile.meta.markerSchema.map(
+    _convertGeckoMarkerSchema
   );
+  const names: Set<string> = new Set(combinedSchemas.map(({ name }) => name));
 
   for (const subprocess of geckoProfile.processes) {
     for (const markerSchema of subprocess.meta.markerSchema) {
       if (!names.has(markerSchema.name)) {
         names.add(markerSchema.name);
-        combinedSchemas.push(markerSchema);
+        combinedSchemas.push(_convertGeckoMarkerSchema(markerSchema));
       }
     }
   }
@@ -1998,11 +2058,13 @@ export function processVisualMetrics(
     maybeAddMetricMarker(tabThread, markerName, INTERVAL, startTime, endTime);
 
     // Add progress markers for every visual progress change for more fine grained information.
-    const progressMarkerSchema = {
+    const progressMarkerSchema: MarkerSchema = {
       name: 'VisualMetricProgress',
       tableLabel: '{marker.name} — {marker.data.percentage}',
       display: ['marker-chart', 'marker-table'],
-      data: [{ key: 'percentage', label: 'Percentage', format: 'percentage' }],
+      fields: [
+        { key: 'percentage', label: 'Percentage', format: 'percentage' },
+      ],
     };
     meta.markerSchema.push(progressMarkerSchema);
 

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -2452,6 +2452,45 @@ const _upgraders = {
     // This field is no longer needed.
     delete profile.meta.doesNotUseFrameImplementation;
   },
+  [55]: (profile) => {
+    for (const markerSchema of profile.meta.markerSchema) {
+      const staticFields = markerSchema.data.filter((f) => f.key === undefined);
+      const fields = markerSchema.data.filter((f) => f.value === undefined);
+
+      markerSchema.fields = fields;
+      delete markerSchema.data;
+
+      if (staticFields.length === 0) {
+        continue;
+      }
+
+      // Migrate one of the static fields to the new `description` property.
+      let staticDescriptionFieldIndex = staticFields.findIndex(
+        (f) => f.label === 'Description'
+      );
+      if (staticDescriptionFieldIndex === -1) {
+        staticDescriptionFieldIndex = 0;
+      }
+      const description = staticFields[staticDescriptionFieldIndex].value;
+      markerSchema.description = description;
+
+      // If there was more than one static field, we may be discarding useful data.
+      // Print a warning to the console if that's the case, unless this is the
+      // old { label: "Marker", value: "UserTiming" } field which never provided
+      // any value. (On the Gecko side, it was removed by D196332.)
+      const discardedFields = staticFields.filter(
+        (_f, i) => i !== staticDescriptionFieldIndex
+      );
+      const potentiallyUsefulDiscardedFields = discardedFields.filter(
+        (f) => f.label !== 'Marker' && f.value !== 'UserTiming'
+      );
+      if (potentiallyUsefulDiscardedFields.length !== 0) {
+        console.warn(
+          `Discarding the following static fields from marker schema "${markerSchema.name}": ${potentiallyUsefulDiscardedFields.map((f) => f.label + ': ' + f.value).join(', ')}`
+        );
+      }
+    }
+  },
   // If you add a new upgrader here, please document the change in
   // `docs-developer/CHANGELOG-formats.md`.
 };

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -264,7 +264,7 @@ describe('timeline/GlobalTrack', function () {
       {
         name: 'task',
         display: ['timeline-overview'],
-        data: [],
+        fields: [],
       },
     ];
     const [thread] = profile.threads;

--- a/src/test/components/TrackCustomMarker.test.js
+++ b/src/test/components/TrackCustomMarker.test.js
@@ -63,7 +63,7 @@ function setup() {
   profile.meta.markerSchema.push({
     name: 'Marker',
     display: ['marker-chart', 'marker-table', 'timeline-memory'],
-    data: [
+    fields: [
       { key: 'first', label: 'first', format: 'integer', searchable: true },
       { key: 'second', label: 'second', format: 'integer', searchable: true },
     ],

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -198,17 +198,6 @@ exports[`MarkerChart persists the selected marker tooltips properly 1`] = `
       <div
         class="tooltipLabel"
       >
-        Marker
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming
-      </div>
-      <div
-        class="tooltipLabel"
-      >
         Entry Type
         :
       </div>
@@ -389,17 +378,6 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         :
       </div>
       Marker B
-      <div
-        class="tooltipLabel"
-      >
-        Marker
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming
-      </div>
       <div
         class="tooltipLabel"
       >

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -2211,7 +2211,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
           class="menuButtonsDownloadSize"
         >
           (
-          1.64 kB
+          1.63 kB
           )
         </span>
       </a>
@@ -2329,7 +2329,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          1.63 kB
+          1.61 kB
           )
         </span>
       </a>
@@ -2442,7 +2442,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
           class="menuButtonsDownloadSize"
         >
           (
-          1.64 kB
+          1.63 kB
           )
         </span>
       </a>

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -858,17 +858,6 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
       <div
         class="tooltipLabel"
       >
-        Marker
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming
-      </div>
-      <div
-        class="tooltipLabel"
-      >
         Entry Type
         :
       </div>

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -4698,17 +4698,6 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
     <div
       class="tooltipLabel"
     >
-      Marker
-      :
-    </div>
-    <div
-      class="tooltipDetailsDescription"
-    >
-      UserTiming
-    </div>
-    <div
-      class="tooltipLabel"
-    >
       Entry Type
       :
     </div>

--- a/src/test/fixtures/profiles/marker-schema.js
+++ b/src/test/fixtures/profiles/marker-schema.js
@@ -9,28 +9,28 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'GCMajor',
     display: ['marker-chart', 'marker-table', 'timeline-memory'],
-    data: [],
+    fields: [],
   },
   {
     name: 'GCMinor',
     display: ['marker-chart', 'marker-table', 'timeline-memory'],
-    data: [],
+    fields: [],
   },
   {
     name: 'GCSlice',
     display: ['marker-chart', 'marker-table', 'timeline-memory'],
-    data: [],
+    fields: [],
   },
   {
     name: 'CC',
     tooltipLabel: 'Cycle Collect',
     display: ['marker-chart', 'marker-table', 'timeline-memory'],
-    data: [],
+    fields: [],
   },
   {
     name: 'FileIO',
     display: ['marker-chart', 'marker-table'],
-    data: [
+    fields: [
       {
         key: 'operation',
         label: 'Operation',
@@ -54,7 +54,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'MediaSample',
     display: ['marker-chart', 'marker-table'],
-    data: [
+    fields: [
       {
         key: 'sampleStartTimeUs',
         label: 'Sample start time',
@@ -70,7 +70,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'Styles',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [
+    fields: [
       {
         key: 'elementsTraversed',
         label: 'Elements traversed',
@@ -85,7 +85,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'PreferenceRead',
     display: ['marker-chart', 'marker-table'],
-    data: [
+    fields: [
       { key: 'prefName', label: 'Name', format: 'string', searchable: true },
       { key: 'prefKind', label: 'Kind', format: 'string' },
       { key: 'prefType', label: 'Type', format: 'string' },
@@ -98,23 +98,19 @@ export const markerSchemaForTests: MarkerSchema[] = [
     chartLabel: '{marker.data.name}',
     tableLabel: '{marker.data.name}',
     display: ['marker-chart', 'marker-table'],
-    data: [
+    fields: [
       { key: 'name', label: 'Name', format: 'string', searchable: true },
-      { label: 'Marker', value: 'UserTiming' },
       { key: 'entryType', label: 'Entry Type', format: 'string' },
-      {
-        label: 'Description',
-        value:
-          'UserTiming is created using the DOM APIs performance.mark() and performance.measure().',
-      },
     ],
+    description:
+      'UserTiming is created using the DOM APIs performance.mark() and performance.measure().',
   },
   {
     name: 'Text',
     tableLabel: '{marker.name} — {marker.data.name}',
     chartLabel: '{marker.name} — {marker.data.name}',
     display: ['marker-chart', 'marker-table'],
-    data: [
+    fields: [
       { key: 'name', label: 'Details', format: 'string', searchable: true },
     ],
   },
@@ -122,7 +118,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
     name: 'Log',
     display: ['marker-table'],
     tableLabel: '({marker.data.module}) {marker.data.name}',
-    data: [
+    fields: [
       { key: 'module', label: 'Module', format: 'string', searchable: true },
       { key: 'name', label: 'Name', format: 'string', searchable: true },
     ],
@@ -133,7 +129,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
     tableLabel: '{marker.data.eventType}',
     chartLabel: '{marker.data.eventType}',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [
+    fields: [
       { key: 'latency', label: 'Latency', format: 'duration' },
       {
         key: 'eventType',
@@ -146,14 +142,14 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'tracing',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [
+    fields: [
       { key: 'category', label: 'Type', format: 'string', searchable: true },
     ],
   },
   {
     name: 'Layout',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [
+    fields: [
       { key: 'category', label: 'Type', format: 'string', searchable: true },
     ],
   },
@@ -164,7 +160,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
       '{marker.name} — {marker.data.messageType} — {marker.data.niceDirection}',
     chartLabel: '{marker.data.messageType}',
     display: ['marker-chart', 'marker-table', 'timeline-ipc'],
-    data: [
+    fields: [
       { key: 'messageType', label: 'Type', format: 'string' },
       { key: 'sync', label: 'Sync', format: 'string' },
       { key: 'sendThreadName', label: 'From', format: 'string' },
@@ -174,12 +170,12 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'VisibleInTimelineOverview',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [],
+    fields: [],
   },
   {
     name: 'StringTesting',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [
+    fields: [
       {
         key: 'searchableString',
         label: 'Searchable string field',
@@ -209,7 +205,7 @@ export const markerSchemaForTests: MarkerSchema[] = [
   {
     name: 'MarkerWithHiddenField',
     display: ['marker-chart', 'marker-table', 'timeline-overview'],
-    data: [
+    fields: [
       {
         key: 'hiddenString',
         label: 'Hidden string',

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -151,8 +151,8 @@ function _replaceUniqueStringFieldValuesWithStringIndexesInMarkerPayload(
   if (schema === undefined) {
     return;
   }
-  for (const fieldSchema of schema.data) {
-    if (!fieldSchema.format || fieldSchema.format !== 'unique-string') {
+  for (const fieldSchema of schema.fields) {
+    if (fieldSchema.format !== 'unique-string') {
       continue;
     }
     const { key } = fieldSchema;

--- a/src/test/integration/symbolicator-cli/__snapshots__/symbolicator-cli.test.js.snap
+++ b/src/test/integration/symbolicator-cli/__snapshots__/symbolicator-cli.test.js.snap
@@ -87,7 +87,7 @@ Object {
     "markerSchema": Array [],
     "oscpu": "macOS 14.6.1",
     "pausedRanges": Array [],
-    "preprocessedProfileVersion": 54,
+    "preprocessedProfileVersion": 55,
     "processType": 0,
     "product": "a.out",
     "sampleUnits": Object {

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -81,44 +81,48 @@ Object {
     "logicalCPUs": 0,
     "markerSchema": Array [
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMajor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMinor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCSlice",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "CC",
         "tooltipLabel": "Cycle Collect",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "operation",
@@ -138,14 +142,14 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "FileIO",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
         ],
-        "name": "FileIO",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "microseconds",
             "key": "sampleStartTimeUs",
@@ -157,14 +161,15 @@ Object {
             "label": "Sample end time",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "MediaSample",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "integer",
             "key": "elementsTraversed",
@@ -191,15 +196,14 @@ Object {
             "label": "Styles reused",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "Styles",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "prefName",
@@ -222,15 +226,16 @@ Object {
             "label": "Value",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "PreferenceRead",
       },
       Object {
         "chartLabel": "{marker.data.name}",
-        "data": Array [
+        "description": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -238,22 +243,10 @@ Object {
             "searchable": true,
           },
           Object {
-            "label": "Marker",
-            "value": "UserTiming",
-          },
-          Object {
             "format": "string",
             "key": "entryType",
             "label": "Entry Type",
           },
-          Object {
-            "label": "Description",
-            "value": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
-          },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
         ],
         "name": "UserTiming",
         "tableLabel": "{marker.data.name}",
@@ -261,7 +254,11 @@ Object {
       },
       Object {
         "chartLabel": "{marker.name} — {marker.data.name}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -269,15 +266,14 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "Text",
         "tableLabel": "{marker.name} — {marker.data.name}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "module",
@@ -291,15 +287,17 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-table",
-        ],
         "name": "Log",
         "tableLabel": "({marker.data.module}) {marker.data.name}",
       },
       Object {
         "chartLabel": "{marker.data.eventType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "duration",
             "key": "latency",
@@ -312,50 +310,50 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "DOMEvent",
         "tableLabel": "{marker.data.eventType}",
         "tooltipLabel": "{marker.data.eventType} — DOMEvent",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "tracing",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Layout",
       },
       Object {
         "chartLabel": "{marker.data.messageType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-ipc",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "messageType",
@@ -377,26 +375,26 @@ Object {
             "label": "To",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-ipc",
-        ],
         "name": "IPC",
         "tableLabel": "{marker.name} — {marker.data.messageType} — {marker.data.niceDirection}",
         "tooltipLabel": "IPC — {marker.data.niceDirection}",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-overview",
         ],
+        "fields": Array [],
         "name": "VisibleInTimelineOverview",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "searchableString",
@@ -422,15 +420,15 @@ Object {
             "searchable": false,
           },
         ],
+        "name": "StringTesting",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-overview",
         ],
-        "name": "StringTesting",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "string",
             "hidden": true,
@@ -439,11 +437,6 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "MarkerWithHiddenField",
       },
     ],
@@ -451,7 +444,7 @@ Object {
     "oscpu": "",
     "physicalCPUs": 0,
     "platform": "",
-    "preprocessedProfileVersion": 54,
+    "preprocessedProfileVersion": 55,
     "processType": 0,
     "product": "Firefox",
     "sourceURL": "",

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -15,7 +15,6 @@ import {
   getNetworkMarkers,
 } from '../fixtures/profiles/processed-profile';
 import { storeWithProfile } from '../fixtures/stores';
-import { markerSchemaForTests } from '../fixtures/profiles/marker-schema';
 
 describe('selectors/getMarkerChartTimingAndBuckets', function () {
   function getMarkerChartTimingAndBuckets(testMarkers: TestDefinedMarkers) {
@@ -321,32 +320,20 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function () {
           'Dummy 1',
           10,
           null,
-          {
-            type: 'tracing',
-            category: 'Navigation',
-            innerWindowID,
-          },
+          { type: 'tracing', category: 'Navigation', innerWindowID },
         ],
         ['Dummy 2', 20, null],
         [
           'Dummy 3',
           30,
           null,
-          {
-            type: 'tracing',
-            category: 'Navigation',
-            innerWindowID: 111111,
-          },
+          { type: 'tracing', category: 'Navigation', innerWindowID: 111111 },
         ],
         [
           'Dummy 4',
           30,
           null,
-          {
-            type: 'tracing',
-            category: 'Navigation',
-            innerWindowID,
-          },
+          { type: 'tracing', category: 'Navigation', innerWindowID },
         ],
         ['Dummy 5', 40],
       ]
@@ -368,12 +355,7 @@ describe('selectors/getCommittedRangeAndTabFilteredMarkerIndexes', function () {
     const { getState, dispatch } = storeWithProfile(profile);
 
     if (ctxId) {
-      dispatch(
-        changeTimelineTrackOrganization({
-          type: 'active-tab',
-          tabID,
-        })
-      );
+      dispatch(changeTimelineTrackOrganization({ type: 'active-tab', tabID }));
     }
     const markerIndexes =
       selectedThreadSelectors.getCommittedRangeAndTabFilteredMarkerIndexes(
@@ -481,23 +463,10 @@ describe('Marker schema filtering', function () {
         oscpu: '',
         platform: '',
         processType: 0,
-        extensions: {
-          id: [],
-          name: [],
-          baseURL: [],
-          length: 0,
-        },
+        extensions: { id: [], name: [], baseURL: [], length: 0 },
         categories: [
-          {
-            name: 'Idle',
-            color: 'transparent',
-            subcategories: ['Other'],
-          },
-          {
-            name: 'Other',
-            color: 'grey',
-            subcategories: ['Other'],
-          },
+          { name: 'Idle', color: 'transparent', subcategories: ['Other'] },
+          { name: 'Other', color: 'grey', subcategories: ['Other'] },
         ],
         product: 'Firefox',
         stackwalk: 0,
@@ -538,22 +507,10 @@ describe('Marker schema filtering', function () {
             category: [0, 0, 0, 0, 0, 0, 0],
             data: [
               null,
-              {
-                type: 'no schema marker',
-              },
-              {
-                type: 'Text',
-                name: 'RefreshDriverTick',
-              },
-              {
-                type: 'UserTiming',
-                name: 'name',
-                entryType: 'mark',
-              },
-              {
-                type: 'tracing',
-                category: 'RandomTracingMarker',
-              },
+              { type: 'no schema marker' },
+              { type: 'Text', name: 'RefreshDriverTick' },
+              { type: 'UserTiming', name: 'name', entryType: 'mark' },
+              { type: 'tracing', category: 'RandomTracingMarker' },
               {
                 type: 'Network',
                 id: 0,
@@ -614,13 +571,7 @@ describe('Marker schema filtering', function () {
             columnNumber: [],
             length: 0,
           },
-          resourceTable: {
-            lib: [],
-            name: [],
-            host: [],
-            type: [],
-            length: 0,
-          },
+          resourceTable: { lib: [], name: [], host: [], type: [], length: 0 },
         },
       ],
     };
@@ -671,23 +622,10 @@ describe('profile upgrading and markers', () => {
         oscpu: '',
         platform: '',
         processType: 0,
-        extensions: {
-          id: [],
-          name: [],
-          baseURL: [],
-          length: 0,
-        },
+        extensions: { id: [], name: [], baseURL: [], length: 0 },
         categories: [
-          {
-            name: 'Idle',
-            color: 'transparent',
-            subcategories: ['Other'],
-          },
-          {
-            name: 'Other',
-            color: 'grey',
-            subcategories: ['Other'],
-          },
+          { name: 'Idle', color: 'transparent', subcategories: ['Other'] },
+          { name: 'Other', color: 'grey', subcategories: ['Other'] },
         ],
         product: 'Firefox',
         stackwalk: 0,
@@ -700,7 +638,187 @@ describe('profile upgrading and markers', () => {
         physicalCPUs: 0,
         logicalCPUs: 0,
         symbolicated: true,
-        markerSchema: markerSchemaForTests,
+        markerSchema: [
+          {
+            name: 'GCMajor',
+            display: ['marker-chart', 'marker-table', 'timeline-memory'],
+            data: [],
+          },
+          {
+            name: 'GCMinor',
+            display: ['marker-chart', 'marker-table', 'timeline-memory'],
+            data: [],
+          },
+          {
+            name: 'GCSlice',
+            display: ['marker-chart', 'marker-table', 'timeline-memory'],
+            data: [],
+          },
+          {
+            name: 'CC',
+            tooltipLabel: 'Cycle Collect',
+            display: ['marker-chart', 'marker-table', 'timeline-memory'],
+            data: [],
+          },
+          {
+            name: 'FileIO',
+            display: ['marker-chart', 'marker-table'],
+            data: [
+              {
+                key: 'operation',
+                label: 'Operation',
+                format: 'string',
+                searchable: true,
+              },
+              {
+                key: 'source',
+                label: 'Source',
+                format: 'string',
+                searchable: true,
+              },
+              {
+                key: 'filename',
+                label: 'Filename',
+                format: 'file-path',
+                searchable: true,
+              },
+            ],
+          },
+          {
+            name: 'MediaSample',
+            display: ['marker-chart', 'marker-table'],
+            data: [
+              {
+                key: 'sampleStartTimeUs',
+                label: 'Sample start time',
+                format: 'microseconds',
+              },
+              {
+                key: 'sampleEndTimeUs',
+                label: 'Sample end time',
+                format: 'microseconds',
+              },
+            ],
+          },
+          {
+            name: 'Styles',
+            display: ['marker-chart', 'marker-table', 'timeline-overview'],
+            data: [
+              {
+                key: 'elementsTraversed',
+                label: 'Elements traversed',
+                format: 'integer',
+              },
+              {
+                key: 'elementsStyled',
+                label: 'Elements styled',
+                format: 'integer',
+              },
+              {
+                key: 'elementsMatched',
+                label: 'Elements matched',
+                format: 'integer',
+              },
+              {
+                key: 'stylesShared',
+                label: 'Styles shared',
+                format: 'integer',
+              },
+              {
+                key: 'stylesReused',
+                label: 'Styles reused',
+                format: 'integer',
+              },
+            ],
+          },
+          {
+            name: 'PreferenceRead',
+            display: ['marker-chart', 'marker-table'],
+            data: [
+              { key: 'prefName', label: 'Name', format: 'string' },
+              { key: 'prefKind', label: 'Kind', format: 'string' },
+              { key: 'prefType', label: 'Type', format: 'string' },
+              { key: 'prefValue', label: 'Value', format: 'string' },
+            ],
+          },
+          {
+            name: 'UserTiming',
+            tooltipLabel: '{marker.data.name}',
+            chartLabel: '{marker.data.name}',
+            tableLabel: '{marker.data.name}',
+            display: ['marker-chart', 'marker-table'],
+            data: [
+              // name
+              { label: 'Marker', value: 'UserTiming' },
+              { key: 'entryType', label: 'Entry Type', format: 'string' },
+              {
+                label: 'Description',
+                value:
+                  'UserTiming is created using the DOM APIs performance.mark() and performance.measure().',
+              },
+            ],
+          },
+          {
+            name: 'Text',
+            tableLabel: '{marker.name} — {marker.data.name}',
+            chartLabel: '{marker.name} — {marker.data.name}',
+            display: ['marker-chart', 'marker-table'],
+            data: [{ key: 'name', label: 'Details', format: 'string' }],
+          },
+          {
+            name: 'Log',
+            display: ['marker-table'],
+            tableLabel: '({marker.data.module}) {marker.data.name}',
+            data: [
+              { key: 'module', label: 'Module', format: 'string' },
+              { key: 'name', label: 'Name', format: 'string' },
+            ],
+          },
+          {
+            name: 'DOMEvent',
+            tooltipLabel: '{marker.data.eventType} — DOMEvent',
+            tableLabel: '{marker.data.eventType}',
+            chartLabel: '{marker.data.eventType}',
+            display: ['marker-chart', 'marker-table', 'timeline-overview'],
+            data: [{ key: 'latency', label: 'Latency', format: 'duration' }],
+          },
+          {
+            name: 'Paint',
+            display: ['marker-chart', 'marker-table', 'timeline-overview'],
+            data: [{ key: 'category', label: 'Type', format: 'string' }],
+          },
+          {
+            name: 'Navigation',
+            display: ['marker-chart', 'marker-table', 'timeline-overview'],
+            data: [{ key: 'category', label: 'Type', format: 'string' }],
+          },
+          {
+            name: 'Layout',
+            display: ['marker-chart', 'marker-table', 'timeline-overview'],
+            data: [{ key: 'category', label: 'Type', format: 'string' }],
+          },
+
+          {
+            name: 'IPC',
+            tooltipLabel: 'IPC — {marker.data.niceDirection}',
+            tableLabel:
+              '{marker.name} — {marker.data.messageType} — {marker.data.niceDirection}',
+            chartLabel: '{marker.data.messageType}',
+            display: ['marker-chart', 'marker-table', 'timeline-ipc'],
+            data: [
+              { key: 'messageType', label: 'Type', format: 'string' },
+              { key: 'sync', label: 'Sync', format: 'string' },
+              { key: 'sendThreadName', label: 'From', format: 'string' },
+              { key: 'recvThreadName', label: 'To', format: 'string' },
+            ],
+          },
+          {
+            name: 'RefreshDriverTick',
+            display: ['marker-chart', 'marker-table', 'timeline-overview'],
+            data: [{ key: 'name', label: 'Tick Reasons', format: 'string' }],
+          },
+          { name: 'Network', display: ['marker-table'], data: [] },
+        ],
       },
       pages: [],
       threads: [
@@ -735,11 +853,7 @@ describe('profile upgrading and markers', () => {
               // One marker without data
               null,
               // One marker without cause
-              {
-                type: 'UserTiming',
-                name: 'name',
-                entryType: 'mark',
-              },
+              { type: 'UserTiming', name: 'name', entryType: 'mark' },
               // One marker with a cause that was already processed in previous versions.
               {
                 type: 'tracing',
@@ -803,13 +917,7 @@ describe('profile upgrading and markers', () => {
             columnNumber: [null],
             length: 1,
           },
-          resourceTable: {
-            lib: [],
-            name: [],
-            host: [],
-            type: [],
-            length: 0,
-          },
+          resourceTable: { lib: [], name: [], host: [], type: [], length: 0 },
         },
       ],
     };

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -135,7 +135,7 @@ describe('ordering and hiding', function () {
       {
         name: 'Marker',
         display: ['marker-chart', 'marker-table', 'timeline-memory'],
-        data: [
+        fields: [
           { key: 'first', label: 'first', format: 'integer', searchable: true },
         ],
         graphs: [
@@ -148,7 +148,7 @@ describe('ordering and hiding', function () {
       {
         name: 'NoGraphMarker',
         display: ['marker-chart', 'marker-table'],
-        data: [
+        fields: [
           { key: 'first', label: 'first', format: 'integer', searchable: true },
         ],
         // An empty array should behave just as if the property isn't present.

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -40,7 +40,7 @@ Object {
     "oscpu": undefined,
     "physicalCPUs": undefined,
     "platform": undefined,
-    "preprocessedProfileVersion": 54,
+    "preprocessedProfileVersion": 55,
     "processType": 0,
     "product": "Firefox",
     "sampleUnits": undefined,
@@ -9360,44 +9360,48 @@ Object {
     "interval": 1,
     "markerSchema": Array [
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMajor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMinor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCSlice",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "CC",
         "tooltipLabel": "Cycle Collect",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "operation",
@@ -9423,14 +9427,14 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "FileIO",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
         ],
-        "name": "FileIO",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "microseconds",
             "key": "sampleStartTimeUs",
@@ -9442,14 +9446,15 @@ Object {
             "label": "Sample end time",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "MediaSample",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "integer",
             "key": "elementsTraversed",
@@ -9476,15 +9481,14 @@ Object {
             "label": "Styles reused",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "Styles",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "prefName",
@@ -9506,32 +9510,21 @@ Object {
             "label": "Value",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "PreferenceRead",
       },
       Object {
         "chartLabel": "{marker.data.name}",
-        "data": Array [
-          Object {
-            "label": "Marker",
-            "value": "UserTiming",
-          },
+        "description": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "entryType",
             "label": "Entry Type",
           },
-          Object {
-            "label": "Description",
-            "value": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
-          },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
         ],
         "name": "UserTiming",
         "tableLabel": "{marker.data.name}",
@@ -9539,7 +9532,11 @@ Object {
       },
       Object {
         "chartLabel": "{marker.name} — {marker.data.name}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -9547,15 +9544,14 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "Text",
         "tableLabel": "{marker.name} — {marker.data.name}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "module",
@@ -9569,15 +9565,17 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-table",
-        ],
         "name": "Log",
         "tableLabel": "({marker.data.module}) {marker.data.name}",
       },
       Object {
         "chartLabel": "{marker.data.eventType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "duration",
             "key": "latency",
@@ -9590,66 +9588,66 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "DOMEvent",
         "tableLabel": "{marker.data.eventType}",
         "tooltipLabel": "{marker.data.eventType} — DOMEvent",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Paint",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Navigation",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Layout",
       },
       Object {
         "chartLabel": "{marker.data.messageType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-ipc",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "messageType",
@@ -9671,17 +9669,17 @@ Object {
             "label": "To",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-ipc",
-        ],
         "name": "IPC",
         "tableLabel": "{marker.name} — {marker.data.messageType} — {marker.data.niceDirection}",
         "tooltipLabel": "IPC — {marker.data.niceDirection}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -9689,32 +9687,27 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "RefreshDriverTick",
+      },
+      Object {
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [],
+        "name": "Network",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-overview",
         ],
-        "name": "RefreshDriverTick",
-      },
-      Object {
-        "data": Array [],
-        "display": Array [
-          "marker-table",
-        ],
-        "name": "Network",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "tracing",
       },
@@ -9722,7 +9715,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 54,
+    "preprocessedProfileVersion": 55,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -10943,44 +10936,48 @@ Object {
     "interval": 1,
     "markerSchema": Array [
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMajor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMinor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCSlice",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "CC",
         "tooltipLabel": "Cycle Collect",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "operation",
@@ -11006,14 +11003,14 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "FileIO",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
         ],
-        "name": "FileIO",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "microseconds",
             "key": "sampleStartTimeUs",
@@ -11025,14 +11022,15 @@ Object {
             "label": "Sample end time",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "MediaSample",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "integer",
             "key": "elementsTraversed",
@@ -11059,15 +11057,14 @@ Object {
             "label": "Styles reused",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "Styles",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "prefName",
@@ -11089,32 +11086,21 @@ Object {
             "label": "Value",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "PreferenceRead",
       },
       Object {
         "chartLabel": "{marker.data.name}",
-        "data": Array [
-          Object {
-            "label": "Marker",
-            "value": "UserTiming",
-          },
+        "description": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "entryType",
             "label": "Entry Type",
           },
-          Object {
-            "label": "Description",
-            "value": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
-          },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
         ],
         "name": "UserTiming",
         "tableLabel": "{marker.data.name}",
@@ -11122,7 +11108,11 @@ Object {
       },
       Object {
         "chartLabel": "{marker.name} — {marker.data.name}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -11130,15 +11120,14 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "Text",
         "tableLabel": "{marker.name} — {marker.data.name}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "module",
@@ -11152,15 +11141,17 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-table",
-        ],
         "name": "Log",
         "tableLabel": "({marker.data.module}) {marker.data.name}",
       },
       Object {
         "chartLabel": "{marker.data.eventType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "duration",
             "key": "latency",
@@ -11173,66 +11164,66 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "DOMEvent",
         "tableLabel": "{marker.data.eventType}",
         "tooltipLabel": "{marker.data.eventType} — DOMEvent",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Paint",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Navigation",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Layout",
       },
       Object {
         "chartLabel": "{marker.data.messageType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-ipc",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "messageType",
@@ -11254,17 +11245,17 @@ Object {
             "label": "To",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-ipc",
-        ],
         "name": "IPC",
         "tableLabel": "{marker.name} — {marker.data.messageType} — {marker.data.niceDirection}",
         "tooltipLabel": "IPC — {marker.data.niceDirection}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -11272,32 +11263,27 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "RefreshDriverTick",
+      },
+      Object {
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [],
+        "name": "Network",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-overview",
         ],
-        "name": "RefreshDriverTick",
-      },
-      Object {
-        "data": Array [],
-        "display": Array [
-          "marker-table",
-        ],
-        "name": "Network",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "tracing",
       },
@@ -11305,7 +11291,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 54,
+    "preprocessedProfileVersion": 55,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,
@@ -12663,44 +12649,48 @@ Object {
     "interval": 1,
     "markerSchema": Array [
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMajor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCMinor",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "GCSlice",
       },
       Object {
-        "data": Array [],
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-memory",
         ],
+        "fields": Array [],
         "name": "CC",
         "tooltipLabel": "Cycle Collect",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "operation",
@@ -12726,14 +12716,14 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "FileIO",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
         ],
-        "name": "FileIO",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "microseconds",
             "key": "sampleStartTimeUs",
@@ -12745,14 +12735,15 @@ Object {
             "label": "Sample end time",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "MediaSample",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "integer",
             "key": "elementsTraversed",
@@ -12779,15 +12770,14 @@ Object {
             "label": "Styles reused",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "Styles",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "prefName",
@@ -12809,32 +12799,21 @@ Object {
             "label": "Value",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "PreferenceRead",
       },
       Object {
         "chartLabel": "{marker.data.name}",
-        "data": Array [
-          Object {
-            "label": "Marker",
-            "value": "UserTiming",
-          },
+        "description": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "entryType",
             "label": "Entry Type",
           },
-          Object {
-            "label": "Description",
-            "value": "UserTiming is created using the DOM APIs performance.mark() and performance.measure().",
-          },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
         ],
         "name": "UserTiming",
         "tableLabel": "{marker.data.name}",
@@ -12842,7 +12821,11 @@ Object {
       },
       Object {
         "chartLabel": "{marker.name} — {marker.data.name}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -12850,15 +12833,14 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-        ],
         "name": "Text",
         "tableLabel": "{marker.name} — {marker.data.name}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "module",
@@ -12872,15 +12854,17 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-table",
-        ],
         "name": "Log",
         "tableLabel": "({marker.data.module}) {marker.data.name}",
       },
       Object {
         "chartLabel": "{marker.data.eventType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "duration",
             "key": "latency",
@@ -12893,66 +12877,66 @@ Object {
             "searchable": true,
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
-        ],
         "name": "DOMEvent",
         "tableLabel": "{marker.data.eventType}",
         "tooltipLabel": "{marker.data.eventType} — DOMEvent",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Paint",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Navigation",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
             "searchable": true,
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "Layout",
       },
       Object {
         "chartLabel": "{marker.data.messageType}",
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-ipc",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "messageType",
@@ -12974,17 +12958,17 @@ Object {
             "label": "To",
           },
         ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-ipc",
-        ],
         "name": "IPC",
         "tableLabel": "{marker.name} — {marker.data.messageType} — {marker.data.niceDirection}",
         "tooltipLabel": "IPC — {marker.data.niceDirection}",
       },
       Object {
-        "data": Array [
+        "display": Array [
+          "marker-chart",
+          "marker-table",
+          "timeline-overview",
+        ],
+        "fields": Array [
           Object {
             "format": "string",
             "key": "name",
@@ -12992,32 +12976,27 @@ Object {
             "searchable": true,
           },
         ],
+        "name": "RefreshDriverTick",
+      },
+      Object {
+        "display": Array [
+          "marker-table",
+        ],
+        "fields": Array [],
+        "name": "Network",
+      },
+      Object {
         "display": Array [
           "marker-chart",
           "marker-table",
           "timeline-overview",
         ],
-        "name": "RefreshDriverTick",
-      },
-      Object {
-        "data": Array [],
-        "display": Array [
-          "marker-table",
-        ],
-        "name": "Network",
-      },
-      Object {
-        "data": Array [
+        "fields": Array [
           Object {
             "format": "string",
             "key": "category",
             "label": "Type",
           },
-        ],
-        "display": Array [
-          "marker-chart",
-          "marker-table",
-          "timeline-overview",
         ],
         "name": "tracing",
       },
@@ -13025,7 +13004,7 @@ Object {
     "misc": "rv:48.0",
     "oscpu": "Intel Mac OS X 10.11",
     "platform": "Macintosh",
-    "preprocessedProfileVersion": 54,
+    "preprocessedProfileVersion": 55,
     "processType": 0,
     "product": "Firefox",
     "stackwalk": 1,

--- a/src/test/unit/marker-schema.test.js
+++ b/src/test/unit/marker-schema.test.js
@@ -24,7 +24,7 @@ import { StringTable } from '../../utils/string-table';
  */
 describe('marker schema labels', function () {
   type LabelOptions = {|
-    schemaData: $PropertyType<MarkerSchema, 'data'>,
+    schemaFields: $PropertyType<MarkerSchema, 'fields'>,
     label: string,
     payload: any,
   |};
@@ -34,7 +34,7 @@ describe('marker schema labels', function () {
   });
 
   function applyLabel(options: LabelOptions): string {
-    const { schemaData, label, payload } = options;
+    const { schemaFields, label, payload } = options;
     const categories = getDefaultCategories();
     const stringTable = StringTable.withBackingArray([
       'IPC Message',
@@ -44,7 +44,7 @@ describe('marker schema labels', function () {
     const schema = {
       name: 'TestDefinedMarker',
       display: [],
-      data: schemaData,
+      fields: schemaFields,
     };
 
     const marker: Marker = {
@@ -65,7 +65,7 @@ describe('marker schema labels', function () {
     expect(
       applyLabel({
         label: 'Just text',
-        schemaData: [],
+        schemaFields: [],
         payload: {},
       })
     ).toEqual('Just text');
@@ -76,7 +76,9 @@ describe('marker schema labels', function () {
     expect(
       applyLabel({
         label: '{marker.data.duration}',
-        schemaData: [{ key: 'duration', label: 'Duration', format: 'seconds' }],
+        schemaFields: [
+          { key: 'duration', label: 'Duration', format: 'seconds' },
+        ],
         payload: { duration: 12345 },
       })
     ).toEqual('12.345s');
@@ -87,7 +89,9 @@ describe('marker schema labels', function () {
     expect(
       applyLabel({
         label: 'It took {marker.data.duration} for this test.',
-        schemaData: [{ key: 'duration', label: 'Duration', format: 'seconds' }],
+        schemaFields: [
+          { key: 'duration', label: 'Duration', format: 'seconds' },
+        ],
         payload: { duration: 12345 },
       })
     ).toEqual('It took 12.345s for this test.');
@@ -98,7 +102,7 @@ describe('marker schema labels', function () {
     expect(
       applyLabel({
         label: 'It took {marker.data.duration}, which is {marker.data.ratio}',
-        schemaData: [
+        schemaFields: [
           { key: 'duration', label: 'Duration', format: 'seconds' },
           { key: 'ratio', label: 'Ratio', format: 'percentage' },
         ],
@@ -115,7 +119,9 @@ describe('marker schema labels', function () {
     expect(
       applyLabel({
         label: 'This will be nothing: "{marker.data.nokey}"',
-        schemaData: [{ key: 'duration', label: 'Duration', format: 'seconds' }],
+        schemaFields: [
+          { key: 'duration', label: 'Duration', format: 'seconds' },
+        ],
         payload: { duration: 12345 },
       })
     ).toEqual('This will be nothing: ""');
@@ -131,7 +137,7 @@ describe('marker schema labels', function () {
         'Name: {marker.name}',
         'Category: {marker.category}',
       ].join('\n'),
-      schemaData: [],
+      schemaFields: [],
       payload: {},
     });
 
@@ -149,7 +155,7 @@ describe('marker schema labels', function () {
     expect(
       applyLabel({
         label: '{marker.data.message} happened because of {marker.data.event}',
-        schemaData: [
+        schemaFields: [
           { key: 'message', label: 'Message', format: 'unique-string' },
           { key: 'event', label: 'Event', format: 'unique-string' },
         ],
@@ -167,7 +173,7 @@ describe('marker schema labels', function () {
       expect(
         applyLabel({
           label,
-          schemaData: [
+          schemaFields: [
             { key: 'duration', label: 'Duration', format: 'seconds' },
           ],
           payload: { duration: 12345 },

--- a/src/test/unit/merge-compare.test.js
+++ b/src/test/unit/merge-compare.test.js
@@ -560,7 +560,7 @@ describe('mergeThreads function', function () {
     profile.meta.markerSchema.push({
       name: 'testSchemaWithUniqueUrlField',
       display: [],
-      data: [{ key: 'fieldWithUniqueString', format: 'unique-string' }],
+      fields: [{ key: 'fieldWithUniqueString', format: 'unique-string' }],
     });
     const thread1 = profile.threads[0];
     const thread2 = profile.threads[1];

--- a/src/test/unit/sanitize.test.js
+++ b/src/test/unit/sanitize.test.js
@@ -16,7 +16,6 @@ import {
   getNetworkMarkers,
 } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/flow';
-import type { RemoveProfileInformation } from 'firefox-profiler/types';
 import {
   correlateIPCMarkers,
   deriveMarkersFromRawMarkerTable,
@@ -29,6 +28,7 @@ import {
   callTreeFromProfile,
   formatTree,
 } from 'firefox-profiler/test/fixtures/utils';
+import type { RemoveProfileInformation } from 'firefox-profiler/types';
 
 describe('sanitizePII', function () {
   function setup(
@@ -73,7 +73,7 @@ describe('sanitizePII', function () {
       FileIO: {
         name: 'FileIO',
         display: ['marker-chart', 'marker-table', 'timeline-fileio'],
-        data: [
+        fields: [
           {
             key: 'operation',
             label: 'Operation',
@@ -104,7 +104,7 @@ describe('sanitizePII', function () {
         name: 'Url',
         tableLabel: '{marker.name} - {marker.data.url}',
         display: ['marker-chart', 'marker-table'],
-        data: [
+        fields: [
           {
             key: 'url',
             format: 'url',
@@ -115,7 +115,7 @@ describe('sanitizePII', function () {
         name: 'HostResolver',
         tableLabel: '{marker.name} - {marker.data.host}',
         display: ['marker-chart', 'marker-table'],
-        data: [
+        fields: [
           {
             key: 'host',
             format: 'sanitized-string',

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -15,7 +15,12 @@ import type {
   ProfilerConfiguration,
   SampleUnits,
 } from './profile';
-import type { MarkerPayload_Gecko, MarkerSchema } from './markers';
+import type {
+  MarkerPayload_Gecko,
+  MarkerDisplayLocation,
+  MarkerFormatType,
+  MarkerGraph,
+} from './markers';
 import type { Milliseconds, Nanoseconds, MemoryOffset, Bytes } from './units';
 
 export type IndexIntoGeckoFrameTable = number;
@@ -76,7 +81,7 @@ export type ExternalMarkers = {
 
 export type ExternalMarkersData =
   | {|
-      markerSchema: MarkerSchema[],
+      markerSchema: GeckoMetaMarkerSchema[],
       categories: CategoryList,
       markers: ExternalMarkers,
     |}
@@ -325,6 +330,72 @@ export type GeckoProfilerOverhead = {|
   statistics?: ProfilerOverheadStats,
 |};
 
+export type GeckoDynamicFieldSchemaData = {|
+  // The property key of the marker data property that carries the field value.
+  key: string,
+
+  // An optional user-facing label.
+  // If no label is provided, the key is displayed instead.
+  label?: string,
+
+  // The format / type of this field. This affects how the field's value is
+  // displayed and determines which types of values are accepted for this field.
+  format: MarkerFormatType,
+
+  // If present and set to true, the marker search string will be matched
+  // against the values of this field when determining which markers match the
+  // search.
+  searchable?: boolean,
+
+  // If present and set to true, this field will not be shown in the list
+  // of fields in the tooltip or in the sidebar. Such fields can still be
+  // used inside labels and they can be searchable.
+  hidden?: boolean,
+|};
+
+export type GeckoStaticFieldSchemaData = {|
+  // This type is a static bit of text that will be displayed
+  label: string,
+  value: string,
+|};
+
+export type GeckoMetaMarkerSchema = {|
+  // The unique identifier for this marker.
+  name: string, // e.g. "CC"
+
+  // The label of how this marker should be displayed in the UI.
+  // If none is provided, then the name is used.
+  tooltipLabel?: string, // e.g. "Cycle Collect"
+
+  // This is how the marker shows up in the Marker Table description.
+  // If none is provided, then the name is used.
+  tableLabel?: string, // e.g. "{marker.data.eventType} – DOMEvent"
+
+  // This is how the marker shows up in the Marker Chart, where it is drawn
+  // on the screen as a bar.
+  // If none is provided, then the name is used.
+  chartLabel?: string,
+
+  // The locations to display
+  display: MarkerDisplayLocation[],
+
+  data: Array<GeckoDynamicFieldSchemaData | GeckoStaticFieldSchemaData>,
+
+  // if present, give the marker its own local track
+  graphs?: Array<MarkerGraph>,
+
+  // If set to true, markers of this type are assumed to be well-nested with all
+  // other stack-based markers on the same thread. Stack-based markers may
+  // be displayed in a different part of the marker chart than non-stack-based
+  // markers.
+  // Instant markers are always well-nested.
+  // For interval markers, or for intervals defined by a start and an end marker,
+  // well-nested means that, for all marker-defined timestamp intervals A and B,
+  // A either fully encompasses B or is fully encompassed by B - there is no
+  // partial overlap.
+  isStackBased?: boolean,
+|};
+
 /* This meta object is used in subprocesses profiles.
  * Using https://searchfox.org/mozilla-central/rev/7556a400affa9eb99e522d2d17c40689fa23a729/tools/profiler/core/platform.cpp#1829
  * as source of truth. (Please update the link whenever there's a new property).
@@ -336,7 +407,7 @@ export type GeckoProfileShortMeta = {|
   startTime: Milliseconds,
   shutdownTime: Milliseconds | null,
   categories: CategoryList,
-  markerSchema: MarkerSchema[],
+  markerSchema: GeckoMetaMarkerSchema[],
 |};
 
 /* This meta object is used on the top level profile object.

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -118,6 +118,29 @@ export type MarkerGraph = {|
   color?: GraphColor,
 |};
 
+export type MarkerSchemaField = {|
+  // The property key of the marker data property that carries the field value.
+  key: string,
+
+  // An optional user-facing label.
+  // If no label is provided, the key is displayed instead.
+  label?: string,
+
+  // The format / type of this field. This affects how the field's value is
+  // displayed and determines which types of values are accepted for this field.
+  format: MarkerFormatType,
+
+  // If present and set to true, the marker search string will be matched
+  // against the values of this field when determining which markers match the
+  // search.
+  searchable?: boolean,
+
+  // If present and set to true, this field will not be shown in the list
+  // of fields in the tooltip or in the sidebar. Such fields can still be
+  // used inside labels and they can be searchable.
+  hidden?: boolean,
+|};
+
 export type MarkerSchema = {|
   // The unique identifier for this marker.
   name: string, // e.g. "CC"
@@ -138,24 +161,13 @@ export type MarkerSchema = {|
   // The locations to display
   display: MarkerDisplayLocation[],
 
-  data: Array<
-    | {|
-        key: string,
-        // If no label is provided, the key is displayed.
-        label?: string,
-        format: MarkerFormatType,
-        searchable?: boolean,
-        // If present and set to true, this field will not be shown in the list
-        // of fields in the tooltip or in the sidebar. Such fields can still be
-        // used inside labels and they can be searchable.
-        hidden?: boolean,
-      |}
-    | {|
-        // This type is a static bit of text that will be displayed
-        label: string,
-        value: string,
-      |},
-  >,
+  // The fields that can be present on markers of this type.
+  // Not all listed fields have to be present on every marker (they're all optional).
+  fields: MarkerSchemaField[],
+
+  // An optional description for markers of this type.
+  // Will be displayed to the user.
+  description?: string,
 
   // if present, give the marker its own local track
   graphs?: Array<MarkerGraph>,


### PR DESCRIPTION
In a marker schema, the `data` array can currently hold both "dynamic" and "static" fields. Dynamic fields get their value from each marker, static fields have a single fixed value.

In the years since the marker schema has been available, the only thing we've used "static" fields for is a "description" field.

So I think we should just have an actual description field which is separate from schema.data. And we should remove generic "static" fields. This simplifies the format, and it also simplifies our code because we can iterate over the fields without having to check whether a field is a static or a dynamic field - Flow was requiring extra verbose checks in this case because the two field types don't have a shared discriminator property.

This change does make the schema a little less expressive, but nobody was making use of the extra expressivity.

Also, at some point we'll want to move to a more compact representation of markers in the profile JSON by not repeating the field keys on every marker. One way to do this would be to store marker field values in an array, where each array value maps to the field at the corresponding index. This representation makes more sense if the fields array only contains fields that actually get their value from the marker.

This PR only changes the processed format. The Gecko profile format remains unchanged. We can change it in a follow-up.

On the Gecko side, we currently have an old and [a new way](https://bugzilla.mozilla.org/show_bug.cgi?id=1869835) to declare marker schemas. The new way got rid of static fields too and just accepts [a description](https://searchfox.org/mozilla-central/rev/f256e50e068136275c1a2aff827aeddc92a75e07/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#1089-1091) (but still outputs the description as a static field).