### PR TITLE
Sanitize query strings of `about:*` urls

### DIFF
--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -174,6 +174,21 @@ describe('utils/string', function () {
 
       string = 'Load: about:home?foo=bar#baz';
       expect(removeURLs(string)).toEqual('Load: about:home?<sanitized>');
+
+      string = 'about:config?u=foo=bar another text';
+      expect(removeURLs(string)).toEqual(
+        'about:config?<sanitized> another text'
+      );
+
+      string = 'about:profiling#foo-bar another text';
+      expect(removeURLs(string)).toEqual(
+        'about:profiling#<sanitized> another text'
+      );
+
+      string = 'Load: about:home?foo=bar#baz another text';
+      expect(removeURLs(string)).toEqual(
+        'Load: about:home?<sanitized> another text'
+      );
     });
 
     it('should remove page URLs from moz-page-thumb URLs', () => {

--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -189,6 +189,11 @@ describe('utils/string', function () {
       expect(removeURLs(string)).toEqual(
         'Load: about:home?<sanitized> another text'
       );
+
+      string = '(about:home?foo=bar#baz) another text';
+      expect(removeURLs(string)).toEqual(
+        '(about:home?<sanitized>) another text'
+      );
     });
 
     it('should remove page URLs from moz-page-thumb URLs', () => {

--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -160,7 +160,19 @@ describe('utils/string', function () {
       string = 'about:profiling?foo=bar&u=https%3A//www.google.com/';
       expect(removeURLs(string)).toEqual('about:profiling?<sanitized>');
 
+      string = 'about:profiling#foo-bar';
+      expect(removeURLs(string)).toEqual('about:profiling#<sanitized>');
+
+      string = 'about:profiling?foo=bar#baz';
+      expect(removeURLs(string)).toEqual('about:profiling?<sanitized>');
+
       string = 'Load: about:home?foo=bar';
+      expect(removeURLs(string)).toEqual('Load: about:home?<sanitized>');
+
+      string = 'Load: about:home#foo-bar';
+      expect(removeURLs(string)).toEqual('Load: about:home#<sanitized>');
+
+      string = 'Load: about:home?foo=bar#baz';
       expect(removeURLs(string)).toEqual('Load: about:home?<sanitized>');
     });
 

--- a/src/test/unit/string.test.js
+++ b/src/test/unit/string.test.js
@@ -136,6 +136,34 @@ describe('utils/string', function () {
       expect(removeURLs(string)).toEqual(string);
     });
 
+    it('should not remove basic about URLs', () => {
+      let string = 'about:profiling';
+      expect(removeURLs(string)).toEqual(string);
+
+      string = 'about:config';
+      expect(removeURLs(string)).toEqual(string);
+
+      string = 'about:home';
+      expect(removeURLs(string)).toEqual(string);
+
+      string = 'Load: about:home';
+      expect(removeURLs(string)).toEqual(string);
+    });
+
+    it('should remove the query strings of about URLs', () => {
+      let string = 'about:config?u=foo=bar';
+      expect(removeURLs(string)).toEqual('about:config?<sanitized>');
+
+      string = 'about:home?u=https%3A//www.google.com/';
+      expect(removeURLs(string)).toEqual('about:home?<sanitized>');
+
+      string = 'about:profiling?foo=bar&u=https%3A//www.google.com/';
+      expect(removeURLs(string)).toEqual('about:profiling?<sanitized>');
+
+      string = 'Load: about:home?foo=bar';
+      expect(removeURLs(string)).toEqual('Load: about:home?<sanitized>');
+    });
+
     it('should remove page URLs from moz-page-thumb URLs', () => {
       const string =
         'Image Load - moz-page-thumb://thumbnails/?url=https%3A%2F%2Fprofiler.firefox.com%2F';

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -32,10 +32,10 @@ const REMOVE_URLS_REGEXP = (function () {
   //                          Word boundary, ensures the protocol isn't part of a larger word.
 
   // Captures the base 'about:...' part (like "about:profiling") in group 2
-  const aboutQueryPattern = `\\b(about:[^?#\\s]+)([?#])[^\\s]*`;
-  //                         ^  ^                ^  ^
-  //                         |  |                |  Captures the query string:
-  //                         |  |                |  Zero or more non-whitespace characters.
+  const aboutQueryPattern = `\\b(about:[^?#\\s]+)([?#])[^\\s)]*`;
+  //                         ^  ^                ^     ^
+  //                         |  |                |     Captures the query string:
+  //                         |  |                |     Zero or more non-whitespace characters except ')'.
   //                         |  |                Matches the literal '?' or '#' as a saparator (Group 3)
   //                         |  Captures the base 'about:' URI (Group 2):
   //                         |  'about:' followed by one or more non-?, non-#, non-whitespace chars.

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -32,13 +32,13 @@ const REMOVE_URLS_REGEXP = (function () {
   //                          Word boundary, ensures the protocol isn't part of a larger word.
 
   // Captures the base 'about:...' part (like "about:profiling") in group 2
-  const aboutQueryPattern = `\\b(about:[^?#\\s]+)\\?([^\\s]*)`;
+  const aboutQueryPattern = `\\b(about:[^?#\\s]+)([?#])[^\\s]*`;
   //                         ^  ^                ^  ^
-  //                         |  |                |  Captures the query string (Group 3):
+  //                         |  |                |  Captures the query string:
   //                         |  |                |  Zero or more non-whitespace characters.
-  //                         |  |                Matches the literal '?' separating path and query.
+  //                         |  |                Matches the literal '?' or '#' as a saparator (Group 3)
   //                         |  Captures the base 'about:' URI (Group 2):
-  //                         |  about:' followed by one or more non-?, non-#, non-whitespace chars.
+  //                         |  'about:' followed by one or more non-?, non-#, non-whitespace chars.
   //                         |
   //                         Word boundary, ensures the protocol isn't part of a larger word.
 
@@ -63,7 +63,7 @@ export function removeURLs(
 ): string {
   return string.replace(
     REMOVE_URLS_REGEXP,
-    (match, protoGroup, aboutBaseGroup) => {
+    (match, protoGroup, aboutBaseGroup, separator) => {
       if (protoGroup) {
         // Matched a standard URL (http, https, ftp, file, etc.).
         // Replace everything after the protocol part
@@ -71,7 +71,7 @@ export function removeURLs(
       } else if (aboutBaseGroup) {
         // Matched an `about:` URL with a query string.
         // Replace only the query string part (after '?')
-        return aboutBaseGroup + '?' + sanitizedQueryText;
+        return aboutBaseGroup + separator + sanitizedQueryText;
       }
       return match;
     }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -19,16 +19,32 @@ const REMOVE_URLS_REGEXP = (function () {
     'moz-page-thumb',
   ];
 
+  // Captures the protocol part (like "http://") in group 1
+  const standardUrlPattern = `\\b((?:${protocols.join('|')})://)/?[^\\s/$.?#][^\\s)]*`;
+  //                          ^  ^                              ^ ^          ^
+  //                          |  |                              | |          Matches any characters except
+  //                          |  |                              | |          whitespaces and ')' character.
+  //                          |  |                              | Matches any character except whitespace
+  //                          |  |                              | and '/', '$', '.', '?' or '#' characters
+  //                          |  |                              | because this is start of the URL path/host
+  //                          |  |                              Optional '/' after '://'
+  //                          |  Captures the protocol and '://' part (Group 1)
+  //                          Word boundary, ensures the protocol isn't part of a larger word.
+
+  // Captures the base 'about:...' part (like "about:profiling") in group 2
+  const aboutQueryPattern = `\\b(about:[^?#\\s]+)\\?([^\\s]*)`;
+  //                         ^  ^                ^  ^
+  //                         |  |                |  Captures the query string (Group 3):
+  //                         |  |                |  Zero or more non-whitespace characters.
+  //                         |  |                Matches the literal '?' separating path and query.
+  //                         |  Captures the base 'about:' URI (Group 2):
+  //                         |  about:' followed by one or more non-?, non-#, non-whitespace chars.
+  //                         |
+  //                         Word boundary, ensures the protocol isn't part of a larger word.
+
   return new RegExp(
-    `\\b((?:${protocols.join('|')})://)/?[^\\s/$.?#][^\\s)]*`,
-    //    ^                              ^          ^
-    //    |                              |          Matches any characters except
-    //    |                              |          whitespaces and ')' character.
-    //    |                              |          Other characters are allowed now
-    //    |                              Matches any character except whitespace
-    //    |                              and '/', '$', '.', '?' or '#' characters
-    //    |                              because this is start of the URL
-    //    Matches URL schemes we need to sanitize.
+    // Combine two patterns into one RegExp.
+    `${standardUrlPattern}|${aboutQueryPattern}`,
     'gi'
   );
 })();
@@ -37,12 +53,29 @@ const REMOVE_URLS_REGEXP = (function () {
  * Takes a string and returns the string with public URLs removed.
  * It doesn't remove the URLs like `chrome://..` because they are internal URLs
  * and they shouldn't be removed.
+ *
+ * Additionally, for "about:*" URLs, only remove the query strings if they exist.
  */
 export function removeURLs(
   string: string,
-  redactedText: string = '<URL>'
+  redactedText: string = '<URL>',
+  sanitizedQueryText: string = '<sanitized>'
 ): string {
-  return string.replace(REMOVE_URLS_REGEXP, '$1' + redactedText);
+  return string.replace(
+    REMOVE_URLS_REGEXP,
+    (match, protoGroup, aboutBaseGroup) => {
+      if (protoGroup) {
+        // Matched a standard URL (http, https, ftp, file, etc.).
+        // Replace everything after the protocol part
+        return protoGroup + redactedText;
+      } else if (aboutBaseGroup) {
+        // Matched an `about:` URL with a query string.
+        // Replace only the query string part (after '?')
+        return aboutBaseGroup + '?' + sanitizedQueryText;
+      }
+      return match;
+    }
+  );
 }
 
 /**


### PR DESCRIPTION
This PR changes the sanitizeURL function to also sanitize the query string parts of `about:*` urls.


The regexp became a bit more scarier, but hopefully it'll be easy to review.