### PR TITLE
Add experimental sampling interval tracks per process

### DIFF
--- a/src/actions/profile-view.ts
+++ b/src/actions/profile-view.ts
@@ -15,6 +15,7 @@ import {
   getLocalTracksByPid,
   getThreads,
   getLastNonShiftClick,
+  getProfile,
 } from 'firefox-profiler/selectors/profile';
 import {
   getThreadSelectors,
@@ -356,6 +357,23 @@ function getInformationFromTrackReference(
             ...commonLocalProperties,
             threadIndex: null,
             relatedThreadIndex: counter.mainThreadIndex,
+            relatedTab: null,
+          };
+        }
+        case 'sampling-interval': {
+          // Find the first thread for this PID to use as related thread.
+          // If no thread is found, use the first thread in the profile as fallback.
+          const profile = getProfile(state);
+          const pidThread = profile.threads.find(
+            (thread: { pid: Pid }) => thread.pid === localTrack.pid
+          );
+          const relatedThreadIndex = pidThread
+            ? profile.threads.indexOf(pidThread)
+            : 0;
+          return {
+            ...commonLocalProperties,
+            threadIndex: null,
+            relatedThreadIndex,
             relatedTab: null,
           };
         }

--- a/src/components/timeline/LocalTrack.tsx
+++ b/src/components/timeline/LocalTrack.tsx
@@ -31,6 +31,7 @@ import { TrackBandwidth } from './TrackBandwidth';
 import { TrackIPC } from './TrackIPC';
 import { TrackProcessCPU } from './TrackProcessCPU';
 import { TrackPower } from './TrackPower';
+import { TrackSamplingInterval } from './TrackSamplingInterval';
 import { getTrackSelectionModifiers } from 'firefox-profiler/utils';
 import type {
   TrackReference,
@@ -118,6 +119,8 @@ class LocalTrackComponent extends PureComponent<Props> {
         return <TrackProcessCPU counterIndex={localTrack.counterIndex} />;
       case 'power':
         return <TrackPower counterIndex={localTrack.counterIndex} />;
+      case 'sampling-interval':
+        return <TrackSamplingInterval pid={localTrack.pid} />;
       case 'marker':
         return (
           <TrackCustomMarker
@@ -248,6 +251,10 @@ export const TimelineLocalTrack = explicitConnect<
         titleText = getCounterSelectors(localTrack.counterIndex).getDescription(
           state
         );
+        break;
+      }
+      case 'sampling-interval': {
+        titleText = 'Sampling Intervals';
         break;
       }
       default:

--- a/src/components/timeline/TrackSamplingInterval.css
+++ b/src/components/timeline/TrackSamplingInterval.css
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.timelineTrackSamplingInterval {
+  position: relative;
+}
+
+.timelineTrackSamplingIntervalCanvas {
+  width: 100%;
+  height: var(--graph-height);
+}
+
+.timelineTrackSamplingIntervalGraph {
+  position: relative;
+  height: 100%;
+  cursor: default;
+}
+
+.timelineTrackSamplingIntervalTooltip {
+  display: grid;
+  gap: 2px 5px;
+  grid-template-columns: min-content minmax(0, 1fr);
+}
+
+.timelineTrackSamplingIntervalTooltipLabel {
+  color: var(--grey-50);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.timelineTrackSamplingIntervalTooltipValue {
+  font-variant-numeric: tabular-nums;
+}
+
+.timelineTrackSamplingIntervalGraphDot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  margin-top: -3px;
+  margin-left: -3px;
+  pointer-events: none;
+}

--- a/src/components/timeline/TrackSamplingInterval.tsx
+++ b/src/components/timeline/TrackSamplingInterval.tsx
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { getCommittedRange } from 'firefox-profiler/selectors/profile';
+import { updatePreviewSelection } from 'firefox-profiler/actions/profile-view';
+import { TrackSamplingIntervalGraph } from './TrackSamplingIntervalGraph';
+import {
+  TRACK_PROCESS_CPU_HEIGHT,
+  TRACK_PROCESS_CPU_LINE_WIDTH,
+} from 'firefox-profiler/app-logic/constants';
+
+import type { Pid, Milliseconds } from 'firefox-profiler/types';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+import './TrackSamplingInterval.css';
+
+type OwnProps = {
+  readonly pid: Pid;
+};
+
+type StateProps = {
+  readonly rangeStart: Milliseconds;
+  readonly rangeEnd: Milliseconds;
+};
+
+type DispatchProps = {
+  updatePreviewSelection: typeof updatePreviewSelection;
+};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+type State = {};
+
+export class TrackSamplingIntervalImpl extends React.PureComponent<
+  Props,
+  State
+> {
+  override render() {
+    const { pid } = this.props;
+    return (
+      <div
+        className="timelineTrackSamplingInterval"
+        style={
+          {
+            height: TRACK_PROCESS_CPU_HEIGHT,
+            '--graph-height': `${TRACK_PROCESS_CPU_HEIGHT}px`,
+          } as React.CSSProperties
+        }
+      >
+        <TrackSamplingIntervalGraph
+          pid={pid}
+          lineWidth={TRACK_PROCESS_CPU_LINE_WIDTH}
+          graphHeight={TRACK_PROCESS_CPU_HEIGHT}
+        />
+      </div>
+    );
+  }
+}
+
+export const TrackSamplingInterval = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state) => {
+    const { start, end } = getCommittedRange(state);
+    return {
+      rangeStart: start,
+      rangeEnd: end,
+    };
+  },
+  mapDispatchToProps: { updatePreviewSelection },
+  component: TrackSamplingIntervalImpl,
+});

