### PR TITLE
Remove the unneeded test-all:ci script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
   # Output useful info for debugging.
   - yarn versions
   # run tests
-  - yarn test-all:ci
+  - yarn test-all
   - yarn build-prod:quiet
 
 cache:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "start-photon": "node res/photon/server",
     "test": "node bin/output-fixing-commands.js cross-env LC_ALL=C TZ=UTC NODE_ENV=test jest",
     "test-all": "run-p --max-parallel 4 ts license-check lint test test-alex test-lockfile",
-    "test-all:ci": "run-p --max-parallel 4 ts license-check lint test test-alex test-lockfile",
     "test-build-coverage": "yarn test --coverage --coverageReporters=html",
     "test-serve-coverage": "ws -d coverage/ -p 4343",
     "test-coverage": "run-s test-build-coverage test-serve-coverage",


### PR DESCRIPTION
Previously, we needed it only for appveyor because flow needed a different command. But we don't need it anymore, now that we switched to typescript. Let's remove it.