### PR TITLE
Fix issues related to the track borders

### DIFF
--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -12,7 +12,9 @@
 }
 
 .timelineTrackLocal {
-  margin-left: 15px;
+  --local-track-margin: 15px;
+
+  margin-left: var(--local-track-margin);
 }
 
 .timelineTrackRow {
@@ -75,8 +77,10 @@
 }
 
 .timelineTrackLabel {
+  --timeline-track-label-width: 150px;
+
   display: flex;
-  width: 150px;
+  width: var(--timeline-track-label-width);
   box-sizing: border-box;
   flex-flow: row nowrap;
   align-items: center;
@@ -167,9 +171,11 @@
 }
 
 .timelineTrackLocalLabel {
-  /* We want the width to look like it's 150px, but need to substract the
-   * margin and the 1px border */
-  width: 134px;
+  /* Calculate the width of the local track label by subtracting the margin and
+   * the 1px border from the total track label width. */
+  width: calc(
+    var(--timeline-track-label-width) - var(--local-track-margin) - 1px
+  );
 }
 
 @media (forced-colors: active) {

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -23,7 +23,6 @@
 
   display: flex;
   flex-flow: row nowrap;
-  border-top: 1px solid var(--grey-30);
   background-color: #fff;
 }
 
@@ -81,6 +80,7 @@
   box-sizing: border-box;
   flex-flow: row nowrap;
   align-items: center;
+  border-top: 1px solid var(--grey-30);
   border-right: 1px solid var(--grey-30);
   cursor: default;
 }
@@ -138,6 +138,7 @@
   display: flex;
   flex: 1;
   flex-flow: column nowrap;
+  border-top: 1px solid var(--grey-30);
 }
 
 .timelineTrackLocalTracks {

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -23,26 +23,27 @@
 
   display: flex;
   flex-flow: row nowrap;
-
-  /* This padding is added to the button's padding as the perceived padding. For
-   * a global row, it will be replaced with a margin when it's selected. */
-  padding-left: var(--selected-left-border-width);
   border-top: 1px solid var(--grey-30);
   background-color: #fff;
 }
 
 .timelineTrackRow.selected {
-  /* We replace the padding by some margin. Indeed the box-shadow used to draw
-   * the blue selected left border is drawn outside of the border box, so the
-   * 3px margin makes this space available. */
+  position: relative;
   padding-left: 0;
-  margin-left: var(--selected-left-border-width);
   background-color: #edf6ff;
+}
 
-  /* We use a box-shadow on the track row instead of using border, so
-   * that when we select adjacent tracks, we see just one line, without any
-   * border on top of it. */
-  box-shadow: calc(-1 * var(--selected-left-border-width)) 0 var(--blue-60);
+/* Showing a blue border on the left side of the track row to indicate that
+ * it's selected */
+.timelineTrackRow.selected::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: var(--selected-left-border-width);
+  background: var(--blue-60);
+  content: '';
+  pointer-events: none;
 }
 
 /* In the active tab view, we don't want any margin or padding, because
@@ -64,6 +65,11 @@
   border-left-color: transparent;
 }
 
+.timelineTrackLocalRow.selected::before {
+  /* We have a left border in local tracks of 1px, moving it left to conceal it. */
+  left: -1px;
+}
+
 .timelineTrackHidden {
   height: 0;
   pointer-events: none;
@@ -71,9 +77,7 @@
 
 .timelineTrackLabel {
   display: flex;
-
-  /* We want the width to look like it's 150px, but need to substract the 3px padding/margin */
-  width: calc(150px - var(--selected-left-border-width));
+  width: 150px;
   box-sizing: border-box;
   flex-flow: row nowrap;
   align-items: center;
@@ -87,10 +91,7 @@
   /* The 8px are used by the box-shadow when the button receives focus */
   width: calc(100% - 8px);
   height: calc(100% - 8px);
-
-  /* We want the left padding to look like 10px, but need to remove 3px to
-   * account for the padding/margin on the row. */
-  padding: 0 0 0 calc(10px - var(--selected-left-border-width));
+  padding: 0 0 0 10px;
   border: none;
   background: none;
   font: inherit;
@@ -165,8 +166,9 @@
 }
 
 .timelineTrackLocalLabel {
-  /* We want the width to look like it's 150px, but need to substract the 3px padding/margin and the 1px border */
-  width: calc(135px - var(--selected-left-border-width) - 1px);
+  /* We want the width to look like it's 150px, but need to substract the
+   * margin and the 1px border */
+  width: 134px;
 }
 
 @media (forced-colors: active) {


### PR DESCRIPTION
Fixes #5458.

This PR fixes these track border/horizontal separator issues:

First commit fixes the issue where it's not right clickable on the blue active thread indicator. It also tries to simplify this indicator by removing a bunch of `calc`s.

Second commit fixes the issue that it's not right clickable on the top border of the thread label.


[Deploy preview](https://deploy-preview-5484--perf-html.netlify.app/public/6rbfb568c11bm1takhaqhw8bb38mtagrrhs1p3r/marker-chart/?globalTrackOrder=60w5&hiddenGlobalTracks=15&hiddenLocalTracksByPid=19538-0wikwx7x9wBbBdBeBgwBo~19559-0wh~19627-0wrtwxu~19643-0wfhwx8xawxm~19649-0wfhwy0~19936-0wfhwx7&localTrackOrderByPid=19538-BgwBo3Abxgxqy4y7oAsAqArAaxdzozvy6xsxt9aB3ysB0B9wBbzdgrypz7Afzazbzeycx0wx2x4x5x9xaxcxexiwxnA6A7iA4A5AoApAtwAvB4B8B278AcuBfly1xrAn5ynxoA8A9AlzcA2qtxb4fy2y0ymz6Beydytyewylyuwz5x7hyb2A1yoky5Amby8zs6B6y9B1BdpB7cwemvx3x6xfxhyazfAhwAk1x8AeAgB5zpzqztxpzgwzn0xusjBcy3nA3A0z9zuAdxvyqyrz8zr~19643-xhwxm3ktqr9wb78i5ox2x0m4s2hx3cx46vldwf1nx5wx8pgx9wxg0ujx1&profileName=applink%20startup%20newssite%202025-05-05&range=m6041~m2022&thread=x9&v=10) / [production](https://share.firefox.dev/3EQY2zF)