--- a/src/components/timeline/TrackSamplingIntervalGraph.tsx
+++ b/src/components/timeline/TrackSamplingIntervalGraph.tsx
@@ -1,0 +1,570 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react';
+import { withSize } from 'firefox-profiler/components/shared/WithSize';
+import explicitConnect from 'firefox-profiler/utils/connect';
+import { formatMilliseconds } from 'firefox-profiler/utils/format-numbers';
+import { bisectionRight } from 'firefox-profiler/utils/bisect';
+import {
+  getCommittedRange,
+  getProfile,
+  getProfileInterval,
+} from 'firefox-profiler/selectors/profile';
+import { BLUE_50 } from 'photon-colors';
+import { Tooltip } from 'firefox-profiler/components/tooltip/Tooltip';
+import { EmptyThreadIndicator } from './EmptyThreadIndicator';
+
+import type {
+  Pid,
+  Profile,
+  Thread,
+  Milliseconds,
+  CssPixels,
+} from 'firefox-profiler/types';
+
+import type { SizeProps } from 'firefox-profiler/components/shared/WithSize';
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+import './TrackSamplingInterval.css';
+
+type SamplingData = {
+  time: Milliseconds[];
+  interval: Milliseconds[];
+};
+
+/**
+ * Collect all sampling intervals from all threads in a process
+ */
+function collectSamplingIntervalsForPid(
+  profile: Profile,
+  pid: Pid
+): SamplingData {
+  const allTimes: Array<{ time: Milliseconds; threadIndex: number }> = [];
+
+  // Collect all sample times from all threads in this process
+  for (
+    let threadIndex = 0;
+    threadIndex < profile.threads.length;
+    threadIndex++
+  ) {
+    const thread = profile.threads[threadIndex];
+
+    if (thread.pid !== pid || thread.samples.length === 0) {
+      continue;
+    }
+
+    // Get absolute times from either the time column or timeDeltas
+    let sampleTimes: Milliseconds[];
+    if (thread.samples.time) {
+      sampleTimes = thread.samples.time;
+    } else if (thread.samples.timeDeltas) {
+      // Convert timeDeltas to absolute times
+      sampleTimes = new Array(thread.samples.timeDeltas.length);
+      let currentTime = 0;
+      for (let i = 0; i < thread.samples.timeDeltas.length; i++) {
+        currentTime += thread.samples.timeDeltas[i];
+        sampleTimes[i] = currentTime;
+      }
+    } else {
+      // No time data available
+      continue;
+    }
+
+    for (let i = 0; i < sampleTimes.length; i++) {
+      allTimes.push({
+        time: sampleTimes[i],
+        threadIndex,
+      });
+    }
+  }
+
+  // Sort by time
+  allTimes.sort((a, b) => a.time - b.time);
+
+  // Calculate intervals
+  const times: Milliseconds[] = [];
+  const intervals: Milliseconds[] = [];
+
+  for (let i = 0; i < allTimes.length; i++) {
+    times.push(allTimes[i].time);
+    if (i > 0) {
+      intervals.push(allTimes[i].time - allTimes[i - 1].time);
+    } else {
+      // First sample uses the profile's default interval
+      intervals.push(profile.meta.interval);
+    }
+  }
+
+  return { time: times, interval: intervals };
+}
+
+type CanvasProps = {
+  readonly rangeStart: Milliseconds;
+  readonly rangeEnd: Milliseconds;
+  readonly samplingData: SamplingData;
+  readonly minInterval: Milliseconds;
+  readonly maxInterval: Milliseconds;
+  readonly profileInterval: Milliseconds;
+  readonly width: CssPixels;
+  readonly height: CssPixels;
+  readonly lineWidth: CssPixels;
+};
+
+class TrackSamplingIntervalCanvas extends React.PureComponent<CanvasProps> {
+  _canvas: null | HTMLCanvasElement = null;
+  _requestedAnimationFrame: boolean = false;
+
+  drawCanvas(canvas: HTMLCanvasElement): void {
+    const {
+      rangeStart,
+      rangeEnd,
+      samplingData,
+      height,
+      width,
+      lineWidth,
+      minInterval,
+      maxInterval,
+    } = this.props;
+    if (width === 0) {
+      return;
+    }
+
+    const ctx = canvas.getContext('2d')!;
+    const devicePixelRatio = window.devicePixelRatio;
+    const deviceWidth = width * devicePixelRatio;
+    const deviceHeight = height * devicePixelRatio;
+    const deviceLineWidth = lineWidth * devicePixelRatio;
+    const deviceLineHalfWidth = deviceLineWidth * 0.5;
+    const innerDeviceHeight = deviceHeight - deviceLineWidth;
+    const rangeLength = rangeEnd - rangeStart;
+    const millisecondWidth = deviceWidth / rangeLength;
+
+    // Resize and clear the canvas.
+    canvas.width = Math.round(deviceWidth);
+    canvas.height = Math.round(deviceHeight);
+    ctx.clearRect(0, 0, deviceWidth, deviceHeight);
+
+    if (samplingData.time.length === 0) {
+      return;
+    }
+
+    // Find sample range within visible time range
+    const startIndex = bisectionRight(samplingData.time, rangeStart);
+    const endIndex = bisectionRight(samplingData.time, rangeEnd);
+
+    if (startIndex >= endIndex) {
+      return;
+    }
+
+    ctx.lineWidth = deviceLineWidth;
+    ctx.lineJoin = 'bevel';
+    ctx.strokeStyle = BLUE_50;
+    ctx.fillStyle = BLUE_50 + '44'; // Blue with transparency
+    ctx.beginPath();
+
+    const getX = (i: number) =>
+      Math.round((samplingData.time[i] - rangeStart) * millisecondWidth);
+    const getY = (intervalValue: Milliseconds) => {
+      const intervalRange = maxInterval - minInterval;
+      const normalizedValue =
+        intervalRange > 0 ? (intervalValue - minInterval) / intervalRange : 0;
+      return Math.round(
+        innerDeviceHeight -
+          innerDeviceHeight * normalizedValue +
+          deviceLineHalfWidth
+      );
+    };
+
+    const firstX = getX(startIndex);
+    let x = firstX;
+    let y = getY(samplingData.interval[startIndex]);
+
+    // Move to the first point
+    ctx.moveTo(x, y);
+
+    // Draw the line with optimization for multiple samples per pixel
+    for (let i = startIndex + 1; i < endIndex; i++) {
+      const intervalValues = [samplingData.interval[i]];
+      x = getX(i);
+      y = getY(intervalValues[0]);
+      ctx.lineTo(x, y);
+
+      // If we have multiple samples to draw on the same horizontal pixel,
+      // we process all of them together with a max-min decimation algorithm
+      // to save time:
+      // - We draw the first and last samples to ensure the display is correct
+      // - For the values in between, we only draw the min and max values,
+      //   to draw a vertical line covering all the other sample values.
+      while (i + 1 < endIndex && getX(i + 1) === x) {
+        intervalValues.push(samplingData.interval[++i]);
+      }
+
+      // Looking for the min and max only makes sense if we have more than 2 samples
+      if (intervalValues.length > 2) {
+        const minY = getY(Math.min(...intervalValues));
+        if (minY !== y) {
+          y = minY;
+          ctx.lineTo(x, y);
+        }
+        const maxY = getY(Math.max(...intervalValues));
+        if (maxY !== y) {
+          y = maxY;
+          ctx.lineTo(x, y);
+        }
+      }
+
+      const lastY = getY(intervalValues[intervalValues.length - 1]);
+      if (lastY !== y) {
+        y = lastY;
+        ctx.lineTo(x, y);
+      }
+    }
+
+    // Stroke the line
+    ctx.stroke();
+
+    // Fill to bottom
+    ctx.lineTo(x, deviceHeight);
+    ctx.lineTo(firstX, deviceHeight);
+    ctx.fill();
+  }
+
+  _scheduleDraw() {
+    if (!this._requestedAnimationFrame) {
+      this._requestedAnimationFrame = true;
+      window.requestAnimationFrame(() => {
+        this._requestedAnimationFrame = false;
+        const canvas = this._canvas;
+        if (canvas) {
+          this.drawCanvas(canvas);
+        }
+      });
+    }
+  }
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  override componentDidMount() {
+    this._scheduleDraw();
+  }
+
+  override componentDidUpdate() {
+    this._scheduleDraw();
+  }
+
+  override render() {
+    return (
+      <canvas
+        className="timelineTrackSamplingIntervalCanvas"
+        ref={this._takeCanvasRef}
+      />
+    );
+  }
+}
+
+type OwnProps = {
+  readonly pid: Pid;
+  readonly lineWidth: CssPixels;
+  readonly graphHeight: CssPixels;
+};
+
+type StateProps = {
+  readonly rangeStart: Milliseconds;
+  readonly rangeEnd: Milliseconds;
+  readonly samplingData: SamplingData;
+  readonly minInterval: Milliseconds;
+  readonly maxInterval: Milliseconds;
+  readonly profileInterval: Milliseconds;
+  readonly profile: Profile;
+};
+
+type DispatchProps = {};
+
+type Props = SizeProps & ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+type State = {
+  hoveredSample: null | number;
+  mouseX: CssPixels;
+  mouseY: CssPixels;
+};
+
+class TrackSamplingIntervalGraphImpl extends React.PureComponent<Props, State> {
+  override state = {
+    hoveredSample: null,
+    mouseX: 0,
+    mouseY: 0,
+  };
+
+  _onMouseLeave = () => {
+    this.setState({ hoveredSample: null });
+  };
+
+  _onMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    const { pageX: mouseX, pageY: mouseY } = event;
+    const { left } = event.currentTarget.getBoundingClientRect();
+    const { width, rangeStart, rangeEnd, samplingData } = this.props;
+    const rangeLength = rangeEnd - rangeStart;
+    const timeAtMouse = rangeStart + ((mouseX - left) / width) * rangeLength;
+
+    if (samplingData.time.length === 0) {
+      this.setState({ hoveredSample: null });
+      return;
+    }
+
+    if (
+      timeAtMouse < samplingData.time[0] ||
+      timeAtMouse > samplingData.time[samplingData.time.length - 1]
+    ) {
+      this.setState({ hoveredSample: null });
+      return;
+    }
+
+    // Find the closest sample
+    const bisectionIndex = bisectionRight(samplingData.time, timeAtMouse);
+    let hoveredSample;
+
+    if (bisectionIndex > 0 && bisectionIndex < samplingData.time.length) {
+      const leftDistance = timeAtMouse - samplingData.time[bisectionIndex - 1];
+      const rightDistance = samplingData.time[bisectionIndex] - timeAtMouse;
+      if (leftDistance < rightDistance) {
+        hoveredSample = bisectionIndex - 1;
+      } else {
+        hoveredSample = bisectionIndex;
+      }
+
+      // If there are samples before or after hoveredSample that fall
+      // horizontally on the same pixel, move hoveredSample to the sample
+      // with the highest interval value.
+      const mouseAtTime = (t: number) =>
+        Math.round(((t - rangeStart) / rangeLength) * width + left);
+      for (
+        let currentIndex = hoveredSample - 1;
+        currentIndex >= 0 &&
+        mouseAtTime(samplingData.time[currentIndex]) === mouseX;
+        --currentIndex
+      ) {
+        if (
+          samplingData.interval[currentIndex] >
+          samplingData.interval[hoveredSample]
+        ) {
+          hoveredSample = currentIndex;
+        }
+      }
+      for (
+        let currentIndex = hoveredSample + 1;
+        currentIndex < samplingData.time.length &&
+        mouseAtTime(samplingData.time[currentIndex]) === mouseX;
+        ++currentIndex
+      ) {
+        if (
+          samplingData.interval[currentIndex] >
+          samplingData.interval[hoveredSample]
+        ) {
+          hoveredSample = currentIndex;
+        }
+      }
+    } else if (bisectionIndex >= samplingData.time.length) {
+      hoveredSample = samplingData.time.length - 1;
+    } else {
+      hoveredSample = bisectionIndex;
+    }
+
+    this.setState({
+      mouseX,
+      mouseY,
+      hoveredSample,
+    });
+  };
+
+  _renderTooltip(sampleIndex: number): React.ReactNode {
+    const { samplingData, profileInterval, rangeStart, rangeEnd } = this.props;
+    const { mouseX, mouseY } = this.state;
+
+    const interval = samplingData.interval[sampleIndex];
+    const time = samplingData.time[sampleIndex];
+
+    if (time < rangeStart || time > rangeEnd) {
+      return null;
+    }
+
+    return (
+      <Tooltip mouseX={mouseX} mouseY={mouseY}>
+        <div className="timelineTrackSamplingIntervalTooltip">
+          <div className="timelineTrackSamplingIntervalTooltipLabel">
+            Sampling Interval:
+          </div>
+          <div className="timelineTrackSamplingIntervalTooltipValue">
+            {formatMilliseconds(interval, 3, 1)}
+          </div>
+          <div className="timelineTrackSamplingIntervalTooltipLabel">
+            Expected Interval:
+          </div>
+          <div className="timelineTrackSamplingIntervalTooltipValue">
+            {formatMilliseconds(profileInterval, 3, 1)}
+          </div>
+        </div>
+      </Tooltip>
+    );
+  }
+
+  /**
+   * Create a div that is a dot on top of the graph representing the current
+   * sample being hovered.
+   */
+  _renderDot(sampleIndex: number): React.ReactNode {
+    const {
+      samplingData,
+      rangeStart,
+      rangeEnd,
+      graphHeight,
+      width,
+      lineWidth,
+      minInterval,
+      maxInterval,
+    } = this.props;
+
+    const sampleTime = samplingData.time[sampleIndex];
+    const intervalValue = samplingData.interval[sampleIndex];
+
+    if (sampleTime < rangeStart || sampleTime > rangeEnd) {
+      return null;
+    }
+
+    const rangeLength = rangeEnd - rangeStart;
+    const left = (width * (sampleTime - rangeStart)) / rangeLength;
+
+    const intervalRange = maxInterval - minInterval;
+    const normalizedValue =
+      intervalRange > 0 ? (intervalValue - minInterval) / intervalRange : 0;
+    const innerTrackHeight = graphHeight - lineWidth / 2;
+    const top =
+      innerTrackHeight - normalizedValue * innerTrackHeight + lineWidth / 2;
+
+    return (
+      <div
+        style={{
+          left,
+          top,
+          backgroundColor: BLUE_50,
+        }}
+        className="timelineTrackSamplingIntervalGraphDot"
+      />
+    );
+  }
+
+  override render() {
+    const { samplingData, profileInterval } = this.props;
+    const { hoveredSample } = this.state;
+
+    if (samplingData.time.length === 0) {
+      return (
+        <EmptyThreadIndicator
+          thread={
+            {
+              name: 'Empty',
+              samples: { length: 0 },
+            } as unknown as Thread
+          }
+          interval={profileInterval}
+          rangeStart={this.props.rangeStart}
+          rangeEnd={this.props.rangeEnd}
+          unfilteredSamplesRange={null}
+        />
+      );
+    }
+
+    const {
+      rangeStart,
+      rangeEnd,
+      minInterval,
+      maxInterval,
+      lineWidth,
+      graphHeight,
+      width,
+    } = this.props;
+
+    return (
+      <div
+        className="timelineTrackSamplingIntervalGraph"
+        onMouseMove={this._onMouseMove}
+        onMouseLeave={this._onMouseLeave}
+      >
+        <TrackSamplingIntervalCanvas
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          samplingData={samplingData}
+          minInterval={minInterval}
+          maxInterval={maxInterval}
+          profileInterval={profileInterval}
+          width={width}
+          height={graphHeight}
+          lineWidth={lineWidth}
+        />
+        {hoveredSample === null ? null : (
+          <>
+            {this._renderDot(hoveredSample)}
+            {this._renderTooltip(hoveredSample)}
+          </>
+        )}
+      </div>
+    );
+  }
+}
+
+const SizedTrackSamplingIntervalGraphImpl = withSize(
+  TrackSamplingIntervalGraphImpl
+);
+
+export const TrackSamplingIntervalGraph = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
+  mapStateToProps: (state, ownProps) => {
+    const { pid } = ownProps;
+    const { start, end } = getCommittedRange(state);
+    const profile = getProfile(state);
+    const profileInterval = getProfileInterval(state);
+    const samplingData = collectSamplingIntervalsForPid(profile, pid);
+
+    // Calculate min/max intervals for normalization based on visible range
+    let minInterval = 0;
+    let maxInterval = profileInterval * 3; // fallback
+    if (samplingData.time.length > 0) {
+      // Find the range of intervals visible in the committed range
+      const startIndex = bisectionRight(samplingData.time, start);
+      const endIndex = bisectionRight(samplingData.time, end);
+
+      if (startIndex < endIndex) {
+        const visibleIntervals = samplingData.interval.slice(
+          startIndex,
+          endIndex
+        );
+        const minVisibleInterval = Math.min(...visibleIntervals);
+        const maxVisibleInterval = Math.max(...visibleIntervals);
+
+        // Add 10% padding to avoid having lines at the very edges
+        const range = maxVisibleInterval - minVisibleInterval;
+        const padding = range * 0.1;
+        minInterval = Math.max(0, minVisibleInterval - padding);
+        maxInterval = maxVisibleInterval + padding;
+      }
+    }
+
+    return {
+      rangeStart: start,
+      rangeEnd: end,
+      samplingData,
+      minInterval,
+      maxInterval,
+      profileInterval,
+      profile,
+    };
+  },
+  mapDispatchToProps: {},
+  component: SizedTrackSamplingIntervalGraphImpl,
+});

