### PR TITLE
Allow markers to provide a marker color.

### DIFF
--- a/src/components/marker-chart/index.tsx
+++ b/src/components/marker-chart/index.tsx
@@ -14,6 +14,7 @@ import { MarkerSettings } from 'firefox-profiler/components/shared/MarkerSetting
 import {
   getCommittedRange,
   getPreviewSelection,
+  getMarkerSchemaByName,
 } from 'firefox-profiler/selectors/profile';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import { getSelectedThreadsKey } from 'firefox-profiler/selectors/url-state';
@@ -28,6 +29,7 @@ import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMe
 import type {
   Marker,
   MarkerIndex,
+  MarkerSchemaByName,
   MarkerTimingAndBuckets,
   UnitIntervalOfProfileRange,
   StartEndRange,
@@ -51,6 +53,7 @@ type DispatchProps = {
 type StateProps = {
   readonly getMarker: (param: MarkerIndex) => Marker;
   readonly getMarkerLabel: (param: MarkerIndex) => string;
+  readonly markerSchemaByName: MarkerSchemaByName;
   readonly markerTimingAndBuckets: MarkerTimingAndBuckets;
   readonly maxMarkerRows: number;
   readonly markerListLength: number;
@@ -106,6 +109,7 @@ class MarkerChartImpl extends React.PureComponent<Props> {
       markerTimingAndBuckets,
       getMarker,
       getMarkerLabel,
+      markerSchemaByName,
       previewSelection,
       updatePreviewSelection,
       changeMouseTimePosition,
@@ -152,6 +156,7 @@ class MarkerChartImpl extends React.PureComponent<Props> {
                 markerTimingAndBuckets,
                 getMarker,
                 getMarkerLabel,
+                markerSchemaByName,
                 markerListLength,
                 updatePreviewSelection,
                 changeMouseTimePosition,
@@ -190,6 +195,7 @@ export const MarkerChart = explicitConnect<{}, StateProps, DispatchProps>({
     return {
       getMarker: selectedThreadSelectors.getMarkerGetter(state),
       getMarkerLabel: selectedThreadSelectors.getMarkerChartLabelGetter(state),
+      markerSchemaByName: getMarkerSchemaByName(state),
       markerTimingAndBuckets,
       maxMarkerRows: markerTimingAndBuckets.length,
       markerListLength: selectedThreadSelectors.getMarkerListLength(state),

--- a/src/profile-logic/graph-color.ts
+++ b/src/profile-logic/graph-color.ts
@@ -84,3 +84,22 @@ export function getDotColor(color: GraphColor) {
       throw new Error('Unexpected track color: ' + color);
   }
 }
+
+/**
+ * Check if a string is a valid GraphColor value.
+ */
+export function isValidGraphColor(value: string): value is GraphColor {
+  const validColors: GraphColor[] = [
+    'blue',
+    'green',
+    'grey',
+    'ink',
+    'magenta',
+    'orange',
+    'purple',
+    'red',
+    'teal',
+    'yellow',
+  ];
+  return validColors.includes(value as GraphColor);
+}

--- a/src/types/markers.ts
+++ b/src/types/markers.ts
@@ -171,6 +171,11 @@ export type MarkerSchema = {
   // if present, give the marker its own local track
   graphs?: Array<MarkerGraph>;
 
+  // If present, specifies the key of a marker field that contains the marker's color.
+  // The field should contain one of the GraphColor values.
+  // This allows individual markers to have different colors based on their data.
+  colorField?: string;
+
   // If set to true, markers of this type are assumed to be well-nested with all
   // other stack-based markers on the same thread. Stack-based markers may
   // be displayed in a different part of the marker chart than non-stack-based


### PR DESCRIPTION
Adds an optional `colorField` field to marker schemas that specifies which marker data field contains a `GraphColor` value, allowing individual markers to render with different colors based on their data.

[deploy preview](https://deploy-preview-5607--perf-html.netlify.app/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FJJ5LLsBzQcm_UnYOzfOhDA%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_resource-usage.json/marker-chart/?globalTrackOrder=0&thread=0&timelineType=category&v=11)