### PR TITLE
fix(FilterNavigatorBar): clip overflow so many breadcrumbs do not expand the parent

### DIFF
--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -12,6 +12,7 @@
   --internal-separator-img: url(../../../res/img/svg/scope-bar-separator.svg);
 
   display: flex;
+  overflow: hidden;
   height: 24px;
   flex-flow: row nowrap;
   flex-shrink: 0;
@@ -20,9 +21,10 @@
   cursor: default;
   user-select: none;
 
-  /* Note: no overflow: hidden for historical reasons - we wanted to see
-     an animation for items at the end while they were fading out, but
-     we have removed this animation in the meantime */
+  /* Without overflow: hidden, the bar's intrinsic min-content width (sum of
+     all nowrap children) propagates up and forces the parent flame-graph tab
+     to expand horizontally past the viewport when there are many breadcrumbs
+     (issue #6028). Items already truncate text via .filterNavigatorBarItemContent. */
 }
 
 :root.dark-mode {


### PR DESCRIPTION
Fixes #6028.

Without `overflow: hidden`, the breadcrumb bar's intrinsic min-content width (sum of all nowrap children) propagates up through the flex column parent and forces `#flame-graph-tab` to grow horizontally past the viewport. On the profile shared in the issue (https://share.firefox.dev/3RKVQPY) the tab ends up around 15k px wide and gains a horizontal scrollbar.

The change is one CSS line on `.filterNavigatorBar` in `src/components/shared/FilterNavigatorBar.css`:

```diff
   display: flex;
+  overflow: hidden;
   height: 24px;
```

Items inside the bar already have `text-overflow: ellipsis` on `.filterNavigatorBarItemContent`, so clipping at the bar level is the intended behaviour. The pre-existing comment in this file explicitly noted that `overflow: hidden` was omitted to preserve a fade-out animation on items at the end; that animation has since been removed, so the constraint no longer applies. The comment is updated to describe the current reason for `overflow: hidden`.

### Verification

- `yarn ts` clean
- `yarn lint-css` clean (the stylelint `order/properties-order` rule wants `overflow` directly after `display`)
- `yarn fmt-check` clean
- `yarn lint-js` clean
- `yarn license-check` clean
- Targeted tests green: `yarn test FilterNavigatorBar|ProfileFilterNavigator|FlameGraph` -> 2 suites, 19 tests, 9 snapshots, all pass. Snapshots are unchanged because the React structure is the same; the fix is CSS only.

This is a CSS-only fix, so there is no unit test surface inside Jest. The profile from the issue is the manual verification path: load it into a local dev server before and after the change and observe whether `#flame-graph-tab` overflows.

### Related

- #5724 is the original "Large amounts of breadcrumbs become unusable" issue that this change works alongside; this PR specifically targets the parent-expansion side noted in #6028.