### PR TITLE
Add missing transform shortcut key handling for S (focus-self)

### DIFF
--- a/src/actions/profile-view.ts
+++ b/src/actions/profile-view.ts
@@ -2051,6 +2051,15 @@ export function handleCallNodeTransformShortcut(
           })
         );
         break;
+      case 'S':
+        dispatch(
+          addTransformToStack(threadsKey, {
+            type: 'focus-self',
+            funcIndex,
+            implementation,
+          })
+        );
+        break;
       case 'M':
         dispatch(
           addTransformToStack(threadsKey, {


### PR DESCRIPTION
This shortcut key is advertised by the context menu but I forgot to actually implement it in #5774.

https://github.com/firefox-devtools/profiler/blob/4bd8b75f1932febe86294629f66ac9d91fea4b4b/src/components/shared/CallNodeContextMenu.tsx#L703