### PR TITLE
Bump profiler cli version to 0.1.0

### DIFF
--- a/docs-developer/deploying.md
+++ b/docs-developer/deploying.md
@@ -128,8 +128,8 @@ yarn publish-profiler-cli
 
 1. Run `yarn build-profiler-cli` to produce `profiler-cli/dist/profiler-cli.js` (a
    single self-contained bundle with no runtime dependencies).
-2. Run `npm publish profiler-cli/`, picking `--tag alpha` when the version
-   contains `-` (e.g. `0.1.0-alpha.5`) and `--tag latest` otherwise.
+2. Run `npm publish profiler-cli/`, picking `--tag next` when the version
+   contains `-` (e.g. `0.1.0-next.1`) and `--tag latest` otherwise.
 3. Trigger the `prepublishOnly` hook in `profiler-cli/package.json`, which runs
    [`scripts/verify-profiler-cli-build.mjs`](../scripts/verify-profiler-cli-build.mjs)
    to confirm the bundle exists and embeds the current `package.json` version —

--- a/profiler-cli/CONTRIBUTING.md
+++ b/profiler-cli/CONTRIBUTING.md
@@ -29,14 +29,7 @@ This means:
 - Developers working on the CLI use the root package.json dependencies
 - The `package.json` in this directory is for npm publishing only, not for development
 
-To publish:
-
-```bash
-# From repository root
-yarn build-profiler-cli
-cd profiler-cli
-npm publish
-```
+To publish, see [`docs-developer/deploying.md`](../docs-developer/deploying.md#publishing-profiler-cli-to-npm).
 
 ## Development Workflow
 

--- a/profiler-cli/README.md
+++ b/profiler-cli/README.md
@@ -2,8 +2,6 @@
 
 A command-line interface for querying Firefox Profiler profiles with persistent daemon sessions.
 
-> **Alpha release** — this package is in early development. Commands and options may change between versions.
-
 ## Installation
 
 ```bash

--- a/profiler-cli/package.json
+++ b/profiler-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firefox-devtools/profiler-cli",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0",
   "description": "Command-line interface for querying Firefox Profiler profiles with persistent daemon sessions",
   "scripts": {
     "prepublishOnly": "node ../scripts/verify-profiler-cli-build.mjs"

--- a/scripts/publish-profiler-cli.mjs
+++ b/scripts/publish-profiler-cli.mjs
@@ -14,11 +14,9 @@ const userSpecifiedTag = forwardedArgs.some(
   (a) => a === '--tag' || a.startsWith('--tag=')
 );
 const isPrerelease = version.includes('-');
-// TODO: switch 'alpha' to 'next' once a stable release exists and we want the
-// conventional pre-release channel.
 const tagArgs = userSpecifiedTag
   ? []
-  : ['--tag', isPrerelease ? 'alpha' : 'latest'];
+  : ['--tag', isPrerelease ? 'next' : 'latest'];
 
 function run(cmd, args) {
   const result = spawnSync(cmd, args, { cwd: repoRoot, stdio: 'inherit' });


### PR DESCRIPTION
This PR bumps the profiler-cli to 0.1.0 for the first npm non-alpha release!

I will publish the release once this PR lands and then add a tag for this release.

Currently the publishing flow is documented in https://github.com/firefox-devtools/profiler/blob/main/docs-developer/deploying.md#publishing-profiler-cli-to-npm, but it's pretty manual. It might be good to make this automated with some github actions. But this is a todo for later time for now. 