--- a/src/reducers/app.ts
+++ b/src/reducers/app.ts
@@ -138,6 +138,7 @@ const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
     case 'TOGGLE_RESOURCES_PANEL':
     case 'ENABLE_EXPERIMENTAL_CPU_GRAPHS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_SAMPLING_INTERVAL_TRACKS':
     case 'CHANGE_TAB_FILTER':
     // Committed range changes: (fallthrough)
     case 'COMMIT_RANGE':
@@ -288,6 +289,19 @@ const processCPUTracks: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+/*
+ * This reducer holds the state for whether the sampling interval tracks are enabled.
+ * This feature is experimental and allows visualization of sampling intervals per process.
+ */
+const samplingIntervalTracks: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'ENABLE_EXPERIMENTAL_SAMPLING_INTERVAL_TRACKS':
+      return true;
+    default:
+      return state;
+  }
+};
+
 /**
  * This keeps the information about the upload for the current profile, if any.
  * This is retrieved from the IndexedDB for published profiles information in
@@ -319,6 +333,7 @@ const experimental: Reducer<ExperimentalFlags> = combineReducers({
   eventDelayTracks,
   cpuGraphs,
   processCPUTracks,
+  samplingIntervalTracks,
 });
 
 const browserConnectionStatus: Reducer<BrowserConnectionStatus> = (

--- a/src/reducers/profile-view.ts
+++ b/src/reducers/profile-view.ts
@@ -111,6 +111,7 @@ const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_SAMPLING_INTERVAL_TRACKS':
     case 'CHANGE_TAB_FILTER':
       return action.localTracksByPid;
     default:

--- a/src/reducers/url-state.ts
+++ b/src/reducers/url-state.ts
@@ -488,6 +488,7 @@ const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
     case 'VIEW_FULL_PROFILE':
     case 'ENABLE_EVENT_DELAY_TRACKS':
     case 'ENABLE_EXPERIMENTAL_PROCESS_CPU_TRACKS':
+    case 'ENABLE_EXPERIMENTAL_SAMPLING_INTERVAL_TRACKS':
     case 'CHANGE_TAB_FILTER':
       return action.localTrackOrderByPid;
     case 'CHANGE_LOCAL_TRACK_ORDER': {

--- a/src/selectors/app.tsx
+++ b/src/selectors/app.tsx
@@ -80,6 +80,10 @@ export const getIsExperimentalProcessCPUTracksEnabled: Selector<boolean> = (
   state
 ) => getExperimental(state).processCPUTracks;
 
+export const getIsExperimentalSamplingIntervalTracksEnabled: Selector<
+  boolean
+> = (state) => getExperimental(state).samplingIntervalTracks;
+
 export const getIsDragAndDropDragging: Selector<boolean> = (state) =>
   getApp(state).isDragAndDropDragging;
 export const getIsDragAndDropOverlayRegistered: Selector<boolean> = (state) =>
@@ -203,6 +207,9 @@ export const getTimelineHeight: Selector<null | CssPixels> = createSelector(
               break;
             case 'marker':
               height += TRACK_MARKER_HEIGHT + border;
+              break;
+            case 'sampling-interval':
+              height += TRACK_PROCESS_CPU_HEIGHT + border;
               break;
             default:
               throw assertExhaustiveCheck(localTrack);

--- a/src/test/fixtures/profiles/tracks.ts
+++ b/src/test/fixtures/profiles/tracks.ts
@@ -106,6 +106,8 @@ export function getHumanReadableTracks(state: State): string[] {
             .getCounter(state).name;
         } else if (track.type === 'marker') {
           trackName = stringArray[track.markerName];
+        } else if (track.type === 'sampling-interval') {
+          trackName = 'Sampling Intervals';
         } else {
           trackName = threads[track.threadIndex].name;
         }

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -335,6 +335,11 @@ type ProfileAction =
       readonly localTrackOrderByPid: Map<Pid, TrackIndex[]>;
     }
   | {
+      readonly type: 'ENABLE_EXPERIMENTAL_SAMPLING_INTERVAL_TRACKS';
+      readonly localTracksByPid: Map<Pid, LocalTrack[]>;
+      readonly localTrackOrderByPid: Map<Pid, TrackIndex[]>;
+    }
+  | {
       readonly type: 'UPDATE_BOTTOM_BOX';
       readonly libIndex: IndexIntoLibs | null;
       readonly sourceIndex: IndexIntoSourceTable | null;

--- a/src/types/profile-derived.ts
+++ b/src/types/profile-derived.ts
@@ -628,6 +628,7 @@ export type LocalTrack =
   | { readonly type: 'event-delay'; readonly threadIndex: ThreadIndex }
   | { readonly type: 'process-cpu'; readonly counterIndex: CounterIndex }
   | { readonly type: 'power'; readonly counterIndex: CounterIndex }
+  | { readonly type: 'sampling-interval'; readonly pid: Pid }
   | {
       readonly type: 'marker';
       readonly threadIndex: ThreadIndex;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -171,6 +171,7 @@ export type ExperimentalFlags = {
   readonly eventDelayTracks: boolean;
   readonly cpuGraphs: boolean;
   readonly processCPUTracks: boolean;
+  readonly samplingIntervalTracks: boolean;
 };
 
 export type AppState = {

--- a/src/utils/window-console.ts
+++ b/src/utils/window-console.ts
@@ -34,6 +34,7 @@ export type ExtraPropertiesOnWindowForConsole = {
     enableEventDelayTracks(): void;
     enableCPUGraphs(): void;
     enableProcessCPUTracks(): void;
+    enableSamplingIntervalTracks(): void;
   };
   togglePseudoLocalization: (pseudoStrategy?: string) => void;
   toggleTimelineType: (timelineType?: string) => void;
@@ -139,6 +140,19 @@ export function addDataToWindowObject(
       if (areExperimentalProcessCPUTracksEnabled) {
         console.log(stripIndent`
           ✅ The process CPU tracks are now enabled and should be displayed in the timeline.
+          👉 Note that this is an experimental feature that might still have bugs.
+          💡 As an experimental feature their presence isn't persisted as a URL parameter like the other things.
+        `);
+      }
+    },
+
+    enableSamplingIntervalTracks() {
+      const areExperimentalSamplingIntervalTracksEnabled = dispatch(
+        actions.enableExperimentalSamplingIntervalTracks()
+      );
+      if (areExperimentalSamplingIntervalTracksEnabled) {
+        console.log(stripIndent`
+          ✅ The sampling interval tracks are now enabled and should be displayed in the timeline.
           👉 Note that this is an experimental feature that might still have bugs.
           💡 As an experimental feature their presence isn't persisted as a URL parameter like the other things.
         `);


### PR DESCRIPTION
Add a new experimental feature to visualize sampling intervals within each process. This helps identify when samples were missed, delayed, or when there are variations in sampling frequency.

The feature is similar to experimental.enableProcessCPUTracks() and can be enabled via the console with:
  experimental.enableSamplingIntervalTracks()

Implementation details:
- Add 'sampling-interval' LocalTrack type
- Create TrackSamplingInterval and TrackSamplingIntervalGraph components
- Implement canvas rendering with max-min decimation optimization
- Add hover tooltips showing actual vs expected sampling intervals
- Include hover dot indicator for currently inspected sample

Example power profile where I was interested in seeing inconsistencies in sampling rate from the power meter: https://share.firefox.dev/48U79KE
Example Firefox profile with lots of missing samples: https://share.firefox.dev/4p5d8mc