### PR TITLE
Remove the findDOMNode usage from ContextMenu 

### DIFF
--- a/src/components/shared/ContextMenu.tsx
+++ b/src/components/shared/ContextMenu.tsx
@@ -4,7 +4,6 @@
 
 import { PureComponent } from 'react';
 import type { ComponentProps } from 'react';
-import ReactDOM from 'react-dom';
 import { ContextMenu as ReactContextMenu } from '@firefox-devtools/react-contextmenu';
 
 import './ContextMenu.css';
@@ -12,44 +11,18 @@ import './ContextMenu.css';
 type Props = ComponentProps<typeof ReactContextMenu>;
 
 export class ContextMenu extends PureComponent<Props> {
-  _contextMenu: any = null;
-  _takeContextMenuRef = (contextMenu: any) => {
-    this._contextMenu = contextMenu;
-  };
-
-  _mouseDownHandler(event: Event): void {
+  _mouseDownHandler = (event: React.MouseEvent<HTMLDivElement>): void => {
     // This prevents from stealing the focus from where it was.
     event.preventDefault();
-  }
-
-  override componentDidMount() {
-    if (this._contextMenu) {
-      // The context menu component does not expose a reference to its internal
-      // DOM node so using findDOMNode is currently unavoidable.
-      // eslint-disable-next-line react/no-find-dom-node
-      const contextMenuNode = ReactDOM.findDOMNode(this._contextMenu);
-      if (contextMenuNode) {
-        // There's no need to remove this event listener since the component is
-        // never unmounted. Duplicate event listeners will also be discarded
-        // automatically so we don't need to handle that.
-        contextMenuNode.addEventListener('mousedown', this._mouseDownHandler);
-      }
-    }
-  }
-
-  override componentWillUnmount() {
-    // eslint-disable-next-line react/no-find-dom-node
-    const contextMenuNode = ReactDOM.findDOMNode(this._contextMenu);
-    if (contextMenuNode) {
-      contextMenuNode.removeEventListener('mousedown', this._mouseDownHandler);
-    }
-  }
+  };
 
   override render() {
     return (
-      <ReactContextMenu ref={this._takeContextMenuRef} {...this.props}>
-        {this.props.children ? this.props.children : <div />}
-      </ReactContextMenu>
+      <div onMouseDown={this._mouseDownHandler}>
+        <ReactContextMenu {...this.props}>
+          {this.props.children ? this.props.children : <div />}
+        </ReactContextMenu>
+      </div>
     );
   }
 }

