### PR TITLE
Make the sidebar start out closed on mobile screens

### DIFF
--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -49,6 +49,8 @@ type DispatchProps = {|
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
+const SMALL_SCREEN_WIDTH = 768;
+
 class ProfileViewerImpl extends PureComponent<Props> {
   _onSelectTab = (selectedTab: string) => {
     const { changeSelectedTab } = this.props;
@@ -63,6 +65,15 @@ class ProfileViewerImpl extends PureComponent<Props> {
     const { selectedTab, isSidebarOpen, changeSidebarOpenState } = this.props;
     changeSidebarOpenState(selectedTab, !isSidebarOpen);
   };
+
+  componentDidMount() {
+    const width = window.innerWidth;
+    const { selectedTab, isSidebarOpen, changeSidebarOpenState } = this.props;
+
+    if (width <= SMALL_SCREEN_WIDTH && isSidebarOpen) {
+      changeSidebarOpenState(selectedTab, false);
+    }
+  }
 
   render() {
     const { visibleTabs, selectedTab, isSidebarOpen } = this.props;


### PR DESCRIPTION
This PR closes the sidebar for mobile view. 

[Deploy preview](https://deploy-preview-5464--perf-html.netlify.app/public/rxabzrr1e4fcb8f05aavnbm7vsgcp4cn2hg7mtr/calltree/?globalTrackOrder=a0w9&hiddenGlobalTracks=1w8&hiddenLocalTracksByPid=4612-0w4~4636-0~4617-0&implementation=js&search=activity-s&thread=f&timelineType=category&v=10)