### PR TITLE
Do not rely on localized texts in the settings menu tests

### DIFF
--- a/src/test/components/SettingsMenu.test.tsx
+++ b/src/test/components/SettingsMenu.test.tsx
@@ -45,9 +45,13 @@ function setup() {
 }
 
 async function openMenu() {
-  const button = await screen.findByRole('button', { name: 'Settings' });
+  // Find the cog button and wait for the panel to open in a
+  // language-agnostic way: before the menu opens there is only a single
+  // button, and the language switcher combobox only appears once the panel
+  // is shown. This avoids depending on localized label text.
+  const button = await screen.findByRole('button');
   fireFullClick(button);
-  await screen.findByText('Legal');
+  await screen.findByRole('combobox');
 }
 
 it('renders the cog button in its closed state', async () => {


### PR DESCRIPTION
`openMenu` is added recently since we moved the locale picker to inside the cog/settings menu. And `openMenu` was checking for an English text to find the settings button. But also some subtests in this file are changing the locales for testing. This commit changes that so we don't use any localized texts in there to make sure that it works even if the localizations are updated.