--- a/src/test/components/__snapshots__/CallNodeContextMenu.test.tsx.snap
+++ b/src/test/components/__snapshots__/CallNodeContextMenu.test.tsx.snap
@@ -1,274 +1,276 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`calltree/CallNodeContextMenu basic rendering renders a full context menu when open, with many nav items 1`] = `
-<nav
-  class="react-contextmenu callNodeContextMenu"
-  role="menu"
-  style="position: fixed; opacity: 0; pointer-events: none;"
-  tabindex="-1"
->
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
+<div>
+  <nav
+    class="react-contextmenu callNodeContextMenu"
+    role="menu"
+    style="position: fixed; opacity: 0; pointer-events: none;"
     tabindex="-1"
   >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconMerge"
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconMerge"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Merging a function removes it from the profile, and assigns its time to the function that called it. This happens anywhere the function was called in the tree."
+      >
+        Merge function
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        m
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconMerge"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Merging a node removes it from the profile, and assigns its time to the function’s node that called it. It only removes the function from that specific part of the tree. Any other places the function was called from will remain in the profile."
+      >
+        Merge node only
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        M
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconFocus"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Focusing on a function will remove any sample that does not include that function. In addition, it re-roots the call tree so that the function is the only root of the tree. This can combine multiple function call sites across a profile into one call node."
+      >
+        Focus on function
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        f
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconFocus"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Focusing on a subtree will remove any sample that does not include that specific part of the call tree. It pulls out a branch of the call tree, however it only does it for that single call node. All other calls of the function are ignored."
+      >
+        Focus on subtree only
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        F
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconFocus"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Focusing on the nodes that belong to the same category as the selected node, thereby merging all nodes that belong to another category."
+      >
+        Focus on category 
+        <strong>
+          ⁨Other⁩
+        </strong>
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        g
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconCollapse"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Collapsing a function will remove everything it called, and assign all of the time to the function. This can help simplify a profile that calls into code that does not need to be analyzed."
+      >
+        Collapse function
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        c
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconCollapse"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Collapsing a resource will flatten out all the calls to that resource into a single collapsed call node."
+      >
+        Collapse 
+        <strong>
+          ⁨XUL⁩
+        </strong>
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        C
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconCollapse"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Collapsing recursion removes calls that repeatedly recurse into the same function, even with intermediate functions on the stack."
+      >
+        Collapse recursion
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        r
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconCollapse"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Collapsing direct recursion removes calls that repeatedly recurse into the same function with no intermediate functions on the stack."
+      >
+        Collapse direct recursion only
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        R
+      </kbd>
+    </div>
+    <div
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <span
+        class="react-contextmenu-icon callNodeContextMenuIconDrop"
+      />
+      <div
+        class="react-contextmenu-item-content"
+        title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not relevant for the analysis."
+      >
+        Drop samples with this function
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        d
+      </kbd>
+    </div>
+    <div
+      class="react-contextmenu-separator"
     />
     <div
-      class="react-contextmenu-item-content"
-      title="Merging a function removes it from the profile, and assigns its time to the function that called it. This happens anywhere the function was called in the tree."
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
     >
-      Merge function
+      <div
+        class="react-contextmenu-item-content"
+      >
+        Expand all
+      </div>
+      <kbd
+        class="callNodeContextMenuShortcut"
+      >
+        *
+      </kbd>
     </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      m
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconMerge"
+    <div
+      class="react-contextmenu-separator"
     />
     <div
-      class="react-contextmenu-item-content"
-      title="Merging a node removes it from the profile, and assigns its time to the function’s node that called it. It only removes the function from that specific part of the tree. Any other places the function was called from will remain in the profile."
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
     >
-      Merge node only
+      Look up the function name on Searchfox
     </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      M
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconFocus"
-    />
     <div
-      class="react-contextmenu-item-content"
-      title="Focusing on a function will remove any sample that does not include that function. In addition, it re-roots the call tree so that the function is the only root of the tree. This can combine multiple function call sites across a profile into one call node."
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
     >
-      Focus on function
+      Copy function name
     </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      f
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconFocus"
-    />
     <div
-      class="react-contextmenu-item-content"
-      title="Focusing on a subtree will remove any sample that does not include that specific part of the call tree. It pulls out a branch of the call tree, however it only does it for that single call node. All other calls of the function are ignored."
+      aria-disabled="false"
+      class="react-contextmenu-item"
+      role="menuitem"
+      tabindex="-1"
     >
-      Focus on subtree only
+      Copy stack
     </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      F
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconFocus"
-    />
-    <div
-      class="react-contextmenu-item-content"
-      title="Focusing on the nodes that belong to the same category as the selected node, thereby merging all nodes that belong to another category."
-    >
-      Focus on category 
-      <strong>
-        ⁨Other⁩
-      </strong>
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      g
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconCollapse"
-    />
-    <div
-      class="react-contextmenu-item-content"
-      title="Collapsing a function will remove everything it called, and assign all of the time to the function. This can help simplify a profile that calls into code that does not need to be analyzed."
-    >
-      Collapse function
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      c
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconCollapse"
-    />
-    <div
-      class="react-contextmenu-item-content"
-      title="Collapsing a resource will flatten out all the calls to that resource into a single collapsed call node."
-    >
-      Collapse 
-      <strong>
-        ⁨XUL⁩
-      </strong>
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      C
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconCollapse"
-    />
-    <div
-      class="react-contextmenu-item-content"
-      title="Collapsing recursion removes calls that repeatedly recurse into the same function, even with intermediate functions on the stack."
-    >
-      Collapse recursion
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      r
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconCollapse"
-    />
-    <div
-      class="react-contextmenu-item-content"
-      title="Collapsing direct recursion removes calls that repeatedly recurse into the same function with no intermediate functions on the stack."
-    >
-      Collapse direct recursion only
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      R
-    </kbd>
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <span
-      class="react-contextmenu-icon callNodeContextMenuIconDrop"
-    />
-    <div
-      class="react-contextmenu-item-content"
-      title="Dropping samples removes their time from the profile. This is useful to eliminate timing information that is not relevant for the analysis."
-    >
-      Drop samples with this function
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      d
-    </kbd>
-  </div>
-  <div
-    class="react-contextmenu-separator"
-  />
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <div
-      class="react-contextmenu-item-content"
-    >
-      Expand all
-    </div>
-    <kbd
-      class="callNodeContextMenuShortcut"
-    >
-      *
-    </kbd>
-  </div>
-  <div
-    class="react-contextmenu-separator"
-  />
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    Look up the function name on Searchfox
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    Copy function name
-  </div>
-  <div
-    aria-disabled="false"
-    class="react-contextmenu-item"
-    role="menuitem"
-    tabindex="-1"
-  >
-    Copy stack
-  </div>
-</nav>
+  </nav>
+</div>
 `;

