### PR TITLE
Some path fixes

### DIFF
--- a/res/index.html
+++ b/res/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1" />
     <title>Firefox Profiler</title>
-    <link rel="preload" href="locales/en-US/app.ftl" as="fetch" />
+    <link rel="preload" href="/locales/en-US/app.ftl" as="fetch" />
   </head>
   <body style="background-color: #363959; /* ink-70 */">
     <svg id="svg-filters"></svg>

--- a/src/components/app/BottomBox.css
+++ b/src/components/app/BottomBox.css
@@ -72,11 +72,11 @@
 }
 
 .bottom-close-button {
-  background-image: url(/res/img/svg/close-dark.svg);
+  background-image: url(firefox-profiler-res/img/svg/close-dark.svg);
 }
 
 .bottom-assembly-button {
-  background-image: url(/res/img/svg/asm-icon.svg);
+  background-image: url(firefox-profiler-res/img/svg/asm-icon.svg);
 }
 
 .codeLoadingOverlay,
@@ -111,7 +111,8 @@
   width: 32px;
   height: 32px;
   flex-shrink: 0;
-  background: url(/res/img/spinner.png) center center / 32px 32px no-repeat;
+  background: url(firefox-profiler-res/img/spinner.png) center center / 32px
+    32px no-repeat;
   content: '';
 }
 
@@ -122,7 +123,8 @@
   width: 50px;
   height: 50px;
   flex-shrink: 0;
-  background: url(/res/img/svg/error.svg) center center / 32px 32px no-repeat;
+  background: url(firefox-profiler-res/img/svg/error.svg) center center / 32px
+    32px no-repeat;
   content: '';
   filter: brightness(70%) drop-shadow(0 1px rgb(255 255 255 / 0.5));
 }

--- a/src/components/app/Details.css
+++ b/src/components/app/Details.css
@@ -26,9 +26,9 @@
 }
 
 .sidebar-open-close-button-isopen {
-  background-image: url(../../../res/img/svg/pane-collapse.svg);
+  background-image: url(firefox-profiler-res/img/svg/pane-collapse.svg);
 }
 
 .sidebar-open-close-button-isclosed {
-  background-image: url(../../../res/img/svg/pane-expand.svg);
+  background-image: url(firefox-profiler-res/img/svg/pane-expand.svg);
 }

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -145,7 +145,7 @@
   width: 20px;
   height: 20px;
   margin: 0 10px -4px 3px;
-  background: url(../../../res/img/svg/help-blue.svg);
+  background: url(firefox-profiler-res/img/svg/help-blue.svg);
   background-size: 100% 100%;
 }
 

--- a/src/components/app/KeyboardShortcut.css
+++ b/src/components/app/KeyboardShortcut.css
@@ -95,8 +95,8 @@
 
   /* Allow for the photon focus ring to fit in the space by using a 4px margin. */
   margin: 4px;
-  background: url(../../../res/img/svg/searchfield-cancel.svg) 10px center
-    no-repeat;
+  background: url(firefox-profiler-res/img/svg/searchfield-cancel.svg) 10px
+    center no-repeat;
   cursor: pointer;
   font-size: inherit;
 }

--- a/src/components/app/ProfileDeleteButton.css
+++ b/src/components/app/ProfileDeleteButton.css
@@ -6,8 +6,8 @@
   /* Note: 20px is: 16px (icon width) + 4px (distance from the text) */
   padding-left: 20px;
   margin: 0;
-  background: url(../../../res/img/svg/check-dark.svg) no-repeat left / 16px
-    16px;
+  background: url(firefox-profiler-res/img/svg/check-dark.svg) no-repeat left /
+    16px 16px;
   white-space: nowrap;
 }
 
@@ -16,8 +16,8 @@
   padding-left: 24px;
 
   /* The icon is 4px below the top */
-  background: url(../../../res/img/svg/error-red.svg) no-repeat 0 4px / 16px
-    16px;
+  background: url(firefox-profiler-res/img/svg/error-red.svg) no-repeat 0 4px /
+    16px 16px;
   color: var(--red-60);
   overflow-wrap: break-word;
 }

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -80,8 +80,8 @@
   margin: 3px 0 3px 3px;
 
   /* Other */
-  background: var(--green-50) url(../../../res/img/svg/back-arrow.svg) center
-    center no-repeat;
+  background: var(--green-50) url(firefox-profiler-res/img/svg/back-arrow.svg)
+    center center no-repeat;
   color: #000;
 }
 

--- a/src/components/calltree/CallTree.css
+++ b/src/components/calltree/CallTree.css
@@ -32,5 +32,5 @@
 
 .treeBadge.inlined,
 .treeBadge.divergent-inlining {
-  background: url(../../../res/img/svg/inlined-icon.svg);
+  background: url(firefox-profiler-res/img/svg/inlined-icon.svg);
 }

--- a/src/components/shared/IdleSearchField.css
+++ b/src/components/shared/IdleSearchField.css
@@ -21,7 +21,7 @@
   position: relative;
   flex: 1;
   margin: 0;
-  background: url(../../../res/img/svg/searchfield-icon.svg) 3px center
+  background: url(firefox-profiler-res/img/svg/searchfield-icon.svg) 3px center
     no-repeat white;
   background-size: 11px 11px;
 }
