### PR TITLE
Do not switch to call tree when clicking the activity graph while on sample based panels

### DIFF
--- a/src/reducers/app.ts
+++ b/src/reducers/app.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { combineReducers } from 'redux';
-import { tabSlugs } from '../app-logic/tabs-handling';
+import { tabSlugs, tabsShowingSampleData } from '../app-logic/tabs-handling';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type { BrowserConnectionStatus } from '../app-logic/browser-connection';
@@ -170,6 +170,10 @@ const lastVisibleThreadTabSlug: Reducer<TabSlug> = (
       }
       return state;
     case 'FOCUS_CALL_TREE':
+      if (tabsShowingSampleData.includes(state)) {
+        // Don't switch to call tree if the tab is already showing sample data.
+        return state;
+      }
       return 'calltree';
     default:
       return state;

--- a/src/reducers/url-state.ts
+++ b/src/reducers/url-state.ts
@@ -5,7 +5,7 @@
 import { combineReducers } from 'redux';
 import { oneLine } from 'common-tags';
 import { objectEntries } from '../utils/types';
-import { tabSlugs } from '../app-logic/tabs-handling';
+import { tabSlugs, tabsShowingSampleData } from '../app-logic/tabs-handling';
 
 import type {
   ThreadIndex,
@@ -98,6 +98,10 @@ const selectedTab: Reducer<TabSlug> = (state = 'calltree', action) => {
     case 'CHANGE_TAB_FILTER':
       return action.selectedTab;
     case 'FOCUS_CALL_TREE':
+      if (tabsShowingSampleData.includes(state)) {
+        // Don't switch to call tree if the tab is already showing sample data.
+        return state;
+      }
       return 'calltree';
     default:
       return state;

--- a/src/test/components/ThreadActivityGraph.test.tsx
+++ b/src/test/components/ThreadActivityGraph.test.tsx
@@ -264,7 +264,7 @@ describe('ThreadActivityGraph', function () {
     expect(getCallNodePath()).toEqual([]);
   });
 
-  it('when clicking a stack, this selects the call tree panel', function () {
+  it('when clicking a stack while on a tab that does not show sample data, this selects the call tree panel', function () {
     const { dispatch, getState, clickActivityGraph } = setup();
 
     expect(getSelectedTab(getState())).toBe('calltree');
@@ -275,6 +275,19 @@ describe('ThreadActivityGraph', function () {
     clickActivityGraph(1, 0.2);
     expect(getSelectedTab(getState())).toBe('calltree');
     expect(getLastVisibleThreadTabSlug(getState())).toBe('calltree');
+  });
+
+  it('when clicking a stack while on a tab that shows sample data, it should not change the selected panel', function () {
+    const { dispatch, getState, clickActivityGraph } = setup();
+
+    expect(getSelectedTab(getState())).toBe('calltree');
+    dispatch(changeSelectedTab('flame-graph'));
+
+    // The full call node at this sample is:
+    //  A -> B -> C -> F -> G
+    clickActivityGraph(1, 0.2);
+    expect(getSelectedTab(getState())).toBe('flame-graph');
+    expect(getLastVisibleThreadTabSlug(getState())).toBe('flame-graph');
   });
 
   it(`when clicking outside of the graph, this doesn't select the call tree panel`, function () {


### PR DESCRIPTION
Fixes #5668.

[Deploy preview](https://deploy-preview-5672--perf-html.netlify.app/public/rpnres9s7rdrsfb240wtskvrq5sv7xzn3f4m2p0/stack-chart/?globalTrackOrder=30w2&hiddenGlobalTracks=01&hiddenLocalTracksByPid=2588-1w3~2591-01&range=9133m2135~9517m70~9537379u6985&tabID=25&thread=f&v=12)