### PR TITLE
Remove SharedArrayBuffer workaround

### DIFF
--- a/src/actions/receive-profile.ts
+++ b/src/actions/receive-profile.ts
@@ -1065,7 +1065,7 @@ async function _extractZipFromResponse(
 async function _extractJsonFromArrayBuffer(
   arrayBuffer: ArrayBuffer
 ): Promise<unknown> {
-  let profileBytes: Uint8Array<ArrayBufferLike> = new Uint8Array(arrayBuffer);
+  let profileBytes = new Uint8Array(arrayBuffer);
   // Check for the gzip magic number in the header.
   if (isGzip(profileBytes)) {
     profileBytes = await decompress(profileBytes);

--- a/src/profile-logic/process-profile.ts
+++ b/src/profile-logic/process-profile.ts
@@ -1980,9 +1980,7 @@ export async function unserializeProfileOfArbitraryFormat(
     // object is constructed from an ArrayBuffer in a different context... which
     // happens in our tests.
     if (String(arbitraryFormat) === '[object ArrayBuffer]') {
-      // Obviously Flow doesn't understand that this is correct, so let's help
-      // Flow here.
-      let arrayBuffer: ArrayBufferLike = arbitraryFormat as any;
+      let arrayBuffer = arbitraryFormat as ArrayBuffer;
 
       // Check for the gzip magic number in the header. If we find it, decompress
       // the data first.

--- a/src/test/store/receive-profile.test.ts
+++ b/src/test/store/receive-profile.test.ts
@@ -131,7 +131,7 @@ describe('actions/receive-profile', function () {
     return states;
   }
 
-  function encode(string: string): Uint8Array {
+  function encode(string: string): Uint8Array<ArrayBuffer> {
     return new TextEncoder().encode(string);
   }
 

--- a/src/utils/gz.ts
+++ b/src/utils/gz.ts
@@ -32,20 +32,8 @@ async function readableStreamToBuffer(
   return result;
 }
 
-// The Streams API doesn't support SAB, and so we need to copy from these to
-// use these API's.
-function copyBufferIfShared(buffer: Uint8Array): Uint8Array<ArrayBuffer> {
-  // Check if the buffer is a view into a larger ArrayBuffer (shared)
-  if (buffer.buffer instanceof SharedArrayBuffer) {
-    // Create a new buffer with its own ArrayBuffer
-    return new Uint8Array(buffer);
-  }
-  // Return the original buffer if it's not shared
-  return buffer as Uint8Array<ArrayBuffer>;
-}
-
 export async function compress(
-  data: string | Uint8Array
+  data: string | Uint8Array<ArrayBuffer>
 ): Promise<Uint8Array<ArrayBuffer>> {
   // Encode the data if it's a string
   const arrayData =
@@ -56,7 +44,7 @@ export async function compress(
 
   // Write the data to the compression stream
   const writer = compressionStream.writable.getWriter();
-  writer.write(copyBufferIfShared(arrayData));
+  writer.write(arrayData);
   writer.close();
 
   // Read the compressed data back into a buffer
@@ -64,14 +52,14 @@ export async function compress(
 }
 
 export async function decompress(
-  data: Uint8Array
+  data: Uint8Array<ArrayBuffer>
 ): Promise<Uint8Array<ArrayBuffer>> {
   // Create a gzip compression stream
   const decompressionStream = new DecompressionStream('gzip');
 
   // Write the data to the compression stream
   const writer = decompressionStream.writable.getWriter();
-  writer.write(copyBufferIfShared(data));
+  writer.write(data);
   writer.close();
 
   // Read the compressed data back into a buffer


### PR DESCRIPTION
[Production](https://profiler.firefox.com/public/283zgs51v5kc3yxtjkm5w2x249468x99ydds610/flame-graph/?globalTrackOrder=1w46705&hiddenGlobalTracks=5&hiddenLocalTracksByPid=5472-0wAiAkwBhBjwE6E8wEhEjwFiFkwHv~5511-0wyp~5607-0wxhxjwCj~5696-0wxj~5855-0wCbCdwDi~6253-0whkwy4&localTrackOrderByPid=5472-HnwHpHbBaBcBnBpAnEhEfEgBlC8FeDqBkEqD7E5CjCkghy6z7zdA1EaA2A3E3EvF0FlF1FnF2FoG3G4FpG5GbGcG7GdGfGgGeGhwGoGuGpwGtGvH2H0H1H3H4HhwHmAuEuFawFcH7HvCtAgDcAoAsAtC7ClCsDsHrHsE0CuBgAbwAeAvB0B2wB4B6wB9BbBdBoBqwC2ErEtAiE9ElEmEoEjHfHgA7wAaF3F4jkA5A6DrDtDuAjAkF5wF9FvwG2AlAqB1G8EeHdC3FdC5DeDfEcE1E7ArBjEsHqHcAfCqCpCiDpC9DgCawChDhwDoBhAhilwy5y7wz6z8wzczewA0HaE2C4FkBeG9HtEdA4BfDdHeEpBmE6FfwFiFqwFtGaEkH9FmG6H8EbEnD8wDaC6CvwD6f0weBiFjFuApCrAmE8EiDvE4B5CmCnHuCoDbH5H6~6253-8mursewgy0wy2cdapx3x1n9txhwxm7x4hx5bx06oxewxgqx6wxd3w5021vliwkxnwxvy4x2y3~5855-D5DhCrC9Cagwimwox0wx8xbxcxexdxfwxhxjwxlxpwy1y4wybydwyuz0wz2z6wz8zcwzkzqwAnApwBoC6wC8CuD2CvD0DbwDdCqqCbD9Day2y3ycD1krx9xaxiz3wz5znwzpDfD7DiD6zlzmAoC2BpwC1yvjlpD4DeCsD8swvxmwxoz9wzbD3dwf0w4b5wacCtDgCpC5C3C4CdCgwCeChCjwClCiCmwCoCc&thread=Kv&v=11) | [Main branch](https://main--perf-html.netlify.app/public/283zgs51v5kc3yxtjkm5w2x249468x99ydds610/flame-graph/?globalTrackOrder=1w46705&hiddenGlobalTracks=5&hiddenLocalTracksByPid=5472-0wAiAkwBhBjwE6E8wEhEjwFiFkwHv~5511-0wyp~5607-0wxhxjwCj~5696-0wxj~5855-0wCbCdwDi~6253-0whkwy4&localTrackOrderByPid=5472-HnwHpHbBaBcBnBpAnEhEfEgBlC8FeDqBkEqD7E5CjCkghy6z7zdA1EaA2A3E3EvF0FlF1FnF2FoG3G4FpG5GbGcG7GdGfGgGeGhwGoGuGpwGtGvH2H0H1H3H4HhwHmAuEuFawFcH7HvCtAgDcAoAsAtC7ClCsDsHrHsE0CuBgAbwAeAvB0B2wB4B6wB9BbBdBoBqwC2ErEtAiE9ElEmEoEjHfHgA7wAaF3F4jkA5A6DrDtDuAjAkF5wF9FvwG2AlAqB1G8EeHdC3FdC5DeDfEcE1E7ArBjEsHqHcAfCqCpCiDpC9DgCawChDhwDoBhAhilwy5y7wz6z8wzczewA0HaE2C4FkBeG9HtEdA4BfDdHeEpBmE6FfwFiFqwFtGaEkH9FmG6H8EbEnD8wDaC6CvwD6f0weBiFjFuApCrAmE8EiDvE4B5CmCnHuCoDbH5H6~6253-8mursewgy0wy2cdapx3x1n9txhwxm7x4hx5bx06oxewxgqx6wxd3w5021vliwkxnwxvy4x2y3~5855-D5DhCrC9Cagwimwox0wx8xbxcxexdxfwxhxjwxlxpwy1y4wybydwyuz0wz2z6wz8zcwzkzqwAnApwBoC6wC8CuD2CvD0DbwDdCqqCbD9Day2y3ycD1krx9xaxiz3wz5znwzpDfD7DiD6zlzmAoC2BpwC1yvjlpD4DeCsD8swvxmwxoz9wzbD3dwf0w4b5wacCtDgCpC5C3C4CdCgwCeChCjwClCiCmwCoCc&thread=Kv&v=11) | [Deploy preview](https://deploy-preview-5596--perf-html.netlify.app/public/283zgs51v5kc3yxtjkm5w2x249468x99ydds610/flame-graph/?globalTrackOrder=1w46705&hiddenGlobalTracks=5&hiddenLocalTracksByPid=5472-0wAiAkwBhBjwE6E8wEhEjwFiFkwHv~5511-0wyp~5607-0wxhxjwCj~5696-0wxj~5855-0wCbCdwDi~6253-0whkwy4&localTrackOrderByPid=5472-HnwHpHbBaBcBnBpAnEhEfEgBlC8FeDqBkEqD7E5CjCkghy6z7zdA1EaA2A3E3EvF0FlF1FnF2FoG3G4FpG5GbGcG7GdGfGgGeGhwGoGuGpwGtGvH2H0H1H3H4HhwHmAuEuFawFcH7HvCtAgDcAoAsAtC7ClCsDsHrHsE0CuBgAbwAeAvB0B2wB4B6wB9BbBdBoBqwC2ErEtAiE9ElEmEoEjHfHgA7wAaF3F4jkA5A6DrDtDuAjAkF5wF9FvwG2AlAqB1G8EeHdC3FdC5DeDfEcE1E7ArBjEsHqHcAfCqCpCiDpC9DgCawChDhwDoBhAhilwy5y7wz6z8wzczewA0HaE2C4FkBeG9HtEdA4BfDdHeEpBmE6FfwFiFqwFtGaEkH9FmG6H8EbEnD8wDaC6CvwD6f0weBiFjFuApCrAmE8EiDvE4B5CmCnHuCoDbH5H6~6253-8mursewgy0wy2cdapx3x1n9txhwxm7x4hx5bx06oxewxgqx6wxd3w5021vliwkxnwxvy4x2y3~5855-D5DhCrC9Cagwimwox0wx8xbxcxexdxfwxhxjwxlxpwy1y4wybydwyuz0wz2z6wz8zcwzkzqwAnApwBoC6wC8CuD2CvD0DbwDdCqqCbD9Day2y3ycD1krx9xaxiz3wz5znwzpDfD7DiD6zlzmAoC2BpwC1yvjlpD4DeCsD8swvxmwxoz9wzbD3dwf0w4b5wacCtDgCpC5C3C4CdCgwCeChCjwClCiCmwCoCc&thread=Kv&v=11)

`instanceof SharedArrayBuffer` throws if `window.crossOriginIsolated` is false (would need COOP and COEP)

This fixes a regression from #5584.