### PR TITLE
Restore 15px fallback for TimelineMarkersMemory height

### DIFF
--- a/src/components/timeline/TrackCounter.css
+++ b/src/components/timeline/TrackCounter.css
@@ -37,6 +37,6 @@
 
 .timelineMarkersCounter,
 .timelineMarkersMemory {
-  height: var(--markers-height);
+  height: var(--markers-height, 15px);
   opacity: 1;
 }


### PR DESCRIPTION
The fallback was dropped in #5944 when the rule moved from TrackMemory.css to TrackCounter.css. TrackThread still renders TimelineMarkersMemory directly on the main thread when a process has no Memory counter track, and that row is not a descendant of any TrackCounter wrapper, so --markers-height is undefined there. Without a fallback the var() resolves to height's initial value (auto), collapsing the row and the canvas inside it.

Add the 15px fallback back so the fallback path renders at its intended height. Counter tracks are unaffected because TrackCounter sets --markers-height explicitly on the wrapper.