### PR TITLE
Don't stringify JSON again in fetchUrlResponse

### DIFF
--- a/src/utils/query-api.ts
+++ b/src/utils/query-api.ts
@@ -137,7 +137,7 @@ export class RegularExternalCommunicationDelegate
     const requestInit: RequestInit =
       postData !== undefined
         ? {
-            body: JSON.stringify(postData),
+            body: postData,
             method: 'POST',
             mode: 'cors',
             credentials: 'omit',


### PR DESCRIPTION
fetchUrlResponse is called from queryApiWithFallback and is given stringified JSON data, but then stringifies the string again. This leads to errors when trying to view source files with a local samply server.

This is a regression from the production branch. I'm not entirely sure this is the right fix, but from the type signature of fetchUrlResponse, it seems to be the intended behavior.