### PR TITLE
Deploy 2 April 28, 2026

### DIFF
--- a/src/components/timeline/TrackCounter.css
+++ b/src/components/timeline/TrackCounter.css
@@ -37,6 +37,6 @@
 
 .timelineMarkersCounter,
 .timelineMarkersMemory {
-  height: var(--markers-height);
+  height: var(--markers-height, 15px);
   opacity: 1;
 }


### PR DESCRIPTION
Changes:

[fatadel] Restore 15px fallback for TimelineMarkersMemory height (https://github.com/firefox-devtools/profiler/pull/5981)