### PR TITLE
Fix text truncation for frames named after Object.prototype methods

### DIFF
--- a/src/utils/text-measurement.ts
+++ b/src/utils/text-measurement.ts
@@ -14,14 +14,14 @@
  */
 class TextMeasurement {
   _ctx: CanvasRenderingContext2D;
-  _cache: { [id: string]: number };
+  _cache: Map<string, number>;
   _averageCharWidth: number;
   overflowChar: string;
   minWidth: number;
 
   constructor(ctx: CanvasRenderingContext2D) {
     this._ctx = ctx;
-    this._cache = {};
+    this._cache = new Map();
     this._averageCharWidth = this._calcAverageCharWidth();
 
     // TODO - L10N
@@ -50,12 +50,12 @@ class TextMeasurement {
    * @return {number} The text width.
    */
   getTextWidth(text: string): number {
-    const cachedWidth = this._cache[text];
+    const cachedWidth = this._cache.get(text);
     if (cachedWidth !== undefined) {
       return cachedWidth;
     }
     const metrics = this._ctx.measureText(text);
-    this._cache[text] = metrics.width;
+    this._cache.set(text, metrics.width);
     return metrics.width;
   }
 


### PR DESCRIPTION
Fixes #6006.

TextMeasurement's width cache was a plain object, so looking up `_cache["toString"]` returned Object.prototype.toString instead of undefined. getFittedText treated that function as a cached width, which collapsed the truncation algorithm and produced just "…".

This affected JS frames whose names collide with Object.prototype: toString, hasOwnProperty, valueOf, constructor, isPrototypeOf, propertyIsEnumerable, toLocaleString, __proto__. Visible in the flame graph, stack chart, marker chart, and js-tracer canvases.

Switching the cache to a Map solves this problem.

Example profile:
[Before](https://share.firefox.dev/4ufD0PH) / [After](https://deploy-preview-6044--perf-html.netlify.app/public/ggg3pacrt5e9vhyzae6wg5p62s00ed48eczre68/flame-graph/?globalTrackOrder=01&implementation=js&profileName=Before%20-%20Firefox%20152%20%E2%80%93%20macOS%2026.4.1&thread=1&v=16)