### PR TITLE
[Deploy preview] Try fetching every js source during the profile load and have a sanitization option

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -664,6 +664,7 @@ MenuButtons--publish--renderCheckbox-label-preference = Include preference value
 MenuButtons--publish--renderCheckbox-label-private-browsing = Include the data from private browsing windows
 MenuButtons--publish--renderCheckbox-label-private-browsing-warning-image =
     .title = This profile contains private browsing data
+MenuButtons--publish--renderCheckbox-label-js-sources = Include JavaScript source code
 MenuButtons--publish--reupload-performance-profile = Re-upload Performance Profile
 MenuButtons--publish--share-performance-profile = Share Performance Profile
 MenuButtons--publish--info-description = Upload your profile and make it accessible to anyone with the link.

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -210,6 +210,10 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
                   </Localized>
                 )
               : null}
+            {this._renderCheckbox(
+              'includeJSSources',
+              'MenuButtons--publish--renderCheckbox-label-js-sources'
+            )}
           </div>
           {sanitizedProfileEncodingState.phase === 'ERROR' ? (
             <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">

--- a/src/components/app/SourceCodeFetcher.tsx
+++ b/src/components/app/SourceCodeFetcher.tsx
@@ -109,7 +109,9 @@ class SourceCodeFetcherImpl extends React.PureComponent<Props> {
       symbolServerUrl,
       addressProof,
       this._archiveCache,
-      delegate
+      delegate,
+      profile,
+      sourceViewSourceIndex
     );
 
     switch (fetchSourceResult.type) {

--- a/src/profile-logic/data-structures.ts
+++ b/src/profile-logic/data-structures.ts
@@ -379,6 +379,7 @@ export function getEmptySourceTable(): SourceTable {
     // be caught by the type system.
     uuid: [],
     filename: [],
+    sourceCode: [],
     length: 0,
   };
 }

--- a/src/profile-logic/global-data-collector.ts
+++ b/src/profile-logic/global-data-collector.ts
@@ -26,7 +26,7 @@ export class GlobalDataCollector {
   _libKeyToLibIndex: Map<string, IndexIntoLibs> = new Map();
   _stringArray: string[] = [];
   _stringTable: StringTable = StringTable.withBackingArray(this._stringArray);
-  _sources: SourceTable = { length: 0, uuid: [], filename: [] };
+  _sources: SourceTable = { length: 0, uuid: [], filename: [], sourceCode: [] };
   _uuidToSourceIndex: Map<string, IndexIntoSourceTable> = new Map();
   _filenameToSourceIndex: Map<IndexIntoStringTable, IndexIntoSourceTable> =
     new Map();
@@ -72,6 +72,7 @@ export class GlobalDataCollector {
       const filenameIndex = this._stringTable.indexForString(filename);
       this._sources.uuid[index] = uuid;
       this._sources.filename[index] = filenameIndex;
+      this._sources.sourceCode[index] = null; // Initially no source code
       this._sources.length++;
 
       if (uuid !== null) {

--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -499,7 +499,12 @@ function mergeSources(
   sources: SourceTable;
   translationMaps: TranslationMapForSources[];
 } {
-  const newSources: SourceTable = { length: 0, uuid: [], filename: [] };
+  const newSources: SourceTable = {
+    length: 0,
+    uuid: [],
+    filename: [],
+    sourceCode: [],
+  };
   const mapOfInsertedSources: Map<string, IndexIntoSourceTable> = new Map();
 
   const translationMaps = sourcesPerProfile.map((sources, profileIndex) => {

--- a/src/profile-logic/profile-compacting.ts
+++ b/src/profile-logic/profile-compacting.ts
@@ -398,6 +398,7 @@ function _createCompactedSourceTable(
   let nextIndex = 0;
   const newUuid = [];
   const newFilename = [];
+  const newSourceCode = [];
 
   for (let i = 0; i < sourceTable.length; i++) {
     if (referencedSources[i] === 0) {
@@ -418,6 +419,21 @@ function _createCompactedSourceTable(
     }
     newFilename[newIndex] = newFilenameIndexPlusOne - 1;
 
+    // Translate the source code string index
+    const oldSourceCodeIndex = sourceTable.sourceCode[i];
+    if (oldSourceCodeIndex !== null) {
+      const newSourceCodeIndexPlusOne =
+        oldStringToNewStringPlusOne[oldSourceCodeIndex];
+      if (newSourceCodeIndexPlusOne === 0) {
+        throw new Error(
+          `String index ${oldSourceCodeIndex} was not found in the translation map`
+        );
+      }
+      newSourceCode[newIndex] = newSourceCodeIndexPlusOne - 1;
+    } else {
+      newSourceCode[newIndex] = null;
+    }
+
     oldSourceToNewSourcePlusOne[i] = newIndex + 1;
   }
 
@@ -425,6 +441,7 @@ function _createCompactedSourceTable(
     length: nextIndex,
     uuid: newUuid,
     filename: newFilename,
+    sourceCode: newSourceCode,
   };
 
   return { newSources, oldSourceToNewSourcePlusOne };

--- a/src/profile-logic/sanitize.ts
+++ b/src/profile-logic/sanitize.ts
@@ -117,6 +117,18 @@ export function sanitizePII(
   }
   const stringTable = StringTable.withBackingArray(stringArray);
 
+  // Handle JS source removal if requested
+  let sources = profile.shared.sources;
+  if (PIIToBeRemoved.shouldRemoveJSSources) {
+    // Create a new sources table with sourceCode set to null for all entries
+    sources = {
+      length: sources.length,
+      uuid: sources.uuid.slice(),
+      filename: sources.filename.slice(),
+      sourceCode: sources.sourceCode.map(() => null),
+    };
+  }
+
   let removingCounters = false;
   const newProfile: Profile = {
     ...profile,
@@ -129,7 +141,7 @@ export function sanitizePII(
     pages: pages,
     shared: {
       stringArray,
-      sources: profile.shared.sources,
+      sources,
     },
     threads: profile.threads.reduce<RawThread[]>((acc, thread, threadIndex) => {
       const newThread: RawThread | null = sanitizeThreadPII(

--- a/src/reducers/publish.ts
+++ b/src/reducers/publish.ts
@@ -25,6 +25,7 @@ function _getSanitizingSharingOptions(): CheckedSharingOptions {
     includeExtension: false,
     includePreferenceValues: false,
     includePrivateBrowsingData: false,
+    includeJSSources: false,
   };
 }
 
@@ -39,6 +40,7 @@ function _getMostlyNonSanitizingSharingOptions(): CheckedSharingOptions {
     includePreferenceValues: true,
     // We always want to sanitize the private browsing data by default
     includePrivateBrowsingData: false,
+    includeJSSources: true,
   };
 }
 

--- a/src/selectors/publish.ts
+++ b/src/selectors/publish.ts
@@ -177,6 +177,7 @@ export const getRemoveProfileInformation: Selector<RemoveProfileInformation | nu
           !checkedSharingOptions.includePreferenceValues,
         shouldRemovePrivateBrowsingData:
           !checkedSharingOptions.includePrivateBrowsingData,
+        shouldRemoveJSSources: !checkedSharingOptions.includeJSSources,
       };
     }
   );

--- a/src/test/unit/sanitize.test.ts
+++ b/src/test/unit/sanitize.test.ts
@@ -46,6 +46,7 @@ describe('sanitizePII', function () {
       shouldRemoveExtensions: false,
       shouldRemovePreferenceValues: false,
       shouldRemovePrivateBrowsingData: false,
+      shouldRemoveJSSources: false,
     };
 
     const PIIToRemove: RemoveProfileInformation = {

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -149,6 +149,7 @@ export type CheckedSharingOptions = {
   includeExtension: boolean;
   includePreferenceValues: boolean;
   includePrivateBrowsingData: boolean;
+  includeJSSources: boolean;
 };
 
 // This type is used when selecting tracks in the timeline. Ctrl and Meta are

--- a/src/types/profile-derived.ts
+++ b/src/types/profile-derived.ts
@@ -664,6 +664,8 @@ export type RemoveProfileInformation = {
   readonly shouldRemovePreferenceValues: boolean;
   // Remove the private browsing data if it's true.
   readonly shouldRemovePrivateBrowsingData: boolean;
+  // Remove the JavaScript sources if it's true.
+  readonly shouldRemoveJSSources: boolean;
 };
 
 /**

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -934,6 +934,9 @@ export type SourceTable = {
   length: number;
   uuid: Array<string | null>;
   filename: Array<IndexIntoStringTable>;
+  // Index into the string table for the source code content.
+  // Null if the source code hasn't been downloaded yet.
+  sourceCode: Array<IndexIntoStringTable | null>;
 };
 
 export type RawProfileSharedData = {


### PR DESCRIPTION
This is only a deploy preview, and **not** a PR that I intend to land.

I only wanted to get a sense of profile size bloat if I were to fetch all the JS sources in the load time and include them to the profile JSON. This will let us understand how much of a difference it makes, so we can make a more informed decision. The code is written only for testing purposes, it's not really in a good shape.