### PR TITLE
Fix the unnecessary stringify of Uint8Array contents during zip profile extraction

### DIFF
--- a/src/actions/zipped-profiles.ts
+++ b/src/actions/zipped-profiles.ts
@@ -57,7 +57,7 @@ export function viewProfileFromZip(
     try {
       // Attempt to unserialize the profile.
       const profile = await unserializeProfileOfArbitraryFormat(
-        await file.async('uint8array'),
+        await file.async('arraybuffer'),
         pathInZipFile
       );
 

--- a/src/profile-logic/process-profile.ts
+++ b/src/profile-logic/process-profile.ts
@@ -2005,10 +2005,12 @@ export async function unserializeProfileOfArbitraryFormat(
   upgradeInfo: ProfileUpgradeInfo = {}
 ): Promise<Profile> {
   try {
-    // We used to use `instanceof ArrayBuffer`, but this doesn't work when the
-    // object is constructed from an ArrayBuffer in a different context... which
-    // happens in our tests.
-    if (String(arbitraryFormat) === '[object ArrayBuffer]') {
+    // We use Object.prototype.toString instead of `instanceof ArrayBuffer`
+    // because instanceof doesn't work cross-realm (e.g. in tests), and we
+    // can't use String() since that serializes the full contents of a Uint8Array.
+    if (
+      Object.prototype.toString.call(arbitraryFormat) === '[object ArrayBuffer]'
+    ) {
       const arrayBuffer = arbitraryFormat as ArrayBuffer;
       arbitraryFormat = new Uint8Array(arrayBuffer);
     }


### PR DESCRIPTION
Fixes #6001.

See my analysis here for more context: https://github.com/firefox-devtools/profiler/issues/6001#issuecomment-4396413166

Example profile: [before](https://profiler.firefox.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FRIPckZZxRlWjmM_wyFnxyQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3.zip) / [after](https://deploy-preview-6004--perf-html.netlify.app/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FRIPckZZxRlWjmM_wyFnxyQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3.zip)