### PR TITLE
Run the CI in the production branch and on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
+      - production
   pull_request:
-    branches:
-      - main
 
 jobs:
   lint:


### PR DESCRIPTION
I think the previous rules were a bit too restrictive.
With this PR:
- The checks will run on pushes to production too.
- Run the CI on every pull request and not just the ones to the main.