### PR TITLE
Display the frame line number in tooltip backtraces

### DIFF
--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -6,11 +6,7 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { filterCallNodeAndCategoryPathByImplementation } from 'firefox-profiler/profile-logic/transforms';
-import {
-  getFuncNamesAndOriginsForPath,
-  convertStackToCallNodeAndCategoryPath,
-} from 'firefox-profiler/profile-logic/profile-data';
+import { getBacktraceItemsForStack } from 'firefox-profiler/profile-logic/transforms';
 
 import type {
   CategoryList,
@@ -34,15 +30,11 @@ type Props = {|
 export function Backtrace(props: Props) {
   const { stackIndex, thread, implementationFilter, maxStacks, categories } =
     props;
-  const callNodePath = filterCallNodeAndCategoryPathByImplementation(
-    thread,
+  const funcNamesAndOrigins = getBacktraceItemsForStack(
+    stackIndex,
     implementationFilter,
-    convertStackToCallNodeAndCategoryPath(thread, stackIndex)
-  );
-  const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(
-    callNodePath,
     thread
-  ).reverse();
+  );
 
   if (funcNamesAndOrigins.length) {
     return (

--- a/src/components/shared/MarkerContextMenu.js
+++ b/src/components/shared/MarkerContextMenu.js
@@ -42,11 +42,7 @@ import type {
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 import { getImplementationFilter } from 'firefox-profiler/selectors/url-state';
 
-import { filterCallNodeAndCategoryPathByImplementation } from 'firefox-profiler/profile-logic/transforms';
-import {
-  convertStackToCallNodeAndCategoryPath,
-  getFuncNamesAndOriginsForPath,
-} from 'firefox-profiler/profile-logic/profile-data';
+import { getBacktraceItemsForStack } from 'firefox-profiler/profile-logic/transforms';
 import { getThreadSelectorsFromThreadsKey } from 'firefox-profiler/selectors/per-thread';
 
 import './MarkerContextMenu.css';
@@ -161,13 +157,12 @@ class MarkerContextMenuImpl extends PureComponent<Props> {
       return '';
     }
 
-    const path = filterCallNodeAndCategoryPathByImplementation(
-      thread,
+    const funcNamesAndOrigins = getBacktraceItemsForStack(
+      stack,
       implementationFilter,
-      convertStackToCallNodeAndCategoryPath(thread, stack)
-    );
+      thread
+    ).reverse();
 
-    const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(path, thread);
     return funcNamesAndOrigins
       .map(({ funcName, origin }) => `${funcName} [${origin}]`)
       .join('\n');

--- a/src/components/shared/SampleTooltipContents.js
+++ b/src/components/shared/SampleTooltipContents.js
@@ -9,8 +9,7 @@ import { Backtrace } from './Backtrace';
 import { TooltipDetailSeparator } from '../tooltip/TooltipDetails';
 import {
   getCategoryPairLabel,
-  getFuncNamesAndOriginsForPath,
-  convertStackToCallNodeAndCategoryPath,
+  isSampleWithNonEmptyStack,
 } from 'firefox-profiler/profile-logic/profile-data';
 import { getFormattedTimelineValue } from 'firefox-profiler/profile-logic/committed-ranges';
 import {
@@ -26,7 +25,6 @@ import type {
   Milliseconds,
 } from 'firefox-profiler/types';
 import type { CpuRatioInTimeRange } from './thread/ActivityGraphFills';
-import { ensureExists } from '../../utils/flow';
 
 type CPUProps = CpuRatioInTimeRange;
 
@@ -134,21 +132,10 @@ export class SampleTooltipContents extends React.PureComponent<Props> {
     let hasStack = false;
     let formattedSampleTime = null;
     if (sampleIndex !== null) {
-      const { samples, stackTable } = rangeFilteredThread;
+      const { samples } = rangeFilteredThread;
       const sampleTime = samples.time[sampleIndex];
-      const stackIndex = samples.stack[sampleIndex];
-      const hasSamples = samples.length > 0 && stackTable.length > 1;
 
-      if (hasSamples) {
-        const stack = getFuncNamesAndOriginsForPath(
-          convertStackToCallNodeAndCategoryPath(
-            rangeFilteredThread,
-            ensureExists(stackIndex)
-          ),
-          rangeFilteredThread
-        );
-        hasStack = stack.length > 1 || stack[0].funcName !== '(root)';
-      }
+      hasStack = isSampleWithNonEmptyStack(sampleIndex, rangeFilteredThread);
 
       formattedSampleTime = getFormattedTimelineValue(
         sampleTime - zeroAt,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -71,7 +71,6 @@ import type {
   PageList,
   CallNodeTable,
   CallNodePath,
-  CallNodeAndCategoryPath,
   IndexIntoCallNodeTable,
   AccumulatedCounterSamples,
   SamplesLikeTable,
@@ -2146,30 +2145,6 @@ export function processEventDelays(
     maxDelay,
     delayRange,
   };
-}
-
-/**
- * This function converts a stack information into a call node and
- * category path structure.
- */
-export function convertStackToCallNodeAndCategoryPath(
-  thread: Thread,
-  stack: IndexIntoStackTable
-): CallNodeAndCategoryPath {
-  const { stackTable, frameTable } = thread;
-  const path = [];
-  for (
-    let stackIndex = stack;
-    stackIndex !== null;
-    stackIndex = stackTable.prefix[stackIndex]
-  ) {
-    const index = stackTable.frame[stackIndex];
-    path.push({
-      category: stackTable.category[stackIndex],
-      func: frameTable.func[index],
-    });
-  }
-  return path.reverse();
 }
 
 /**

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -33,7 +33,6 @@ import type {
   IndexIntoStackTable,
   IndexIntoResourceTable,
   CallNodePath,
-  CallNodeAndCategoryPath,
   CallNodeTable,
   StackType,
   ImplementationFilter,
@@ -1561,17 +1560,6 @@ export function filterCallNodePathByImplementation(
   const funcMatchesImplementation = FUNC_MATCHES[implementationFilter];
   return callNodePath.filter((funcIndex) =>
     funcMatchesImplementation(thread, funcIndex)
-  );
-}
-
-export function filterCallNodeAndCategoryPathByImplementation(
-  thread: Thread,
-  implementationFilter: ImplementationFilter,
-  path: CallNodeAndCategoryPath
-): CallNodeAndCategoryPath {
-  const funcMatchesImplementation = FUNC_MATCHES[implementationFilter];
-  return path.filter((funcIndex) =>
-    funcMatchesImplementation(thread, funcIndex.func)
   );
 }
 

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -12,6 +12,7 @@ import {
   updateThreadStacks,
   updateThreadStacksByGeneratingNewStackColumns,
   getMapStackUpdater,
+  getOriginAnnotationForFunc,
 } from './profile-data';
 import { timeCode } from '../utils/time-code';
 import { assertExhaustiveCheck, convertToTransformType } from '../utils/flow';
@@ -1572,6 +1573,74 @@ export function filterCallNodeAndCategoryPathByImplementation(
   return path.filter((funcIndex) =>
     funcMatchesImplementation(thread, funcIndex.func)
   );
+}
+
+// User-facing properties about a stack frame.
+export type BacktraceItem = {|
+  // The function name of the stack frame.
+  funcName: string,
+  // The frame category of the stack frame.
+  category: IndexIntoCategoryList,
+  // Whether this frame is a label frame.
+  isFrameLabel: boolean,
+  // A string which is usually displayed after the function name, and which
+  // describes, in some way, where this function or frame came from.
+  // If known, this contains the file name of the function, and the line and
+  // column number of the frame, i.e. the spot within the function that was
+  // being executed.
+  // If the source file name is not known, this might be the name of a native
+  // library instead.
+  // May also be empty.
+  origin: string,
+|};
+
+/**
+ * Convert the stack into an array of "backtrace items" for each stack frame.
+ * The returned array is ordered from callee-most to caller-most, i.e. the root
+ * caller is at the end.
+ */
+export function getBacktraceItemsForStack(
+  stack: IndexIntoStackTable,
+  implementationFilter: ImplementationFilter,
+  thread: Thread
+): BacktraceItem[] {
+  const { funcTable, stringTable, resourceTable } = thread;
+
+  const { stackTable, frameTable } = thread;
+  const unfilteredPath = [];
+  for (
+    let stackIndex = stack;
+    stackIndex !== null;
+    stackIndex = stackTable.prefix[stackIndex]
+  ) {
+    const frameIndex = stackTable.frame[stackIndex];
+    unfilteredPath.push({
+      category: stackTable.category[stackIndex],
+      funcIndex: frameTable.func[frameIndex],
+      frameLine: frameTable.line[frameIndex],
+      frameColumn: frameTable.column[frameIndex],
+    });
+  }
+
+  const funcMatchesImplementation = FUNC_MATCHES[implementationFilter];
+  const path = unfilteredPath.filter(({ funcIndex }) =>
+    funcMatchesImplementation(thread, funcIndex)
+  );
+  return path.map(({ category, funcIndex, frameLine, frameColumn }) => {
+    return {
+      funcName: stringTable.getString(funcTable.name[funcIndex]),
+      category: category,
+      isFrameLabel: funcTable.resource[funcIndex] === -1,
+      origin: getOriginAnnotationForFunc(
+        funcIndex,
+        funcTable,
+        resourceTable,
+        stringTable,
+        frameLine,
+        frameColumn
+      ),
+    };
+  });
 }
 
 /**

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -16,7 +16,6 @@ import {
   getInvertedCallNodeInfo,
   filterThreadByImplementation,
   getSampleIndexClosestToStartTime,
-  convertStackToCallNodeAndCategoryPath,
   getSampleIndexToCallNodeIndex,
   getTreeOrderComparator,
   getSamplesSelectedStates,
@@ -947,24 +946,6 @@ describe('funcHasDirectRecursiveCall and funcHasRecursiveCall', function () {
     expect(
       funcHasRecursiveCall(callNodeTable, funcNames.indexOf('C.cpp'))
     ).toBeFalse();
-  });
-});
-
-describe('convertStackToCallNodeAndCategoryPath', function () {
-  it('correctly returns a call node path for a stack', function () {
-    const profile = getCallNodeProfile();
-    const { derivedThreads } = getProfileWithDicts(profile);
-    const [thread] = derivedThreads;
-    const stack1 = thread.samples.stack[0];
-    const stack2 = thread.samples.stack[1];
-    if (stack1 === null || stack2 === null) {
-      // Makes flow happy
-      throw new Error("stack shouldn't be null");
-    }
-    let callNodePath = convertStackToCallNodeAndCategoryPath(thread, stack1);
-    expect(callNodePath.map((f) => f.func)).toEqual([0, 1, 2, 3, 4]);
-    callNodePath = convertStackToCallNodeAndCategoryPath(thread, stack2);
-    expect(callNodePath.map((f) => f.func)).toEqual([0, 1, 2, 3, 5]);
   });
 });
 

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -431,13 +431,6 @@ export type AddressProof = {|
  */
 export type CallNodePath = IndexIntoFuncTable[];
 
-export type CallNodeAndCategory = {|
-  func: IndexIntoFuncTable,
-  category: IndexIntoCategoryList,
-|};
-
-export type CallNodeAndCategoryPath = CallNodeAndCategory[];
-
 /**
  * This type contains the first derived `Marker[]` information, plus an IndexedArray
  * to get back to the RawMarkerTable.


### PR DESCRIPTION
[Production](https://share.firefox.dev/4kDaBxg) | [Deploy preview](https://deploy-preview-5512--perf-html.netlify.app/public/73df76308b29355bd1b42a56b99b7a293b244b18/marker-chart/?globalTrackOrder=013w52&hiddenGlobalTracks=013w5&implementation=js&markerSearch=Reflow&range=1515m27&thread=3&timelineType=category&v=11)

[Production](https://share.firefox.dev/44M7w8c) | [Deploy preview](https://deploy-preview-5512--perf-html.netlify.app/public/fpcrs77zkn48n4b4zj6z5evg7tecpzevth5mc2g/marker-chart/?globalTrackOrder=x20wx1&hiddenGlobalTracks=1wx2&hiddenLocalTracksByPid=2261-0wa&markerSearch=NotifyObs&profileName=delete_cookies%2Ffilter.py%20macos%20timeout&range=3209m2403~3278m335&thread=0&v=11)

Fixes #1150.