### PR TITLE
Pass callNodeInfo to handleCallNodeTransformShortcut.

### DIFF
--- a/src/actions/profile-view.ts
+++ b/src/actions/profile-view.ts
@@ -2015,6 +2015,7 @@ export function toggleBottomBoxFullscreen(): ThunkAction<void> {
 export function handleCallNodeTransformShortcut(
   event: React.KeyboardEvent<HTMLElement>,
   threadsKey: ThreadsKey,
+  callNodeInfo: CallNodeInfo,
   callNodeIndex: IndexIntoCallNodeTable
 ): ThunkAction<void> {
   return (dispatch, getState) => {
@@ -2023,7 +2024,6 @@ export function handleCallNodeTransformShortcut(
     }
     const threadSelectors = getThreadSelectorsFromThreadsKey(threadsKey);
     const unfilteredThread = threadSelectors.getThread(getState());
-    const callNodeInfo = threadSelectors.getCallNodeInfo(getState());
     const implementation = getImplementationFilter(getState());
     const inverted = getInvertCallstack(getState());
     const callNodePath = callNodeInfo.getCallNodePathFromIndex(callNodeIndex);

--- a/src/components/calltree/CallTree.tsx
+++ b/src/components/calltree/CallTree.tsx
@@ -276,6 +276,7 @@ class CallTreeImpl extends PureComponent<Props> {
       rightClickedCallNodeIndex,
       handleCallNodeTransformShortcut,
       threadsKey,
+      callNodeInfo,
     } = this.props;
     const nodeIndex =
       rightClickedCallNodeIndex !== null
@@ -284,7 +285,7 @@ class CallTreeImpl extends PureComponent<Props> {
     if (nodeIndex === null) {
       return;
     }
-    handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
+    handleCallNodeTransformShortcut(event, threadsKey, callNodeInfo, nodeIndex);
   };
 
   _onEnterOrDoubleClick = (nodeId: IndexIntoCallNodeTable) => {

--- a/src/components/flame-graph/FlameGraph.tsx
+++ b/src/components/flame-graph/FlameGraph.tsx
@@ -302,7 +302,7 @@ class FlameGraphImpl
       return;
     }
 
-    handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
+    handleCallNodeTransformShortcut(event, threadsKey, callNodeInfo, nodeIndex);
   };
 
   _onCopy = (event: ClipboardEvent) => {

--- a/src/components/stack-chart/index.tsx
+++ b/src/components/stack-chart/index.tsx
@@ -179,7 +179,7 @@ class StackChartImpl extends React.PureComponent<Props> {
       return;
     }
 
-    handleCallNodeTransformShortcut(event, threadsKey, nodeIndex);
+    handleCallNodeTransformShortcut(event, threadsKey, callNodeInfo, nodeIndex);
   };
 
   _onDoubleClick = (callNodeIndex: IndexIntoCallNodeTable | null) => {


### PR DESCRIPTION
The function handleCallNodeTransformShortcut takes a call node index as a parameter, but it was getting the call node info separately from a selector. At the moment that's fine because this is always the right call node info.

But once we add separate call node infos for things like "the callees of the selected function in the function list", the two might get out of sync, so it's better to pass the correct call node info that is compatible with the passed call node index.

Functionally-neutral change.