### PR TITLE
Remove Flow and no-TypeScript settings from .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  // Bypass check for node_modules/flow-bin/SHASUM256.txt.sign since it
-  // doesn't exist in flow-bin 0.96.0.
-  "flow.useNPMPackagedFlow": false,
-  "flow.pathToFlow": "${workspaceFolder}/node_modules/.bin/flow",
-  // VS Code uses TypeScript to validate JavaScript, which conflicts with the Flow
-  // integration.
-  "javascript.validate.enable": false
-}


### PR DESCRIPTION
I don't actually notice a difference but this seems cleaner.

~~I kept the file, to make it slightly easier to experiment with adding stuff there. But I'm also happy to remove it if you ask me to.~~

Nevermind, I'm removing the entire file because prettier would want it to be formatted as `{}`.