### PR TITLE
Redirect unpublished url loads to the homepage similar to from-file

### DIFF
--- a/src/actions/app.ts
+++ b/src/actions/app.ts
@@ -150,8 +150,12 @@ export function setupInitialUrlState(
       return;
     }
 
-    // Validate the initial URL state. We can't refresh on a from-file URL.
-    if (urlState.dataSource === 'from-file') {
+    // Validate the initial URL state. We can't refresh on from-file or
+    // unpublished URLs.
+    if (
+      urlState.dataSource === 'from-file' ||
+      urlState.dataSource === 'unpublished'
+    ) {
       urlState = null;
     }
 

--- a/src/actions/receive-profile.ts
+++ b/src/actions/receive-profile.ts
@@ -1400,9 +1400,10 @@ export function retrieveProfileForRawUrl(
     }
 
     let dataSource = ensureIsValidDataSource(possibleDataSource);
-    if (dataSource === 'from-file') {
-      // Redirect to 'none' if `dataSource` is 'from-file' since initial urls can't
-      // be 'from-file' and needs to be redirected to home page.
+    // Redirect to 'none' for from-file and unpublished data sources since initial
+    // urls can't be 'from-file' or 'unpublished' and need to be redirected to
+    // home page. 'unpublished' is a transient state after profile deletion.
+    if (dataSource === 'from-file' || dataSource === 'unpublished') {
       dataSource = 'none';
     }
     dispatch(setDataSource(dataSource));
@@ -1475,7 +1476,6 @@ export function retrieveProfileForRawUrl(
       case 'uploaded-recordings':
       case 'none':
       case 'local':
-      case 'unpublished':
         // There is no profile to download for these datasources.
         break;
       default:

--- a/src/test/store/receive-profile.test.ts
+++ b/src/test/store/receive-profile.test.ts
@@ -2190,6 +2190,20 @@ describe('actions/receive-profile', function () {
         });
       }
     );
+
+    it('redirects unpublished initial URLs to home page', async function () {
+      const { getState } = await setup({
+        pathname: '/unpublished/',
+        search: '',
+        hash: '',
+      });
+
+      // The data source should be redirected from 'unpublished' to 'none'.
+      expect(UrlStateSelectors.getDataSource(getState())).toEqual('none');
+
+      // No profile should be loaded.
+      expect(ProfileViewSelectors.getProfileOrNull(getState())).toEqual(null);
+    });
   });
 });
 


### PR DESCRIPTION
Fixed #5709.

Initially `unpublished` was an alias of `from-addon` and then it was made a separate data source. But reloading the url or loading from scratch was hanging in the profile loading animation indefinitely and it wasn't trying to load any profile either. It makes sense to make it behave more like `from-file` in that sense and just redirect to the home page.

Issue #5709 has an STR for this bug.