### PR TITLE
Revert the overflow change on .profileViewTopBar

### DIFF
--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -113,8 +113,6 @@
   border-bottom: 1px solid var(--grey-30);
   margin: 0;
   background: var(--grey-10);
-  overflow-x: auto;
-  scrollbar-width: none;
 }
 
 .profileViewerSpacer {


### PR DESCRIPTION
[Main branch](https://main--perf-html.netlify.app/public/fx5sg9g8p9bp6bq36aggg74r8cmrbfcaxcm1rb0/calltree/?globalTrackOrder=b0a97w583241&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=10860-235w9~10868-0~10863-0~10861-0~10871-0~10870-0~10872-0&localTrackOrderByPid=10860-325w798401&range=m567&thread=0&v=11) | [Deploy preview](https://deploy-preview-5527--perf-html.netlify.app/public/fx5sg9g8p9bp6bq36aggg74r8cmrbfcaxcm1rb0/calltree/?globalTrackOrder=b0a97w583241&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=10860-235w9~10868-0~10863-0~10861-0~10871-0~10870-0~10872-0&localTrackOrderByPid=10860-325w798401&range=m567&thread=0&v=11)

It was clipping the arrow panels. I'll need to find a different solution.

This is a partial revert of #5521.