### PR TITLE
Fix the base64url decoding function

### DIFF
--- a/src/test/unit/jwt.test.js
+++ b/src/test/unit/jwt.test.js
@@ -43,8 +43,8 @@ describe('jwt/isValidJwtToken', () => {
 
 describe('jwt/decodeJwtBase64Url', () => {
   it('decodes base64url values', () => {
-    const fixture = 'eyJuYW1lIjoiP34_fj9-In0';
-    const expected = '{"name":"?~?~?~"}';
+    const fixture = 'eyJuYW1lIjoiP34_fj9-P34_fj9-P34ifQ';
+    const expected = '{"name":"?~?~?~?~?~?~?~"}';
     expect(Jwt.decodeJwtBase64Url(fixture)).toEqual(expected);
   });
 });

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -45,9 +45,17 @@ export function decodeJwtBase64Url(base64UrlEncodedValue: string): string {
   // most implementations do.
 
   // We do need to convert the string to a "normal" base64 encoding though.
-  const base64EncodedValue = base64UrlEncodedValue
-    .replace('-', '+')
-    .replace('_', '/');
+  const base64EncodedValue = base64UrlEncodedValue.replace(
+    /[-_]/g,
+    (matched) => {
+      // prettier-ignore
+      switch (matched) {
+        case '-': return '+';
+        case '_': return '/';
+        default: throw new Error(`Unexpected match ${matched}`);
+      }
+    }
+  );
 
   return atob(base64EncodedValue);
 }


### PR DESCRIPTION
I realized, while working on another project, that our implementation was wrong: we were replacing only the first occurrence of `-` and `_` 😱. Fortunately with JWT we're working with small strings so this probably has been a problem very rarely.

I'll also have to change it in https://phabricator.services.mozilla.com/D243185#:~:text=export%20function%20decodejwtbase64url(base64urlencodedvalue)%20%7B once you approve this patch.