### PR TITLE
[Deploy preview] Skip pseudo-libraries like [vdso] during symbolication

### DIFF
--- a/src/profile-logic/symbol-store.ts
+++ b/src/profile-logic/symbol-store.ts
@@ -245,6 +245,24 @@ export class SymbolStore {
         );
         return false;
       }
+      // Skip pseudo-modules such as [vdso], [vsyscall], [heap], [stack] and
+      // [anon:...]. These are kernel- or allocator-provided mappings with no
+      // symbol files, so requesting them is always pointless. Worse, the
+      // Mozilla symbolication server rejects the entire batched request with an
+      // HTTP 400 ("invalid debug_filename") when any job's module name contains
+      // brackets, which would prevent every other library in the same chunk
+      // (e.g. libxul) from being symbolicated.
+      if (debugName.startsWith('[')) {
+        errorCb(
+          request,
+          new SymbolsNotFoundError(
+            `Cannot symbolicate pseudo-library ${debugName}`,
+            request.lib,
+            new Error('Pseudo-library without symbols')
+          )
+        );
+        return false;
+      }
       return true;
     });
 

--- a/src/test/unit/symbol-store.test.ts
+++ b/src/test/unit/symbol-store.test.ts
@@ -270,6 +270,10 @@ describe('SymbolStore', function () {
         debugName: '',
         breakpadId: 'empty-debugname',
       },
+      {
+        debugName: '[vdso]',
+        breakpadId: 'dont-care',
+      },
     ];
 
     const symbolTable = new Map([
@@ -291,6 +295,9 @@ describe('SymbolStore', function () {
           const { debugName, breakpadId } = request.lib;
           expect(debugName).not.toEqual('');
           expect(breakpadId).not.toEqual('');
+          // Pseudo-libraries must be filtered out before reaching the server,
+          // otherwise they cause the whole batched request to be rejected.
+          expect(debugName.startsWith('[')).toBe(false);
           await fakeSymbolStore.getSymbols(
             [request],
             (lib, results) => {
@@ -367,7 +374,7 @@ describe('SymbolStore', function () {
     // Empty debugNames or breakpadIds should cause errors. And if symbols are
     // not available from any source, all errors along the way should be included
     // in the reported error.
-    expect([...failedLibs]).toBeArrayOfSize(3);
+    expect([...failedLibs]).toBeArrayOfSize(4);
     expect(failedLibs.get('empty-breakpadid')).toEqual(
       expect.objectContaining({
         message: expect.stringContaining('Invalid debugName or breakpadId'),
@@ -376,6 +383,14 @@ describe('SymbolStore', function () {
     expect(failedLibs.get('')).toEqual(
       expect.objectContaining({
         message: expect.stringContaining('Invalid debugName or breakpadId'),
+      })
+    );
+
+    // Pseudo-libraries such as [vdso] should fail without being sent to any
+    // symbol source, so they can't take down the rest of the batch.
+    expect(failedLibs.get('[vdso]')).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('Cannot symbolicate pseudo-library'),
       })
     );
 


### PR DESCRIPTION
Pseudo-modules such as [vdso], [vsyscall], [heap], [stack] and [anon:...] are kernel- or allocator-provided mappings that have no symbol files, so requesting symbols for them is always pointless.

Worse, it is now actively harmful because the Mozilla symbolication server (Eliot) rejects the entire batched /symbolicate/v5 request with an HTTP 400 ("job N has invalid modules: module index 0 has an invalid debug_filename") when any job's module name contains brackets. Because we batch up to 10 libraries into a single request, that 400 has no `results` field and our response validation throws for the whole chunk, so every other library in it (most importantly libxul) fails to symbolicate too. The net effect is a profile with no symbols at all, even though the symbols are available on the server.

This was previously harmless, Eliot (I think) used to tolerate [vdso], returning found_modules: false for that job while symbolicating the rest, which only produced a per-library warning in the console.