### PR TITLE
Fix JSZip dynamic import for esbuild

### DIFF
--- a/src/actions/receive-profile.ts
+++ b/src/actions/receive-profile.ts
@@ -1178,7 +1178,7 @@ async function _extractZipFromResponse(
   // that comes from this realm.
   const typedBuffer = new Uint8Array(buffer);
   try {
-    const JSZip = await import('jszip');
+    const { default: JSZip } = await import('jszip');
     const zip = await JSZip.loadAsync(typedBuffer);
     // Catch the error if unable to load the zip.
     return zip;
@@ -1369,7 +1369,7 @@ export function retrieveProfileFromFile(
       if (_deduceContentType(file.name, file.type) === 'application/zip') {
         // Open a zip file in the zip file viewer
         const buffer = await fileReader(file).asArrayBuffer();
-        const JSZip = await import('jszip');
+        const { default: JSZip } = await import('jszip');
         const zip = await JSZip.loadAsync(buffer);
         await dispatch(receiveZipFile(zip));
       } else {


### PR DESCRIPTION
Previously webpack was always using the CommonJS modules and had a transform for ES modules.

JSZip is a CommonJS module, but it looks like now esbuild returns an ES module namespace object for dynamic imports of CommonJS modules. Because of that, the JSZip import contents live inside .default.

I checked other dynamic imports too and it looks like this is the only one that is affected.


[Before](https://profiler.firefox.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2Faq0v3RbWRP62PNONPZ3kkQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3.zip) / [After](https://deploy-preview-5858--perf-html.netlify.app/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2Faq0v3RbWRP62PNONPZ3kkQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3.zip)