### PR TITLE
Use RawThread in getThreadProcessDetails.

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -2850,7 +2850,7 @@ export function getFriendlyThreadName(
 }
 
 export function getThreadProcessDetails(
-  thread: Thread,
+  thread: RawThread,
   friendlyThreadName: string
 ): string {
   let label = `${friendlyThreadName}\n`;

--- a/src/selectors/per-thread/thread.js
+++ b/src/selectors/per-thread/thread.js
@@ -316,7 +316,7 @@ export function getBasicThreadSelectorsPerThread(
   );
 
   const getThreadProcessDetails: Selector<string> = createSelector(
-    getThread,
+    getRawThread,
     getFriendlyThreadName,
     ProfileData.getThreadProcessDetails
   );


### PR DESCRIPTION
This means that we don't need to compute the derived thread for non-visible threads. We call getThreadProcessDetails on non-visible threads when deriving the props for TimelineLocalTrack components.

Furthermore, this speeds up calls to getThreadProcessDetails after redux state changes, because getRawThread doesn't have any dependent selectors that need to be revalidated.