### PR TITLE
Use appropriate highlighter dialects for ts + jsx

### DIFF
--- a/src/components/shared/SourceView-codemirror.ts
+++ b/src/components/shared/SourceView-codemirror.ts
@@ -53,14 +53,16 @@ function _languageExtForPath(path: string | null): LanguageSupport | [] {
   if (path.endsWith('.rs')) {
     return rust();
   }
-  if (
-    path.endsWith('.js') ||
-    path.endsWith('.jsm') ||
-    path.endsWith('.jsx') ||
-    path.endsWith('.mjs') ||
-    path.endsWith('.ts') ||
-    path.endsWith('.tsx')
-  ) {
+  if (path.endsWith('.tsx')) {
+    return javascript({ typescript: true, jsx: true });
+  }
+  if (path.endsWith('.ts')) {
+    return javascript({ typescript: true });
+  }
+  if (path.endsWith('.jsx')) {
+    return javascript({ jsx: true });
+  }
+  if (path.endsWith('.js') || path.endsWith('.jsm') || path.endsWith('.mjs')) {
     return javascript();
   }
   if (


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6141--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

I noticed incorrect highlighting in the source view for a .ts file (from a source map).