### PR TITLE
Remove leftover $FlowExpectError comments

### DIFF
--- a/src/components/app/AppHeader.tsx
+++ b/src/components/app/AppHeader.tsx
@@ -22,7 +22,6 @@ export class AppHeader extends React.PureComponent<{}> {
             id="AppHeader--app-header"
             elems={{
               header: (
-                // $FlowExpectError Flow doesn't know about this fluent rule for react component.
                 <InnerNavigationLink
                   dataSource="none"
                   className="appHeaderLink"

--- a/src/components/app/Home.tsx
+++ b/src/components/app/Home.tsx
@@ -660,7 +660,6 @@ class HomeImpl extends React.PureComponent<HomeProps, HomeState> {
                 id="Home--compare-recordings-info"
                 elems={{
                   a: (
-                    // $FlowExpectError Flow doesn't know about this fluent rule for react component.
                     <InnerNavigationLink dataSource="compare">
                       Compare
                     </InnerNavigationLink>

--- a/src/components/js-tracer/Chart.tsx
+++ b/src/components/js-tracer/Chart.tsx
@@ -104,7 +104,6 @@ class JsTracerExpensiveChartImpl extends React.PureComponent<Props> {
         chartProps={{
           jsTracerTimingRows,
           jsTracerTable,
-          // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
           updatePreviewSelection,
           rangeStart: timeRange.start,
           rangeEnd: timeRange.end,

--- a/src/components/marker-chart/index.tsx
+++ b/src/components/marker-chart/index.tsx
@@ -153,7 +153,6 @@ class MarkerChartImpl extends React.PureComponent<Props> {
                 getMarker,
                 getMarkerLabel,
                 markerListLength,
-                // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
                 updatePreviewSelection,
                 changeMouseTimePosition,
                 changeRightClickedMarker,

--- a/src/components/stack-chart/index.tsx
+++ b/src/components/stack-chart/index.tsx
@@ -266,7 +266,6 @@ class StackChartImpl extends React.PureComponent<Props> {
                   combinedTimingRows,
                   sameWidthsIndexToTimestampMap,
                   getMarker,
-                  // $FlowFixMe Error introduced by upgrading to v0.96.0. See issue #1936.
                   updatePreviewSelection,
                   changeMouseTimePosition,
                   rangeStart: timeRange.start,

--- a/src/components/tooltip/TrackPower.tsx
+++ b/src/components/tooltip/TrackPower.tsx
@@ -142,7 +142,6 @@ class TooltipTrackPowerImpl extends React.PureComponent<Props> {
     );
 
     return (
-      // $FlowExpectError our version of Flow doesn't understand Fragments very well.
       <>
         {this._formatPowerValue(
           powerSumForPreviewRange,

--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -1363,9 +1363,6 @@ function mergeMarkers(
           );
         }
 
-        // Flow doesn't know well how to handle the spread operator with our
-        // MarkerPayload type.
-        // $FlowExpectError
         newMarkerTable.data.push({
           ...oldData,
           cause: {

--- a/src/test/components/AppLocalizationProvider.test.tsx
+++ b/src/test/components/AppLocalizationProvider.test.tsx
@@ -70,7 +70,6 @@ describe('AppLocalizationProvider', () => {
       await screen.findByText(translatedText('en-US'))
     ).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'en-US');
-    // $FlowExpectError Our version of flow doesn't know about document.dir
     expect(document.dir).toBe('ltr');
 
     // Now we're testing the LTR pseudo-localization.
@@ -79,7 +78,6 @@ describe('AppLocalizationProvider', () => {
     });
     expect(await screen.findByText('Ŧħīş īş ḗḗƞ-ŬŞ Ŧḗḗẋŧ')).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'en-US');
-    // $FlowExpectError Our version of flow doesn't know about document.dir
     expect(document.dir).toBe('ltr');
 
     // And now the RTL pseudo-localization.
@@ -88,7 +86,6 @@ describe('AppLocalizationProvider', () => {
     });
     expect(await screen.findByText(/⊥ɥıs ıs ǝu-∩S ⊥ǝxʇ/)).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'en-US');
-    // $FlowExpectError Our version of flow doesn't know about document.dir
     expect(document.dir).toBe('rtl');
 
     // Back to no pseudo-localization
@@ -99,7 +96,6 @@ describe('AppLocalizationProvider', () => {
       await screen.findByText(translatedText('en-US'))
     ).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'en-US');
-    // $FlowExpectError Our version of flow doesn't know about document.dir
     expect(document.dir).toBe('ltr');
   });
 
@@ -136,7 +132,6 @@ describe('AppLocalizationProvider', () => {
       await screen.findByText(translatedText('en-US'))
     ).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'en-US');
-    // $FlowExpectError Our version of flow doesn't know about document.dir
     expect(document.dir).toBe('ltr');
 
     // Switch to german
@@ -146,7 +141,6 @@ describe('AppLocalizationProvider', () => {
     });
     expect(await screen.findByText(translatedText('de'))).toBeInTheDocument();
     expect(document.documentElement).toHaveAttribute('lang', 'de');
-    // $FlowExpectError Our version of flow doesn't know about document.dir
     expect(document.dir).toBe('ltr');
   });
 

--- a/src/test/components/BeforeUnloadManager.test.tsx
+++ b/src/test/components/BeforeUnloadManager.test.tsx
@@ -38,10 +38,8 @@ describe('app/BeforeUnloadManager', () => {
     const event = new Event('beforeunload');
 
     /* Because of the current jsdom implementation, we need to mock
-       preventDefault(). To prevent a Flow error when assigning jest.fn()
-       to event.preventDefault (not writeable), we add the following line.
+       preventDefault().
     */
-    // $FlowExpectError
     event.preventDefault = jest.fn();
 
     fireEvent(window as any, event);

--- a/src/test/components/FooterLinks.test.tsx
+++ b/src/test/components/FooterLinks.test.tsx
@@ -19,7 +19,6 @@ beforeEach(() => {
     .get(fetchUrlRe, ({ url }: { url: string }) => {
       const matchUrlResult = fetchUrlRe.exec(url);
       if (matchUrlResult) {
-        // $FlowExpectError Our Flow doesn't know about named groups.
         const { language } = matchUrlResult.groups!;
         const path = `locales/${language}/app.ftl`;
         if (fs.existsSync(path)) {

--- a/src/test/components/GlobalTrack.test.tsx
+++ b/src/test/components/GlobalTrack.test.tsx
@@ -180,7 +180,6 @@ describe('timeline/GlobalTrack', function () {
   it('displays the private browsing status of a fission thread', () => {
     setup(PRIVATE_TRACK_INDEX);
     const track = screen.getByText('Private');
-    // $FlowExpectError The parent element is an HTML Element but Flow doesn't know that.
     expect(ensureExists(track.parentElement).title).toBe(stripIndent`
       Private
       Thread: "Private" (6666)
@@ -192,7 +191,6 @@ describe('timeline/GlobalTrack', function () {
   it('displays the container status of a fission thread', () => {
     setup(CONTAINER_TRACK_INDEX);
     const track = screen.getByText('InContainer');
-    // $FlowExpectError The parent element is an HTML Element but Flow doesn't know that.
     expect(ensureExists(track.parentElement).title).toBe(stripIndent`
       InContainer
       Thread: "InContainer" (7777)

--- a/src/test/components/MenuButtons.test.tsx
+++ b/src/test/components/MenuButtons.test.tsx
@@ -416,7 +416,6 @@ describe('app/MenuButtons', function () {
 
     it('matches the snapshot for a compression error', async () => {
       const { compress } = require('firefox-profiler/utils/gz');
-      // $FlowExpectError Flow doesn't know about Jest mocks
       compress.mockRejectedValue(new Error('Compression error'));
       jest.spyOn(console, 'error').mockImplementation(() => {});
       const { getPanel, openPublishPanel } = setupForPublish();

--- a/src/test/components/ServiceWorkerManager.test.tsx
+++ b/src/test/components/ServiceWorkerManager.test.tsx
@@ -43,7 +43,6 @@ describe('app/ServiceWorkerManager', () => {
 
     // It seems node v8 doesn't let us change the value unless we delete it before.
     delete (window as any).location;
-    // $FlowExpectError because the value we pass isn't a proper Location object.
     Object.defineProperty(window, 'location', {
       value: { reload: jest.fn() },
       writable: true,

--- a/src/test/components/Viewport.test.tsx
+++ b/src/test/components/Viewport.test.tsx
@@ -623,8 +623,6 @@ function setup(profileOverrides: MixedObject = {}) {
 
   // Hook up a dummy chart with a viewport.
   const DummyChart = jest.fn((_props) => <div id="dummy-chart" />);
-  // Flow's internal structures for React don't recognize our mock function as a
-  // valid stateless component. $FlowExpectError
   const ChartWithViewport = withChartViewport(DummyChart);
 
   type OwnProps = {

--- a/src/test/fixtures/mocks/indexeddb.ts
+++ b/src/test/fixtures/mocks/indexeddb.ts
@@ -9,9 +9,8 @@ import { IDBFactory } from 'fake-indexeddb';
 
 function resetIndexedDb() {
   // This is the recommended way to reset the IDB state between test runs, but
-  // neither flow nor eslint like that we assign to indexedDB directly, for
-  // different reasons.
-  /* $FlowExpectError */ /* eslint-disable-next-line no-global-assign */
+  // eslint does not like that we assign to indexedDB directly.
+  /* eslint-disable-next-line no-global-assign */
   indexedDB = new IDBFactory();
 }
 

--- a/src/test/fixtures/mocks/intersection-observer.ts
+++ b/src/test/fixtures/mocks/intersection-observer.ts
@@ -101,18 +101,11 @@ function triggerSingleObserver(
 
   for (const element of item.elements) {
     entries.push({
-      // $FlowExpectError Flow thinks they are different but they are both DOMRectReadOnly.
       boundingClientRect: element.getBoundingClientRect(),
       intersectionRatio: 1,
-      // $FlowExpectError Flow thinks they are different but they are both DOMRectReadOnly.
       intersectionRect: element.getBoundingClientRect(),
       isIntersecting: isIntersecting,
-      rootBounds: observer.root
-        ? // $FlowExpectError Flow thinks they are different but they are both DOMRectReadOnly.
-          observer.root.getBoundingClientRect()
-        : // $FlowExpectError We don't know anything, so putting null instead.
-          null,
-
+      rootBounds: observer.root ? observer.root.getBoundingClientRect() : null,
       target: element,
       time: Date.now() - item.created,
     });

--- a/src/test/integration/symbolicator-cli/symbolicator-cli.test.ts
+++ b/src/test/integration/symbolicator-cli/symbolicator-cli.test.ts
@@ -19,7 +19,6 @@ describe('symbolicator-cli tool', function () {
       await run(options);
       return JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
     } finally {
-      // $FlowExpectError Flow doesn't know about the rmSync API despite it's been implemented in node v16. Sigh
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   }

--- a/src/test/unit/process-profile.test.ts
+++ b/src/test/unit/process-profile.test.ts
@@ -655,7 +655,6 @@ describe('threadCPUDelta processing', function () {
 
     // Fill the threadCPUDelta with null values.
     for (const item of geckoSamples.data) {
-      // $FlowExpectError because Flow thinks this access can be out of bounds, but it is not.
       item[geckoSchema.threadCPUDelta] = null;
     }
 
@@ -679,10 +678,8 @@ describe('threadCPUDelta processing', function () {
 
     // Fill the threadCPUDelta with null values except the first.
     for (const item of geckoSamples.data) {
-      // $FlowExpectError because Flow thinks this access can be out of bounds, but it is not.
       item[geckoSchema.threadCPUDelta] = null;
     }
-    // $FlowExpectError same reason as above
     geckoSamples.data[0][geckoSchema.threadCPUDelta] = 2;
 
     // Process the profile.


### PR DESCRIPTION
The ones in window-navigation.ts are handled in #5559. This cleans up the rest.