### PR TITLE
Make the argument-values.json profile fixture go through profile upgrading

### DIFF
--- a/src/test/components/StackChart.test.tsx
+++ b/src/test/components/StackChart.test.tsx
@@ -63,6 +63,7 @@ import {
 import { autoMockElementSize } from '../fixtures/mocks/element-size';
 
 import type { CssPixels, Store } from 'firefox-profiler/types';
+import { unserializeProfileOfArbitraryFormat } from 'firefox-profiler/profile-logic/process-profile';
 
 jest.useFakeTimers();
 
@@ -315,9 +316,11 @@ describe('StackChart', function () {
 });
 
 describe('ArgumentValues', () => {
-  it('shows argument values when a profile has them', () => {
-    const profile = require('../fixtures/upgrades/argument-values.json');
-    const store = storeWithProfile(profile);
+  it('shows argument values when a profile has them', async () => {
+    const profiler = await unserializeProfileOfArbitraryFormat(
+      require('../fixtures/upgrades/argument-values.json')
+    );
+    const store = storeWithProfile(profiler);
     const { getTooltip, moveMouse, findFillTextPosition } = setup(store);
 
     moveMouse(findFillTextPosition('bar'));

--- a/src/test/fixtures/stores.ts
+++ b/src/test/fixtures/stores.ts
@@ -8,6 +8,7 @@ import { processGeckoProfile } from '../../profile-logic/process-profile';
 import { getProfileFromTextSamples } from './profiles/processed-profile';
 
 import type { Store, Profile } from 'firefox-profiler/types';
+import { PROCESSED_PROFILE_VERSION } from 'firefox-profiler/app-logic/constants';
 
 export function blankStore() {
   return createStore();
@@ -18,6 +19,13 @@ export function storeWithProfile(profile?: Profile): Store {
     profile = processGeckoProfile(createGeckoProfileWithJsTimings());
     profile.meta.symbolicated = true;
   }
+
+  if (profile.meta.preprocessedProfileVersion !== PROCESSED_PROFILE_VERSION) {
+    throw new Error(
+      `storeWithProfile called with something that's not a fully-uprgaded processed profile!`
+    );
+  }
+
   const store = createStore();
   store.dispatch(viewProfile(profile));
   return store;


### PR DESCRIPTION
Otherwise we'll have to change it whenever we change the format.