### PR TITLE
Make the uncommitted selection range directly editable as text

### DIFF
--- a/src/components/app/ProfileViewer.tsx
+++ b/src/components/app/ProfileViewer.tsx
@@ -2,7 +2,7 @@
  * license, v. 2.0. if a copy of the mpl was not distributed with this
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
-import { PureComponent } from 'react';
+import * as React from 'react';
 import explicitConnect from 'firefox-profiler/utils/connect';
 
 import { DetailsContainer } from './DetailsContainer';
@@ -59,7 +59,16 @@ type DispatchProps = {
 
 type Props = ConnectedProps<{}, StateProps, DispatchProps>;
 
-class ProfileViewerImpl extends PureComponent<Props> {
+class ProfileViewerImpl extends React.PureComponent<Props> {
+  uncommittedInputFieldRef = React.createRef<HTMLInputElement>();
+
+  _onSelectionMove = () => {
+    if (!this.uncommittedInputFieldRef.current) {
+      return;
+    }
+    this.uncommittedInputFieldRef.current.blur();
+  };
+
   override render() {
     const {
       hasZipFile,
@@ -114,7 +123,9 @@ class ProfileViewerImpl extends PureComponent<Props> {
               />
             ) : null}
             <ProfileName />
-            <ProfileFilterNavigator />
+            <ProfileFilterNavigator
+              uncommittedInputFieldRef={this.uncommittedInputFieldRef}
+            />
             {
               // Define a spacer in the middle that will shrink based on the availability
               // of space in the top bar. It will shrink away before any of the items
@@ -139,7 +150,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
             secondaryInitialSize={270}
             onDragEnd={invalidatePanelLayout}
           >
-            <Timeline />
+            <Timeline onSelectionMove={this._onSelectionMove} />
             <SplitterLayout
               vertical
               percentage={true}

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -67,6 +67,17 @@
   white-space: nowrap;
 }
 
+.filterNavigatorBarItemUncommittedFieldInput {
+  display: flex;
+  overflow: hidden;
+  width: 60px;
+  height: 19px;
+  box-sizing: border-box;
+  border: 0.5px solid #aaa;
+  margin-top: 2.5px;
+  font-size: 11px;
+}
+
 .filterNavigatorBarItemContent > .nodeIcon {
   margin-inline-end: 5px;
 }

--- a/src/components/timeline/FullTimeline.tsx
+++ b/src/components/timeline/FullTimeline.tsx
@@ -50,6 +50,7 @@ import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 type OwnProps = {
   // This ref will be added to the inner container.
   readonly innerElementRef?: React.Ref<any>;
+  readonly onSelectionMove?: () => void;
 };
 
 type StateProps = {
@@ -149,11 +150,12 @@ class FullTimelineImpl extends React.PureComponent<Props, State> {
       trackCount,
       changeRightClickedTrack,
       innerElementRef,
+      onSelectionMove,
     } = this.props;
 
     return (
       <>
-        <TimelineSelection width={width}>
+        <TimelineSelection width={width} onSelectionMove={onSelectionMove}>
           <div className="timelineHeader">
             {trackCount.total > 1 ? (
               <TimelineSettingsHiddenTracks

--- a/src/components/timeline/Selection.tsx
+++ b/src/components/timeline/Selection.tsx
@@ -38,6 +38,7 @@ type OwnProps = {
   readonly width: number;
   readonly children: React.ReactNode;
   readonly className?: string;
+  readonly onSelectionMove?: () => void;
 };
 
 type StateProps = {
@@ -98,7 +99,11 @@ class TimelineRulerAndSelection extends React.PureComponent<Props> {
     // browsers.
     event.preventDefault();
 
-    const { committedRange } = this.props;
+    const { committedRange, onSelectionMove } = this.props;
+    if (onSelectionMove) {
+      onSelectionMove();
+    }
+
     const minSelectionStartWidth: CssPixels = 3;
     const mouseDownX = event.pageX;
     const mouseDownTime =
@@ -286,7 +291,12 @@ class TimelineRulerAndSelection extends React.PureComponent<Props> {
     dx: number,
     isModifying: boolean
   ) {
-    const { committedRange, width, updatePreviewSelection } = this.props;
+    const { committedRange, width, updatePreviewSelection, onSelectionMove } =
+      this.props;
+    if (onSelectionMove) {
+      onSelectionMove();
+    }
+
     const delta = (dx / width) * (committedRange.end - committedRange.start);
     const selectionDeltas = selectionDeltasForDx(delta);
     let selectionStart = clamp(

--- a/src/components/timeline/index.tsx
+++ b/src/components/timeline/index.tsx
@@ -5,7 +5,9 @@
 import { PureComponent } from 'react';
 import { FullTimeline } from 'firefox-profiler/components/timeline/FullTimeline';
 
-type TimelineProps = {};
+type TimelineProps = {
+  readonly onSelectionMove?: () => void;
+};
 
 export class Timeline extends PureComponent<TimelineProps> {
   // This may contain a function that's called whenever we want to remove the
@@ -66,6 +68,13 @@ export class Timeline extends PureComponent<TimelineProps> {
   }
 
   override render() {
-    return <FullTimeline innerElementRef={this._onTimelineMountWithRef} />;
+    const { onSelectionMove } = this.props;
+
+    return (
+      <FullTimeline
+        innerElementRef={this._onTimelineMountWithRef}
+        onSelectionMove={onSelectionMove}
+      />
+    );
   }
 }

--- a/src/test/components/FilterNavigatorBar.test.tsx
+++ b/src/test/components/FilterNavigatorBar.test.tsx
@@ -56,6 +56,182 @@ describe('shared/FilterNavigatorBar', () => {
     fireEvent.click(lastElement);
     expect(onPop).toHaveBeenCalledWith(1);
   });
+
+  it(`updates the preview selection when duration is modified`, () => {
+    const onPop = jest.fn();
+    const updatePreviewSelection = jest.fn();
+    const committedRange = {
+      start: 1000,
+      end: 3000,
+    };
+    const previewSelection = {
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1060,
+    };
+
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['100ms']}
+        selectedItem={1}
+        uncommittedItem="10ms"
+        onPop={onPop}
+        committedRange={committedRange}
+        previewSelection={previewSelection}
+        updatePreviewSelection={updatePreviewSelection}
+      />
+    );
+
+    const uncommittedItem = screen.getByDisplayValue(
+      '10ms'
+    ) as HTMLInputElement;
+    fireEvent.focus(uncommittedItem);
+
+    // Setting a valid value should update.
+    fireEvent.change(uncommittedItem, {
+      target: { value: '20ms' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1070,
+    });
+    expect(uncommittedItem.value).toBe('20ms');
+
+    fireEvent.change(uncommittedItem, {
+      target: { value: '20.5ms' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1070.5,
+    });
+
+    fireEvent.change(uncommittedItem, {
+      target: { value: '500us' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1050.5,
+    });
+
+    fireEvent.change(uncommittedItem, {
+      target: { value: '1.5s' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 2550,
+    });
+
+    fireEvent.change(uncommittedItem, {
+      target: { value: '110' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1160,
+    });
+
+    // Setting invalid value shouldn't trigger update,
+    // and the next valid value should be reflected.
+    fireEvent.change(uncommittedItem, {
+      target: { value: 'a' },
+    });
+    fireEvent.change(uncommittedItem, {
+      target: { value: '100' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1150,
+    });
+
+    // The selectionEnd should not exceed the committedRange.
+    fireEvent.change(uncommittedItem, {
+      target: { value: '200s' },
+    });
+    expect(updatePreviewSelection).toHaveBeenCalledWith({
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 3000,
+    });
+  });
+
+  it(`commits the range when duration is submitted`, () => {
+    const onPop = jest.fn();
+    const commitRange = jest.fn();
+    const previewSelection = {
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1060,
+    };
+
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['100ms']}
+        selectedItem={1}
+        uncommittedItem="10ms"
+        onPop={onPop}
+        previewSelection={previewSelection}
+        commitRange={commitRange}
+        zeroAt={0}
+      />
+    );
+
+    const uncommittedItem = screen.getByDisplayValue(
+      '10ms'
+    ) as HTMLInputElement;
+
+    fireEvent.submit(uncommittedItem, {});
+    expect(commitRange).toHaveBeenCalledWith(1050, 1060);
+  });
+
+  it(`resets to the unmodified value on blur`, () => {
+    const onPop = jest.fn();
+    const updatePreviewSelection = jest.fn();
+    const committedRange = {
+      start: 1000,
+      end: 3000,
+    };
+    const previewSelection = {
+      isModifying: false,
+      selectionStart: 1050,
+      selectionEnd: 1060,
+    };
+
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['100ms']}
+        selectedItem={1}
+        uncommittedItem="10ms"
+        onPop={onPop}
+        committedRange={committedRange}
+        previewSelection={previewSelection}
+        updatePreviewSelection={updatePreviewSelection}
+      />
+    );
+
+    const uncommittedItem = screen.getByDisplayValue(
+      '10ms'
+    ) as HTMLInputElement;
+    fireEvent.focus(uncommittedItem);
+
+    fireEvent.change(uncommittedItem, {
+      target: { value: '20ms' },
+    });
+    expect(uncommittedItem.value).toBe('20ms');
+
+    fireEvent.blur(uncommittedItem);
+    expect(uncommittedItem.value).toBe('10ms');
+
+    fireEvent.focus(uncommittedItem);
+    expect(uncommittedItem.value).toBe('10ms');
+  });
 });
 
 describe('app/ProfileFilterNavigator', () => {

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.tsx.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.tsx.snap
@@ -83,11 +83,14 @@ exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] 
     class="filterNavigatorBarItem filterNavigatorBarUncommittedItem filterNavigatorBarLeafItem"
     title="100μs"
   >
-    <span
-      class="filterNavigatorBarItemContent"
-    >
-      100μs
-    </span>
+    <form>
+      <input
+        aria-label="Range duration"
+        class="filterNavigatorBarItemUncommittedFieldInput photon-input"
+        title="Edit the range duration"
+        value="100μs"
+      />
+    </form>
   </li>
 </ol>
 `;


### PR DESCRIPTION
Fixed #5723

This makes the uncommitted range in the FilterNavigatorBar an input field instead of a plain text,
so that the range can be directly modified, which allows selecting the same range between two profiles loaded in different tabs, for comparison purpose.

  * The input field accepts "s", "ms", "us", and "μs" units, with floating point number
    * If there's no unit, it's treated as "ms"
  * The modification to the input field is immediately reflected to the selection in the timeline
  * The modification to the selection in the timeline is immediately reflected to the input field
  * While the input field has focus, it shows raw input value, which can also be a temporary invalid value, or something that's different than the formatted value
  * Once the input field lost the focus, the actual formatted range is shown
    * The `onSelectionMove` part is added in order to blur the input field when the selection in the timeline is modified, which by default doesn't take any focus
  * Completely invalid value (which `parseFloat` returns NaN) is ignored and the previous value is kept
  * If the duration exceeds the current committed range, it's cropped at the end of the range
  * Hitting enter key in the input field commits the range

<img width="1068" height="426" alt="uncommiitted-range-input" src="https://github.com/user-attachments/assets/c3626684-f1a1-4c68-a3ca-d441cd0fece5" />
