### PR TITLE
[deploy preview] Order global tracks by activity and select the most active non-parent process by default

### DIFF
--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -260,11 +260,13 @@ export function finalizeFullProfileView(
     );
     const localTracksByPid = computeLocalTracksByPid(profile, globalTracks);
 
+    const threadActivityScores = getThreadActivityScores(getState());
     const legacyThreadOrder = getLegacyThreadOrder(getState());
     const globalTrackOrder = initializeGlobalTrackOrder(
       globalTracks,
       hasUrlInfo ? getGlobalTrackOrder(getState()) : null,
-      legacyThreadOrder
+      legacyThreadOrder,
+      threadActivityScores
     );
     const localTrackOrderByPid = initializeLocalTrackOrderByPid(
       hasUrlInfo ? getLocalTrackOrderByPid(getState()) : null,
@@ -308,7 +310,7 @@ export function finalizeFullProfileView(
       hiddenTracks = computeDefaultHiddenTracks(
         tracksWithOrder,
         profile,
-        getThreadActivityScores(getState()),
+        threadActivityScores,
         // Only include the parent process if there is no tab filter applied.
         includeParentProcessThreads
       );
@@ -1489,11 +1491,13 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
     );
     const localTracksByPid = computeLocalTracksByPid(profile, globalTracks);
 
+    const threadActivityScores = getThreadActivityScores(getState());
     const legacyThreadOrder = getLegacyThreadOrder(getState());
     const globalTrackOrder = initializeGlobalTrackOrder(
       globalTracks,
       null, // Passing null to urlGlobalTrackOrder to reinitilize it.
-      legacyThreadOrder
+      legacyThreadOrder,
+      threadActivityScores
     );
     const localTrackOrderByPid = initializeLocalTrackOrderByPid(
       null, // Passing null to urlTrackOrderByPid to reinitilize it.
@@ -1530,7 +1534,7 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
       hiddenTracks = computeDefaultHiddenTracks(
         tracksWithOrder,
         profile,
-        getThreadActivityScores(getState()),
+        threadActivityScores,
         // Only include the parent process if there is no tab filter applied.
         includeParentProcessThreads
       );

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -319,7 +319,8 @@ export function finalizeFullProfileView(
     const selectedThreadIndexes = initializeSelectedThreadIndex(
       maybeSelectedThreadIndexes,
       getVisibleThreads(tracksWithOrder, hiddenTracks),
-      profile
+      profile,
+      threadActivityScores
     );
 
     let timelineType = null;
@@ -1543,7 +1544,8 @@ export function changeTabFilter(tabID: TabID | null): ThunkAction<void> {
     const selectedThreadIndexes = initializeSelectedThreadIndex(
       null, // maybeSelectedThreadIndexes
       getVisibleThreads(tracksWithOrder, hiddenTracks),
-      profile
+      profile,
+      threadActivityScores
     );
 
     // If the currently selected tab is only visible when the selected track

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -265,8 +265,8 @@ describe('actions/receive-profile', function () {
 
       store.dispatch(viewProfile(profile));
       expect(getHumanReadableTracks(store.getState())).toEqual([
-        'hide [thread GeckoMain tab]',
         'show [thread GeckoMain tab] SELECTED',
+        'hide [thread GeckoMain tab]',
         'hide [thread GeckoMain tab]',
       ]);
     });
@@ -396,8 +396,8 @@ describe('actions/receive-profile', function () {
 
       store.dispatch(viewProfile(profile));
       expect(getHumanReadableTracks(store.getState())).toEqual([
-        'hide [thread GeckoMain tab]',
         'show [thread GeckoMain tab] SELECTED',
+        'hide [thread GeckoMain tab]',
       ]);
     });
 


### PR DESCRIPTION
Previously we were keeping the original order in the profile data structure when we were initializing the global track order, and selecting the first tab visible process by default. But this was mostly incorrect for the cases where we have more than one visible tab process, because usually busier thread arrives later during the profile collection.

This should help our users to see the most active process very quickly instead of having to scroll down every time.


Deploy preview / [main branch](https://main--perf-html.netlify.app/public/6x3vd1dns0qjt8cjvcdgvjrk0mcn6xwf9np1e60/)