### PR TITLE
Fix a type case inconsistency

### DIFF
--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -85,7 +85,7 @@ import type {
   CallTreeSummaryStrategy,
   EventDelayInfo,
   ThreadsKey,
-  resourceTypeEnum,
+  ResourceTypeEnum,
   MarkerPayload,
   Address,
   AddressProof,
@@ -2822,7 +2822,7 @@ export function getThreadProcessDetails(
 function _shouldShowBothOriginAndFileName(
   fileName: string,
   origin: string,
-  resourceType: resourceTypeEnum | null
+  resourceType: ResourceTypeEnum | null
 ): boolean {
   // If the origin string is just a URL prefix that's part of the
   // filename, it doesn't add any useful information, so only show

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -17,7 +17,7 @@ export type IndexIntoLibs = number;
 export type IndexIntoNativeSymbolTable = number;
 export type IndexIntoCategoryList = number;
 export type IndexIntoSubcategoryListForCategory = number;
-export type resourceTypeEnum = number;
+export type ResourceTypeEnum = number;
 export type ThreadIndex = number;
 // The Tid is most often a number. However in some cases such as merged profiles
 // we could generate a string.
@@ -370,7 +370,7 @@ export type ResourceTable = {
   lib: Array<IndexIntoLibs | null>;
   name: Array<IndexIntoStringTable>;
   host: Array<IndexIntoStringTable | null>;
-  type: resourceTypeEnum[];
+  type: ResourceTypeEnum[];
 };
 
 /**


### PR DESCRIPTION
This is a small PR that converts a camelCase type into PascalCase that we normally use for types.

Noticed it while I was looking at the typescript migration and I had a note to fix it.