### PR TITLE
feat: invert call stack in flame graph to render as icicle graph

### DIFF
--- a/src/actions/profile-view.ts
+++ b/src/actions/profile-view.ts
@@ -1696,6 +1696,7 @@ export function changeInvertCallstack(
     dispatch({
       type: 'CHANGE_INVERT_CALLSTACK',
       invertCallstack,
+      selectedTab: getSelectedTab(getState()),
       selectedThreadIndexes: getSelectedThreadIndexes(getState()),
       newSelectedCallNodePath,
     });

--- a/src/app-logic/url-handling.ts
+++ b/src/app-logic/url-handling.ts
@@ -184,6 +184,7 @@ type BaseQuery = {
 type CallTreeQuery = BaseQuery & {
   search: string; // "js::RunScript"
   invertCallstack: null | undefined;
+  invertFlameGraph: null | undefined;
   hideIdleSamples: null | undefined;
   ctSummary: string;
 };
@@ -201,6 +202,7 @@ type NetworkQuery = BaseQuery & {
 type StackChartQuery = BaseQuery & {
   search: string; // "js::RunScript"
   invertCallstack: null | undefined;
+  invertFlameGraph: null | undefined;
   hideIdleSamples: null | undefined;
   showUserTimings: null | undefined;
   sameWidths: null | undefined;
@@ -216,6 +218,7 @@ type Query = BaseQuery & {
   // CallTree/StackChart specific
   search?: string;
   invertCallstack?: null | undefined;
+  invertFlameGraph?: null | undefined;
   hideIdleSamples?: null | undefined;
   ctSummary?: string;
   transforms?: string;
@@ -342,7 +345,10 @@ export function getQueryStringFromUrlState(urlState: UrlState): string {
       query = baseQuery as CallTreeQueryShape;
 
       query.search = urlState.profileSpecific.callTreeSearchString || undefined;
-      query.invertCallstack = urlState.profileSpecific.invertCallstack
+      query.invertCallstack = urlState.profileSpecific.invertCallTree
+        ? null
+        : undefined;
+      query.invertFlameGraph = urlState.profileSpecific.invertFlameGraph
         ? null
         : undefined;
       // The URL param is inverted (`hideIdleSamples`) so the default-on state
@@ -605,7 +611,8 @@ export function stateFromLocation(
       lastSelectedCallTreeSummaryStrategy: toValidCallTreeSummaryStrategy(
         query.ctSummary || undefined
       ),
-      invertCallstack: query.invertCallstack === undefined ? false : true,
+      invertCallTree: query.invertCallstack === undefined ? false : true,
+      invertFlameGraph: query.invertFlameGraph === undefined ? false : true,
       includeIdleSamples: query.hideIdleSamples === undefined,
       showUserTimings: query.showUserTimings === undefined ? false : true,
       stackChartSameWidths: query.sameWidths === undefined ? false : true,

--- a/src/components/flame-graph/Canvas.tsx
+++ b/src/components/flame-graph/Canvas.tsx
@@ -18,6 +18,7 @@ import {
 } from 'firefox-profiler/utils/format-numbers';
 import { TooltipCallNode } from 'firefox-profiler/components/tooltip/CallNode';
 import { getTimingsForCallNodeIndex } from 'firefox-profiler/profile-logic/profile-data';
+import { getSelfAndTotalForCallNode } from 'firefox-profiler/profile-logic/call-tree';
 import MixedTupleMap from 'mixedtuplemap';
 
 import type {
@@ -49,7 +50,7 @@ import type {
 
 import type {
   CallTree,
-  CallTreeTimingsNonInverted,
+  CallTreeTimings,
 } from 'firefox-profiler/profile-logic/call-tree';
 
 export type OwnProps = {
@@ -74,7 +75,7 @@ export type OwnProps = {
   readonly callTreeSummaryStrategy: CallTreeSummaryStrategy;
   readonly ctssSamples: SamplesLikeTable;
   readonly ctssSampleCategoriesAndSubcategories: SampleCategoriesAndSubcategories;
-  readonly tracedTiming: CallTreeTimingsNonInverted | null;
+  readonly tracedTiming: CallTreeTimings | null;
   readonly displayStackType: boolean;
 };
 
@@ -397,11 +398,12 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
 
     let percentage = formatPercent(ratio);
     if (tracedTiming) {
-      const time = formatCallNodeNumberWithUnit(
-        'tracing-ms',
-        false,
-        tracedTiming.total[callNodeIndex]
+      const { total } = getSelfAndTotalForCallNode(
+        callNodeIndex,
+        callNodeInfo,
+        tracedTiming
       );
+      const time = formatCallNodeNumberWithUnit('tracing-ms', false, total);
       percentage = `${time} (${percentage})`;
     }
 

--- a/src/components/flame-graph/ConnectedFlameGraph.tsx
+++ b/src/components/flame-graph/ConnectedFlameGraph.tsx
@@ -16,7 +16,10 @@ import {
   getProfileUsesMultipleStackTypes,
 } from 'firefox-profiler/selectors/profile';
 import { selectedThreadSelectors } from 'firefox-profiler/selectors/per-thread';
-import { getSelectedThreadsKey } from '../../selectors/url-state';
+import {
+  getInvertCallstack,
+  getSelectedThreadsKey,
+} from '../../selectors/url-state';
 import {
   changeSelectedCallNode,
   changeRightClickedCallNode,
@@ -56,7 +59,6 @@ type StateProps = {
   readonly thread: Thread;
   readonly weightType: WeightType;
   readonly innerWindowIDToPageMap: Map<InnerWindowID, Page> | null;
-  readonly maxStackDepthPlusOne: number;
   readonly timeRange: StartEndRange;
   readonly previewSelection: PreviewSelection | null;
   readonly flameGraphTiming: FlameGraphTiming;
@@ -68,6 +70,7 @@ type StateProps = {
   readonly scrollToSelectionGeneration: number;
   readonly categories: CategoryList;
   readonly interval: Milliseconds;
+  readonly startsAtBottom: boolean;
   readonly callTreeSummaryStrategy: CallTreeSummaryStrategy;
   readonly ctssSamples: SamplesLikeTable;
   readonly ctssSampleCategoriesAndSubcategories: SampleCategoriesAndSubcategories;
@@ -139,7 +142,6 @@ class ConnectedFlameGraphImpl
     const {
       thread,
       threadsKey,
-      maxStackDepthPlusOne,
       flameGraphTiming,
       callTree,
       callNodeInfo,
@@ -151,6 +153,7 @@ class ConnectedFlameGraphImpl
       callTreeSummaryStrategy,
       categories,
       interval,
+      startsAtBottom,
       innerWindowIDToPageMap,
       weightType,
       ctssSamples,
@@ -165,7 +168,7 @@ class ConnectedFlameGraphImpl
         thread={thread}
         weightType={weightType}
         innerWindowIDToPageMap={innerWindowIDToPageMap}
-        maxStackDepthPlusOne={maxStackDepthPlusOne}
+        maxStackDepthPlusOne={flameGraphTiming.rowCount}
         timeRange={timeRange}
         previewSelection={previewSelection}
         flameGraphTiming={flameGraphTiming}
@@ -177,7 +180,7 @@ class ConnectedFlameGraphImpl
         scrollToSelectionGeneration={scrollToSelectionGeneration}
         categories={categories}
         interval={interval}
-        startsAtBottom={true}
+        startsAtBottom={startsAtBottom}
         callTreeSummaryStrategy={callTreeSummaryStrategy}
         ctssSamples={ctssSamples}
         ctssSampleCategoriesAndSubcategories={
@@ -203,10 +206,6 @@ export const ConnectedFlameGraph = explicitConnectWithForwardRef<
   mapStateToProps: (state) => ({
     thread: selectedThreadSelectors.getFilteredThread(state),
     weightType: selectedThreadSelectors.getWeightTypeForCallTree(state),
-    // Use the filtered call node max depth, rather than the preview filtered one, so
-    // that the viewport height is stable across preview selections.
-    maxStackDepthPlusOne:
-      selectedThreadSelectors.getFilteredCallNodeMaxDepthPlusOne(state),
     flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
     callTree: selectedThreadSelectors.getCallTree(state),
     timeRange: getCommittedRange(state),
@@ -220,6 +219,7 @@ export const ConnectedFlameGraph = explicitConnectWithForwardRef<
       selectedThreadSelectors.getRightClickedCallNodeIndex(state),
     scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
     interval: getProfileInterval(state),
+    startsAtBottom: !getInvertCallstack(state),
     callTreeSummaryStrategy:
       selectedThreadSelectors.getCallTreeSummaryStrategy(state),
     innerWindowIDToPageMap: getInnerWindowIDToPageMap(state),

--- a/src/components/flame-graph/FlameGraph.tsx
+++ b/src/components/flame-graph/FlameGraph.tsx
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as React from 'react';
 
-import { FlameGraphCanvas } from './Canvas';
+import {
+  FlameGraphCanvas,
+  type OwnProps as FlameGraphCanvasProps,
+} from './Canvas';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
 import { extractNonInvertedCallTreeTimings } from 'firefox-profiler/profile-logic/call-tree';
-import { ensureExists } from 'firefox-profiler/utils/types';
 
 import type {
   Thread,
@@ -288,17 +290,9 @@ export class FlameGraph
       onCallNodeEnterOrDoubleClick,
     } = this.props;
 
-    // Get the CallTreeTimingsNonInverted out of tracedTiming. We pass this
-    // along rather than the more generic CallTreeTimings type so that the
-    // FlameGraphCanvas component can operate on the more specialized type.
-    // (CallTreeTimingsNonInverted and CallTreeTimingsInverted are very
-    // different, and the flame graph is only used with non-inverted timings.)
     const tracedTimingNonInverted =
       tracedTiming !== null
-        ? ensureExists(
-            extractNonInvertedCallTreeTimings(tracedTiming),
-            'The flame graph should only ever see non-inverted timings, see UrlState.getInvertCallstack'
-          )
+        ? extractNonInvertedCallTreeTimings(tracedTiming)
         : null;
 
     const maxViewportHeight = maxStackDepthPlusOne * STACK_FRAME_HEIGHT;
@@ -359,10 +353,14 @@ export class FlameGraph
   }
 }
 
-function viewportNeedsUpdate() {
-  // By always returning false we prevent the viewport from being
+function viewportNeedsUpdate(
+  prevProps: FlameGraphCanvasProps,
+  nextProps: FlameGraphCanvasProps
+) {
+  // By returning false we prevent the viewport from being
   // reset and scrolled all the way to the bottom when doing
   // operations like changing the time selection or applying a
   // transform.
-  return false;
+  // We only reset the viewport if the layout direction changes.
+  return prevProps.startsAtBottom !== nextProps.startsAtBottom;
 }

--- a/src/components/flame-graph/FlameGraph.tsx
+++ b/src/components/flame-graph/FlameGraph.tsx
@@ -8,7 +8,6 @@ import {
   type OwnProps as FlameGraphCanvasProps,
 } from './Canvas';
 import { ContextMenuTrigger } from 'firefox-profiler/components/shared/ContextMenuTrigger';
-import { extractNonInvertedCallTreeTimings } from 'firefox-profiler/profile-logic/call-tree';
 
 import type {
   Thread,
@@ -290,11 +289,6 @@ export class FlameGraph
       onCallNodeEnterOrDoubleClick,
     } = this.props;
 
-    const tracedTimingNonInverted =
-      tracedTiming !== null
-        ? extractNonInvertedCallTreeTimings(tracedTiming)
-        : null;
-
     const maxViewportHeight = maxStackDepthPlusOne * STACK_FRAME_HEIGHT;
 
     return (
@@ -343,7 +337,7 @@ export class FlameGraph
               startsAtBottom,
               ctssSamples,
               ctssSampleCategoriesAndSubcategories,
-              tracedTiming: tracedTimingNonInverted,
+              tracedTiming,
               displayStackType,
             }}
           />

--- a/src/components/flame-graph/index.tsx
+++ b/src/components/flame-graph/index.tsx
@@ -40,7 +40,7 @@ class FlameGraphViewImpl extends React.PureComponent<Props> {
         role="tabpanel"
         aria-labelledby="flame-graph-tab-button"
       >
-        <StackSettings hideInvertCallstack={true} />
+        <StackSettings />
         <TransformNavigator />
         {isPreviewSelectionEmpty ? (
           <FlameGraphEmptyReasons />

--- a/src/profile-logic/flame-graph.ts
+++ b/src/profile-logic/flame-graph.ts
@@ -8,7 +8,11 @@ import type {
   IndexIntoCallNodeTable,
 } from 'firefox-profiler/types';
 import type { StringTable } from 'firefox-profiler/utils/string-table';
-import type { CallTreeTimingsNonInverted } from './call-tree';
+import type {
+  CallTreeTimingsInverted,
+  CallTreeTimingsNonInverted,
+} from './call-tree';
+import type { CallNodeInfoInverted } from './call-node-info';
 
 import { bisectionRightByStrKey } from 'firefox-profiler/utils/bisect';
 
@@ -44,7 +48,13 @@ export type FlameGraphTimingRow = {
  * the implementation to generate rows lazily as the user scrolls towards
  * deeper calls.
  */
-export class FlameGraphTiming {
+export interface FlameGraphTiming {
+  readonly rowCount: number;
+  getRow(depth: number): FlameGraphTimingRow;
+  getAllRowsForTesting(): FlameGraphTimingRow[];
+}
+
+class FlameGraphTimingNonInverted implements FlameGraphTiming {
   _flameGraphRows: FlameGraphRows;
   _callNodeTable: CallNodeTable;
   _callTreeTimings: CallTreeTimingsNonInverted;
@@ -348,5 +358,256 @@ export function getFlameGraphTiming(
   callNodeTable: CallNodeTable,
   callTreeTimings: CallTreeTimingsNonInverted
 ): FlameGraphTiming {
-  return new FlameGraphTiming(flameGraphRows, callNodeTable, callTreeTimings);
+  return new FlameGraphTimingNonInverted(
+    flameGraphRows,
+    callNodeTable,
+    callTreeTimings
+  );
+}
+
+type InvertedNodeTiming = {
+  total: number;
+  hasChildren: boolean;
+};
+
+type InvertedFlameGraphRowItem = {
+  nodeIndex: IndexIntoCallNodeTable;
+  start: UnitIntervalOfProfileRange;
+  end: UnitIntervalOfProfileRange;
+};
+
+// The flame graph does not support horizontal zooming, so boxes that are smaller
+// than a fraction of a 16k-wide display cannot be hovered or read. We still take
+// their width into account when positioning later boxes, but we do not expand
+// their descendants.
+const MIN_INVERTED_FLAME_GRAPH_BOX_WIDTH = 1 / 16384;
+
+class FlameGraphTimingInverted implements FlameGraphTiming {
+  _callNodeInfo: CallNodeInfoInverted;
+  _callTreeTimings: CallTreeTimingsInverted;
+  _funcTable: FuncTable;
+  _stringTable: StringTable;
+  _nonRootTimingCache: Map<IndexIntoCallNodeTable, InvertedNodeTiming> =
+    new Map();
+  _timingRows: FlameGraphTimingRow[] = [];
+  _nextRowItems: InvertedFlameGraphRowItem[];
+  _rowCount: number;
+
+  constructor(
+    callNodeInfo: CallNodeInfoInverted,
+    callTreeTimings: CallTreeTimingsInverted,
+    funcTable: FuncTable,
+    stringTable: StringTable
+  ) {
+    this._callNodeInfo = callNodeInfo;
+    this._callTreeTimings = callTreeTimings;
+    this._funcTable = funcTable;
+    this._stringTable = stringTable;
+
+    const { rootTotalSummary } = callTreeTimings;
+    this._rowCount =
+      rootTotalSummary === 0 ? 0 : callNodeInfo.getCallNodeTable().maxDepth + 1;
+    this._nextRowItems = this._getRootRowItems();
+  }
+
+  get rowCount(): number {
+    return this._rowCount;
+  }
+
+  getRow(depth: number): FlameGraphTimingRow {
+    if (depth < 0 || depth >= this.rowCount) {
+      throw new Error(
+        `Out-of-bounds call to getRow: ${depth} is outside 0..${this.rowCount}`
+      );
+    }
+    while (this._timingRows.length <= depth) {
+      this._buildNextTimingRow();
+    }
+    return this._timingRows[depth];
+  }
+
+  // Convenience method for tests, don't call in production
+  getAllRowsForTesting(): FlameGraphTimingRow[] {
+    const rows = [];
+    for (let depth = 0; depth < this.rowCount; depth++) {
+      rows.push(this.getRow(depth));
+    }
+    return rows;
+  }
+
+  _compareCallNodesByFuncName = (
+    a: IndexIntoCallNodeTable,
+    b: IndexIntoCallNodeTable
+  ): number => {
+    const callNodeInfo = this._callNodeInfo;
+    const { name } = this._funcTable;
+    const stringTable = this._stringTable;
+    const funcA = callNodeInfo.funcForNode(a);
+    const funcB = callNodeInfo.funcForNode(b);
+    const funcNameA = stringTable.getString(name[funcA]);
+    const funcNameB = stringTable.getString(name[funcB]);
+    if (funcNameA < funcNameB) {
+      return -1;
+    }
+    if (funcNameA > funcNameB) {
+      return 1;
+    }
+    return funcA - funcB;
+  };
+
+  _getNodeTiming(nodeIndex: IndexIntoCallNodeTable): InvertedNodeTiming {
+    const callNodeInfo = this._callNodeInfo;
+    const { callNodeSelf, totalPerRootFunc, hasChildrenPerRootFunc } =
+      this._callTreeTimings;
+
+    if (callNodeInfo.isRoot(nodeIndex)) {
+      return {
+        total: totalPerRootFunc[nodeIndex],
+        hasChildren: hasChildrenPerRootFunc[nodeIndex] !== 0,
+      };
+    }
+
+    const cached = this._nonRootTimingCache.get(nodeIndex);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const nodeDepth = callNodeInfo.depthForNode(nodeIndex);
+    const [rangeStart, rangeEnd] =
+      callNodeInfo.getSuffixOrderIndexRangeForCallNode(nodeIndex);
+    const suffixOrderedCallNodes = callNodeInfo.getSuffixOrderedCallNodes();
+    const callNodeTableDepthCol = callNodeInfo.getCallNodeTable().depth;
+
+    let total = 0;
+    let hasChildren = false;
+    for (let i = rangeStart; i < rangeEnd; i++) {
+      const selfNode = suffixOrderedCallNodes[i];
+      const self = callNodeSelf[selfNode];
+      total += self;
+      hasChildren =
+        hasChildren ||
+        (self !== 0 && callNodeTableDepthCol[selfNode] > nodeDepth);
+    }
+
+    const timing = { total, hasChildren };
+    this._nonRootTimingCache.set(nodeIndex, timing);
+    return timing;
+  }
+
+  _getChildrenWithTiming(
+    nodeIndex: IndexIntoCallNodeTable
+  ): IndexIntoCallNodeTable[] {
+    const callNodeInfo = this._callNodeInfo;
+    const children = callNodeInfo.getChildren(nodeIndex);
+    const displayedChildren = [];
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      const { total, hasChildren } = this._getNodeTiming(child);
+      if (total !== 0 || hasChildren) {
+        displayedChildren.push(child);
+      }
+    }
+    displayedChildren.sort(this._compareCallNodesByFuncName);
+    return displayedChildren;
+  }
+
+  _getRootRowItems(): InvertedFlameGraphRowItem[] {
+    const { rootTotalSummary, sortedRoots, totalPerRootFunc } =
+      this._callTreeTimings;
+    const abs = Math.abs;
+
+    if (rootTotalSummary === 0) {
+      return [];
+    }
+
+    const roots = [];
+    for (let i = 0; i < sortedRoots.length; i++) {
+      roots.push(sortedRoots[i]);
+    }
+    roots.sort(this._compareCallNodesByFuncName);
+
+    const rootRowItems: InvertedFlameGraphRowItem[] = [];
+    let currentRootStart = 0;
+    for (let i = 0; i < roots.length; i++) {
+      const root = roots[i];
+      const totalRelative = abs(totalPerRootFunc[root] / rootTotalSummary);
+      const start = currentRootStart;
+      const end = start + totalRelative;
+      if (totalRelative >= MIN_INVERTED_FLAME_GRAPH_BOX_WIDTH) {
+        rootRowItems.push({ nodeIndex: root, start, end });
+      }
+      currentRootStart = end;
+    }
+
+    return rootRowItems;
+  }
+
+  _buildNextTimingRow(): void {
+    const { rootTotalSummary } = this._callTreeTimings;
+    const callNodeInfo = this._callNodeInfo;
+    const abs = Math.abs;
+
+    const rowItems = this._nextRowItems;
+    const start: UnitIntervalOfProfileRange[] = [];
+    const end: UnitIntervalOfProfileRange[] = [];
+    const selfRelative: number[] = [];
+    const timingCallNodes: IndexIntoCallNodeTable[] = [];
+    const nextRowItems: InvertedFlameGraphRowItem[] = [];
+
+    for (let i = 0; i < rowItems.length; i++) {
+      const { nodeIndex, start: itemStart, end: itemEnd } = rowItems[i];
+      const { total } = this._getNodeTiming(nodeIndex);
+
+      start.push(itemStart);
+      end.push(itemEnd);
+      selfRelative.push(
+        callNodeInfo.isRoot(nodeIndex) ? abs(total / rootTotalSummary) : 0
+      );
+      timingCallNodes.push(nodeIndex);
+
+      if (itemEnd - itemStart < MIN_INVERTED_FLAME_GRAPH_BOX_WIDTH) {
+        continue;
+      }
+
+      const children = this._getChildrenWithTiming(nodeIndex);
+      let currentChildStart = itemStart;
+      for (let childIndex = 0; childIndex < children.length; childIndex++) {
+        const child = children[childIndex];
+        const childTotal = this._getNodeTiming(child).total;
+        const childTotalRelative = abs(childTotal / rootTotalSummary);
+        const childEnd = currentChildStart + childTotalRelative;
+        if (childTotalRelative >= MIN_INVERTED_FLAME_GRAPH_BOX_WIDTH) {
+          nextRowItems.push({
+            nodeIndex: child,
+            start: currentChildStart,
+            end: childEnd,
+          });
+        }
+        currentChildStart = childEnd;
+      }
+    }
+
+    this._nextRowItems = nextRowItems;
+    this._timingRows.push({
+      start,
+      end,
+      selfRelative,
+      callNode: timingCallNodes,
+      length: timingCallNodes.length,
+    });
+  }
+}
+
+export function getInvertedFlameGraphTiming(
+  callNodeInfo: CallNodeInfoInverted,
+  callTreeTimings: CallTreeTimingsInverted,
+  funcTable: FuncTable,
+  stringTable: StringTable
+): FlameGraphTiming {
+  return new FlameGraphTimingInverted(
+    callNodeInfo,
+    callTreeTimings,
+    funcTable,
+    stringTable
+  );
 }

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -2690,7 +2690,6 @@ export function computeCallNodeMaxDepthPlusOne(
   // computed for the filtered thread, but a samples-like table can use the preview
   // filtered thread, which involves a subset of the total call nodes.
   let maxDepth = -1;
-  const callNodeTable = callNodeInfo.getCallNodeTable();
   // TODO: Use sampleCallNodes instead
   const stackIndexToCallNodeIndex =
     callNodeInfo.getStackIndexToNonInvertedCallNodeIndex();
@@ -2700,7 +2699,7 @@ export function computeCallNodeMaxDepthPlusOne(
       continue;
     }
     const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
-    const depth = callNodeTable.depth[callNodeIndex];
+    const depth = callNodeInfo.depthForNode(callNodeIndex);
     if (depth > maxDepth) {
       maxDepth = depth;
     }

--- a/src/reducers/url-state.ts
+++ b/src/reducers/url-state.ts
@@ -316,10 +316,24 @@ const lastSelectedCallTreeSummaryStrategy: Reducer<CallTreeSummaryStrategy> = (
   }
 };
 
-const invertCallstack: Reducer<boolean> = (state = false, action) => {
+const invertCallTree: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
-      return action.invertCallstack;
+      return action.selectedTab === 'calltree' ||
+        action.selectedTab === 'stack-chart'
+        ? action.invertCallstack
+        : state;
+    default:
+      return state;
+  }
+};
+
+const invertFlameGraph: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'CHANGE_INVERT_CALLSTACK':
+      return action.selectedTab === 'flame-graph'
+        ? action.invertCallstack
+        : state;
     default:
       return state;
   }
@@ -784,7 +798,8 @@ const profileSpecific = combineReducers({
   selectedThreads,
   implementation,
   lastSelectedCallTreeSummaryStrategy,
-  invertCallstack,
+  invertCallTree,
+  invertFlameGraph,
   includeIdleSamples,
   showUserTimings,
   stackChartSameWidths,

--- a/src/reducers/url-state.ts
+++ b/src/reducers/url-state.ts
@@ -319,10 +319,7 @@ const lastSelectedCallTreeSummaryStrategy: Reducer<CallTreeSummaryStrategy> = (
 const invertCallTree: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
-      return action.selectedTab === 'calltree' ||
-        action.selectedTab === 'stack-chart'
-        ? action.invertCallstack
-        : state;
+      return action.selectedTab === 'calltree' ? action.invertCallstack : state;
     default:
       return state;
   }

--- a/src/selectors/per-thread/stack-sample.ts
+++ b/src/selectors/per-thread/stack-sample.ts
@@ -141,6 +141,9 @@ export function getStackAndSampleSelectorsPerThread(
     return _getNonInvertedCallNodeInfo(state);
   };
 
+  const getNonInvertedCallNodeInfo: Selector<CallNodeInfo> =
+    _getNonInvertedCallNodeInfo;
+
   const _getCallNodeTable: Selector<CallNodeTable> = (state) =>
     _getNonInvertedCallNodeInfo(state).getCallNodeTable();
 
@@ -309,6 +312,13 @@ export function getStackAndSampleSelectorsPerThread(
     ProfileData.computeCallNodeMaxDepthPlusOne
   );
 
+  const getNonInvertedFilteredCallNodeMaxDepthPlusOne: Selector<number> =
+    createSelector(
+      threadSelectors.getFilteredCtssSamples,
+      _getNonInvertedCallNodeInfo,
+      ProfileData.computeCallNodeMaxDepthPlusOne
+    );
+
   /**
    * When computing the call tree, a "samples" table is used, which
    * can represent a variety of formats with different weight types.
@@ -320,6 +330,32 @@ export function getStackAndSampleSelectorsPerThread(
     threadSelectors.getUnfilteredCtssSamples,
     (samples) => samples.weightType || 'samples'
   );
+
+  const _getSampleIndexToNonInvertedCallNodeIndexForPreviewFilteredCtssThreadNonInverted: Selector<
+    Array<IndexIntoCallNodeTable | null>
+  > = createSelector(
+    (state: State) =>
+      threadSelectors.getPreviewFilteredCtssSamples(state).stack,
+    (state: State) =>
+      _getNonInvertedCallNodeInfo(
+        state
+      ).getStackIndexToNonInvertedCallNodeIndex(),
+    ProfileData.getSampleIndexToCallNodeIndex
+  );
+
+  const getCallNodeSelfAndSummaryNonInverted: Selector<CallNodeSelfAndSummary> =
+    createSelector(
+      threadSelectors.getPreviewFilteredCtssSamples,
+      _getSampleIndexToNonInvertedCallNodeIndexForPreviewFilteredCtssThreadNonInverted,
+      _getNonInvertedCallNodeInfo,
+      (samples, sampleIndexToCallNodeIndex, callNodeInfo) => {
+        return CallTree.computeCallNodeSelfAndSummary(
+          samples,
+          sampleIndexToCallNodeIndex,
+          callNodeInfo.getCallNodeTable().length
+        );
+      }
+    );
 
   const getCallNodeSelfAndSummary: Selector<CallNodeSelfAndSummary> =
     createSelector(
@@ -343,8 +379,8 @@ export function getStackAndSampleSelectorsPerThread(
 
   const getCallTreeTimingsNonInverted: Selector<CallTree.CallTreeTimingsNonInverted> =
     createSelector(
-      getCallNodeInfo,
-      getCallNodeSelfAndSummary,
+      _getNonInvertedCallNodeInfo,
+      getCallNodeSelfAndSummaryNonInverted,
       CallTree.computeCallTreeTimingsNonInverted
     );
 
@@ -364,6 +400,23 @@ export function getStackAndSampleSelectorsPerThread(
     ProfileSelectors.getCategories,
     threadSelectors.getPreviewFilteredCtssSamples,
     getCallTreeTimings,
+    getWeightTypeForCallTree,
+    ProfileSelectors.getSourceTable,
+    CallTree.getCallTree
+  );
+
+  const getNonInvertedCallTreeTimingsWrapper: Selector<CallTree.CallTreeTimings> =
+    createSelector(getCallTreeTimingsNonInverted, (timings) => ({
+      type: 'NON_INVERTED' as const,
+      timings,
+    }));
+
+  const getNonInvertedCallTree: Selector<CallTree.CallTree> = createSelector(
+    threadSelectors.getFilteredThread,
+    _getNonInvertedCallNodeInfo,
+    ProfileSelectors.getCategories,
+    threadSelectors.getPreviewFilteredCtssSamples,
+    getNonInvertedCallTreeTimingsWrapper,
     getWeightTypeForCallTree,
     ProfileSelectors.getSourceTable,
     CallTree.getCallTree
@@ -431,6 +484,30 @@ export function getStackAndSampleSelectorsPerThread(
       }
     );
 
+  const getTracedTimingNonInverted: Selector<CallTree.CallTreeTimings | null> =
+    createSelector(
+      threadSelectors.getPreviewFilteredCtssSamples,
+      _getSampleIndexToNonInvertedCallNodeIndexForPreviewFilteredCtssThreadNonInverted,
+      _getNonInvertedCallNodeInfo,
+      ProfileSelectors.getProfileInterval,
+      (samples, sampleIndexToCallNodeIndex, callNodeInfo, interval) => {
+        const CallNodeSelfAndSummary =
+          CallTree.computeCallNodeTracedSelfAndSummary(
+            samples,
+            sampleIndexToCallNodeIndex,
+            callNodeInfo.getCallNodeTable().length,
+            interval
+          );
+        if (CallNodeSelfAndSummary === null) {
+          return null;
+        }
+        return CallTree.computeCallTreeTimings(
+          callNodeInfo,
+          CallNodeSelfAndSummary
+        );
+      }
+    );
+
   const getTracedSelfAndTotalForSelectedCallNode: Selector<SelfAndTotal | null> =
     createSelector(
       getSelectedCallNodeIndex,
@@ -466,19 +543,40 @@ export function getStackAndSampleSelectorsPerThread(
     _getStackTimingByDepthWithMap(state).sameWidthsIndexToTimestampMap;
 
   const getFlameGraphRows: Selector<FlameGraph.FlameGraphRows> = createSelector(
-    (state: State) => getCallNodeInfo(state).getCallNodeTable(),
+    (state: State) => _getNonInvertedCallNodeInfo(state).getCallNodeTable(),
     (state: State) => threadSelectors.getFilteredThread(state).funcTable,
     (state: State) => threadSelectors.getFilteredThread(state).stringTable,
     FlameGraph.computeFlameGraphRows
   );
 
-  const getFlameGraphTiming: Selector<FlameGraph.FlameGraphTiming> =
+  const getFlameGraphTimingNonInverted: Selector<FlameGraph.FlameGraphTiming> =
     createSelector(
       getFlameGraphRows,
-      (state: State) => getCallNodeInfo(state).getCallNodeTable(),
+      (state: State) => _getNonInvertedCallNodeInfo(state).getCallNodeTable(),
       getCallTreeTimingsNonInverted,
       FlameGraph.getFlameGraphTiming
     );
+
+  const getCallTreeTimingsInverted: Selector<CallTree.CallTreeTimingsInverted> =
+    createSelector(
+      _getInvertedCallNodeInfo,
+      getCallNodeSelfAndSummaryNonInverted,
+      CallTree.computeCallTreeTimingsInverted
+    );
+
+  const getFlameGraphTimingInverted: Selector<FlameGraph.FlameGraphTiming> =
+    createSelector(
+      _getInvertedCallNodeInfo,
+      getCallTreeTimingsInverted,
+      (state: State) => threadSelectors.getFilteredThread(state).funcTable,
+      (state: State) => threadSelectors.getFilteredThread(state).stringTable,
+      FlameGraph.getInvertedFlameGraphTiming
+    );
+
+  const getFlameGraphTiming: Selector<FlameGraph.FlameGraphTiming> = (state) =>
+    UrlState.getInvertCallstack(state)
+      ? getFlameGraphTimingInverted(state)
+      : getFlameGraphTimingNonInverted(state);
 
   const getRightClickedCallNodeIndex: Selector<null | IndexIntoCallNodeTable> =
     createSelector(
@@ -502,6 +600,7 @@ export function getStackAndSampleSelectorsPerThread(
     unfilteredSamplesRange,
     getWeightTypeForCallTree,
     getCallNodeInfo,
+    getNonInvertedCallNodeInfo,
     getSourceViewStackLineInfo,
     getAssemblyViewNativeSymbolIndex,
     getAssemblyViewStackAddressInfo,
@@ -513,15 +612,18 @@ export function getStackAndSampleSelectorsPerThread(
     getSampleSelectedStatesInFilteredThread,
     getTreeOrderComparatorInFilteredThread,
     getCallTree,
+    getNonInvertedCallTree,
     getFunctionListTree,
     getFunctionListTimings,
     getSourceViewLineTimings,
     getAssemblyViewAddressTimings,
     getTracedTiming,
+    getTracedTimingNonInverted,
     getTracedSelfAndTotalForSelectedCallNode,
     getStackTimingByDepth,
     getSameWidthsIndexToTimestampMap,
     getFilteredCallNodeMaxDepthPlusOne,
+    getNonInvertedFilteredCallNodeMaxDepthPlusOne,
     getFlameGraphTiming,
     getRightClickedCallNodeIndex,
   };

--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -125,10 +125,17 @@ export const getNetworkSearchString: Selector<string> = (state) =>
   getProfileSpecificState(state).networkSearchString;
 export const getSelectedTab: Selector<TabSlug> = (state) =>
   getUrlState(state).selectedTab;
-export const getInvertCallstack: Selector<boolean> = (state) =>
-  (getSelectedTab(state) === 'calltree' ||
-    getSelectedTab(state) === 'flame-graph') &&
-  getProfileSpecificState(state).invertCallstack;
+export const getInvertCallstack: Selector<boolean> = (state) => {
+  const tab = getSelectedTab(state);
+  const profileSpecific = getProfileSpecificState(state);
+  if (tab === 'calltree' || tab === 'stack-chart') {
+    return profileSpecific.invertCallTree;
+  }
+  if (tab === 'flame-graph') {
+    return profileSpecific.invertFlameGraph;
+  }
+  return false;
+};
 export const getIncludeIdleSamples: Selector<boolean> = (state) =>
   getProfileSpecificState(state).includeIdleSamples;
 

--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -126,7 +126,8 @@ export const getNetworkSearchString: Selector<string> = (state) =>
 export const getSelectedTab: Selector<TabSlug> = (state) =>
   getUrlState(state).selectedTab;
 export const getInvertCallstack: Selector<boolean> = (state) =>
-  getSelectedTab(state) === 'calltree' &&
+  (getSelectedTab(state) === 'calltree' ||
+    getSelectedTab(state) === 'flame-graph') &&
   getProfileSpecificState(state).invertCallstack;
 export const getIncludeIdleSamples: Selector<boolean> = (state) =>
   getProfileSpecificState(state).includeIdleSamples;

--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -128,7 +128,7 @@ export const getSelectedTab: Selector<TabSlug> = (state) =>
 export const getInvertCallstack: Selector<boolean> = (state) => {
   const tab = getSelectedTab(state);
   const profileSpecific = getProfileSpecificState(state);
-  if (tab === 'calltree' || tab === 'stack-chart') {
+  if (tab === 'calltree') {
     return profileSpecific.invertCallTree;
   }
   if (tab === 'flame-graph') {

--- a/src/test/components/FlameGraph.test.tsx
+++ b/src/test/components/FlameGraph.test.tsx
@@ -102,6 +102,27 @@ describe('FlameGraph', function () {
     expect(getInvertCallstack(getState())).toBe(false);
   });
 
+  it('shows traced timing in icicle graph tooltips', () => {
+    const {
+      dispatch,
+      flushRafCalls,
+      getTooltip,
+      moveMouse,
+      findFillTextPosition,
+    } = setupFlameGraph();
+    flushDrawLog();
+
+    act(() => {
+      dispatch(changeInvertCallstack(true));
+    });
+    flushRafCalls();
+
+    moveMouse(findFillTextPosition('E'));
+    expect(
+      within(ensureExists(getTooltip())).getByText('1.0ms (33%)')
+    ).toBeInTheDocument();
+  });
+
   it('shows a tooltip when hovering', () => {
     const { getTooltip, moveMouse, findFillTextPosition } = setupFlameGraph();
     expect(getTooltip()).toBe(null);

--- a/src/test/components/FlameGraph.test.tsx
+++ b/src/test/components/FlameGraph.test.tsx
@@ -80,13 +80,22 @@ describe('FlameGraph', function () {
     expect(drawCalls.length).toBeGreaterThan(0);
   });
 
-  it('ignores invertCallstack and always displays non-inverted', () => {
-    const { getState, dispatch } = setupFlameGraph();
+  it('respects invertCallstack and toggles icicle graph mode', () => {
+    const { getState, dispatch, flushRafCalls } = setupFlameGraph();
     expect(getInvertCallstack(getState())).toBe(false);
+
+    const initialDrawCalls = flushDrawLog();
+
     act(() => {
       dispatch(changeInvertCallstack(true));
     });
-    expect(getInvertCallstack(getState())).toBe(false);
+    expect(getInvertCallstack(getState())).toBe(true);
+    flushRafCalls();
+
+    const icicleDrawCalls = flushDrawLog();
+    expect(icicleDrawCalls.length).toBeGreaterThan(0);
+    expect(icicleDrawCalls).not.toEqual(initialDrawCalls);
+
     act(() => {
       dispatch(changeInvertCallstack(false));
     });
@@ -443,5 +452,6 @@ function setupFlameGraph() {
     getContextMenu,
     clickMenuItem,
     findFillTextPosition,
+    flushRafCalls,
   };
 }

--- a/src/test/components/__snapshots__/FlameGraph.test.tsx.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.tsx.snap
@@ -475,6 +475,19 @@ exports[`FlameGraph matches the snapshot 1`] = `
           class="photon-label photon-label-micro photon-label-horiz-padding"
         >
           <input
+            class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
+            type="checkbox"
+          />
+          <span
+            title="Sort by the time spent in a call node, ignoring its children."
+          >
+            Invert call stack
+          </span>
+        </label>
+        <label
+          class="photon-label photon-label-micro photon-label-horiz-padding"
+        >
+          <input
             checked=""
             class="photon-checkbox photon-checkbox-micro stackSettingsCheckbox"
             type="checkbox"

--- a/src/test/store/actions.test.ts
+++ b/src/test/store/actions.test.ts
@@ -201,7 +201,6 @@ describe('selectors/getFlameGraphTiming', function () {
     const callNodeInfo = selectedThreadSelectors.getCallNodeInfo(
       store.getState()
     );
-    const callNodeTable = callNodeInfo.getCallNodeTable();
     const flameGraphTiming = selectedThreadSelectors.getFlameGraphTiming(
       store.getState()
     );
@@ -212,7 +211,7 @@ describe('selectors/getFlameGraphTiming', function () {
       const lines = [];
       for (let i = 0; i < length; i++) {
         const callNodeIndex = callNode[i];
-        const funcIndex = callNodeTable.func[callNodeIndex];
+        const funcIndex = callNodeInfo.funcForNode(callNodeIndex);
         const funcName = funcNames[funcIndex];
         lines.push(
           `${funcName} (${parseFloat(start[i].toFixed(2))}:${parseFloat(
@@ -237,7 +236,6 @@ describe('selectors/getFlameGraphTiming', function () {
     const callNodeInfo = selectedThreadSelectors.getCallNodeInfo(
       store.getState()
     );
-    const callNodeTable = callNodeInfo.getCallNodeTable();
     const flameGraphTiming = selectedThreadSelectors.getFlameGraphTiming(
       store.getState()
     );
@@ -247,7 +245,7 @@ describe('selectors/getFlameGraphTiming', function () {
       const lines = [];
       for (let i = 0; i < length; i++) {
         const callNodeIndex = callNode[i];
-        const funcIndex = callNodeTable.func[callNodeIndex];
+        const funcIndex = callNodeInfo.funcForNode(callNodeIndex);
         const funcName = funcNames[funcIndex];
         lines.push(`${funcName} (${selfRelative[i]})`);
       }
@@ -317,6 +315,26 @@ describe('selectors/getFlameGraphTiming', function () {
       'A (0:0.25) | D (0.25:1)',
       'B (0:0.25) | E (0.25:0.5) | F (0.5:1)',
       'C (0:0.25) | G (0.5:0.75)',
+    ]);
+  });
+
+  it('computes inverted stacks without combining unrelated same-name nodes', function () {
+    const {
+      profile,
+      funcNamesPerThread: [funcNames],
+    } = getProfileFromTextSamples(`
+      A  A  A
+      B  B  C
+      C     D
+    `);
+
+    const store = storeWithProfile(profile);
+    store.dispatch(changeInvertCallstack(true));
+
+    expect(getHumanReadableFlameGraphRanges(store, funcNames)).toEqual([
+      'B (0:0.33) | C (0.33:0.67) | D (0.67:1)',
+      'A (0:0.33) | B (0.33:0.67) | C (0.67:1)',
+      'A (0.33:0.67) | A (0.67:1)',
     ]);
   });
 

--- a/src/test/store/profile-view.test.ts
+++ b/src/test/store/profile-view.test.ts
@@ -2461,7 +2461,7 @@ describe('changeSelectedCallNode', function () {
       E  E  G
     `);
 
-    const { A, B, C, D, E, F } = funcNamesDict;
+    const { A, B, C, D, E, F, G } = funcNamesDict;
 
     const { dispatch, getState } = storeWithProfile(profile);
 
@@ -2480,25 +2480,25 @@ describe('changeSelectedCallNode', function () {
     );
 
     dispatch(App.changeSelectedTab('flame-graph'));
-    // In the flame graph, everything should still be non-inverted.
-    expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(false);
-    // The original non-inverted selected call node should be selected.
+    // In the flame graph, everything should now remain inverted.
+    expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
+    // The inverted selected call node should remain selected.
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, B, C]
+      [E, D, C]
     );
 
     // Now we select a different call node in the flame graph.
-    dispatch(ProfileView.changeSelectedCallNode(0, [A, B, C, F]));
+    dispatch(ProfileView.changeSelectedCallNode(0, [G, F, C]));
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [A, B, C, F]
+      [G, F, C]
     );
 
     // Switch back to the call tree tab. In the call tree tab, we should still
-    // be looking at the inverted tree, with the unchanged inverted selection.
+    // be looking at the inverted tree, with the new inverted selection.
     dispatch(App.changeSelectedTab('calltree'));
     expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [E, D, C]
+      [G, F, C]
     );
 
     // Switching back to non-inverted mode should pick a new non-inverted

--- a/src/test/store/profile-view.test.ts
+++ b/src/test/store/profile-view.test.ts
@@ -1713,6 +1713,30 @@ describe('actions/ProfileView', function () {
       });
       expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
     });
+
+    it('does not apply call tree inversion to the stack chart', function () {
+      const { profile } = getProfileFromTextSamples(`
+        A
+        B
+      `);
+      const { dispatch, getState } = storeWithProfile(profile);
+
+      dispatch(App.changeSelectedTab('calltree'));
+      dispatch(ProfileView.changeInvertCallstack(true));
+      expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
+      expect(
+        selectedThreadSelectors.getCallNodeInfo(getState()).isInverted()
+      ).toBe(true);
+
+      dispatch(App.changeSelectedTab('stack-chart'));
+      expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(false);
+      expect(
+        selectedThreadSelectors.getCallNodeInfo(getState()).isInverted()
+      ).toBe(false);
+
+      dispatch(App.changeSelectedTab('calltree'));
+      expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
+    });
   });
 
   describe('changeIncludeIdleSamples', function () {

--- a/src/test/store/profile-view.test.ts
+++ b/src/test/store/profile-view.test.ts
@@ -2461,7 +2461,7 @@ describe('changeSelectedCallNode', function () {
       E  E  G
     `);
 
-    const { A, B, C, D, E, F, G } = funcNamesDict;
+    const { A, B, C, D, E, F } = funcNamesDict;
 
     const { dispatch, getState } = storeWithProfile(profile);
 
@@ -2480,25 +2480,25 @@ describe('changeSelectedCallNode', function () {
     );
 
     dispatch(App.changeSelectedTab('flame-graph'));
-    // In the flame graph, everything should now remain inverted.
-    expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
-    // The inverted selected call node should remain selected.
+    // In the flame graph, the invert state is independent and defaults to false.
+    expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(false);
+    // The original non-inverted selected call node should be selected.
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [E, D, C]
+      [A, B, C]
     );
 
     // Now we select a different call node in the flame graph.
-    dispatch(ProfileView.changeSelectedCallNode(0, [G, F, C]));
+    dispatch(ProfileView.changeSelectedCallNode(0, [A, B, C, F]));
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [G, F, C]
+      [A, B, C, F]
     );
 
     // Switch back to the call tree tab. In the call tree tab, we should still
-    // be looking at the inverted tree, with the new inverted selection.
+    // be looking at the inverted tree, with the unchanged inverted selection.
     dispatch(App.changeSelectedTab('calltree'));
     expect(UrlStateSelectors.getInvertCallstack(getState())).toEqual(true);
     expect(selectedThreadSelectors.getSelectedCallNodePath(getState())).toEqual(
-      [G, F, C]
+      [E, D, C]
     );
 
     // Switching back to non-inverted mode should pick a new non-inverted

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -536,6 +536,7 @@ type UrlStateAction =
   | {
       readonly type: 'CHANGE_INVERT_CALLSTACK';
       readonly invertCallstack: boolean;
+      readonly selectedTab: TabSlug;
       readonly newSelectedCallNodePath: CallNodePath;
       readonly selectedThreadIndexes: Set<ThreadIndex>;
     }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -360,7 +360,8 @@ export type ProfileSpecificUrlState = {
   selectedThreads: Set<ThreadIndex> | null;
   implementation: ImplementationFilter;
   lastSelectedCallTreeSummaryStrategy: CallTreeSummaryStrategy;
-  invertCallstack: boolean;
+  invertCallTree: boolean;
+  invertFlameGraph: boolean;
   includeIdleSamples: boolean;
   showUserTimings: boolean;
   stackChartSameWidths: boolean;


### PR DESCRIPTION
<img width="468" height="186" alt="image" src="https://github.com/user-attachments/assets/0227c0fa-271f-47f4-b88d-a6152bb1f4ff" />

add a invert callstack checkbox.

before:

<img width="3806" height="732" alt="image" src="https://github.com/user-attachments/assets/f531607a-321b-4289-823b-149f1985ef30" />

after:
<img width="3834" height="776" alt="image" src="https://github.com/user-attachments/assets/bf9dd906-a04d-4b9d-82e5-e3cc43990a2f" />

fix #6077
