### PR TITLE
Streamline some code related to profile publishing

### DIFF
--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -38,12 +38,14 @@ import type {
   State,
 } from 'firefox-profiler/types';
 
-export function toggleCheckedSharingOptions(
-  slug: keyof CheckedSharingOptions
+export function updateSharingOption(
+  slug: keyof CheckedSharingOptions,
+  value: boolean
 ): Action {
   return {
-    type: 'TOGGLE_CHECKED_SHARING_OPTION',
+    type: 'UPDATE_SHARING_OPTION',
     slug,
+    value,
   };
 }
 

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -9,9 +9,9 @@ import type { SanitizeProfileResult } from 'firefox-profiler/profile-logic/sanit
 import {
   getUploadGeneration,
   getSanitizedProfile,
-  getSanitizedProfileData,
   getRemoveProfileInformation,
   getPrePublishedState,
+  getSanitizedProfileEncodingState,
 } from 'firefox-profiler/selectors/publish';
 import {
   getDataSource,
@@ -36,7 +36,10 @@ import type {
   StartEndRange,
   ThreadIndex,
   State,
+  Profile,
 } from 'firefox-profiler/types';
+import { compress } from 'firefox-profiler/utils/gz';
+import { serializeProfile } from 'firefox-profiler/profile-logic/process-profile';
 
 export function updateSharingOption(
   slug: keyof CheckedSharingOptions,
@@ -46,6 +49,37 @@ export function updateSharingOption(
     type: 'UPDATE_SHARING_OPTION',
     slug,
     value,
+  };
+}
+
+export function sanitizedProfileEncodingStarted(
+  sanitizedProfile: Profile
+): Action {
+  return {
+    type: 'SANITIZED_PROFILE_ENCODING_STARTED',
+    sanitizedProfile,
+  };
+}
+
+export function sanitizedProfileEncodingCompleted(
+  sanitizedProfile: Profile,
+  profileData: Blob
+): Action {
+  return {
+    type: 'SANITIZED_PROFILE_ENCODING_COMPLETED',
+    sanitizedProfile,
+    profileData,
+  };
+}
+
+export function sanitizedProfileEncodingFailed(
+  sanitizedProfile: Profile,
+  error: Error
+): Action {
+  return {
+    type: 'SANITIZED_PROFILE_ENCODING_FAILED',
+    sanitizedProfile,
+    error,
   };
 }
 
@@ -198,6 +232,90 @@ async function persistJustUploadedProfileInformationToDb(
   }
 }
 
+export type ProfileEncodingResult =
+  | {
+      type: 'SUCCESS';
+      profileData: Blob;
+    }
+  | { type: 'ERROR'; error: Error };
+
+function unwrapEncodedProfile(encodingResult: ProfileEncodingResult): Blob {
+  if (encodingResult.type === 'ERROR') {
+    throw encodingResult.error;
+  }
+  return encodingResult.profileData;
+}
+
+export type InflightProfileEncoding = {
+  sanitizedProfile: Profile;
+  encodingPromise: Promise<ProfileEncodingResult>;
+};
+
+/**
+ * Kick off "encoding" of the sanitized profile. Specifically this means:
+ * - Compute the sanitized profile
+ * - Serialize the profile to a buffer
+ * - Kick off the asynchronous compression of the buffer
+ *
+ * The asynchronous compression can take a few seconds, so we want to kick
+ * it off immediately when the profile publishing panel is opened. We also
+ * want to be able to make use of the current in-flight compression if the
+ * user clicks the upload button before compression is done. This is why
+ * we return an `InflightProfileEncoding` object from this action; it contains
+ * a promise which lets other parts of the publishing pipeline wait on the
+ * compressed results.
+ *
+ * This thunk action is synchronous.
+ */
+export function encodeSanitizedProfile(
+  previousInflightEncoding?: InflightProfileEncoding
+): ThunkAction<InflightProfileEncoding> {
+  return (dispatch, getState): InflightProfileEncoding => {
+    const state = getState();
+    const sanitizedProfile = getSanitizedProfile(state).profile;
+
+    if (previousInflightEncoding?.sanitizedProfile === sanitizedProfile) {
+      // No need to kick of another compression. The current encoding may still
+      // be in-flight, and returning the original promise allows the caller to
+      // await it.
+      return previousInflightEncoding;
+    }
+
+    const encodingState = getSanitizedProfileEncodingState(state);
+    if (
+      encodingState.phase === 'DONE' &&
+      encodingState.sanitizedProfile === sanitizedProfile
+    ) {
+      // We already have an encoded version of this profile in our state! Use it.
+      return {
+        sanitizedProfile,
+        encodingPromise: Promise.resolve({
+          type: 'SUCCESS',
+          profileData: encodingState.profileData,
+        }),
+      };
+    }
+
+    // Kick off a new encoding for this profile. Don't await the promise,
+    // just return it as part of the InflightProfileEncoding.
+    const encodingPromise: Promise<ProfileEncodingResult> = (async function () {
+      try {
+        dispatch(sanitizedProfileEncodingStarted(sanitizedProfile));
+        const gzipData = await compress(serializeProfile(sanitizedProfile));
+        const blob = new Blob([gzipData], { type: 'application/octet-binary' });
+        dispatch(sanitizedProfileEncodingCompleted(sanitizedProfile, blob));
+        return { type: 'SUCCESS', profileData: blob };
+      } catch (error) {
+        dispatch(sanitizedProfileEncodingFailed(sanitizedProfile, error));
+        console.error('Error while compressing the profile data', error);
+        return { type: 'ERROR', error };
+      }
+    })();
+
+    return { sanitizedProfile, encodingPromise };
+  };
+}
+
 /**
  * This function starts the profile sharing process. Takes an optional argument that
  * indicates if the share attempt is being made for the second time. We have two share
@@ -210,7 +328,9 @@ async function persistJustUploadedProfileInformationToDb(
  * The return value is used for tests to determine if the request went all the way
  * through (true) or was quit early due to the generation value being invalidated (false).
  */
-export function attemptToPublish(): ThunkAction<Promise<boolean>> {
+export function attemptToPublish(
+  previousInflightEncoding?: InflightProfileEncoding
+): ThunkAction<Promise<boolean>> {
   return async (dispatch, getState) => {
     try {
       sendAnalytics({
@@ -244,7 +364,10 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
       dispatch(uploadCompressionStarted(abortfunction));
 
       const sanitizedInformation = getSanitizedProfile(prePublishedState);
-      const gzipData = await getSanitizedProfileData(prePublishedState);
+      const profileEncoding = dispatch(
+        encodeSanitizedProfile(previousInflightEncoding)
+      );
+      const encodingResult = await profileEncoding.encodingPromise;
 
       // The previous line was async, check to make sure that this request is still valid.
       // The upload could have been aborted while we were compressing the data.
@@ -252,13 +375,18 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
         return false;
       }
 
+      const encodedProfile = unwrapEncodedProfile(encodingResult);
+
       dispatch(uploadStarted());
 
       // Upload the profile, and notify it with the amount of data that has been
       // uploaded.
-      const hashOrToken = await startUpload(gzipData, (uploadProgress) => {
-        dispatch(updateUploadProgress(uploadProgress));
-      });
+      const hashOrToken = await startUpload(
+        encodedProfile,
+        (uploadProgress) => {
+          dispatch(updateUploadProgress(uploadProgress));
+        }
+      );
 
       const hash = extractProfileTokenFromJwt(hashOrToken);
 

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -30,18 +30,18 @@
   background-image: url(../../../../res/img/svg/error.svg);
 }
 
-.menuButtonsPublishPanel {
+.publishPanelPanel {
   --width: 510px;
 }
 
-.menuButtonsPublishContent {
+.publishPanelContent {
   position: relative;
 
   /* This aligns all content, except the big icon. */
   padding-left: 70px;
 }
 
-.menuButtonsPublishTitle {
+.publishPanelTitle {
   /* "60px" This is the value to put the background image at the right location.
    * This background image is 44x44, so this puts it 16px left of the text. */
   padding-left: 60px;
@@ -50,32 +50,32 @@
   line-height: 44px; /* This is the height of the background image */
 }
 
-.menuButtonsPublishInfoDescription {
+.publishPanelInfoDescription {
   flex: 1;
   margin-bottom: 1em;
   line-height: 1.5;
 }
 
-.menuButtonsPublishDataChoices {
+.publishPanelDataChoices {
   margin-left: 10px;
 }
 
-.menuButtonsPublishDataChoicesLabel {
+.publishPanelDataChoicesLabel {
   display: flex;
   margin: 4px 0;
 }
 
-.menuButtonsPublishDataChoicesIndicator {
+.publishPanelDataChoicesIndicator {
   margin-left: 8px;
 }
 
-.menuButtonsPublishButtons {
+.publishPanelButtons {
   display: flex;
   justify-content: right;
   margin-top: 20px;
 }
 
-.menuButtonsPublishButton {
+.publishPanelButton {
   display: inline-flex;
   min-width: 132px;
   box-sizing: content-box;
@@ -87,16 +87,16 @@
   text-decoration: none;
 }
 
-.menuButtonsPublishButtonDisabled {
+.publishPanelButtonDisabled {
   opacity: 0.6;
 }
 
-.menuButtonsPublishButtonDisabled:hover,
-.menuButtonsPublishButtonDisabled:active:hover {
+.publishPanelButtonDisabled:hover,
+.publishPanelButtonDisabled:active:hover {
   background-color: var(--grey-90-a10);
 }
 
-.menuButtonsPublishButtonsSvg {
+.publishPanelButtonsSvg {
   position: relative;
   top: 4px;
   display: inline-block;
@@ -104,13 +104,13 @@
   margin-right: 5px;
 }
 
-.menuButtonsPublishButtonsSvgUpload {
+.publishPanelButtonsSvgUpload {
   width: 20px;
   height: 20px;
   background: url(../../../../res/img/svg/upload.svg) center center no-repeat;
 }
 
-.menuButtonsPublishButtonsSvgDownload {
+.publishPanelButtonsSvgDownload {
   width: 20px;
   height: 20px;
   background: url(../../../../res/img/svg/download.svg) center center no-repeat;
@@ -122,28 +122,28 @@
   font-size: 11px;
 }
 
-.menuButtonsPublishUpload {
+.publishPanelUpload {
   position: relative;
   padding: 10px 0;
 }
 
-.menuButtonsPublishUploadTop {
+.publishPanelUploadTop {
   margin: 10px;
 }
 
-.menuButtonsPublishUploadPercentage {
+.publishPanelUploadPercentage {
   margin: 10px 0;
   color: var(--blue-60);
 }
 
-.menuButtonsPublishUploadBar {
+.publishPanelUploadBar {
   overflow: hidden;
   height: 5px;
   border-radius: 2px;
   background-color: var(--grey-40);
 }
 
-.menuButtonsPublishUploadBarInner {
+.publishPanelUploadBarInner {
   position: absolute;
   top: 0;
   height: 3px;
@@ -173,13 +173,13 @@
   }
 }
 
-.menuButtonsPublishError {
+.publishPanelError {
   margin: 10px 0;
 }
 
 /* Do not animate the publish animation for stripes at the top loading bar. */
 @media (prefers-reduced-motion) {
-  .menuButtonsPublishUploadBarInner {
+  .publishPanelUploadBarInner {
     animation: none;
   }
 }

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -83,23 +83,11 @@ class MenuButtonsPublishImpl extends React.PureComponent<
   PublishState
 > {
   override state = { compressError: null, prevCompressedPromise: null };
-  _toggles: { [K in keyof CheckedSharingOptions]: () => void } = {
-    includeHiddenThreads: () =>
-      this.props.toggleCheckedSharingOptions('includeHiddenThreads'),
-    includeAllTabs: () =>
-      this.props.toggleCheckedSharingOptions('includeAllTabs'),
-    includeFullTimeRange: () =>
-      this.props.toggleCheckedSharingOptions('includeFullTimeRange'),
-    includeScreenshots: () =>
-      this.props.toggleCheckedSharingOptions('includeScreenshots'),
-    includeUrls: () => this.props.toggleCheckedSharingOptions('includeUrls'),
-    includeExtension: () =>
-      this.props.toggleCheckedSharingOptions('includeExtension'),
-    includePreferenceValues: () =>
-      this.props.toggleCheckedSharingOptions('includePreferenceValues'),
-    includePrivateBrowsingData: () =>
-      this.props.toggleCheckedSharingOptions('includePrivateBrowsingData'),
-  };
+
+  _onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const sharingOption = e.target.name as keyof CheckedSharingOptions;
+    this.props.toggleCheckedSharingOptions(sharingOption);
+  }
 
   _renderCheckbox(
     slug: keyof CheckedSharingOptions,
@@ -107,14 +95,13 @@ class MenuButtonsPublishImpl extends React.PureComponent<
     additionalContent?: React.ReactNode
   ) {
     const { checkedSharingOptions } = this.props;
-    const toggle = this._toggles[slug];
     return (
       <label className="photon-label menuButtonsPublishDataChoicesLabel">
         <input
           type="checkbox"
           className="photon-checkbox photon-checkbox-default"
           name={slug}
-          onChange={toggle}
+          onChange={this._onCheckboxChange}
           checked={checkedSharingOptions[slug]}
         />
         <Localized id={labelL10nId} />

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -78,10 +78,7 @@ type PublishState = {
   prevCompressedPromise: Promise<Uint8Array> | null;
 };
 
-class MenuButtonsPublishImpl extends React.PureComponent<
-  PublishProps,
-  PublishState
-> {
+class PublishPanelImpl extends React.PureComponent<PublishProps, PublishState> {
   override state = { compressError: null, prevCompressedPromise: null };
 
   _onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -96,7 +93,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
   ) {
     const { checkedSharingOptions } = this.props;
     return (
-      <label className="photon-label menuButtonsPublishDataChoicesLabel">
+      <label className="photon-label publishPanelDataChoicesLabel">
         <input
           type="checkbox"
           className="photon-checkbox photon-checkbox-default"
@@ -140,12 +137,12 @@ class MenuButtonsPublishImpl extends React.PureComponent<
     } = this.props;
 
     return (
-      <div data-testid="MenuButtonsPublish-container">
+      <div data-testid="PublishPanel-container">
         <form
-          className="menuButtonsPublishContent photon-body-10"
+          className="publishPanelContent photon-body-10"
           onSubmit={attemptToPublish}
         >
-          <h1 className="menuButtonsPublishTitle photon-title-40">
+          <h1 className="publishPanelTitle photon-title-40">
             {isRepublish ? (
               <Localized id="MenuButtons--publish--reupload-performance-profile">
                 Re-upload Performance Profile
@@ -156,7 +153,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
               </Localized>
             )}
           </h1>
-          <p className="menuButtonsPublishInfoDescription">
+          <p className="publishPanelInfoDescription">
             <Localized id="MenuButtons--publish--info-description">
               Upload your profile and make it accessible to anyone with the
               link.
@@ -177,7 +174,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
               Include additional data that may be identifiable
             </Localized>
           </h3>
-          <div className="menuButtonsPublishDataChoices">
+          <div className="publishPanelDataChoices">
             {this._renderCheckbox(
               'includeHiddenThreads',
               'MenuButtons--publish--renderCheckbox-label-hidden-threads'
@@ -213,7 +210,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
                     attrs={{ title: true }}
                   >
                     <img
-                      className="menuButtonsPublishDataChoicesIndicator"
+                      className="publishPanelDataChoicesIndicator"
                       src={WarningImage}
                       title="This profile contains private browsing data"
                     />
@@ -231,7 +228,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
               </div>
             </div>
           ) : null}
-          <div className="menuButtonsPublishButtons">
+          <div className="publishPanelButtons">
             <DownloadButton
               downloadFileName={downloadFileName}
               sanitizedProfileDataPromise={sanitizedProfileDataPromise}
@@ -239,10 +236,10 @@ class MenuButtonsPublishImpl extends React.PureComponent<
             />
             <button
               type="submit"
-              className="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
+              className="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
               disabled={!!this.state.compressError}
             >
-              <span className="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload" />
+              <span className="publishPanelButtonsSvg publishPanelButtonsSvgUpload" />
               <Localized id="MenuButtons--publish--button-upload">
                 Upload
               </Localized>
@@ -264,26 +261,26 @@ class MenuButtonsPublishImpl extends React.PureComponent<
 
     return (
       <div
-        className="menuButtonsPublishUpload photon-body-10"
-        data-testid="MenuButtonsPublish-container"
+        className="publishPanelUpload photon-body-10"
+        data-testid="PublishPanel-container"
       >
-        <div className="menuButtonsPublishUploadTop">
-          <div className="menuButtonsPublishUploadTitle photon-title-20">
+        <div className="publishPanelUploadTop">
+          <div className="publishPanelUploadTitle photon-title-20">
             <Localized id="MenuButtons--publish--upload-title">
               Uploading profile…
             </Localized>
           </div>
-          <div className="menuButtonsPublishUploadPercentage">
+          <div className="publishPanelUploadPercentage">
             {uploadProgressString}
           </div>
-          <div className="menuButtonsPublishUploadBar">
+          <div className="publishPanelUploadBar">
             <div
-              className="menuButtonsPublishUploadBarInner"
+              className="publishPanelUploadBarInner"
               style={{ width: `${uploadProgress * 100}%` }}
             />
           </div>
         </div>
-        <div className="menuButtonsPublishButtons">
+        <div className="publishPanelButtons">
           <DownloadButton
             downloadFileName={downloadFileName}
             sanitizedProfileDataPromise={sanitizedProfileDataPromise}
@@ -291,7 +288,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
           />
           <button
             type="button"
-            className="photon-button photon-button-default menuButtonsPublishButton menuButtonsPublishButtonsCancelUpload"
+            className="photon-button photon-button-default publishPanelButton publishPanelButtonsCancelUpload"
             onClick={abortFunction}
           >
             <Localized id="MenuButtons--publish--cancel-upload">
@@ -321,8 +318,8 @@ class MenuButtonsPublishImpl extends React.PureComponent<
 
     return (
       <div
-        className="menuButtonsPublishUpload photon-body-10"
-        data-testid="MenuButtonsPublish-container"
+        className="publishPanelUpload photon-body-10"
+        data-testid="PublishPanel-container"
       >
         <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">
           <div className="photon-message-bar-inner-text">
@@ -340,7 +337,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
             </Localized>
           </button>
         </div>
-        <div className="menuButtonsPublishError">{message}</div>
+        <div className="publishPanelError">{message}</div>
       </div>
     );
   }
@@ -362,7 +359,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
   }
 }
 
-export const MenuButtonsPublish = explicitConnect<
+export const PublishPanel = explicitConnect<
   OwnProps,
   StateProps,
   DispatchProps
@@ -388,7 +385,7 @@ export const MenuButtonsPublish = explicitConnect<
     attemptToPublish,
     resetUploadState,
   },
-  component: MenuButtonsPublishImpl,
+  component: PublishPanelImpl,
 });
 
 type DownloadButtonProps = {
@@ -472,7 +469,7 @@ class DownloadButton extends React.PureComponent<
     const { downloadFileName } = this.props;
     const { sanitizedProfileData, error } = this.state;
     const className =
-      'photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload';
+      'photon-button publishPanelButton publishPanelButtonsDownload';
 
     if (sanitizedProfileData) {
       const blob = new Blob([sanitizedProfileData], {
@@ -486,7 +483,7 @@ class DownloadButton extends React.PureComponent<
             className,
           }}
         >
-          <span className="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgDownload" />
+          <span className="publishPanelButtonsSvg publishPanelButtonsSvgDownload" />
           <Localized id="MenuButtons--publish--download">Download</Localized>{' '}
           <span className="menuButtonsDownloadSize">
             ({prettyBytes(blob.size)})
@@ -506,7 +503,7 @@ class DownloadButton extends React.PureComponent<
     return (
       <button
         type="button"
-        className={classNames(className, 'menuButtonsPublishButtonDisabled')}
+        className={classNames(className, 'publishPanelButtonDisabled')}
       >
         <Localized id="MenuButtons--publish--compressing">
           Compressing…

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import {
-  toggleCheckedSharingOptions,
+  updateSharingOption,
   attemptToPublish,
   resetUploadState,
 } from 'firefox-profiler/actions/publish';
@@ -67,7 +67,7 @@ type StateProps = {
 };
 
 type DispatchProps = {
-  readonly toggleCheckedSharingOptions: typeof toggleCheckedSharingOptions;
+  readonly updateSharingOption: typeof updateSharingOption;
   readonly attemptToPublish: typeof attemptToPublish;
   readonly resetUploadState: typeof resetUploadState;
 };
@@ -86,7 +86,7 @@ class MenuButtonsPublishImpl extends React.PureComponent<
 
   _onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const sharingOption = e.target.name as keyof CheckedSharingOptions;
-    this.props.toggleCheckedSharingOptions(sharingOption);
+    this.props.updateSharingOption(sharingOption, e.target.checked);
   }
 
   _renderCheckbox(
@@ -384,7 +384,7 @@ export const MenuButtonsPublish = explicitConnect<
     abortFunction: getAbortFunction(state),
   }),
   mapDispatchToProps: {
-    toggleCheckedSharingOptions,
+    updateSharingOption,
     attemptToPublish,
     resetUploadState,
   },

--- a/src/components/app/MenuButtons/index.tsx
+++ b/src/components/app/MenuButtons/index.tsx
@@ -25,7 +25,7 @@ import {
  * so that the CSS rules are in the correct order. */
 import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
 import { MetaInfoPanel } from './MetaInfo';
-import { MenuButtonsPublish } from './Publish';
+import { PublishPanel } from './Publish';
 import { MenuButtonsPermalink } from './Permalink';
 import {
   ProfileDeletePanel,
@@ -285,10 +285,10 @@ class MenuButtonsImpl extends React.PureComponent<Props, State> {
               menuButtonsShareButtonError: isError,
             }
           )}
-          panelClassName="menuButtonsPublishPanel"
+          panelClassName="publishPanelPanel"
           // The value for the label following will be replaced
           label=""
-          panelContent={<MenuButtonsPublish isRepublish={isRepublish} />}
+          panelContent={<PublishPanel isRepublish={isRepublish} />}
         />
       </Localized>
     );

--- a/src/components/app/ProfileViewer.tsx
+++ b/src/components/app/ProfileViewer.tsx
@@ -124,7 +124,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
             <MenuButtons />
             {isUploading ? (
               <div
-                className="menuButtonsPublishUploadBarInner"
+                className="publishPanelUploadBarInner"
                 style={{ width: `${uploadProgress * 100}%` }}
               />
             ) : null}

--- a/src/profile-logic/profile-store.ts
+++ b/src/profile-logic/profile-store.ts
@@ -29,7 +29,7 @@ export function uploadBinaryProfileData() {
       xhr.abort();
     },
     startUpload: (
-      data: ArrayBufferView<ArrayBuffer>,
+      data: ArrayBufferView<ArrayBuffer> | Blob,
       progressChangeCallback?: (param: number) => unknown
     ): Promise<string> =>
       new Promise((resolve, reject) => {

--- a/src/reducers/publish.ts
+++ b/src/reducers/publish.ts
@@ -52,10 +52,10 @@ const checkedSharingOptions: Reducer<CheckedSharingOptions> = (
         : _getMostlyNonSanitizingSharingOptions();
       return newState;
     }
-    case 'TOGGLE_CHECKED_SHARING_OPTION':
+    case 'UPDATE_SHARING_OPTION':
       return {
         ...state,
-        [action.slug]: !state[action.slug],
+        [action.slug]: action.value,
       };
     default:
       return state;

--- a/src/reducers/publish.ts
+++ b/src/reducers/publish.ts
@@ -12,6 +12,7 @@ import type {
   UploadPhase,
   Reducer,
   State,
+  SanitizedProfileEncodingState,
 } from 'firefox-profiler/types';
 
 function _getSanitizingSharingOptions(): CheckedSharingOptions {
@@ -212,8 +213,43 @@ const hasSanitizedProfile: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+const sanitizedProfileEncodingState: Reducer<SanitizedProfileEncodingState> = (
+  state = { phase: 'INITIAL' },
+  action
+): SanitizedProfileEncodingState => {
+  switch (action.type) {
+    case 'SANITIZED_PROFILE_ENCODING_STARTED': {
+      const { sanitizedProfile } = action;
+      return { phase: 'ENCODING', sanitizedProfile };
+    }
+    case 'SANITIZED_PROFILE_ENCODING_COMPLETED': {
+      const { sanitizedProfile, profileData } = action;
+      if (
+        state.phase === 'ENCODING' &&
+        state.sanitizedProfile === sanitizedProfile
+      ) {
+        return { phase: 'DONE', sanitizedProfile, profileData };
+      }
+      return state; // Ignore updates from earlier encodings.
+    }
+    case 'SANITIZED_PROFILE_ENCODING_FAILED': {
+      const { sanitizedProfile, error } = action;
+      if (
+        state.phase === 'ENCODING' &&
+        state.sanitizedProfile === sanitizedProfile
+      ) {
+        return { phase: 'ERROR', sanitizedProfile, error };
+      }
+      return state; // Ignore updates from earlier encodings.
+    }
+    default:
+      return state;
+  }
+};
+
 const publishReducer: Reducer<PublishState> = combineReducers({
   checkedSharingOptions,
+  sanitizedProfileEncodingState,
   upload,
   isHidingStaleProfile,
   hasSanitizedProfile,

--- a/src/test/components/MenuButtons.test.tsx
+++ b/src/test/components/MenuButtons.test.tsx
@@ -226,7 +226,7 @@ describe('app/MenuButtons', function () {
         screen.getByRole('checkbox', {
           name: /Include the data from other tabs/,
         });
-      const getPanel = () => screen.getByTestId('MenuButtonsPublish-container');
+      const getPanel = () => screen.getByTestId('PublishPanel-container');
       const openPublishPanel = async () => {
         fireFullClick(getPublishButton());
         await screen.findByText(/^(Share|Re-upload) Performance Profile$/);

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -1891,18 +1891,18 @@ exports[`app/MenuButtons <Publish> can publish and revert 1`] = `
 
 exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 1`] = `
 <div
-  data-testid="MenuButtonsPublish-container"
+  data-testid="PublishPanel-container"
 >
   <form
-    class="menuButtonsPublishContent photon-body-10"
+    class="publishPanelContent photon-body-10"
   >
     <h1
-      class="menuButtonsPublishTitle photon-title-40"
+      class="publishPanelTitle photon-title-40"
     >
       Share Performance Profile
     </h1>
     <p
-      class="menuButtonsPublishInfoDescription"
+      class="publishPanelInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
        
@@ -1914,10 +1914,10 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
       Include additional data that may be identifiable
     </h3>
     <div
-      class="menuButtonsPublishDataChoices"
+      class="publishPanelDataChoices"
     >
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -1927,7 +1927,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
         Include hidden threads
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -1937,7 +1937,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
         Include hidden time range
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -1947,7 +1947,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
         Include screenshots
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -1957,7 +1957,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
         Include resource URLs and paths
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -1977,22 +1977,22 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
       </div>
     </div>
     <div
-      class="menuButtonsPublishButtons"
+      class="publishPanelButtons"
     >
       <button
-        class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload"
+        class="photon-button publishPanelButton publishPanelButtonsDownload"
         disabled=""
         type="button"
       >
         Download
       </button>
       <button
-        class="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
+        class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         disabled=""
         type="submit"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgUpload"
         />
         Upload
       </button>
@@ -2003,8 +2003,8 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
 
 exports[`app/MenuButtons <Publish> matches the snapshot for an upload error 1`] = `
 <div
-  class="menuButtonsPublishUpload photon-body-10"
-  data-testid="MenuButtonsPublish-container"
+  class="publishPanelUpload photon-body-10"
+  data-testid="PublishPanel-container"
 >
   <div
     class="photon-message-bar photon-message-bar-error photon-message-bar-inner-content"
@@ -2022,7 +2022,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for an upload error 1`] 
     </button>
   </div>
   <div
-    class="menuButtonsPublishError"
+    class="publishPanelError"
   >
     This is a mock error
   </div>
@@ -2118,18 +2118,18 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
 
 exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and the opened panel for an already uploaded profile 2`] = `
 <div
-  data-testid="MenuButtonsPublish-container"
+  data-testid="PublishPanel-container"
 >
   <form
-    class="menuButtonsPublishContent photon-body-10"
+    class="publishPanelContent photon-body-10"
   >
     <h1
-      class="menuButtonsPublishTitle photon-title-40"
+      class="publishPanelTitle photon-title-40"
     >
       Re-upload Performance Profile
     </h1>
     <p
-      class="menuButtonsPublishInfoDescription"
+      class="publishPanelInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
        
@@ -2141,10 +2141,10 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
       Include additional data that may be identifiable
     </h3>
     <div
-      class="menuButtonsPublishDataChoices"
+      class="publishPanelDataChoices"
     >
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2154,7 +2154,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
         Include hidden threads
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2164,7 +2164,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
         Include hidden time range
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2174,7 +2174,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
         Include screenshots
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2184,7 +2184,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
         Include resource URLs and paths
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2195,15 +2195,15 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
       </label>
     </div>
     <div
-      class="menuButtonsPublishButtons"
+      class="publishPanelButtons"
     >
       <a
-        class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload"
+        class="photon-button publishPanelButton publishPanelButtonsDownload"
         download="Firefox 1970-01-01 00.00 profile.json.gz"
         href="mockCreateObjectUrl"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgDownload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
         />
         Download
          
@@ -2216,11 +2216,11 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
         </span>
       </a>
       <button
-        class="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
+        class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         type="submit"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgUpload"
         />
         Upload
       </button>
@@ -2231,18 +2231,18 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
 
 exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for a nightly profile 1`] = `
 <div
-  data-testid="MenuButtonsPublish-container"
+  data-testid="PublishPanel-container"
 >
   <form
-    class="menuButtonsPublishContent photon-body-10"
+    class="publishPanelContent photon-body-10"
   >
     <h1
-      class="menuButtonsPublishTitle photon-title-40"
+      class="publishPanelTitle photon-title-40"
     >
       Share Performance Profile
     </h1>
     <p
-      class="menuButtonsPublishInfoDescription"
+      class="publishPanelInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
        
@@ -2254,10 +2254,10 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       Include additional data that may be identifiable
     </h3>
     <div
-      class="menuButtonsPublishDataChoices"
+      class="publishPanelDataChoices"
     >
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           checked=""
@@ -2268,7 +2268,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include hidden threads
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           checked=""
@@ -2279,7 +2279,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include hidden time range
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           checked=""
@@ -2290,7 +2290,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include screenshots
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           checked=""
@@ -2301,7 +2301,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include resource URLs and paths
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           checked=""
@@ -2313,15 +2313,15 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       </label>
     </div>
     <div
-      class="menuButtonsPublishButtons"
+      class="publishPanelButtons"
     >
       <a
-        class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload"
+        class="photon-button publishPanelButton publishPanelButtonsDownload"
         download="Firefox 1970-01-01 00.00 profile.json.gz"
         href="mockCreateObjectUrl"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgDownload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
         />
         Download
          
@@ -2334,11 +2334,11 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         </span>
       </a>
       <button
-        class="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
+        class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         type="submit"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgUpload"
         />
         Upload
       </button>
@@ -2349,18 +2349,18 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
 
 exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for a release profile 1`] = `
 <div
-  data-testid="MenuButtonsPublish-container"
+  data-testid="PublishPanel-container"
 >
   <form
-    class="menuButtonsPublishContent photon-body-10"
+    class="publishPanelContent photon-body-10"
   >
     <h1
-      class="menuButtonsPublishTitle photon-title-40"
+      class="publishPanelTitle photon-title-40"
     >
       Share Performance Profile
     </h1>
     <p
-      class="menuButtonsPublishInfoDescription"
+      class="publishPanelInfoDescription"
     >
       Upload your profile and make it accessible to anyone with the link.
        
@@ -2372,10 +2372,10 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       Include additional data that may be identifiable
     </h3>
     <div
-      class="menuButtonsPublishDataChoices"
+      class="publishPanelDataChoices"
     >
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2385,7 +2385,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include hidden threads
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2395,7 +2395,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include hidden time range
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2405,7 +2405,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include screenshots
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2415,7 +2415,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         Include resource URLs and paths
       </label>
       <label
-        class="photon-label menuButtonsPublishDataChoicesLabel"
+        class="photon-label publishPanelDataChoicesLabel"
       >
         <input
           class="photon-checkbox photon-checkbox-default"
@@ -2426,15 +2426,15 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
       </label>
     </div>
     <div
-      class="menuButtonsPublishButtons"
+      class="publishPanelButtons"
     >
       <a
-        class="photon-button menuButtonsPublishButton menuButtonsPublishButtonsDownload"
+        class="photon-button publishPanelButton publishPanelButtonsDownload"
         download="Firefox 1970-01-01 00.00 profile.json.gz"
         href="mockCreateObjectUrl"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgDownload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
         />
         Download
          
@@ -2447,11 +2447,11 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
         </span>
       </a>
       <button
-        class="photon-button photon-button-primary menuButtonsPublishButton menuButtonsPublishButtonsUpload"
+        class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         type="submit"
       >
         <span
-          class="menuButtonsPublishButtonsSvg menuButtonsPublishButtonsSvgUpload"
+          class="publishPanelButtonsSvg publishPanelButtonsSvgUpload"
         />
         Upload
       </button>

--- a/src/test/store/publish.test.ts
+++ b/src/test/store/publish.test.ts
@@ -5,7 +5,7 @@
 import {
   attemptToPublish,
   resetUploadState,
-  toggleCheckedSharingOptions,
+  updateSharingOption,
   revertToPrePublishedState,
 } from '../../actions/publish';
 import { changeSelectedTab } from '../../actions/app';
@@ -127,8 +127,8 @@ describe('getCheckedSharingOptions', function () {
     });
   });
 
-  describe('toggleCheckedSharingOptions', function () {
-    it('can toggle options', function () {
+  describe('updateSharingOption', function () {
+    it('can update options', function () {
       const { profile } = getProfileFromTextSamples('A');
       // This will cause the profile to be sanitized by default when uploading.
       profile.meta.updateChannel = 'release';
@@ -138,13 +138,13 @@ describe('getCheckedSharingOptions', function () {
         includeHiddenThreads: false,
       });
 
-      dispatch(toggleCheckedSharingOptions('includeHiddenThreads'));
+      dispatch(updateSharingOption('includeHiddenThreads', true));
 
       expect(getCheckedSharingOptions(getState())).toMatchObject({
         includeHiddenThreads: true,
       });
 
-      dispatch(toggleCheckedSharingOptions('includeHiddenThreads'));
+      dispatch(updateSharingOption('includeHiddenThreads', false));
 
       expect(getCheckedSharingOptions(getState())).toMatchObject({
         includeHiddenThreads: false,
@@ -160,7 +160,7 @@ describe('getRemoveProfileInformation', function () {
     expect(getHasPreferenceMarkers(getState())).toEqual(false);
 
     // Setting includePreferenceValues option to false
-    dispatch(toggleCheckedSharingOptions('includePreferenceValues'));
+    dispatch(updateSharingOption('includePreferenceValues', false));
     expect(
       getCheckedSharingOptions(getState()).includePreferenceValues
     ).toEqual(false);
@@ -202,8 +202,8 @@ describe('getRemoveProfileInformation', function () {
       '  - show [thread Thread <3>]',
     ]);
 
-    // Toggle the preference to remove hidden tracks
-    dispatch(toggleCheckedSharingOptions('includeHiddenThreads'));
+    // Change the preference to remove hidden tracks
+    dispatch(updateSharingOption('includeHiddenThreads', false));
     // Note: Jest doesn't check Set values with toMatchObject, so we're checking the
     // properties individually. See https://github.com/facebook/jest/issues/11250
     expect(
@@ -474,10 +474,7 @@ describe('attemptToPublish', function () {
     expect(getSelectedTab(getState())).toEqual(originalTab);
 
     // Ensure we are sanitizing something.
-    const sharingOptions = getCheckedSharingOptions(getState());
-    if (sharingOptions.includeUrls) {
-      dispatch(toggleCheckedSharingOptions('includeUrls'));
-    }
+    dispatch(updateSharingOption('includeUrls', false));
 
     // Now upload.
     const publishAttempt = dispatch(attemptToPublish());
@@ -776,7 +773,7 @@ describe('attemptToPublish', function () {
       abortFunction();
 
       // Then we check new options to sanitize the profile, and attempt a new publish.
-      dispatch(toggleCheckedSharingOptions('includeFullTimeRange'));
+      dispatch(updateSharingOption('includeFullTimeRange', false));
       expect(getRemoveProfileInformation(getState())).toMatchObject({
         shouldFilterToCommittedRange: { start: 1, end: 4 },
       });

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -603,6 +603,20 @@ type PublishAction =
       readonly value: boolean;
     }
   | {
+      readonly type: 'SANITIZED_PROFILE_ENCODING_STARTED';
+      readonly sanitizedProfile: Profile;
+    }
+  | {
+      readonly type: 'SANITIZED_PROFILE_ENCODING_COMPLETED';
+      readonly sanitizedProfile: Profile;
+      readonly profileData: Blob;
+    }
+  | {
+      readonly type: 'SANITIZED_PROFILE_ENCODING_FAILED';
+      readonly sanitizedProfile: Profile;
+      readonly error: Error;
+    }
+  | {
       readonly type: 'UPLOAD_STARTED';
     }
   | {

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -598,8 +598,9 @@ type SidebarAction = {
 
 type PublishAction =
   | {
-      readonly type: 'TOGGLE_CHECKED_SHARING_OPTION';
+      readonly type: 'UPDATE_SHARING_OPTION';
       readonly slug: keyof CheckedSharingOptions;
+      readonly value: boolean;
     }
   | {
       readonly type: 'UPLOAD_STARTED';

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -204,8 +204,21 @@ export type UploadState = {
   generation: number;
 };
 
+export type SanitizedProfileEncodingState =
+  | {
+      phase: 'INITIAL';
+    }
+  | { phase: 'ENCODING'; sanitizedProfile: Profile }
+  | {
+      phase: 'DONE';
+      sanitizedProfile: Profile;
+      profileData: Blob;
+    }
+  | { phase: 'ERROR'; sanitizedProfile: Profile; error: Error };
+
 export type PublishState = {
   readonly checkedSharingOptions: CheckedSharingOptions;
+  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
   readonly upload: UploadState;
   readonly isHidingStaleProfile: boolean;
   readonly hasSanitizedProfile: boolean;


### PR DESCRIPTION
[Production](https://profiler.firefox.com/public/283zgs51v5kc3yxtjkm5w2x249468x99ydds610/flame-graph/?globalTrackOrder=1w46705&hiddenGlobalTracks=5&hiddenLocalTracksByPid=5472-0wAiAkwBhBjwE6E8wEhEjwFiFkwHv~5511-0wyp~5607-0wxhxjwCj~5696-0wxj~5855-0wCbCdwDi~6253-0whkwy4&localTrackOrderByPid=5472-HnwHpHbBaBcBnBpAnEhEfEgBlC8FeDqBkEqD7E5CjCkghy6z7zdA1EaA2A3E3EvF0FlF1FnF2FoG3G4FpG5GbGcG7GdGfGgGeGhwGoGuGpwGtGvH2H0H1H3H4HhwHmAuEuFawFcH7HvCtAgDcAoAsAtC7ClCsDsHrHsE0CuBgAbwAeAvB0B2wB4B6wB9BbBdBoBqwC2ErEtAiE9ElEmEoEjHfHgA7wAaF3F4jkA5A6DrDtDuAjAkF5wF9FvwG2AlAqB1G8EeHdC3FdC5DeDfEcE1E7ArBjEsHqHcAfCqCpCiDpC9DgCawChDhwDoBhAhilwy5y7wz6z8wzczewA0HaE2C4FkBeG9HtEdA4BfDdHeEpBmE6FfwFiFqwFtGaEkH9FmG6H8EbEnD8wDaC6CvwD6f0weBiFjFuApCrAmE8EiDvE4B5CmCnHuCoDbH5H6~6253-8mursewgy0wy2cdapx3x1n9txhwxm7x4hx5bx06oxewxgqx6wxd3w5021vliwkxnwxvy4x2y3~5855-D5DhCrC9Cagwimwox0wx8xbxcxexdxfwxhxjwxlxpwy1y4wybydwyuz0wz2z6wz8zcwzkzqwAnApwBoC6wC8CuD2CvD0DbwDdCqqCbD9Day2y3ycD1krx9xaxiz3wz5znwzpDfD7DiD6zlzmAoC2BpwC1yvjlpD4DeCsD8swvxmwxoz9wzbD3dwf0w4b5wacCtDgCpC5C3C4CdCgwCeChCjwClCiCmwCoCc&thread=Kv&v=11) | [Main branch](https://main--perf-html.netlify.app/public/283zgs51v5kc3yxtjkm5w2x249468x99ydds610/flame-graph/?globalTrackOrder=1w46705&hiddenGlobalTracks=5&hiddenLocalTracksByPid=5472-0wAiAkwBhBjwE6E8wEhEjwFiFkwHv~5511-0wyp~5607-0wxhxjwCj~5696-0wxj~5855-0wCbCdwDi~6253-0whkwy4&localTrackOrderByPid=5472-HnwHpHbBaBcBnBpAnEhEfEgBlC8FeDqBkEqD7E5CjCkghy6z7zdA1EaA2A3E3EvF0FlF1FnF2FoG3G4FpG5GbGcG7GdGfGgGeGhwGoGuGpwGtGvH2H0H1H3H4HhwHmAuEuFawFcH7HvCtAgDcAoAsAtC7ClCsDsHrHsE0CuBgAbwAeAvB0B2wB4B6wB9BbBdBoBqwC2ErEtAiE9ElEmEoEjHfHgA7wAaF3F4jkA5A6DrDtDuAjAkF5wF9FvwG2AlAqB1G8EeHdC3FdC5DeDfEcE1E7ArBjEsHqHcAfCqCpCiDpC9DgCawChDhwDoBhAhilwy5y7wz6z8wzczewA0HaE2C4FkBeG9HtEdA4BfDdHeEpBmE6FfwFiFqwFtGaEkH9FmG6H8EbEnD8wDaC6CvwD6f0weBiFjFuApCrAmE8EiDvE4B5CmCnHuCoDbH5H6~6253-8mursewgy0wy2cdapx3x1n9txhwxm7x4hx5bx06oxewxgqx6wxd3w5021vliwkxnwxvy4x2y3~5855-D5DhCrC9Cagwimwox0wx8xbxcxexdxfwxhxjwxlxpwy1y4wybydwyuz0wz2z6wz8zcwzkzqwAnApwBoC6wC8CuD2CvD0DbwDdCqqCbD9Day2y3ycD1krx9xaxiz3wz5znwzpDfD7DiD6zlzmAoC2BpwC1yvjlpD4DeCsD8swvxmwxoz9wzbD3dwf0w4b5wacCtDgCpC5C3C4CdCgwCeChCjwClCiCmwCoCc&thread=Kv&v=11) | [Deploy preview](https://deploy-preview-5608--perf-html.netlify.app/public/283zgs51v5kc3yxtjkm5w2x249468x99ydds610/flame-graph/?globalTrackOrder=1w46705&hiddenGlobalTracks=5&hiddenLocalTracksByPid=5472-0wAiAkwBhBjwE6E8wEhEjwFiFkwHv~5511-0wyp~5607-0wxhxjwCj~5696-0wxj~5855-0wCbCdwDi~6253-0whkwy4&localTrackOrderByPid=5472-HnwHpHbBaBcBnBpAnEhEfEgBlC8FeDqBkEqD7E5CjCkghy6z7zdA1EaA2A3E3EvF0FlF1FnF2FoG3G4FpG5GbGcG7GdGfGgGeGhwGoGuGpwGtGvH2H0H1H3H4HhwHmAuEuFawFcH7HvCtAgDcAoAsAtC7ClCsDsHrHsE0CuBgAbwAeAvB0B2wB4B6wB9BbBdBoBqwC2ErEtAiE9ElEmEoEjHfHgA7wAaF3F4jkA5A6DrDtDuAjAkF5wF9FvwG2AlAqB1G8EeHdC3FdC5DeDfEcE1E7ArBjEsHqHcAfCqCpCiDpC9DgCawChDhwDoBhAhilwy5y7wz6z8wzczewA0HaE2C4FkBeG9HtEdA4BfDdHeEpBmE6FfwFiFqwFtGaEkH9FmG6H8EbEnD8wDaC6CvwD6f0weBiFjFuApCrAmE8EiDvE4B5CmCnHuCoDbH5H6~6253-8mursewgy0wy2cdapx3x1n9txhwxm7x4hx5bx06oxewxgqx6wxd3w5021vliwkxnwxvy4x2y3~5855-D5DhCrC9Cagwimwox0wx8xbxcxexdxfwxhxjwxlxpwy1y4wybydwyuz0wz2z6wz8zcwzkzqwAnApwBoC6wC8CuD2CvD0DbwDdCqqCbD9Day2y3ycD1krx9xaxiz3wz5znwzpDfD7DiD6zlzmAoC2BpwC1yvjlpD4DeCsD8swvxmwxoz9wzbD3dwf0w4b5wacCtDgCpC5C3C4CdCgwCeChCjwClCiCmwCoCc&thread=Kv&v=11)

I was looking at this code when I was doing the worker compression stuff and noticed some opportunities for improvement. Nothing urgent here, just some cleanup.

The "Simplify profile publishing flow" commit fixes one bug: If you trigger a new compression while an existing compression is already going on, and the new compression finishes before the old compression, then the old compression's completion will no longer overwrite the size in the download button with an outdated value.