### PR TITLE
Fix eslint-config-prettier silently overriding custom rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,11 @@ export default defineConfig(
   // React config
   reactPlugin.configs.flat.recommended,
 
+  // Prettier config must be placed here to disable formatting rules from the
+  // base configs above, while allowing our custom rules below to take
+  // precedence.
+  prettierConfig,
+
   // Custom configuration for all files
   {
     files: ['**/*.js', '**/*.mjs', '**/*.cjs', '**/*.ts', '**/*.tsx'],
@@ -311,8 +316,5 @@ export default defineConfig(
         ...globals.jest,
       },
     },
-  },
-
-  // Prettier config (must be last to override other formatting rules)
-  prettierConfig
+  }
 );

--- a/scripts/lib/dev-server.mjs
+++ b/scripts/lib/dev-server.mjs
@@ -128,7 +128,9 @@ export async function startDevServer(buildConfig, options = {}) {
   // Graceful shutdown
   let isShuttingDown = false;
   process.on('SIGINT', async () => {
-    if (isShuttingDown) return;
+    if (isShuttingDown) {
+      return;
+    }
     isShuttingDown = true;
 
     console.log('\nShutting down...');

--- a/scripts/lib/esbuild-plugins.mjs
+++ b/scripts/lib/esbuild-plugins.mjs
@@ -24,7 +24,9 @@ export function circularDependencyPlugin() {
     setup(build) {
       build.initialOptions.metafile = true;
       build.onEnd((result) => {
-        if (!result.metafile?.inputs) return;
+        if (!result.metafile?.inputs) {
+          return;
+        }
 
         const { inputs } = result.metafile;
         const recursionStack = new Set();

--- a/src/components/stack-chart/Canvas.tsx
+++ b/src/components/stack-chart/Canvas.tsx
@@ -665,7 +665,9 @@ class StackChartCanvasImpl extends React.PureComponent<Props> {
   };
 
   _onDoubleClickStack = (hoveredItem: HoveredStackTiming | null) => {
-    if (!hoveredItem) return;
+    if (!hoveredItem) {
+      return;
+    }
 
     const result =
       this._getCallNodeIndexOrMarkerIndexFromHoveredItem(hoveredItem);

--- a/src/test/store/symbolication.test.ts
+++ b/src/test/store/symbolication.test.ts
@@ -259,7 +259,9 @@ describe('doSymbolicateProfile', function () {
       // Helper function to get filename from source index
       const getFileName = (funcIndex: number): string | null => {
         const sourceIndex = funcTable.source[funcIndex];
-        if (sourceIndex === null) return null;
+        if (sourceIndex === null) {
+          return null;
+        }
         const urlIndex = sources.filename[sourceIndex];
         return stringTable.getString(urlIndex);
       };


### PR DESCRIPTION
Fixes #5867.

I saw another `if` branch without a curly brace and I was curious why we don't have a rule for it. And after looking at the eslint config, I realized that there was actually a rule in place:
https://github.com/firefox-devtools/profiler/blob/d5eb4f2fdc6bb2c0d2fb5ee8ed9799a6ff04f747/eslint.config.mjs#L112
But it looks like prettier rules were overriding it because they were at the end of the config. 

This PR moves it right above the custom rule override so it doesn't override our custom rules.