### PR TITLE
Make sure that sanitized urls still appear in the tab selector

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -3386,8 +3386,9 @@ export function extractProfileFilterPageData(
     const isExtension = pageUrl.startsWith('moz-extension://');
     const defaultFavicon = isExtension ? ExtensionFavicon : DefaultLinkFavicon;
     const pageData: ProfileFilterPageData = {
-      origin: '',
-      hostname: '',
+      // These will be used as a fallback if the urls have been sanitized.
+      origin: pageUrl,
+      hostname: pageUrl,
       favicon: currentPage.favicon ?? defaultFavicon,
     };
 
@@ -3409,10 +3410,9 @@ export function extractProfileFilterPageData(
 
       pageData.origin = page.origin;
     } catch (e) {
-      console.warn(
-        'Error while extracing the hostname and favicon from the page url',
-        pageUrl
-      );
+      // Error while extracting the hostname and favicon from the page url.
+      // It's likely that it's because sanitization removed the urls. Just
+      // ignore it and default to the initial sanitized url.
     }
 
     // Adding it to the map outside of the try-catch block, just in case something

--- a/src/test/components/TabSelectorMenu.test.js
+++ b/src/test/components/TabSelectorMenu.test.js
@@ -19,6 +19,7 @@ import { storeWithProfile } from '../fixtures/stores';
 import { fireFullClick } from '../fixtures/utils';
 import { getTabFilter } from '../../selectors/url-state';
 import { ensureExists } from 'firefox-profiler/utils/flow';
+import { removeURLs } from 'firefox-profiler/utils/string';
 
 describe('app/TabSelectorMenu', () => {
   function setup() {
@@ -176,5 +177,49 @@ describe('app/TabSelectorMenu', () => {
     expect(profilerTab.compareDocumentPosition(mozillaTab)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
+  });
+
+  it('should render sanitized page urls correctly', () => {
+    const { profile, ...extraPageData } = addActiveTabInformationToProfile(
+      getProfileWithNiceTracks()
+    );
+    // This is needed for the thread activity score calculation.
+    profile.meta.sampleUnits = {
+      time: 'ms',
+      eventDelay: 'ms',
+      threadCPUDelta: 'ns',
+    };
+
+    // Add a webextension url to test it.
+    ensureExists(profile.pages)[4].url =
+      'moz-extension://259ec0ce-9df7-8e4a-ad30-3b67bed900f3/';
+
+    // Sanitize the page urls.
+    profile.pages = ensureExists(profile.pages).map((page, index) => ({
+      ...page,
+      url: removeURLs(page.url, `<Page #${index}>`),
+    }));
+
+    // Attach innerWindowIDs to the samples.
+    profile.threads[0].frameTable.innerWindowID[0] =
+      extraPageData.parentInnerWindowIDsWithChildren;
+    profile.threads[0].frameTable.length++;
+    profile.threads[0].frameTable.innerWindowID[1] =
+      extraPageData.secondTabInnerWindowIDs[0];
+    profile.threads[0].frameTable.length++;
+
+    const store = storeWithProfile(profile);
+    render(
+      <Provider store={store}>
+        <TabSelectorMenu />
+      </Provider>
+    );
+
+    // Make sure that sanitized https and moz-extension urls are still visible.
+    expect(screen.getByText('https://', { exact: false })).toBeInTheDocument();
+    expect(
+      screen.getByText('moz-extension://', { exact: false })
+    ).toBeInTheDocument();
+    expect(document.body).toMatchSnapshot();
   });
 });

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.js.snap
@@ -61,3 +61,50 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
   </div>
 </body>
 `;
+
+exports[`app/TabSelectorMenu should render sanitized page urls correctly 1`] = `
+<body>
+  <div>
+    <nav
+      class="react-contextmenu TabSelectorMenu"
+      role="menu"
+      style="position: fixed; opacity: 0; pointer-events: none;"
+      tabindex="-1"
+    >
+      <div
+        aria-checked="false"
+        aria-disabled="false"
+        class="react-contextmenu-item tabSelectorMenuItem checkable checked"
+        role="menuitem"
+        tabindex="-1"
+      >
+        All tabs and windows
+      </div>
+      <div
+        aria-checked="true"
+        aria-disabled="false"
+        class="react-contextmenu-item tabSelectorMenuItem checkable"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <div
+          class="nodeIcon "
+        />
+        moz-extension://&lt;Page #4&gt;
+      </div>
+      <div
+        aria-checked="true"
+        aria-disabled="false"
+        class="react-contextmenu-item tabSelectorMenuItem checkable"
+        role="menuitem"
+        tabindex="-1"
+      >
+        <div
+          class="nodeIcon "
+        />
+        https://&lt;Page #3&gt;
+      </div>
+    </nav>
+  </div>
+</body>
+`;


### PR DESCRIPTION
Fixes #5400.

Previously we were simply using empty strings for the fallback texts, which was not correct in case the urls were sanitized. Now we are adding the sanitized url as a fallback url in case we fail to get the hostname and domain which is the case for sanitized urls.

[Production](https://share.firefox.dev/41YaftP) / [Deploy preview](https://deploy-preview-5404--perf-html.netlify.app/public/edyfn8aay61ddac2r44v7r8bbkhp03mk51v934g/calltree/?globalTrackOrder=0wx2&hiddenGlobalTracks=1wx0&hiddenLocalTracksByPid=24215-13wl~27162-0w2~35744-0w4~24229-01~26114-0w2~24244-0~24226-0~26051-0w2~24224-01~24219-0~35745-01~33884-0w2~35642-0w2~24216-01~27171-0w2~34116-0w2~36699-01~24223-0w6~24221-0w7~35690-01~33889-0w3~35405-0w3~27369-0w3~35691-01~35246-0w2~33984-0w4~33883-0w3~35746-01~35692-01~34153-0w2~27260-0w4~35283-0w2~34151-0w5~24218-0w4~24222-0w4&thread=zu&v=10)