### PR TITLE
More additions to profiler-edit, for sp3 profiles

### DIFF
--- a/src/node-tools/profiler-edit.ts
+++ b/src/node-tools/profiler-edit.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import fs from 'fs';
-import { Command, CommanderError, Option } from 'commander';
+import {
+  Command,
+  CommanderError,
+  InvalidArgumentError,
+  Option,
+} from 'commander';
 import { parse as parseToml } from 'smol-toml';
 
 import {
@@ -84,6 +89,7 @@ export interface CliOptions {
   insertLabelFrames?: string;
   onlyKeepThreadsWithMarkersMatching?: string;
   mergeNonOverlappingThreadsByName?: boolean;
+  setName?: string;
 }
 
 export function loadWasmSymbolicationSpecs(
@@ -295,6 +301,10 @@ export async function run(options: CliOptions) {
     profile = mergeNonOverlappingThreadsByName(profile);
   }
 
+  if (options.setName !== undefined) {
+    profile.meta.product = options.setName;
+  }
+
   const { profile: compactedProfile } = computeCompactedProfile(profile);
 
   const outputFilename = options.output;
@@ -326,6 +336,15 @@ function collectWasm(
     ];
   }
   return [...previous, { unstrippedWasmPath: value }];
+}
+
+function requireNonEmpty(flagName: string): (value: string) => string {
+  return (value: string) => {
+    if (value === '') {
+      throw new InvalidArgumentError(`${flagName} requires a non-empty value`);
+    }
+    return value;
+  };
 }
 
 export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
@@ -362,6 +381,11 @@ export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
     .option(
       '--merge-non-overlapping-threads-by-name',
       'Merge same-named threads across non-overlapping process runs'
+    )
+    .option(
+      '--set-name <name>',
+      'Override the profile product name',
+      requireNonEmpty('--set-name')
     );
 
   program.parse(processArgv);
@@ -421,6 +445,7 @@ export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
         : undefined,
     mergeNonOverlappingThreadsByName:
       opts.mergeNonOverlappingThreadsByName === true,
+    setName: typeof opts.setName === 'string' ? opts.setName : undefined,
   };
 }
 

--- a/src/node-tools/profiler-edit.ts
+++ b/src/node-tools/profiler-edit.ts
@@ -31,14 +31,21 @@ import {
   type WasmSymbolicationSpec,
 } from 'firefox-profiler/profile-logic/wasm-symbolication';
 import { getThreadsWithMarkersMatchingSearchFilter } from 'firefox-profiler/profile-logic/marker-data';
-import type { Profile } from 'firefox-profiler/types/profile';
+import type {
+  Profile,
+  RawThread,
+  ThreadIndex,
+} from 'firefox-profiler/types/profile';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import {
   type AutoLabel,
   type LabelDescription,
   resolveAllLabels,
 } from 'firefox-profiler/utils/label-templates';
