### PR TITLE
Use ephemeral port for esbuild's internal dev server

### DIFF
--- a/scripts/lib/dev-server.mjs
+++ b/scripts/lib/dev-server.mjs
@@ -66,6 +66,7 @@ export async function startDevServer(buildConfig, options = {}) {
   // Create build context for watching
   const buildContext = await esbuild.context(buildConfig);
   const { hosts, port: esbuildServerPort } = await buildContext.serve({
+    port: 0,
     host: '127.0.0.1',
     servedir: distDir,
     fallback: fallback ? path.join(distDir, fallback) : undefined,


### PR DESCRIPTION
Pass `port: 0` to `buildContext.serve` so esbuild binds an OS-assigned ephemeral port instead of grabbing 8000, which is commonly used by other local projects. The public port (4242 by default) is unaffected.

Fixes #5881