### PR TITLE
Support zoom by click in flame graph

### DIFF
--- a/src/actions/profile-view.ts
+++ b/src/actions/profile-view.ts
@@ -130,6 +130,19 @@ export function changeSelectedCallNode(
 }
 
 /**
+ * Zoom in a call node. This action is used when the user clicks on a call node in
+ * the flame chart panel.
+ */
+export function changeZoomedInCallNode(
+  zoomedInCallNodePath: CallNodePath | null
+): Action {
+  return {
+    type: 'CHANGE_ZOOMED_IN_CALL_NODE',
+    zoomedInCallNodePath,
+  };
+}
+
+/**
  * This action is used when the user right clicks on a call node (in panels such
  * as the call tree, the flame chart, or the stack chart). It's especially used
  * to display the context menu.

--- a/src/app-logic/url-handling.ts
+++ b/src/app-logic/url-handling.ts
@@ -217,6 +217,9 @@ type Query = BaseQuery & {
   sourceViewIndex?: number;
   assemblyView?: string;
 
+  // FlameGraph specific
+  zoomedInNode?: string;
+
   // StackChart specific
   showUserTimings?: null | undefined;
   sameWidths?: null | undefined;
@@ -338,6 +341,11 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       query.invertCallstack = urlState.profileSpecific.invertCallstack
         ? null
         : undefined;
+      if (urlState.profileSpecific.zoomedInCallNodePath !== null) {
+        query.zoomedInNode = encodeUintArrayForUrlComponent(
+          urlState.profileSpecific.zoomedInCallNodePath
+        );
+      }
       if (
         selectedThreadsKey !== null &&
         urlState.profileSpecific.transforms[selectedThreadsKey]
@@ -525,6 +533,11 @@ export function stateFromLocation(
     }
   }
 
+  const zoomedInCallNodePath: CallNodePath | null =
+    selectedThreadsKey !== null && query.zoomedInNode !== undefined
+      ? decodeUintArrayFromUrlComponent(query.zoomedInNode)
+      : null;
+
   // tabID is used for the tab selector that we have in our full view.
   let tabID = null;
   if (query.tabID && Number.isInteger(Number(query.tabID))) {
@@ -614,6 +627,7 @@ export function stateFromLocation(
         ? query.hiddenThreads.split('-').map((index) => Number(index))
         : null,
       selectedMarkers,
+      zoomedInCallNodePath,
     },
   };
 }

--- a/src/components/flame-graph/Canvas.tsx
+++ b/src/components/flame-graph/Canvas.tsx
@@ -63,6 +63,7 @@ export type OwnProps = {
   readonly callTree: CallTree;
   readonly stackFrameHeight: CssPixels;
   readonly selectedCallNodeIndex: IndexIntoCallNodeTable | null;
+  readonly zoomedInCallNodeIndex: IndexIntoCallNodeTable | null;
   readonly rightClickedCallNodeIndex: IndexIntoCallNodeTable | null;
   readonly onSelectionChange: (param: IndexIntoCallNodeTable | null) => void;
   readonly onRightClick: (param: IndexIntoCallNodeTable | null) => void;
@@ -142,25 +143,25 @@ function findLastIndex<T>(
 }
 
 /**
- * Get the timing information of the selected call node.
- * If there is no selected call node, it defaults to the root call node.
+ * Get the timing information of the zoomed in call node.
+ * If there is no zoomed in call node, it defaults to the root call node.
  */
