### PR TITLE
Dim non-matching nodes in the stack chart when searching

### DIFF
--- a/src/components/stack-chart/Canvas.tsx
+++ b/src/components/stack-chart/Canvas.tsx
@@ -41,6 +41,8 @@ import type {
   Page,
   TimelineUnit,
 } from 'firefox-profiler/types';
+import type { BitSet } from 'firefox-profiler/utils/bitset';
+import { checkBit } from 'firefox-profiler/utils/bitset';
 import type { CallNodeInfo } from 'firefox-profiler/profile-logic/call-node-info';
 
 import type {
@@ -79,7 +81,7 @@ type OwnProps = {
   readonly displayStackType: boolean;
   readonly useStackChartSameWidths: boolean;
   readonly timelineUnit: TimelineUnit;
-  readonly searchStringsRegExp: RegExp | null;
+  readonly searchFilteredFuncMatchesBitSet: BitSet | null;
 };
 
 type Props = Readonly<
@@ -185,7 +187,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       getMarker,
       marginLeft,
       useStackChartSameWidths,
-      searchStringsRegExp,
+      searchFilteredFuncMatchesBitSet,
       viewport: {
         containerWidth,
         containerHeight,
@@ -362,48 +364,6 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
 
     const callNodeTable = callNodeInfo.getCallNodeTable();
 
-    // Pre-compute which call nodes match the search string so we can dim
-    // non-matching nodes when a search is active.
-    let searchMatchedCallNodes: Set<IndexIntoCallNodeTable> | null = null;
-    if (searchStringsRegExp) {
-      searchMatchedCallNodes = new Set();
-      const { funcTable, resourceTable, sources, stringTable } = thread;
-      for (
-        let callNodeIndex = 0;
-        callNodeIndex < callNodeTable.length;
-        callNodeIndex++
-      ) {
-        const funcIndex = callNodeTable.func[callNodeIndex];
-        searchStringsRegExp.lastIndex = 0;
-        const funcName = stringTable.getString(funcTable.name[funcIndex]);
-        if (searchStringsRegExp.test(funcName)) {
-          searchMatchedCallNodes.add(callNodeIndex);
-          continue;
-        }
-
-        const sourceIndex = funcTable.source[funcIndex];
-        if (sourceIndex !== null) {
-          searchStringsRegExp.lastIndex = 0;
-          const fileName = stringTable.getString(sources.filename[sourceIndex]);
-          if (searchStringsRegExp.test(fileName)) {
-            searchMatchedCallNodes.add(callNodeIndex);
-            continue;
-          }
-        }
-
-        const resourceIndex = funcTable.resource[funcIndex];
-        if (resourceIndex !== -1) {
-          searchStringsRegExp.lastIndex = 0;
-          const resourceName = stringTable.getString(
-            resourceTable.name[resourceIndex]
-          );
-          if (searchStringsRegExp.test(resourceName)) {
-            searchMatchedCallNodes.add(callNodeIndex);
-          }
-        }
-      }
-    }
-
     // Only draw the stack frames that are vertically within view.
     for (let depth = startDepth; depth < endDepth; depth++) {
       // Get the timing information for a row of stack frames.
@@ -525,11 +485,11 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
 
         // Look up information about this stack frame.
         let text, category, isSelected;
-        let currentCallNodeIndex: IndexIntoCallNodeTable | null = null;
+        let currentFuncIndex: number | null = null;
         if ('callNode' in stackTiming && stackTiming.callNode) {
           const callNodeIndex = stackTiming.callNode[i];
-          currentCallNodeIndex = callNodeIndex;
           const funcIndex = callNodeTable.func[callNodeIndex];
+          currentFuncIndex = funcIndex;
           const funcNameIndex = thread.funcTable.name[funcIndex];
           text = thread.stringTable.getString(funcNameIndex);
           const categoryIndex = callNodeTable.category[callNodeIndex];
@@ -558,9 +518,9 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
         // so that matching nodes stand out with their category color.
         // Hovered or selected nodes always use their real category color.
         const isDimmed =
-          searchMatchedCallNodes !== null &&
-          currentCallNodeIndex !== null &&
-          !searchMatchedCallNodes.has(currentCallNodeIndex) &&
+          searchFilteredFuncMatchesBitSet !== null &&
+          currentFuncIndex !== null &&
+          !checkBit(searchFilteredFuncMatchesBitSet, currentFuncIndex) &&
           !isHovered &&
           !isSelected;
         const colorStyles = isDimmed

--- a/src/components/stack-chart/Canvas.tsx
+++ b/src/components/stack-chart/Canvas.tsx
@@ -15,6 +15,7 @@ import type { changeMouseTimePosition } from '../../actions/profile-view';
 type ChangeMouseTimePosition = typeof changeMouseTimePosition;
 import {
   mapCategoryColorNameToStackChartStyles,
+  getDimmedStyles,
   getForegroundColor,
   getBackgroundColor,
 } from '../../utils/colors';
@@ -78,6 +79,7 @@ type OwnProps = {
   readonly displayStackType: boolean;
   readonly useStackChartSameWidths: boolean;
   readonly timelineUnit: TimelineUnit;
+  readonly searchStringsRegExp: RegExp | null;
 };
 
 type Props = Readonly<
@@ -183,6 +185,7 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
       getMarker,
       marginLeft,
       useStackChartSameWidths,
+      searchStringsRegExp,
       viewport: {
         containerWidth,
         containerHeight,
@@ -359,6 +362,48 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
 
     const callNodeTable = callNodeInfo.getCallNodeTable();
 
+    // Pre-compute which call nodes match the search string so we can dim
+    // non-matching nodes when a search is active.
+    let searchMatchedCallNodes: Set<IndexIntoCallNodeTable> | null = null;
+    if (searchStringsRegExp) {
+      searchMatchedCallNodes = new Set();
+      const { funcTable, resourceTable, sources, stringTable } = thread;
+      for (
+        let callNodeIndex = 0;
+        callNodeIndex < callNodeTable.length;
+        callNodeIndex++
+      ) {
+        const funcIndex = callNodeTable.func[callNodeIndex];
+        searchStringsRegExp.lastIndex = 0;
+        const funcName = stringTable.getString(funcTable.name[funcIndex]);
+        if (searchStringsRegExp.test(funcName)) {
+          searchMatchedCallNodes.add(callNodeIndex);
+          continue;
+        }
+
+        const sourceIndex = funcTable.source[funcIndex];
+        if (sourceIndex !== null) {
+          searchStringsRegExp.lastIndex = 0;
+          const fileName = stringTable.getString(sources.filename[sourceIndex]);
+          if (searchStringsRegExp.test(fileName)) {
+            searchMatchedCallNodes.add(callNodeIndex);
+            continue;
+          }
+        }
+
+        const resourceIndex = funcTable.resource[funcIndex];
+        if (resourceIndex !== -1) {
+          searchStringsRegExp.lastIndex = 0;
+          const resourceName = stringTable.getString(
+            resourceTable.name[resourceIndex]
+          );
+          if (searchStringsRegExp.test(resourceName)) {
+            searchMatchedCallNodes.add(callNodeIndex);
+          }
+        }
+      }
+    }
+
     // Only draw the stack frames that are vertically within view.
     for (let depth = startDepth; depth < endDepth; depth++) {
       // Get the timing information for a row of stack frames.
@@ -480,8 +525,10 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
 
         // Look up information about this stack frame.
         let text, category, isSelected;
+        let currentCallNodeIndex: IndexIntoCallNodeTable | null = null;
         if ('callNode' in stackTiming && stackTiming.callNode) {
           const callNodeIndex = stackTiming.callNode[i];
+          currentCallNodeIndex = callNodeIndex;
           const funcIndex = callNodeTable.func[callNodeIndex];
           const funcNameIndex = thread.funcTable.name[funcIndex];
           text = thread.stringTable.getString(funcNameIndex);
@@ -507,9 +554,19 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
           depth === hoveredItem.depth &&
           i === hoveredItem.stackTimingIndex;
 
-        const colorStyles = mapCategoryColorNameToStackChartStyles(
-          category.color
-        );
+        // When a search is active, use the dimmed style for non-matching nodes
+        // so that matching nodes stand out with their category color.
+        // Hovered or selected nodes always use their real category color.
+        const isDimmed =
+          searchMatchedCallNodes !== null &&
+          currentCallNodeIndex !== null &&
+          !searchMatchedCallNodes.has(currentCallNodeIndex) &&
+          !isHovered &&
+          !isSelected;
+        const colorStyles = isDimmed
+          ? getDimmedStyles()
+          : mapCategoryColorNameToStackChartStyles(category.color);
+
         // Draw the box.
         fastFillStyle.set(
           isHovered || isSelected
@@ -542,11 +599,11 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
         if (textW > textMeasurement.minWidth) {
           const fittedText = textMeasurement.getFittedText(text, textW);
           if (fittedText) {
-            fastFillStyle.set(
-              isHovered || isSelected
-                ? colorStyles.getSelectedTextColor()
-                : getForegroundColor()
-            );
+            if (isHovered || isSelected || isDimmed) {
+              fastFillStyle.set(colorStyles.getSelectedTextColor());
+            } else {
+              fastFillStyle.set(getForegroundColor());
+            }
             ctx.fillText(fittedText, textX, intY + textDevicePixelsOffsetTop);
           }
         }

--- a/src/components/stack-chart/index.tsx
+++ b/src/components/stack-chart/index.tsx
@@ -23,6 +23,7 @@ import {
   getStackChartSameWidths,
   getShowUserTimings,
   getSelectedThreadsKey,
+  getSearchStringsAsRegExp,
 } from 'firefox-profiler/selectors/url-state';
 import type { SameWidthsIndexToTimestampMap } from 'firefox-profiler/profile-logic/stack-timing';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
@@ -87,6 +88,7 @@ type StateProps = {
   readonly hasFilteredCtssSamples: boolean;
   readonly useStackChartSameWidths: boolean;
   readonly timelineUnit: TimelineUnit;
+  readonly searchStringsRegExp: RegExp | null;
 };
 
 type DispatchProps = {
@@ -244,6 +246,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       hasFilteredCtssSamples,
       useStackChartSameWidths,
       timelineUnit,
+      searchStringsRegExp,
     } = this.props;
 
     const maxViewportHeight = combinedTimingRows.length * STACK_FRAME_HEIGHT;
@@ -304,6 +307,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   displayStackType: displayStackType,
                   useStackChartSameWidths,
                   timelineUnit,
+                  searchStringsRegExp,
                 }}
               />
             </div>
@@ -347,6 +351,7 @@ export const StackChart = explicitConnect<{}, StateProps, DispatchProps>({
         selectedThreadSelectors.getHasFilteredCtssSamples(state),
       useStackChartSameWidths: getStackChartSameWidths(state),
       timelineUnit: getProfileTimelineUnit(state),
+      searchStringsRegExp: getSearchStringsAsRegExp(state),
     };
   },
   mapDispatchToProps: {

--- a/src/components/stack-chart/index.tsx
+++ b/src/components/stack-chart/index.tsx
@@ -23,7 +23,6 @@ import {
   getStackChartSameWidths,
   getShowUserTimings,
   getSelectedThreadsKey,
-  getSearchStringsAsRegExp,
 } from 'firefox-profiler/selectors/url-state';
 import type { SameWidthsIndexToTimestampMap } from 'firefox-profiler/profile-logic/stack-timing';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
@@ -59,6 +58,7 @@ import type {
   Page,
   TimelineUnit,
 } from 'firefox-profiler/types';
+import type { BitSet } from 'firefox-profiler/utils/bitset';
 import type { CallNodeInfo } from 'firefox-profiler/profile-logic/call-node-info';
 
 import type { ConnectedProps } from '../../utils/connect';
@@ -88,7 +88,7 @@ type StateProps = {
   readonly hasFilteredCtssSamples: boolean;
   readonly useStackChartSameWidths: boolean;
   readonly timelineUnit: TimelineUnit;
-  readonly searchStringsRegExp: RegExp | null;
+  readonly searchFilteredFuncMatchesBitSet: BitSet | null;
 };
 
 type DispatchProps = {
@@ -246,7 +246,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       hasFilteredCtssSamples,
       useStackChartSameWidths,
       timelineUnit,
-      searchStringsRegExp,
+      searchFilteredFuncMatchesBitSet,
     } = this.props;
 
     const maxViewportHeight = combinedTimingRows.length * STACK_FRAME_HEIGHT;
@@ -307,7 +307,7 @@ class StackChartImpl extends React.PureComponent<Props> {
                   displayStackType: displayStackType,
                   useStackChartSameWidths,
                   timelineUnit,
-                  searchStringsRegExp,
+                  searchFilteredFuncMatchesBitSet,
                 }}
               />
             </div>
@@ -351,7 +351,8 @@ export const StackChart = explicitConnect<{}, StateProps, DispatchProps>({
         selectedThreadSelectors.getHasFilteredCtssSamples(state),
       useStackChartSameWidths: getStackChartSameWidths(state),
       timelineUnit: getProfileTimelineUnit(state),
-      searchStringsRegExp: getSearchStringsAsRegExp(state),
+      searchFilteredFuncMatchesBitSet:
+        selectedThreadSelectors.getSearchFilteredFuncMatchesBitSet(state),
     };
   },
   mapDispatchToProps: {

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -28,6 +28,7 @@ import {
   type BitSet,
   checkBit,
   combineTwoBitSetsWithAnd,
+  combineTwoBitSetsWithOr,
   makeBitSet,
   setBit,
 } from 'firefox-profiler/utils/bitset';
@@ -1720,7 +1721,22 @@ export function applyTransformOutputToThread(
   });
 }
 
-export function computeTransformOutputForSearchStringFilter(
+/**
+ * Output of the search string filter: both the filter's TransformOutput (used
+ * to drop non-matching stacks) and the combined func bitset (used to highlight
+ * matching nodes in the stack chart). Exposed together so both are computed
+ * once and memoized together.
+ *
+ * Stacks are AND-combined across search strings (a stack is kept only if it
+ * contains a match for every search string), while funcs are OR-combined (a
+ * func is highlighted if it matches any of the search strings).
+ */
+export type SearchStringFilterOutput = {
+  transformOutput: TransformOutput;
+  funcMatches: BitSet | null;
+};
+
+export function computeSearchStringFilterOutput(
   stackTable: StackTable,
   frameTable: FrameTable,
   funcTable: FuncTable,
@@ -1728,44 +1744,51 @@ export function computeTransformOutputForSearchStringFilter(
   sources: SourceTable,
   stringTable: StringTable,
   searchStrings: string[] | null
-): TransformOutput {
-  return timeCode('computeTransformOutputForSearchStringFilter', () => {
-    if (!searchStrings) {
-      return { newStackTable: stackTable, effectOnThreadData: {} };
+): SearchStringFilterOutput {
+  return timeCode('computeSearchStringFilterOutput', () => {
+    const nonEmptySearchStrings = searchStrings
+      ? searchStrings.filter((s) => s)
+      : [];
+    if (nonEmptySearchStrings.length === 0) {
+      return {
+        transformOutput: { newStackTable: stackTable, effectOnThreadData: {} },
+        funcMatches: null,
+      };
     }
 
-    const stackMatchesAllSearchStrings = searchStrings
-      .filter((s) => s)
-      .reduce(
-        (
-          stackMatchesPreviousSearchStrings: BitSet | undefined,
-          searchString: string
-        ) => {
-          const stackMatchesThisString = _computeStackMatchesSearchString(
-            stackTable,
-            frameTable,
-            funcTable,
-            resourceTable,
-            sources,
-            stringTable,
-            searchString
-          );
-          if (stackMatchesPreviousSearchStrings !== undefined) {
-            return combineTwoBitSetsWithAnd(
-              stackMatchesThisString,
-              stackMatchesPreviousSearchStrings
-            );
-          }
-          return stackMatchesThisString;
-        },
-        undefined
+    let combinedFuncMatches: BitSet | undefined;
+    let combinedStackMatches: BitSet | undefined;
+    for (const searchString of nonEmptySearchStrings) {
+      const funcMatches = computeFuncMatchesSearchString(
+        funcTable,
+        resourceTable,
+        sources,
+        stringTable,
+        searchString
       );
+      const stackMatches = _computeStackMatchesFromFuncMatches(
+        stackTable,
+        frameTable,
+        funcMatches
+      );
+      combinedFuncMatches =
+        combinedFuncMatches === undefined
+          ? funcMatches
+          : combineTwoBitSetsWithOr(funcMatches, combinedFuncMatches);
+      combinedStackMatches =
+        combinedStackMatches === undefined
+          ? stackMatches
+          : combineTwoBitSetsWithAnd(stackMatches, combinedStackMatches);
+    }
 
     return {
-      newStackTable: stackTable,
-      effectOnThreadData: {
-        dropIfOldStackIsNot: stackMatchesAllSearchStrings,
+      transformOutput: {
+        newStackTable: stackTable,
+        effectOnThreadData: {
+          dropIfOldStackIsNot: combinedStackMatches,
+        },
       },
+      funcMatches: combinedFuncMatches ?? null,
     };
   });
 }
@@ -1821,23 +1844,11 @@ export function computeFuncMatchesSearchString(
   return funcMatchesSearch;
 }
 
-function _computeStackMatchesSearchString(
+function _computeStackMatchesFromFuncMatches(
   stackTable: StackTable,
   frameTable: FrameTable,
-  funcTable: FuncTable,
-  resourceTable: ResourceTable,
-  sources: SourceTable,
-  stringTable: StringTable,
-  searchString: string
+  funcMatchesSearch: BitSet
 ): BitSet {
-  const funcMatchesSearch = computeFuncMatchesSearchString(
-    funcTable,
-    resourceTable,
-    sources,
-    stringTable,
-    searchString
-  );
-
   const stackMatchesSearch = makeBitSet(stackTable.length);
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
     const prefix = stackTable.prefix[stackIndex];

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -1770,9 +1770,12 @@ export function computeTransformOutputForSearchStringFilter(
   });
 }
 
-function _computeStackMatchesSearchString(
-  stackTable: StackTable,
-  frameTable: FrameTable,
+/**
+ * Compute a BitSet of functions whose name, source filename, or resource name
+ * matches the given search string. This is used both for filtering stacks and
+ * for dimming non-matching nodes in the stack chart.
+ */
+export function computeFuncMatchesSearchString(
   funcTable: FuncTable,
   resourceTable: ResourceTable,
   sources: SourceTable,
@@ -1815,6 +1818,25 @@ function _computeStackMatchesSearchString(
       setBit(funcMatchesSearch, funcIndex);
     }
   }
+  return funcMatchesSearch;
+}
+
+function _computeStackMatchesSearchString(
+  stackTable: StackTable,
+  frameTable: FrameTable,
+  funcTable: FuncTable,
+  resourceTable: ResourceTable,
+  sources: SourceTable,
+  stringTable: StringTable,
+  searchString: string
+): BitSet {
+  const funcMatchesSearch = computeFuncMatchesSearchString(
+    funcTable,
+    resourceTable,
+    sources,
+    stringTable,
+    searchString
+  );
 
   const stackMatchesSearch = makeBitSet(stackTable.length);
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -1733,7 +1733,7 @@ export function applyTransformOutputToThread(
  */
 export type SearchStringFilterOutput = {
   transformOutput: TransformOutput;
-  funcMatches: BitSet | null;
+  funcMatchesSearchStrings: BitSet | null;
 };
 
 export function computeSearchStringFilterOutput(
@@ -1746,19 +1746,14 @@ export function computeSearchStringFilterOutput(
   searchStrings: string[] | null
 ): SearchStringFilterOutput {
   return timeCode('computeSearchStringFilterOutput', () => {
-    const nonEmptySearchStrings = searchStrings
-      ? searchStrings.filter((s) => s)
-      : [];
-    if (nonEmptySearchStrings.length === 0) {
+    if (!searchStrings || searchStrings.length === 0) {
       return {
         transformOutput: { newStackTable: stackTable, effectOnThreadData: {} },
-        funcMatches: null,
+        funcMatchesSearchStrings: null,
       };
     }
 
-    let combinedFuncMatches: BitSet | undefined;
-    let combinedStackMatches: BitSet | undefined;
-    for (const searchString of nonEmptySearchStrings) {
+    const computeMatchesForString = (searchString: string) => {
       const funcMatches = computeFuncMatchesSearchString(
         funcTable,
         resourceTable,
@@ -1771,14 +1766,25 @@ export function computeSearchStringFilterOutput(
         frameTable,
         funcMatches
       );
-      combinedFuncMatches =
-        combinedFuncMatches === undefined
-          ? funcMatches
-          : combineTwoBitSetsWithOr(funcMatches, combinedFuncMatches);
-      combinedStackMatches =
-        combinedStackMatches === undefined
-          ? stackMatches
-          : combineTwoBitSetsWithAnd(stackMatches, combinedStackMatches);
+      return { funcMatches, stackMatches };
+    };
+
+    let {
+      funcMatches: combinedFuncMatches,
+      stackMatches: combinedStackMatches,
+    } = computeMatchesForString(searchStrings[0]);
+    for (let i = 1; i < searchStrings.length; i++) {
+      const { funcMatches, stackMatches } = computeMatchesForString(
+        searchStrings[i]
+      );
+      combinedFuncMatches = combineTwoBitSetsWithOr(
+        funcMatches,
+        combinedFuncMatches
+      );
+      combinedStackMatches = combineTwoBitSetsWithAnd(
+        stackMatches,
+        combinedStackMatches
+      );
     }
 
     return {
@@ -1788,7 +1794,7 @@ export function computeSearchStringFilterOutput(
           dropIfOldStackIsNot: combinedStackMatches,
         },
       },
-      funcMatches: combinedFuncMatches ?? null,
+      funcMatchesSearchStrings: combinedFuncMatches,
     };
   });
 }

--- a/src/selectors/per-thread/thread.tsx
+++ b/src/selectors/per-thread/thread.tsx
@@ -46,6 +46,7 @@ import type {
 } from 'firefox-profiler/types';
 
 import type { TransformLabeL10nIds } from 'firefox-profiler/profile-logic/transforms';
+import type { BitSet } from 'firefox-profiler/utils/bitset';
 import type { MarkerSelectorsPerThread } from './markers';
 
 import { mergeThreads } from '../../profile-logic/merge-compare';
@@ -64,6 +65,12 @@ const globallyMemoizedComputeTransformOutputForImplementationFilter = memoize(
 );
 const globallyMemoizedComputeTransformOutputForSearchStringFilter = memoize(
   ProfileData.computeTransformOutputForSearchStringFilter,
+  {
+    limit: 2,
+  }
+);
+const globallyMemoizedComputeFuncMatchesSearchString = memoize(
+  ProfileData.computeFuncMatchesSearchString,
   {
     limit: 2,
   }
@@ -507,6 +514,51 @@ export function getThreadSelectorsWithMarkersPerThread(
     }
   );
 
+  /**
+   * Get a BitSet of func indices that match the current search strings.
+   * Returns null when there is no active search. This is used by the stack
+   * chart to dim non-matching nodes without recomputing on every draw call.
+   */
+  const getSearchFilteredFuncMatchesBitSet: Selector<BitSet | null> =
+    createSelector(
+      _getImplementationFilteredThread,
+      UrlState.getSearchStrings,
+      (thread: Thread, searchStrings): BitSet | null => {
+        const nonEmptySearchStrings = searchStrings
+          ? searchStrings.filter((s) => s)
+          : [];
+        if (nonEmptySearchStrings.length === 0) {
+          return null;
+        }
+        // Compute a BitSet per search string and AND them together.
+        let combined: BitSet = globallyMemoizedComputeFuncMatchesSearchString(
+          thread.funcTable,
+          thread.resourceTable,
+          thread.sources,
+          thread.stringTable,
+          nonEmptySearchStrings[0]
+        );
+        for (let i = 1; i < nonEmptySearchStrings.length; i++) {
+          const matches = globallyMemoizedComputeFuncMatchesSearchString(
+            thread.funcTable,
+            thread.resourceTable,
+            thread.sources,
+            thread.stringTable,
+            nonEmptySearchStrings[i]
+          );
+          if (i === 1) {
+            // Copy before mutating so we don't modify the memoized result.
+            combined = new Int32Array(combined);
+          }
+          // AND with previous results — a func must match all strings.
+          for (let j = 0; j < combined.length; j++) {
+            combined[j] &= matches[j];
+          }
+        }
+        return combined;
+      }
+    );
+
   const getPreviewFilteredThread: Selector<Thread> = createSelector(
     getFilteredThread,
     ProfileSelectors.getPreviewSelection,
@@ -613,6 +665,7 @@ export function getThreadSelectorsWithMarkersPerThread(
     getTransformStack,
     getRangeAndTransformFilteredThread,
     getFilteredThread,
+    getSearchFilteredFuncMatchesBitSet,
     getPreviewFilteredThread,
     getFilteredCtssSamples,
     getPreviewFilteredCtssSamples,

--- a/src/selectors/per-thread/thread.tsx
+++ b/src/selectors/per-thread/thread.tsx
@@ -523,7 +523,7 @@ export function getThreadSelectorsWithMarkersPerThread(
    * chart to dim non-matching nodes without recomputing on every draw call.
    */
   const getSearchFilteredFuncMatchesBitSet: Selector<BitSet | null> = (state) =>
-    _getSearchStringFilterOutput(state).funcMatches;
+    _getSearchStringFilterOutput(state).funcMatchesSearchStrings;
 
   const getPreviewFilteredThread: Selector<Thread> = createSelector(
     getFilteredThread,

--- a/src/selectors/per-thread/thread.tsx
+++ b/src/selectors/per-thread/thread.tsx
@@ -63,14 +63,8 @@ const globallyMemoizedComputeTransformOutputForImplementationFilter = memoize(
     limit: 2,
   }
 );
-const globallyMemoizedComputeTransformOutputForSearchStringFilter = memoize(
-  ProfileData.computeTransformOutputForSearchStringFilter,
-  {
-    limit: 2,
-  }
-);
-const globallyMemoizedComputeFuncMatchesSearchString = memoize(
-  ProfileData.computeFuncMatchesSearchString,
+const globallyMemoizedComputeSearchStringFilterOutput = memoize(
+  ProfileData.computeSearchStringFilterOutput,
   {
     limit: 2,
   }
@@ -495,13 +489,17 @@ export function getThreadSelectorsWithMarkersPerThread(
     }
   );
 
-  const getFilteredThread: Selector<Thread> = createSelector(
-    _getImplementationFilteredThread,
-    UrlState.getSearchStrings,
-    (thread: Thread, searchStrings) => {
-      // Apply the search string filter.
-      const transformOutput =
-        globallyMemoizedComputeTransformOutputForSearchStringFilter(
+  /**
+   * Single memoized computation of the search string filter, shared by
+   * `getFilteredThread` (which needs the stack-drop bitset) and
+   * `getSearchFilteredFuncMatchesBitSet` (which needs the func-match bitset).
+   */
+  const _getSearchStringFilterOutput: Selector<ProfileData.SearchStringFilterOutput> =
+    createSelector(
+      _getImplementationFilteredThread,
+      UrlState.getSearchStrings,
+      (thread: Thread, searchStrings) =>
+        globallyMemoizedComputeSearchStringFilterOutput(
           thread.stackTable,
           thread.frameTable,
           thread.funcTable,
@@ -509,9 +507,14 @@ export function getThreadSelectorsWithMarkersPerThread(
           thread.sources,
           thread.stringTable,
           searchStrings
-        );
-      return ProfileData.applyTransformOutputToThread(transformOutput, thread);
-    }
+        )
+    );
+
+  const getFilteredThread: Selector<Thread> = createSelector(
+    _getImplementationFilteredThread,
+    _getSearchStringFilterOutput,
+    (thread: Thread, { transformOutput }) =>
+      ProfileData.applyTransformOutputToThread(transformOutput, thread)
   );
 
   /**
@@ -519,45 +522,8 @@ export function getThreadSelectorsWithMarkersPerThread(
    * Returns null when there is no active search. This is used by the stack
    * chart to dim non-matching nodes without recomputing on every draw call.
    */
-  const getSearchFilteredFuncMatchesBitSet: Selector<BitSet | null> =
-    createSelector(
-      _getImplementationFilteredThread,
-      UrlState.getSearchStrings,
-      (thread: Thread, searchStrings): BitSet | null => {
-        const nonEmptySearchStrings = searchStrings
-          ? searchStrings.filter((s) => s)
-          : [];
-        if (nonEmptySearchStrings.length === 0) {
-          return null;
-        }
-        // Compute a BitSet per search string and AND them together.
-        let combined: BitSet = globallyMemoizedComputeFuncMatchesSearchString(
-          thread.funcTable,
-          thread.resourceTable,
-          thread.sources,
-          thread.stringTable,
-          nonEmptySearchStrings[0]
-        );
-        for (let i = 1; i < nonEmptySearchStrings.length; i++) {
-          const matches = globallyMemoizedComputeFuncMatchesSearchString(
-            thread.funcTable,
-            thread.resourceTable,
-            thread.sources,
-            thread.stringTable,
-            nonEmptySearchStrings[i]
-          );
-          if (i === 1) {
-            // Copy before mutating so we don't modify the memoized result.
-            combined = new Int32Array(combined);
-          }
-          // AND with previous results — a func must match all strings.
-          for (let j = 0; j < combined.length; j++) {
-            combined[j] &= matches[j];
-          }
-        }
-        return combined;
-      }
-    );
+  const getSearchFilteredFuncMatchesBitSet: Selector<BitSet | null> = (state) =>
+    _getSearchStringFilterOutput(state).funcMatches;
 
   const getPreviewFilteredThread: Selector<Thread> = createSelector(
     getFilteredThread,

--- a/src/test/components/StackChart.test.tsx
+++ b/src/test/components/StackChart.test.tsx
@@ -33,6 +33,7 @@ import {
   changeImplementationFilter,
   changeCallTreeSummaryStrategy,
   updatePreviewSelection,
+  changeCallTreeSearchString,
 } from '../../actions/profile-view';
 import { changeSelectedTab } from '../../actions/app';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
@@ -269,6 +270,56 @@ describe('StackChart', function () {
     drawnFrames = getDrawnFrames();
     expect(drawnFrames).toContain('A');
     expect(drawnFrames).not.toContain('Z');
+  });
+
+  it('dims non-matching boxes when searching', function () {
+    const { dispatch, flushRafCalls } = setupSamples();
+    flushDrawLog();
+
+    // Dispatch a search string that matches some function names.
+    act(() => {
+      dispatch(changeCallTreeSearchString('B'));
+    });
+    flushRafCalls();
+
+    const drawCalls = flushDrawLog();
+
+    // Non-matching boxes should be drawn with the dimmed style.
+    const dimmedFillCalls = drawCalls.filter(
+      ([fn, value]) => fn === 'set fillStyle' && value === '#f9f9fa'
+    );
+    expect(dimmedFillCalls.length).toBeGreaterThan(0);
+  });
+
+  it('does not dim boxes that match the search string', function () {
+    // Use a single-node call stack so there is exactly one box.
+    const { dispatch, flushRafCalls } = setupSamples(`
+      A[cat:DOM]
+    `);
+    flushDrawLog();
+
+    // Search for "A" — the only node matches, so nothing should be dimmed.
+    act(() => {
+      dispatch(changeCallTreeSearchString('A'));
+    });
+    flushRafCalls();
+
+    const drawCalls = flushDrawLog();
+    const dimmedFillCalls = drawCalls.filter(
+      ([fn, value]) => fn === 'set fillStyle' && value === '#f9f9fa'
+    );
+    expect(dimmedFillCalls).toHaveLength(0);
+  });
+
+  it('does not dim any boxes when there is no search string', function () {
+    setupSamples();
+    const drawCalls = flushDrawLog();
+
+    // No dimmed fill should be applied without a search.
+    const dimmedFillCalls = drawCalls.filter(
+      ([fn, value]) => fn === 'set fillStyle' && value === '#f9f9fa'
+    );
+    expect(dimmedFillCalls).toHaveLength(0);
   });
 
   describe('EmptyReasons', () => {

--- a/src/test/fixtures/mocks/canvas-context.ts
+++ b/src/test/fixtures/mocks/canvas-context.ts
@@ -35,6 +35,7 @@ export type SetFillStyleOperation = ['set fillStyle', string];
 export type FillRectOperation = ['fillRect', number, number, number, number];
 export type ClearRectOperation = ['clearRect', number, number, number, number];
 export type FillTextOperation = ['fillText', string];
+
 export type DrawOperation =
   | BeginPathOperation
   | MoveToOperation

--- a/src/test/fixtures/mocks/canvas-context.ts
+++ b/src/test/fixtures/mocks/canvas-context.ts
@@ -35,7 +35,6 @@ export type SetFillStyleOperation = ['set fillStyle', string];
 export type FillRectOperation = ['fillRect', number, number, number, number];
 export type ClearRectOperation = ['clearRect', number, number, number, number];
 export type FillTextOperation = ['fillText', string];
-
 export type DrawOperation =
   | BeginPathOperation
   | MoveToOperation

--- a/src/test/store/profile-view.test.ts
+++ b/src/test/store/profile-view.test.ts
@@ -48,6 +48,7 @@ import {
   type BreakdownByCategory,
 } from '../../profile-logic/profile-data';
 import { getSelfAndTotalForCallNode } from '../../profile-logic/call-tree';
+import { checkBit } from '../../utils/bitset';
 
 import type {
   TrackReference,
@@ -919,6 +920,91 @@ describe('actions/ProfileView', function () {
         '      - D (total: 1, self: 1)',
         '- D (total: 1, self: 1)',
       ]);
+    });
+  });
+
+  /**
+   * Covers the bitset returned by `getSearchFilteredFuncMatchesBitSet`, which
+   * the stack chart uses to dim non-matching nodes. The stack filter above
+   * only exercises whether each stack is kept; these tests pin down the
+   * per-func match semantics across name, filename, and library fields, and
+   * the OR semantics when multiple search strings are provided.
+   */
+  describe('getSearchFilteredFuncMatchesBitSet', function () {
+    // Each func's three searchable fields (name, resource/lib, filename) use
+    // distinct prefixes ("fn", "rs", "sc") and a unique per-func index, so
+    // every search string used below appears in exactly one field on exactly
+    // one func. That lets us assert unambiguously which field triggered a
+    // match.
+    function setup() {
+      const {
+        profile,
+        funcNamesPerThread: [funcNames],
+      } = getProfileFromTextSamples(`
+        fn1[lib:rs1][file:sc1]  fn2[lib:rs2][file:sc2]  fn3[lib:rs3][file:sc3]
+        fn4[lib:rs4][file:sc4]
+      `);
+      const { dispatch, getState } = storeWithProfile(profile);
+      return { dispatch, getState, funcNames };
+    }
+
+    function getMatchingFuncNames(
+      getState: () => any,
+      funcNames: string[]
+    ): string[] {
+      const bitSet =
+        selectedThreadSelectors.getSearchFilteredFuncMatchesBitSet(getState());
+      if (bitSet === null) {
+        return [];
+      }
+      const matched: string[] = [];
+      for (let i = 0; i < funcNames.length; i++) {
+        if (checkBit(bitSet, i)) {
+          matched.push(funcNames[i]);
+        }
+      }
+      return matched.sort();
+    }
+
+    it('returns null when there is no active search', function () {
+      const { getState } = setup();
+      expect(
+        selectedThreadSelectors.getSearchFilteredFuncMatchesBitSet(getState())
+      ).toBeNull();
+    });
+
+    it('matches a single func by its name', function () {
+      const { dispatch, getState, funcNames } = setup();
+      dispatch(ProfileView.changeCallTreeSearchString('fn1'));
+      expect(getMatchingFuncNames(getState, funcNames)).toEqual(['fn1']);
+    });
+
+    it('matches a func by its filename', function () {
+      const { dispatch, getState, funcNames } = setup();
+      // sc2 is only set on fn2.
+      dispatch(ProfileView.changeCallTreeSearchString('sc2'));
+      expect(getMatchingFuncNames(getState, funcNames)).toEqual(['fn2']);
+    });
+
+    it('matches a func by its resource/library name', function () {
+      const { dispatch, getState, funcNames } = setup();
+      // rs3 is only set on fn3. Match is case-insensitive.
+      dispatch(ProfileView.changeCallTreeSearchString('RS3'));
+      expect(getMatchingFuncNames(getState, funcNames)).toEqual(['fn3']);
+    });
+
+    it('matches every func matching any of several search strings (OR)', function () {
+      const { dispatch, getState, funcNames } = setup();
+      // "fn1" matches only func fn1; "fn3" matches only func fn3.
+      dispatch(ProfileView.changeCallTreeSearchString('fn1,fn3'));
+      expect(getMatchingFuncNames(getState, funcNames)).toEqual(['fn1', 'fn3']);
+    });
+
+    it('combines matches across different fields with OR', function () {
+      const { dispatch, getState, funcNames } = setup();
+      // "sc1" matches fn1 by filename; "rs4" matches fn4 by lib name.
+      dispatch(ProfileView.changeCallTreeSearchString('sc1,rs4'));
+      expect(getMatchingFuncNames(getState, funcNames)).toEqual(['fn1', 'fn4']);
     });
   });
 

--- a/src/utils/bitset.ts
+++ b/src/utils/bitset.ts
@@ -54,6 +54,15 @@ export function combineTwoBitSetsWithAnd(a: BitSet, b: BitSet): BitSet {
   return result;
 }
 
+export function combineTwoBitSetsWithOr(a: BitSet, b: BitSet): BitSet {
+  const slotCount = a.length;
+  const result = new Int32Array(slotCount);
+  for (let i = 0; i < slotCount; i++) {
+    result[i] = a[i] | b[i];
+  }
+  return result;
+}
+
 export class BitSetOutOfBoundsError extends Error {
   override name = 'BitSetOutOfBoundsError';
   bitIndex: number;

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -10,12 +10,14 @@ import {
   GREEN_50,
   GREEN_60,
   GREEN_70,
+  GREY_10,
   GREY_20,
   GREY_30,
   GREY_40,
   GREY_50,
   GREY_60,
   GREY_70,
+  GREY_80,
   MAGENTA_60,
   MAGENTA_70,
   ORANGE_50,
@@ -207,6 +209,23 @@ export function mapCategoryColorNameToStackChartStyles(
     return PSEUDO_TRANSPARENT_STYLE;
   }
   return mapCategoryColorNameToStyles(colorName);
+}
+
+/**
+ * A neutral style used to dim non-matching nodes in the stack chart when a
+ * search filter is active. Closer to the background than any category color
+ * so that matching nodes stand out clearly.
+ */
+const DIMMED_STYLE: ColorStyles = {
+  ...DEFAULT_STYLE,
+  _selectedFillStyle: [GREY_10, GREY_80],
+  _unselectedFillStyle: [GREY_10, GREY_80],
+  _selectedTextColor: [GREY_50, GREY_40],
+  gravity: 0,
+};
+
+export function getDimmedStyles(): ColorStyles {
+  return DIMMED_STYLE;
 }
 
 export function getForegroundColor(): string {


### PR DESCRIPTION
Closes #1818.

When the search box is active, the stack chart now dims funcs that don't
match the search, making hits visually scannable without losing the
surrounding context. Matching is OR-combined across comma-separated
search strings (a func is highlighted if any term matches its name,
filename, or library), while the existing stack-drop behavior keeps its
AND semantics.

The match computation lives in a memoized selector
(computeSearchStringFilterOutput) that returns both the stack-drop
TransformOutput and a combined func-match BitSet, shared between
getFilteredThread and getSearchFilteredFuncMatchesBitSet. The canvas
draw loop does a single checkBit lookup per node instead of rebuilding
a Set and re-running string matching on every frame.


[This is the profile](https://deploy-preview-5935--perf-html.netlify.app/public/671cf336e06a20333fbbfa599c76e0f496410cc0/stack-chart/?globalTrackOrder=0wa&hiddenGlobalTracks=1wa&hiddenLocalTracksByPid=7814-2&search=remoteframe&thread=0&timelineType=category&v=15) from the STR of the original issue with the changes of this PR.