### PR TITLE
Fix test/lint commands on Windows and fix CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalize line endings to LF on all platforms.
+* text=auto eol=lf
+
 # The following are not technically binary, but this makes it so that git does not try
 # and treat them like normal text.
 *.min.js binary

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
+  endOfLine: 'lf',
 };

--- a/bin/output-fixing-commands.js
+++ b/bin/output-fixing-commands.js
@@ -5,7 +5,7 @@
 // This file runs before linting commands and intercept errors so that more
 // friendly errors can be output.
 
-const cp = require('child_process');
+const spawn = require('cross-spawn');
 
 const fixingCommands = {
   lint: 'lint-fix',
@@ -21,14 +21,22 @@ const currentScriptName = process.env.npm_lifecycle_event;
 // Redirect the main lint command, but not individual commands.
 if (currentScriptName === 'lint' && command.includes('--fix')) {
   console.log(`🔧 Detected --fix flag, running: yarn lint-fix`);
-  const result = cp.spawnSync('yarn', ['lint-fix'], { stdio: 'inherit' });
-  process.exitCode = result.status;
+  const result = spawn.sync('yarn', ['lint-fix'], { stdio: 'inherit' });
+  if (result.error) {
+    console.error(`❌ Failed to spawn command: ${result.error.message}`);
+    process.exitCode = 1;
+  } else {
+    process.exitCode = result.status;
+  }
   process.exit();
 }
 
-const result = cp.spawnSync(command[0], command.slice(1), { stdio: 'inherit' });
+const result = spawn.sync(command[0], command.slice(1), { stdio: 'inherit' });
 
-if (result.status !== 0) {
+if (result.error) {
+  console.error(`❌ Failed to spawn command: ${result.error.message}`);
+  process.exitCode = 1;
+} else if (result.status !== 0) {
   process.exitCode = result.status;
   if (currentScriptName && currentScriptName in fixingCommands) {
     console.log(

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "browserslist-to-esbuild": "^2.1.1",
     "caniuse-lite": "^1.0.30001770",
     "cross-env": "^10.1.0",
+    "cross-spawn": "^7.0.6",
     "devtools-license-check": "^0.9.0",
     "esbuild": "^0.28.0",
     "esbuild-plugin-copy": "^2.1.1",


### PR DESCRIPTION
So apparently `yarn test` and `yarn lint` etc. were silently failing on Windows because `spawnSync` requires a `shell: true` for Windows. Instead it was returning `status: null` on ENOENT, which triggered the `if (result.status !== 0)` check below, but `process.exitCode = result.status;` was assigning `process.exitCode = null` and that was treated like `exitCode = 0` like success.

And then the next commit fixes the GitHub Actions issue since it converts all line endings to CRLF, and our linter wasn't happy about it. We now normalize the line endings to LF.