### PR TITLE
Make the range duration text white again

### DIFF
--- a/src/components/timeline/Selection.css
+++ b/src/components/timeline/Selection.css
@@ -161,7 +161,7 @@
   border-radius: 0 0 4px 4px;
   background-color: var(--internal-range-background-color);
   box-shadow: 0 2px 2px var(--base-shadow-color);
-  color: var(--base-foreground-color);
+  color: var(--internal-overlay-time-foreground-color);
   opacity: 1;
   pointer-events: none;
   transition: opacity 200ms;


### PR DESCRIPTION
Fixes #5791

Before:
<img width="618" height="390" alt="Screenshot 2026-01-28 at 5 49 40 PM" src="https://github.com/user-attachments/assets/7a8fc421-1616-426c-9fd2-da2ec8605114" />

After:
<img width="449" height="326" alt="Screenshot 2026-01-28 at 6 05 42 PM" src="https://github.com/user-attachments/assets/76ea5e1e-db13-496f-a628-0c68dc599ca1" />

Dark mode is still the same:
<img width="573" height="215" alt="Screenshot 2026-01-28 at 6 15 22 PM" src="https://github.com/user-attachments/assets/3dd0fc8d-0489-45e7-b6f9-225c11f7b0c8" />


Example profile: [before](https://share.firefox.dev/4bXzNOa) / [after](https://deploy-preview-5792--perf-html.netlify.app/public/5at6ae9jv2vn122j05hre5daek5d0cy3twchpwg/network-chart/?globalTrackOrder=0&thread=0&v=13)