--- a/src/test/components/__snapshots__/ContextMenu.test.tsx.snap
+++ b/src/test/components/__snapshots__/ContextMenu.test.tsx.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ContextMenu correctly renders the context-menu with the props that were passed through 1`] = `
-<nav
-  class="react-contextmenu context-menu"
-  role="menu"
-  style="position: fixed; opacity: 0; pointer-events: none;"
-  tabindex="-1"
->
-  <div />
-</nav>
+<div>
+  <nav
+    class="react-contextmenu context-menu"
+    role="menu"
+    style="position: fixed; opacity: 0; pointer-events: none;"
+    tabindex="-1"
+  >
+    <div />
+  </nav>
+</div>
 `;

--- a/src/test/components/__snapshots__/MarkerChart.test.tsx.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.tsx.snap
@@ -512,25 +512,27 @@ exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`
       title="Marker Filters"
       type="button"
     />
-    <nav
-      class="react-contextmenu markerFiltersContextMenu"
-      role="menu"
-      style="position: fixed; opacity: 0; pointer-events: none;"
-      tabindex="-1"
-    >
-      <div
-        aria-disabled="false"
-        class="react-contextmenu-item"
-        role="menuitem"
+    <div>
+      <nav
+        class="react-contextmenu markerFiltersContextMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
         tabindex="-1"
       >
-        Drop samples outside of markers matching “
-        <strong>
-          ⁨⁩
-        </strong>
-        ”
-      </div>
-    </nav>
+        <div
+          aria-disabled="false"
+          class="react-contextmenu-item"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Drop samples outside of markers matching “
+          <strong>
+            ⁨⁩
+          </strong>
+          ”
+        </div>
+      </nav>
+    </div>
   </div>
   <div
     class="react-contextmenu-wrapper treeViewContextMenu"

--- a/src/test/components/__snapshots__/MarkerTable.test.tsx.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.tsx.snap
@@ -138,25 +138,27 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
       title="Marker Filters"
       type="button"
     />
-    <nav
-      class="react-contextmenu markerFiltersContextMenu"
-      role="menu"
-      style="position: fixed; opacity: 0; pointer-events: none;"
-      tabindex="-1"
-    >
-      <div
-        aria-disabled="false"
-        class="react-contextmenu-item"
-        role="menuitem"
+    <div>
+      <nav
+        class="react-contextmenu markerFiltersContextMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
         tabindex="-1"
       >
-        Drop samples outside of markers matching “
-        <strong>
-          ⁨⁩
-        </strong>
-        ”
-      </div>
-    </nav>
+        <div
+          aria-disabled="false"
+          class="react-contextmenu-item"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Drop samples outside of markers matching “
+          <strong>
+            ⁨⁩
+          </strong>
+          ”
+        </div>
+      </nav>
+    </div>
   </div>
   <div
     class="treeView"

--- a/src/test/components/__snapshots__/TabSelectorMenu.test.tsx.snap
+++ b/src/test/components/__snapshots__/TabSelectorMenu.test.tsx.snap
@@ -3,14 +3,16 @@
 exports[`app/TabSelectorMenu should not render when the profile does not contain any page data 1`] = `
 <body>
   <div>
-    <nav
-      class="react-contextmenu TabSelectorMenu"
-      role="menu"
-      style="position: fixed; opacity: 0; pointer-events: none;"
-      tabindex="-1"
-    >
-      <div />
-    </nav>
+    <div>
+      <nav
+        class="react-contextmenu TabSelectorMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
+        tabindex="-1"
+      >
+        <div />
+      </nav>
+    </div>
   </div>
 </body>
 `;
