### PR TITLE
Fix loading .json.gz profiles from inside zip archives

### DIFF
--- a/src/actions/zipped-profiles.ts
+++ b/src/actions/zipped-profiles.ts
@@ -57,7 +57,7 @@ export function viewProfileFromZip(
     try {
       // Attempt to unserialize the profile.
       const profile = await unserializeProfileOfArbitraryFormat(
-        await file.async('string'),
+        await file.async('uint8array'),
         pathInZipFile
       );
 

--- a/src/test/store/zipped-profiles.test.ts
+++ b/src/test/store/zipped-profiles.test.ts
@@ -15,6 +15,9 @@ import JSZip from 'jszip';
 import * as ZippedProfilesActions from '../../actions/zipped-profiles';
 import * as ReceiveProfileActions from '../../actions/receive-profile';
 import * as ProfileViewActions from '../../actions/profile-view';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { serializeProfile } from '../../profile-logic/process-profile';
+import { compress } from '../../utils/gz';
 import type { PreviewSelection } from 'firefox-profiler/types';
 
 describe('reducer zipFileState', function () {
@@ -99,6 +102,33 @@ describe('reducer zipFileState', function () {
         profileNameFromURL
       );
     });
+  });
+
+  it('can load a gzipped profile from a zip file', async function () {
+    const store = createStore();
+    const { getState, dispatch } = store;
+    const { profile } = getProfileFromTextSamples('A');
+    // Re-wrap in this realm's Uint8Array: the worker-backed `compress`
+    // returns a typed array whose `instanceof Uint8Array` check fails against
+    // the main realm's global, so JSZip wouldn't recognize it directly.
+    const gzippedProfile = new Uint8Array(
+      await compress(serializeProfile(profile))
+    );
+
+    const zip = new JSZip();
+    zip.file('profile.json.gz', gzippedProfile);
+    const zipBytes = await zip.generateAsync({ type: 'uint8array' });
+    const loadedZip = await JSZip.loadAsync(zipBytes);
+    dispatch(ReceiveProfileActions.receiveZipFile(loadedZip));
+
+    await dispatch(
+      ZippedProfilesActions.viewProfileFromPathInZipFile('profile.json.gz')
+    );
+
+    expect(ZippedProfilesSelectors.getZipFileState(getState()).phase).toBe(
+      'VIEW_PROFILE_IN_ZIP_FILE'
+    );
+    expect(ProfileViewSelectors.getProfile(getState())).toBeTruthy();
   });
 
   it('will fail when trying to load an invalid profile', async function () {


### PR DESCRIPTION
This fixes #5958.

When clicking a .json.gz entry in a zip file, `viewProfileFromZip` called `file.async('string')`, which decoded the gzip bytes as UTF-8 and corrupted the stream before `unserializeProfileOfArbitraryFormat` could detect the gzip magic and decompress. Switching to `'uint8array'` keeps the content binary so the existing `isGzip`/`decompress` path runs. Plain .json entries still work via the Uint8Array to TextDecoder fallback.

[Example profile](https://deploy-preview-5959--perf-html.netlify.app/from-url/https%3A%2F%2Fstorage.googleapis.com%2Fprofiler-get-symbols-fixtures%2Fprofile_speedometer3.zip/calltree/?file=simpleperf%2Freact-stockcharts-svg-19.json.gz&v=15)