-import { mergeNonOverlappingThreadsByName } from 'firefox-profiler/profile-logic/merge-compare';
+import {
+  mergeNonOverlappingThreadsByName,
+  remapCountersAndProfilerOverhead,
+} from 'firefox-profiler/profile-logic/merge-compare';
 
 /**
  * A CLI tool for editing profiles.
@@ -288,10 +295,19 @@ export async function run(options: CliOptions) {
       profile,
       options.onlyKeepThreadsWithMarkersMatching
     );
-    const matchingThreads = profile.threads.filter((_thread, threadIndex) =>
-      matchingThreadIndexes.has(threadIndex)
-    );
-    profile = { ...profile, threads: matchingThreads };
+    const oldThreadIndexToNew = new Map<ThreadIndex, ThreadIndex>();
+    const matchingThreads: RawThread[] = [];
+    profile.threads.forEach((thread, oldIndex) => {
+      if (matchingThreadIndexes.has(oldIndex)) {
+        oldThreadIndexToNew.set(oldIndex, matchingThreads.length);
+        matchingThreads.push(thread);
+      }
+    });
+    profile = {
+      ...profile,
+      threads: matchingThreads,
+      ...remapCountersAndProfilerOverhead(profile, oldThreadIndexToNew),
+    };
     console.log(
       `Kept ${profile.threads.length} of ${before} threads with markers matching ${JSON.stringify(options.onlyKeepThreadsWithMarkersMatching)}.`
     );

--- a/src/node-tools/profiler-edit.ts
+++ b/src/node-tools/profiler-edit.ts
@@ -25,6 +25,7 @@ import {
   applyWasmSymbolication,
   type WasmSymbolicationSpec,
 } from 'firefox-profiler/profile-logic/wasm-symbolication';
+import { getThreadsWithMarkersMatchingSearchFilter } from 'firefox-profiler/profile-logic/marker-data';
 import type { Profile } from 'firefox-profiler/types/profile';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import {
@@ -52,6 +53,9 @@ import {
  *
  *   node node-tools-dist/profiler-edit.js --from-hash w1spyw917hg... -o out.json.gz \
  *     --insert-label-frames known-functions.toml
+ *
+ *   node node-tools-dist/profiler-edit.js -i big.json.gz -o small.json.gz \
+ *     --only-keep-threads-with-markers-matching '-async,-sync'
  */
 
 type ProfileSource =
@@ -76,6 +80,7 @@ export interface CliOptions {
   symbolicateWithServer?: string;
   symbolicateWasm: WasmSymbolicationCliSpec[];
   insertLabelFrames?: string;
+  onlyKeepThreadsWithMarkersMatching?: string;
 }
 
 function loadWasmSymbolicationSpecs(
@@ -265,6 +270,24 @@ export async function run(options: CliOptions) {
     profile = insertStackLabels(profile, labels);
   }
 
+  if (
+    options.onlyKeepThreadsWithMarkersMatching !== undefined &&
+    options.onlyKeepThreadsWithMarkersMatching !== ''
+  ) {
+    const before = profile.threads.length;
+    const matchingThreadIndexes = getThreadsWithMarkersMatchingSearchFilter(
+      profile,
+      options.onlyKeepThreadsWithMarkersMatching
+    );
+    const matchingThreads = profile.threads.filter((_thread, threadIndex) =>
+      matchingThreadIndexes.has(threadIndex)
+    );
+    profile = { ...profile, threads: matchingThreads };
+    console.log(
+      `Kept ${profile.threads.length} of ${before} threads with markers matching ${JSON.stringify(options.onlyKeepThreadsWithMarkersMatching)}.`
+    );
+  }
+
   const { profile: compactedProfile } = computeCompactedProfile(profile);
 
   const outputFilename = options.output;
@@ -324,7 +347,11 @@ export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
         .argParser(collectWasm)
         .default([] as WasmSymbolicationCliSpec[])
     )
-    .option('--insert-label-frames <path>', 'TOML file with label definitions');
+    .option('--insert-label-frames <path>', 'TOML file with label definitions')
+    .option(
+      '--only-keep-threads-with-markers-matching <search>',
+      'Keep only threads with markers matching the given search string'
+    );
 
   program.parse(processArgv);
   const opts = program.opts();
@@ -375,6 +402,11 @@ export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
       typeof opts.insertLabelFrames === 'string' &&
       opts.insertLabelFrames !== ''
         ? opts.insertLabelFrames
+        : undefined,
+    onlyKeepThreadsWithMarkersMatching:
+      typeof opts.onlyKeepThreadsWithMarkersMatching === 'string' &&
+      opts.onlyKeepThreadsWithMarkersMatching !== ''
+        ? opts.onlyKeepThreadsWithMarkersMatching
         : undefined,
   };
 }

--- a/src/node-tools/profiler-edit.ts
+++ b/src/node-tools/profiler-edit.ts
@@ -33,6 +33,7 @@ import {
   type LabelDescription,
   resolveAllLabels,
 } from 'firefox-profiler/utils/label-templates';
