### PR TITLE
Print also the status output right after cli `load` command

### DIFF
--- a/profiler-cli/src/index.ts
+++ b/profiler-cli/src/index.ts
@@ -116,6 +116,12 @@ Examples:
       opts.symbolServer
     );
     console.log(`Session started: ${sessionId}`);
+    const status = await sendCommand(
+      SESSION_DIR,
+      { command: 'status' },
+      sessionId
+    );
+    console.log(formatOutput(status, opts.json ?? false));
   });
 
   // profiler-cli status


### PR DESCRIPTION
Previously, we didn't show any info about the profile that's being loaded to after `pq load xyz`. This status output at least shows some basic information like, selected thread, time range and filters.