### PR TITLE
Ignore the Symbol Store database cache when the user presses the resymbolication button

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -38,6 +38,7 @@ import {
   getRelevantPagesForActiveTab,
   getSymbolServerUrl,
   getActiveTabID,
+  getBrowserConnection,
 } from 'firefox-profiler/selectors';
 import {
   getSelectedTab,
@@ -722,7 +723,7 @@ export function resymbolicateProfile(): ThunkAction<Promise<void>> {
     const symbolStore = getSymbolStore(
       dispatch,
       getSymbolServerUrl(getState()),
-      null
+      getBrowserConnection(getState())
     );
     const profile = getProfile(getState());
     if (!symbolStore) {
@@ -730,7 +731,12 @@ export function resymbolicateProfile(): ThunkAction<Promise<void>> {
         'There was no symbol store when attempting to re-symbolicate.'
       );
     }
-    await doSymbolicateProfile(dispatch, profile, symbolStore);
+    await doSymbolicateProfile(
+      dispatch,
+      profile,
+      symbolStore,
+      /* ignoreCache */ true
+    );
   };
 }
 
@@ -1004,7 +1010,8 @@ function getSymbolStore(
 export async function doSymbolicateProfile(
   dispatch: Dispatch,
   profile: Profile,
-  symbolStore: SymbolStore
+  symbolStore: SymbolStore,
+  ignoreCache?: boolean
 ) {
   dispatch(startSymbolicating());
 
@@ -1027,7 +1034,8 @@ export async function doSymbolicateProfile(
           );
         })
       );
-    }
+    },
+    ignoreCache
   );
 
   await Promise.all(completionPromises);

--- a/src/profile-logic/symbol-store-db.js
+++ b/src/profile-logic/symbol-store-db.js
@@ -177,7 +177,7 @@ export default class SymbolStoreDB {
           this._maxCount - 1,
           () => {
             const lastUsedDate = new Date();
-            const addReq = store.add({
+            const addReq = store.put({
               debugName,
               breakpadId,
               addrs,

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -863,7 +863,8 @@ function _partiallyApplySymbolicationStep(
 export async function symbolicateProfile(
   profile: Profile,
   symbolStore: AbstractSymbolStore,
-  symbolicationStepCallback: SymbolicationStepCallback
+  symbolicationStepCallback: SymbolicationStepCallback,
+  ignoreCache?: boolean
 ): Promise<void> {
   const symbolicationInfo = profile.threads.map((thread) =>
     getThreadSymbolicationInfo(thread, profile.libs)
@@ -890,7 +891,8 @@ export async function symbolicateProfile(
       }
       // We could not find symbols for this library.
       console.warn(error);
-    }
+    },
+    ignoreCache
   );
 }
 

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -183,6 +183,54 @@ describe('doSymbolicateProfile', function () {
       ]);
     });
 
+    it('uses the cache when available', async () => {
+      // This reuses the db from the previous test
+      const {
+        store: { dispatch, getState },
+        profile,
+        symbolStore,
+        switchSymbolTable,
+      } = init();
+
+      // This partial symbol table should not be used, because the db cache is
+      // used instead.
+      switchSymbolTable(partialSymbolTable);
+
+      await doSymbolicateProfile(dispatch, profile, symbolStore);
+      expect(formatTree(getCallTree(getState()))).toEqual([
+        // 0x0000 and 0x000a get merged together.
+        '- first symbol (total: 2, self: —)',
+        '  - last symbol (total: 2, self: 2)',
+        '- third symbol (total: 1, self: 1)',
+        '- second symbol (total: 1, self: 1)',
+      ]);
+
+      // But the partial symbol table should be used when ignoring the cache.
+      await doSymbolicateProfile(
+        dispatch,
+        profile,
+        symbolStore,
+        /* ignoreCache */ true
+      );
+      expect(formatTree(getCallTree(getState()))).toEqual([
+        '- overencompassing first symbol (total: 4, self: 2)',
+        '  - last symbol (total: 2, self: 2)',
+      ]);
+
+      // And then the cache should have been overwritten, let's check this by
+      // switching the symbol table again.
+      switchSymbolTable(completeSymbolTable);
+      // This time do not ignore the cache.
+      await doSymbolicateProfile(dispatch, profile, symbolStore);
+      // The result should be the same despite that the complete symbol table
+      // has been configured, this means the incomplete symbol table is in the
+      // DB cache.
+      expect(formatTree(getCallTree(getState()))).toEqual([
+        '- overencompassing first symbol (total: 4, self: 2)',
+        '  - last symbol (total: 2, self: 2)',
+      ]);
+    });
+
     it('can symbolicate a profile when symbols come from-server', async () => {
       // Get rid of any cached symbol tables from the previous test.
       await _deleteDatabase(`${symbolStoreName}-symbol-tables`);


### PR DESCRIPTION
This makes the resymbolication button work by ignoring the cache.

The use case this fixes is:
1. Capture an Android profile, forgetting to add the objdir to the configuration.
2. Add the objdir.
3. Capture another Android profile. => symbols still not right at load time.
4. Click "resymbolicate".
5. Capture another Android profile. => this time the symbols are ok at load time.

Unfortunately clicking "resymbolicate" between 2 and 3 still doesn't work for the original profile, because the symbolication service is tied to the page. This could probably be fixed on the profiler side by fetching the objdirs from the pref when needed rather than passing them in the constructor.

Also I don't have a good idea to fix step 3, and getting the right symbols here, if we still keep the cache. I wonder if the cache is really useful actually nowadays, what do you think @mstange ?