+import { mergeNonOverlappingThreadsByName } from 'firefox-profiler/profile-logic/merge-compare';
 
 /**
  * A CLI tool for editing profiles.
@@ -55,10 +56,11 @@ import {
  *     --insert-label-frames known-functions.toml
  *
  *   node node-tools-dist/profiler-edit.js -i big.json.gz -o small.json.gz \
- *     --only-keep-threads-with-markers-matching '-async,-sync'
+ *     --only-keep-threads-with-markers-matching '-async,-sync' \
+ *     --merge-non-overlapping-threads-by-name
  */
 
-type ProfileSource =
+export type ProfileSource =
   | { type: 'FILE'; path: string }
   | { type: 'URL'; url: string }
   | { type: 'HASH'; hash: string };
@@ -67,7 +69,7 @@ type ProfileSource =
 // supplies symbol names, plus (optionally) the URL of the stripped wasm in the
 // profile to which those names should be applied. If `strippedWasmUrl` is
 // omitted, the profile must contain exactly one .wasm source, which is used.
-interface WasmSymbolicationCliSpec {
+export interface WasmSymbolicationCliSpec {
   // Path to the local unstripped .wasm file (with a "name" custom section).
   unstrippedWasmPath: string;
   // URL of the matching stripped wasm as it appears in the profile.
@@ -81,9 +83,10 @@ export interface CliOptions {
   symbolicateWasm: WasmSymbolicationCliSpec[];
   insertLabelFrames?: string;
   onlyKeepThreadsWithMarkersMatching?: string;
+  mergeNonOverlappingThreadsByName?: boolean;
 }
 
-function loadWasmSymbolicationSpecs(
+export function loadWasmSymbolicationSpecs(
   cliSpecs: WasmSymbolicationCliSpec[]
 ): WasmSymbolicationSpec[] {
   return cliSpecs.map((spec) => {
@@ -102,7 +105,7 @@ function loadWasmSymbolicationSpecs(
  * (mirrors getLabelIndexForFunc in insert-stack-labels.ts), so auto-discovery
  * sees the same strings the labeler will compare against.
  */
-function collectFuncNames(profile: Profile): string[] {
+export function collectFuncNames(profile: Profile): string[] {
   const { funcTable, sources, stringArray } = profile.shared;
   const result: string[] = [];
   for (let i = 0; i < funcTable.length; i++) {
@@ -288,6 +291,10 @@ export async function run(options: CliOptions) {
     );
   }
 
+  if (options.mergeNonOverlappingThreadsByName) {
+    profile = mergeNonOverlappingThreadsByName(profile);
+  }
+
   const { profile: compactedProfile } = computeCompactedProfile(profile);
 
   const outputFilename = options.output;
@@ -351,6 +358,10 @@ export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
     .option(
       '--only-keep-threads-with-markers-matching <search>',
       'Keep only threads with markers matching the given search string'
+    )
+    .option(
+      '--merge-non-overlapping-threads-by-name',
+      'Merge same-named threads across non-overlapping process runs'
     );
 
   program.parse(processArgv);
@@ -408,6 +419,8 @@ export function makeOptionsFromArgv(processArgv: string[]): CliOptions {
       opts.onlyKeepThreadsWithMarkersMatching !== ''
         ? opts.onlyKeepThreadsWithMarkersMatching
         : undefined,
+    mergeNonOverlappingThreadsByName:
+      opts.mergeNonOverlappingThreadsByName === true,
   };
 }
 

--- a/src/profile-logic/marker-data.ts
+++ b/src/profile-logic/marker-data.ts
@@ -1,9 +1,17 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { getEmptyRawMarkerTable } from './data-structures';
-import { getFriendlyThreadName } from './profile-data';
-import { removeFilePath, removeURLs, stringsToRegExp } from '../utils/string';
+import {
+  getDefaultCategories,
+  getEmptyRawMarkerTable,
+} from './data-structures';
+import { getFriendlyThreadName, getTimeRangeForThread } from './profile-data';
+import {
+  removeFilePath,
+  removeURLs,
+  stringsToRegExp,
+  splitSearchString,
+} from '../utils/string';
 import { StringTable } from '../utils/string-table';
 import { ensureExists, assertExhaustiveCheck } from '../utils/types';
 import {
@@ -15,6 +23,7 @@ import {
 import {
   getSchemaFromMarker,
   markerPayloadMatchesSearch,
+  markerSchemaFrontEndOnly,
 } from './marker-schema';
 
 import type {
@@ -42,6 +51,8 @@ import type {
   MarkerDisplayLocation,
   Tid,
   LogMarkerPayload,
+  ThreadIndex,
+  Profile,
 } from 'firefox-profiler/types';
 
 /**
@@ -996,6 +1007,99 @@ export function deriveMarkersFromRawMarkerTable(
   }
 
   return { markers, markerIndexToRawMarkerIndexes };
+}
+
+/**
+ * Return the merged list of marker schemas which contains both the schemas
+ * from the profile, and the front-end only schemas ("Jank" etc).
+ */
+export function computeCombinedMarkerSchemaList(
+  markerSchemaFromProfile: MarkerSchema[]
+): MarkerSchema[] {
+  const frontEndSchemaNames = new Set(
+    markerSchemaFrontEndOnly.map((schema) => schema.name)
+  );
+  return [
+    ...markerSchemaFromProfile.filter(
+      (schema) => !frontEndSchemaNames.has(schema.name)
+    ),
+    ...markerSchemaFrontEndOnly,
+  ];
+}
+
+/**
+ * Create a Set from the list, with the key being schema.name.
+ */
+export function computeMarkerSchemaByName(
+  schemaList: MarkerSchema[]
+): MarkerSchemaByName {
+  const markerSchemaByName: MarkerSchemaByName = Object.create(null);
+  for (const schema of schemaList) {
+    markerSchemaByName[schema.name] = schema;
+  }
+  return markerSchemaByName;
+}
+
+/**
+ * Return the set of threads that have at least one marker matching the given
+ * marker search string, using the same regular marker search syntax: comma-
+ * separated terms, optional `field:value` and `-field:value` qualifiers.
+ *
+ * This is a somewhat expensive operation because we call deriveMarkersFromRawMarkerTable
+ * for every thread.
+ */
+export function getThreadsWithMarkersMatchingSearchFilter(
+  profile: Profile,
+  markerSearch: string
+): Set<ThreadIndex> {
+  const searchRegExps = stringsToMarkerRegExps(splitSearchString(markerSearch));
+  if (searchRegExps === null) {
+    return new Set();
+  }
+
+  const stringTable = StringTable.withBackingArray(profile.shared.stringArray);
+  const categoryList = profile.meta.categories ?? getDefaultCategories();
+
+  const schemaList = computeCombinedMarkerSchemaList(
+    profile.meta.markerSchema ?? []
+  );
+  const markerSchemaByName = computeMarkerSchemaByName(schemaList);
+
+  const ipcCorrelations = correlateIPCMarkers(profile.threads, profile.shared);
+
+  const matchingThreads = new Set<ThreadIndex>();
+
+  for (
+    let threadIndex = 0;
+    threadIndex < profile.threads.length;
+    threadIndex++
+  ) {
+    const thread = profile.threads[threadIndex];
+    const { markers } = deriveMarkersFromRawMarkerTable(
+      thread.markers,
+      profile.shared.stringArray,
+      thread.tid,
+      getTimeRangeForThread(thread, profile.meta.interval),
+      ipcCorrelations
+    );
+    if (markers.length === 0) {
+      continue;
+    }
+    const markerIndexes = markers.map((_, i) => i);
+    const filtered = getSearchFilteredMarkerIndexes(
+      (i) => markers[i],
+      markerIndexes,
+      markerSchemaByName,
+      searchRegExps,
+      stringTable,
+      categoryList
+    );
+    if (filtered.length > 0) {
+      matchingThreads.add(threadIndex);
+    }
+  }
+
+  return matchingThreads;
 }
 
 /**

--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -70,6 +70,9 @@ import type {
   ProfileIndexTranslationMaps,
   StartEndRange,
   Pid,
+  RawCounter,
+  ProfilerOverhead,
+  ThreadIndex,
 } from 'firefox-profiler/types';
 import { translateTransformStack } from './transforms';
 
@@ -1553,6 +1556,41 @@ function partitionNonOverlapping<T>(
 }
 
 /**
+ * Remap the `mainThreadIndex` of counters and profilerOverhead entries
+ * according to `oldThreadIndexToNew`. Entries whose main thread is not in the
+ * map (i.e. has been removed) are dropped.
+ */
+export function remapCountersAndProfilerOverhead(
+  profile: Profile,
+  oldThreadIndexToNew: Map<ThreadIndex, ThreadIndex>
+): {
+  counters: RawCounter[] | undefined;
+  profilerOverhead: ProfilerOverhead[] | undefined;
+} {
+  return {
+    counters: profile.counters?.reduce<RawCounter[]>((acc, counter) => {
+      const newThreadIndex = oldThreadIndexToNew.get(counter.mainThreadIndex);
+      if (newThreadIndex !== undefined) {
+        acc.push({ ...counter, mainThreadIndex: newThreadIndex });
+      }
+      return acc;
+    }, []),
+    profilerOverhead: profile.profilerOverhead?.reduce<ProfilerOverhead[]>(
+      (acc, overhead) => {
+        const newThreadIndex = oldThreadIndexToNew.get(
+          overhead.mainThreadIndex
+        );
+        if (newThreadIndex !== undefined) {
+          acc.push({ ...overhead, mainThreadIndex: newThreadIndex });
+        }
+        return acc;
+      },
+      []
+    ),
+  };
+}
+
+/**
  * Merges threads from sequential runs of the same logical workload.
  *
  * Two-stage approach:
@@ -1630,6 +1668,9 @@ export function mergeNonOverlappingThreadsByName(profile: Profile): Profile {
 
   const mergedIndexes = new Set<number>();
   const mergeReplacements = new Map<number, RawThread>();
+  // For each old index that has been merged away (i.e. is in `mergedIndexes`),
+  // the old index of the surviving thread (`tb[0]`) it was merged into.
+  const mergedAwayToSurvivor = new Map<number, number>();
 
   for (const procs of processGroups.values()) {
     if (procs.length <= 1) {
@@ -1684,6 +1725,7 @@ export function mergeNonOverlappingThreadsByName(profile: Profile): Profile {
           mergeReplacements.set(tb[0], merged);
           for (let k = 1; k < tb.length; k++) {
             mergedIndexes.add(tb[k]);
+            mergedAwayToSurvivor.set(tb[k], tb[0]);
           }
         }
       }
@@ -1694,14 +1736,26 @@ export function mergeNonOverlappingThreadsByName(profile: Profile): Profile {
     return profile;
   }
 
+  const oldThreadIndexToNew = new Map<ThreadIndex, ThreadIndex>();
   const newThreads: RawThread[] = [];
   for (let i = 0; i < threads.length; i++) {
     if (mergedIndexes.has(i)) {
       continue;
     }
+    oldThreadIndexToNew.set(i, newThreads.length);
     const replacement = mergeReplacements.get(i);
     newThreads.push(replacement ?? threads[i]);
   }
+  for (const [removed, survivor] of mergedAwayToSurvivor) {
+    oldThreadIndexToNew.set(
+      removed,
+      ensureExists(oldThreadIndexToNew.get(survivor))
+    );
+  }
 
-  return { ...profile, threads: newThreads };
+  return {
+    ...profile,
+    threads: newThreads,
+    ...remapCountersAndProfilerOverhead(profile, oldThreadIndexToNew),
+  };
 }

--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -68,6 +68,8 @@ import type {
   Tid,
   RawProfileSharedData,
   ProfileIndexTranslationMaps,
+  StartEndRange,
+  Pid,
 } from 'firefox-profiler/types';
 import { translateTransformStack } from './transforms';
 
@@ -1491,4 +1493,185 @@ function getThreadMarkersAndScreenshotMarkers(
   }
 
   return targetMarkerTable;
+}
+
+/**
+ * First-fit interval coloring: partition `items` (sorted by start time) into
+ * subgroups such that within each subgroup no two items overlap.
+ */
+function partitionNonOverlapping<T>(
+  itemsSortedByStart: T[],
+  rangeOf: (item: T) => StartEndRange
+): T[][] {
+  const subgroups: { items: T[]; lastEnd: number }[] = [];
+  for (const item of itemsSortedByStart) {
+    const range = rangeOf(item);
+    let placed = false;
+    for (const sg of subgroups) {
+      if (sg.lastEnd <= range.start) {
+        sg.items.push(item);
+        sg.lastEnd = range.end;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      subgroups.push({ items: [item], lastEnd: range.end });
+    }
+  }
+  return subgroups.map((sg) => sg.items);
+}
+
+/**
+ * Merges threads from sequential runs of the same logical workload.
+ *
+ * Two-stage approach:
+ *
+ *   1. Group processes (i.e. all threads sharing a pid) by (processName,
+ *      processType, mainThreadName) and partition each group into matched
+ *      bundles of non-overlapping processes via first-fit interval coloring.
+ *      Each non-singleton bundle represents one logical process whose
+ *      lifetime spans multiple runs.
+ *
+ *   2. Within each matched bundle, merge same-named threads across the
+ *      bundled processes. Same-named threads inside a single process are
+ *      not merged (they may overlap), so we again partition by non-overlap
+ *      before merging.
+ *
+ * Threads belonging to a singleton process bundle are passed through
+ * unchanged.
+ */
+export function mergeNonOverlappingThreadsByName(profile: Profile): Profile {
+  const interval = profile.meta.interval;
+  const threads = profile.threads;
+
+  const threadRanges = threads.map((t) => getTimeRangeForThread(t, interval));
+
+  type ProcessInfo = {
+    pid: Pid;
+    threadIndices: number[];
+    range: StartEndRange;
+    processName: string | undefined;
+    processType: string;
+    mainThreadName: string;
+  };
+
+  const processesByPid = new Map<Pid, ProcessInfo>();
+  for (let i = 0; i < threads.length; i++) {
+    const t = threads[i];
+    let proc = processesByPid.get(t.pid);
+    if (proc === undefined) {
+      proc = {
+        pid: t.pid,
+        threadIndices: [],
+        range: { start: Infinity, end: -Infinity },
+        processName: t.processName,
+        processType: t.processType,
+        mainThreadName: t.name,
+      };
+      processesByPid.set(t.pid, proc);
+    }
+    proc.threadIndices.push(i);
+    if (t.isMainThread) {
+      proc.mainThreadName = t.name;
+      if (t.processName !== undefined) {
+        proc.processName = t.processName;
+      }
+    }
+    const r = threadRanges[i];
+    if (r.start < proc.range.start) {
+      proc.range.start = r.start;
+    }
+    if (r.end > proc.range.end) {
+      proc.range.end = r.end;
+    }
+  }
+
+  const processGroups = new Map<string, ProcessInfo[]>();
+  for (const proc of processesByPid.values()) {
+    const key = `${proc.processName ?? ''}\u0000${proc.processType}\u0000${proc.mainThreadName}`;
+    let g = processGroups.get(key);
+    if (g === undefined) {
+      g = [];
+      processGroups.set(key, g);
+    }
+    g.push(proc);
+  }
+
+  const mergedIndexes = new Set<number>();
+  const mergeReplacements = new Map<number, RawThread>();
+
+  for (const procs of processGroups.values()) {
+    if (procs.length <= 1) {
+      continue;
+    }
+    procs.sort((a, b) => a.range.start - b.range.start);
+    const bundles = partitionNonOverlapping(procs, (p) => p.range);
+
+    for (const bundle of bundles) {
+      if (bundle.length <= 1) {
+        continue;
+      }
+
+      // Group threads in this bundle by name, partition each by non-overlap,
+      // and merge subgroups of size > 1.
+      const threadsByName = new Map<string, number[]>();
+      for (const proc of bundle) {
+        for (const tIdx of proc.threadIndices) {
+          const name = threads[tIdx].name;
+          let arr = threadsByName.get(name);
+          if (arr === undefined) {
+            arr = [];
+            threadsByName.set(name, arr);
+          }
+          arr.push(tIdx);
+        }
+      }
+
+      for (const tIndices of threadsByName.values()) {
+        if (tIndices.length <= 1) {
+          continue;
+        }
+        tIndices.sort((a, b) => threadRanges[a].start - threadRanges[b].start);
+        const tBundles = partitionNonOverlapping(
+          tIndices,
+          (i) => threadRanges[i]
+        );
+        for (const tb of tBundles) {
+          if (tb.length <= 1) {
+            continue;
+          }
+          const sourceThreads = tb.map((i) => threads[i]);
+          const original = sourceThreads[0];
+          const merged = mergeThreads(sourceThreads);
+          merged.name = original.name;
+          merged.pid = original.pid;
+          merged.tid = original.tid;
+          merged.processType = original.processType;
+          merged.processName = original.processName;
+          merged.isMainThread = original.isMainThread;
+
+          mergeReplacements.set(tb[0], merged);
+          for (let k = 1; k < tb.length; k++) {
+            mergedIndexes.add(tb[k]);
+          }
+        }
+      }
+    }
+  }
+
+  if (mergeReplacements.size === 0) {
+    return profile;
+  }
+
+  const newThreads: RawThread[] = [];
+  for (let i = 0; i < threads.length; i++) {
+    if (mergedIndexes.has(i)) {
+      continue;
+    }
+    const replacement = mergeReplacements.get(i);
+    newThreads.push(replacement ?? threads[i]);
+  }
+
+  return { ...profile, threads: newThreads };
 }

--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -1361,6 +1361,26 @@ function combineSamplesForMerging(threads: RawThread[]): RawSamplesTable {
     threadId: newThreadId,
   };
 
+  // If every source thread has threadCPUDelta, and if the threads are
+  // non-overlapping in time, create a combined threadCPUDelta for the
+  // merged thread.
+  // For overlapping threads we drop threadCPUDelta entirely because the
+  // deltas are non-sensical if samples are interleaved.
+  const allHaveThreadCPUDelta = samplesPerThread.every(
+    (s) => s.threadCPUDelta !== undefined
+  );
+  const sortedThreadTimeRanges = sampleTimesPerThread
+    .filter((times) => times.length > 0)
+    .map((times) => ({ start: times[0], end: times[times.length - 1] }))
+    .sort((a, b) => a.start - b.start);
+  const threadsAreNonOverlapping = sortedThreadTimeRanges.every(
+    (range, i) => i === 0 || range.start >= sortedThreadTimeRanges[i - 1].end
+  );
+  const shouldCombineThreadCPUDelta =
+    allHaveThreadCPUDelta && threadsAreNonOverlapping;
+  const newThreadCPUDelta: Array<number | null> | undefined =
+    shouldCombineThreadCPUDelta ? [] : undefined;
+
   while (true) {
     let earliestNextSampleThreadIndex: number | null = null;
     let earliestNextSampleTime = Infinity;
@@ -1410,11 +1430,21 @@ function combineSamplesForMerging(threads: RawThread[]): RawSamplesTable {
         ? sourceThreadSamples.threadId[sourceThreadSampleIndex]
         : threads[sourceThreadIndex].tid
     );
+    if (newThreadCPUDelta !== undefined) {
+      newThreadCPUDelta.push(
+        ensureExists(sourceThreadSamples.threadCPUDelta)[
+          sourceThreadSampleIndex
+        ]
+      );
+    }
 
     newSamples.length++;
     nextSampleIndexPerThread[sourceThreadIndex]++;
   }
 
+  if (newThreadCPUDelta !== undefined) {
+    return { ...newSamples, threadCPUDelta: newThreadCPUDelta };
+  }
   return newSamples;
 }
 

--- a/src/selectors/profile.ts
+++ b/src/selectors/profile.ts
@@ -23,8 +23,11 @@ import {
   computeSamplesTableFromRawSamplesTable,
 } from '../profile-logic/profile-data';
 import type { IPCMarkerCorrelations } from '../profile-logic/marker-data';
-import { correlateIPCMarkers } from '../profile-logic/marker-data';
-import { markerSchemaFrontEndOnly } from '../profile-logic/marker-schema';
+import {
+  computeCombinedMarkerSchemaList,
+  computeMarkerSchemaByName,
+  correlateIPCMarkers,
+} from '../profile-logic/marker-data';
 import { getDefaultCategories } from 'firefox-profiler/profile-logic/data-structures';
 import * as CommittedRanges from '../profile-logic/committed-ranges';
 import { defaultTableViewOptions } from '../reducers/profile-view';
@@ -301,26 +304,11 @@ export const getSourceTable: Selector<SourceTable> = (state: State) =>
 // to generate markers such as the Jank markers, and display them.
 export const getMarkerSchema: Selector<MarkerSchema[]> = createSelector(
   getMarkerSchemaGecko,
-  (geckoSchema) => {
-    const frontEndSchemaNames = new Set([
-      ...markerSchemaFrontEndOnly.map((schema) => schema.name),
-    ]);
-    return [
-      // Don't duplicate schema definitions that the front-end already has.
-      ...geckoSchema.filter((schema) => !frontEndSchemaNames.has(schema.name)),
-      ...markerSchemaFrontEndOnly,
-    ];
-  }
+  computeCombinedMarkerSchemaList
 );
 
 export const getMarkerSchemaByName: Selector<MarkerSchemaByName> =
-  createSelector(getMarkerSchema, (schemaList) => {
-    const result = Object.create(null);
-    for (const schema of schemaList) {
-      result[schema.name] = schema;
-    }
-    return result;
-  });
+  createSelector(getMarkerSchema, computeMarkerSchemaByName);
 
 type CounterSelectors = ReturnType<typeof _createCounterSelectors>;
 


### PR DESCRIPTION
This makes it so that you can run profiler-edit with `--insert-label-frames browser_labels.toml --only-keep-threads-with-markers-matching='-async,-sync' --merge-non-overlapping-threads-by-name --set-name 'Sp3 5x (with labels, combined main threads)'` to turn https://share.firefox.dev/4cXQFED into https://share.firefox.dev/4ezEcsa

The label frames are useful in the JS-only view when applied to profiles from samply; they let us group work like "Paint" and "JS Parsing" ([example toml](https://gist.github.com/mstange/f9c0028fda7a4e495785877ba736f4a3)). You can best see them in action in the [function list deploy preview](https://deploy-preview-5233--perf-html.netlify.app/public/t7hap0spr801q16sec386dkazfrkdwvx6808790/function-list/?funcListSections=self&functionListSort=self-desc~total-desc&globalTrackOrder=0&implementation=js&selectedFunc=155510&thread=0&transforms=fs-m--async%2C-sync~fs-m-charts-chart~df-155697&v=17): JS-only, ordered by self, with the Self wing showing where the time is spent.