### PR TITLE
Use getEmptySourceTable instead of constructing the table manually

### DIFF
--- a/src/profile-logic/global-data-collector.ts
+++ b/src/profile-logic/global-data-collector.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { StringTable } from '../utils/string-table';
+import { getEmptySourceTable } from './data-structures';
+
 import type {
   Lib,
   LibMapping,
@@ -26,7 +28,7 @@ export class GlobalDataCollector {
   _libKeyToLibIndex: Map<string, IndexIntoLibs> = new Map();
   _stringArray: string[] = [];
   _stringTable: StringTable = StringTable.withBackingArray(this._stringArray);
-  _sources: SourceTable = { length: 0, uuid: [], filename: [] };
+  _sources: SourceTable = getEmptySourceTable();
   _uuidToSourceIndex: Map<string, IndexIntoSourceTable> = new Map();
   _filenameToSourceIndex: Map<IndexIntoStringTable, IndexIntoSourceTable> =
     new Map();

--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -19,6 +19,7 @@ import {
   getEmptyRawMarkerTable,
   getEmptySamplesTableWithEventDelay,
   shallowCloneRawMarkerTable,
+  getEmptySourceTable,
 } from './data-structures';
 import {
   filterRawThreadSamplesToRange,
@@ -499,7 +500,7 @@ function mergeSources(
   sources: SourceTable;
   translationMaps: TranslationMapForSources[];
 } {
-  const newSources: SourceTable = { length: 0, uuid: [], filename: [] };
+  const newSources = getEmptySourceTable();
   const mapOfInsertedSources: Map<string, IndexIntoSourceTable> = new Map();
 
   const translationMaps = sourcesPerProfile.map((sources, profileIndex) => {


### PR DESCRIPTION
This is something I noticed that's pretty small while looking at the code. It doesn't change the behavior at all.