### PR TITLE
Simplify the eslint command in package.json so that eslint.config.mjs is the only place you need to look if you want to know if a file is being checked

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,8 @@ export default [
     ignores: [
       'src/profile-logic/import/proto/**',
       'src/types/libdef/npm/**',
+      'res/**',
+      'dist/**',
       'docs-user/**',
       'coverage/**',
     ],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-symbolicator-cli:quiet": "yarn build:clean && cross-env NODE_ENV=production webpack --config src/symbolicator-cli/webpack.config.js",
     "lint": "node bin/output-fixing-commands.js run-p lint-js lint-css prettier-run",
     "lint-fix": "run-p lint-fix-js lint-fix-css prettier-fix",
-    "lint-js": "node bin/output-fixing-commands.js eslint *.js bin src --report-unused-disable-directives --cache --cache-strategy content",
+    "lint-js": "node bin/output-fixing-commands.js eslint . --report-unused-disable-directives --cache --cache-strategy content",
     "lint-fix-js": "yarn lint-js --fix",
     "lint-css": "node bin/output-fixing-commands.js stylelint \"src/**/*.css\" \"res/**/*.css\"",
     "lint-fix-css": "yarn lint-css --fix",


### PR DESCRIPTION
It's currently not checking .mjs files in the repo root directory, for example.