### PR TITLE
Refine tree view a11y

### DIFF
--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -194,6 +194,11 @@
 }
 
 .treeViewMainColumn.dim {
+  opacity: 0.7;
+}
+
+/* Override dimming level when selected for better a11y */
+.treeViewBody:focus .treeViewRow.isSelected .treeViewMainColumn.dim {
   opacity: 0.9;
 }
 


### PR DESCRIPTION
The issue fixes #5674.

The original issue mentions inaccessibility of the .treeViewAppendageColumn element (the filename). However, during development I've also noticed inaccessibility of the label frames. As discussed in the matrix channel, for now I just increased their opacity level. Shall we create an issue for further improvement of the dimming functionality? @canova 

### Appendage Column

#### Before

<img width="1521" height="625" alt="Screenshot 2026-01-23 at 13 48 03" src="https://github.com/user-attachments/assets/5d81a874-f88d-41bf-9e12-3fbaf3f5652e" />

#### After

<img width="1521" height="625" alt="Screenshot 2026-01-23 at 13 53 08" src="https://github.com/user-attachments/assets/141ec50d-ef38-4f24-b480-2c99e638c755" />

### Label Frames

#### Before

<img width="1521" height="625" alt="Screenshot 2026-01-23 at 13 48 11" src="https://github.com/user-attachments/assets/bcf7679d-8cc2-4f40-85cc-61945e342aa5" />

#### After

<img width="1521" height="625" alt="Screenshot 2026-01-23 at 15 37 44" src="https://github.com/user-attachments/assets/7daf4dda-fe24-4427-aedf-50a595ac3ec9" />


Deploy preview: [Before](https://share.firefox.dev/4611qlC) / [After](https://deploy-preview-5779--perf-html.netlify.app/public/5at6ae9jv2vn122j05hre5daek5d0cy3twchpwg/calltree/?globalTrackOrder=0&thread=0&v=12)

Closes #5674.
