### PR TITLE
Add a menu to copy the Marker Table as text

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -468,6 +468,16 @@ MarkerContextMenu--select-the-sender-thread =
 MarkerFiltersContextMenu--drop-samples-outside-of-markers-matching =
     Drop samples outside of markers matching “<strong>{ $filter }</strong>”
 
+## MarkerCopyTableContextMenu
+## This is the menu when the copy icon is clicked in Marker Chart and Marker
+## Table panels.
+
+MarkerCopyTableContextMenu--copy-table-as-plain =
+    Copy marker table as plain text
+
+MarkerCopyTableContextMenu--copy-table-as-markdown =
+    Copy marker table as Markdown
+
 ## MarkerSettings
 ## This is used in all panels related to markers.
 
@@ -477,6 +487,17 @@ MarkerSettings--panel-search =
 
 MarkerSettings--marker-filters =
     .title = Marker Filters
+
+MarkerSettings--copy-table =
+    .title = Copy table as text
+
+# This string is used when the user tries to copy a marker table with
+# more than 10000 rows.
+# Variable:
+#   $rows (Number) - Number of rows the marker table has
+#   $maxRows (Number) - Number of maximum rows that can be copied
+MarkerSettings--copy-table-exceeed-max-rows =
+    The number of rows exceeds the limit: { $rows } > { $maxRows }. Only the first { $maxRows } rows will be copied.
 
 ## MarkerSidebar
 ## This is the sidebar component that is used in Marker Table panel.

--- a/src/components/shared/MarkerCopyTableContextMenu.tsx
+++ b/src/components/shared/MarkerCopyTableContextMenu.tsx
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { PureComponent } from 'react';
+import { MenuItem } from '@firefox-devtools/react-contextmenu';
+import { Localized } from '@fluent/react';
+
+import { ContextMenu } from './ContextMenu';
+import explicitConnect from 'firefox-profiler/utils/connect';
+
+import type { ConnectedProps } from 'firefox-profiler/utils/connect';
+
+type OwnProps = {
+  readonly onShow: () => void;
+  readonly onHide: () => void;
+  readonly onCopy: (format: 'plain' | 'markdown') => void;
+};
+
+type Props = ConnectedProps<OwnProps, {}, {}>;
+
+class MarkerCopyTableContextMenuImpl extends PureComponent<Props> {
+  copyAsPlain = () => {
+    const { onCopy } = this.props;
+    onCopy('plain');
+  };
+
+  copyAsMarkdown = () => {
+    const { onCopy } = this.props;
+    onCopy('markdown');
+  };
+
+  override render() {
+    const { onShow, onHide } = this.props;
+    return (
+      <ContextMenu
+        id="MarkerCopyTableContextMenu"
+        className="markerCopyTableContextMenu"
+        onShow={onShow}
+        onHide={onHide}
+      >
+        <MenuItem onClick={this.copyAsPlain}>
+          <Localized id="MarkerCopyTableContextMenu--copy-table-as-plain">
+            Copy marker table as plain text
+          </Localized>
+        </MenuItem>
+        <MenuItem onClick={this.copyAsMarkdown}>
+          <Localized id="MarkerCopyTableContextMenu--copy-table-as-markdown">
+            Copy marker table as Markdown
+          </Localized>
+        </MenuItem>
+      </ContextMenu>
+    );
+  }
+}
+
+export const MarkerCopyTableContextMenu = explicitConnect<OwnProps, {}, {}>({
+  component: MarkerCopyTableContextMenuImpl,
+});

--- a/src/components/shared/MarkerSettings.css
+++ b/src/components/shared/MarkerSettings.css
@@ -13,20 +13,30 @@
   white-space: nowrap;
 }
 
