### PR TITLE
Remove async attribute from module script tag

### DIFF
--- a/scripts/lib/esbuild-plugins.mjs
+++ b/scripts/lib/esbuild-plugins.mjs
@@ -126,7 +126,7 @@ export function generateHtmlPlugin(options) {
         const headTags = [];
 
         headTags.push(
-          `<script src="${convertPath(mainBundlePath)}" type="module" async></script>`
+          `<script src="${convertPath(mainBundlePath)}" type="module"></script>`
         );
 
         if (mainBundle.cssBundle) {


### PR DESCRIPTION
Fixes #5869.

Module scripts are deferred by default per HTML spec section 4.12.1 ([prepare a script element](https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element)): parser-inserted type=module scripts without async go into the "list of scripts that will execute when the document has finished parsing" (executed in [section 13.2.7 "The end"](https://html.spec.whatwg.org/multipage/parsing.html#the-end)).

Adding async makes the script execute as soon as it downloads, which can happen before DOM parsing completes, breaking document.getElementById and similar DOM access in the main bundle.