@@ -18,46 +20,48 @@ exports[`app/TabSelectorMenu should not render when the profile does not contain
 exports[`app/TabSelectorMenu should render properly 1`] = `
 <body>
   <div>
-    <nav
-      class="react-contextmenu TabSelectorMenu"
-      role="menu"
-      style="position: fixed; opacity: 0; pointer-events: none;"
-      tabindex="-1"
-    >
-      <div
-        aria-checked="false"
-        aria-disabled="false"
-        class="react-contextmenu-item tabSelectorMenuItem checkable checked"
-        role="menuitem"
-        tabindex="-1"
-      >
-        All tabs and windows
-      </div>
-      <div
-        aria-checked="true"
-        aria-disabled="false"
-        class="react-contextmenu-item tabSelectorMenuItem checkable"
-        role="menuitem"
+    <div>
+      <nav
+        class="react-contextmenu TabSelectorMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
         tabindex="-1"
       >
         <div
-          class="nodeIcon "
-        />
-        profiler.firefox.com
-      </div>
-      <div
-        aria-checked="true"
-        aria-disabled="false"
-        class="react-contextmenu-item tabSelectorMenuItem checkable"
-        role="menuitem"
-        tabindex="-1"
-      >
+          aria-checked="false"
+          aria-disabled="false"
+          class="react-contextmenu-item tabSelectorMenuItem checkable checked"
+          role="menuitem"
+          tabindex="-1"
+        >
+          All tabs and windows
+        </div>
         <div
-          class="nodeIcon "
-        />
-        mozilla.org
-      </div>
-    </nav>
+          aria-checked="true"
+          aria-disabled="false"
+          class="react-contextmenu-item tabSelectorMenuItem checkable"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <div
+            class="nodeIcon "
+          />
+          profiler.firefox.com
+        </div>
+        <div
+          aria-checked="true"
+          aria-disabled="false"
+          class="react-contextmenu-item tabSelectorMenuItem checkable"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <div
+            class="nodeIcon "
+          />
+          mozilla.org
+        </div>
+      </nav>
+    </div>
   </div>
 </body>
 `;
@@ -65,46 +69,48 @@ exports[`app/TabSelectorMenu should render properly 1`] = `
 exports[`app/TabSelectorMenu should render sanitized page urls correctly 1`] = `
 <body>
   <div>
-    <nav
-      class="react-contextmenu TabSelectorMenu"
-      role="menu"
-      style="position: fixed; opacity: 0; pointer-events: none;"
-      tabindex="-1"
-    >
-      <div
-        aria-checked="false"
-        aria-disabled="false"
-        class="react-contextmenu-item tabSelectorMenuItem checkable checked"
-        role="menuitem"
-        tabindex="-1"
-      >
-        All tabs and windows
-      </div>
-      <div
-        aria-checked="true"
-        aria-disabled="false"
-        class="react-contextmenu-item tabSelectorMenuItem checkable"
-        role="menuitem"
+    <div>
+      <nav
+        class="react-contextmenu TabSelectorMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
         tabindex="-1"
       >
         <div
-          class="nodeIcon "
-        />
-        moz-extension://&lt;Page #4&gt;
-      </div>
-      <div
-        aria-checked="true"
-        aria-disabled="false"
-        class="react-contextmenu-item tabSelectorMenuItem checkable"
-        role="menuitem"
-        tabindex="-1"
-      >
+          aria-checked="false"
+          aria-disabled="false"
+          class="react-contextmenu-item tabSelectorMenuItem checkable checked"
+          role="menuitem"
+          tabindex="-1"
+        >
+          All tabs and windows
+        </div>
         <div
-          class="nodeIcon "
-        />
-        https://&lt;Page #3&gt;
-      </div>
-    </nav>
+          aria-checked="true"
+          aria-disabled="false"
+          class="react-contextmenu-item tabSelectorMenuItem checkable"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <div
+            class="nodeIcon "
+          />
+          moz-extension://&lt;Page #4&gt;
+        </div>
+        <div
+          aria-checked="true"
+          aria-disabled="false"
+          class="react-contextmenu-item tabSelectorMenuItem checkable"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <div
+            class="nodeIcon "
+          />
+          https://&lt;Page #3&gt;
+        </div>
+      </nav>
+    </div>
   </div>
 </body>
 `;


### PR DESCRIPTION
`findDOMNode` is deprecated in react 18 and it's removed from version 19. It's one of the blockers of the React 19 upgrade for us right now. There are a few more `findDOMNode` usages, but I expect to look at them next.

It looks like there 2 more places where we use `findDOMNode`:
- `withSize` higher order component
- `CSSTransition` component that's from the `react-transition-group` package (internally).

"Hide whitespace" option in github would make it easier to review the snapshot tests as we only wrap the component with a div.

[Production](https://share.firefox.dev/3V2tAa6) / [Deploy preview](https://deploy-preview-5588--perf-html.netlify.app/public/etegz8k5g139b8q7n74qfqv6z4ztb0nzvy051k0/calltree/?globalTrackOrder=0&thread=0&v=11)