-.filterMarkersButton {
+.filterMarkersButton,
+.copyTableButton {
   position: relative;
   width: 24px;
   height: 24px;
   flex: none;
   padding-right: 30px;
   margin: 0 4px;
-  background-image: url(../../../res/img/svg/filter.svg);
   background-position: 4px center;
   background-repeat: no-repeat;
 }
 
+.filterMarkersButton {
+  background-image: url(../../../res/img/svg/filter.svg);
+}
+
+.copyTableButton {
+  margin-right: 16px;
+  background-image: url(../../../res/img/svg/copy-dark.svg);
+}
+
 /* This is the dropdown arrow on the right of the button. */
-.filterMarkersButton::after {
+.filterMarkersButton::after,
+.copyTableButton::after {
   position: absolute;
   top: 2px;
   right: 2px;
@@ -39,4 +49,24 @@
   margin-left: 4px;
   color: var(--grey-90);
   content: '';
+}
+
+.copyTableButtonWarningWrapper {
+  /* Position */
+  position: fixed;
+  z-index: 4;
+  top: 0;
+  right: 0;
+  left: 0;
+
+  /* Box */
+  display: flex;
+
+  /* Other */
+  pointer-events: none;
+}
+
+.copyTableButtonWarning {
+  margin: 0 auto;
+  pointer-events: auto;
 }

--- a/src/components/shared/MarkerSettings.tsx
+++ b/src/components/shared/MarkerSettings.tsx
@@ -14,11 +14,19 @@ import { getProfileUsesMultipleStackTypes } from 'firefox-profiler/selectors/pro
 import { PanelSearch } from './PanelSearch';
 import { StackImplementationSetting } from 'firefox-profiler/components/shared/StackImplementationSetting';
 import { MarkerFiltersContextMenu } from './MarkerFiltersContextMenu';
+import { MarkerCopyTableContextMenu } from './MarkerCopyTableContextMenu';
 
 import type { ConnectedProps } from 'firefox-profiler/utils/connect';
 
 import 'firefox-profiler/components/shared/PanelSettingsList.css';
 import './MarkerSettings.css';
+
+type OwnProps = {
+  readonly copyTable?: (
+    format: 'plain' | 'markdown',
+    onExceeedMaxCopyRows: (rows: number, maxRows: number) => void
+  ) => void;
+};
 
 type StateProps = {
   readonly searchString: string;
@@ -29,7 +37,7 @@ type DispatchProps = {
   readonly changeMarkersSearchString: typeof changeMarkersSearchString;
 };
 
-type Props = ConnectedProps<{}, StateProps, DispatchProps>;
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 type State = {
   readonly isMarkerFiltersMenuVisible: boolean;
@@ -39,12 +47,22 @@ type State = {
   // Otherwise, if we check this in onClick event, the state will always be
   // `false` since the library already hid it on mousedown.
   readonly isFilterMenuVisibleOnMouseDown: boolean;
+  readonly isMarkerCopyTableMenuVisible: boolean;
+  readonly isCopyTableMenuVisibleOnMouseDown: boolean;
+  readonly copyTableWarningRows: number | null;
+  readonly copyTableWarningMaxRows: number | null;
 };
 
 class MarkerSettingsImpl extends PureComponent<Props, State> {
+  _copyTableWarningTimeout: NodeJS.Timeout | null = null;
+
   override state = {
     isMarkerFiltersMenuVisible: false,
     isFilterMenuVisibleOnMouseDown: false,
+    isMarkerCopyTableMenuVisible: false,
+    isCopyTableMenuVisibleOnMouseDown: false,
+    copyTableWarningRows: null,
+    copyTableWarningMaxRows: null,
   };
 
   _onSearch = (value: string) => {
@@ -72,6 +90,50 @@ class MarkerSettingsImpl extends PureComponent<Props, State> {
     });
   };
 
+  _onClickToggleCopyTableMenu = (event: React.MouseEvent<HTMLElement>) => {
+    const { isCopyTableMenuVisibleOnMouseDown } = this.state;
+    if (isCopyTableMenuVisibleOnMouseDown) {
+      // Do nothing as we would like to hide the menu if the menu was already visible on mouse down.
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    // FIXME: Currently we assume that the context menu is 250px wide, but ideally
+    // we should get the real width. It's not so easy though, because the context
+    // menu is not rendered yet.
+    const isRightAligned = rect.right > window.innerWidth - 250;
+
+    showMenu({
+      data: null,
+      id: 'MarkerCopyTableContextMenu',
+      position: { x: isRightAligned ? rect.right : rect.left, y: rect.bottom },
+      target: event.target,
+    });
+  };
+
+  _onCopyTable = (format: 'plain' | 'markdown') => {
+    const { copyTable } = this.props;
+    if (!copyTable) {
+      return;
+    }
+
+    copyTable(format, (rows: number, maxRows: number) => {
+      this.setState({
+        copyTableWarningRows: rows,
+        copyTableWarningMaxRows: maxRows,
+      });
+      if (this._copyTableWarningTimeout) {
+        clearTimeout(this._copyTableWarningTimeout);
+      }
+      this._copyTableWarningTimeout = setTimeout(() => {
+        this.setState({
+          copyTableWarningRows: null,
+          copyTableWarningMaxRows: null,
+        });
+      }, 3000);
+    });
+  };
+
   _onShowFiltersContextMenu = () => {
     this.setState({ isMarkerFiltersMenuVisible: true });
   };
@@ -80,15 +142,34 @@ class MarkerSettingsImpl extends PureComponent<Props, State> {
     this.setState({ isMarkerFiltersMenuVisible: false });
   };
 
+  _onShowCopyTableContextMenu = () => {
+    this.setState({ isMarkerCopyTableMenuVisible: true });
+  };
+
+  _onHideCopyTableContextMenu = () => {
+    this.setState({ isMarkerCopyTableMenuVisible: false });
+  };
+
   _onMouseDownToggleFilterButton = () => {
     this.setState((state) => ({
       isFilterMenuVisibleOnMouseDown: state.isMarkerFiltersMenuVisible,
     }));
   };
 
+  _onMouseDownToggleCopyTableMenu = () => {
+    this.setState((state) => ({
+      isCopyTableMenuVisibleOnMouseDown: state.isMarkerCopyTableMenuVisible,
+    }));
+  };
+
   override render() {
-    const { searchString, allowSwitchingStackType } = this.props;
-    const { isMarkerFiltersMenuVisible } = this.state;
+    const { searchString, allowSwitchingStackType, copyTable } = this.props;
+    const {
+      isMarkerFiltersMenuVisible,
+      isMarkerCopyTableMenuVisible,
+      copyTableWarningRows,
+      copyTableWarningMaxRows,
+    } = this.state;
 
     return (
       <div className="markerSettings">
@@ -99,6 +180,43 @@ class MarkerSettingsImpl extends PureComponent<Props, State> {
             </li>
           ) : null}
         </ul>
+        {copyTable ? (
+          <Localized id="MarkerSettings--copy-table" attrs={{ title: true }}>
+            <button
+              className={classNames(
+                'copyTableButton',
+                'photon-button',
+                'photon-button-ghost',
+                {
+                  'photon-button-ghost--checked': isMarkerCopyTableMenuVisible,
+                }
+              )}
+              title="Copy table as text"
+              type="button"
+              onClick={this._onClickToggleCopyTableMenu}
+              onMouseDown={this._onMouseDownToggleCopyTableMenu}
+            />
+          </Localized>
+        ) : null}
+        {copyTableWarningRows !== null && copyTableWarningMaxRows !== null ? (
+          <div className="copyTableButtonWarningWrapper">
+            <div className="photon-message-bar photon-message-bar-warning copyTableButtonWarning">
+              <div className="photon-message-bar-inner-content">
+                <Localized
+                  id="MarkerSettings--copy-table-exceeed-max-rows"
+                  vars={{
+                    rows: copyTableWarningRows,
+                    maxRows: copyTableWarningMaxRows,
+                  }}
+                >
+                  <div className="photon-message-bar-inner-text">
+                    {`The number of rows exceeds the limit: ${copyTableWarningRows} > ${copyTableWarningMaxRows}. Only the first ${copyTableWarningMaxRows} rows will be copied.`}
+                  </div>
+                </Localized>
+              </div>
+            </div>
+          </div>
+        ) : null}
         <Localized
           id="MarkerSettings--panel-search"
           attrs={{ label: true, title: true }}
@@ -132,12 +250,21 @@ class MarkerSettingsImpl extends PureComponent<Props, State> {
           onShow={this._onShowFiltersContextMenu}
           onHide={this._onHideFiltersContextMenu}
         />
+        <MarkerCopyTableContextMenu
+          onShow={this._onShowCopyTableContextMenu}
+          onHide={this._onHideCopyTableContextMenu}
+          onCopy={this._onCopyTable}
+        />
       </div>
     );
   }
 }
 
-export const MarkerSettings = explicitConnect<{}, StateProps, DispatchProps>({
+export const MarkerSettings = explicitConnect<
+  OwnProps,
+  StateProps,
+  DispatchProps
+>({
   mapStateToProps: (state) => ({
     searchString: getMarkersSearchString(state),
     allowSwitchingStackType: getProfileUsesMultipleStackTypes(state),

--- a/src/test/components/__snapshots__/MarkerChart.test.tsx.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.tsx.snap
@@ -562,6 +562,31 @@ exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`
         </div>
       </nav>
     </div>
+    <div>
+      <nav
+        class="react-contextmenu markerCopyTableContextMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
+        tabindex="-1"
+      >
+        <div
+          aria-disabled="false"
+          class="react-contextmenu-item"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Copy marker table as plain text
+        </div>
+        <div
+          aria-disabled="false"
+          class="react-contextmenu-item"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Copy marker table as Markdown
+        </div>
+      </nav>
+    </div>
   </div>
   <div
     class="react-contextmenu-wrapper treeViewContextMenu"

--- a/src/test/components/__snapshots__/MarkerTable.test.tsx.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.tsx.snap
@@ -109,6 +109,11 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
         </label>
       </li>
     </ul>
+    <button
+      class="copyTableButton photon-button photon-button-ghost"
+      title="Copy table as text"
+      type="button"
+    />
     <div
       class="panelSearchField markerSettingsSearchField"
     >
@@ -165,6 +170,31 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
             ⁨⁩
           </strong>
           ”
+        </div>
+      </nav>
+    </div>
+    <div>
+      <nav
+        class="react-contextmenu markerCopyTableContextMenu"
+        role="menu"
+        style="position: fixed; opacity: 0; pointer-events: none;"
+        tabindex="-1"
+      >
+        <div
+          aria-disabled="false"
+          class="react-contextmenu-item"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Copy marker table as plain text
+        </div>
+        <div
+          aria-disabled="false"
+          class="react-contextmenu-item"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Copy marker table as Markdown
         </div>
       </nav>
     </div>


### PR DESCRIPTION
Fixed https://github.com/firefox-devtools/profiler/issues/5731

This adds a button to the Marker Table settings bar, which shows a context menu that provides the following:
  * copy as plain text
  * copy as Markdown

(not sure if Markdown is actually necessary.  If not, it can be simplified to just a single button that copies as plain text)

the plain text copies the table in the following style:
```
  Start  Duration                     Name  Details
 0.002s                   Process Priority  priority: BACKGROUND
 0.002s   unknown                    Awake
 0.002s  603.25us                 Runnable  TriggerPollJSSamplingOnMainThread - priority: Normal (4) task: 4d9c1b1537e9fcf80
```

the Markdown copies the table in the following style:
```
|   Start | Duration |                    Name | Details |
|--------:|---------:|------------------------:|---------|
|  0.002s |          |        Process Priority | priority: BACKGROUND |
|  0.002s |  unknown |                   Awake |  |
|  0.002s | 603.25us |                Runnable | TriggerPollJSSamplingOnMainThread - priority: Normal (4) task: 4d9c1b1537e9fcf80 |
```


<img width="501" height="194" alt="copy-table" src="https://github.com/user-attachments/assets/c5d6234e-7a34-4906-b086-437c1c216cc5" />
