### PR TITLE
Make profiler-cli work in sandboxed environments

### DIFF
--- a/profiler-cli/src/client.ts
+++ b/profiler-cli/src/client.ts
@@ -266,6 +266,9 @@ export async function startNewDaemon(
   const scriptPath = process.argv[1];
 
   const daemonArgs = [
+    // Make fetch respect HTTP_PROXY/HTTPS_PROXY/NO_PROXY. This is the default
+    // in a lot of tools like, curl, python, go etc.
+    '--use-env-proxy',
     scriptPath,
     '--daemon',
     absolutePath,

--- a/profiler-cli/src/client.ts
+++ b/profiler-cli/src/client.ts
@@ -22,10 +22,10 @@ import {
   getCurrentSessionId,
   getCurrentSocketPath,
   getSocketPath,
-  isProcessRunning,
+  isDaemonReachable,
   loadSessionMetadata,
   validateSession,
-  waitForProcessExit,
+  waitForSocketClose,
 } from './session';
 import { BUILD_HASH } from './constants';
 
@@ -77,17 +77,8 @@ async function sendMessageToSocket(
 async function attemptShutdownOnBuildMismatch(
   sessionDir: string,
   sessionId: string,
-  socketPath: string,
-  pid: number
+  socketPath: string
 ): Promise<BuildMismatchShutdownResult> {
-  if (process.platform !== 'win32' && !fs.existsSync(socketPath)) {
-    if (!isProcessRunning(pid)) {
-      cleanupSession(sessionDir, sessionId);
-      return 'already-dead';
-    }
-    return 'still-running';
-  }
-
   try {
     const response = await sendMessageToSocket(
       socketPath,
@@ -99,10 +90,12 @@ async function attemptShutdownOnBuildMismatch(
       console.error(
         `Failed to stop mismatched daemon for session ${sessionId}: unexpected response ${response.type}`
       );
-      return isProcessRunning(pid) ? 'still-running' : 'already-dead';
+      return (await isDaemonReachable(socketPath))
+        ? 'still-running'
+        : 'already-dead';
     }
 
-    const exited = await waitForProcessExit(pid);
+    const exited = await waitForSocketClose(socketPath);
     if (!exited) {
       console.error(
         `Mismatched daemon for session ${sessionId} acknowledged shutdown but did not exit within timeout`
@@ -113,7 +106,7 @@ async function attemptShutdownOnBuildMismatch(
     cleanupSession(sessionDir, sessionId);
     return 'stopped';
   } catch (error) {
-    if (!isProcessRunning(pid)) {
+    if (!(await isDaemonReachable(socketPath))) {
       cleanupSession(sessionDir, sessionId);
       return 'already-dead';
     }
@@ -140,7 +133,7 @@ async function sendRawMessage(
   }
 
   // Validate the session
-  if (!validateSession(sessionDir, resolvedSessionId)) {
+  if (!(await validateSession(sessionDir, resolvedSessionId))) {
     cleanupSession(sessionDir, resolvedSessionId);
     throw new Error(
       `Session ${resolvedSessionId} is not running or is invalid.`
@@ -153,8 +146,7 @@ async function sendRawMessage(
     const shutdownResult = await attemptShutdownOnBuildMismatch(
       sessionDir,
       resolvedSessionId,
-      metadata.socketPath,
-      metadata.pid
+      metadata.socketPath
     );
 
     const shutdownMessage =
@@ -250,7 +242,7 @@ export async function startNewDaemon(
   const targetSessionId = sessionId || generateSessionId();
 
   if (sessionId) {
-    const existingSession = validateSession(sessionDir, targetSessionId);
+    const existingSession = await validateSession(sessionDir, targetSessionId);
     if (existingSession) {
       throw new Error(
         `Session ${targetSessionId} is already running. Stop it first or choose a different session id.`
@@ -302,14 +294,14 @@ export async function startNewDaemon(
     attempts++;
 
     // Validate the session (checks metadata exists, process running, socket exists)
-    if (validateSession(sessionDir, targetSessionId)) {
+    if (await validateSession(sessionDir, targetSessionId)) {
       // Daemon is validated and running
       break;
     }
   }
 
   // Check if daemon started successfully after polling
-  if (!validateSession(sessionDir, targetSessionId)) {
+  if (!(await validateSession(sessionDir, targetSessionId))) {
     throw new Error(
       `Failed to start daemon: session not validated after ${daemonStartMaxAttempts * 50}ms`
     );

--- a/profiler-cli/src/commands/session.ts
+++ b/profiler-cli/src/commands/session.ts
@@ -27,13 +27,13 @@ export function registerSessionCommand(
   session
     .command('list', { isDefault: true })
     .description('List all running daemon sessions')
-    .action(() => {
+    .action(async () => {
       const sessionIds = listSessions(sessionDir);
       let numCleaned = 0;
       const runningSessionMetadata = [];
 
       for (const sessionId of sessionIds) {
-        const metadata = validateSession(sessionDir, sessionId);
+        const metadata = await validateSession(sessionDir, sessionId);
         if (metadata === null) {
           cleanupSession(sessionDir, sessionId);
           numCleaned++;
@@ -70,8 +70,8 @@ export function registerSessionCommand(
   session
     .command('use <id>')
     .description('Switch the current session')
-    .action((sessionId: string) => {
-      const metadata = validateSession(sessionDir, sessionId);
+    .action(async (sessionId: string) => {
+      const metadata = await validateSession(sessionDir, sessionId);
       if (metadata === null) {
         console.error(`Error: session "${sessionId}" not found or not running`);
         process.exit(1);

--- a/profiler-cli/src/session.ts
+++ b/profiler-cli/src/session.ts
@@ -12,6 +12,7 @@
  */
 
 import * as fs from 'fs';
+import * as net from 'net';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import type { SessionMetadata } from './protocol';
@@ -141,36 +142,45 @@ export function getCurrentSocketPath(sessionDir: string): string | null {
 }
 
 /**
- * Check if a process is running.
+ * Check if a daemon is reachable by attempting a socket connection.
+ * Works for both Unix domain sockets and Windows named pipes.
  */
-export function isProcessRunning(pid: number): boolean {
-  try {
-    // Sending signal 0 checks if process exists without killing it
-    process.kill(pid, 0);
-    return true;
-  } catch (_error) {
-    return false;
-  }
+export async function isDaemonReachable(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect(socketPath);
+    socket.setTimeout(1000);
+    socket.on('connect', () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.on('error', () => {
+      resolve(false);
+    });
+    socket.on('timeout', () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
 }
 
 /**
- * Wait for a process to exit.
+ * Wait for a daemon's socket to become unreachable (i.e. for the daemon to stop).
  */
-export async function waitForProcessExit(
-  pid: number,
+export async function waitForSocketClose(
+  socketPath: string,
   timeoutMs: number = 5000,
   pollIntervalMs: number = 50
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    if (!isProcessRunning(pid)) {
+    if (!(await isDaemonReachable(socketPath))) {
       return true;
     }
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 
-  return !isProcessRunning(pid);
+  return !(await isDaemonReachable(socketPath));
 }
 
 /**
@@ -202,25 +212,19 @@ export function cleanupSession(sessionDir: string, sessionId: string): void {
 }
 
 /**
- * Validate that a session is healthy (process running, socket exists).
+ * Validate that a session is healthy (daemon reachable via socket).
  * If not, clean up stale files.
  */
-export function validateSession(
+export async function validateSession(
   sessionDir: string,
   sessionId: string
-): SessionMetadata | null {
+): Promise<SessionMetadata | null> {
   const metadata = loadSessionMetadata(sessionDir, sessionId);
   if (!metadata) {
     return null;
   }
 
-  // Check if process is still running
-  if (!isProcessRunning(metadata.pid)) {
-    return null;
-  }
-
-  // Check if socket exists (Unix only — named pipes on Windows are not filesystem files)
-  if (process.platform !== 'win32' && !fs.existsSync(metadata.socketPath)) {
+  if (!(await isDaemonReachable(metadata.socketPath))) {
     return null;
   }
 

--- a/profiler-cli/src/test/unit/session.test.ts
+++ b/profiler-cli/src/test/unit/session.test.ts
@@ -12,9 +12,9 @@
  */
 
 import * as fs from 'fs';
+import * as net from 'net';
 import * as path from 'path';
 import * as os from 'os';
-import { spawn } from 'child_process';
 import {
   ensureSessionDir,
   generateSessionId,
@@ -27,8 +27,8 @@ import {
   setCurrentSession,
   getCurrentSessionId,
   getCurrentSocketPath,
-  isProcessRunning,
-  waitForProcessExit,
+  isDaemonReachable,
+  waitForSocketClose,
   cleanupSession,
   validateSession,
   listSessions,
@@ -235,38 +235,47 @@ describe('profiler-cli session management', function () {
     });
   });
 
-  describe('isProcessRunning', function () {
-    it('returns true for current process', function () {
-      expect(isProcessRunning(process.pid)).toBe(true);
+  describe('isDaemonReachable', function () {
+    it('returns false when nothing is listening', async function () {
+      const socketPath = getSocketPath(testSessionDir, 'test-socket');
+      expect(await isDaemonReachable(socketPath)).toBe(false);
     });
 
-    it('returns false for non-existent PID', function () {
-      expect(isProcessRunning(999999)).toBe(false);
-    });
-
-    it('waits for a process to exit', async function () {
-      const child = spawn(process.execPath, [
-        '-e',
-        'setTimeout(() => process.exit(0), 100)',
-      ]);
-
-      const exited = await waitForProcessExit(child.pid!, 2000, 10);
-
-      expect(exited).toBe(true);
-    });
-
-    it('times out if a process does not exit', async function () {
-      const child = spawn(process.execPath, [
-        '-e',
-        'setTimeout(() => process.exit(0), 5000)',
-      ]);
+    it('returns true when a server is listening', async function () {
+      const socketPath = getSocketPath(testSessionDir, 'test-socket');
+      const server = net.createServer();
+      await new Promise<void>((resolve) => server.listen(socketPath, resolve));
 
       try {
-        const exited = await waitForProcessExit(child.pid!, 50, 10);
-        expect(exited).toBe(false);
+        expect(await isDaemonReachable(socketPath)).toBe(true);
       } finally {
-        child.kill('SIGTERM');
-        await waitForProcessExit(child.pid!, 2000, 10);
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+  });
+
+  describe('waitForSocketClose', function () {
+    it('returns true when the server closes', async function () {
+      const socketPath = getSocketPath(testSessionDir, 'test-socket');
+      const server = net.createServer();
+      await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+      setTimeout(() => server.close(), 100);
+
+      const closed = await waitForSocketClose(socketPath, 2000, 10);
+      expect(closed).toBe(true);
+    });
+
+    it('times out if the server does not close', async function () {
+      const socketPath = getSocketPath(testSessionDir, 'test-socket');
+      const server = net.createServer();
+      await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+      try {
+        const closed = await waitForSocketClose(socketPath, 50, 10);
+        expect(closed).toBe(false);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
       }
     });
   });
@@ -320,17 +329,36 @@ describe('profiler-cli session management', function () {
   });
 
   describe('validateSession', function () {
-    it('returns false for non-existent session', function () {
-      expect(validateSession(testSessionDir, 'nonexistent')).toBe(null);
+    it('returns null for non-existent session', async function () {
+      expect(await validateSession(testSessionDir, 'nonexistent')).toBe(null);
     });
 
-    it('returns false for session with dead PID', function () {
+    it('returns null when nothing is listening on the socket', async function () {
       const sessionId = 'test123';
       const metadata: SessionMetadata = {
         id: sessionId,
         socketPath: getSocketPath(testSessionDir, sessionId),
         logPath: getLogPath(testSessionDir, sessionId),
-        pid: 999999, // Non-existent PID
+        pid: process.pid,
+        profilePath: '/path/to/profile.json',
+        createdAt: new Date().toISOString(),
+        buildHash: TEST_BUILD_HASH,
+      };
+
+      saveSessionMetadata(testSessionDir, metadata);
+      // Intentionally don't start a server
+
+      expect(await validateSession(testSessionDir, sessionId)).toBe(null);
+    });
+
+    it('returns metadata for a valid session with an active socket', async function () {
+      const sessionId = 'test123';
+      const socketPath = getSocketPath(testSessionDir, sessionId);
+      const metadata: SessionMetadata = {
+        id: sessionId,
+        socketPath,
+        logPath: getLogPath(testSessionDir, sessionId),
+        pid: process.pid,
         profilePath: '/path/to/profile.json',
         createdAt: new Date().toISOString(),
         buildHash: TEST_BUILD_HASH,
@@ -338,52 +366,14 @@ describe('profiler-cli session management', function () {
 
       saveSessionMetadata(testSessionDir, metadata);
 
-      expect(validateSession(testSessionDir, sessionId)).toBe(null);
-    });
+      const server = net.createServer();
+      await new Promise<void>((resolve) => server.listen(socketPath, resolve));
 
-    it('returns false for session with missing socket', function () {
-      if (process.platform === 'win32') {
-        // Not applicable on Windows: named pipes are self-cleaning and disappear
-        // automatically when the server stops, so a session can't have a live PID
-        // but a missing socket. validateSession skips the socket check on Windows
-        // for this reason.
-        return;
+      try {
+        expect(await validateSession(testSessionDir, sessionId)).not.toBe(null);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
       }
-      const sessionId = 'test123';
-      const metadata: SessionMetadata = {
-        id: sessionId,
-        socketPath: getSocketPath(testSessionDir, sessionId),
-        logPath: getLogPath(testSessionDir, sessionId),
-        pid: process.pid, // Use current process PID (guaranteed to exist)
-        profilePath: '/path/to/profile.json',
-        createdAt: new Date().toISOString(),
-        buildHash: TEST_BUILD_HASH,
-      };
-
-      saveSessionMetadata(testSessionDir, metadata);
-      // Intentionally don't create socket file
-
-      expect(validateSession(testSessionDir, sessionId)).toBe(null);
-    });
-
-    it('returns true for valid session', function () {
-      const sessionId = 'test123';
-      const metadata: SessionMetadata = {
-        id: sessionId,
-        socketPath: getSocketPath(testSessionDir, sessionId),
-        logPath: getLogPath(testSessionDir, sessionId),
-        pid: process.pid, // Use current process PID
-        profilePath: '/path/to/profile.json',
-        createdAt: new Date().toISOString(),
-        buildHash: TEST_BUILD_HASH,
-      };
-
-      saveSessionMetadata(testSessionDir, metadata);
-      if (process.platform !== 'win32') {
-        fs.writeFileSync(metadata.socketPath, '');
-      }
-
-      expect(validateSession(testSessionDir, sessionId)).not.toBe(null);
     });
   });
 


### PR DESCRIPTION
There were two things that prevented us from having a working cli in the sandboxed environments:
1. HTTP(S) proxy needs to be used
    - All network request must go through some proxy, so the sandboxed environment can choose to allow or block the requests per domain. If it doesn't use this proxy, the requests are usually blocked automatically without a way to allow. It seemed a bit sketchy to me at first but then I realized that this is the default behavior on many places like curl, python, go, and node is considering enabling this by default.
2. Signaling a process is not allowed
    -  `process.kill(pid, 0);` isn't allowed in sandboxed environments, so this can't be used to check if the process is still alive. Instead, I converted that `isProcessRunning` to `isDaemonReachable` and used the existing sockets to check if the daemon is still listening that socket (for example with ECONNREFUSED).

Also please see the individual commit messages.

I tested both on macOS and Linux, and they seem to work (with some additional config depending on what you use for sandboxing)