-function getSelectedOrRootCallNodeTiming(
+function getZoomedInOrRootCallNodeTiming(
   flameGraphTiming: FlameGraphTiming,
   callNodeInfo: CallNodeInfo,
-  selectedCallNodeIndex: IndexIntoCallNodeTable | null
+  zoomedInCallNodeIndex: IndexIntoCallNodeTable | null
 ): { start: number; end: number } {
-  if (selectedCallNodeIndex === null) {
+  if (zoomedInCallNodeIndex === null) {
     return { start: 0, end: 1 };
   }
 
-  const depth = callNodeInfo.depthForNode(selectedCallNodeIndex);
+  const depth = callNodeInfo.depthForNode(zoomedInCallNodeIndex);
   const stackTiming = flameGraphTiming[depth];
   if (!stackTiming) {
     return { start: 0, end: 1 };
   }
 
-  const posInStackTiming = stackTiming.callNode.indexOf(selectedCallNodeIndex);
+  const posInStackTiming = stackTiming.callNode.indexOf(zoomedInCallNodeIndex);
   return {
     start: stackTiming.start[posInStackTiming],
     end: stackTiming.end[posInStackTiming],
@@ -236,6 +237,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       maxStackDepthPlusOne,
       rightClickedCallNodeIndex,
       selectedCallNodeIndex,
+      zoomedInCallNodeIndex,
       categories,
       viewport: {
         containerWidth,
@@ -292,27 +294,27 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       maxStackDepthPlusOne - viewportTop / stackFrameHeight
     );
 
-    const selectedOrRootCallNodeTiming = getSelectedOrRootCallNodeTiming(
+    const zoomedInOrRootCallNodeTiming = getZoomedInOrRootCallNodeTiming(
       flameGraphTiming,
       callNodeInfo,
-      selectedCallNodeIndex
+      zoomedInCallNodeIndex
     );
-    // Indicates how much selected call node has "grown" by zooming in,
+    // Indicates how much zoomed in call node has "grown" by zooming in,
     // compared to its original size.
-    // It is 1 when there is no selected call node.
-    const selectedCallNodeGrownRatio =
+    // It is 1 when there is no zoomed in call node.
+    const zoomedInCallNodeGrownRatio =
       1 /
-      (selectedOrRootCallNodeTiming.end - selectedOrRootCallNodeTiming.start);
+      (zoomedInOrRootCallNodeTiming.end - zoomedInOrRootCallNodeTiming.start);
 
-    const selectedCallNodeInclusivePrefixes: IndexIntoCallNodeTable[] | null =
-      selectedCallNodeIndex !== null ? [] : null;
-    if (selectedCallNodeInclusivePrefixes !== null) {
-      let cni = selectedCallNodeIndex!;
+    const zoomedInCallNodeInclusivePrefixes: IndexIntoCallNodeTable[] | null =
+      zoomedInCallNodeIndex !== null ? [] : null;
+    if (zoomedInCallNodeInclusivePrefixes !== null) {
+      let cni = zoomedInCallNodeIndex!;
       do {
-        selectedCallNodeInclusivePrefixes.push(cni);
+        zoomedInCallNodeInclusivePrefixes.push(cni);
         cni = callNodeInfo.prefixForNode(cni);
       } while (cni !== -1);
-      selectedCallNodeInclusivePrefixes.reverse();
+      zoomedInCallNodeInclusivePrefixes.reverse();
     }
 
     // Only draw the stack frames that are vertically within view.
@@ -338,23 +340,23 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
         deviceRowTop + snap(TEXT_OFFSET_TOP * cssToDeviceScale);
 
       const shouldDrawFullWidthBox =
-        selectedCallNodeIndex !== null &&
-        depth <= callNodeInfo.depthForNode(selectedCallNodeIndex);
+        zoomedInCallNodeIndex !== null &&
+        depth <= callNodeInfo.depthForNode(zoomedInCallNodeIndex);
       const startIndex = shouldDrawFullWidthBox
         ? stackTiming.callNode.indexOf(
-            selectedCallNodeInclusivePrefixes![depth]
+            zoomedInCallNodeInclusivePrefixes![depth]
           )
         : stackTiming.end.findIndex(
-            (x) => x > selectedOrRootCallNodeTiming.start
+            (x) => x > zoomedInOrRootCallNodeTiming.start
           );
       const endIndex = shouldDrawFullWidthBox
         ? startIndex + 1
         : findLastIndex(
             stackTiming.start,
-            (x) => x < selectedOrRootCallNodeTiming.end
+            (x) => x < zoomedInOrRootCallNodeTiming.end
           ) + 1;
       if (startIndex === -1 || endIndex === 0) {
-        // There is no box related to the selected one. Skip.
+        // There is no box related to the zoomed in one. Skip.
         continue;
       }
 
@@ -370,15 +372,15 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
 
         const rawBoxLeftFraction = stackTiming.start[i];
         const zoomedInBoxLeftFraction = clamp(
-          (rawBoxLeftFraction - selectedOrRootCallNodeTiming.start) *
-            selectedCallNodeGrownRatio,
+          (rawBoxLeftFraction - zoomedInOrRootCallNodeTiming.start) *
+            zoomedInCallNodeGrownRatio,
           0,
           1
         );
         const rawBoxRightFraction = stackTiming.end[i];
         const zoomedInBoxRightFraction = clamp(
-          (rawBoxRightFraction - selectedOrRootCallNodeTiming.start) *
-            selectedCallNodeGrownRatio,
+          (rawBoxRightFraction - zoomedInOrRootCallNodeTiming.start) *
+            zoomedInCallNodeGrownRatio,
           0,
           1
         );
@@ -581,7 +583,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       callNodeInfo,
       flameGraphTiming,
       maxStackDepthPlusOne,
-      selectedCallNodeIndex,
+      zoomedInCallNodeIndex,
       viewport: { viewportTop, containerWidth },
     } = this.props;
     const pos = x / containerWidth;
@@ -594,30 +596,30 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       return null;
     }
 
-    const selectedOrRootCallNodeTiming = getSelectedOrRootCallNodeTiming(
+    const zoomedInOrRootCallNodeTiming = getZoomedInOrRootCallNodeTiming(
       flameGraphTiming,
       callNodeInfo,
-      selectedCallNodeIndex
+      zoomedInCallNodeIndex
     );
-    // Indicates how much selected call node has "grown" by zooming in,
+    // Indicates how much zoomed in call node has "grown" by zooming in,
     // compared to its original size.
-    // It is 1 when there is no selected call node.
-    const selectedCallNodeGrownRatio =
+    // It is 1 when there is no zoomed in call node.
+    const zoomedInCallNodeGrownRatio =
       1 /
-      (selectedOrRootCallNodeTiming.end - selectedOrRootCallNodeTiming.start);
+      (zoomedInOrRootCallNodeTiming.end - zoomedInOrRootCallNodeTiming.start);
 
     for (let i = 0; i < stackTiming.length; i++) {
       const rawStart = stackTiming.start[i];
       const rawEnd = stackTiming.end[i];
       const zoomedInStart = clamp(
-        (rawStart - selectedOrRootCallNodeTiming.start) *
-          selectedCallNodeGrownRatio,
+        (rawStart - zoomedInOrRootCallNodeTiming.start) *
+          zoomedInCallNodeGrownRatio,
         0,
         1
       );
       const zoomedInEnd = clamp(
-        (rawEnd - selectedOrRootCallNodeTiming.start) *
-          selectedCallNodeGrownRatio,
+        (rawEnd - zoomedInOrRootCallNodeTiming.start) *
+          zoomedInCallNodeGrownRatio,
         0,
         1
       );

--- a/src/components/flame-graph/FlameGraph.tsx
+++ b/src/components/flame-graph/FlameGraph.tsx
@@ -23,6 +23,7 @@ import {
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
 import {
   changeSelectedCallNode,
+  changeZoomedInCallNode,
   changeRightClickedCallNode,
   handleCallNodeTransformShortcut,
   updateBottomBoxContentsAndMaybeOpen,
@@ -79,6 +80,7 @@ type StateProps = {
   readonly callNodeInfo: CallNodeInfo;
   readonly threadsKey: ThreadsKey;
   readonly selectedCallNodeIndex: IndexIntoCallNodeTable | null;
+  readonly zoomedInCallNodeIndex: IndexIntoCallNodeTable | null;
   readonly rightClickedCallNodeIndex: IndexIntoCallNodeTable | null;
   readonly scrollToSelectionGeneration: number;
   readonly categories: CategoryList;
@@ -92,6 +94,7 @@ type StateProps = {
 };
 type DispatchProps = {
   readonly changeSelectedCallNode: typeof changeSelectedCallNode;
+  readonly changeZoomedInCallNode: typeof changeZoomedInCallNode;
   readonly changeRightClickedCallNode: typeof changeRightClickedCallNode;
   readonly handleCallNodeTransformShortcut: typeof handleCallNodeTransformShortcut;
   readonly updateBottomBoxContentsAndMaybeOpen: typeof updateBottomBoxContentsAndMaybeOpen;
@@ -119,9 +122,17 @@ class FlameGraphImpl
   _onSelectedCallNodeChange = (
     callNodeIndex: IndexIntoCallNodeTable | null
   ) => {
-    const { callNodeInfo, threadsKey, changeSelectedCallNode } = this.props;
+    const {
+      callNodeInfo,
+      threadsKey,
+      changeSelectedCallNode,
+      changeZoomedInCallNode,
+    } = this.props;
     changeSelectedCallNode(
       threadsKey,
+      callNodeInfo.getCallNodePathFromIndex(callNodeIndex)
+    );
+    changeZoomedInCallNode(
       callNodeInfo.getCallNodePathFromIndex(callNodeIndex)
     );
   };
@@ -332,6 +343,7 @@ class FlameGraphImpl
       previewSelection,
       rightClickedCallNodeIndex,
       selectedCallNodeIndex,
+      zoomedInCallNodeIndex,
       scrollToSelectionGeneration,
       callTreeSummaryStrategy,
       categories,
@@ -394,6 +406,7 @@ class FlameGraphImpl
               callNodeInfo,
               categories,
               selectedCallNodeIndex,
+              zoomedInCallNodeIndex,
               rightClickedCallNodeIndex,
               scrollToSelectionGeneration,
               callTreeSummaryStrategy,
@@ -446,6 +459,8 @@ export const FlameGraph = explicitConnectWithForwardRef<
     threadsKey: getSelectedThreadsKey(state),
     selectedCallNodeIndex:
       selectedThreadSelectors.getSelectedCallNodeIndex(state),
+    zoomedInCallNodeIndex:
+      selectedThreadSelectors.getZoomedInCallNodeIndex(state),
     rightClickedCallNodeIndex:
       selectedThreadSelectors.getRightClickedCallNodeIndex(state),
     scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
@@ -464,6 +479,7 @@ export const FlameGraph = explicitConnectWithForwardRef<
   }),
   mapDispatchToProps: {
     changeSelectedCallNode,
+    changeZoomedInCallNode,
     changeRightClickedCallNode,
     handleCallNodeTransformShortcut,
     updateBottomBoxContentsAndMaybeOpen,

--- a/src/reducers/url-state.ts
+++ b/src/reducers/url-state.ts
@@ -24,6 +24,7 @@ import type {
   IsOpenPerPanelState,
   TabID,
   SelectedMarkersPerThread,
+  CallNodePath,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -732,6 +733,18 @@ const selectedMarkers: Reducer<SelectedMarkersPerThread> = (
   }
 };
 
+const zoomedInCallNodePath: Reducer<CallNodePath | null> = (
+  state = null,
+  action
+): CallNodePath | null => {
+  switch (action.type) {
+    case 'CHANGE_ZOOMED_IN_CALL_NODE':
+      return action.zoomedInCallNodePath;
+    default:
+      return state;
+  }
+};
+
 /**
  * These values are specific to an individual profile.
  */
@@ -759,6 +772,7 @@ const profileSpecific = combineReducers({
   showJsTracerSummary,
   tabFilter,
   selectedMarkers,
+  zoomedInCallNodePath,
   // The timeline tracks used to be hidden and sorted by thread indexes, rather than
   // track indexes. The only way to migrate this information to tracks-based data is to
   // first retrieve the profile, so they can't be upgraded by the normal url upgrading

--- a/src/selectors/per-thread/stack-sample.ts
+++ b/src/selectors/per-thread/stack-sample.ts
@@ -220,6 +220,23 @@ export function getStackAndSampleSelectorsPerThread(
       }
     );
 
+  const getZoomedInCallNodePath: Selector<CallNodePath | null> = createSelector(
+    UrlState.getZoomedInCallNodePath,
+    (state) => state
+  );
+
+  const getZoomedInCallNodeIndex: Selector<IndexIntoCallNodeTable | null> =
+    createSelector(
+      getCallNodeInfo,
+      getZoomedInCallNodePath,
+      (callNodeInfo, zoomedInCallNodePath) => {
+        if (zoomedInCallNodePath === null) {
+          return null;
+        }
+        return callNodeInfo.getCallNodeIndexFromPath(zoomedInCallNodePath);
+      }
+    );
+
   const getExpandedCallNodePaths: Selector<PathSet> = createSelector(
     threadSelectors.getViewOptions,
     UrlState.getInvertCallstack,
@@ -501,6 +518,8 @@ export function getStackAndSampleSelectorsPerThread(
     getAssemblyViewStackAddressInfo,
     getSelectedCallNodePath,
     getSelectedCallNodeIndex,
+    getZoomedInCallNodePath,
+    getZoomedInCallNodeIndex,
     getExpandedCallNodePaths,
     getExpandedCallNodeIndexes,
     getSampleIndexToNonInvertedCallNodeIndexForFilteredThread,

--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -32,6 +32,7 @@ import type {
   TabID,
   IndexIntoSourceTable,
   MarkerIndex,
+  CallNodePath,
 } from 'firefox-profiler/types';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -124,6 +125,8 @@ export const getSelectedTab: Selector<TabSlug> = (state) =>
 export const getInvertCallstack: Selector<boolean> = (state) =>
   getSelectedTab(state) === 'calltree' &&
   getProfileSpecificState(state).invertCallstack;
+export const getZoomedInCallNodePath: Selector<CallNodePath | null> = (state) =>
+  getProfileSpecificState(state).zoomedInCallNodePath;
 
 export const getSelectedThreadIndexesOrNull: Selector<
   Set<ThreadIndex> | null

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -185,6 +185,10 @@ type ProfileAction =
       readonly context: SelectionContext;
     }
   | {
+      readonly type: 'CHANGE_ZOOMED_IN_CALL_NODE';
+      readonly zoomedInCallNodePath: CallNodePath | null;
+    }
+  | {
       readonly type: 'UPDATE_TRACK_THREAD_HEIGHT';
       readonly height: CssPixels;
       readonly threadsKey: ThreadsKey;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -377,6 +377,7 @@ export type ProfileSpecificUrlState = {
   legacyThreadOrder: ThreadIndex[] | null;
   legacyHiddenThreads: ThreadIndex[] | null;
   selectedMarkers: SelectedMarkersPerThread;
+  zoomedInCallNodePath: CallNodePath | null;
 };
 
 export type UrlState = {


### PR DESCRIPTION
[Production](https://share.firefox.dev/3PhzyEx) | [Deploy preview](https://deploy-preview-5893--perf-html.netlify.app/public/02zdxmc6747mp8pa213g9fzjm4fmkgvx2sskrc0/flame-graph/?globalTrackOrder=ylzcy8ybx9zjyazbygy3jy7ysxuzizvxevmx0xgz8yj1A0ytA3A1yezdzgxqA2x7uxj02wiklnwtx1wx6x8xawxdxfxhxixkwxpxrwxtxvwy2y4wy6y9ycydyfyhyiykymwyryuwz7z9zazezfzhzkwzuA4wA6&hiddenGlobalTracks=0wxsxuwA6&hiddenLocalTracksByPid=368-0w5~44511-013wg~46196-0~569-0~783-0w5~788-0~843-0~848-0w2~9345-0w2&profileName=reliost%20with%20download%2C%20running%20on%20Hetzner%20CPX11%2C%202025-09-06&range=74508m22397~75577m7948&thread=y6&v=15)

Closes #969

You can zoom in/out flame graph by clicking a box(bar).

## Design Questions
### Initial Selection
(Implementation detail: the implementation is based on [selected call node state](https://github.com/firefox-devtools/profiler/blob/3d5a1c1ef72a0182dc7f0b26d0500dc2fcf03562/src/components/flame-graph/FlameGraph.tsx#L447-L448).)
The profiler currently determines initially selected call node using [some heuristics](https://github.com/firefox-devtools/profiler/blob/3d5a1c1ef72a0182dc7f0b26d0500dc2fcf03562/src/components/calltree/CallTree.tsx#L295).
That feature does not only expand call tree, but also set selected call node. The selected call node is shared in tabs, so if you select a call node in call tree tab, it persists in flame graph tab. It means that, if you switch tab to flame graph, what you see is probably unexpected. See below:

**Expected**:
```
[A] [B ]
[C ][D  ] [E][F ]
[G       ][H     ]
[I                ] (root node)
```
**Actual**:
```
[ A          ]
[ C               ] (selected using heuristic)
[ G               ]
[ I               ] (root node)
```
Actually, I experienced this while implementing the feature, and I thought I made a weird bug or there is a bug in state management.
Fixing it to only expand call tree seems desirable to me, although I'm not sure if it is simple as I haven't looked into it closely.

### Click on Background
Currently clicking background of graph deselects boxes(bars), leading to get back to the root, which is annoying IMO. Should we keep it selected even we click background?

## Help Needed
### New color style and its name
It seems that introducing new color style to contrast ascendants with descendants of the selected call node would be good. For your information, "color style" refers to:
https://github.com/firefox-devtools/profiler/blob/3d5a1c1ef72a0182dc7f0b26d0500dc2fcf03562/src/utils/colors.ts#L30-L33
Anyway, the problem is:
- What should it be called?
- I'm not sure what exact color should be used

For name, I'm considering "uninterested":  we zoom in a box(bar), so its ascendants are uninterested at this time.

Comments appreciated!