### PR TITLE
Change the tests that check co2 values so they don't fail on every co2 dependency update

### DIFF
--- a/src/test/components/TrackBandwidth.test.js
+++ b/src/test/components/TrackBandwidth.test.js
@@ -159,10 +159,36 @@ describe('TrackBandwidth', function () {
     expect(getTooltipContents()).toBeFalsy();
   });
 
-  it('has a tooltip that matches the snapshot', function () {
-    const { moveMouseAtCounter, getTooltipContents } = setup();
+  it('has a tooltip that has all the necessary information', function () {
+    const { moveMouseAtCounter } = setup();
     moveMouseAtCounter(4, 0.5);
-    expect(getTooltipContents()).toMatchSnapshot();
+
+    // Note: Fluent adds isolation characters \u2068 and \u2069 around variables.
+    expect(
+      screen.getByText('Transfer speed for this sample:')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/speed/).nextSibling).toHaveTextContent(
+      '4.66GB\u2069 per second'
+    );
+
+    expect(
+      screen.getByText('read/write operations since the previous sample:')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/operations/).nextSibling).toHaveTextContent('0');
+
+    expect(
+      screen.getByText('Data transferred up to this time:')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/transferred up to/).nextSibling).toHaveTextContent(
+      /6.86MB\u2069 \(\u2068\d+(\.\d+)?\u2069 g CO₂e\)/
+    );
+
+    expect(
+      screen.getByText('Data transferred in the visible range:')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/visible range/).nextSibling).toHaveTextContent(
+      /7.97MB\u2069 \(\u2068\d+(\.\d+)?\u2069 g CO₂e\)/
+    );
   });
 
   it('draws a dot on the graph', function () {

--- a/src/test/components/__snapshots__/TrackBandwidth.test.js.snap
+++ b/src/test/components/__snapshots__/TrackBandwidth.test.js.snap
@@ -7,48 +7,6 @@ exports[`TrackBandwidth draws a dot that matches the snapshot 1`] = `
 />
 `;
 
-exports[`TrackBandwidth has a tooltip that matches the snapshot 1`] = `
-<div
-  class="timelineTrackBandwidthTooltip"
->
-  <div
-    class="tooltipDetails"
-  >
-    <div
-      class="tooltipLabel"
-    >
-      Transfer speed for this sample
-      :
-    </div>
-    ⁨4.66GB⁩ per second
-    <div
-      class="tooltipLabel"
-    >
-      read/write operations since the previous sample
-      :
-    </div>
-    0
-    <div
-      class="tooltipDetailSeparator"
-    />
-    <div
-      class="tooltipLabel"
-    >
-      Data transferred up to this time
-      :
-    </div>
-    ⁨6.86MB⁩ (⁨1.3⁩ g CO₂e)
-    <div
-      class="tooltipLabel"
-    >
-      Data transferred in the visible range
-      :
-    </div>
-    ⁨7.97MB⁩ (⁨1.5⁩ g CO₂e)
-  </div>
-</div>
-`;
-
 exports[`TrackBandwidth matches the 2d canvas draw snapshot 1`] = `
 Array [
   Array [


### PR DESCRIPTION
I wanted to do that for a while but finally got around to it. The latest PR that we had to update the expectations was #5474. It's not a huge thing, but it's distracting enough that triggers a context switch. So this PR changes there parts to make sure that the tests don't fail on every co2 package update

I replaced the snapshot test with a more granular test. Technically there were ways to keep the snapshot tests by doing some hacky things, but I didn't want to do them. See the commit message for more info.