### PR TITLE
Add hint to enable JavaScript Sources feature in source view error

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -1195,9 +1195,12 @@ SourceView--close-button =
 ## The string IDs here currently all start with SourceView for historical reasons.
 
 # Displayed below SourceView--cannot-obtain-source, if the profiler does not
-# know which URL to request source code from.
-SourceView--no-known-cors-url =
-    There is no known cross-origin-accessible URL for this file.
+# know which URL to request source code from. This can happen for JavaScript
+# files when the "JavaScript Sources" feature is not enabled.
+SourceView--no-known-cors-url1 =
+    There is no known cross-origin-accessible URL for this file. If this is a
+    JavaScript file, you may need to enable the “JavaScript Sources” feature in
+    about:profiling.
 
 # Displayed below SourceView--cannot-obtain-source, if there was a network error
 # when fetching the source code for a file.

--- a/src/components/app/CodeErrorOverlay.tsx
+++ b/src/components/app/CodeErrorOverlay.tsx
@@ -17,7 +17,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
         switch (error.type) {
           case 'NO_KNOWN_CORS_URL': {
             return (
-              <Localized key={key} id="SourceView--no-known-cors-url">
+              <Localized key={key} id="SourceView--no-known-cors-url1">
                 <li>No known cross-origin-accessible URL.</li>
               </Localized>
             );


### PR DESCRIPTION
Fixes #5640.

This is not the ideal solution I had in mind initially.

I initially wanted to add a new error, that shows this only when it's a JS file. But when this feature is disabled, there isn't a way to know if this is a JS source. We have `sourceUuid`, but it becomes null when this feature is disabled, because we don't serialize the source table in the backend when the this feature doesn't exist (since we don't collect the sources in the first place):
https://github.com/firefox-devtools/profiler/blob/d396f271ed9c5c1cef258c5f13a32aaa989b8e27/src/utils/fetch-source.ts#L93-L110

Potentially we can propagate an `isJS` argument to this function. But not so sure if that's worth it. I think this is an okay middle ground for this.