@@ -34,7 +34,7 @@
   height: 11px;
   padding: 0;
   border: 0;
-  background: url(../../../res/img/svg/searchfield-cancel.svg) top left
+  background: url(firefox-profiler-res/img/svg/searchfield-cancel.svg) top left
     no-repeat;
   background-size: contain;
   color: transparent;

--- a/src/components/shared/ProfileMetaInfoSummary.css
+++ b/src/components/shared/ProfileMetaInfoSummary.css
@@ -20,32 +20,34 @@
 
 .profileMetaInfoSummaryProductAndVersion {
   padding-left: 1.4em; /* 1 (for the background image) + 0.4 */
-  background: url(../../../res/img/svg/info.svg) left center / 1em no-repeat;
+  background: url(firefox-profiler-res/img/svg/info.svg) left center / 1em
+    no-repeat;
 }
 
 .profileMetaInfoSummaryProductAndVersion[data-product^='Firefox'],
 .profileMetaInfoSummaryProductAndVersion[data-product='Fennec'] {
-  background-image: url(../../../res/img/svg/brands/firefoxbrowser.svg);
+  background-image: url(firefox-profiler-res/img/svg/brands/firefoxbrowser.svg);
 }
 
 .profileMetaInfoSummaryPlatform {
   padding-left: 1.4em; /* 1 (for the background image) + 0.4 */
   margin-left: 1em;
-  background: url(../../../res/img/svg/info.svg) left center / 1em no-repeat;
+  background: url(firefox-profiler-res/img/svg/info.svg) left center / 1em
+    no-repeat;
 }
 
 .profileMetaInfoSummaryPlatform[data-toolkit^='macOS'] {
-  background-image: url(../../../res/img/svg/brands/apple.svg);
+  background-image: url(firefox-profiler-res/img/svg/brands/apple.svg);
 }
 
 .profileMetaInfoSummaryPlatform[data-toolkit^='Windows'] {
-  background-image: url(../../../res/img/svg/brands/windows.svg);
+  background-image: url(firefox-profiler-res/img/svg/brands/windows.svg);
 }
 
 .profileMetaInfoSummaryPlatform[data-toolkit^='Linux'] {
-  background-image: url(../../../res/img/svg/brands/linux.svg);
+  background-image: url(firefox-profiler-res/img/svg/brands/linux.svg);
 }
 
 .profileMetaInfoSummaryPlatform[data-toolkit^='Android'] {
-  background-image: url(../../../res/img/svg/brands/android.svg);
+  background-image: url(firefox-profiler-res/img/svg/brands/android.svg);
 }

--- a/src/components/shared/TrackSearchField.css
+++ b/src/components/shared/TrackSearchField.css
@@ -26,7 +26,7 @@
   position: relative;
   flex: 1;
   margin: 0;
-  background: url(../../../res/img/svg/searchfield-icon.svg) 3px center
+  background: url(firefox-profiler-res/img/svg/searchfield-icon.svg) 3px center
     no-repeat white;
   background-size: 11px 11px;
 }
@@ -41,7 +41,7 @@
   height: 11px;
   padding: 0;
   border: 0;
-  background: url(../../../res/img/svg/searchfield-cancel.svg) top left
+  background: url(firefox-profiler-res/img/svg/searchfield-cancel.svg) top left
     no-repeat;
   background-size: contain;
   color: transparent;

--- a/src/components/timeline/Track.css
+++ b/src/components/timeline/Track.css
@@ -109,7 +109,7 @@
   padding: 1px;
   border: 0;
   border-radius: 2px;
-  background: url(../../../res/img/svg/close-dark.svg) no-repeat center;
+  background: url(firefox-profiler-res/img/svg/close-dark.svg) no-repeat center;
   background-origin: content-box;
   background-size: contain;
   color: transparent;
@@ -217,7 +217,7 @@
   @media (prefers-color-scheme: dark) {
     /* We need to adapt the cross icon in dark mode so it still visible */
     .timelineTrackCloseButton {
-      background-image: url(../../../res/img/svg/close-light.svg);
+      background-image: url(firefox-profiler-res/img/svg/close-light.svg);
     }
   }
 }


### PR DESCRIPTION
[Production](https://profiler.firefox.com/public/g09y396tf8e5ga5cc1k8ec2wxet3acg4hx27pw8/calltree/?globalTrackOrder=9a08w312&hiddenGlobalTracks=1w6&hiddenLocalTracksByPid=48531-1w3~48542-0~48534-0~48536-0~48545-0~48544-0~48543-0&thread=c&v=11) | [Deploy preview](https://deploy-preview-5581--perf-html.netlify.app/public/g09y396tf8e5ga5cc1k8ec2wxet3acg4hx27pw8/calltree/?globalTrackOrder=9a08w312&hiddenGlobalTracks=1w6&hiddenLocalTracksByPid=48531-1w3~48542-0~48534-0~48536-0~48545-0~48544-0~48543-0&thread=c&v=11)

Two changes:
1. Fix the link preload path to app.ftl to be absolute
2. Consistently use firefox-profiler-res paths in CSS files