### PR TITLE
Make FilterNavigatorBar scrollable

### DIFF
--- a/src/components/app/Details.tsx
+++ b/src/components/app/Details.tsx
@@ -47,9 +47,25 @@ type DispatchProps = {
 
 type Props = ConnectedProps<{}, StateProps, DispatchProps>;
 
+type State = {
+  // The scroll position of the FilterNavigatorBar, shared among
+  // the call tree, the frame graph, and the stack chart.
+  readonly filterScrollPos: number;
+};
+
 const SMALL_SCREEN_WIDTH = 768;
 
-class ProfileViewerImpl extends PureComponent<Props> {
+class ProfileViewerImpl extends PureComponent<Props, State> {
+  override state = {
+    filterScrollPos: 0,
+  };
+
+  _setFilterScrollPos = (pos: number) => {
+    this.setState({
+      filterScrollPos: pos,
+    });
+  };
+
   _onSelectTab = (selectedTab: string) => {
     const { changeSelectedTab } = this.props;
     const tabSlug = toValidTabSlug(selectedTab);
@@ -75,6 +91,7 @@ class ProfileViewerImpl extends PureComponent<Props> {
 
   override render() {
     const { visibleTabs, selectedTab, isSidebarOpen } = this.props;
+    const { filterScrollPos } = this.state;
     const hasSidebar = selectSidebar(selectedTab) !== null;
     return (
       <div className="Details">
@@ -121,9 +138,24 @@ class ProfileViewerImpl extends PureComponent<Props> {
           >
             {
               {
-                calltree: <ProfileCallTreeView />,
-                'flame-graph': <FlameGraph />,
-                'stack-chart': <StackChart />,
+                calltree: (
+                  <ProfileCallTreeView
+                    filterScrollPos={filterScrollPos}
+                    setFilterScrollPos={this._setFilterScrollPos}
+                  />
+                ),
+                'flame-graph': (
+                  <FlameGraph
+                    filterScrollPos={filterScrollPos}
+                    setFilterScrollPos={this._setFilterScrollPos}
+                  />
+                ),
+                'stack-chart': (
+                  <StackChart
+                    filterScrollPos={filterScrollPos}
+                    setFilterScrollPos={this._setFilterScrollPos}
+                  />
+                ),
                 'marker-chart': <MarkerChart />,
                 'marker-table': <MarkerTable />,
                 'network-chart': <NetworkChart />,

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -115,7 +115,7 @@
   background: var(--grey-10);
 }
 
-.profileViewerSpacer {
+.profileViewerTopBar .filterNavigatorBarScrollContainer {
   flex: 1;
 }
 

--- a/src/components/app/ProfileViewer.tsx
+++ b/src/components/app/ProfileViewer.tsx
@@ -114,13 +114,10 @@ class ProfileViewerImpl extends PureComponent<Props> {
               />
             ) : null}
             <ProfileName />
-            <ProfileFilterNavigator />
             {
-              // Define a spacer in the middle that will shrink based on the availability
-              // of space in the top bar. It will shrink away before any of the items
-              // with actual content in them do.
+              // TODO: Update the sroll position when other elements are updated.
             }
-            <div className="profileViewerSpacer" />
+            <ProfileFilterNavigator />
             <MenuButtons />
             {isUploading ? (
               <div

--- a/src/components/calltree/ProfileCallTreeView.tsx
+++ b/src/components/calltree/ProfileCallTreeView.tsx
@@ -6,7 +6,12 @@ import { CallTree } from './CallTree';
 import { StackSettings } from 'firefox-profiler/components/shared/StackSettings';
 import { TransformNavigator } from 'firefox-profiler/components/shared/TransformNavigator';
 
-export const ProfileCallTreeView = () => (
+type Props = {
+  readonly filterScrollPos?: number;
+  readonly setFilterScrollPos?: (pos: number) => void;
+};
+
+export const ProfileCallTreeView = (props: Props) => (
   <div
     className="treeAndSidebarWrapper"
     id="calltree-tab"
@@ -14,7 +19,10 @@ export const ProfileCallTreeView = () => (
     aria-labelledby="calltree-tab-button"
   >
     <StackSettings />
-    <TransformNavigator />
+    <TransformNavigator
+      filterScrollPos={props.filterScrollPos}
+      setFilterScrollPos={props.setFilterScrollPos}
+    />
     <CallTree />
   </div>
 );

--- a/src/components/flame-graph/index.tsx
+++ b/src/components/flame-graph/index.tsx
@@ -6,7 +6,12 @@ import { StackSettings } from '../shared/StackSettings';
 import { TransformNavigator } from '../shared/TransformNavigator';
 import { MaybeFlameGraph } from './MaybeFlameGraph';
 
-const FlameGraphView = () => (
+type Props = {
+  readonly filterScrollPos?: number;
+  readonly setFilterScrollPos?: (pos: number) => void;
+};
+
+const FlameGraphView = (props: Props) => (
   <div
     className="flameGraph"
     id="flame-graph-tab"
@@ -14,7 +19,10 @@ const FlameGraphView = () => (
     aria-labelledby="flame-graph-tab-button"
   >
     <StackSettings hideInvertCallstack={true} />
-    <TransformNavigator />
+    <TransformNavigator
+      filterScrollPos={props.filterScrollPos}
+      setFilterScrollPos={props.setFilterScrollPos}
+    />
     <MaybeFlameGraph />
   </div>
 );

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -2,6 +2,63 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+.filterNavigatorBarScrollContainer {
+  position: relative;
+  height: 24px;
+}
+
+.filterNavigatorBarScrollParent {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 24px;
+  flex: 1;
+}
+
+.filterNavigatorBarScrollContent {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  padding: 0 24px;
+}
+
+.filterNavigatorBarScrollButtonLeft,
+.filterNavigatorBarScrollButtonRight {
+  position: absolute;
+  z-index: 2;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border: 1px solid var(--grey-30);
+  background: var(--grey-10);
+  color: var(--grey-80);
+}
+
+.filterNavigatorBarScrollButtonLeft {
+  top: 0px;
+  left: 0px;
+}
+
+.filterNavigatorBarScrollButtonRight {
+  top: 0px;
+  right: 0px;
+}
+
+.filterNavigatorBarScrollButtonLeft.disabled,
+.filterNavigatorBarScrollButtonRight.disabled {
+  color: var(--grey-40);
+}
+
+.filterNavigatorBarScrollButtonLeft:not(.disabled):hover,
+.filterNavigatorBarScrollButtonRight:not(.disabled):hover {
+  background: var(--grey-20);
+}
+
+.filterNavigatorBarScrollButtonLeft:not(.disabled):active,
+.filterNavigatorBarScrollButtonRight:not(.disabled):active {
+  background: var(--grey-30);
+}
+
 .filterNavigatorBar {
   --internal-background-color: transparent;
   --internal-hover-background-color: rgb(0 0 0 / 0.1);

--- a/src/components/shared/FilterNavigatorBar.tsx
+++ b/src/components/shared/FilterNavigatorBar.tsx
@@ -6,10 +6,13 @@ import * as React from 'react';
 import classNames from 'classnames';
 import './FilterNavigatorBar.css';
 
+import { isReducedMotion } from 'firefox-profiler/utils/reduced-motion';
+
 type FilterNavigatorBarListItemProps = {
   readonly onClick?:
     | null
     | ((index: number, event: React.MouseEvent<HTMLElement>) => unknown);
+  readonly onFocus?: (e: React.FocusEvent<HTMLElement>) => void;
   readonly index: number;
   readonly isFirstItem: boolean;
   readonly isLastItem: boolean;
@@ -35,6 +38,7 @@ class FilterNavigatorBarListItem extends React.PureComponent<FilterNavigatorBarL
       children,
       additionalClassName,
       onClick,
+      onFocus,
       title,
     } = this.props;
     return (
@@ -48,7 +52,11 @@ class FilterNavigatorBarListItem extends React.PureComponent<FilterNavigatorBarL
         onClick={onClick ? this._onClick : undefined}
       >
         {onClick ? (
-          <button type="button" className="filterNavigatorBarItemContent">
+          <button
+            type="button"
+            className="filterNavigatorBarItemContent"
+            onFocus={onFocus}
+          >
             {children}
           </button>
         ) : (
@@ -59,6 +67,130 @@ class FilterNavigatorBarListItem extends React.PureComponent<FilterNavigatorBarL
   }
 }
 
+const AUTO_SCROLL_INTERVAL: number = 10;
+const CLICK_SCROLL_AMOUNT: number = 200;
+const DELAYED_SAVE_FILTER_SCROLL_POS_TIMEOUT: number = 100;
+const AUTO_SCROLL_VELOCITY: number = 10;
+const SCROLL_TO_DURATION: number = 300;
+
+type ScrollTarget = {
+  readonly scrollBy: (pos: number) => boolean;
+  readonly scrollTo: (pos: number) => boolean;
+  readonly onStopAutoScroll: () => void;
+};
+
+class AutoScrollBase {
+  target: ScrollTarget;
+  timer: NodeJS.Timeout | null = null;
+
+  constructor(target: ScrollTarget) {
+    this.target = target;
+  }
+
+  start() {
+    this.timer = setInterval(this.callback, AUTO_SCROLL_INTERVAL);
+    this.callback();
+  }
+
+  callback = () => {};
+
+  scrollTo(pos: number) {
+    this.target.scrollTo(pos);
+  }
+
+  scrollBy(velocity: number) {
+    const stopped = this.target.scrollBy(velocity);
+    if (stopped) {
+      this.stopImmediate();
+    }
+  }
+
+  stopGradually() {
+    this.stopImmediate();
+  }
+
+  stopImmediate() {
+    if (!this.timer) {
+      return;
+    }
+    clearInterval(this.timer);
+    this.timer = null;
+
+    this.target.onStopAutoScroll();
+  }
+
+  allowOverflowToLeft() {
+    return false;
+  }
+}
+
+class AutoScrollFromTo extends AutoScrollBase {
+  fromPos: number;
+  toPos: number;
+  endTime: number;
+  allowOverflow: boolean;
+
+  constructor(
+    target: ScrollTarget,
+    fromPos: number,
+    toPos: number,
+    allowOverflow: boolean
+  ) {
+    super(target);
+
+    this.fromPos = fromPos;
+    this.toPos = toPos;
+    this.endTime = Date.now() + SCROLL_TO_DURATION;
+    this.allowOverflow = allowOverflow;
+  }
+
+  override callback = () => {
+    const now = Date.now();
+    const diff = this.endTime - now;
+    if (diff <= 0) {
+      this.scrollTo(this.toPos);
+      this.stopImmediate();
+      return;
+    }
+
+    const t = (diff / SCROLL_TO_DURATION) ** 2;
+    const pos = this.fromPos * t + this.toPos * (1 - t);
+    this.scrollTo(pos);
+  };
+
+  override allowOverflowToLeft() {
+    return this.allowOverflow;
+  }
+}
+
+class AutoScrollVelocity extends AutoScrollBase {
+  velocity: number;
+  stopping: boolean;
+
+  constructor(target: ScrollTarget, velocity: number) {
+    super(target);
+    this.velocity = velocity;
+    this.stopping = false;
+  }
+
+  override callback = () => {
+    if (this.stopping) {
+      this.velocity = this.velocity * 0.9;
+    }
+
+    if (Math.abs(this.velocity) < 1) {
+      this.stopImmediate();
+      return;
+    }
+
+    this.scrollBy(this.velocity);
+  };
+
+  override stopGradually() {
+    this.stopping = true;
+  }
+}
+
 type Props = {
   readonly className: string;
   readonly items: ReadonlyArray<React.ReactNode>;
@@ -66,9 +198,383 @@ type Props = {
   readonly onFirstItemClick?: (event: React.MouseEvent<HTMLElement>) => void;
   readonly selectedItem: number;
   readonly uncommittedItem?: string;
+  // The consumer can specify the scroll postion and the callback for the
+  // update, to share the scroll position across multiple components.
+  readonly filterScrollPos?: number;
+  readonly setFilterScrollPos?: (pos: number) => void;
 };
 
-export class FilterNavigatorBar extends React.PureComponent<Props> {
+type StateProps = {
+  readonly canScrollLeft: boolean;
+  readonly canScrollRight: boolean;
+};
+
+export class FilterNavigatorBar extends React.PureComponent<Props, StateProps> {
+  // Elements for the scrolling.
+  _scrollContent: HTMLElement | null = null;
+  _scrollParent: HTMLElement | null = null;
+
+  // In order to avoid re-rendering for each scroll, cache the scroll position
+  // in this class, and save the scroll position to the parent component only
+  // after the scroll finishses.
+  _scrollLeft = 0;
+  _scrollLeftInitialized = false;
+
+  // In order to coalesce successive requests to save the scroll position,
+  // use a timer callback with a flag to delay it again.
+  _saveFilterScrollPosTimer: NodeJS.Timeout | null = null;
+  _saveFilterScrollPosDelayAgain = false;
+
+  // A reference to the currently-ongoing auto-scroll.
+  // Auto-scroll is used for three purposes:
+  //   * Keep scrolling while the scroll buttons are pressed
+  //     (initiated by _startAutoScrollWithVelocity)
+  //   * Scroll to the focused item
+  //     (initiated by _startAutoScrollTo)
+  //   * Scroll to thelast item when items are added or removed
+  //     (also initiated by _startAutoScrollTo)
+  _autoScroll: AutoScrollBase | null = null;
+
+  // The scroll button listen to both mousedown/mouseup and click, in order to
+  // perform the auto-scroll for mousedown/mouseup, and also perform an oneshot
+  // scroll for other click events, such as keyboard access.
+  // In order to avoid performing scroll twice, suppress the click event for
+  // mouse click which is already handled by mousedown/mouseup.
+  _ignoreNextClick = false;
+
+  // Observe the resize of the bar, in order to update the scroll position
+  // and the scroll buttons' state.
+  _resizeObserver: ResizeObserver | null = null;
+
+  override state = {
+    canScrollLeft: false,
+    canScrollRight: false,
+  };
+
+  _takeScrollContentRef = (scrollContent: HTMLElement | null) => {
+    this._scrollContent = scrollContent;
+    if (!this._scrollContent) {
+      return;
+    }
+    this._scrollParent = this._scrollContent.parentNode as HTMLElement;
+    if (!this._scrollParent) {
+      return;
+    }
+
+    this._resizeObserver = new ResizeObserver(this._onResize);
+    this._resizeObserver.observe(this._scrollParent);
+
+    this._updateScrollLayout();
+    this._updateScrollButtonState();
+  };
+
+  _onWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    this._stopAutoScroll();
+
+    if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+      this.scrollBy(e.deltaX);
+    } else {
+      this.scrollBy(e.deltaY);
+    }
+
+    this._updateScrollButtonState();
+    this._delayedSaveFilterScrollPos();
+  };
+
+  _onScrollLeftMouseDown = () => {
+    this._onScrollMouseDown(-1);
+  };
+  _onScrollRightMouseDown = () => {
+    this._onScrollMouseDown(1);
+  };
+
+  _onScrollMouseDown = (sign: number) => {
+    this._ignoreNextClick = true;
+    this._startAutoScrollWithVelocity(sign * AUTO_SCROLL_VELOCITY);
+  };
+
+  _onScrollLeftClick = () => {
+    this._onScrollClick(-1);
+  };
+  _onScrollRightClick = () => {
+    this._onScrollClick(1);
+  };
+  _onScrollClick = (sign: number) => {
+    if (this._ignoreNextClick) {
+      this._ignoreNextClick = false;
+      return;
+    }
+
+    if (isReducedMotion()) {
+      this.scrollBy(sign * CLICK_SCROLL_AMOUNT);
+
+      this._updateScrollButtonState();
+      this._delayedSaveFilterScrollPos();
+    } else {
+      this._startAutoScrollWithVelocity(sign * AUTO_SCROLL_VELOCITY);
+      if (this._autoScroll) {
+        this._autoScroll.stopGradually();
+      }
+    }
+  };
+
+  _onScrollMouseUp = () => {
+    if (!this._autoScroll) {
+      return;
+    }
+
+    if (isReducedMotion()) {
+      this._stopAutoScroll();
+    } else {
+      this._autoScroll.stopGradually();
+    }
+  };
+
+  _startAutoScrollWithVelocity = (velocity: number) => {
+    this._stopAutoScroll();
+
+    this._autoScroll = new AutoScrollVelocity(this, velocity);
+    this._autoScroll.start();
+  };
+  _startAutoScrollTo = (pos: number, allowOverflow: boolean) => {
+    this._stopAutoScroll();
+
+    this._autoScroll = new AutoScrollFromTo(
+      this,
+      this._scrollLeft,
+      pos,
+      allowOverflow
+    );
+    this._autoScroll.start();
+  };
+  _stopAutoScroll = () => {
+    if (!this._autoScroll) {
+      return;
+    }
+
+    this._autoScroll.stopImmediate();
+    this._autoScroll = null;
+  };
+
+  /* This method is used by AutoScrollBase. */
+  scrollBy = (delta: number): boolean => {
+    this._scrollLeft -= delta;
+    const stopped = this._updateScrollLayout();
+    if (stopped) {
+      this._updateScrollButtonState();
+    }
+    return stopped;
+  };
+
+  /* This method is used by AutoScrollBase. */
+  /* eslint-disable-next-line react/no-unused-class-component-methods */
+  scrollTo = (pos: number): boolean => {
+    this._scrollLeft = pos;
+    const stopped = this._updateScrollLayout();
+    if (stopped) {
+      this._updateScrollButtonState();
+    }
+    return stopped;
+  };
+
+  /* This method is used by AutoScrollBase. */
+  /* eslint-disable-next-line react/no-unused-class-component-methods */
+  onStopAutoScroll = () => {
+    this._autoScroll = null;
+    this._updateScrollButtonState();
+    this._delayedSaveFilterScrollPos();
+  };
+
+  _allowScrollOverflowToLeft = (): boolean => {
+    if (!this._autoScroll) {
+      return false;
+    }
+
+    return this._autoScroll.allowOverflowToLeft();
+  };
+
+  _updateScrollLayout = () => {
+    if (!this._scrollContent || !this._scrollParent) {
+      return true;
+    }
+
+    const contentWidth = this._scrollContent.getBoundingClientRect().width;
+    const parentWidth = this._scrollParent.getBoundingClientRect().width;
+
+    let stopped = false;
+
+    if (contentWidth <= parentWidth) {
+      this._scrollLeft = 0;
+      stopped = true;
+    } else {
+      if (this._scrollLeft >= 0) {
+        this._scrollLeft = 0;
+        stopped = true;
+      }
+      if (
+        !this._allowScrollOverflowToLeft() &&
+        this._scrollLeft + contentWidth <= parentWidth
+      ) {
+        this._scrollLeft = parentWidth - contentWidth;
+        stopped = true;
+      }
+    }
+
+    this._scrollContent.style.left = Math.round(this._scrollLeft) + 'px';
+
+    return stopped;
+  };
+
+  _updateScrollButtonState = () => {
+    if (!this._scrollContent || !this._scrollParent) {
+      return;
+    }
+
+    let canScrollLeft = true;
+    let canScrollRight = true;
+
+    if (this._scrollLeft === 0) {
+      canScrollLeft = false;
+    }
+
+    const contentWidth = this._scrollContent.getBoundingClientRect().width;
+    const parentWidth = this._scrollParent.getBoundingClientRect().width;
+
+    if (contentWidth <= parentWidth) {
+      canScrollLeft = false;
+      canScrollRight = false;
+    }
+
+    if (this._scrollLeft + contentWidth <= parentWidth) {
+      canScrollRight = false;
+    }
+
+    if (
+      canScrollLeft === this.state.canScrollLeft &&
+      canScrollRight === this.state.canScrollRight
+    ) {
+      return;
+    }
+
+    this.setState({
+      canScrollLeft,
+      canScrollRight,
+    });
+  };
+
+  _delayedSaveFilterScrollPos = () => {
+    const { setFilterScrollPos } = this.props;
+    if (!setFilterScrollPos) {
+      return;
+    }
+
+    if (this._saveFilterScrollPosTimer) {
+      this._saveFilterScrollPosDelayAgain = true;
+      return;
+    }
+
+    this._saveFilterScrollPosTimer = setTimeout(() => {
+      this._saveFilterScrollPosTimer = null;
+
+      if (this._saveFilterScrollPosDelayAgain) {
+        this._saveFilterScrollPosDelayAgain = false;
+        this._delayedSaveFilterScrollPos();
+        return;
+      }
+
+      this._saveFilterScrollPos();
+    }, DELAYED_SAVE_FILTER_SCROLL_POS_TIMEOUT);
+  };
+
+  _saveFilterScrollPos = () => {
+    const { setFilterScrollPos, filterScrollPos } = this.props;
+    if (setFilterScrollPos && filterScrollPos !== this._scrollLeft) {
+      setFilterScrollPos(Math.round(this._scrollLeft));
+    }
+  };
+
+  override componentWillUnmount() {
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect();
+      this._resizeObserver = null;
+    }
+  }
+
+  _onResize = () => {
+    const prev = this._scrollLeft;
+    this._updateScrollLayout();
+    if (prev !== this._scrollLeft) {
+      this._delayedSaveFilterScrollPos();
+    }
+    this._updateScrollButtonState();
+  };
+
+  override componentDidUpdate = (prevProps: Props) => {
+    if (!this._scrollContent || !this._scrollParent) {
+      return;
+    }
+
+    const currentItems = this.props.items;
+    const prevItems = prevProps.items;
+
+    if (prevItems.length !== currentItems.length) {
+      const contentWidth = this._scrollContent.getBoundingClientRect().width;
+      const parentWidth = this._scrollParent.getBoundingClientRect().width;
+
+      const expectedLeft = parentWidth - contentWidth;
+      if (isReducedMotion()) {
+        this._scrollLeft = parentWidth - contentWidth;
+      } else {
+        this._startAutoScrollTo(expectedLeft, true);
+      }
+    }
+
+    const prev = this._scrollLeft;
+    this._updateScrollLayout();
+    if (prev !== this._scrollLeft) {
+      this._delayedSaveFilterScrollPos();
+    }
+    this._updateScrollButtonState();
+  };
+
+  _onItemFocus = (e: React.FocusEvent<HTMLElement>) => {
+    if (!this._scrollParent || !this._scrollContent) {
+      return;
+    }
+
+    // Focusing the element can scroll the "overflow: hidden" element.
+    // Reset the scroll, so that the following code can properly scroll to
+    // the focused element.
+    this._scrollParent.scrollTo(0, 0);
+
+    const BUTTON_WIDTH = 24;
+    const SCROLL_MARGIN = 32;
+
+    const itemRect = e.target.getBoundingClientRect();
+    const parentRect = this._scrollParent.getBoundingClientRect();
+    if (itemRect.left < parentRect.left + BUTTON_WIDTH) {
+      const diff = itemRect.left - (parentRect.left + BUTTON_WIDTH);
+      if (isReducedMotion()) {
+        this.scrollBy(diff - SCROLL_MARGIN);
+
+        this._updateScrollButtonState();
+        this._delayedSaveFilterScrollPos();
+      } else {
+        this._startAutoScrollTo(this._scrollLeft - diff + SCROLL_MARGIN, false);
+      }
+    } else if (itemRect.right > parentRect.right - BUTTON_WIDTH) {
+      const diff = itemRect.right - (parentRect.right - BUTTON_WIDTH);
+      if (isReducedMotion()) {
+        this.scrollBy(diff + SCROLL_MARGIN);
+
+        this._updateScrollButtonState();
+        this._delayedSaveFilterScrollPos();
+      } else {
+        this._startAutoScrollTo(this._scrollLeft - diff - SCROLL_MARGIN, false);
+      }
+    }
+  };
+
   _onPop = (index: number, _event: React.MouseEvent<HTMLElement>) => {
     const { onPop } = this.props;
     onPop(index);
@@ -88,9 +594,16 @@ export class FilterNavigatorBar extends React.PureComponent<Props> {
       selectedItem,
       uncommittedItem,
       onFirstItemClick,
+      filterScrollPos,
     } = this.props;
+    const { canScrollLeft, canScrollRight } = this.state;
 
-    return (
+    if (!this._scrollLeftInitialized) {
+      this._scrollLeftInitialized = true;
+      this._scrollLeft = filterScrollPos ?? 0;
+    }
+
+    const bar = (
       <ol className={classNames('filterNavigatorBar', className)}>
         {items.map((item, i) => {
           let onClick = null;
@@ -107,6 +620,7 @@ export class FilterNavigatorBar extends React.PureComponent<Props> {
               key={i}
               index={i}
               onClick={onClick}
+              onFocus={this._onItemFocus}
               isFirstItem={i === 0}
               isLastItem={i === items.length - 1}
               isSelectedItem={i === selectedItem}
@@ -128,6 +642,59 @@ export class FilterNavigatorBar extends React.PureComponent<Props> {
           </FilterNavigatorBarListItem>
         ) : null}
       </ol>
+    );
+
+    const canScroll = canScrollLeft || canScrollRight;
+
+    return (
+      <div className="filterNavigatorBarScrollContainer">
+        {canScroll ? (
+          <button
+            type="button"
+            className={
+              'filterNavigatorBarScrollButtonLeft' +
+              (canScrollLeft ? '' : ' disabled')
+            }
+            onClick={this._onScrollLeftClick}
+            onMouseDown={this._onScrollLeftMouseDown}
+            onMouseUp={this._onScrollMouseUp}
+            onMouseLeave={this._onScrollMouseUp}
+            disabled={!canScrollLeft}
+          >
+            &lt;
+          </button>
+        ) : null}
+        <div
+          className={classNames('filterNavigatorBarScrollParent', className)}
+          onWheel={this._onWheel}
+          data-testid="FilterNavigatorBarScrollParent"
+        >
+          <div
+            className="filterNavigatorBarScrollContent"
+            style={{ left: Math.round(this._scrollLeft) + 'px' }}
+            ref={this._takeScrollContentRef}
+            data-testid="FilterNavigatorBarScrollContent"
+          >
+            {bar}
+          </div>
+        </div>
+        {canScroll ? (
+          <button
+            type="button"
+            className={
+              'filterNavigatorBarScrollButtonRight' +
+              (canScrollRight ? '' : ' disabled')
+            }
+            onClick={this._onScrollRightClick}
+            onMouseDown={this._onScrollRightMouseDown}
+            onMouseUp={this._onScrollMouseUp}
+            onMouseLeave={this._onScrollMouseUp}
+            disabled={!canScrollRight}
+          >
+            &gt;
+          </button>
+        ) : null}
+      </div>
     );
   }
 }

--- a/src/components/shared/TransformNavigator.tsx
+++ b/src/components/shared/TransformNavigator.tsx
@@ -16,10 +16,14 @@ type Props = ComponentProps<typeof FilterNavigatorBar>;
 type DispatchProps = {
   readonly onPop: Props['onPop'];
 };
+type OwnProps = {
+  readonly filterScrollPos?: number;
+  readonly setFilterScrollPos?: (pos: number) => void;
+};
 type StateProps = Omit<Props, keyof DispatchProps>;
 
 export const TransformNavigator = explicitConnect<
-  {},
+  OwnProps,
   StateProps,
   DispatchProps
 >({

--- a/src/components/stack-chart/index.tsx
+++ b/src/components/stack-chart/index.tsx
@@ -66,6 +66,11 @@ import './index.css';
 
 const STACK_FRAME_HEIGHT = 16;
 
+type OwnProps = {
+  readonly filterScrollPos?: number;
+  readonly setFilterScrollPos?: (pos: number) => void;
+};
+
 type StateProps = {
   readonly thread: Thread;
   readonly weightType: WeightType;
@@ -98,7 +103,7 @@ type DispatchProps = {
   readonly changeMouseTimePosition: typeof changeMouseTimePosition;
 };
 
-type Props = ConnectedProps<{}, StateProps, DispatchProps>;
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class StackChartImpl extends React.PureComponent<Props> {
   _viewport: HTMLDivElement | null = null;
@@ -227,6 +232,8 @@ class StackChartImpl extends React.PureComponent<Props> {
       hasFilteredCtssSamples,
       useStackChartSameWidths,
       timelineUnit,
+      filterScrollPos,
+      setFilterScrollPos,
     } = this.props;
 
     const maxViewportHeight = combinedTimingRows.length * STACK_FRAME_HEIGHT;
@@ -239,7 +246,10 @@ class StackChartImpl extends React.PureComponent<Props> {
         aria-labelledby="stack-chart-tab-button"
       >
         <StackSettings hideInvertCallstack={true} />
-        <TransformNavigator />
+        <TransformNavigator
+          filterScrollPos={filterScrollPos}
+          setFilterScrollPos={setFilterScrollPos}
+        />
         {!hasFilteredCtssSamples && userTimings.length === 0 ? (
           <StackChartEmptyReasons />
         ) : (
@@ -297,7 +307,7 @@ class StackChartImpl extends React.PureComponent<Props> {
   }
 }
 
-export const StackChart = explicitConnect<{}, StateProps, DispatchProps>({
+export const StackChart = explicitConnect<OwnProps, StateProps, DispatchProps>({
   mapStateToProps: (state) => {
     const showUserTimings = getShowUserTimings(state);
     const combinedTimingRows = showUserTimings

--- a/src/test/components/FilterNavigatorBar.test.tsx
+++ b/src/test/components/FilterNavigatorBar.test.tsx
@@ -16,6 +16,7 @@ import * as ProfileView from '../../actions/profile-view';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import { ensureExists } from '../../utils/types';
+import { resetIsReducedMotionSetupForTest } from '../../utils/reduced-motion';
 
 describe('shared/FilterNavigatorBar', () => {
   it(`pops the item unless the last one is clicked`, () => {
@@ -55,6 +56,941 @@ describe('shared/FilterNavigatorBar', () => {
     const lastElement = screen.getByText('bar');
     fireEvent.click(lastElement);
     expect(onPop).toHaveBeenCalledWith(1);
+  });
+
+  let parentWidth_ = 100,
+    contentWidth_ = 50;
+  const additionalRects = new Map();
+  function initBoundingClientRect(parentWidth: number, contentWidth: number) {
+    parentWidth_ = parentWidth;
+    contentWidth_ = contentWidth;
+    additionalRects.clear();
+
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+      jest.fn(function () {
+        // eslint-disable-next-line @babel/no-invalid-this
+        if (this.classList.contains('filterNavigatorBarScrollParent')) {
+          return new DOMRect(0, 0, parentWidth_, 24);
+        }
+        // eslint-disable-next-line @babel/no-invalid-this
+        if (this.classList.contains('filterNavigatorBarScrollContent')) {
+          return new DOMRect(0, 0, contentWidth_, 24);
+        }
+        for (const [className, rect] of additionalRects.entries()) {
+          // eslint-disable-next-line @babel/no-invalid-this
+          if (this.classList.contains(className)) {
+            return rect;
+          }
+        }
+        return { x: 0, y: 0, width: 0, height: 0 } as DOMRect;
+      })
+    );
+  }
+  function updateBoundingClientRect(parentWidth: number, contentWidth: number) {
+    parentWidth_ = parentWidth;
+    contentWidth_ = contentWidth;
+  }
+  function addBoundingClientRect(
+    className: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ) {
+    additionalRects.set(className, new DOMRect(x, y, width, height));
+  }
+
+  let matchMediaListener: ((result: MediaQueryList) => void) | null = null;
+  function initReduceMotion(reduce: boolean) {
+    matchMediaListener = null;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: () => {
+        return {
+          matches: !reduce,
+          set onchange(listener: ((result: MediaQueryList) => void) | null) {
+            matchMediaListener = listener;
+          },
+        };
+      },
+    });
+    resetIsReducedMotionSetupForTest();
+  }
+  function updateReduceMotion(reduce: boolean) {
+    matchMediaListener!({
+      matches: !reduce,
+      media: '',
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: (_: Event) => false,
+    });
+  }
+
+  it(`cannot be scrolled if the content does not overflow`, () => {
+    initBoundingClientRect(100, 50);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+      />
+    );
+
+    const parent = screen.getByTestId('FilterNavigatorBarScrollParent');
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    // No buttons should be rendered.
+    expect(parent.previousElementSibling).toBeNull();
+    expect(parent.nextElementSibling).toBeNull();
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    fireEvent.wheel(parent, {
+      deltaX: 0,
+      deltaY: 5,
+    });
+    expect(content).toHaveStyle({ left: '0px' });
+
+    fireEvent.wheel(parent, {
+      deltaX: 0,
+      deltaY: -5,
+    });
+    expect(content).toHaveStyle({ left: '0px' });
+  });
+
+  it(`can be scrolled with buttons if the content overflows`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+      />
+    );
+
+    const leftButton = screen.getByText('<');
+    const rightButton = screen.getByText('>');
+
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    fireEvent.mouseDown(rightButton);
+
+    // The scroll should have an immediate effect.
+    expect(content).toHaveStyle({ left: '-10px' });
+
+    // The button state is not immediately updated.
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-20px' });
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-30px' });
+
+    // The scroll gradually stops.
+    fireEvent.mouseUp(rightButton);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-110px' });
+
+    // The button state is updated once the scroll finishes.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    // The successive click event should be ignored.
+    fireEvent.click(rightButton);
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-110px' });
+
+    // Keyboard-initiated click should also scroll.
+    fireEvent.click(rightButton);
+    expect(content).toHaveStyle({ left: '-120px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-200px' });
+
+    // Leaving the button stops the scroll.
+    fireEvent.mouseDown(rightButton);
+    fireEvent.mouseLeave(rightButton);
+    expect(content).toHaveStyle({ left: '-210px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-290px' });
+
+    // Press the scroll button until it hits the end.
+    fireEvent.mouseDown(rightButton);
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+
+    expect(content).toHaveStyle({ left: '-900px' });
+
+    // When the scroll hits the end, the scroll immediately stops and the
+    // button state is immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // Do the same for the left scroll.
+
+    fireEvent.mouseDown(leftButton);
+
+    // The scroll should have an immediate effect.
+    expect(content).toHaveStyle({ left: '-890px' });
+
+    // The button state is not immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-880px' });
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-870px' });
+
+    // The scroll gradually stops.
+    fireEvent.mouseUp(leftButton);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-790px' });
+
+    // The button state is updated once the scroll finishes.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    // The successive click event should be ignored.
+    fireEvent.click(leftButton);
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-790px' });
+
+    // Keyboard-initiated click should also scroll.
+    fireEvent.click(leftButton);
+    expect(content).toHaveStyle({ left: '-780px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-700px' });
+
+    // Leaving the button stops the scroll.
+    fireEvent.mouseDown(leftButton);
+    fireEvent.mouseLeave(leftButton);
+    expect(content).toHaveStyle({ left: '-690px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-610px' });
+
+    // Press the scroll button until it hits the end.
+    fireEvent.mouseDown(leftButton);
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    fireEvent.mouseUp(leftButton);
+    fireEvent.click(leftButton);
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    // When the scroll hits the end, the scroll immediately stops and the
+    // button state is immediately updated.
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+  });
+
+  it(`can be scrolled with the wheel if the content overflows`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+      />
+    );
+
+    const leftButton = screen.getByText('<');
+    const rightButton = screen.getByText('>');
+
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    const parent = screen.getByTestId('FilterNavigatorBarScrollParent');
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    fireEvent.wheel(parent, {
+      deltaX: 0,
+      deltaY: 5,
+    });
+
+    // The scroll should have an immediate effect.
+    expect(content).toHaveStyle({ left: '-5px' });
+
+    // The button state is immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    // It uses the delta that has larger magintude.
+    fireEvent.wheel(parent, {
+      deltaX: 5,
+      deltaY: -1,
+    });
+    expect(content).toHaveStyle({ left: '-10px' });
+    fireEvent.wheel(parent, {
+      deltaX: 5,
+      deltaY: 1,
+    });
+    expect(content).toHaveStyle({ left: '-15px' });
+
+    // The scroll stops at the end.
+    fireEvent.wheel(parent, {
+      deltaX: 2000,
+      deltaY: 1,
+    });
+    expect(content).toHaveStyle({ left: '-900px' });
+
+    // The button state is immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // Do the same for the left scroll.
+
+    fireEvent.wheel(parent, {
+      deltaX: -5,
+      deltaY: 0,
+    });
+    expect(content).toHaveStyle({ left: '-895px' });
+
+    // The button state is immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    fireEvent.wheel(parent, {
+      deltaX: -5,
+      deltaY: 1,
+    });
+    expect(content).toHaveStyle({ left: '-890px' });
+    fireEvent.wheel(parent, {
+      deltaX: -5,
+      deltaY: -1,
+    });
+    expect(content).toHaveStyle({ left: '-885px' });
+
+    // The scroll stops at the end.
+    fireEvent.wheel(parent, {
+      deltaX: -2000,
+      deltaY: 1,
+    });
+    expect(content).toHaveStyle({ left: '0px' });
+
+    // The button state is immediately updated.
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+  });
+
+  it(`reduces the button scroll motion if preferred`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(true);
+
+    const onPop = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+      />
+    );
+
+    const leftButton = screen.getByText('<');
+    const rightButton = screen.getByText('>');
+
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    fireEvent.mouseDown(rightButton);
+
+    // The scroll should have an immediate effect.
+    expect(content).toHaveStyle({ left: '-10px' });
+
+    // The button state is not immediately updated
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-20px' });
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-30px' });
+
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+
+    // The scroll should immediately finish in the reduced motion mode,
+    // and the button state is immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-30px' });
+
+    // Keyboard-initiated click scrolls large amount.
+    fireEvent.click(rightButton);
+    expect(content).toHaveStyle({ left: '-230px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-230px' });
+
+    // Scroll to the end, as a preparation for the next test.
+    fireEvent.mouseDown(rightButton);
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+
+    expect(content).toHaveStyle({ left: '-900px' });
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // Do the same for the left scroll.
+
+    fireEvent.mouseDown(leftButton);
+
+    // The scroll should have an immediate effect.
+    expect(content).toHaveStyle({ left: '-890px' });
+
+    // The button state is not immediately updated
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-880px' });
+
+    // The subsequent scroll should be performed by timer.
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-870px' });
+
+    fireEvent.mouseUp(leftButton);
+    fireEvent.click(leftButton);
+
+    // The scroll should immediately finish in the reduced motion mode,
+    // and the button state is immediately updated.
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-870px' });
+
+    // Keyboard-initiated click scrolls large amount.
+    fireEvent.click(leftButton);
+    expect(content).toHaveStyle({ left: '-670px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '-670px' });
+
+    // It should reflect the change to enable the motion.
+    updateReduceMotion(false);
+
+    fireEvent.mouseDown(leftButton);
+    fireEvent.mouseUp(leftButton);
+    fireEvent.click(leftButton);
+    expect(content).toHaveStyle({ left: '-660px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-580px' });
+
+    fireEvent.mouseDown(rightButton);
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+    expect(content).toHaveStyle({ left: '-590px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-670px' });
+
+    // It should reflect the change to disable the motion.
+    updateReduceMotion(true);
+
+    fireEvent.mouseDown(leftButton);
+    fireEvent.mouseUp(leftButton);
+    fireEvent.click(leftButton);
+    expect(content).toHaveStyle({ left: '-660px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-660px' });
+
+    fireEvent.mouseDown(rightButton);
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+    expect(content).toHaveStyle({ left: '-670px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-670px' });
+  });
+
+  it(`scrolls to the right end if items are added/removed`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 100);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    const { rerender } = render(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2']}
+        selectedItem={2}
+        onPop={onPop}
+      />
+    );
+
+    // Add an item.
+    updateBoundingClientRect(100, 1000);
+    rerender(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2', 'item3']}
+        selectedItem={3}
+        onPop={onPop}
+      />
+    );
+
+    const leftButton = screen.getByText('<');
+    const rightButton = screen.getByText('>');
+
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(leftButton).toBeDisabled();
+    expect(rightButton).toBeEnabled();
+
+    // The scroll should happen gradually.
+    expect(content).toHaveStyle({ left: '0px' });
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-59px' });
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-116px' });
+    act(() => {
+      jest.advanceTimersByTime(280);
+    });
+    expect(content).toHaveStyle({ left: '-900px' });
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // Add an item again.
+    updateBoundingClientRect(100, 2000);
+    rerender(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2', 'item3', 'item4']}
+        selectedItem={4}
+        onPop={onPop}
+      />
+    );
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeEnabled();
+
+    expect(content).toHaveStyle({ left: '-900px' });
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-966px' });
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-1029px' });
+    act(() => {
+      jest.advanceTimersByTime(280);
+    });
+    expect(content).toHaveStyle({ left: '-1900px' });
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // Remove an item.
+    updateBoundingClientRect(100, 1000);
+    rerender(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2', 'item3']}
+        selectedItem={3}
+        onPop={onPop}
+      />
+    );
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    expect(content).toHaveStyle({ left: '-1900px' });
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-1834px' });
+    jest.advanceTimersByTime(10);
+    expect(content).toHaveStyle({ left: '-1771px' });
+    act(() => {
+      jest.advanceTimersByTime(280);
+    });
+    expect(content).toHaveStyle({ left: '-900px' });
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+
+    // It should reflect the "reduce motion" change.
+    updateReduceMotion(true);
+
+    updateBoundingClientRect(100, 2000);
+    rerender(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2', 'item3', 'item4']}
+        selectedItem={4}
+        onPop={onPop}
+      />
+    );
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+    expect(content).toHaveStyle({ left: '-1900px' });
+
+    updateBoundingClientRect(100, 1000);
+    rerender(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2', 'item3']}
+        selectedItem={3}
+        onPop={onPop}
+      />
+    );
+
+    expect(leftButton).toBeEnabled();
+    expect(rightButton).toBeDisabled();
+    expect(content).toHaveStyle({ left: '-900px' });
+  });
+
+  it(`saves and restores the provided scroll position`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    const setFilterScrollPos = jest.fn();
+    const { rerender } = render(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+        filterScrollPos={-50}
+        setFilterScrollPos={setFilterScrollPos}
+      />
+    );
+
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '-50px' });
+
+    const rightButton = screen.getByText('>');
+    fireEvent.mouseDown(rightButton);
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+
+    expect(content).toHaveStyle({ left: '-60px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-140px' });
+    expect(setFilterScrollPos).toHaveBeenCalledWith(-140);
+
+    // Given the setFilterScrollPos is called asynchronously and the
+    // rerendering can happen in between the scroll and the setFilterScrollPos
+    // call, the filterScrollPos value comes from rerendering should be ignored.
+
+    rerender(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+        filterScrollPos={-100}
+        setFilterScrollPos={setFilterScrollPos}
+      />
+    );
+
+    // The scroll position should be unchanged.
+    expect(content).toHaveStyle({ left: '-140px' });
+
+    fireEvent.mouseDown(rightButton);
+    fireEvent.mouseUp(rightButton);
+    fireEvent.click(rightButton);
+    expect(content).toHaveStyle({ left: '-150px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-230px' });
+    expect(setFilterScrollPos).toHaveBeenNthCalledWith(2, -230);
+  });
+
+  it(`coalesces setFilterScrollPos calls on wheel scroll`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    const setFilterScrollPos = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['foo', 'bar']}
+        selectedItem={2}
+        onPop={onPop}
+        filterScrollPos={0}
+        setFilterScrollPos={setFilterScrollPos}
+      />
+    );
+
+    const parent = screen.getByTestId('FilterNavigatorBarScrollParent');
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '-0px' });
+
+    fireEvent.wheel(parent, {
+      deltaX: 10,
+      deltaY: 0,
+    });
+    expect(content).toHaveStyle({ left: '-10px' });
+
+    jest.advanceTimersByTime(50);
+
+    fireEvent.wheel(parent, {
+      deltaX: 10,
+      deltaY: 0,
+    });
+    expect(content).toHaveStyle({ left: '-20px' });
+
+    jest.advanceTimersByTime(50);
+
+    fireEvent.wheel(parent, {
+      deltaX: 10,
+      deltaY: 0,
+    });
+    expect(content).toHaveStyle({ left: '-30px' });
+
+    jest.advanceTimersByTime(50);
+
+    fireEvent.wheel(parent, {
+      deltaX: 10,
+      deltaY: 0,
+    });
+    expect(content).toHaveStyle({ left: '-40px' });
+
+    jest.advanceTimersByTime(300);
+
+    // setFilterScrollPos should be called only once for the last position.
+    expect(setFilterScrollPos).toHaveBeenCalledWith(-40);
+  });
+
+  it(`scrolls to the focused item`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(false);
+
+    const onPop = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2', 'item3', 'item4']}
+        selectedItem={4}
+        onPop={onPop}
+      />
+    );
+
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    // The scrollTo method does not exist in the test env.
+    const scrollTo = jest.fn();
+    Element.prototype.scrollTo = scrollTo;
+
+    // Focus the 3rd item which overflows to the right.
+    addBoundingClientRect('filterNavigatorBarItemContent', 300, 0, 100, 24);
+    const item3 = screen.getByText('item3');
+    fireEvent.focus(item3);
+
+    expect(content).toHaveStyle({ left: '0px' });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    // 356 == ITEM_WIDTH + BUTTON_WIDTH + SCROLL_MARGIN
+    //     == 300 + 24 + 32
+    expect(content).toHaveStyle({ left: '-356px' });
+
+    // In order to prevent the browser's automatic scroll on the
+    // "overflow: hidden" element, the scrollTo must be called.
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+
+    // Focus the 1st item which overflows to the left.
+    addBoundingClientRect('filterNavigatorBarItemContent', -300, 0, 100, 24);
+    const item1 = screen.getByText('item1');
+    fireEvent.focus(item1);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(content).toHaveStyle({ left: '0px' });
+
+    expect(scrollTo).toHaveBeenNthCalledWith(2, 0, 0);
+
+    // The scroll should happen immediately if motion is reduced.
+    updateReduceMotion(true);
+
+    addBoundingClientRect('filterNavigatorBarItemContent', 300, 0, 100, 24);
+    fireEvent.focus(item3);
+
+    expect(content).toHaveStyle({ left: '-356px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '-356px' });
+
+    expect(scrollTo).toHaveBeenNthCalledWith(3, 0, 0);
+
+    addBoundingClientRect('filterNavigatorBarItemContent', -300, 0, 100, 24);
+    fireEvent.focus(item1);
+
+    expect(content).toHaveStyle({ left: '0px' });
+    jest.advanceTimersByTime(1000);
+    expect(content).toHaveStyle({ left: '0px' });
+
+    expect(scrollTo).toHaveBeenNthCalledWith(4, 0, 0);
+  });
+
+  it(`updates the scroll position and the button state on resize`, () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+
+    initBoundingClientRect(100, 1000);
+    initReduceMotion(false);
+
+    let callResizeCallback: (() => void) | null = null;
+    jest.spyOn(window, 'ResizeObserver').mockImplementation(
+      jest.fn(function (callback: ResizeObserverCallback): ResizeObserver {
+        const observer = {
+          observe() {},
+          unobserve() {},
+          disconnect() {},
+        };
+
+        callResizeCallback = () => {
+          callback([], observer);
+        };
+
+        return observer;
+      })
+    );
+
+    const onPop = jest.fn();
+    render(
+      <FilterNavigatorBar
+        className=""
+        items={['item1', 'item2']}
+        selectedItem={3}
+        onPop={onPop}
+      />
+    );
+
+    const parent = screen.getByTestId('FilterNavigatorBarScrollParent');
+    const content = screen.getByTestId('FilterNavigatorBarScrollContent');
+
+    expect(content).toHaveStyle({ left: '0px' });
+
+    {
+      const leftButton = screen.getByText('<');
+      const rightButton = screen.getByText('>');
+
+      expect(leftButton).toBeDisabled();
+      expect(rightButton).toBeEnabled();
+
+      fireEvent.click(rightButton);
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(content).toHaveStyle({ left: '-90px' });
+    }
+
+    // The parent becomes larger than the content,
+    updateBoundingClientRect(2000, 1000);
+    act(() => {
+      callResizeCallback!();
+    });
+
+    // No buttons should be rendered.
+    expect(parent.previousElementSibling).toBeNull();
+    expect(parent.nextElementSibling).toBeNull();
+
+    // The scroll position should be reset.
+    expect(content).toHaveStyle({ left: '0px' });
+
+    // The parent becomes smaller than the content,
+    updateBoundingClientRect(100, 1000);
+    act(() => {
+      callResizeCallback!();
+    });
+
+    {
+      // The buttons should be rendered.
+      const leftButton = screen.getByText('<');
+      const rightButton = screen.getByText('>');
+
+      expect(leftButton).toBeDisabled();
+      expect(rightButton).toBeEnabled();
+
+      expect(content).toHaveStyle({ left: '0px' });
+    }
   });
 });
 

--- a/src/test/components/__snapshots__/FilterNavigatorBar.test.tsx.snap
+++ b/src/test/components/__snapshots__/FilterNavigatorBar.test.tsx.snap
@@ -1,93 +1,138 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 1`] = `
-<ol
-  class="filterNavigatorBar profileFilterNavigator"
+<div
+  class="filterNavigatorBarScrollContainer"
 >
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+  <div
+    class="filterNavigatorBarScrollParent profileFilterNavigator"
+    data-testid="FilterNavigatorBarScrollParent"
   >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
+    <div
+      class="filterNavigatorBarScrollContent"
+      data-testid="FilterNavigatorBarScrollContent"
+      style="left: 0px;"
     >
-      <span
-        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector button"
+      <ol
+        class="filterNavigatorBar profileFilterNavigator"
       >
-        Full Range (⁨51ms⁩)
-      </span>
-    </button>
-  </li>
-</ol>
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+        >
+          <button
+            class="filterNavigatorBarItemContent"
+            type="button"
+          >
+            <span
+              class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector button"
+            >
+              Full Range (⁨51ms⁩)
+            </span>
+          </button>
+        </li>
+      </ol>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 2`] = `
-<ol
-  class="filterNavigatorBar profileFilterNavigator"
+<div
+  class="filterNavigatorBarScrollContainer"
 >
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarRootItem"
+  <div
+    class="filterNavigatorBarScrollParent profileFilterNavigator"
+    data-testid="FilterNavigatorBarScrollParent"
   >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
+    <div
+      class="filterNavigatorBarScrollContent"
+      data-testid="FilterNavigatorBarScrollContent"
+      style="left: 0px;"
     >
-      <span
-        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
+      <ol
+        class="filterNavigatorBar profileFilterNavigator"
       >
-        Full Range (⁨51ms⁩)
-      </span>
-    </button>
-  </li>
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
-  >
-    <span
-      class="filterNavigatorBarItemContent"
-    >
-      40ms
-    </span>
-  </li>
-</ol>
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarRootItem"
+        >
+          <button
+            class="filterNavigatorBarItemContent"
+            type="button"
+          >
+            <span
+              class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
+            >
+              Full Range (⁨51ms⁩)
+            </span>
+          </button>
+        </li>
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+        >
+          <span
+            class="filterNavigatorBarItemContent"
+          >
+            40ms
+          </span>
+        </li>
+      </ol>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`app/ProfileFilterNavigator renders ProfileFilterNavigator properly 3`] = `
-<ol
-  class="filterNavigatorBar profileFilterNavigator"
+<div
+  class="filterNavigatorBarScrollContainer"
 >
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarRootItem"
+  <div
+    class="filterNavigatorBarScrollParent profileFilterNavigator"
+    data-testid="FilterNavigatorBarScrollParent"
   >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
+    <div
+      class="filterNavigatorBarScrollContent"
+      data-testid="FilterNavigatorBarScrollContent"
+      style="left: 0px;"
     >
-      <span
-        class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
+      <ol
+        class="filterNavigatorBar profileFilterNavigator"
       >
-        Full Range (⁨51ms⁩)
-      </span>
-    </button>
-  </li>
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
-  >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
-    >
-      40ms
-    </button>
-  </li>
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarUncommittedItem filterNavigatorBarLeafItem"
-    title="100μs"
-  >
-    <span
-      class="filterNavigatorBarItemContent"
-    >
-      100μs
-    </span>
-  </li>
-</ol>
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarRootItem"
+        >
+          <button
+            class="filterNavigatorBarItemContent"
+            type="button"
+          >
+            <span
+              class="filterNavigatorBarItemContent profileFilterNavigator--tab-selector"
+            >
+              Full Range (⁨51ms⁩)
+            </span>
+          </button>
+        </li>
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+        >
+          <button
+            class="filterNavigatorBarItemContent"
+            type="button"
+          >
+            40ms
+          </button>
+        </li>
+        <li
+          class="filterNavigatorBarItem filterNavigatorBarUncommittedItem filterNavigatorBarLeafItem"
+          title="100μs"
+        >
+          <span
+            class="filterNavigatorBarItemContent"
+          >
+            100μs
+          </span>
+        </li>
+      </ol>
+    </div>
+  </div>
+</div>
 `;

--- a/src/test/components/__snapshots__/FlameGraph.test.tsx.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.tsx.snap
@@ -502,19 +502,34 @@ exports[`FlameGraph matches the snapshot 1`] = `
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="flameGraphContent"
   >

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.tsx.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.tsx.snap
@@ -144,19 +144,34 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -937,19 +952,34 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -1730,19 +1760,34 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -2511,19 +2556,34 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -3292,19 +3352,34 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -3891,19 +3966,34 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty Thread⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty Thread⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="EmptyReasons"
   >
@@ -4041,19 +4131,34 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Thread with samples⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Thread with samples⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="EmptyReasons"
   >
@@ -4191,19 +4296,34 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Thread with samples⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Thread with samples⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="EmptyReasons"
   >
@@ -4222,49 +4342,60 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
 `;
 
 exports[`calltree/ProfileCallTreeView TransformNavigator renders with multiple transforms applied 1`] = `
-<ol
-  class="filterNavigatorBar calltreeTransformNavigator"
+<div
+  class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+  data-testid="FilterNavigatorBarScrollParent"
 >
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarRootItem"
+  <div
+    class="filterNavigatorBarScrollContent"
+    data-testid="FilterNavigatorBarScrollContent"
+    style="left: 0px;"
   >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
+    <ol
+      class="filterNavigatorBar calltreeTransformNavigator"
     >
-      Complete “⁨Thread with samples⁩”
-    </button>
-  </li>
-  <li
-    class="filterNavigatorBarItem"
-  >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
-    >
-      Focus Node: ⁨A⁩
-    </button>
-  </li>
-  <li
-    class="filterNavigatorBarItem"
-  >
-    <button
-      class="filterNavigatorBarItemContent"
-      type="button"
-    >
-      Focus Node: ⁨B⁩
-    </button>
-  </li>
-  <li
-    class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
-  >
-    <span
-      class="filterNavigatorBarItemContent"
-    >
-      Focus Node: ⁨C⁩
-    </span>
-  </li>
-</ol>
+      <li
+        class="filterNavigatorBarItem filterNavigatorBarRootItem"
+      >
+        <button
+          class="filterNavigatorBarItemContent"
+          type="button"
+        >
+          Complete “⁨Thread with samples⁩”
+        </button>
+      </li>
+      <li
+        class="filterNavigatorBarItem"
+      >
+        <button
+          class="filterNavigatorBarItemContent"
+          type="button"
+        >
+          Focus Node: ⁨A⁩
+        </button>
+      </li>
+      <li
+        class="filterNavigatorBarItem"
+      >
+        <button
+          class="filterNavigatorBarItemContent"
+          type="button"
+        >
+          Focus Node: ⁨B⁩
+        </button>
+      </li>
+      <li
+        class="filterNavigatorBarItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+      >
+        <span
+          class="filterNavigatorBarItemContent"
+        >
+          Focus Node: ⁨C⁩
+        </span>
+      </li>
+    </ol>
+  </div>
+</div>
 `;
 
 exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
@@ -4388,19 +4519,34 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -5136,19 +5282,34 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -5884,19 +6045,34 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -6416,19 +6592,34 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -7164,19 +7355,34 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -7840,19 +8046,34 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -8516,19 +8737,34 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -9049,19 +9285,34 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >
@@ -9582,19 +9833,34 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="treeView"
   >

--- a/src/test/components/__snapshots__/StackChart.test.tsx.snap
+++ b/src/test/components/__snapshots__/StackChart.test.tsx.snap
@@ -125,19 +125,34 @@ exports[`CombinedChart renders combined stack chart 1`] = `
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="react-contextmenu-wrapper treeViewContextMenu"
   >
@@ -630,19 +645,34 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="react-contextmenu-wrapper treeViewContextMenu"
   >
@@ -1189,19 +1219,34 @@ exports[`StackChart matches the snapshot and can display a tooltip with the same
           </div>
         </div>
       </div>
-      <ol
-        class="filterNavigatorBar calltreeTransformNavigator"
+      <div
+        class="filterNavigatorBarScrollContainer"
       >
-        <li
-          class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+        <div
+          class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+          data-testid="FilterNavigatorBarScrollParent"
         >
-          <span
-            class="filterNavigatorBarItemContent"
+          <div
+            class="filterNavigatorBarScrollContent"
+            data-testid="FilterNavigatorBarScrollContent"
+            style="left: 0px;"
           >
-            Complete “⁨Empty⁩”
-          </span>
-        </li>
-      </ol>
+            <ol
+              class="filterNavigatorBar calltreeTransformNavigator"
+            >
+              <li
+                class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+              >
+                <span
+                  class="filterNavigatorBarItemContent"
+                >
+                  Complete “⁨Empty⁩”
+                </span>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
       <div
         class="react-contextmenu-wrapper treeViewContextMenu"
       >
@@ -1895,19 +1940,34 @@ exports[`StackChart matches the snapshot and can display a tooltip: dom 1`] = `
       </div>
     </div>
   </div>
-  <ol
-    class="filterNavigatorBar calltreeTransformNavigator"
+  <div
+    class="filterNavigatorBarScrollContainer"
   >
-    <li
-      class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+    <div
+      class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+      data-testid="FilterNavigatorBarScrollParent"
     >
-      <span
-        class="filterNavigatorBarItemContent"
+      <div
+        class="filterNavigatorBarScrollContent"
+        data-testid="FilterNavigatorBarScrollContent"
+        style="left: 0px;"
       >
-        Complete “⁨Empty⁩”
-      </span>
-    </li>
-  </ol>
+        <ol
+          class="filterNavigatorBar calltreeTransformNavigator"
+        >
+          <li
+            class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+          >
+            <span
+              class="filterNavigatorBarItemContent"
+            >
+              Complete “⁨Empty⁩”
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
   <div
     class="react-contextmenu-wrapper treeViewContextMenu"
   >
@@ -2430,19 +2490,34 @@ exports[`StackChart works when the user selects the JS allocations option 1`] = 
           </div>
         </div>
       </div>
-      <ol
-        class="filterNavigatorBar calltreeTransformNavigator"
+      <div
+        class="filterNavigatorBarScrollContainer"
       >
-        <li
-          class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+        <div
+          class="filterNavigatorBarScrollParent calltreeTransformNavigator"
+          data-testid="FilterNavigatorBarScrollParent"
         >
-          <span
-            class="filterNavigatorBarItemContent"
+          <div
+            class="filterNavigatorBarScrollContent"
+            data-testid="FilterNavigatorBarScrollContent"
+            style="left: 0px;"
           >
-            Complete “⁨Empty⁩”
-          </span>
-        </li>
-      </ol>
+            <ol
+              class="filterNavigatorBar calltreeTransformNavigator"
+            >
+              <li
+                class="filterNavigatorBarItem filterNavigatorBarRootItem filterNavigatorBarSelectedItem filterNavigatorBarLeafItem"
+              >
+                <span
+                  class="filterNavigatorBarItemContent"
+                >
+                  Complete “⁨Empty⁩”
+                </span>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
       <div
         class="react-contextmenu-wrapper treeViewContextMenu"
       >

--- a/src/utils/reduced-motion.ts
+++ b/src/utils/reduced-motion.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+let _isReducedMotionSetup = false;
+let _isReducedMotion = false;
+
+export function isReducedMotion() {
+  if (!_isReducedMotionSetup) {
+    if (window.matchMedia) {
+      const result = window.matchMedia(
+        '(prefers-reduced-motion: no-preference)'
+      );
+      _isReducedMotion = !result.matches;
+      result.onchange = (event) => {
+        _isReducedMotion = !event.matches;
+      };
+    }
+    _isReducedMotionSetup = true;
+  }
+
+  return _isReducedMotion;
+}
+
+export function resetIsReducedMotionSetupForTest() {
+  _isReducedMotionSetup = false;
+}


### PR DESCRIPTION
Fixed #5724

This makes the `FilterNavigatorBar` scrollable.
  * `FilterNavigatorBarListItem` no longer shrinks.
  * When items overflows, left/right scroll buttons are shown
  * Items can be scrolled with the following:
    * mouse wheel
    * clicking the left/right scroll buttons
      * with mouse, it scrolls while the button is pressed
      * with keyboard etc, it performs one-shot scroll
    * scroll to the focused item
    * scroll to the last item when items are added/removed
  * If the user prefers reduced motion, the scroll happens immediately
  * In order to avoid shifting the items when buttons are added/removed, 24px horizontal paddings are added to the bar
  * The button state and the scroll position is updated when the bar is resized
  * The scroll position is synced between Call Tree, Flame Graph, and Stack Chart as much as possible
    * Given they can have different width (due to the sidebar), this is done as best-effort
  * The `profileViewerSpacer` is removed, and the navigation bar is now flex:1 and it fills the entire space

Demo on the call tree

https://github.com/user-attachments/assets/4803fcc1-04b7-4acf-b1f6-fcda8c70751c

Demo on the profile filter

https://github.com/user-attachments/assets/82cec972-12db-4c21-8c13-a59f82ee94de

Problems:
  * Given the items don't shrink, it shows less items in given width, and it requires either scroll or more clicks for going up multiple filters
    * Maybe we can make it shrink to fixed width, like the Firefox's tabs, and make it scrollable only when the shrinked items overflow
