### PR TITLE
Add missing key props to CodeErrorOverlay error list items

### DIFF
--- a/src/components/app/CodeErrorOverlay.tsx
+++ b/src/components/app/CodeErrorOverlay.tsx
@@ -50,6 +50,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { apiErrorMessage } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--browser-api-error-when-obtaining-source"
                 vars={{ apiErrorMessage }}
               >
@@ -61,6 +62,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { apiErrorMessage } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--local-symbol-server-api-error-when-obtaining-source"
                 vars={{ apiErrorMessage }}
               >
@@ -72,6 +74,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { errorMessage } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--browser-api-malformed-response-when-obtaining-source"
                 vars={{ errorMessage }}
               >
@@ -83,6 +86,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { errorMessage } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--local-symbol-server-api-malformed-response-when-obtaining-source"
                 vars={{ errorMessage }}
               >
@@ -94,6 +98,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { url, pathInArchive } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--not-in-archive-error-when-obtaining-source"
                 vars={{ url, pathInArchive }}
               >
@@ -105,6 +110,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { url, parsingErrorMessage } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--archive-parsing-error-when-obtaining-source"
                 vars={{ url, parsingErrorMessage }}
               >
@@ -116,6 +122,7 @@ export function CodeErrorOverlay({ errors }: CodeErrorOverlayProps) {
             const { sourceUuid, url, errorMessage } = error;
             return (
               <Localized
+                key={key}
                 id="SourceView--not-in-browser-error-when-obtaining-js-source"
                 vars={{ url, sourceUuid, errorMessage }}
               >


### PR DESCRIPTION
Seven of the ten error cases in the errors.map() were missing a key prop on their Localized wrapper, and that was causing a React dev warning about non-unique keys in a list when the source didn't exist in the source view.

It was showing these warnings before but only on dev environment:
<img width="777" height="523" alt="Screenshot 2026-05-22 at 13 05 56" src="https://github.com/user-attachments/assets/6fef44bc-3844-4a09-88f4-9ec303e29b2b" />
