### PR TITLE
Extract a `runCommand` helper for profiler-cli command handlers

### DIFF
--- a/profiler-cli/CONTRIBUTING.md
+++ b/profiler-cli/CONTRIBUTING.md
@@ -139,9 +139,7 @@ export type AllocationInfoResult = {
 
 ```typescript
 import { Command } from 'commander';
-import { sendCommand } from '../client';
-import { addGlobalOptions } from './shared';
-import { formatOutput } from '../output';
+import { addGlobalOptions, runCommand } from './shared';
 
 export function registerAllocationCommand(
   program: Command,
@@ -157,12 +155,11 @@ export function registerAllocationCommand(
       .description('Show allocation summary')
       .option('--thread <handle>', 'Thread to query')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'allocation', subcommand: 'info', thread: opts.thread },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }
 ```

--- a/profiler-cli/src/commands/counter.ts
+++ b/profiler-cli/src/commands/counter.ts
@@ -7,9 +7,7 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
-import { addGlobalOptions } from './shared';
+import { addGlobalOptions, runCommand } from './shared';
 
 export function registerCounterCommand(
   program: Command,
@@ -24,12 +22,11 @@ export function registerCounterCommand(
       .command('list')
       .description('List all counters with one-line summaries')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'counter', subcommand: 'list' },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
@@ -39,11 +36,10 @@ export function registerCounterCommand(
       .option('--counter <handle>', 'Counter handle')
   ).action(async (handleArg: string | undefined, opts) => {
     const counterHandle = handleArg ?? opts.counter;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'counter', subcommand: 'info', counter: counterHandle },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/commands/filter.ts
+++ b/profiler-cli/src/commands/filter.ts
@@ -7,13 +7,12 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
 import { parseFilterSpec } from '../utils/parse';
 import {
   addGlobalOptions,
   addSampleFilterOptions,
   parseIntArg,
+  runCommand,
   wasExplicit,
 } from './shared';
 
@@ -48,12 +47,11 @@ export function registerFilterCommand(
       outsideMarker: opts.outsideMarker,
       search: opts.search,
     });
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'filter', subcommand: 'push', thread: opts.thread, spec },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
@@ -70,12 +68,11 @@ export function registerFilterCommand(
       1,
       'Error: count must be a positive integer'
     );
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'filter', subcommand: 'pop', thread: opts.thread, count },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
@@ -84,12 +81,11 @@ export function registerFilterCommand(
       .description('List active filters for current thread')
       .option('--thread <handle>', 'Thread handle')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'filter', subcommand: 'list', thread: opts.thread },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
 
     if (!wasExplicit('filter', 'list')) {
       console.log(
@@ -104,11 +100,10 @@ export function registerFilterCommand(
       .description('Remove all filters for current thread')
       .option('--thread <handle>', 'Thread handle')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'filter', subcommand: 'clear', thread: opts.thread },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/commands/function.ts
+++ b/profiler-cli/src/commands/function.ts
@@ -7,9 +7,7 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
-import { addGlobalOptions } from './shared';
+import { addGlobalOptions, runCommand } from './shared';
 
 export function registerFunctionCommand(
   program: Command,
@@ -24,12 +22,11 @@ export function registerFunctionCommand(
       .option('--function <handle>', 'Function handle')
   ).action(async (handleArg: string | undefined, opts) => {
     const funcHandle = handleArg ?? opts.function;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'function', subcommand: 'expand', function: funcHandle },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
@@ -39,12 +36,11 @@ export function registerFunctionCommand(
       .option('--function <handle>', 'Function handle')
   ).action(async (handleArg: string | undefined, opts) => {
     const funcHandle = handleArg ?? opts.function;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'function', subcommand: 'info', function: funcHandle },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
@@ -70,7 +66,7 @@ export function registerFunctionCommand(
       )
   ).action(async (handleArg: string | undefined, opts) => {
     const funcHandle = handleArg ?? opts.function;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'function',
@@ -80,8 +76,7 @@ export function registerFunctionCommand(
         symbolServerUrl: opts.symbolServer,
         annotateContext: opts.context,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/commands/marker.ts
+++ b/profiler-cli/src/commands/marker.ts
@@ -7,9 +7,7 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
-import { addGlobalOptions } from './shared';
+import { addGlobalOptions, runCommand } from './shared';
 
 export function registerMarkerCommand(
   program: Command,
@@ -24,12 +22,11 @@ export function registerMarkerCommand(
       .option('--marker <handle>', 'Marker handle')
   ).action(async (handleArg: string | undefined, opts) => {
     const markerHandle = handleArg ?? opts.marker;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'marker', subcommand: 'info', marker: markerHandle },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
@@ -39,11 +36,10 @@ export function registerMarkerCommand(
       .option('--marker <handle>', 'Marker handle')
   ).action(async (handleArg: string | undefined, opts) => {
     const markerHandle = handleArg ?? opts.marker;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'marker', subcommand: 'stack', marker: markerHandle },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/commands/profile.ts
+++ b/profiler-cli/src/commands/profile.ts
@@ -7,9 +7,7 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
-import { addGlobalOptions, parseIntArg } from './shared';
+import { addGlobalOptions, parseIntArg, runCommand } from './shared';
 
 export function registerProfileCommand(
   program: Command,
@@ -29,7 +27,7 @@ export function registerProfileCommand(
       )
       .option('--search <term>', 'Filter by substring')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'profile',
@@ -37,9 +35,8 @@ export function registerProfileCommand(
         all: opts.all,
         search: opts.search,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   const VALID_LOG_LEVELS = ['error', 'warn', 'info', 'debug', 'verbose'];
@@ -76,7 +73,7 @@ export function registerProfileCommand(
       opts.search !== undefined ||
       limit !== undefined;
 
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'profile',
@@ -91,8 +88,7 @@ export function registerProfileCommand(
             }
           : undefined,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/commands/shared.ts
+++ b/profiler-cli/src/commands/shared.ts
@@ -9,6 +9,31 @@
 import type { Command } from 'commander';
 import { Option } from 'commander';
 import { collectStrings } from '../utils/parse';
+import { sendCommand } from '../client';
+import { formatOutput } from '../output';
+import type { ClientCommand } from '../protocol';
+
+/**
+ * Options shared by every command action via `addGlobalOptions`.
+ */
+export type GlobalOptions = {
+  session?: string;
+  json?: boolean;
+};
+
+/**
+ * Send a command to the daemon and print the formatted result. Centralizes the
+ * `sendCommand` + `formatOutput` tail that every command action shares, so no
+ * call site can forget to pass `opts.session` or honor `opts.json`.
+ */
+export async function runCommand(
+  sessionDir: string,
+  command: ClientCommand,
+  opts: GlobalOptions
+): Promise<void> {
+  const result = await sendCommand(sessionDir, command, opts.session);
+  console.log(formatOutput(result, opts.json ?? false));
+}
 
 /**
  * Parse a string as an integer and exit with an error if it is not a valid

--- a/profiler-cli/src/commands/thread.ts
+++ b/profiler-cli/src/commands/thread.ts
@@ -7,14 +7,13 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
 import { parseEphemeralFilters } from '../utils/parse';
 import {
   addGlobalOptions,
   addSampleFilterOptions,
   parseIntArg,
   parseFloatArg,
+  runCommand,
 } from './shared';
 import type {
   CallTreeScoringStrategy,
@@ -95,12 +94,11 @@ export function registerThreadCommand(
       .description('Print detailed thread information')
       .option('--thread <handle>', 'Thread handle (e.g. t-0)')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'thread', subcommand: 'info', thread: opts.thread },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread select
@@ -111,12 +109,11 @@ export function registerThreadCommand(
       .option('--thread <handle>', 'Thread handle')
   ).action(async (handleArg: string | undefined, opts) => {
     const threadHandle = handleArg ?? opts.thread;
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'thread', subcommand: 'select', thread: threadHandle },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread samples
@@ -126,7 +123,7 @@ export function registerThreadCommand(
       .description('Show hot functions list for a thread')
   ).action(async (opts) => {
     const sampleFilters = parseEphemeralFilters(opts);
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -136,9 +133,8 @@ export function registerThreadCommand(
         search: opts.search,
         sampleFilters: sampleFilters.length ? sampleFilters : undefined,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread samples-top-down
@@ -148,7 +144,7 @@ export function registerThreadCommand(
       .description('Show top-down call tree (where CPU time is spent)')
   ).action(async (opts) => {
     const sampleFilters = parseEphemeralFilters(opts);
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -159,9 +155,8 @@ export function registerThreadCommand(
         callTreeOptions: parseCallTreeOptions(opts),
         sampleFilters: sampleFilters.length ? sampleFilters : undefined,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread samples-bottom-up
@@ -171,7 +166,7 @@ export function registerThreadCommand(
       .description('Show bottom-up call tree (what calls hot functions)')
   ).action(async (opts) => {
     const sampleFilters = parseEphemeralFilters(opts);
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -182,9 +177,8 @@ export function registerThreadCommand(
         callTreeOptions: parseCallTreeOptions(opts),
         sampleFilters: sampleFilters.length ? sampleFilters : undefined,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread markers
@@ -282,7 +276,7 @@ export function registerThreadCommand(
       }
     }
 
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -290,9 +284,8 @@ export function registerThreadCommand(
         thread: opts.thread,
         markerFilters,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread network
@@ -351,7 +344,7 @@ export function registerThreadCommand(
       networkFilters.limit = 20;
     }
 
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -359,9 +352,8 @@ export function registerThreadCommand(
         thread: opts.thread,
         networkFilters,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread page-load
@@ -401,7 +393,7 @@ export function registerThreadCommand(
       );
     }
 
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -409,9 +401,8 @@ export function registerThreadCommand(
         thread: opts.thread,
         pageLoadOptions,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   // thread functions
@@ -457,7 +448,7 @@ export function registerThreadCommand(
 
     const sampleFilters = parseEphemeralFilters(opts);
 
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       {
         command: 'thread',
@@ -467,8 +458,7 @@ export function registerThreadCommand(
         functionFilters,
         sampleFilters: sampleFilters.length ? sampleFilters : undefined,
       },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/commands/zoom.ts
+++ b/profiler-cli/src/commands/zoom.ts
@@ -7,9 +7,7 @@
  */
 
 import type { Command } from 'commander';
-import { sendCommand } from '../client';
-import { formatOutput } from '../output';
-import { addGlobalOptions } from './shared';
+import { addGlobalOptions, runCommand } from './shared';
 
 export function registerZoomCommand(
   program: Command,
@@ -24,23 +22,17 @@ export function registerZoomCommand(
         'Push a zoom range (e.g. 2.7,3.1 in seconds, 2700ms,3100ms in milliseconds, 10%,20% as percentage, or m-158 for a marker)'
       )
   ).action(async (range: string, opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'zoom', subcommand: 'push', range },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 
   addGlobalOptions(
     zoom.command('pop').description('Pop the most recent zoom range')
   ).action(async (opts) => {
-    const result = await sendCommand(
-      sessionDir,
-      { command: 'zoom', subcommand: 'pop' },
-      opts.session
-    );
-    console.log(formatOutput(result, opts.json ?? false));
+    await runCommand(sessionDir, { command: 'zoom', subcommand: 'pop' }, opts);
   });
 
   addGlobalOptions(
@@ -48,11 +40,10 @@ export function registerZoomCommand(
       .command('clear')
       .description('Clear all zoom ranges (return to full profile)')
   ).action(async (opts) => {
-    const result = await sendCommand(
+    await runCommand(
       sessionDir,
       { command: 'zoom', subcommand: 'clear' },
-      opts.session
+      opts
     );
-    console.log(formatOutput(result, opts.json ?? false));
   });
 }

--- a/profiler-cli/src/index.ts
+++ b/profiler-cli/src/index.ts
@@ -31,7 +31,7 @@ import { startDaemon } from './daemon';
 import { startNewDaemon, stopDaemon, sendCommand } from './client';
 import { listSessions } from './session';
 import { formatOutput } from './output';
-import { addGlobalOptions } from './commands/shared';
+import { addGlobalOptions, runCommand } from './commands/shared';
 import { VERSION } from './constants';
 import { registerProfileCommand } from './commands/profile';
 import { registerThreadCommand } from './commands/thread';
@@ -135,12 +135,7 @@ Examples:
         'Show session status (selected thread, zoom ranges, filters)'
       )
   ).action(async (opts) => {
-    const result = await sendCommand(
-      SESSION_DIR,
-      { command: 'status' },
-      opts.session
-    );
-    console.log(formatOutput(result, opts.json ?? false));
+    await runCommand(SESSION_DIR, { command: 'status' }, opts);
   });
 
   // profiler-cli stop [id]


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6148--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

This is mostly a cleanup commit. For every command action we pretty much had the same code at the end. This patch adds a shared `runCommand` function that sends the command and prints the formatted result in one place to reduce the code duplication.