### PR TITLE
Do not apply sticky tooltip on double click

### DIFF
--- a/src/components/shared/chart/Canvas.tsx
+++ b/src/components/shared/chart/Canvas.tsx
@@ -327,6 +327,17 @@ export class ChartCanvas<Item> extends React.Component<
 
   _onDoubleClick = () => {
     this.props.onDoubleClickItem(this.state.hoveredItem);
+
+    if (this.props.stickyTooltips) {
+      // The double click is received as a sequence of click + click + dblclick.
+      // The each click sets the selectedItem inside _onClick.
+      //
+      // Unset the selectedItem here to differentiate the behavior between
+      // the single click vs the double clicks.
+      this.setState(() => ({
+        selectedItem: null,
+      }));
+    }
   };
 
   _getHoveredItemInfo = (): React.ReactNode => {

--- a/src/test/components/MarkerChart.test.tsx
+++ b/src/test/components/MarkerChart.test.tsx
@@ -319,7 +319,7 @@ describe('MarkerChart', function () {
     // No tooltip displayed yet
     expect(document.querySelector('.tooltip')).toBeFalsy();
 
-    function leftClick(pos: { x: CssPixels; y: CssPixels }) {
+    function leftClick(pos: { x: CssPixels; y: CssPixels }, dblClick = false) {
       const positioningOptions = {
         offsetX: pos.x,
         offsetY: pos.y,
@@ -333,7 +333,7 @@ describe('MarkerChart', function () {
       // Because different components listen to different events, we trigger
       // all the right events, to be as close as possible to the real stuff.
       fireMouseEvent('mousemove', positioningOptions);
-      fireFullClick(canvas, positioningOptions);
+      fireFullClick(canvas, positioningOptions, dblClick);
       flushRafCalls();
     }
 
@@ -364,6 +364,20 @@ describe('MarkerChart', function () {
     leftClick({ x: 0, y: 0 });
 
     // Now the tooltip should not be displayed.
+    expect(document.querySelector('.tooltip')).toBeFalsy();
+
+    // The tooltip should be displayed also on double click.
+    leftClick(position, true);
+
+    // Move the mouse outside of the marker.
+    fireMouseEvent('mousemove', {
+      offsetX: 0,
+      offsetY: 0,
+      pageX: 0,
+      pageY: 0,
+    });
+
+    // The double click shouldn't make the tooltip persisted.
     expect(document.querySelector('.tooltip')).toBeFalsy();
   });
 

--- a/src/test/fixtures/utils.ts
+++ b/src/test/fixtures/utils.ts
@@ -491,11 +491,18 @@ export function findFillTextPositionFromDrawLog(
  */
 export function fireFullClick(
   element: HTMLElement,
-  options?: FakeMouseEventInit
+  options?: FakeMouseEventInit,
+  dblClick?: boolean
 ) {
   fireEvent(element, getMouseEvent('mousedown', options));
   fireEvent(element, getMouseEvent('mouseup', options));
   fireEvent(element, getMouseEvent('click', options));
+  if (dblClick) {
+    fireEvent(element, getMouseEvent('mousedown', options));
+    fireEvent(element, getMouseEvent('mouseup', options));
+    fireEvent(element, getMouseEvent('click', options));
+    fireEvent(element, getMouseEvent('dblclick', options));
+  }
 }
 
 /**


### PR DESCRIPTION
Fixed #5736.

The problem with the #5736's workflow is that, the double click performs both "update selection range" and "apply sticky tooltip".
The "apply sticky tooltip" is actually performed by the single click's handler.
This patch unsets the sticky tooltip on dblclick handler, so that the single click vs double click are clearly differentiated in terms of the effect.
