### PR TITLE
Use a longer test timeout when debugging with VS code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["test"],
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      "args": ["--runInBand", "${file}"],
+      "args": ["--runInBand", "--testTimeout=300000", "${file}"],
       "cwd": "${workspaceFolder}",
       "internalConsoleOptions": "openOnSessionStart",
       "request": "launch",


### PR DESCRIPTION
It has happened to me a few times that I was debugging a test in VS code and suddenly the test was terminated because it took too long.