### PR TITLE
Keep menu panels above the selected-marker tooltip

### DIFF
--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -47,10 +47,7 @@
 }
 
 .profileViewer {
-  /* Create a stacking context, so that the KeyboardShortcut can overlay the profile
-     viewer. */
   position: relative;
-  z-index: 0;
   display: flex;
   min-width: 0; /* This allows Flexible Layout to shrink this further than its min-content */
   flex: 1;


### PR DESCRIPTION
When a marker stayed selected, its sticky tooltip rendered on top of the Re-upload and other top-bar menu panels, covering them and intercepting clicks.

The panels already carry a higher z-index than tooltips (--z-arrow-panel above --z-tooltip), but .profileViewer set z-index: 0, creating a stacking context that trapped the panels at its own altitude. Tooltips render in the body-level #root-overlay layer, which paints later, so they always won regardless of the scale. Removing that z-index lets the panels and tooltips share the root stacking context, where the scale orders them correctly.

Closes #6102.

---

I've inspected the UI visually and it seems like there is no regression to me but please have another look yourself too.
Profile [before](https://share.firefox.dev/4b6giSa) / [after](https://deploy-preview-6125--perf-html.netlify.app/public/er4e7900q7tbjwvgg94wes6b1ca86m0pdmb8mh8/marker-chart/?globalTrackOrder=i0hfd845e61a2bgc397&hiddenGlobalTracks=1weg&hiddenLocalTracksByPid=38642-0w3~38676-0~38678-01~38652-0~38689-0~38690-0~38651-0~38657-0~38662-0~38648-0~38659-0~38686-0~38687-0~38679-01~38654-01~38647-02~38660-0wj~38669-0w9&thread=xd&v=16)