### PR TITLE
Display download progress bar when loading profiles from URLs

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -836,6 +836,18 @@ ProfileLoaderAnimation--loading-view-not-found = View not found
 
 ProfileRootMessage--title = { -profiler-brand-name }
 ProfileRootMessage--additional = Back to home
+# This string is used as the accessible label for the download progress bar.
+ProfileRootMessage--download-progress-label =
+    .aria-label = Download progress
+# This string is displayed when the total download size is known.
+# Variables:
+#   $receivedSize (String) - Amount of data received so far, e.g. "3.2 MB"
+#   $totalSize (String) - Total download size, e.g. "14.5 MB"
+ProfileRootMessage--download-progress-known = { $receivedSize } / { $totalSize }
+# This string is displayed when the total download size is unknown.
+# Variables:
+#   $receivedSize (String) - Amount of data received so far, e.g. "3.2 MB"
+ProfileRootMessage--download-progress-unknown = { $receivedSize } downloaded
 
 ## Root
 

--- a/src/actions/receive-profile.ts
+++ b/src/actions/receive-profile.ts
@@ -6,6 +6,7 @@ import {
   fetchProfile,
   getProfileUrlForHash,
   type ProfileOrZip,
+  type DownloadProgress,
   deduceContentType,
   extractJsonFromArrayBuffer,
 } from 'firefox-profiler/utils/profile-fetch';
