### PR TITLE
Keep the sidebar toggle button visible regardless of the selected tab.

### DIFF
--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -86,32 +86,32 @@ class ProfileViewerImpl extends PureComponent<Props> {
             visibleTabs={visibleTabs}
             onSelectTab={this._onSelectTab}
           />
-          {hasSidebar ? (
-            <Localized
-              id={
-                isSidebarOpen
-                  ? 'Details--close-sidebar-button'
-                  : 'Details--open-sidebar-button'
-              }
-              attrs={{ title: true }}
-              vars={{ isSidebarOpen: isSidebarOpen }}
-            >
-              <button
-                className={classNames(
-                  'sidebar-open-close-button',
-                  'photon-button',
-                  'photon-button-ghost',
-                  {
-                    'sidebar-open-close-button-isopen': isSidebarOpen,
-                    'sidebar-open-close-button-isclosed': !isSidebarOpen,
-                  }
-                )}
-                title={isSidebarOpen ? 'Close the sidebar' : 'Open the sidebar'}
-                type="button"
-                onClick={this._onClickSidebarButton}
-              />
-            </Localized>
-          ) : null}
+
+          <Localized
+            id={
+              isSidebarOpen
+                ? 'Details--close-sidebar-button'
+                : 'Details--open-sidebar-button'
+            }
+            attrs={{ title: true }}
+            vars={{ isSidebarOpen: isSidebarOpen }}
+          >
+            <button
+              className={classNames(
+                'sidebar-open-close-button',
+                'photon-button',
+                'photon-button-ghost',
+                {
+                  'sidebar-open-close-button-isopen': isSidebarOpen,
+                  'sidebar-open-close-button-isclosed': !isSidebarOpen,
+                }
+              )}
+              title={isSidebarOpen ? 'Close the sidebar' : 'Open the sidebar'}
+              type="button"
+              disabled={!hasSidebar}
+              onClick={this._onClickSidebarButton}
+            />
+          </Localized>
         </div>
         <Localized
           id="Details--error-boundary-message"


### PR DESCRIPTION
Small fix for the following issue:

1. Open the profiler UI on a small screen.
2. Select the call tree tab (which has a sidebar toggle button), and close the sidebar if its open.
3. Scroll the tab bar to the right so that you can see the Network tab.
4. Select the Marker Chart tab.

Before this fix, step 4 would remove the sidebar button and make the tapped tab change positions, causing an odd visual jump.