### PR TITLE
Reduce allocations for getStackLineInfo + getStackAddressInfo

### DIFF
--- a/src/profile-logic/address-timings.ts
+++ b/src/profile-logic/address-timings.ts
@@ -76,7 +76,9 @@ import type {
   StackAddressInfo,
   AddressTimings,
   Address,
+  IndexIntoAddressSetTable,
 } from 'firefox-profiler/types';
+import { SetCollectionBuilder } from 'firefox-profiler/utils/set-collection';
 
 /**
  * For each stack in `stackTable`, and one specific native symbol, compute the
@@ -85,9 +87,9 @@ import type {
  *
  * For each stack we answer the following question:
  *  - "Does this stack contribute to address X's self time?"
- *       Answer: result.selfAddress[stack] === X
+ *       Answer: result.addressSetTable.self[result.stackIndexToAddressSetIndex[stack]] === X
  *  - "Does this stack contribute to address X's total time?"
- *       Answer: result.stackAddresses[stack].has(X)
+ *       Answer: X is in the set represented by entry result.stackIndexToAddressSetIndex[stack] in result.addressSetTable
  *
  * Compute the sets of instruction addresses for the given native symbol that
  * are hit by each stack.
@@ -112,18 +114,6 @@ import type {
  * If there is recursion, and the same address is present in multiple frames in
  * the same stack, the address is only counted once - the addresses are stored
  * in a set.
- *
- * The returned StackAddressInfo is computed as follows:
- *   selfAddress[stack]:
- *     For stacks whose stack.frame.nativeSymbol is the given native symbol,
- *     this is stack.frame.address.
- *     For all other stacks this is null.
- *   stackAddresses[stack]:
- *     For stacks whose stack.frame.nativeSymbol is the given native symbol,
- *     this is the stackAddresses of its prefix stack, plus stack.frame.address
- *     added to the set.
- *     For all other stacks this is the same as the stackAddresses set of the
- *     stack's prefix.
  */
 export function getStackAddressInfo(
   stackTable: StackTable,
@@ -131,48 +121,31 @@ export function getStackAddressInfo(
   _funcTable: FuncTable,
   nativeSymbol: IndexIntoNativeSymbolTable
 ): StackAddressInfo {
-  // "self address" == "the address which a stack's self time is contributed to"
-  const selfAddressForAllStacks = [];
-  // "total addresses" == "the set of addresses whose total time this stack contributes to"
-  const totalAddressesForAllStacks: Array<Set<Address> | null> = [];
+  const builder = new SetCollectionBuilder<number>();
+  const stackIndexToAddressSetIndex = new Int32Array(stackTable.length);
 
-  // This loop takes advantage of the fact that the stack table is topologically ordered:
-  // Prefix stacks are always visited before their descendants.
-  // Each stack inherits the "total" addresses from its parent stack, and then adds its
-  // self address to that set. If the stack doesn't have a self address in the library, we just
-  // re-use the prefix's set object without copying it.
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
-    const frame = stackTable.frame[stackIndex];
     const prefixStack = stackTable.prefix[stackIndex];
+    const prefixAddressSet: IndexIntoAddressSetTable | -1 =
+      prefixStack !== null ? stackIndexToAddressSetIndex[prefixStack] : -1;
+
+    const frame = stackTable.frame[stackIndex];
     const nativeSymbolOfThisStack = frameTable.nativeSymbol[frame];
+    const matchesNativeSymbol = nativeSymbolOfThisStack === nativeSymbol;
+    if (prefixAddressSet === -1 && !matchesNativeSymbol) {
+      stackIndexToAddressSetIndex[stackIndex] = -1;
+    } else {
+      const selfAddress = matchesNativeSymbol ? frameTable.address[frame] : -1;
 
-    let selfAddress: Address | null = null;
-    let totalAddresses: Set<Address> | null =
-      prefixStack !== null ? totalAddressesForAllStacks[prefixStack] : null;
-
-    if (nativeSymbolOfThisStack === nativeSymbol) {
-      selfAddress = frameTable.address[frame];
-      if (selfAddress !== -1) {
-        // Add this stack's address to this stack's totalAddresses. The rest of this stack's
-        // totalAddresses is the same as for the parent stack.
-        // We avoid creating new Set objects unless the new set is actually
-        // different.
-        if (totalAddresses === null) {
-          // None of the ancestor stack nodes have hit a address in the given library.
-          totalAddresses = new Set([selfAddress]);
-        } else if (!totalAddresses.has(selfAddress)) {
-          totalAddresses = new Set(totalAddresses);
-          totalAddresses.add(selfAddress);
-        }
-      }
+      stackIndexToAddressSetIndex[stackIndex] = builder.extend(
+        prefixAddressSet !== -1 ? prefixAddressSet : null,
+        selfAddress
+      );
     }
-
-    selfAddressForAllStacks.push(selfAddress);
-    totalAddressesForAllStacks.push(totalAddresses);
   }
   return {
-    selfAddress: selfAddressForAllStacks,
-    stackAddresses: totalAddressesForAllStacks,
+    stackIndexToAddressSetIndex,
+    addressSetTable: builder.finish(),
   };
 }
 
@@ -192,30 +165,70 @@ export function getAddressTimings(
   if (stackAddressInfo === null) {
     return emptyAddressTimings;
   }
-  const { selfAddress, stackAddresses } = stackAddressInfo;
-  const totalAddressHits: Map<Address, number> = new Map();
-  const selfAddressHits: Map<Address, number> = new Map();
 
-  // Iterate over all the samples, and aggregate the sample's weight into the
-  // addresses which are hit by the sample's stack.
-  // TODO: Maybe aggregate sample count per stack first, and then visit each stack only once?
+  const { stackIndexToAddressSetIndex, addressSetTable } = stackAddressInfo;
+
+  // We do two passes to compute the timings:
+  // 1. One pass over the samples to accumulate the sample weight onto the
+  //    nodes in the addressSetTable.
+  // 2. One pass (from back to front) over the addressSetTable, propagating
+  //    values up the tree and, at the same time, accumulating per-address
+  //    totals.
+
+  // First, do the pass over the samples to compute the weight per address set.
+  const selfPerAddressSet = new Float64Array(addressSetTable.length);
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
     const stackIndex = samples.stack[sampleIndex];
     if (stackIndex === null) {
       continue;
     }
-    const weight = samples.weight ? samples.weight[sampleIndex] : 1;
-    const setOfHitAddresses = stackAddresses[stackIndex];
-    if (setOfHitAddresses !== null) {
-      for (const address of setOfHitAddresses) {
-        const oldHitCount = totalAddressHits.get(address) ?? 0;
-        totalAddressHits.set(address, oldHitCount + weight);
+    const addressSetIndex = stackIndexToAddressSetIndex[stackIndex];
+    if (addressSetIndex !== -1) {
+      const weight = samples.weight ? samples.weight[sampleIndex] : 1;
+      selfPerAddressSet[addressSetIndex] += weight;
+    }
+  }
+
+  // Now, do a pass over the addressSetTable, from back to front.
+  // This is a similar idea to what we do for the call tree or the function
+  // list. The upwards propagation of a sample's weight will not contribute
+  // to the same address multiple times thanks to the guarantees of the
+  // addressSetTable - there are no duplicate values on a node's path to the
+  // root.
+  const totalAddressHits: Map<Address, number> = new Map();
+  const selfAddressHits: Map<Address, number> = new Map();
+  const selfSumOfAddressSetDescendants = new Float64Array(
+    addressSetTable.length
+  );
+  for (
+    let addressSetIndex = addressSetTable.length - 1;
+    addressSetIndex >= 0;
+    addressSetIndex--
+  ) {
+    const selfWeight = selfPerAddressSet[addressSetIndex];
+    if (selfWeight !== 0) {
+      const selfAddress = addressSetTable.self[addressSetIndex];
+      if (selfAddress !== -1) {
+        const oldHitCount = selfAddressHits.get(selfAddress) ?? 0;
+        selfAddressHits.set(selfAddress, oldHitCount + selfWeight);
       }
     }
-    const address = selfAddress[stackIndex];
-    if (address !== null) {
-      const oldHitCount = selfAddressHits.get(address) ?? 0;
-      selfAddressHits.set(address, oldHitCount + weight);
+
+    const selfSumOfThisAddressSetDescendants =
+      selfSumOfAddressSetDescendants[addressSetIndex];
+    const thisAddressSetWeight =
+      selfWeight + selfSumOfThisAddressSetDescendants;
+    const addressSetParent = addressSetTable.parent[addressSetIndex];
+    if (addressSetParent !== null) {
+      selfSumOfAddressSetDescendants[addressSetParent] += thisAddressSetWeight;
+    }
+
+    if (thisAddressSetWeight !== 0) {
+      const address = addressSetTable.value[addressSetIndex];
+      if (address !== -1) {
+        const oldHitCount = totalAddressHits.get(address) ?? 0;
+        totalAddressHits.set(address, oldHitCount + thisAddressSetWeight);
+      }
     }
   }
   return { totalAddressHits, selfAddressHits };

--- a/src/profile-logic/line-timings.ts
+++ b/src/profile-logic/line-timings.ts
@@ -11,7 +11,9 @@ import type {
   LineTimings,
   LineNumber,
   IndexIntoSourceTable,
+  IndexIntoLineSetTable,
 } from 'firefox-profiler/types';
+import { SetCollectionBuilder } from 'firefox-profiler/utils/set-collection';
 
 /**
  * For each stack in `stackTable`, and one specific source file, compute the
@@ -19,9 +21,9 @@ import type {
  *
  * For each stack we answer the following question:
  *  - "Does this stack contribute to line X's self time?"
- *       Answer: result.selfLine[stack] === X
+ *       Answer: result.lineSetTable.self[result.stackIndexToLineSetIndex[stack]] === X
  *  - "Does this stack contribute to line X's total time?"
- *       Answer: result.stackLines[stack].has(X)
+ *       Answer: X is in the set represented by entry result.stackIndexToLineSetIndex[stack] in result.lineSetTable
  *
  * Compute the sets of line numbers in the given file that are hit by each stack.
  * For each stack in the stack table and each line in the file, we answer the
@@ -40,15 +42,6 @@ import type {
  * This last line is the stack's "self line".
  * If there is recursion, and the same line is present in multiple frames in the
  * same stack, the line is only counted once - the lines are stored in a set.
- *
- * The returned StackLineInfo is computed as follows:
- *   selfLine[stack]:
- *     For stacks whose stack.frame.func.file is the given file, this is stack.frame.line.
- *     For all other stacks this is null.
- *   stackLines[stack]:
- *     For stacks whose stack.frame.func.file is the given file, this is the stackLines
- *     of its prefix stack, plus stack.frame.line added to the set.
- *     For all other stacks this is the same as the stackLines set of the stack's prefix.
  */
 export function getStackLineInfo(
   stackTable: StackTable,
@@ -56,53 +49,34 @@ export function getStackLineInfo(
   funcTable: FuncTable,
   sourceViewSourceIndex: IndexIntoSourceTable
 ): StackLineInfo {
-  // "self line" == "the line which a stack's self time is contributed to"
-  const selfLineForAllStacks = [];
-  // "total lines" == "the set of lines whose total time this stack contributes to"
-  const totalLinesForAllStacks: Array<Set<LineNumber> | null> = [];
+  const builder = new SetCollectionBuilder<number>();
+  const stackIndexToLineSetIndex = new Int32Array(stackTable.length);
 
-  // This loop takes advantage of the fact that the stack table is topologically ordered:
-  // Prefix stacks are always visited before their descendants.
-  // Each stack inherits the "total" lines from its parent stack, and then adds its
-  // self line to that set. If the stack doesn't have a self line in the file, we just
-  // re-use the prefix's set object without copying it.
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
-    const frame = stackTable.frame[stackIndex];
     const prefixStack = stackTable.prefix[stackIndex];
+    const prefixLineSet: IndexIntoLineSetTable | -1 =
+      prefixStack !== null ? stackIndexToLineSetIndex[prefixStack] : -1;
+
+    const frame = stackTable.frame[stackIndex];
     const func = frameTable.func[frame];
     const sourceIndexOfThisStack = funcTable.source[func];
+    const matchesSource = sourceIndexOfThisStack === sourceViewSourceIndex;
+    if (prefixLineSet === -1 && !matchesSource) {
+      stackIndexToLineSetIndex[stackIndex] = -1;
+    } else {
+      const selfLineOrNull = matchesSource
+        ? (frameTable.line[frame] ?? funcTable.lineNumber[func])
+        : null;
 
-    let selfLine: LineNumber | null = null;
-    let totalLines: Set<LineNumber> | null =
-      prefixStack !== null ? totalLinesForAllStacks[prefixStack] : null;
-
-    if (sourceIndexOfThisStack === sourceViewSourceIndex) {
-      selfLine = frameTable.line[frame];
-      // Fallback to func line info if frame line info is not available
-      if (selfLine === null) {
-        selfLine = funcTable.lineNumber[func];
-      }
-      if (selfLine !== null) {
-        // Add this stack's line to this stack's totalLines. The rest of this stack's
-        // totalLines is the same as for the parent stack.
-        // We avoid creating new Set objects unless the new set is actually
-        // different.
-        if (totalLines === null) {
-          // None of the ancestor stack nodes have hit a line in the given file.
-          totalLines = new Set([selfLine]);
-        } else if (!totalLines.has(selfLine)) {
-          totalLines = new Set(totalLines);
-          totalLines.add(selfLine);
-        }
-      }
+      stackIndexToLineSetIndex[stackIndex] = builder.extend(
+        prefixLineSet !== -1 ? prefixLineSet : null,
+        selfLineOrNull !== null ? selfLineOrNull : -1
+      );
     }
-
-    selfLineForAllStacks.push(selfLine);
-    totalLinesForAllStacks.push(totalLines);
   }
   return {
-    selfLine: selfLineForAllStacks,
-    stackLines: totalLinesForAllStacks,
+    stackIndexToLineSetIndex,
+    lineSetTable: builder.finish(),
   };
 }
 
@@ -122,30 +96,66 @@ export function getLineTimings(
   if (stackLineInfo === null) {
     return emptyLineTimings;
   }
-  const { selfLine, stackLines } = stackLineInfo;
-  const totalLineHits: Map<LineNumber, number> = new Map();
-  const selfLineHits: Map<LineNumber, number> = new Map();
+  const { stackIndexToLineSetIndex, lineSetTable } = stackLineInfo;
 
-  // Iterate over all the samples, and aggregate the sample's weight into the
-  // lines which are hit by the sample's stack.
-  // TODO: Maybe aggregate sample count per stack first, and then visit each stack only once?
+  // We do two passes to compute the timings:
+  // 1. One pass over the samples to accumulate the sample weight onto the
+  //    nodes in the lineSetTable.
+  // 2. One pass (from back to front) over the lineSetTable, propagating
+  //    values up the tree and, at the same time, accumulating per-line
+  //    totals.
+
+  // First, do the pass over the samples to compute the weight per line set.
+  const selfPerLineSet = new Float64Array(lineSetTable.length);
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
     const stackIndex = samples.stack[sampleIndex];
     if (stackIndex === null) {
       continue;
     }
-    const weight = samples.weight ? samples.weight[sampleIndex] : 1;
-    const setOfHitLines = stackLines[stackIndex];
-    if (setOfHitLines !== null) {
-      for (const line of setOfHitLines) {
-        const oldHitCount = totalLineHits.get(line) ?? 0;
-        totalLineHits.set(line, oldHitCount + weight);
+    const lineSetIndex = stackIndexToLineSetIndex[stackIndex];
+    if (lineSetIndex !== -1) {
+      const weight = samples.weight ? samples.weight[sampleIndex] : 1;
+      selfPerLineSet[lineSetIndex] += weight;
+    }
+  }
+
+  // Now, do a pass over the lineSetTable, from back to front.
+  // This is a similar idea to what we do for the call tree or the function
+  // list. The upwards propagation of a sample's weight will not contribute
+  // to the same line multiple times thanks to the guarantees of the
+  // lineSetTable - there are no duplicate values on a node's path to the
+  // root.
+  const totalLineHits: Map<LineNumber, number> = new Map();
+  const selfLineHits: Map<LineNumber, number> = new Map();
+  const selfSumOfLineSetDescendants = new Float64Array(lineSetTable.length);
+  for (
+    let lineSetIndex = lineSetTable.length - 1;
+    lineSetIndex >= 0;
+    lineSetIndex--
+  ) {
+    const selfWeight = selfPerLineSet[lineSetIndex];
+    if (selfWeight !== 0) {
+      const selfLine = lineSetTable.self[lineSetIndex];
+      if (selfLine !== -1) {
+        const oldHitCount = selfLineHits.get(selfLine) ?? 0;
+        selfLineHits.set(selfLine, oldHitCount + selfWeight);
       }
     }
-    const line = selfLine[stackIndex];
-    if (line !== null) {
-      const oldHitCount = selfLineHits.get(line) ?? 0;
-      selfLineHits.set(line, oldHitCount + weight);
+
+    const selfSumOfThisLineSetDescendants =
+      selfSumOfLineSetDescendants[lineSetIndex];
+    const thisLineSetWeight = selfWeight + selfSumOfThisLineSetDescendants;
+    const lineSetParent = lineSetTable.parent[lineSetIndex];
+    if (lineSetParent !== null) {
+      selfSumOfLineSetDescendants[lineSetParent] += thisLineSetWeight;
+    }
+
+    if (thisLineSetWeight !== 0) {
+      const line = lineSetTable.value[lineSetIndex];
+      if (line !== -1) {
+        const oldHitCount = totalLineHits.get(line) ?? 0;
+        totalLineHits.set(line, oldHitCount + thisLineSetWeight);
+      }
     }
   }
   return { totalLineHits, selfLineHits };

--- a/src/test/unit/address-timings.test.ts
+++ b/src/test/unit/address-timings.test.ts
@@ -42,10 +42,11 @@ describe('getStackAddressInfo', function () {
       Asym
     );
 
-    // Expect the returned arrays to have the same length as the stackTable.
+    // Expect the returned stackIndexToAddressSetIndex array to have the same length as the stackTable.
     expect(stackTable.length).toBe(9);
-    expect(stackLineInfoOne.selfAddress.length).toBe(9);
-    expect(stackLineInfoOne.stackAddresses.length).toBe(9);
+    expect(stackLineInfoOne.stackIndexToAddressSetIndex.length).toBe(9);
+
+    expect(stackLineInfoOne.addressSetTable.length).toBe(4);
   });
 });
 

--- a/src/test/unit/line-timings.test.ts
+++ b/src/test/unit/line-timings.test.ts
@@ -42,10 +42,11 @@ describe('getStackLineInfo', function () {
       fileOneSourceIndex
     );
 
-    // Expect the returned arrays to have the same length as the stackTable.
+    // Expect the returned stackIndexToLineSetIndex array to have the same length as the stackTable.
     expect(stackTable.length).toBe(9);
-    expect(stackLineInfoOne.selfLine.length).toBe(9);
-    expect(stackLineInfoOne.stackLines.length).toBe(9);
+    expect(stackLineInfoOne.stackIndexToLineSetIndex.length).toBe(9);
+
+    expect(stackLineInfoOne.lineSetTable.length).toBe(7);
   });
 });
 

--- a/src/test/unit/set-collection.test.ts
+++ b/src/test/unit/set-collection.test.ts
@@ -1,0 +1,205 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  SetCollectionBuilder,
+  type SetCollectionTable,
+  type IndexIntoSetCollectionTable,
+} from '../../utils/set-collection';
+
+function buildMulti<T>(
+  builder: SetCollectionBuilder<T>,
+  values: T[]
+): IndexIntoSetCollectionTable | null {
+  let parent = null;
+  for (const value of values) {
+    parent = builder.extend(parent, value);
+  }
+  return parent;
+}
+
+/**
+ * Helper function to convert a SetCollectionTable entry to a Set,
+ * while also validating that there are no duplicate values in the chain.
+ */
+function checkedMakeSet<T>(
+  table: SetCollectionTable<T>,
+  index: IndexIntoSetCollectionTable | null
+): Set<T> {
+  const result = new Set<T>();
+  for (
+    let ancestor = index;
+    ancestor !== null;
+    ancestor = table.parent[ancestor]
+  ) {
+    const value = table.value[ancestor];
+    if (result.has(value)) {
+      throw new Error(
+        `Duplicate value ${value} found in chain at index ${index}`
+      );
+    }
+    result.add(value);
+  }
+  return result;
+}
+
+describe('SetCollectionBuilder', function () {
+  describe('set construction with parent', function () {
+    it('creates a three-element set', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const index1 = builder.extend(null, 1);
+      const index2 = builder.extend(index1, 2);
+      const index3 = builder.extend(index2, 3);
+      const table = builder.finish();
+
+      expect(checkedMakeSet(table, index3)).toEqual(new Set([1, 2, 3]));
+    });
+
+    it('creates multiple children under same parent', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const parent = builder.extend(null, 1);
+      const child1 = builder.extend(parent, 2);
+      const child2 = builder.extend(parent, 3);
+      const child3 = builder.extend(parent, 4);
+      const table = builder.finish();
+
+      // All children should have the same parent
+      expect(table.parent[child1]).toBe(parent);
+      expect(table.parent[child2]).toBe(parent);
+      expect(table.parent[child3]).toBe(parent);
+
+      // But different values
+      expect(table.value[child1]).toBe(2);
+      expect(table.value[child2]).toBe(3);
+      expect(table.value[child3]).toBe(4);
+    });
+  });
+
+  describe('deduplication - exact match', function () {
+    it('returns same index for identical single-value set', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const index1 = builder.extend(null, 5);
+      const index2 = builder.extend(null, 5);
+      const table = builder.finish();
+
+      expect(index1).toBe(index2);
+      expect(table.length).toBe(1);
+    });
+
+    it('returns same index for identical two-element set', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const parent1 = builder.extend(null, 2);
+      const set1 = builder.extend(parent1, 3);
+
+      const parent2 = builder.extend(null, 2);
+      const set2 = builder.extend(parent2, 3);
+
+      expect(parent1).toBe(parent2);
+      expect(set1).toBe(set2);
+    });
+
+    it('returns same index when requesting subset', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const parent = builder.extend(null, 2);
+      builder.extend(parent, 3);
+
+      // Now request just (2) again
+      const parentAgain = builder.extend(null, 2);
+
+      expect(parentAgain).toBe(parent);
+    });
+  });
+
+  describe('deduplication - value already in parent chain', function () {
+    it('detects value in immediate parent', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const set1 = builder.extend(null, 5);
+      const set2 = builder.extend(set1, 5);
+
+      // Adding 5 to a set that already contains 5 should return the parent
+      expect(set2).toBe(set1);
+    });
+
+    it('detects value deep in ancestor chain', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const set1 = builder.extend(null, 1);
+      const set2 = builder.extend(set1, 2);
+      const set3 = builder.extend(set2, 3);
+      const set4 = builder.extend(set3, 4);
+      const set5 = builder.extend(set4, 2); // 2 is in the chain
+      const table = builder.finish();
+
+      // When adding 2 to (1,2,3,4), since 2 is already in the chain,
+      // it creates a non-canonical node with value=4 (from parent), self=2, parent=set3
+      expect(set5).not.toBe(set4);
+      expect(checkedMakeSet(table, set5)).toEqual(new Set([1, 2, 3, 4]));
+      expect(table.value[set5]).toBe(4);
+      expect(table.self[set5]).toBe(2);
+      expect(table.parent[set5]).toBe(set3);
+    });
+
+    it('example: (2, 4, 3) + 3/4 -> (2, 4, 3)', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const set243 = buildMulti(builder, [2, 4, 3]);
+      const set2433 = buildMulti(builder, [2, 4, 3, 3]);
+      const set2434 = buildMulti(builder, [2, 4, 3, 4]);
+      const set2435 = buildMulti(builder, [2, 4, 3, 5]);
+      const set24345 = buildMulti(builder, [2, 4, 3, 4, 5]);
+      const table = builder.finish();
+
+      expect(set2433).toBe(set243);
+      expect(set2434).not.toBe(set243); // different self
+      expect(set2435).toBe(set24345);
+      expect(checkedMakeSet(table, set243)).toEqual(new Set([2, 4, 3]));
+      expect(checkedMakeSet(table, set2434)).toEqual(new Set([2, 4, 3]));
+      expect(checkedMakeSet(table, set24345)).toEqual(new Set([2, 4, 3, 5]));
+    });
+
+    it('multiple roots with reordering', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const set1 = buildMulti(builder, [1]);
+      const set2 = buildMulti(builder, [2]);
+      const set3 = buildMulti(builder, [3]);
+      expect(buildMulti(builder, [1])).toBe(set1);
+      expect(buildMulti(builder, [3])).toBe(set3);
+      expect(buildMulti(builder, [3])).toBe(set3);
+      expect(buildMulti(builder, [2])).toBe(set2);
+      const set4 = buildMulti(builder, [4]);
+      expect(buildMulti(builder, [2])).toBe(set2);
+      const table = builder.finish();
+
+      expect(checkedMakeSet(table, set1)).toEqual(new Set([1]));
+      expect(checkedMakeSet(table, set2)).toEqual(new Set([2]));
+      expect(checkedMakeSet(table, set3)).toEqual(new Set([3]));
+      expect(checkedMakeSet(table, set4)).toEqual(new Set([4]));
+    });
+
+    it('multiple canonical children with reordering', function () {
+      const builder = new SetCollectionBuilder<number>();
+      const set24345 = buildMulti(builder, [2, 4, 3, 4, 5]);
+      const set2435 = buildMulti(builder, [2, 4, 3, 5]);
+      expect(set24345).toBe(set2435);
+      const set2436 = buildMulti(builder, [2, 4, 3, 6]);
+      expect(buildMulti(builder, [2, 4, 3, 5])).toBe(set2435);
+      const set2437 = buildMulti(builder, [2, 4, 3, 7]);
+      expect(buildMulti(builder, [2, 4, 3, 4, 6])).toBe(set2436);
+      expect(buildMulti(builder, [2, 4, 3, 4, 7])).toBe(set2437);
+      const table = builder.finish();
+
+      expect(checkedMakeSet(table, set2437)).toEqual(new Set([2, 4, 3, 7]));
+    });
+  });
+
+  describe('edge cases', function () {
+    it('handles string equality correctly', function () {
+      const builder = new SetCollectionBuilder<string>();
+      const index1 = builder.extend(null, 'test');
+      const index2 = builder.extend(null, 'test');
+      const index3 = builder.extend(null, 'test '); // different!
+
+      expect(index1).toBe(index2);
+      expect(index1).not.toBe(index3);
+    });
+  });
+});