@@ -995,6 +996,30 @@ export function retrieveProfileFromStore(
 }
 
 /**
+ * Create a callback that aggregates download progress across multiple parallel
+ * fetches and dispatches the combined totals. Used for compare-mode downloads.
+ */
+function _makeAggregatedProgressDispatcher(
+  dispatch: (receivedBytes: number, totalBytes: number | null) => void
+): (key: string, progress: DownloadProgress) => void {
+  const progressByKey = new Map<string, DownloadProgress>();
+  return (key: string, progress: DownloadProgress) => {
+    progressByKey.set(key, progress);
+    let receivedBytes = 0;
+    let totalBytes: number | null = 0;
+    for (const p of progressByKey.values()) {
+      receivedBytes += p.receivedBytes;
+      if (totalBytes !== null && p.totalBytes !== null) {
+        totalBytes += p.totalBytes;
+      } else {
+        totalBytes = null;
+      }
+    }
+    dispatch(receivedBytes, totalBytes);
+  };
+}
+
+/**
  * Runs a fetch on a URL, and downloads the file. If it's JSON, then it attempts
  * to process the profile. If it's a zip file, it tries to unzip it, and save it
  * into the store so that the user can then choose which file to load.
@@ -1011,6 +1036,13 @@ export function retrieveProfileOrZipFromUrl(
         url: profileUrl,
         onTemporaryError: (e: TemporaryError) => {
           dispatch(temporaryError(e));
+        },
+        onDownloadProgress: ({ receivedBytes, totalBytes }) => {
+          dispatch({
+            type: 'PROFILE_DOWNLOAD_PROGRESS',
+            receivedBytes,
+            totalBytes,
+          });
         },
       });
 
@@ -1178,6 +1210,16 @@ export function retrieveProfilesToCompare(
   return async (dispatch) => {
     dispatch(waitingForProfileFromUrl());
 
+    const reportAggregatedProgress = _makeAggregatedProgressDispatcher(
+      (receivedBytes, totalBytes) => {
+        dispatch({
+          type: 'PROFILE_DOWNLOAD_PROGRESS',
+          receivedBytes,
+          totalBytes,
+        });
+      }
+    );
+
     try {
       const profilesAndStates = await Promise.all(
         profileViewUrls.map(async (url) => {
@@ -1195,6 +1237,9 @@ export function retrieveProfilesToCompare(
             url: profileUrl,
             onTemporaryError: (e: TemporaryError) => {
               dispatch(temporaryError(e));
+            },
+            onDownloadProgress: (progress: DownloadProgress) => {
+              reportAggregatedProgress(profileUrl, progress);
             },
           });
           if (response.responseType !== 'PROFILE') {

--- a/src/components/app/ProfileLoaderAnimation.tsx
+++ b/src/components/app/ProfileLoaderAnimation.tsx
@@ -65,12 +65,16 @@ class ProfileLoaderAnimationImpl extends PureComponent<ProfileLoaderAnimationPro
       dataSource === 'from-file'
     );
 
+    const downloadProgress =
+      'downloadProgress' in view ? view.downloadProgress : null;
+
     return (
       <Localized id={message} attrs={{ title: true }} elems={{ a: <span /> }}>
         <ProfileRootMessage
           additionalMessage={this._renderAdditionalMessage()}
           showLoader={showLoader}
           showBackHomeLink={showBackHomeLink}
+          downloadProgress={downloadProgress}
         >{`Untranslated ${message}`}</ProfileRootMessage>
       </Localized>
     );

--- a/src/components/app/ProfileRootMessage.css
+++ b/src/components/app/ProfileRootMessage.css
@@ -43,6 +43,56 @@
   font-size: 12px;
 }
 
+.downloadProgress {
+  margin-top: 16px;
+}
+
+.downloadProgressBarTrack {
+  overflow: hidden;
+  height: 8px;
+  border-radius: 4px;
+  background-color: var(--grey-30);
+}
+
+.downloadProgressBarFill {
+  height: 100%;
+  border-radius: 4px;
+  background-color: var(--blue-60);
+  transition: width 150ms ease-out;
+}
+
+.downloadProgressBarFillIndeterminate {
+  width: 30%;
+  height: 100%;
+  border-radius: 4px;
+  animation: indeterminateProgress 1.5s ease-in-out infinite;
+  background-color: var(--blue-60);
+}
+
+@keyframes indeterminateProgress {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(433%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .downloadProgressBarFillIndeterminate {
+    width: 100%;
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
+.downloadProgressText {
+  margin-top: 4px;
+  color: var(--grey-50);
+  font-size: 12px;
+}
+
 .loading {
   position: relative;
   height: 40px;

--- a/src/components/app/ProfileRootMessage.tsx
+++ b/src/components/app/ProfileRootMessage.tsx
@@ -7,18 +7,40 @@ import * as React from 'react';
 
 import './ProfileRootMessage.css';
 
+type DownloadProgressInfo = {
+  readonly receivedBytes: number;
+  readonly totalBytes: number | null;
+};
+
 type Props = {
   readonly title?: string;
   readonly additionalMessage: React.ReactNode;
   readonly showLoader: boolean;
   readonly showBackHomeLink: boolean;
+  readonly downloadProgress?: DownloadProgressInfo | null;
   readonly children: React.ReactNode;
 };
 
+function _formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export class ProfileRootMessage extends React.PureComponent<Props> {
   override render() {
-    const { children, additionalMessage, showLoader, showBackHomeLink, title } =
-      this.props;
+    const {
+      children,
+      additionalMessage,
+      showLoader,
+      showBackHomeLink,
+      downloadProgress,
+      title,
+    } = this.props;
     return (
       <div className="rootMessageContainer">
         <div className="rootMessage">
@@ -29,6 +51,9 @@ export class ProfileRootMessage extends React.PureComponent<Props> {
           <div className="rootMessageText">
             <p>{children}</p>
           </div>
+          {downloadProgress
+            ? this._renderDownloadProgress(downloadProgress)
+            : null}
           {additionalMessage ? (
             <div className="rootMessageAdditional">{additionalMessage}</div>
           ) : null}
@@ -41,7 +66,7 @@ export class ProfileRootMessage extends React.PureComponent<Props> {
               </a>
             </div>
           ) : null}
-          {showLoader ? (
+          {showLoader && !downloadProgress ? (
             <div className="loading">
               <div className="loading-div loading-div-1 loading-row-1" />
               <div className="loading-div loading-div-2 loading-row-2" />
@@ -55,6 +80,65 @@ export class ProfileRootMessage extends React.PureComponent<Props> {
               <div className="loading-div loading-div-10 loading-row-4" />
             </div>
           ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  _renderDownloadProgress(
+    downloadProgress: DownloadProgressInfo
+  ): React.ReactNode {
+    const receivedStr = _formatBytes(downloadProgress.receivedBytes);
+    const progressText = downloadProgress.totalBytes
+      ? `${receivedStr} / ${_formatBytes(downloadProgress.totalBytes)}`
+      : `${receivedStr} downloaded`;
+
+    return (
+      <div className="downloadProgress">
+        <Localized
+          id="ProfileRootMessage--download-progress-label"
+          attrs={{ 'aria-label': true }}
+        >
+          <div
+            className="downloadProgressBarTrack"
+            role="progressbar"
+            aria-valuenow={downloadProgress.receivedBytes}
+            aria-valuemin={0}
+            aria-valuemax={downloadProgress.totalBytes ?? undefined}
+            aria-valuetext={progressText}
+            aria-label="Download progress"
+          >
+            {downloadProgress.totalBytes ? (
+              <div
+                className="downloadProgressBarFill"
+                style={{
+                  width: `${Math.min(100, (downloadProgress.receivedBytes / downloadProgress.totalBytes) * 100)}%`,
+                }}
+              />
+            ) : (
+              <div className="downloadProgressBarFillIndeterminate" />
+            )}
+          </div>
+        </Localized>
+        <div className="downloadProgressText">
+          {downloadProgress.totalBytes ? (
+            <Localized
+              id="ProfileRootMessage--download-progress-known"
+              vars={{
+                receivedSize: receivedStr,
+                totalSize: _formatBytes(downloadProgress.totalBytes),
+              }}
+            >
+              {progressText}
+            </Localized>
+          ) : (
+            <Localized
+              id="ProfileRootMessage--download-progress-unknown"
+              vars={{ receivedSize: receivedStr }}
+            >
+              {progressText}
+            </Localized>
+          )}
         </div>
       </div>
     );

--- a/src/reducers/app.ts
+++ b/src/reducers/app.ts
@@ -34,6 +34,14 @@ const view: Reducer<AppViewState> = (
       };
     case 'FATAL_ERROR':
       return { phase: 'FATAL_ERROR', error: action.error };
+    case 'PROFILE_DOWNLOAD_PROGRESS':
+      return {
+        phase: 'INITIALIZING',
+        downloadProgress: {
+          receivedBytes: action.receivedBytes,
+          totalBytes: action.totalBytes,
+        },
+      };
     case 'WAITING_FOR_PROFILE_FROM_BROWSER':
     case 'WAITING_FOR_PROFILE_FROM_URL':
     case 'WAITING_FOR_PROFILE_FROM_FILE':

--- a/src/test/store/receive-profile.test.ts
+++ b/src/test/store/receive-profile.test.ts
@@ -958,6 +958,12 @@ describe('actions/receive-profile', function () {
             message: errorMessage,
           },
         },
+        expect.objectContaining({
+          phase: 'INITIALIZING',
+          downloadProgress: expect.objectContaining({
+            receivedBytes: expect.any(Number),
+          }),
+        }),
         { phase: 'PROFILE_LOADED' },
         { phase: 'DATA_LOADED' },
       ]);
@@ -1082,6 +1088,12 @@ describe('actions/receive-profile', function () {
             message: errorMessage,
           },
         },
+        expect.objectContaining({
+          phase: 'INITIALIZING',
+          downloadProgress: expect.objectContaining({
+            receivedBytes: expect.any(Number),
+          }),
+        }),
         { phase: 'PROFILE_LOADED' },
         { phase: 'DATA_LOADED' },
       ]);

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -437,6 +437,11 @@ type ReceiveProfileAction =
     }
   | { readonly type: 'TRIGGER_LOADING_FROM_URL'; readonly profileUrl: string }
   | {
+      readonly type: 'PROFILE_DOWNLOAD_PROGRESS';
+      readonly receivedBytes: number;
+      readonly totalBytes: number | null;
+    }
+  | {
       readonly type: 'UPDATE_PAGES';
       readonly newPages: PageList;
     };

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -125,6 +125,10 @@ export type AppViewState =
         readonly attempt: Attempt | null;
         readonly message: string;
       };
+      readonly downloadProgress?: {
+        readonly receivedBytes: number;
+        readonly totalBytes: number | null;
+      };
     };
 
 export type Phase = AppViewState['phase'];

--- a/src/utils/profile-fetch.ts
+++ b/src/utils/profile-fetch.ts
@@ -155,18 +155,16 @@ export async function extractJsonFromArrayBuffer(
 }
 
 /**
- * Don't trust third party responses, try and handle a variety of responses gracefully.
+ * Don't trust third party data, try and handle a variety of inputs gracefully.
  */
