### PR TITLE
feat(theme): add color-scheme meta

### DIFF
--- a/res/index.html
+++ b/res/index.html
@@ -6,6 +6,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <title>Firefox Profiler</title>
     <link rel="preload" href="/locales/en-US/app.ftl" as="fetch" />
     <style>


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6150--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

add color-scheme meta so that allow disable dark-reader.

Since firefox-profiler already has a dark theme, you can disable datareader for a better visual experience.

before:

<img width="918" height="206" alt="image" src="https://github.com/user-attachments/assets/09cc2ee6-e6b9-44b6-80ce-8f42852821b2" />

after:

<img width="738" height="130" alt="image" src="https://github.com/user-attachments/assets/23a9e243-bde6-434f-98b7-f4566cd2e6c2" />

Oddly enough, before this patch was applied, dark-reader sometimes recognized dark mode and sometimes it didn't.

However, this patch gives dark-reader a deterministic behavior in any case.