### PR TITLE
Make the tab bar scrollable to allow accessing tabs on narrow page widths (mobile layout)

### DIFF
--- a/src/components/app/Details.css
+++ b/src/components/app/Details.css
@@ -7,7 +7,6 @@
 /* contains the tabbar and, if present, the sidebar button */
 .Details-top-bar {
   display: flex;
-  overflow: hidden;
   flex-flow: row nowrap;
   align-items: center;
   justify-content: space-between; /* This pushes the sidebar button to the right */

--- a/src/components/app/Details.css
+++ b/src/components/app/Details.css
@@ -7,6 +7,7 @@
 /* contains the tabbar and, if present, the sidebar button */
 .Details-top-bar {
   display: flex;
+  overflow: hidden;
   flex-flow: row nowrap;
   align-items: center;
   justify-content: space-between; /* This pushes the sidebar button to the right */

--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -22,7 +22,7 @@
   flex: 1;
   flex-flow: row nowrap;
   padding: 0;
-  margin: 0 -0.5px -1px; /* This combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border */
+  margin: 0 -0.5px -1px; /* The -0.5px horizontal margin combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border. The -1px bottom margin makes our contents overlap the .Details-top-bar bottom border, so that the selected tab can cover that bottom border. */
   list-style: none;
   scrollbar-width: none;
 }
@@ -33,7 +33,7 @@
   padding: 6px 4px 5px;
   border: solid transparent;
   border-width: 0 1px;
-  margin: 0 -0.5px 1px; /* This makes the 1px border between adjacent tabs overlap */
+  margin: 0 -0.5px 1px; /* The -0.5px horizontal margin makes the 1px border between adjacent tabs overlap. The 1px bottom margin makes space for the .Details-top-bar bottom border. */
   background-clip: padding-box;
   cursor: default;
   font-size: 12px;
@@ -79,7 +79,7 @@
   z-index: 1;
   padding: 6px 4px;
   border-color: var(--grey-30);
-  margin: 0 -0.5px; /* Expand 1px towards the bottom to cover the tab bar bottom border. */
+  margin: 0 -0.5px; /* No bottom margin, so that this tab covers the .Details-top-bar bottom border. */
   background: #fff;
   color: var(--blue-60);
   transition: none; /* Switch the background color instantly when a tab is selected */

--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -22,6 +22,12 @@
   padding: 0;
   margin: 0 -0.5px; /* This combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border */
   list-style: none;
+
+  @media screen and (max-width: 768px) {
+    overflow: scroll hidden;
+    border-right: 1px solid var(--grey-30);
+    scrollbar-width: none;
+  }
 }
 
 .tabBarTab {

--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -18,16 +18,13 @@
 .tabBarTabWrapper {
   display: flex;
   min-width: 0; /* This makes the tab container actually shrinkable below min-content */
+  flex: 1;
   flex-flow: row nowrap;
   padding: 0;
   margin: 0 -0.5px; /* This combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border */
   list-style: none;
-
-  @media screen and (max-width: 768px) {
-    overflow: scroll hidden;
-    border-right: 1px solid var(--grey-30);
-    scrollbar-width: none;
-  }
+  overflow-x: auto;
+  scrollbar-width: none;
 }
 
 .tabBarTab {

--- a/src/components/app/TabBar.css
+++ b/src/components/app/TabBar.css
@@ -17,23 +17,23 @@
 
 .tabBarTabWrapper {
   display: flex;
+  overflow: auto hidden;
   min-width: 0; /* This makes the tab container actually shrinkable below min-content */
   flex: 1;
   flex-flow: row nowrap;
   padding: 0;
-  margin: 0 -0.5px; /* This combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border */
+  margin: 0 -0.5px -1px; /* This combines with the -0.5px horizontal margin of .tabBarTab to clip off the first tab's 1px starting border */
   list-style: none;
-  overflow-x: auto;
   scrollbar-width: none;
 }
 
 .tabBarTab {
   position: relative;
   min-width: 8em;
-  padding: 6px 4px;
+  padding: 6px 4px 5px;
   border: solid transparent;
   border-width: 0 1px;
-  margin: 0 -0.5px; /* This makes the 1px border between adjacent tabs overlap */
+  margin: 0 -0.5px 1px; /* This makes the 1px border between adjacent tabs overlap */
   background-clip: padding-box;
   cursor: default;
   font-size: 12px;
@@ -77,8 +77,9 @@
 
 .tabBarTab.selected {
   z-index: 1;
+  padding: 6px 4px;
   border-color: var(--grey-30);
-  margin-bottom: -1px; /* Expand 1px towards the bottom to cover the tab bar bottom border. */
+  margin: 0 -0.5px; /* Expand 1px towards the bottom to cover the tab bar bottom border. */
   background: #fff;
   color: var(--blue-60);
   transition: none; /* Switch the background color instantly when a tab is selected */

--- a/src/components/shared/MarkerSettings.css
+++ b/src/components/shared/MarkerSettings.css
@@ -8,6 +8,9 @@
   flex-flow: row nowrap;
   padding: 0;
   line-height: 25px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  white-space: nowrap;
 }
 
 .filterMarkersButton {

--- a/src/components/shared/MarkerSettings.css
+++ b/src/components/shared/MarkerSettings.css
@@ -4,11 +4,11 @@
 
 .markerSettings {
   display: flex;
+  overflow: auto hidden;
   height: 25px;
   flex-flow: row nowrap;
   padding: 0;
   line-height: 25px;
-  overflow-x: auto;
   scrollbar-width: none;
   white-space: nowrap;
 }

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -9,6 +9,11 @@
   align-items: stretch;
   padding: 0;
   white-space: nowrap;
+
+  @media screen and (max-width: 768px) {
+    overflow: scroll hidden;
+    scrollbar-width: none;
+  }
 }
 
 .stackSettingsSelect {

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -4,11 +4,11 @@
 
 .stackSettings {
   display: flex;
+  overflow: auto hidden;
   height: 25px;
   flex-flow: row nowrap;
   align-items: stretch;
   padding: 0;
-  overflow-x: auto;
   scrollbar-width: none;
   white-space: nowrap;
 }

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -8,12 +8,9 @@
   flex-flow: row nowrap;
   align-items: stretch;
   padding: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
   white-space: nowrap;
-
-  @media screen and (max-width: 768px) {
-    overflow: scroll hidden;
-    scrollbar-width: none;
-  }
 }
 
 .stackSettingsSelect {


### PR DESCRIPTION
A duplicate of the closed [Mobile View Fix for bottom sidebar #5428](https://github.com/firefox-devtools/profiler/pull/5428). Please see the former for relevant history and notes. 

Please open the profile  and set your screen to mobile view: [Deploy Preview](https://deploy-preview-5463--perf-html.netlify.app/public/rxabzrr1e4fcb8f05aavnbm7vsgcp4cn2hg7mtr/calltree/?globalTrackOrder=a0w9&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=4612-0w4~4636-0~4617-0&implementation=js&search=activity-s&thread=f&timelineType=category&v=10)


Offered solution:
- [x] Make the tab bar and stack menu scroll horizontally within the defined width. 

<img width="416" alt="Screenshot 2025-05-21 at 15 18 11" src="https://github.com/user-attachments/assets/e4f503a5-2f39-4a2a-9bd6-8162166ead07" />
