### PR TITLE
Make sure that the test-debug command runs the tests properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test-coverage": "run-s test-build-coverage test-serve-coverage",
     "test-alex": "alex ./docs-* *.md",
     "test-lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
-    "test-debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test-debug": "cross-env LC_ALL=C TZ=UTC NODE_ENV=test node --inspect-brk node_modules/.bin/jest --runInBand",
     "postinstall": "patch-package"
   },
   "license": "MPL-2.0",


### PR DESCRIPTION
We should set these environment variables to make sure that all the tests behave the same way they would with `yarn test`.

Also, we added this check so we make sure people run the tests through `yarn test`:
https://github.com/firefox-devtools/profiler/blob/082631b9ab95733b5e1e36b5edfb73cbcedcd866/src/test/setup.js#L19-L21 But it was preventing us to run `yarn test-debug` all together too.