### PR TITLE
Remove unused samples.thread column

### DIFF
--- a/src/profile-logic/merge-compare.ts
+++ b/src/profile-logic/merge-compare.ts
@@ -1177,21 +1177,19 @@ function combineSamplesDiffing(
 ): RawSamplesTable {
   const [
     {
-      thread: { samples: samples1, tid: tid1 },
+      thread: { samples: samples1 },
       weightMultiplier: weightMultiplier1,
     },
     {
-      thread: { samples: samples2, tid: tid2 },
+      thread: { samples: samples2 },
       weightMultiplier: weightMultiplier2,
     },
   ] = threadsAndWeightMultipliers;
 
   const newWeight: number[] = [];
-  const newThreadId: Tid[] = [];
   const newSamples = {
     ...getRawSamplesTableBuilderWithEventDelay(),
     weight: newWeight,
-    threadId: newThreadId,
   };
 
   const samples1Time = computeTimeColumnForRawSamplesTable(samples1);
@@ -1217,7 +1215,6 @@ function combineSamplesDiffing(
       // of eventDelay/responsiveness don't mean anything.
       newSamples.eventDelay!.push(null);
       newSamples.time!.push(samples1Time[i]);
-      newThreadId.push(samples1.threadId ? samples1.threadId[i] : tid1);
       // TODO (issue #3151): Figure out a way to diff CPU usage numbers.
       // We add the first thread with a negative weight, because this is the
       // base profile.
@@ -1233,7 +1230,6 @@ function combineSamplesDiffing(
       // of eventDelay/responsiveness don't mean anything.
       newSamples.eventDelay!.push(null);
       newSamples.time!.push(samples2Time[j]);
-      newThreadId.push(samples2.threadId ? samples2.threadId[j] : tid2);
       const sampleWeight = samples2.weight ? samples2.weight[j] : 1;
       newWeight.push(weightMultiplier2 * sampleWeight);
 
@@ -1364,13 +1360,9 @@ function combineSamplesForMerging(threads: RawThread[]): RawSamplesTable {
   const nextSampleIndexPerThread: number[] = Array(
     samplesPerThread.length
   ).fill(0);
-  // This array will contain the source thread ids. It will be added to the
-  // samples table after the loop.
-  const newThreadId: Tid[] = [];
   // Creating a new empty samples table to fill.
   const newSamples = {
     ...getRawSamplesTableBuilderWithEventDelay(),
-    threadId: newThreadId,
   };
 
   // If every source thread has threadCPUDelta, and if the threads are
@@ -1437,11 +1429,6 @@ function combineSamplesForMerging(threads: RawThread[]): RawSamplesTable {
     // from independent threads instead.
     ensureExists(newSamples.eventDelay).push(null);
     newSamples.time!.push(sourceThreadSamplesTimeCol[sourceThreadSampleIndex]);
-    newThreadId.push(
-      sourceThreadSamples.threadId
-        ? sourceThreadSamples.threadId[sourceThreadSampleIndex]
-        : threads[sourceThreadIndex].tid
-    );
     if (newThreadCPUDelta !== undefined) {
       newThreadCPUDelta.push(
         ensureExists(sourceThreadSamples.threadCPUDelta)[

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -2174,13 +2174,6 @@ export function filterThreadSamplesToRange(
     );
   }
 
-  if (samples.threadId) {
-    newSamples.threadId = samples.threadId.slice(
-      beginSampleIndex,
-      endSampleIndex
-    );
-  }
-
   const newThread: Thread = {
     ...thread,
     samples: newSamples,
@@ -2302,13 +2295,6 @@ export function filterRawThreadSamplesToRange(
 
   if (samples.argumentValues) {
     newSamples.argumentValues = samples.argumentValues.slice(
-      beginSampleIndex,
-      endSampleIndex
-    );
-  }
-
-  if (samples.threadId) {
-    newSamples.threadId = samples.threadId.slice(
       beginSampleIndex,
       endSampleIndex
     );
@@ -2745,7 +2731,6 @@ export function computeSamplesTableFromRawSamplesTable(
     threadCPUDelta,
     weight,
     weightType,
-    threadId,
     length,
   } = rawSamples;
 
@@ -2782,7 +2767,6 @@ export function computeSamplesTableFromRawSamplesTable(
     stack,
     weight,
     weightType,
-    threadId,
     length,
 
     // These fields are derived:

--- a/src/types/profile-derived.ts
+++ b/src/types/profile-derived.ts
@@ -150,9 +150,6 @@ export type SamplesTable = {
   category: Uint8Array;
   // The subcategory of each sample's stack in the unfiltered thread.
   subcategory: Uint16Array | Uint8Array;
-  // This property isn't present in normal threads. However it's present for
-  // merged threads, so that we know the origin thread for these samples.
-  threadId?: Tid[];
   argumentValues?: Array<number | null>;
   length: number;
 };

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -142,9 +142,6 @@ export type RawSamplesTable = {
   // The first value is ignored - it's not meaningful because there is no previous
   // sample.
   threadCPUDelta?: Array<number | null>;
-  // This property isn't present in normal threads. However it's present for
-  // merged threads, so that we know the origin thread for these samples.
-  threadId?: Tid[];
   length: number;
 };
 


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6151--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

This was added by the merging/diffing code and propagated in various places, but never actually read. There is a possibility that we may want to make use of this field in the future, but it's been many years and it hasn't happened, so let's just remove it for now. We can always add it back once we need it.

I noticed it because it ends up in the "compact" speedometer profiles from CI via `profiler-edit --merge-non-overlapping-threads-by-name`.