### PR TITLE
Always consider markers in time range for thread

### DIFF
--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -1267,9 +1267,13 @@ function _getTimeRangeForThread(
       }
       result.end = accumTime + interval;
     }
-  } else if (markers.length) {
-    // Looking at the markers only if there are no samples in the profile.
-    // We need to look at those because it can be a marker only profile(no-sampling mode).
+  }
+
+  if (markers.length) {
+    // Also check markers to ensure the timeline extends to cover all marker data.
+    // This is necessary both for marker-only profiles (no-sampling mode) and for
+    // profiles where markers may extend beyond the last sample.
+
     // Finding start and end times sadly requires looping through all markers :(
     for (let i = 0; i < markers.length; i++) {
       const maybeStartTime = markers.startTime[i];


### PR DESCRIPTION
## Description

This pull request updates the `_getTimeRangeForThread()` function to always consider the lengths of markers, if present.

It is possible to have a profile where the final marker time extends beyond the final sample time.

## Example

Here is an example, coming from Samply:

 - https://share.firefox.dev/3WVrNol

### Before

 You can see before the change that the markers are truncated at the right side, only 2 samples were recorded. 

<img width="3753" height="1970" alt="image" src="https://github.com/user-attachments/assets/1daa1621-8a1a-4282-a4eb-1292c8ca8e51" />

### After

After the change, the full range of markers is shown. 

<img width="3753" height="1970" alt="image" src="https://github.com/user-attachments/assets/58d7a9ce-ac95-44ba-9d6f-52cd3ec17700" />
