### PR TITLE
Move paddings inside the tree header cells.

### DIFF
--- a/res/css/global.css
+++ b/res/css/global.css
@@ -15,6 +15,7 @@
   --z-copy-table-warning: 4;
   --z-tree-view: 0;
   --z-tree-view-inner: 2;
+  --z-tree-view-header-divider: 1;
   --z-overflow-edge-indicator: 3;
   --z-chart-viewport-expanded: 1;
   --z-timeline-selection: 1;

--- a/src/components/calltree/CallTree.tsx
+++ b/src/components/calltree/CallTree.tsx
@@ -111,7 +111,7 @@ class CallTreeImpl extends PureComponent<Props> {
             {
               propName: 'totalPercent',
               titleL10nId: '',
-              initialWidth: 50,
+              initialWidth: 55,
               hideDividerAfter: true,
             },
             {
@@ -120,20 +120,20 @@ class CallTreeImpl extends PureComponent<Props> {
               minWidth: 30,
               initialWidth: 70,
               resizable: true,
-              headerWidthAdjustment: 50,
+              headerWidthAdjustment: 55 /* totalPercent initialWidth */,
             },
             {
               propName: 'self',
               titleL10nId: 'CallTree--tracing-ms-self',
-              minWidth: 30,
-              initialWidth: 70,
+              minWidth: 40,
+              initialWidth: 80,
               resizable: true,
             },
             {
               propName: 'icon',
               titleL10nId: '',
               component: Icon as any,
-              initialWidth: 10,
+              initialWidth: 20,
             },
           ];
         case 'samples':
@@ -141,7 +141,7 @@ class CallTreeImpl extends PureComponent<Props> {
             {
               propName: 'totalPercent',
               titleL10nId: '',
-              initialWidth: 50,
+              initialWidth: 55,
               hideDividerAfter: true,
             },
             {
@@ -150,20 +150,20 @@ class CallTreeImpl extends PureComponent<Props> {
               minWidth: 30,
               initialWidth: 70,
               resizable: true,
-              headerWidthAdjustment: 50,
+              headerWidthAdjustment: 55 /* totalPercent initialWidth */,
             },
             {
               propName: 'self',
               titleL10nId: 'CallTree--samples-self',
-              minWidth: 30,
-              initialWidth: 70,
+              minWidth: 40,
+              initialWidth: 80,
               resizable: true,
             },
             {
               propName: 'icon',
               titleL10nId: '',
               component: Icon as any,
-              initialWidth: 10,
+              initialWidth: 20,
             },
           ];
         case 'bytes':
@@ -171,7 +171,7 @@ class CallTreeImpl extends PureComponent<Props> {
             {
               propName: 'totalPercent',
               titleL10nId: '',
-              initialWidth: 50,
+              initialWidth: 55,
               hideDividerAfter: true,
             },
             {
@@ -180,20 +180,20 @@ class CallTreeImpl extends PureComponent<Props> {
               minWidth: 30,
               initialWidth: 140,
               resizable: true,
-              headerWidthAdjustment: 50,
+              headerWidthAdjustment: 55 /* totalPercent initialWidth */,
             },
             {
               propName: 'self',
               titleL10nId: 'CallTree--bytes-self',
-              minWidth: 30,
-              initialWidth: 90,
+              minWidth: 40,
+              initialWidth: 100,
               resizable: true,
             },
             {
               propName: 'icon',
               titleL10nId: '',
               component: Icon as any,
-              initialWidth: 10,
+              initialWidth: 20,
             },
           ];
         default:

--- a/src/components/marker-table/index.tsx
+++ b/src/components/marker-table/index.tsx
@@ -253,22 +253,22 @@ class MarkerTableImpl extends PureComponent<Props> {
     {
       propName: 'start',
       titleL10nId: 'MarkerTable--start',
-      minWidth: 30,
-      initialWidth: 90,
+      minWidth: 35,
+      initialWidth: 95,
       resizable: true,
     },
     {
       propName: 'duration',
       titleL10nId: 'MarkerTable--duration',
-      minWidth: 30,
-      initialWidth: 80,
+      minWidth: 40,
+      initialWidth: 90,
       resizable: true,
     },
     {
       propName: 'name',
       titleL10nId: 'MarkerTable--name',
-      minWidth: 30,
-      initialWidth: 150,
+      minWidth: 40,
+      initialWidth: 160,
       resizable: true,
     },
   ];

--- a/src/components/shared/TreeView.css
+++ b/src/components/shared/TreeView.css
@@ -58,8 +58,7 @@
 }
 
 .treeViewHeader {
-  height: 15px;
-  padding: 4px 0;
+  height: 23px;
   border-bottom: 1px solid var(--base-border-color);
   background: var(--raised-background-color);
   color: var(--raised-foreground-color);
@@ -118,33 +117,57 @@
   white-space: nowrap;
 }
 
+.treeViewHeaderColumn,
+.treeViewRowColumn,
+.treeViewRowScrolledColumns {
+  box-sizing: border-box;
+  padding-right: 5px;
+  padding-left: 5px;
+}
+
 .treeViewFixedColumn {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.treeViewColumnDivider {
+.treeViewHeaderColumnDivider,
+.treeViewRowColumnDivider {
   display: flex;
-  width: 20px;
+  width: 1px;
   flex: none;
   align-items: stretch;
   justify-content: center;
+  padding-right: 5px;
+  padding-left: 5px;
   margin-right: -5px;
   margin-left: -5px;
 }
 
-.treeViewColumnDivider.isResizable,
+.treeViewHeaderColumn,
+.treeViewHeaderColumnDivider {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.treeViewHeaderColumnDivider.isResizable {
+  position: relative;
+  z-index: var(--z-tree-view-header-divider);
+}
+
+.treeViewHeaderColumnDivider.isResizable,
 .treeView.isResizingColumns {
   cursor: col-resize;
 }
 
-.treeViewColumnDivider::before {
+.treeViewRowColumnDivider::before,
+.treeViewHeaderColumnDivider::before {
   border-right: 1px solid var(--base-border-color);
   content: '';
 }
 
-.treeViewColumnDivider.isResizable::before {
+.treeViewHeaderColumnDivider.isResizable::before {
   width: 1px;
+  flex-shrink: 0;
   border-left: 1px solid var(--base-border-color);
 }
 

--- a/src/components/shared/TreeView.tsx
+++ b/src/components/shared/TreeView.tsx
@@ -113,7 +113,7 @@ class TreeViewHeader<
               {col.hideDividerAfter !== true ? (
                 <span
                   key={col.propName + 'Divider'}
-                  className={classNames('treeViewColumnDivider', {
+                  className={classNames('treeViewHeaderColumnDivider', {
                     isResizable: col.resizable,
                   })}
                   onMouseDown={
@@ -241,7 +241,7 @@ class TreeViewRowFixedColumns<
                 )}
               </span>
               {col.hideDividerAfter !== true ? (
-                <span className="treeViewColumnDivider"></span>
+                <span className="treeViewRowColumnDivider"></span>
               ) : null}
             </React.Fragment>
           );
@@ -380,14 +380,9 @@ class TreeViewRowScrolledColumns<
           ) : null
         }
         <span
-          className={classNames(
-            'treeViewRowColumn',
-            'treeViewMainColumn',
-            mainColumn.propName,
-            {
-              dim: displayData.isFrameLabel,
-            }
-          )}
+          className={classNames('treeViewMainColumn', mainColumn.propName, {
+            dim: displayData.isFrameLabel,
+          })}
         >
           {displayData.badge ? (
             <Localized
@@ -415,7 +410,7 @@ class TreeViewRowScrolledColumns<
         </span>
         {appendageColumn ? (
           <span
-            className={`treeViewRowColumn treeViewAppendageColumn ${appendageColumn.propName}`}
+            className={`treeViewAppendageColumn ${appendageColumn.propName}`}
           >
             {reactStringWithHighlightedSubstrings(
               displayData[appendageColumn.propName],

--- a/src/test/components/MarkerTable.test.tsx
+++ b/src/test/components/MarkerTable.test.tsx
@@ -476,11 +476,11 @@ describe('MarkerTable', function () {
       );
 
       let dividerForFirstColumn = ensureExists(
-        document.querySelector('.treeViewColumnDivider')
+        document.querySelector('.treeViewHeaderColumnDivider')
       );
       let firstColumn = screen.getByText('Start');
-      expect(firstColumn).toHaveStyle({ width: '90px' });
-      fireEvent.mouseDown(dividerForFirstColumn, { clientX: 90 });
+      expect(firstColumn).toHaveStyle({ width: '95px' });
+      fireEvent.mouseDown(dividerForFirstColumn, { clientX: 95 });
 
       const body = ensureExists(document.body);
 
@@ -510,10 +510,10 @@ describe('MarkerTable', function () {
 
       // Now double click to reset the style.
       dividerForFirstColumn = ensureExists(
-        document.querySelector('.treeViewColumnDivider')
+        document.querySelector('.treeViewHeaderColumnDivider')
       );
       fireEvent.dblClick(dividerForFirstColumn, { detail: 2 });
-      expect(firstColumn).toHaveStyle({ width: '90px' });
+      expect(firstColumn).toHaveStyle({ width: '95px' });
     });
   });
 

--- a/src/test/components/__snapshots__/MarkerTable.test.tsx.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.tsx.snap
@@ -207,32 +207,32 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn start"
-        style="width: 90px;"
+        style="width: 95px;"
       >
         Start
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="0"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn duration"
-        style="width: 80px;"
+        style="width: 90px;"
       >
         Duration
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn name"
-        style="width: 150px;"
+        style="width: 160px;"
       >
         Name
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
@@ -270,33 +270,33 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
+                  style="width: 95px;"
+                  title="0s"
+                >
+                  0s
+                </span>
+                <span
+                  class="treeViewRowColumnDivider"
+                />
+                <span
+                  class="treeViewRowColumn treeViewFixedColumn duration"
                   style="width: 90px;"
                   title="0s"
                 >
                   0s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
-                />
-                <span
-                  class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
-                  title="0s"
-                >
-                  0s
-                </span>
-                <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="UserTiming"
                 >
                   UserTiming
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -305,31 +305,31 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
-                  style="width: 90px;"
+                  style="width: 95px;"
                   title="0.002s"
                 >
                   0.002s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
+                  style="width: 90px;"
                   title=""
                 />
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="NotifyDidPaint"
                 >
                   NotifyDidPaint
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -338,33 +338,33 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
-                  style="width: 90px;"
+                  style="width: 95px;"
                   title="0.108s"
                 >
                   0.108s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
+                  style="width: 90px;"
                   title="unknown"
                 >
                   unknown
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="IPCOut"
                 >
                   IPCOut
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -373,33 +373,33 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
-                  style="width: 90px;"
+                  style="width: 95px;"
                   title="0.153s"
                 >
                   0.153s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
+                  style="width: 90px;"
                   title="584.00ns"
                 >
                   584.00ns
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="setTimeout"
                 >
                   setTimeout
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -408,33 +408,33 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
-                  style="width: 90px;"
+                  style="width: 95px;"
                   title="0.153s"
                 >
                   0.153s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
+                  style="width: 90px;"
                   title="584.00ns"
                 >
                   584.00ns
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Quisque pulvinar blandit ullamcorper. Donec id justo at metus scelerisque pulvinar. Proin suscipit suscipit nisi, quis tempus ipsum vulputate quis. Pellentesque sodales rutrum eros, eget pulvinar ante condimentum a. Donec accumsan, ante ut facilisis cursus, nibh quam congue eros, vitae placerat tortor magna vel lacus. Etiam odio diam, venenatis eu sollicitudin non, ultrices ut urna. Aliquam vehicula diam eu eros eleifend, ac vulputate purus faucibus."
                 >
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget magna sed magna vehicula congue id id nulla. Ut convallis, neque consequat aliquam egestas, dui urna interdum quam, id semper magna erat et nisi. Vivamus molestie quis ligula eget aliquam. Sed facilisis, turpis sed facilisis posuere, risus odio convallis velit, vitae vehicula justo risus at ipsum. Proin non porttitor neque. Vivamus fringilla ex nec iaculis cursus. Vestibulum suscipit mauris sem, vitae gravida ipsum fermentum id. Quisque pulvinar blandit ullamcorper. Donec id justo at metus scelerisque pulvinar. Proin suscipit suscipit nisi, quis tempus ipsum vulputate quis. Pellentesque sodales rutrum eros, eget pulvinar ante condimentum a. Donec accumsan, ante ut facilisis cursus, nibh quam congue eros, vitae placerat tortor magna vel lacus. Etiam odio diam, venenatis eu sollicitudin non, ultrices ut urna. Aliquam vehicula diam eu eros eleifend, ac vulputate purus faucibus.
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -443,31 +443,31 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
-                  style="width: 90px;"
+                  style="width: 95px;"
                   title="0.158s"
                 >
                   0.158s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
+                  style="width: 90px;"
                   title=""
                 />
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="LogMessages"
                 >
                   LogMessages
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -476,33 +476,33 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn start"
-                  style="width: 90px;"
+                  style="width: 95px;"
                   title="0.162s"
                 >
                   0.162s
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn duration"
-                  style="width: 80px;"
+                  style="width: 90px;"
                   title="1ms"
                 >
                   1ms
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn name"
-                  style="width: 150px;"
+                  style="width: 160px;"
                   title="FileIO"
                 >
                   FileIO
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -534,7 +534,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 >
                   foobar
                 </span>
@@ -555,7 +555,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 />
               </div>
               <div
@@ -574,7 +574,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 >
                   PContent::Msg_PreferenceUpdate — sent to 2222
                 </span>
@@ -595,7 +595,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 >
                   5.5
                 </span>
@@ -616,7 +616,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 >
                   5.5
                 </span>
@@ -637,7 +637,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 >
                   (nsJarProtocol) nsJARChannel::nsJARChannel [this=0x87f1ec80]
 
@@ -659,7 +659,7 @@ exports[`MarkerTable renders some basic markers and updates when needed 1`] = `
                   class="treeRowToggleButton collapsed leaf"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn details"
+                  class="treeViewMainColumn details"
                 >
                   (PoisonIOInterposer) create/open — /foo/bar
                 </span>

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.tsx.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.tsx.snap
@@ -179,11 +179,11 @@ exports[`ProfileCallTreeView with JS Allocations matches the snapshot for JS all
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 190px;"
+        style="width: 195px;"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -192,12 +192,12 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 90px;"
+        style="width: 100px;"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -207,15 +207,15 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -252,7 +252,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -265,21 +265,21 @@ allocated or deallocated in the program."
                   15
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -287,7 +287,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -296,7 +296,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -309,21 +309,21 @@ allocated or deallocated in the program."
                   15
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -331,7 +331,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -340,7 +340,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="80%"
                 >
                   80%
@@ -353,21 +353,21 @@ allocated or deallocated in the program."
                   12
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -375,7 +375,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -384,7 +384,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="80%"
                 >
                   80%
@@ -397,21 +397,21 @@ allocated or deallocated in the program."
                   12
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="5"
                 >
                   5
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -419,7 +419,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -428,7 +428,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="47%"
                 >
                   47%
@@ -441,21 +441,21 @@ allocated or deallocated in the program."
                   7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -463,7 +463,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -472,7 +472,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="47%"
                 >
                   47%
@@ -485,21 +485,21 @@ allocated or deallocated in the program."
                   7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="7"
                 >
                   7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -507,7 +507,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -516,7 +516,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="20%"
                 >
                   20%
@@ -529,21 +529,21 @@ allocated or deallocated in the program."
                   3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -551,7 +551,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -589,12 +589,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -619,12 +619,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -649,12 +649,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Fjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -679,12 +679,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Gjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -709,12 +709,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   Hjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   jQuery.js
                 </span>
@@ -740,12 +740,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   I
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libI.so
                 </span>
@@ -772,12 +772,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -986,11 +986,11 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 190px;"
+        style="width: 195px;"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -999,12 +999,12 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 90px;"
+        style="width: 100px;"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -1014,15 +1014,15 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -1059,7 +1059,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-100%"
                 >
                   -100%
@@ -1072,21 +1072,21 @@ allocated or deallocated in the program."
                   -15
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1094,7 +1094,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1103,7 +1103,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-100%"
                 >
                   -100%
@@ -1116,21 +1116,21 @@ allocated or deallocated in the program."
                   -15
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1138,7 +1138,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1147,7 +1147,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-80%"
                 >
                   -80%
@@ -1160,21 +1160,21 @@ allocated or deallocated in the program."
                   -12
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1182,7 +1182,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1191,7 +1191,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-80%"
                 >
                   -80%
@@ -1204,21 +1204,21 @@ allocated or deallocated in the program."
                   -12
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="-5"
                 >
                   -5
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1226,7 +1226,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1235,7 +1235,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-47%"
                 >
                   -47%
@@ -1248,21 +1248,21 @@ allocated or deallocated in the program."
                   -7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1270,7 +1270,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1279,7 +1279,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-47%"
                 >
                   -47%
@@ -1292,21 +1292,21 @@ allocated or deallocated in the program."
                   -7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="-7"
                 >
                   -7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1314,7 +1314,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1323,7 +1323,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-20%"
                 >
                   -20%
@@ -1336,21 +1336,21 @@ allocated or deallocated in the program."
                   -3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1358,7 +1358,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -1396,12 +1396,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -1426,12 +1426,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -1456,12 +1456,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Fjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -1486,12 +1486,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Gjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -1516,12 +1516,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   Hjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   jQuery.js
                 </span>
@@ -1547,12 +1547,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   I
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libI.so
                 </span>
@@ -1579,12 +1579,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -1793,11 +1793,11 @@ exports[`ProfileCallTreeView with balanced native allocations matches the snapsh
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 190px;"
+        style="width: 195px;"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -1806,12 +1806,12 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 90px;"
+        style="width: 100px;"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -1821,15 +1821,15 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -1866,7 +1866,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -1879,21 +1879,21 @@ allocated or deallocated in the program."
                   41
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1901,7 +1901,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1910,7 +1910,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -1923,21 +1923,21 @@ allocated or deallocated in the program."
                   41
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1945,7 +1945,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1954,7 +1954,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="73%"
                 >
                   73%
@@ -1967,21 +1967,21 @@ allocated or deallocated in the program."
                   30
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -1989,7 +1989,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -1998,7 +1998,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="73%"
                 >
                   73%
@@ -2011,21 +2011,21 @@ allocated or deallocated in the program."
                   30
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="13"
                 >
                   13
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2033,7 +2033,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2042,7 +2042,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="41%"
                 >
                   41%
@@ -2055,21 +2055,21 @@ allocated or deallocated in the program."
                   17
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2077,7 +2077,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2086,7 +2086,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="41%"
                 >
                   41%
@@ -2099,21 +2099,21 @@ allocated or deallocated in the program."
                   17
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="17"
                 >
                   17
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2121,7 +2121,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2130,7 +2130,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="27%"
                 >
                   27%
@@ -2143,21 +2143,21 @@ allocated or deallocated in the program."
                   11
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2165,7 +2165,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -2203,12 +2203,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -2233,12 +2233,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -2263,12 +2263,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Fjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -2293,12 +2293,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Gjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -2323,12 +2323,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   Hjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   jQuery.js
                 </span>
@@ -2354,12 +2354,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   I
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libI.so
                 </span>
@@ -2386,12 +2386,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -2588,11 +2588,11 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 190px;"
+        style="width: 195px;"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -2601,12 +2601,12 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 90px;"
+        style="width: 100px;"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -2616,15 +2616,15 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -2661,7 +2661,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -2674,21 +2674,21 @@ allocated or deallocated in the program."
                   15
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2696,7 +2696,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2705,7 +2705,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -2718,21 +2718,21 @@ allocated or deallocated in the program."
                   15
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2740,7 +2740,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2749,7 +2749,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="80%"
                 >
                   80%
@@ -2762,21 +2762,21 @@ allocated or deallocated in the program."
                   12
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2784,7 +2784,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2793,7 +2793,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="80%"
                 >
                   80%
@@ -2806,21 +2806,21 @@ allocated or deallocated in the program."
                   12
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="5"
                 >
                   5
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2828,7 +2828,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2837,7 +2837,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="47%"
                 >
                   47%
@@ -2850,21 +2850,21 @@ allocated or deallocated in the program."
                   7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2872,7 +2872,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2881,7 +2881,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="47%"
                 >
                   47%
@@ -2894,21 +2894,21 @@ allocated or deallocated in the program."
                   7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="7"
                 >
                   7
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2916,7 +2916,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -2925,7 +2925,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="20%"
                 >
                   20%
@@ -2938,21 +2938,21 @@ allocated or deallocated in the program."
                   3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -2960,7 +2960,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -2998,12 +2998,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3028,12 +3028,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3058,12 +3058,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Fjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3088,12 +3088,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Gjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3118,12 +3118,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   Hjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   jQuery.js
                 </span>
@@ -3149,12 +3149,12 @@ allocated or deallocated in the program."
                   title="Layout"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   I
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libI.so
                 </span>
@@ -3181,12 +3181,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -3383,11 +3383,11 @@ exports[`ProfileCallTreeView with unbalanced native allocations matches the snap
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 190px;"
+        style="width: 195px;"
         title="The “total size” includes a summary of all of the bytes allocated or
 deallocated while this function was observed to be on the stack. This
 includes both the bytes where the function was actually running, and the
@@ -3396,12 +3396,12 @@ bytes of the callers from this function."
         Total Size (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 90px;"
+        style="width: 100px;"
         title="The “self” bytes includes the bytes allocated or deallocated while this
 function was the end of the stack. If this function called into
 other functions, then the “other” functions’ bytes are not included.
@@ -3411,15 +3411,15 @@ allocated or deallocated in the program."
         Self (bytes)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -3456,7 +3456,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-100%"
                 >
                   -100%
@@ -3469,21 +3469,21 @@ allocated or deallocated in the program."
                   -41
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -3491,7 +3491,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -3500,7 +3500,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-100%"
                 >
                   -100%
@@ -3513,21 +3513,21 @@ allocated or deallocated in the program."
                   -41
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -3535,7 +3535,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -3544,7 +3544,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-59%"
                 >
                   -59%
@@ -3557,21 +3557,21 @@ allocated or deallocated in the program."
                   -24
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -3579,7 +3579,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -3588,7 +3588,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-41%"
                 >
                   -41%
@@ -3601,21 +3601,21 @@ allocated or deallocated in the program."
                   -17
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -3623,7 +3623,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -3632,7 +3632,7 @@ allocated or deallocated in the program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="-41%"
                 >
                   -41%
@@ -3645,21 +3645,21 @@ allocated or deallocated in the program."
                   -17
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 90px;"
+                  style="width: 100px;"
                   title="-17"
                 >
                   -17
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -3667,7 +3667,7 @@ allocated or deallocated in the program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -3705,12 +3705,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3735,12 +3735,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3765,12 +3765,12 @@ allocated or deallocated in the program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3795,12 +3795,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Fjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -3824,12 +3824,12 @@ allocated or deallocated in the program."
                   title="JavaScript"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Gjs
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -4535,11 +4535,11 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -4548,12 +4548,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -4562,15 +4562,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -4607,7 +4607,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="67%"
                 >
                   67%
@@ -4620,21 +4620,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="2"
                 >
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4642,7 +4642,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -4651,7 +4651,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="67%"
                 >
                   67%
@@ -4664,21 +4664,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4686,7 +4686,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -4695,7 +4695,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="67%"
                 >
                   67%
@@ -4708,21 +4708,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4730,7 +4730,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -4739,7 +4739,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -4752,21 +4752,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4774,7 +4774,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -4783,7 +4783,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -4796,21 +4796,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4818,7 +4818,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -4827,7 +4827,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -4840,21 +4840,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4862,7 +4862,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -4871,7 +4871,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -4884,21 +4884,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -4906,7 +4906,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -4944,12 +4944,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Z
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -4974,12 +4974,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   Y
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5004,12 +5004,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   X
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libX.so
                 </span>
@@ -5036,12 +5036,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5065,12 +5065,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5095,12 +5095,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5125,12 +5125,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   E
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -5297,11 +5297,11 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -5310,12 +5310,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -5324,15 +5324,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -5369,7 +5369,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -5382,21 +5382,21 @@ for understanding where time was actually spent in a program."
                   3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5404,7 +5404,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -5413,7 +5413,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -5426,21 +5426,21 @@ for understanding where time was actually spent in a program."
                   3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5448,7 +5448,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -5457,7 +5457,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="67%"
                 >
                   67%
@@ -5470,21 +5470,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5492,7 +5492,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -5501,7 +5501,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -5514,21 +5514,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5536,7 +5536,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -5545,7 +5545,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -5558,21 +5558,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5580,7 +5580,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -5589,7 +5589,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -5602,21 +5602,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5624,7 +5624,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -5633,7 +5633,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -5646,21 +5646,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -5668,7 +5668,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -5706,12 +5706,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5736,12 +5736,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5766,12 +5766,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5796,12 +5796,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   D
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5825,12 +5825,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   E
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5855,12 +5855,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   F
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -5885,12 +5885,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   H
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libH.so
                 </span>
@@ -6059,11 +6059,11 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree with filen
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -6072,12 +6072,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -6086,15 +6086,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -6131,7 +6131,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -6144,21 +6144,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6166,7 +6166,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6175,7 +6175,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -6188,21 +6188,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6210,7 +6210,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6219,7 +6219,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -6232,21 +6232,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6254,7 +6254,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6263,7 +6263,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -6276,21 +6276,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6298,7 +6298,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -6336,12 +6336,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   widget/cocoa/nsAppShell.mm
                 </span>
@@ -6368,12 +6368,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   library/std/src/sys/unix/thread.rs
                 </span>
@@ -6400,12 +6400,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   ipc/ipdl/PBackgroundChild.cpp
                 </span>
@@ -6431,12 +6431,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   D
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libD.so
                 </span>
@@ -6605,11 +6605,11 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -6618,12 +6618,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -6632,15 +6632,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -6677,7 +6677,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -6690,21 +6690,21 @@ for understanding where time was actually spent in a program."
                   3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6712,7 +6712,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6721,7 +6721,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -6734,21 +6734,21 @@ for understanding where time was actually spent in a program."
                   3
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6756,7 +6756,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6765,7 +6765,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="67%"
                 >
                   67%
@@ -6778,21 +6778,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6800,7 +6800,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6809,7 +6809,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -6822,21 +6822,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6844,7 +6844,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6853,7 +6853,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -6866,21 +6866,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6888,7 +6888,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6897,7 +6897,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -6910,21 +6910,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6932,7 +6932,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -6941,7 +6941,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="33%"
                 >
                   33%
@@ -6954,21 +6954,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -6976,7 +6976,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -7014,12 +7014,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7044,12 +7044,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7074,12 +7074,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   C
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7104,12 +7104,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   D
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7133,12 +7133,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   E
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7163,12 +7163,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   F
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7193,12 +7193,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name"
+                  class="treeViewMainColumn name"
                 >
                   H
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 >
                   libH.so
                 </span>
@@ -7367,11 +7367,11 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -7380,12 +7380,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -7394,15 +7394,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -7439,7 +7439,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -7452,21 +7452,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -7474,7 +7474,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -7483,7 +7483,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -7496,21 +7496,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -7518,7 +7518,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -7527,7 +7527,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -7540,21 +7540,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -7562,7 +7562,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -7571,7 +7571,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -7584,21 +7584,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -7606,7 +7606,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -7615,7 +7615,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -7628,21 +7628,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -7650,7 +7650,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -7659,7 +7659,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -7672,21 +7672,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -7694,7 +7694,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -7732,12 +7732,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7762,12 +7762,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7792,7 +7792,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -7801,7 +7801,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7826,12 +7826,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   D
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7855,12 +7855,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   E
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -7885,12 +7885,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   F
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -8057,11 +8057,11 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -8070,12 +8070,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -8084,15 +8084,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -8129,7 +8129,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8142,21 +8142,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8164,7 +8164,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8173,7 +8173,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8186,21 +8186,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8208,7 +8208,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8217,7 +8217,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8230,21 +8230,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8252,7 +8252,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8261,7 +8261,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -8274,21 +8274,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8296,7 +8296,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8305,7 +8305,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -8318,21 +8318,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8340,7 +8340,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8349,7 +8349,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -8362,21 +8362,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8384,7 +8384,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -8422,12 +8422,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -8452,12 +8452,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -8482,7 +8482,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -8491,7 +8491,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -8516,12 +8516,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   D
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -8545,12 +8545,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   E
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -8575,12 +8575,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   F
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -8747,11 +8747,11 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -8760,12 +8760,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -8774,15 +8774,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -8819,7 +8819,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8832,21 +8832,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8854,7 +8854,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8863,7 +8863,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8876,21 +8876,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8898,7 +8898,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8907,7 +8907,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8920,21 +8920,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8942,7 +8942,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -8951,7 +8951,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -8964,21 +8964,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -8986,7 +8986,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -9024,12 +9024,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -9054,12 +9054,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -9084,7 +9084,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -9093,7 +9093,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -9118,7 +9118,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -9127,7 +9127,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -9294,11 +9294,11 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -9307,12 +9307,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -9321,15 +9321,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -9366,7 +9366,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -9379,21 +9379,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -9401,7 +9401,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -9410,7 +9410,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -9423,21 +9423,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -9445,7 +9445,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -9454,7 +9454,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -9467,21 +9467,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -9489,7 +9489,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -9498,7 +9498,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -9511,21 +9511,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -9533,7 +9533,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -9571,12 +9571,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -9601,12 +9601,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -9631,7 +9631,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -9640,7 +9640,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -9665,7 +9665,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -9674,7 +9674,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>
@@ -9841,11 +9841,11 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
     >
       <span
         class="treeViewHeaderColumn treeViewFixedColumn totalPercent"
-        style="width: 50px;"
+        style="width: 55px;"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn total"
-        style="width: 120px;"
+        style="width: 125px;"
         title="The “total” sample count includes a summary of every sample where this
 function was observed to be on the stack. This includes the time where the
 function was actually running, and the time spent in the callers from this
@@ -9854,12 +9854,12 @@ function."
         Total (samples)
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="1"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn self"
-        style="width: 70px;"
+        style="width: 80px;"
         title="The “self” sample count only includes the samples where the function was
 the end of the stack. If this function called into other functions,
 then the “other” functions’ counts are not included. The “self” count is useful
@@ -9868,15 +9868,15 @@ for understanding where time was actually spent in a program."
         Self
       </span>
       <span
-        class="treeViewColumnDivider isResizable"
+        class="treeViewHeaderColumnDivider isResizable"
         data-column-index="2"
       />
       <span
         class="treeViewHeaderColumn treeViewFixedColumn icon"
-        style="width: 10px;"
+        style="width: 20px;"
       />
       <span
-        class="treeViewColumnDivider"
+        class="treeViewHeaderColumnDivider"
         data-column-index="3"
       />
       <span
@@ -9913,7 +9913,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -9926,21 +9926,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -9948,7 +9948,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -9957,7 +9957,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -9970,21 +9970,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -9992,7 +9992,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -10001,7 +10001,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="100%"
                 >
                   100%
@@ -10014,21 +10014,21 @@ for understanding where time was actually spent in a program."
                   2
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -10036,7 +10036,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -10045,7 +10045,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -10058,21 +10058,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -10080,7 +10080,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -10089,7 +10089,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -10102,21 +10102,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="1"
                 >
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -10124,7 +10124,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
               <div
@@ -10133,7 +10133,7 @@ for understanding where time was actually spent in a program."
               >
                 <span
                   class="treeViewRowColumn treeViewFixedColumn totalPercent"
-                  style="width: 50px;"
+                  style="width: 55px;"
                   title="50%"
                 >
                   50%
@@ -10146,21 +10146,21 @@ for understanding where time was actually spent in a program."
                   1
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn self"
-                  style="width: 70px;"
+                  style="width: 80px;"
                   title="—"
                 >
                   —
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
                 <span
                   class="treeViewRowColumn treeViewFixedColumn icon"
-                  style="width: 10px;"
+                  style="width: 20px;"
                   title=""
                 >
                   <div
@@ -10168,7 +10168,7 @@ for understanding where time was actually spent in a program."
                   />
                 </span>
                 <span
-                  class="treeViewColumnDivider"
+                  class="treeViewRowColumnDivider"
                 />
               </div>
             </div>
@@ -10206,12 +10206,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   A
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -10236,12 +10236,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   B
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -10266,7 +10266,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -10275,7 +10275,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -10300,12 +10300,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   D
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -10329,7 +10329,7 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   <span
                     class="treeViewHighlighting"
@@ -10338,7 +10338,7 @@ for understanding where time was actually spent in a program."
                   </span>
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
               <div
@@ -10363,12 +10363,12 @@ for understanding where time was actually spent in a program."
                   title="Other"
                 />
                 <span
-                  class="treeViewRowColumn treeViewMainColumn name dim"
+                  class="treeViewMainColumn name dim"
                 >
                   F
                 </span>
                 <span
-                  class="treeViewRowColumn treeViewAppendageColumn lib"
+                  class="treeViewAppendageColumn lib"
                 />
               </div>
             </div>

--- a/src/test/components/__snapshots__/ZipFileTree.test.tsx.snap
+++ b/src/test/components/__snapshots__/ZipFileTree.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     foo
                   </span>
@@ -161,7 +161,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     bar
                   </span>
@@ -182,7 +182,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton collapsed leaf"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     <a
                       href="http://localhost/from-url//calltree/?file=foo%2Fbar%2Fprofile1.json"
@@ -207,7 +207,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton collapsed leaf"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     <a
                       href="http://localhost/from-url//calltree/?file=foo%2Fprofile2.json"
@@ -233,7 +233,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     baz
                   </span>
@@ -254,7 +254,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton collapsed leaf"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     <a
                       href="http://localhost/from-url//calltree/?file=baz%2Fprofile3.json"
@@ -280,7 +280,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     boat
                   </span>
@@ -302,7 +302,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     ship
                   </span>
@@ -324,7 +324,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     new
                   </span>
@@ -346,7 +346,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     anything
                   </span>
@@ -368,7 +368,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     explore
                   </span>
@@ -390,7 +390,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     yes
                   </span>
@@ -411,7 +411,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton collapsed leaf"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     <a
                       href="http://localhost/from-url//calltree/?file=boat%2Fship%2Fnew%2Fanything%2Fexplore%2Fyes%2Fprofile4.json"
@@ -437,7 +437,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     not
                   </span>
@@ -459,7 +459,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton expanded canBeExpanded"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     a
                   </span>
@@ -480,7 +480,7 @@ exports[`calltree/ZipFileTree renders a zip file tree 1`] = `
                     class="treeRowToggleButton collapsed leaf"
                   />
                   <span
-                    class="treeViewRowColumn treeViewMainColumn name"
+                    class="treeViewMainColumn name"
                   >
                     <a
                       href="http://localhost/from-url//calltree/?file=not%2Fa%2Fprofile.pdf"


### PR DESCRIPTION
[Main](https://main--perf-html.netlify.app/public/3t89gzy0pk5ndt09g12rxcm8za1t2624dfym900/calltree/?ctSummary=js-allocations&globalTrackOrder=504213&hiddenGlobalTracks=3&hiddenLocalTracksByPid=5405-0wxoxrwy3~5829-0wlnwq~5516-0wpswx0~5549-0woqwu~5582-0wvx1wx4&invertCallstack&localTrackOrderByPid=5582-x0wx27x3x4452ca0ed91fwn63ourtpqvs8b&range=m2720&symbolServer=http%3A%2F%2F127.0.0.1%3A3001%2F3clk8kpswhprpn1na0qf4dy839qc3119z37pa28&thread=A6&v=16) | [Deploy preview](https://deploy-preview-6002--perf-html.netlify.app/public/3t89gzy0pk5ndt09g12rxcm8za1t2624dfym900/calltree/?ctSummary=js-allocations&globalTrackOrder=504213&hiddenGlobalTracks=3&hiddenLocalTracksByPid=5405-0wxoxrwy3~5829-0wlnwq~5516-0wpswx0~5549-0woqwu~5582-0wvx1wx4&invertCallstack&localTrackOrderByPid=5582-x0wx27x3x4452ca0ed91fwn63ourtpqvs8b&range=m2720&symbolServer=http%3A%2F%2F127.0.0.1%3A3001%2F3clk8kpswhprpn1na0qf4dy839qc3119z37pa28&thread=A6&v=16)

When we make columns sortable, this will offer a bigger click target and mousedown feedback area.