### PR TITLE
Update the command to gather locale changes

### DIFF
--- a/docs-developer/deploying.md
+++ b/docs-developer/deploying.md
@@ -68,10 +68,8 @@ git fetch upstream && git log upstream/production..upstream/main --first-parent 
 3. Gather the locales author changes:
 
 ```
-for i in ./locales/* ; do git log upstream/production..upstream/main --grep Pontoon: --oneline --no-decorate --format="format:$(basename $i): %an" $i ; done
+git log upstream/production..upstream/main --grep '^Pontoon' --format="%(trailers:key=Co-authored-by,valueonly)" | awk NF | sed -E 's/([^<]*).*\(([a-z-]+)\)/\2: \1/i' | sort -h | uniq
 ```
-
-4. You'll also need to adjust the result, by merging the lines for the same locale.
 
 ## How to revert to a previous version
 


### PR DESCRIPTION
Here is the new command:

```
git log upstream/production..upstream/main --grep '^Pontoon' --format="%(trailers:key=Co-authored-by,valueonly)" | awk NF | sed -E 's/([^<]*).*\(([a-z-]+)\)/\2: \1/i' | sort -h | uniq
```

There are a few tricks:
* `awk NF` removes empty lines. Indeed `NF` (number of fields) is 0 for an empty line, and therefore `false`, skipping the default `print` for that line.
* the `sed` line captures the part before `<` and the part between parentheses, and inverts them.
* `sort -h` sorts the results, and `uniq` removes the identical lines

I believe that we should probably do a shell script (or else) to merge this line (with comments) with the one for the other changes, but that will be for later.