-async function _extractJsonFromResponse(
+async function _extractJsonFromBuffer(
+  buffer: ArrayBuffer,
   response: Response,
   reportError: (...data: Array<any>) => void,
   fileType: 'application/json' | null
 ): Promise<unknown> {
-  let arrayBuffer: ArrayBuffer | null = null;
   try {
-    // await before returning so that we can catch JSON parse errors.
-    arrayBuffer = await response.arrayBuffer();
-    return await extractJsonFromArrayBuffer(arrayBuffer);
+    return await extractJsonFromArrayBuffer(buffer);
   } catch (error) {
     // Change the error message depending on the circumstance:
     let message;
@@ -174,10 +172,10 @@ async function _extractJsonFromResponse(
       message = 'The network request to load the profile was aborted.';
     } else if (fileType === 'application/json') {
       message = 'The profile’s JSON could not be decoded.';
-    } else if (fileType === null && arrayBuffer !== null) {
+    } else if (fileType === null) {
       // If the content type is not specified, use a raw array buffer
       // to fallback to other supported profile formats.
-      return arrayBuffer;
+      return buffer;
     } else {
       message = oneLine`
         The profile could not be downloaded and decoded. This does not look like a supported file
@@ -197,14 +195,14 @@ async function _extractJsonFromResponse(
 }
 
 /**
- * Attempt to load a zip file from a third party. This process can fail, so make sure
- * to handle and report the error if it does.
+ * Attempt to load a zip file from a pre-read buffer. This process can fail, so make
+ * sure to handle and report the error if it does.
  */
-async function _extractZipFromResponse(
+async function _extractZipFromBuffer(
+  buffer: ArrayBuffer,
   response: Response,
   reportError: (...data: Array<any>) => void
 ): Promise<JSZip> {
-  const buffer = await response.arrayBuffer();
   // Workaround for https://github.com/Stuk/jszip/issues/941
   // When running this code in tests, `buffer` doesn't inherits from _this_
   // realm's ArrayBuffer object, and this breaks JSZip which doesn't account for
@@ -233,10 +231,11 @@ export type ProfileOrZip =
 
 /**
  * This function guesses the correct content-type (even if one isn't sent) and then
- * attempts to use the proper method to extract the response.
+ * attempts to use the proper method to extract the profile or zip from a pre-read buffer.
  */
-async function _extractProfileOrZipFromResponse(
+async function _extractProfileOrZipFromBuffer(
   url: string,
+  buffer: ArrayBuffer,
   response: Response,
   reportError: (...data: Array<any>) => void
 ): Promise<ProfileOrZip> {
@@ -248,7 +247,7 @@ async function _extractProfileOrZipFromResponse(
     case 'application/zip':
       return {
         responseType: 'ZIP',
-        zip: await _extractZipFromResponse(response, reportError),
+        zip: await _extractZipFromBuffer(buffer, response, reportError),
       };
     case 'application/json':
     case null:
@@ -256,7 +255,8 @@ async function _extractProfileOrZipFromResponse(
       // and try to process it as a profile.
       return {
         responseType: 'PROFILE',
-        profile: await _extractJsonFromResponse(
+        profile: await _extractJsonFromBuffer(
+          buffer,
           response,
           reportError,
           contentType
@@ -267,9 +267,94 @@ async function _extractProfileOrZipFromResponse(
   }
 }
 
+export type DownloadProgress = {
+  receivedBytes: number;
+  totalBytes: number | null;
+};
+
+/**
+ * Read the full response body as an ArrayBuffer, reporting download progress
+ * via the onProgress callback. If the response body is not streamable (e.g. in
+ * older browsers or test environments), falls back to response.arrayBuffer().
+ */
+async function _readResponseWithProgress(
+  response: Response,
+  onProgress?: (progress: DownloadProgress) => void
+): Promise<ArrayBuffer> {
+  if (!onProgress || !response.body) {
+    return response.arrayBuffer();
+  }
+
+  const PROGRESS_THROTTLE_MS = 100;
+  const contentLength = response.headers.get('Content-Length');
+  const totalBytes = contentLength ? parseInt(contentLength, 10) : null;
+  const reader = response.body.getReader();
+
+  const chunks: Uint8Array[] = [];
+  let lastProgressTime = 0;
+  let lastReportedBytes = -1;
+  let receivedBytes = 0;
+
+  // When Content-Length is known and trustworthy, pre-allocate a single buffer
+  // and write directly into it to avoid a 2x memory spike. If the server sends
+  // more data than declared, fall back to chunk accumulation.
+  let preAllocated: Uint8Array | null =
+    totalBytes && totalBytes > 0 ? new Uint8Array(totalBytes) : null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    if (preAllocated) {
+      if (receivedBytes + value.length <= totalBytes!) {
+        preAllocated.set(value, receivedBytes);
+      } else {
+        // Content-Length was wrong; abandon pre-allocated buffer and switch
+        // to chunk accumulation for the rest of the download.
+        chunks.push(preAllocated.slice(0, receivedBytes));
+        chunks.push(value);
+        preAllocated = null;
+      }
+    } else {
+      chunks.push(value);
+    }
+
+    receivedBytes += value.length;
+
+    // Throttle progress callbacks to avoid excessive Redux dispatches.
+    const now = performance.now();
+    if (now - lastProgressTime >= PROGRESS_THROTTLE_MS) {
+      onProgress({ receivedBytes, totalBytes });
+      lastProgressTime = now;
+      lastReportedBytes = receivedBytes;
+    }
+  }
+
+  // Report final progress so the bar reaches 100%, unless we just reported it.
+  if (lastReportedBytes !== receivedBytes) {
+    onProgress({ receivedBytes, totalBytes });
+  }
+
+  if (preAllocated) {
+    return preAllocated.buffer as ArrayBuffer;
+  }
+
+  // Concatenate accumulated chunks.
+  const result = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result.buffer as ArrayBuffer;
+}
+
 export type FetchProfileArgs = {
   url: string;
   onTemporaryError: (param: TemporaryError) => void;
+  onDownloadProgress?: (progress: DownloadProgress) => void;
   // Allow tests to capture the reported error, but normally use console.error.
   reportError?: (...data: Array<any>) => void;
 };
@@ -290,7 +375,7 @@ export async function fetchProfile(
 ): Promise<ProfileOrZip> {
   const MAX_WAIT_SECONDS = 10;
   let i = 0;
-  const { url, onTemporaryError } = args;
+  const { url, onTemporaryError, onDownloadProgress } = args;
   // Allow tests to capture the reported error, but normally use console.error.
   const reportError = args.reportError || console.error;
 
@@ -310,7 +395,11 @@ export async function fetchProfile(
 
     // Case 2: successful answer.
     if (response.ok) {
-      return _extractProfileOrZipFromResponse(url, response, reportError);
+      const buffer = await _readResponseWithProgress(
+        response,
+        onDownloadProgress
+      );
+      return _extractProfileOrZipFromBuffer(url, buffer, response, reportError);
     }
 
     // case 3: unrecoverable error.


### PR DESCRIPTION
This PR adds a download progress bar when loading profiles from URL-based data sources (`from-url`, `public`, and `compare`). Currently the app shows a decorative animation with no indication of actual download progress, which can be confusing when loading large profiles (100+ MB is common).

The fetch path is changed from `response.arrayBuffer()` (which provides no intermediate feedback) to streaming via `response.body.getReader()`, reporting progress through a new `PROFILE_DOWNLOAD_PROGRESS` Redux action. When the server provides a `Content-Length` header, a determinate progress bar with "X MB / Y MB" is shown; otherwise an indeterminate animation with "X MB downloaded" is displayed. In compare mode, progress is aggregated across the parallel downloads into a single bar.

Memory-conscious: when `Content-Length` is known, the response is read directly into a pre-allocated buffer (identical memory footprint to the original `response.arrayBuffer()`). Progress dispatches are throttled to ~10/s to avoid excessive Redux/React overhead. Falls back gracefully to `response.arrayBuffer()` when `response.body` is unavailable.

Accessibility: the progress bar uses `role="progressbar"` with `aria-valuenow`, `aria-valuemax`, `aria-valuetext` (formatted sizes), and a localized `aria-label`. Respects `prefers-reduced-motion: reduce`. All user-visible strings go through Fluent (en-US only, as expected).

🤖 Prepared with Claude Code