### PR TITLE
Compute FlameGraphTiming rows lazily

### DIFF
--- a/src/components/flame-graph/Canvas.tsx
+++ b/src/components/flame-graph/Canvas.tsx
@@ -243,12 +243,12 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
     // Only draw the stack frames that are vertically within view.
     // The graph is drawn from bottom to top, in order of increasing depth.
     for (let depth = startDepth; depth < endDepth; depth++) {
-      // Get the timing information for a row of stack frames.
-      const stackTiming = flameGraphTiming[depth];
-
-      if (!stackTiming) {
+      if (depth < 0 || depth >= flameGraphTiming.rowCount) {
         continue;
       }
+
+      // Get the timing information for a row of stack frames.
+      const stackTiming = flameGraphTiming.getRow(depth);
 
       const cssRowTop: CssPixels =
         (maxStackDepthPlusOne - depth - 1) * ROW_HEIGHT - viewportTop;
@@ -372,10 +372,11 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
       return null;
     }
 
-    const stackTiming = flameGraphTiming[depth];
-    if (!stackTiming) {
+    if (depth < 0 || depth >= flameGraphTiming.rowCount) {
       return null;
     }
+
+    const stackTiming = flameGraphTiming.getRow(depth);
     const callNodeIndex = stackTiming.callNode[flameGraphTimingIndex];
     if (callNodeIndex === undefined) {
       return null;
@@ -442,7 +443,7 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
 
     const { depth, flameGraphTimingIndex } = hoveredItem;
     const { flameGraphTiming } = this.props;
-    const stackTiming = flameGraphTiming[depth];
+    const stackTiming = flameGraphTiming.getRow(depth);
     const callNodeIndex = stackTiming.callNode[flameGraphTimingIndex];
     return callNodeIndex;
   }
@@ -476,12 +477,10 @@ class FlameGraphCanvasImpl extends React.PureComponent<Props> {
     const depth = Math.floor(
       maxStackDepthPlusOne - (y + viewportTop) / ROW_HEIGHT
     );
-    const stackTiming = flameGraphTiming[depth];
-
-    if (!stackTiming) {
+    if (depth < 0 || depth >= flameGraphTiming.rowCount) {
       return null;
     }
-
+    const stackTiming = flameGraphTiming.getRow(depth);
     for (let i = 0; i < stackTiming.length; i++) {
       const start = stackTiming.start[i];
       const end = stackTiming.end[i];

--- a/src/components/flame-graph/FlameGraph.tsx
+++ b/src/components/flame-graph/FlameGraph.tsx
@@ -165,7 +165,7 @@ class FlameGraphImpl
 
     const callNodeTable = callNodeInfo.getCallNodeTable();
     const depth = callNodeTable.depth[callNodeIndex];
-    const row = flameGraphTiming[depth];
+    const row = flameGraphTiming.getRow(depth);
     const columnIndex = row.callNode.indexOf(callNodeIndex);
     return row.end[columnIndex] - row.start[columnIndex] > SELECTABLE_THRESHOLD;
   };
@@ -190,7 +190,7 @@ class FlameGraphImpl
 
     const callNodeTable = callNodeInfo.getCallNodeTable();
     const depth = callNodeTable.depth[callNodeIndex];
-    const row = flameGraphTiming[depth];
+    const row = flameGraphTiming.getRow(depth);
     let columnIndex = row.callNode.indexOf(callNodeIndex);
 
     do {

--- a/src/profile-logic/flame-graph.ts
+++ b/src/profile-logic/flame-graph.ts
@@ -45,14 +45,32 @@ export type FlameGraphTimingRow = {
  * deeper calls.
  */
 export class FlameGraphTiming {
-  _rows: FlameGraphTimingRow[];
+  _flameGraphRows: FlameGraphRows;
+  _callNodeTable: CallNodeTable;
+  _callTreeTimings: CallTreeTimingsNonInverted;
 
-  constructor(rows: FlameGraphTimingRow[]) {
-    this._rows = rows;
+  // Populated lazily by _buildNextTimingRow().
+  _timingRows: FlameGraphTimingRow[];
+
+  // Used to position the children call node boxes: For a given parent box, its
+  // first (left-most) child box starts at the same x position as the parent.
+  _startPerCallNode: Float32Array;
+
+  constructor(
+    flameGraphRows: FlameGraphRows,
+    callNodeTable: CallNodeTable,
+    callTreeTimings: CallTreeTimingsNonInverted
+  ) {
+    this._flameGraphRows = flameGraphRows;
+    this._callNodeTable = callNodeTable;
+    this._callTreeTimings = callTreeTimings;
+
+    this._timingRows = [];
+    this._startPerCallNode = new Float32Array(callNodeTable.length);
   }
 
   get rowCount(): number {
-    return this._rows.length;
+    return this._flameGraphRows.length;
   }
 
   getRow(depth: number): FlameGraphTimingRow {
@@ -61,13 +79,78 @@ export class FlameGraphTiming {
         `Out-of-bounds call to getRow: ${depth} is outside 0..${this.rowCount}`
       );
     }
-
-    return this._rows[depth];
+    while (this._timingRows.length <= depth) {
+      this._buildNextTimingRow();
+    }
+    return this._timingRows[depth];
   }
 
   // Convenience method for tests, don't call in production
   getAllRowsForTesting(): FlameGraphTimingRow[] {
-    return this._rows;
+    const rows = [];
+    for (let depth = 0; depth < this.rowCount; depth++) {
+      rows.push(this.getRow(depth));
+    }
+    return rows;
+  }
+
+  _buildNextTimingRow(): void {
+    const { total, self, rootTotalSummary } = this._callTreeTimings;
+    const { prefix } = this._callNodeTable;
+
+    const depth = this._timingRows.length;
+    const rowNodes = this._flameGraphRows[depth];
+    const startPerCallNode = this._startPerCallNode;
+
+    // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1858310
+    const abs = Math.abs;
+
+    const start: UnitIntervalOfProfileRange[] = [];
+    const end: UnitIntervalOfProfileRange[] = [];
+    const selfRelative: number[] = [];
+    const timingCallNodes: IndexIntoCallNodeTable[] = [];
+
+    // Sibling boxes are adjacent. Whenever the prefix changes, jump ahead to
+    // the new parent's start so children stay aligned under their parent.
+    //
+    // Previous row: [B          ][D      ]       [G        ]
+    // Current row:  [C][E][F]    [I    ]
+    // (Note: upside down from how the flame graph is usually displayed.)
+    let currentStart = 0;
+    let previousPrefixCallNode = -1;
+    for (let i = 0; i < rowNodes.length; i++) {
+      const nodeIndex = rowNodes[i];
+      const totalVal = total[nodeIndex];
+      if (totalVal === 0) {
+        continue;
+      }
+
+      const nodePrefix = prefix[nodeIndex];
+      if (nodePrefix !== previousPrefixCallNode) {
+        currentStart = nodePrefix === -1 ? 0 : startPerCallNode[nodePrefix];
+        previousPrefixCallNode = nodePrefix;
+      }
+      startPerCallNode[nodeIndex] = currentStart;
+
+      const totalRelative = abs(totalVal / rootTotalSummary);
+      const selfRelativeVal = abs(self[nodeIndex] / rootTotalSummary);
+
+      const currentEnd = currentStart + totalRelative;
+      start.push(currentStart);
+      end.push(currentEnd);
+      selfRelative.push(selfRelativeVal);
+      timingCallNodes.push(nodeIndex);
+
+      currentStart = currentEnd;
+    }
+
+    this._timingRows.push({
+      start,
+      end,
+      selfRelative,
+      callNode: timingCallNodes,
+      length: timingCallNodes.length,
+    });
   }
 }
 
@@ -258,85 +341,12 @@ export function computeFlameGraphRows(
 }
 
 /**
- * Build a FlameGraphTiming table from a call tree.
+ * Build a FlameGraphTiming from a call tree.
  */
 export function getFlameGraphTiming(
   flameGraphRows: FlameGraphRows,
   callNodeTable: CallNodeTable,
   callTreeTimings: CallTreeTimingsNonInverted
 ): FlameGraphTiming {
-  const { total, self, rootTotalSummary } = callTreeTimings;
-  const { prefix } = callNodeTable;
-
-  // This is where we build up the return value, one row at a time.
-  const timing = [];
-
-  // This is used to adjust the start position of a call node's box based on the
-  // start position of its prefix node's box.
-  const startPerCallNode = new Float32Array(callNodeTable.length);
-
-  // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1858310
-  const abs = Math.abs;
-
-  // Go row by row.
-  for (let depth = 0; depth < flameGraphRows.length; depth++) {
-    const rowNodes = flameGraphRows[depth];
-
-    const start = [];
-    const end = [];
-    const selfRelative = [];
-    const timingCallNodes = [];
-
-    // Process the call nodes in this row. Sibling boxes are adjacent to each other.
-    // Whenever the prefix changes, we need to add a gap so that the child boxes
-    // start at the same position as the parent box.
-    //
-    // Previous row: [B          ][D      ]       [G        ]
-    // Current row:  [C][E][F]    [I    ]
-    // (Note that this is upside down from how the flame graph is usually displayed)
-    let currentStart = 0;
-    let previousPrefixCallNode = -1;
-    for (let indexInRow = 0; indexInRow < rowNodes.length; indexInRow++) {
-      const nodeIndex = rowNodes[indexInRow];
-      const totalVal = total[nodeIndex];
-      if (totalVal === 0) {
-        // Skip boxes with zero width.
-        continue;
-      }
-
-      const nodePrefix = prefix[nodeIndex];
-      if (nodePrefix !== previousPrefixCallNode) {
-        // We have advanced to a node with a different parent, so we need to
-        // jump ahead to the parent box's start position.
-        currentStart = startPerCallNode[nodePrefix];
-        previousPrefixCallNode = nodePrefix;
-      }
-
-      // Write down the start position of this call node so that it can be
-      // checked later by this node's children.
-      startPerCallNode[nodeIndex] = currentStart;
-
-      // Take the absolute value, as native deallocations can be negative.
-      const totalRelativeVal = abs(totalVal / rootTotalSummary);
-      const selfRelativeVal = abs(self[nodeIndex] / rootTotalSummary);
-
-      const currentEnd = currentStart + totalRelativeVal;
-      start.push(currentStart);
-      end.push(currentEnd);
-      selfRelative.push(selfRelativeVal);
-      timingCallNodes.push(nodeIndex);
-
-      // The start position of the next box is the end position of the current box.
-      currentStart = currentEnd;
-    }
-    timing[depth] = {
-      start,
-      end,
-      selfRelative,
-      callNode: timingCallNodes,
-      length: timingCallNodes.length,
-    };
-  }
-
-  return new FlameGraphTiming(timing);
+  return new FlameGraphTiming(flameGraphRows, callNodeTable, callTreeTimings);
 }

--- a/src/profile-logic/flame-graph.ts
+++ b/src/profile-logic/flame-graph.ts
@@ -16,9 +16,8 @@ export type FlameGraphDepth = number;
 export type IndexIntoFlameGraphTiming = number;
 
 /**
- * FlameGraphTiming is an array containing data used for rendering the
- * flame graph. Each element in the array describes one row in the
- * graph. Each such element in turn contains one or more functions,
+ * FlameGraphTimingRow contains the data used for rendering a single
+ * row of the flame graph. Each row contains one or more functions,
  * drawn as boxes with start and end positions, represented as unit
  * intervals of the profile range. It should be noted that start and
  * end does not represent units of time, but only positions on the
@@ -30,13 +29,47 @@ export type IndexIntoFlameGraphTiming = number;
  * selfRelative contains the self time relative to the total time,
  * which is used to color the drawn functions.
  */
-export type FlameGraphTiming = Array<{
+export type FlameGraphTimingRow = {
   start: UnitIntervalOfProfileRange[];
   end: UnitIntervalOfProfileRange[];
   selfRelative: Array<number>;
   callNode: IndexIntoCallNodeTable[];
   length: number;
-}>;
+};
+
+/**
+ * Used by the flame graph canvas to know which boxes to render where.
+ *
+ * The flame graph only calls getRow(depth) for on-screen rows; this allows
+ * the implementation to generate rows lazily as the user scrolls towards
+ * deeper calls.
+ */
+export class FlameGraphTiming {
+  _rows: FlameGraphTimingRow[];
+
+  constructor(rows: FlameGraphTimingRow[]) {
+    this._rows = rows;
+  }
+
+  get rowCount(): number {
+    return this._rows.length;
+  }
+
+  getRow(depth: number): FlameGraphTimingRow {
+    if (depth < 0 || depth >= this.rowCount) {
+      throw new Error(
+        `Out-of-bounds call to getRow: ${depth} is outside 0..${this.rowCount}`
+      );
+    }
+
+    return this._rows[depth];
+  }
+
+  // Convenience method for tests, don't call in production
+  getAllRowsForTesting(): FlameGraphTimingRow[] {
+    return this._rows;
+  }
+}
 
 /**
  * FlameGraphRows is an array of rows, where each row is an array of call node
@@ -305,5 +338,5 @@ export function getFlameGraphTiming(
     };
   }
 
-  return timing;
+  return new FlameGraphTiming(timing);
 }

--- a/src/test/store/__snapshots__/profile-view.test.ts.snap
+++ b/src/test/store/__snapshots__/profile-view.test.ts.snap
@@ -3181,68 +3181,70 @@ Object {
 `;
 
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getFlameGraphTiming 1`] = `
-Array [
-  Object {
-    "callNode": Array [
-      0,
-    ],
-    "end": Array [
-      1,
-    ],
-    "length": 1,
-    "selfRelative": Array [
-      0,
-    ],
-    "start": Array [
-      0,
-    ],
-  },
-  Object {
-    "callNode": Array [
-      1,
-    ],
-    "end": Array [
-      1,
-    ],
-    "length": 1,
-    "selfRelative": Array [
-      0,
-    ],
-    "start": Array [
-      0,
-    ],
-  },
-  Object {
-    "callNode": Array [
-      5,
-    ],
-    "end": Array [
-      1,
-    ],
-    "length": 1,
-    "selfRelative": Array [
-      0,
-    ],
-    "start": Array [
-      0,
-    ],
-  },
-  Object {
-    "callNode": Array [
-      6,
-    ],
-    "end": Array [
-      1,
-    ],
-    "length": 1,
-    "selfRelative": Array [
-      1,
-    ],
-    "start": Array [
-      0,
-    ],
-  },
-]
+Object {
+  "rows": Array [
+    Object {
+      "callNode": Array [
+        0,
+      ],
+      "end": Array [
+        1,
+      ],
+      "length": 1,
+      "selfRelative": Array [
+        0,
+      ],
+      "start": Array [
+        0,
+      ],
+    },
+    Object {
+      "callNode": Array [
+        1,
+      ],
+      "end": Array [
+        1,
+      ],
+      "length": 1,
+      "selfRelative": Array [
+        0,
+      ],
+      "start": Array [
+        0,
+      ],
+    },
+    Object {
+      "callNode": Array [
+        5,
+      ],
+      "end": Array [
+        1,
+      ],
+      "length": 1,
+      "selfRelative": Array [
+        0,
+      ],
+      "start": Array [
+        0,
+      ],
+    },
+    Object {
+      "callNode": Array [
+        6,
+      ],
+      "end": Array [
+        1,
+      ],
+      "length": 1,
+      "selfRelative": Array [
+        1,
+      ],
+      "start": Array [
+        0,
+      ],
+    },
+  ],
+}
 `;
 
 exports[`snapshots of selectors/profile matches the last stored run of selectedThreadSelector.getJankMarkersForHeader 1`] = `

--- a/src/test/store/actions.test.ts
+++ b/src/test/store/actions.test.ts
@@ -206,7 +206,9 @@ describe('selectors/getFlameGraphTiming', function () {
       store.getState()
     );
 
-    return flameGraphTiming.map(({ callNode, end, length, start }) => {
+    const flameGraphTimingRows = flameGraphTiming.getAllRowsForTesting();
+
+    return flameGraphTimingRows.map(({ callNode, end, length, start }) => {
       const lines = [];
       for (let i = 0; i < length; i++) {
         const callNodeIndex = callNode[i];
@@ -239,8 +241,9 @@ describe('selectors/getFlameGraphTiming', function () {
     const flameGraphTiming = selectedThreadSelectors.getFlameGraphTiming(
       store.getState()
     );
+    const flameGraphTimingRows = flameGraphTiming.getAllRowsForTesting();
 
-    return flameGraphTiming.map(({ selfRelative, callNode, length }) => {
+    return flameGraphTimingRows.map(({ selfRelative, callNode, length }) => {
       const lines = [];
       for (let i = 0; i < length; i++) {
         const callNodeIndex = callNode[i];

--- a/src/test/store/profile-view.test.ts
+++ b/src/test/store/profile-view.test.ts
@@ -2385,9 +2385,13 @@ describe('snapshots of selectors/profile', function () {
 
   it('matches the last stored run of selectedThreadSelector.getFlameGraphTiming', function () {
     const { getState } = setupStore();
-    expect(
-      selectedThreadSelectors.getFlameGraphTiming(getState())
-    ).toMatchSnapshot();
+    const timing = selectedThreadSelectors.getFlameGraphTiming(getState());
+    // Build a plain shape with the flame graph timing contents, so that the
+    // snapshot doesn't contain the class name / class fields.
+    const plainTiming = {
+      rows: timing.getAllRowsForTesting(),
+    };
+    expect(plainTiming).toMatchSnapshot();
   });
 
   it('matches the last stored run of selectedThreadSelector.getFriendlyThreadName', function () {


### PR DESCRIPTION
Before this PR, we were always computing positioning information for the entire flame graph, even though the viewport is usually too small to display the entire flame graph - only the N root-most rows are displayed, until the user starts scrolling / panning. This PR changes it so that we only compute the box positions / "FlameGraphTiming" for the rows that get rendered by the flame graph canvas. This speeds up the initial render of the flame graph panel.

When switching to the Flame Graph panel on https://share.firefox.dev/4g4xGue , with a flame graph canvas height of 564px, I'm getting the following profiles:

Before: https://share.firefox.dev/4w2QEG3 (410ms tab switch)
After: https://share.firefox.dev/3QYB7IA (272ms tab switch)