### PR TITLE
Add "Include idle samples" toggle to the call tree settings

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -888,6 +888,8 @@ StackSettings--call-tree-strategy-native-deallocations-sites = Deallocation Site
 
 StackSettings--invert-call-stack = Invert call stack
     .title = Sort by the time spent in a call node, ignoring its children.
+StackSettings--include-idle-samples = Include idle samples
+    .title = Uncheck to hide samples whose leaf frame is in the Idle category.
 StackSettings--show-user-timing = Show user timing
 StackSettings--use-stack-chart-same-widths = Use the same width for each stack
 

--- a/src/actions/profile-view.ts
+++ b/src/actions/profile-view.ts
@@ -1711,6 +1711,17 @@ export function changeShowUserTimings(
   };
 }
 
+export function changeIncludeIdleSamples(
+  includeIdleSamples: boolean
+): ThunkAction<void> {
+  return (dispatch) => {
+    dispatch({
+      type: 'CHANGE_INCLUDE_IDLE_SAMPLES',
+      includeIdleSamples,
+    });
+  };
+}
+
 export function changeStackChartSameWidths(
   stackChartSameWidths: boolean
 ): ThunkAction<void> {

--- a/src/app-logic/url-handling.ts
+++ b/src/app-logic/url-handling.ts
@@ -183,6 +183,7 @@ type BaseQuery = {
 type CallTreeQuery = BaseQuery & {
   search: string; // "js::RunScript"
   invertCallstack: null | undefined;
+  hideIdleSamples: null | undefined;
   ctSummary: string;
 };
 
@@ -198,6 +199,7 @@ type NetworkQuery = BaseQuery & {
 type StackChartQuery = BaseQuery & {
   search: string; // "js::RunScript"
   invertCallstack: null | undefined;
+  hideIdleSamples: null | undefined;
   showUserTimings: null | undefined;
   sameWidths: null | undefined;
   ctSummary: string;
@@ -212,6 +214,7 @@ type Query = BaseQuery & {
   // CallTree/StackChart specific
   search?: string;
   invertCallstack?: null | undefined;
+  hideIdleSamples?: null | undefined;
   ctSummary?: string;
   transforms?: string;
   sourceViewIndex?: number;
@@ -339,6 +342,11 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       query.invertCallstack = urlState.profileSpecific.invertCallstack
         ? null
         : undefined;
+      // The URL param is inverted (`hideIdleSamples`) so the default-on state
+      // doesn't clutter the URL; only the non-default "hide" case is encoded.
+      query.hideIdleSamples = urlState.profileSpecific.includeIdleSamples
+        ? undefined
+        : null;
       if (
         selectedThreadsKey !== null &&
         urlState.profileSpecific.transforms[selectedThreadsKey]
@@ -590,6 +598,7 @@ export function stateFromLocation(
         query.ctSummary || undefined
       ),
       invertCallstack: query.invertCallstack === undefined ? false : true,
+      includeIdleSamples: query.hideIdleSamples === undefined,
       showUserTimings: query.showUserTimings === undefined ? false : true,
       stackChartSameWidths: query.sameWidths === undefined ? false : true,
       committedRanges: query.range ? parseCommittedRanges(query.range) : [],

--- a/src/components/calltree/CallTree.tsx
+++ b/src/components/calltree/CallTree.tsx
@@ -17,7 +17,7 @@ import {
   getScrollToSelectionGeneration,
   getFocusCallTreeGeneration,
   getPreviewSelectionIsBeingModified,
-  getCategories,
+  getIdleCategoryIndex,
   getCurrentTableViewOptions,
 } from 'firefox-profiler/selectors/profile';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
@@ -36,7 +36,7 @@ import type {
   State,
   ImplementationFilter,
   ThreadsKey,
-  CategoryList,
+  IndexIntoCategoryList,
   IndexIntoCallNodeTable,
   CallNodeDisplayData,
   WeightType,
@@ -60,7 +60,7 @@ type StateProps = {
   readonly focusCallTreeGeneration: number;
   readonly tree: CallTreeType;
   readonly callNodeInfo: CallNodeInfo;
-  readonly categories: CategoryList;
+  readonly idleCategoryIndex: IndexIntoCategoryList | null;
   readonly selectedCallNodeIndex: IndexIntoCallNodeTable | null;
   readonly rightClickedCallNodeIndex: IndexIntoCallNodeTable | null;
   readonly expandedCallNodeIndexes: Array<IndexIntoCallNodeTable | null>;
@@ -300,17 +300,13 @@ class CallTreeImpl extends PureComponent<Props> {
       expandedCallNodeIndexes,
       selectedCallNodeIndex,
       callNodeInfo,
-      categories,
+      idleCategoryIndex,
     } = this.props;
 
     if (selectedCallNodeIndex !== null || expandedCallNodeIndexes.length > 0) {
       // Let's not change some existing state.
       return;
     }
-
-    const idleCategoryIndex = categories.findIndex(
-      (category) => category.name === 'Idle'
-    );
 
     const newExpandedCallNodeIndexes = expandedCallNodeIndexes.slice();
     const maxInterestingDepth = 17; // scientifically determined
@@ -402,7 +398,7 @@ export const CallTree = explicitConnect<{}, StateProps, DispatchProps>({
     focusCallTreeGeneration: getFocusCallTreeGeneration(state),
     tree: selectedThreadSelectors.getCallTree(state),
     callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
-    categories: getCategories(state),
+    idleCategoryIndex: getIdleCategoryIndex(state),
     selectedCallNodeIndex:
       selectedThreadSelectors.getSelectedCallNodeIndex(state),
     rightClickedCallNodeIndex:

--- a/src/components/calltree/CallTreeEmptyReasons.tsx
+++ b/src/components/calltree/CallTreeEmptyReasons.tsx
@@ -5,6 +5,7 @@ import { PureComponent } from 'react';
 
 import { EmptyReasons } from '../shared/EmptyReasons';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getIncludeIdleSamples } from 'firefox-profiler/selectors/url-state';
 import { oneLine } from 'common-tags';
 import explicitConnect, {
   type ConnectedProps,
@@ -16,6 +17,7 @@ type StateProps = {
   threadName: string;
   rangeFilteredThread: Thread;
   thread: Thread;
+  includeIdleSamples: boolean;
 };
 
 type Props = ConnectedProps<{}, StateProps, {}>;
@@ -26,7 +28,9 @@ type Props = ConnectedProps<{}, StateProps, {}>;
  */
 class CallTreeEmptyReasonsImpl extends PureComponent<Props> {
   override render() {
-    const { thread, rangeFilteredThread, threadName } = this.props;
+    const { thread, rangeFilteredThread, threadName, includeIdleSamples } =
+      this.props;
+    // FIXME: These strings should be localized.
     let reason;
 
     if (thread.samples.length === 0) {
@@ -34,9 +38,12 @@ class CallTreeEmptyReasonsImpl extends PureComponent<Props> {
     } else if (rangeFilteredThread.samples.length === 0) {
       reason = 'Broaden the selected range to view samples.';
     } else {
+      const idleHint = includeIdleSamples
+        ? ''
+        : ', checking "Include idle samples"';
       reason = oneLine`
-        Try broadening the selected range, removing search terms, or call tree transforms
-        to view samples.
+        Try broadening the selected range, removing search terms${idleHint},
+        or call tree transforms to view samples.
       `;
     }
 
@@ -55,6 +62,7 @@ export const CallTreeEmptyReasons = explicitConnect<{}, StateProps, {}>({
     threadName: selectedThreadSelectors.getFriendlyThreadName(state),
     thread: selectedThreadSelectors.getThread(state),
     rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
+    includeIdleSamples: getIncludeIdleSamples(state),
   }),
   component: CallTreeEmptyReasonsImpl,
 });

--- a/src/components/flame-graph/FlameGraphEmptyReasons.tsx
+++ b/src/components/flame-graph/FlameGraphEmptyReasons.tsx
@@ -5,6 +5,7 @@ import { PureComponent } from 'react';
 
 import { EmptyReasons } from '../shared/EmptyReasons';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getIncludeIdleSamples } from 'firefox-profiler/selectors/url-state';
 import { oneLine } from 'common-tags';
 import explicitConnect, {
   type ConnectedProps,
@@ -16,6 +17,7 @@ type StateProps = {
   threadName: string;
   rangeFilteredThread: Thread;
   thread: Thread;
+  includeIdleSamples: boolean;
 };
 
 type Props = ConnectedProps<{}, StateProps, {}>;
@@ -26,7 +28,9 @@ type Props = ConnectedProps<{}, StateProps, {}>;
  */
 class FlameGraphEmptyReasonsImpl extends PureComponent<Props> {
   override render() {
-    const { thread, rangeFilteredThread, threadName } = this.props;
+    const { thread, rangeFilteredThread, threadName, includeIdleSamples } =
+      this.props;
+    // FIXME: These strings should be localized.
     let reason;
 
     if (thread.samples.length === 0) {
@@ -34,9 +38,12 @@ class FlameGraphEmptyReasonsImpl extends PureComponent<Props> {
     } else if (rangeFilteredThread.samples.length === 0) {
       reason = 'Broaden the selected range to view samples.';
     } else {
+      const idleHint = includeIdleSamples
+        ? ''
+        : ', checking "Include idle samples"';
       reason = oneLine`
-        Try broadening the selected range, removing search terms, or call tree transforms
-        to view samples.
+        Try broadening the selected range, removing search terms${idleHint},
+        or call tree transforms to view samples.
       `;
     }
 
@@ -55,6 +62,7 @@ export const FlameGraphEmptyReasons = explicitConnect<{}, StateProps, {}>({
     threadName: selectedThreadSelectors.getFriendlyThreadName(state),
     thread: selectedThreadSelectors.getThread(state),
     rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
+    includeIdleSamples: getIncludeIdleSamples(state),
   }),
   component: FlameGraphEmptyReasonsImpl,
 });

--- a/src/components/shared/StackSettings.tsx
+++ b/src/components/shared/StackSettings.tsx
@@ -7,18 +7,23 @@ import { Localized } from '@fluent/react';
 
 import {
   changeInvertCallstack,
+  changeIncludeIdleSamples,
   changeCallTreeSearchString,
   changeShowUserTimings,
   changeStackChartSameWidths,
 } from 'firefox-profiler/actions/profile-view';
 import {
   getInvertCallstack,
+  getIncludeIdleSamples,
   getSelectedTab,
   getShowUserTimings,
   getStackChartSameWidths,
   getCurrentSearchString,
 } from 'firefox-profiler/selectors/url-state';
-import { getProfileUsesMultipleStackTypes } from 'firefox-profiler/selectors/profile';
+import {
+  getIdleCategoryIndex,
+  getProfileUsesMultipleStackTypes,
+} from 'firefox-profiler/selectors/profile';
 import { PanelSearch } from './PanelSearch';
 import { StackImplementationSetting } from './StackImplementationSetting';
 import { CallTreeStrategySetting } from './CallTreeStrategySetting';
@@ -39,6 +44,8 @@ type StateProps = {
   readonly selectedTab: string;
   readonly allowSwitchingStackType: boolean;
   readonly invertCallstack: boolean;
+  readonly includeIdleSamples: boolean;
+  readonly hasIdleCategory: boolean;
   readonly showUserTimings: boolean;
   readonly stackChartSameWidths: boolean;
   readonly currentSearchString: string;
@@ -48,6 +55,7 @@ type StateProps = {
 
 type DispatchProps = {
   readonly changeInvertCallstack: typeof changeInvertCallstack;
+  readonly changeIncludeIdleSamples: typeof changeIncludeIdleSamples;
   readonly changeShowUserTimings: typeof changeShowUserTimings;
   readonly changeCallTreeSearchString: typeof changeCallTreeSearchString;
   readonly changeStackChartSameWidths: typeof changeStackChartSameWidths;
@@ -58,6 +66,10 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 class StackSettingsImpl extends PureComponent<Props> {
   _onInvertCallstackClick = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.props.changeInvertCallstack(e.currentTarget.checked);
+  };
+
+  _onIncludeIdleSamplesClick = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.props.changeIncludeIdleSamples(e.currentTarget.checked);
   };
 
   _onShowUserTimingsClick = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -76,6 +88,8 @@ class StackSettingsImpl extends PureComponent<Props> {
     const {
       allowSwitchingStackType,
       invertCallstack,
+      includeIdleSamples,
+      hasIdleCategory,
       selectedTab,
       showUserTimings,
       stackChartSameWidths,
@@ -86,6 +100,10 @@ class StackSettingsImpl extends PureComponent<Props> {
     } = this.props;
 
     const hasAllocations = hasUsefulJsAllocations || hasUsefulNativeAllocations;
+    const showInvertCallstack = !hideInvertCallstack;
+    const showStackChartOptions = selectedTab === 'stack-chart';
+    const showSettingsItem =
+      showInvertCallstack || showStackChartOptions || hasIdleCategory;
 
     return (
       <div className="stackSettings">
@@ -100,9 +118,9 @@ class StackSettingsImpl extends PureComponent<Props> {
               <CallTreeStrategySetting />
             </li>
           ) : null}
-          {hideInvertCallstack && selectedTab !== 'stack-chart' ? null : (
+          {showSettingsItem ? (
             <li className="panelSettingsListItem">
-              {hideInvertCallstack ? null : (
+              {showInvertCallstack ? (
                 <label className="photon-label photon-label-micro photon-label-horiz-padding">
                   <input
                     type="checkbox"
@@ -117,8 +135,24 @@ class StackSettingsImpl extends PureComponent<Props> {
                     <span>Invert call stack</span>
                   </Localized>
                 </label>
-              )}
-              {selectedTab !== 'stack-chart' ? null : (
+              ) : null}
+              {hasIdleCategory ? (
+                <label className="photon-label photon-label-micro photon-label-horiz-padding">
+                  <input
+                    type="checkbox"
+                    className="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                    onChange={this._onIncludeIdleSamplesClick}
+                    checked={includeIdleSamples}
+                  />
+                  <Localized
+                    id="StackSettings--include-idle-samples"
+                    attrs={{ title: true }}
+                  >
+                    <span>Include idle samples</span>
+                  </Localized>
+                </label>
+              ) : null}
+              {showStackChartOptions ? (
                 <>
                   <label className="photon-label photon-label-micro photon-label-horiz-padding">
                     <input
@@ -143,9 +177,9 @@ class StackSettingsImpl extends PureComponent<Props> {
                     </Localized>
                   </label>
                 </>
-              )}
+              ) : null}
             </li>
-          )}
+          ) : null}
         </ul>
         <Localized
           id="StackSettings--panel-search"
@@ -172,6 +206,8 @@ export const StackSettings = explicitConnect<
   mapStateToProps: (state) => ({
     allowSwitchingStackType: getProfileUsesMultipleStackTypes(state),
     invertCallstack: getInvertCallstack(state),
+    includeIdleSamples: getIncludeIdleSamples(state),
+    hasIdleCategory: getIdleCategoryIndex(state) !== null,
     selectedTab: getSelectedTab(state),
     showUserTimings: getShowUserTimings(state),
     stackChartSameWidths: getStackChartSameWidths(state),
@@ -183,6 +219,7 @@ export const StackSettings = explicitConnect<
   }),
   mapDispatchToProps: {
     changeInvertCallstack,
+    changeIncludeIdleSamples,
     changeCallTreeSearchString,
     changeShowUserTimings,
     changeStackChartSameWidths,

--- a/src/components/stack-chart/StackChartEmptyReasons.tsx
+++ b/src/components/stack-chart/StackChartEmptyReasons.tsx
@@ -5,6 +5,7 @@ import { PureComponent } from 'react';
 
 import { EmptyReasons } from '../shared/EmptyReasons';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
+import { getIncludeIdleSamples } from 'firefox-profiler/selectors/url-state';
 import { oneLine } from 'common-tags';
 import explicitConnect, { type ConnectedProps } from '../../utils/connect';
 
@@ -14,6 +15,7 @@ type StateProps = {
   threadName: string;
   rangeFilteredThread: Thread;
   thread: Thread;
+  includeIdleSamples: boolean;
 };
 
 type Props = ConnectedProps<{}, StateProps, {}>;
@@ -24,7 +26,9 @@ type Props = ConnectedProps<{}, StateProps, {}>;
  */
 class StackChartEmptyReasonsImpl extends PureComponent<Props> {
   override render() {
-    const { thread, rangeFilteredThread, threadName } = this.props;
+    const { thread, rangeFilteredThread, threadName, includeIdleSamples } =
+      this.props;
+    // FIXME: These strings should be localized.
     let reason;
 
     if (thread.samples.length === 0) {
@@ -32,9 +36,12 @@ class StackChartEmptyReasonsImpl extends PureComponent<Props> {
     } else if (rangeFilteredThread.samples.length === 0) {
       reason = 'Broaden the selected range to view samples.';
     } else {
+      const idleHint = includeIdleSamples
+        ? ''
+        : ', checking "Include idle samples"';
       reason = oneLine`
-        Try broadening the selected range, removing search terms, or call tree transforms
-        to view samples.
+        Try broadening the selected range, removing search terms${idleHint},
+        or call tree transforms to view samples.
       `;
     }
 
@@ -53,6 +60,7 @@ export const StackChartEmptyReasons = explicitConnect<{}, StateProps, {}>({
     threadName: selectedThreadSelectors.getFriendlyThreadName(state),
     thread: selectedThreadSelectors.getThread(state),
     rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
+    includeIdleSamples: getIncludeIdleSamples(state),
   }),
   component: StackChartEmptyReasonsImpl,
 });

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -2059,6 +2059,35 @@ export function getInclusiveIndexRangeForSelection(
 }
 
 /**
+ * Return a thread where samples whose leaf stack frame is in the given
+ * category have had their stack nulled out. These samples are still present in
+ * the samples table (indexes are preserved), but they become invisible to the
+ * call tree, stack chart, and flame graph.
+ *
+ * This is used by the "Include idle samples" toggle to hide idle time from
+ * the call tree.
+ */
+export function filterThreadSamplesByLeafCategory(
+  thread: Thread,
+  categoryToExclude: IndexIntoCategoryList
+): Thread {
+  const { samples } = thread;
+  const newStackCol = samples.stack.slice();
+  for (let i = 0; i < samples.length; i++) {
+    if (samples.category[i] === categoryToExclude) {
+      newStackCol[i] = null;
+    }
+  }
+  return {
+    ...thread,
+    samples: {
+      ...samples,
+      stack: newStackCol,
+    },
+  };
+}
+
+/**
  * Return a thread whose samples (including allocation samples) have been
  * filtered to include just those in the given time window.
  *

--- a/src/reducers/url-state.ts
+++ b/src/reducers/url-state.ts
@@ -312,6 +312,15 @@ const invertCallstack: Reducer<boolean> = (state = false, action) => {
   }
 };
 
+const includeIdleSamples: Reducer<boolean> = (state = true, action) => {
+  switch (action.type) {
+    case 'CHANGE_INCLUDE_IDLE_SAMPLES':
+      return action.includeIdleSamples;
+    default:
+      return state;
+  }
+};
+
 /**
  * Signals whether user timing markers will be shown in the stack chart.
  */
@@ -750,6 +759,7 @@ const profileSpecific = combineReducers({
   implementation,
   lastSelectedCallTreeSummaryStrategy,
   invertCallstack,
+  includeIdleSamples,
   showUserTimings,
   stackChartSameWidths,
   committedRanges,

--- a/src/selectors/per-thread/thread.tsx
+++ b/src/selectors/per-thread/thread.tsx
@@ -157,9 +157,10 @@ export function getBasicThreadSelectorsPerThread(
    * 3. Reserved functions - New funcTable with reserved functions for collapsed resources.
    * 4. Range - New samples table with only samples in the committed range.
    * 5. Transform - Apply the transform stack that modifies the stacks and samples.
-   * 6. Implementation - Modify stacks and samples to only show a single implementation.
-   * 7. Search - Exclude samples that don't include some text in the stack.
-   * 8. Preview - Only include samples that are within a user's preview range selection.
+   * 6. Idle - Optionally null out the stack of samples whose leaf frame is idle.
+   * 7. Implementation - Modify stacks and samples to only show a single implementation.
+   * 8. Search - Exclude samples that don't include some text in the stack.
+   * 9. Preview - Only include samples that are within a user's preview range selection.
    */
 
   const getThread: Selector<Thread> = createSelector(
@@ -472,8 +473,23 @@ export function getThreadSelectorsWithMarkersPerThread(
     }
   );
 
-  const _getImplementationFilteredThread: Selector<Thread> = createSelector(
+  const _getIdleFilteredThread: Selector<Thread> = createSelector(
     getRangeAndTransformFilteredThread,
+    UrlState.getIncludeIdleSamples,
+    ProfileSelectors.getIdleCategoryIndex,
+    (thread, includeIdleSamples, idleCategoryIndex) => {
+      if (includeIdleSamples || idleCategoryIndex === null) {
+        return thread;
+      }
+      return ProfileData.filterThreadSamplesByLeafCategory(
+        thread,
+        idleCategoryIndex
+      );
+    }
+  );
+
+  const _getImplementationFilteredThread: Selector<Thread> = createSelector(
+    _getIdleFilteredThread,
     UrlState.getImplementationFilter,
     (thread: Thread, implementationFilter: ImplementationFilter) => {
       // Apply the implementation filter.

--- a/src/selectors/profile.ts
+++ b/src/selectors/profile.ts
@@ -192,6 +192,12 @@ export const getPageList = (state: State): PageList | null =>
   getProfile(state).pages || null;
 export const getDefaultCategory: Selector<IndexIntoCategoryList> = (state) =>
   getCategories(state).findIndex((c) => c.color === 'grey');
+export const getIdleCategoryIndex: Selector<IndexIntoCategoryList | null> = (
+  state
+) => {
+  const index = getCategories(state).findIndex((c) => c.name === 'Idle');
+  return index === -1 ? null : index;
+};
 export const getThreads: Selector<RawThread[]> = (state) =>
   getProfile(state).threads;
 export const getThreadNames: Selector<string[]> = (state) =>

--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -124,6 +124,8 @@ export const getSelectedTab: Selector<TabSlug> = (state) =>
 export const getInvertCallstack: Selector<boolean> = (state) =>
   getSelectedTab(state) === 'calltree' &&
   getProfileSpecificState(state).invertCallstack;
+export const getIncludeIdleSamples: Selector<boolean> = (state) =>
+  getProfileSpecificState(state).includeIdleSamples;
 
 export const getSelectedThreadIndexesOrNull: Selector<
   Set<ThreadIndex> | null

--- a/src/test/components/ProfileCallTreeView.test.tsx
+++ b/src/test/components/ProfileCallTreeView.test.tsx
@@ -25,6 +25,7 @@ import {
 import {
   changeCallTreeSearchString,
   changeImplementationFilter,
+  changeIncludeIdleSamples,
   changeInvertCallstack,
   commitRange,
   addTransformToStack,
@@ -342,6 +343,27 @@ describe('calltree/ProfileCallTreeView', function () {
     const { getRowElement } = setup(profile);
     expect(getRowElement('E', { selected: true })).toHaveClass('isSelected');
     expect(getRowElement('B', { expanded: true })).toBeInTheDocument();
+  });
+
+  it('hides samples whose leaf frame is idle when "Include idle samples" is unchecked', () => {
+    const { profile } = getProfileFromTextSamples(`
+      A  A            A  A
+      B  B            B  B
+      C  D[cat:Idle]  C  D[cat:Idle]
+    `);
+    const { dispatch } = setup(profile);
+
+    expect(screen.getByRole('treeitem', { name: /^C/ })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: /^D/ })).toBeInTheDocument();
+
+    act(() => {
+      dispatch(changeIncludeIdleSamples(false));
+    });
+
+    expect(screen.getByRole('treeitem', { name: /^C/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('treeitem', { name: /^D/ })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/test/components/__snapshots__/FlameGraph.test.tsx.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.tsx.snap
@@ -468,6 +468,24 @@ exports[`FlameGraph matches the snapshot 1`] = `
           </span>
         </label>
       </li>
+      <li
+        class="panelSettingsListItem"
+      >
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
+      </li>
     </ul>
     <div
       class="panelSearchField stackSettingsSearchField"

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.tsx.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.tsx.snap
@@ -109,6 +109,20 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -900,6 +914,20 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>
@@ -1695,6 +1723,20 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -2474,6 +2516,20 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>
@@ -3257,6 +3313,20 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -3856,6 +3926,20 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -4006,6 +4090,20 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -4154,6 +4252,20 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>
@@ -4351,6 +4463,20 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>
@@ -5101,6 +5227,20 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -5849,6 +5989,20 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -6379,6 +6533,20 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>
@@ -7129,6 +7297,20 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -7803,6 +7985,20 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>
@@ -8481,6 +8677,20 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -9014,6 +9224,20 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             Invert call stack
           </span>
         </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
       </li>
     </ul>
     <div
@@ -9545,6 +9769,20 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
             title="Sort by the time spent in a call node, ignoring its children."
           >
             Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
           </span>
         </label>
       </li>

--- a/src/test/components/__snapshots__/StackChart.test.tsx.snap
+++ b/src/test/components/__snapshots__/StackChart.test.tsx.snap
@@ -173,6 +173,20 @@ exports[`CombinedChart renders combined stack chart 1`] = `
           class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
@@ -674,6 +688,20 @@ exports[`MarkerChart matches the snapshots for the component and draw log 1`] = 
       <li
         class="panelSettingsListItem"
       >
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
         <label
           class="photon-label photon-label-micro photon-label-horiz-padding"
         >
@@ -1233,6 +1261,20 @@ exports[`StackChart matches the snapshot and can display a tooltip with the same
           <li
             class="panelSettingsListItem"
           >
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+            >
+              <input
+                checked=""
+                class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                type="checkbox"
+              />
+              <span
+                title="Uncheck to hide samples whose leaf frame is in the Idle category."
+              >
+                Include idle samples
+              </span>
+            </label>
             <label
               class="photon-label photon-label-micro photon-label-horiz-padding"
             >
@@ -1943,6 +1985,20 @@ exports[`StackChart matches the snapshot and can display a tooltip: dom 1`] = `
           class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
+            checked=""
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Uncheck to hide samples whose leaf frame is in the Idle category."
+          >
+            Include idle samples
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"
           />
@@ -2474,6 +2530,20 @@ exports[`StackChart works when the user selects the JS allocations option 1`] = 
           <li
             class="panelSettingsListItem"
           >
+            <label
+              class="photon-label photon-label-micro photon-label-horiz-padding"
+            >
+              <input
+                checked=""
+                class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+                type="checkbox"
+              />
+              <span
+                title="Uncheck to hide samples whose leaf frame is in the Idle category."
+              >
+                Include idle samples
+              </span>
+            </label>
             <label
               class="photon-label photon-label-micro photon-label-horiz-padding"
             >

--- a/src/test/store/profile-view.test.ts
+++ b/src/test/store/profile-view.test.ts
@@ -1715,6 +1715,78 @@ describe('actions/ProfileView', function () {
     });
   });
 
+  describe('changeIncludeIdleSamples', function () {
+    function setup() {
+      // Four samples: two with an Idle leaf, two with a non-idle leaf.
+      const { profile } = getProfileFromTextSamples(`
+        A          A              A          A
+        B[cat:DOM] B[cat:Idle]    B[cat:DOM] B[cat:Idle]
+      `);
+      return storeWithProfile(profile);
+    }
+
+    it('defaults to true and toggles through the reducer', function () {
+      const { dispatch, getState } = setup();
+
+      expect(UrlStateSelectors.getIncludeIdleSamples(getState())).toEqual(true);
+      dispatch(ProfileView.changeIncludeIdleSamples(false));
+      expect(UrlStateSelectors.getIncludeIdleSamples(getState())).toEqual(
+        false
+      );
+    });
+
+    it('nulls out stacks of samples whose leaf frame is idle when off', function () {
+      const { dispatch, getState } = setup();
+
+      const beforeThread =
+        selectedThreadSelectors.getFilteredThread(getState());
+      expect(beforeThread.samples.stack.every((s) => s !== null)).toBe(true);
+
+      dispatch(ProfileView.changeIncludeIdleSamples(false));
+
+      const afterThread = selectedThreadSelectors.getFilteredThread(getState());
+      const idleCategoryIndex = ensureExists(
+        ProfileViewSelectors.getIdleCategoryIndex(getState()),
+        'Expected the test profile to have an Idle category'
+      );
+
+      // Samples 0 and 2 have DOM leaves; 1 and 3 have Idle leaves.
+      expect(afterThread.samples.stack[0]).not.toBe(null);
+      expect(afterThread.samples.stack[1]).toBe(null);
+      expect(afterThread.samples.stack[2]).not.toBe(null);
+      expect(afterThread.samples.stack[3]).toBe(null);
+
+      // The stackTable is untouched. Only sample.stack entries are nulled.
+      expect(afterThread.stackTable).toBe(beforeThread.stackTable);
+      // The kept samples still point at a stack whose category is not idle.
+      const keptStackCategories = afterThread.samples.stack
+        .filter((s): s is number => s !== null)
+        .map((s) => afterThread.stackTable.category[s]);
+      expect(keptStackCategories).not.toContain(idleCategoryIndex);
+    });
+
+    it('is a no-op when the profile has no idle category', function () {
+      const { profile } = getProfileFromTextSamples(`
+        A          A
+        B[cat:DOM] B[cat:DOM]
+      `);
+      // Replace categories with a set that has no "Idle" entry.
+      profile.meta.categories = [
+        { name: 'Other', color: 'grey', subcategories: ['Other'] },
+        { name: 'DOM', color: 'blue', subcategories: ['Other'] },
+      ];
+      const { dispatch, getState } = storeWithProfile(profile);
+
+      expect(ProfileViewSelectors.getIdleCategoryIndex(getState())).toBe(null);
+
+      const before = selectedThreadSelectors.getFilteredThread(getState());
+      dispatch(ProfileView.changeIncludeIdleSamples(false));
+      const after = selectedThreadSelectors.getFilteredThread(getState());
+      // Without an idle category there is nothing to filter.
+      expect(after).toBe(before);
+    });
+  });
+
   describe('updatePreviewSelection', function () {
     it('updates the profile selection', function () {
       const { profile } = getProfileFromTextSamples('A');

--- a/src/test/url-handling.test.ts
+++ b/src/test/url-handling.test.ts
@@ -20,6 +20,7 @@ import {
   closeBottomBox,
   changeShowUserTimings,
   changeStackChartSameWidths,
+  changeIncludeIdleSamples,
   changeSelectedMarker,
 } from '../actions/profile-view';
 import { changeSelectedTab, changeProfilesToCompare } from '../actions/app';
@@ -1661,6 +1662,28 @@ describe('stack chart specific queries', function () {
     expect(
       urlStateSelectors.getStackChartSameWidths(storeAfterReload.getState())
     ).toBe(true);
+  });
+});
+
+describe('"include idle samples" query', function () {
+  it('defaults to true and is absent from the URL', function () {
+    const { getState } = _getStoreWithURL();
+    expect(urlStateSelectors.getIncludeIdleSamples(getState())).toBe(true);
+    expect(getQueryStringFromState(getState())).not.toContain(
+      'hideIdleSamples'
+    );
+  });
+
+  it('persists hideIdleSamples through a URL roundtrip when toggled off', function () {
+    const { getState, dispatch } = _getStoreWithURL();
+
+    dispatch(changeIncludeIdleSamples(false));
+    expect(getQueryStringFromState(getState())).toContain('hideIdleSamples');
+
+    const storeAfterReload = _getStoreFromStateAfterUrlRoundtrip(getState());
+    expect(
+      urlStateSelectors.getIncludeIdleSamples(storeAfterReload.getState())
+    ).toBe(false);
   });
 });
 

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -527,6 +527,10 @@ type UrlStateAction =
       readonly showUserTimings: boolean;
     }
   | {
+      readonly type: 'CHANGE_INCLUDE_IDLE_SAMPLES';
+      readonly includeIdleSamples: boolean;
+    }
+  | {
       readonly type: 'CHANGE_STACK_CHART_SAME_WIDTHS';
       readonly stackChartSameWidths: boolean;
     }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -355,6 +355,7 @@ export type ProfileSpecificUrlState = {
   implementation: ImplementationFilter;
   lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy;
   invertCallstack: boolean;
+  includeIdleSamples: boolean;
   showUserTimings: boolean;
   stackChartSameWidths: boolean;
   committedRanges: StartEndRange[];


### PR DESCRIPTION
This is the approach we wanted to go with instead of #5943, also discussed there. This PR adds a new checkbox that's called "Include idle samples" to the settings of the call tree/flame graph/stack chart.

It's visible only when we have an Idle category. It's checked by default in the web view, but can be unchecked to hide the idle samples. It will be unchecked by default in the profiler-cli though, as we think it's more important to be concise there. But it can be toggled there as well.

[Here's a deploy preview](https://deploy-preview-5968--perf-html.netlify.app/public/p2fc32xj20c900rgyq8car76010v9gvc6995ab8/flame-graph/?globalTrackOrder=m0eafhlkijcb6g7w9d51w4&hiddenGlobalTracks=1w9bcgij&hiddenLocalTracksByPid=10715-1w3~10735-0~10741-0~10726-0~10723-0~10739-01~16424-0~16294-0~16367-0~14881-0~10725-0~13801-0w2~10924-0w3~10722-2~16395-0~10731-0~14104-0&range=3017m585&thread=s&v=15)

