### PR TITLE
Fix call node context menu being hidden behind source view bottom box

### DIFF
--- a/src/components/app/DetailsContainer.css
+++ b/src/components/app/DetailsContainer.css
@@ -1,6 +1,4 @@
 .DetailsContainer {
-  position: relative;
-  z-index: 0;
   display: flex;
   box-sizing: border-box;
   flex: 1;


### PR DESCRIPTION
The CallNodeContextMenu and MaybeMarkerContextMenu were rendered inside .Details, which sits inside .DetailsContainer. DetailsContainer sets `position: relative; z-index: 0`, which creates a stacking context that capped the context menu's z-index at 0 relative to its siblings. Since the BottomBox is a sibling of DetailsContainer declared later in the DOM, it always painted on top of the context menus, and it makes them unreadable when the source view was open.

Moved both context menus from Details.tsx into ProfileViewer.tsx, and placed after BottomBox, so they share a stacking context with both DetailsContainer and BottomBox. Their `--z-context-menu: 5` now paints above the BottomBox as intended. Context menus are wired to triggers by id rather than DOM proximity, so the move does not affect the behavior.

Technically MaybeMarkerContextMenu can't be visible while we still have the source view visible, but I think it makes sense to keep them together.

Before:
<img width="932" height="607" alt="Screenshot 2026-05-22 at 11 08 21" src="https://github.com/user-attachments/assets/31de36de-7f5f-4965-830f-dc1dca033f74" />

After:
<img width="1050" height="717" alt="Screenshot 2026-05-22 at 11 08 36" src="https://github.com/user-attachments/assets/889bcc8d-f72e-4ece-abbc-3239e450887b" />

Example profile:
[Before](https://share.firefox.dev/4dVQeuW) / [after](https://deploy-preview-6045--perf-html.netlify.app/public/ggg3pacrt5e9vhyzae6wg5p62s00ed48eczre68/flame-graph/?globalTrackOrder=01&hideIdleSamples&profileName=Before%20-%20Firefox%20152%20%E2%80%93%20macOS%2026.4.1&sourceViewIndex=67&thread=1&v=16)
