### PR TITLE
Fix the color of dark mode back arrow svg

### DIFF
--- a/res/img/svg/back-arrow-light.svg
+++ b/res/img/svg/back-arrow-light.svg
@@ -8,6 +8,6 @@
       <rect x="0" y="0" width="7" height="2"></rect>
       <rect x="0" y="0" width="2" height="7"></rect>
     </g>
-    <rect fill="#000" x="5" y="7" width="8" height="2"></rect>
+    <rect fill="#ededf0" x="5" y="7" width="8" height="2"></rect>
   </g>
 </svg>


### PR DESCRIPTION
The `fill` attribute of the `<g>` element was change properly but not the `<rect>` fill.

Fixes #5862.

[Before](https://profiler.firefox.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2Faq0v3RbWRP62PNONPZ3kkQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3.zip/calltree/?v=13) / [After](https://deploy-preview-5863--perf-html.netlify.app//from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2Faq0v3RbWRP62PNONPZ3kkQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3.zip/calltree/?v=13)