### PR TITLE
Build and upload the cli artifact in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,16 @@ jobs:
           name: node-tools-dist
           path: node-tools-dist/
 
+      - name: Build profiler-cli
+        run: yarn build-profiler-cli
+
+      - name: Upload profiler-cli artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: profiler-cli
+          path: profiler-cli/dist/
+
   licence-check:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This PR does similarly to what we did for the node tools artifact. It would be nice to have profiler-cli uploaded as an artifact for PRs etc so people can try it out easily for manual testing.