--- a/src/types/profile-derived.ts
+++ b/src/types/profile-derived.ts
@@ -39,6 +39,10 @@ import type { IndexedArray } from './utils';
 import type { BitSet } from '../utils/bitset';
 import type { StackTiming } from '../profile-logic/stack-timing';
 import type { StringTable } from '../utils/string-table';
+import type {
+  IndexIntoSetCollectionTable,
+  SetCollectionTable,
+} from 'firefox-profiler/utils/set-collection';
 export type IndexIntoCallNodeTable = number;
 
 /**
@@ -342,19 +346,15 @@ export type LineNumber = number;
 // stackLine may be null. This is fine because their values are not accessed
 // during the LineTimings computation.
 export type StackLineInfo = {
-  // An array that contains, for each "self" stack, the line number that this stack
-  // spends its self time in, in this file, or null if the self time of the
-  // stack is in a different file or if the line number is not known.
-  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
-  // never referred to from a SamplesLikeTable, the value may be null.
-  selfLine: Array<LineNumber | null>;
-  // An array that contains, for each "self" stack, all the lines that the frames in
-  // this stack hit in this file, or null if this stack does not hit any line
-  // in the given file.
-  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
-  // never referred to from a SamplesLikeTable, the value may be null.
-  stackLines: Array<Set<LineNumber> | null>;
+  // Represents a Map<IndexIntoStackTable, IndexIntoLineSetTable | -1>
+  stackIndexToLineSetIndex: Int32Array;
+  // Stores entries representing a pair of (set of lines, self line), usually
+  // much much smaller than the stackTable because it only stores entries for
+  // the current source.
+  lineSetTable: SetCollectionTable<LineNumber>;
 };
+
+export type IndexIntoLineSetTable = IndexIntoSetCollectionTable;
 
 // Stores, for all lines of one specific file, how many times each line is hit
 // by samples in a thread. The maps only contain non-zero values.
@@ -382,19 +382,15 @@ export type LineTimings = {
 // stackAddress may be null. This is fine because their values are not accessed
 // during the AddressTimings computation.
 export type StackAddressInfo = {
-  // An array that contains, for each "self" stack, the address that this stack
-  // spends its self time in, in this native symbol, or null if the self time of
-  // the stack is in a different native symbol or if the address is not known.
-  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
-  // never referred to from a SamplesLikeTable, the value may be null.
-  selfAddress: Array<Address | null>;
-  // An array that contains, for each "self" stack, all the addresses that the
-  // frames in this stack hit in this native symbol, or null if this stack does
-  // not hit any address in the given native symbol.
-  // For non-"self" stacks, i.e. stacks which are only used as prefix stacks and
-  // never referred to from a SamplesLikeTable, the value may be null.
-  stackAddresses: Array<Set<Address> | null>;
+  // Represents a Map<IndexIntoStackTable, IndexIntoAddressSetTable | -1>
+  stackIndexToAddressSetIndex: Int32Array;
+  // Stores entries representing the pair (set of addresses, self address), usually
+  // much much smaller than the stackTable because it only stores entries for the
+  // current native symbol.
+  addressSetTable: SetCollectionTable<Address>;
 };
+
+export type IndexIntoAddressSetTable = IndexIntoSetCollectionTable;
 
 // Stores, for all addresses of one specific library, how many times each
 // address is hit by samples in a thread. The maps only contain non-zero values.

--- a/src/utils/set-collection.ts
+++ b/src/utils/set-collection.ts
@@ -1,0 +1,349 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type IndexIntoSetCollectionTable = number;
+
+/**
+ * A data structure which efficiently stores a collection of sets of T
+ * in a trie-like structure.
+ *
+ * Given the index i of an entry in the collection, the elements in the
+ * set i are the following:
+ * ```
+ * for (let ancestor = i; ancestor !== null; ancestor = table.parent[ancestor]) {
+ *   yield table.value[ancestor];
+ * }
+ * ```
+ *
+ * The creator of the table guarantees:
+ * - The loop above does not yield any duplicates.
+ * - The loop above always terminates (there are no cycles).
+ *
+ * Example:
+ *
+ *    value        parent    represents set
+ * -----------------------------------------
+ * 0: A            null      { A }
+ * 1: - B          0         { A, B }
+ * 2:   - C        1         { A, B, C }
+ * 3:   - D        1         { A, B, D }
+ * 4:   - C        1         { A, B, C }
+ * 5: D            null      { D }
+ * 6: - A          5         { D, A }
+ * 7:   - B        6         { D, A, B }
+ * 8: - A          5         { D, A }
+ *
+ * This example demonstrates the structural sharing, as well as the limits of that
+ * sharing. For example, we have some duplicates:
+ * - The set { A, B, C } is present twice.
+ * - The set { D, A } is present twice.
+ * - We have both { A, B, D } and { D, A, B }, even though both represent the same
+ *   set of values.
+ *
+ * This is allowed.
+ *
+ * It's just things like { A, B, A } that are not allowed.
+ *
+ * ## The "self" value
+ *
+ * In addition to storing a set per entry, we also store a "self" value.
+ * So really, each entry represents a pair (set of values, self value).
+ *
+ * This is kind of an unrelated concern, but quite useful.
+ *
+ * For every entry i, table.self[i] is one of the values in the set represented by
+ * i, but not necessarily the same as table.value[i] - for example, it could be
+ * the same as parent or grand-parent's value instead.
+ *
+ * Here's a valid example with some self values:
+ *
+ *    value        parent    represents set   self
+ *   ---------------------------------------------
+ * 0: A            null      { A }            A
+ * 1: - B          0         { A, B }         B
+ * 2:   - C        1         { A, B, C }      C
+ * 3:   - D        1         { A, B, D }      D
+ * 4:   - C        1         { A, B, C }      B
+ * 5: D            null      { D }            D
+ * 6: - A          5         { D, A }         A
+ * 7:   - B        6         { D, A, B }      B
+ * 8: - A          5         { D, A }         D
+ *
+ * For example, the entry at i==8 has a set of { D, A } and a self of D.
+ * This entry would be used for any input sequences that only contain D
+ * and A and which end in D, for example [D, D, A, D] or [D, A, A, D].
+ *
+ * ## Application
+ *
+ * We use this data structure when we compute per-line timings for the source view,
+ * specifically for compactly storing the set of line numbers per stack.
+ *
+ * Example stackTable:
+ * - A [file.cpp:23]
+ *   - B [file.cpp:45]
+ *     - C [file.cpp:54]
+ *       - B [file.cpp:45]
+ *         - D [file.cpp:63]
+ *
+ * Here, the deepest stack node has self-line 63 and hits the lines { 23, 45, 54, 63 }.
+ * Crucially, we only want to count 45 once!
+ *
+ * And we want to store only one index per stack, because the stackTable can
+ * be extremely large. The SetCollectionTable lets us use a single index to
+ * represent both the set of hit lines and the self line.
+ *
+ * For the above example, we would create the following SetCollectionTable<LineNumber>:
+ *
+ *      value  parent   represents set       self
+ * -------------------------------------------------
+ * 0:   23     null     { 23 }               23
+ * 1:   45     0        { 23, 45 }           45
+ * 2:   54     1        { 23, 45, 54 }       54
+ * 3:   54     1        { 23, 45, 54 }       45
+ * 4:   63     2        { 23, 45, 54, 63 }   63
+ *
+ * And then have stackIndexToLineSetIndex: [0, 1, 2, 3, 4].
+ */
+export type SetCollectionTable<T> = {
+  parent: Array<IndexIntoSetCollectionTable | null>;
+  value: Array<T>;
+  self: Array<T>;
+  length: number;
+};
+
+/**
+ * Builds a SetCollectionTable via a series calls to `extend`.
+ * The type T must have value equality semantics.
+ *
+ * ```
+ * const builder = new SetCollectionBuilder<number>();
+ * const set1 = builder.extend(null, 1);      // {1}
+ * const set12 = builder.extend(set1, 2);     // {1,2}
+ * const set123 = builder.extend(set12, 3);   // {1,2,3}
+ * const table = builder.finish();
+ *
+ * table.value[set123] == 3
+ * table.value[table.parent[set123]] == 2
+ * table.value[table.parent[table.parent[set123]]] == 1
+ * ```
+ */
+export class SetCollectionBuilder<T> {
+  // These columns will become the table.
+  _parentCol: Array<IndexIntoSetCollectionTable | null> = [];
+  _valueCol: Array<T> = [];
+  _selfCol: Array<T> = [];
+  _length: number = 0;
+
+  // These columns are only used while building the structure and
+  // do not end up in the table.
+  _headRoot: IndexIntoSetCollectionTable | null = null;
+  _headChild: Array<IndexIntoSetCollectionTable | null> = [];
+  _next: Array<IndexIntoSetCollectionTable | null> = [];
+  _nextNonCanonical: Array<IndexIntoSetCollectionTable | null> = [];
+  _canonicalIndex: Array<IndexIntoSetCollectionTable> = [];
+
+  /**
+   * Contains "canonical" and "non-canonical" nodes.
+   * A canonical node is one which has value == self, a non-canonical node is one which has value != self.
+   * Canonical nodes are connected to other canonical nodes via _next.
+   * Canonical nodes also have a linked list of non-canonical nodes (_nextNonCanonical).
+   * _nextNonCanonical, if non-null, always points to a node with the same value and same parent.
+   * _canonicalIndex always points back at a canonical node with the same value and same parent.
+   * Only canonical nodes have children.
+   *
+   *  builder
+   *     │
+   *     | headRoot
+   *     ▼
+   *     A  ────┐
+   *     │      │ headChild
+   *     │      ▼
+   *     │      B ───┐
+   *     │           │ headChild
+   *     │           ▼              nextNC
+   *     │           C ─────────────────────► C [self=B]
+   *     │           │
+   *     │           │ next
+   *     │           ▼
+   *     │ next      D
+   *     │
+   *     ▼
+   *     D ────┐
+   *           │ headChild
+   *           ▼              nextNC
+   *           A ─────────────────────► A [self=D]
+   *            `───┐
+   *                │ headChild
+   *                ▼
+   *                B
+   *
+   */
+
+  /**
+   * Returns the index for an entry that represents the pair (parentSet ∪ { self }, self)
+   */
+  extend(
+    parent: IndexIntoSetCollectionTable | null,
+    self: T
+  ): IndexIntoSetCollectionTable {
+    let canonicalParent = parent;
+    if (parent !== null) {
+      if (this._selfCol[parent] === self) {
+        return parent;
+      }
+
+      canonicalParent = this._canonicalIndex[parent];
+    }
+
+    const canonicalNode = this._getOrCreateCanonicalNode(canonicalParent, self);
+    return this._getOrCreateNodeWithCorrectSelf(canonicalNode, self);
+  }
+
+  _getOrCreateCanonicalNode(
+    parent: IndexIntoSetCollectionTable | null,
+    value: T
+  ): IndexIntoSetCollectionTable {
+    if (parent !== null && this._doesSetAlreadyContainValue(parent, value)) {
+      return parent;
+    }
+
+    return (
+      this._findCanonicalSiblingWithValue(parent, value) ??
+      this._createCanonicalNode(parent, value)
+    );
+  }
+
+  _doesSetAlreadyContainValue(
+    node: IndexIntoSetCollectionTable,
+    value: T
+  ): boolean {
+    for (
+      let ancestor: IndexIntoSetCollectionTable | null = node;
+      ancestor !== null;
+      ancestor = this._parentCol[ancestor]
+    ) {
+      if (this._valueCol[ancestor] === value) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _findCanonicalSiblingWithValue(
+    parent: IndexIntoSetCollectionTable | null,
+    value: T
+  ): IndexIntoSetCollectionTable | null {
+    const head = parent !== null ? this._headChild[parent] : this._headRoot;
+    for (
+      let candidate: IndexIntoSetCollectionTable | null = head,
+        prevCandidate: IndexIntoSetCollectionTable | null = null;
+      candidate !== null;
+      prevCandidate = candidate, candidate = this._next[candidate]
+    ) {
+      if (this._valueCol[candidate] === value) {
+        // We found a matching node!
+        // At this point we could just return it.
+        //
+        // However, to improve performance, we will reorder the linked list of canonical siblings
+        // such that the most-recently used node is at the front. This has performance advantages
+        // because the more frequently-used siblings will be more likely to be near the front
+        // of the list, requiring fewer next-sibling hops.
+        // Without LRU: https://share.firefox.dev/4rFbzwZ , with LRU: https://share.firefox.dev/4qmvPlR
+
+        if (candidate !== head) {
+          // Before: head -> ... -> prevCandidate -> candidate -> nextCandidate -> ...
+          // After:  candidate -> head -> ... -> prevCandidate -> nextCandidate -> ...
+          if (parent !== null) {
+            this._headChild[parent] = candidate;
+          } else {
+            this._headRoot = candidate;
+          }
+          const nextCandidate = this._next[candidate];
+          this._next[candidate] = head;
+          if (prevCandidate !== null) {
+            this._next[prevCandidate] = nextCandidate;
+          }
+        }
+
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  _getOrCreateNodeWithCorrectSelf(
+    canonicalNode: IndexIntoSetCollectionTable,
+    self: T
+  ): IndexIntoSetCollectionTable {
+    return (
+      this._findNodeWithCorrectSelf(canonicalNode, self) ??
+      this._createNonCanonicalNode(canonicalNode, self)
+    );
+  }
+
+  _findNodeWithCorrectSelf(
+    canonicalNode: IndexIntoSetCollectionTable,
+    self: T
+  ): IndexIntoSetCollectionTable | null {
+    for (
+      let candidate: IndexIntoSetCollectionTable | null = canonicalNode;
+      candidate !== null;
+      candidate = this._nextNonCanonical[candidate]
+    ) {
+      if (this._selfCol[candidate] === self) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  _createCanonicalNode(
+    parent: IndexIntoSetCollectionTable | null,
+    value: T
+  ): IndexIntoSetCollectionTable {
+    const headSibling =
+      parent !== null ? this._headChild[parent] : this._headRoot;
+
+    const newNode = this._length++;
+    this._parentCol[newNode] = parent;
+    this._valueCol[newNode] = value;
+    this._selfCol[newNode] = value;
+    this._canonicalIndex[newNode] = newNode;
+    this._nextNonCanonical[newNode] = null;
+    this._headChild[newNode] = null;
+    this._next[newNode] = headSibling;
+
+    if (parent !== null) {
+      this._headChild[parent] = newNode;
+    } else {
+      this._headRoot = newNode;
+    }
+    return newNode;
+  }
+
+  _createNonCanonicalNode(
+    canonicalNode: IndexIntoSetCollectionTable,
+    self: T
+  ): IndexIntoSetCollectionTable {
+    const newNode = this._length++;
+    this._parentCol[newNode] = this._parentCol[canonicalNode];
+    this._valueCol[newNode] = this._valueCol[canonicalNode];
+    this._selfCol[newNode] = self;
+    this._canonicalIndex[newNode] = canonicalNode;
+    this._nextNonCanonical[newNode] = this._nextNonCanonical[canonicalNode];
+    this._nextNonCanonical[canonicalNode] = newNode;
+    this._headChild[newNode] = null;
+    this._next[newNode] = null;
+    return newNode;
+  }
+
+  finish(): SetCollectionTable<T> {
+    return {
+      parent: this._parentCol,
+      self: this._selfCol,
+      value: this._valueCol,
+      length: this._length,
+    };
+  }
+}


### PR DESCRIPTION
[Production](https://share.firefox.dev/3NnzEcF) | [Deploy preview](https://deploy-preview-5761--perf-html.netlify.app/public/fkmw9djz29ntsmaznezy93hhft85jy0zjrp5my8/calltree/?globalTrackOrder=0&invertCallstack&profileName=FullSp3Firefox-15x-symbolicated&thread=0&v=12)

On large profiles, opening the source view can cause large allocations because we create `Set` objects for many stacks. In this PR I've experimented with a more compact storage of a collection of sets.

Before: https://share.firefox.dev/3NnthpO
After: https://share.firefox.dev/45dMNv1

`getStackLineInfo` now allocates 46MB instead of 220MB (4.8x reduction), and takes 146ms instead of 338ms (2.3x reduction), when opening the source view for `mozjemalloc.cpp` on https://share.firefox.dev/3NnzEcF.