### PR TITLE
Display the marker description at the top inside the marker tooltips

### DIFF
--- a/src/components/tooltip/Marker.js
+++ b/src/components/tooltip/Marker.js
@@ -241,6 +241,17 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
       // Add the details for the markers based on their Marker schema.
       const schema = getSchemaFromMarker(markerSchemaByName, marker.data);
       if (schema) {
+        if (schema.description) {
+          const key = schema.name + '-description';
+          details.push(
+            <TooltipDetail key={key} label="Description">
+              <div className="tooltipDetailsDescription">
+                {schema.description}
+              </div>
+            </TooltipDetail>
+          );
+        }
+
         for (const field of schema.fields) {
           if (field.hidden) {
             // Do not include hidden fields.
@@ -265,17 +276,6 @@ class MarkerTooltipContents extends React.PureComponent<Props> {
                 threadIdToNameMap,
                 processIdToNameMap
               )}
-            </TooltipDetail>
-          );
-        }
-
-        if (schema.description) {
-          const key = schema.name + '-description';
-          details.push(
-            <TooltipDetail key={key} label="Description">
-              <div className="tooltipDetailsDescription">
-                {schema.description}
-              </div>
             </TooltipDetail>
           );
         }

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MarkerChart EmptyReasons shows a reason when a profile has no markers 1`] = `
 <div
@@ -191,6 +191,17 @@ exports[`MarkerChart persists the selected marker tooltips properly 1`] = `
       <div
         class="tooltipLabel"
       >
+        Description
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
+      <div
+        class="tooltipLabel"
+      >
         Name
         :
       </div>
@@ -202,17 +213,6 @@ exports[`MarkerChart persists the selected marker tooltips properly 1`] = `
         :
       </div>
       measure
-      <div
-        class="tooltipLabel"
-      >
-        Description
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
-      </div>
       <div
         class="tooltipLabel"
       >
@@ -374,6 +374,17 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
       <div
         class="tooltipLabel"
       >
+        Description
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
+      <div
+        class="tooltipLabel"
+      >
         Name
         :
       </div>
@@ -385,17 +396,6 @@ exports[`MarkerChart renders the hoveredItem markers properly 2`] = `
         :
       </div>
       measure
-      <div
-        class="tooltipLabel"
-      >
-        Description
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
-      </div>
       <div
         class="tooltipLabel"
       >

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -869,6 +869,17 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
       <div
         class="tooltipLabel"
       >
+        Description
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
+      <div
+        class="tooltipLabel"
+      >
         Name
         :
       </div>
@@ -880,17 +891,6 @@ exports[`MarkerChart shows a tooltip when hovering 1`] = `
         :
       </div>
       measure
-      <div
-        class="tooltipLabel"
-      >
-        Description
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
-      </div>
       <div
         class="tooltipLabel"
       >
@@ -936,6 +936,17 @@ exports[`MarkerChart shows a tooltip when hovering 2`] = `
       <div
         class="tooltipLabel"
       >
+        Description
+        :
+      </div>
+      <div
+        class="tooltipDetailsDescription"
+      >
+        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+      </div>
+      <div
+        class="tooltipLabel"
+      >
         Name
         :
       </div>
@@ -947,17 +958,6 @@ exports[`MarkerChart shows a tooltip when hovering 2`] = `
         :
       </div>
       measure
-      <div
-        class="tooltipLabel"
-      >
-        Description
-        :
-      </div>
-      <div
-        class="tooltipDetailsDescription"
-      >
-        UserTiming is created using the DOM APIs performance.mark() and performance.measure().
-      </div>
       <div
         class="tooltipLabel"
       >

--- a/src/test/components/__snapshots__/TooltipMarker.test.js.snap
+++ b/src/test/components/__snapshots__/TooltipMarker.test.js.snap
@@ -4684,6 +4684,17 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
     <div
       class="tooltipLabel"
     >
+      Description
+      :
+    </div>
+    <div
+      class="tooltipDetailsDescription"
+    >
+      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
+    </div>
+    <div
+      class="tooltipLabel"
+    >
       Name
       :
     </div>
@@ -4695,17 +4706,6 @@ exports[`TooltipMarker renders tooltips for various markers: UserTiming-12.5 1`]
       :
     </div>
     mark
-    <div
-      class="tooltipLabel"
-    >
-      Description
-      :
-    </div>
-    <div
-      class="tooltipDetailsDescription"
-    >
-      UserTiming is created using the DOM APIs performance.mark() and performance.measure().
-    </div>
     <div
       class="tooltipLabel"
     >


### PR DESCRIPTION
Previously the "Description" field from marker schema was displayed at the bottom of the marker fields inside the marker tooltips. This PR moves this field to the top instead.

Before:
<img width="802" height="462" alt="Screenshot 2025-08-01 at 3 42 23 PM" src="https://github.com/user-attachments/assets/fea151d3-21ff-4ac6-955e-f4ceffdd92c0" />


After:

<img width="623" height="361" alt="Screenshot 2025-08-01 at 3 42 45 PM" src="https://github.com/user-attachments/assets/1f98d4c5-b04c-40ef-a858-78b6c46a117e" />


Deploy preview: [production](https://share.firefox.dev/45vha0q) / [deploy preview](https://deploy-preview-5534--perf-html.netlify.app/public/7wymytdxg41bg78vyd3eh83bn4dt71gvzwydgy8/marker-chart/?globalTrackOrder=ewgd0wc&hiddenGlobalTracks=1wb&hiddenLocalTracksByPid=23030-12~23241-01~23214-0~23094-0~23143-0~23135-0~23229-0~23416-0~23421-0~23176-0~23277-01~23371-0&markerSearch=gc%2Cslice&profileName=bing-search-pageload-cold%2Fbrowser-cycle-1.json.gz&range=11942m451~12122m128~12232571u5995&thread=f&v=11)