### PR TITLE
fix foreground color of the button on error page

### DIFF
--- a/res/css/photon/message-bar.css
+++ b/res/css/photon/message-bar.css
@@ -142,7 +142,7 @@
 .photon-message-bar-error .photon-message-bar-action-button,
 .photon-message-bar-error .photon-message-bar-close-button:hover {
   background-color: var(--internal-error-action-background-color);
-  color: var(photon-message-bar-error-action-foreground-color);
+  color: var(--internal-error-action-foreground-color);
 }
 
 .photon-message-bar-warning .photon-message-bar-action-button,


### PR DESCRIPTION
Closes #5844.

#### Before
<img width="983" height="429" alt="Screenshot 2026-02-18 at 14 04 23" src="https://github.com/user-attachments/assets/3fa695f8-f335-4c42-bab4-72291fcfb79b" />
<img width="983" height="429" alt="Screenshot 2026-02-18 at 14 04 28" src="https://github.com/user-attachments/assets/d1adce23-f6e9-4025-b507-739c88626fd0" />

[Profile](https://profiler.firefox.com/public/jg978rry9dja43ydvdbm2hs42dyv7hfzzh76k0g/marker-chart/?globalTrackOrder=0ed7681fa9cb3524&hiddenGlobalTracks=2w59wc&hiddenLocalTracksByPid=39952-0w9~46852-0w7~47260-0~40008-0~29704-0~47756-0~28280-0w7~32112-0w7~31896-0w7~37164-0w8~2332-0w8~33932-0w9~33172-0w9~44568-2wa~30320-2wfhjwo&markerSearch=setneeds&range=1330m116&thread=yp&v=13)

#### After
<img width="983" height="429" alt="Screenshot 2026-02-18 at 13 55 13" src="https://github.com/user-attachments/assets/e444ccf0-c128-42bb-9cfe-7d0b9daebab2" />
<img width="983" height="429" alt="Screenshot 2026-02-18 at 13 55 53" src="https://github.com/user-attachments/assets/abd38d29-1ae3-4889-bbf2-3414884c6f14" />

[Profile](https://deploy-preview-5849--perf-html.netlify.app/public/jg978rry9dja43ydvdbm2hs42dyv7hfzzh76k0g/marker-chart/?globalTrackOrder=0ed7681fa9cb3524&hiddenGlobalTracks=2w59wc&hiddenLocalTracksByPid=39952-0w9~46852-0w7~47260-0~40008-0~29704-0~47756-0~28280-0w7~32112-0w7~31896-0w7~37164-0w8~2332-0w8~33932-0w9~33172-0w9~44568-2wa~30320-2wfhjwo&markerSearch=setneeds&range=1330m116&thread=yp&v=13)


#### Notes

I've made it look the same way as it used to look before it got broken in [this PR](https://github.com/firefox-devtools/profiler/pull/5740). This is how it looked before that PR:

<img width="983" height="429" alt="Screenshot 2026-02-18 at 13 41 00" src="https://github.com/user-attachments/assets/4b9baaaf-c00c-4ed1-86ee-99abc341aef6" />
<img width="983" height="429" alt="Screenshot 2026-02-18 at 13 41 07" src="https://github.com/user-attachments/assets/1496854b-1b09-455e-a2d0-238ed53e6881" />

However, I am not sure if this even looks nice.

Use [these instructions](https://github.com/firefox-devtools/profiler/issues/5819#issue-3907471498) to hit an error and see the page live.