### PR TITLE
Don't crash when upgrading a gecko profile with an empty sample_groups

### DIFF
--- a/src/profile-logic/gecko-profile-versioning.ts
+++ b/src/profile-logic/gecko-profile-versioning.ts
@@ -1463,7 +1463,13 @@ const _upgraders: {
             // upgraded counters; ignore them.
             continue;
           }
-          counter.samples = counter.sample_groups[0].samples;
+          // A counter that collected no data has an empty sample_groups array
+          // (see the version 18 upgrader), so fall back to an empty samples
+          // table when there is no group to unwrap.
+          counter.samples =
+            counter.sample_groups.length > 0
+              ? counter.sample_groups[0].samples
+              : { schema: { time: 0, count: 1, number: 2 }, data: [] };
           delete counter.sample_groups;
         }
       }

--- a/src/test/unit/profile-upgrading.test.ts
+++ b/src/test/unit/profile-upgrading.test.ts
@@ -71,6 +71,30 @@ describe('upgrading gecko profiles', function () {
     //  - upgrading tracing markers without interval information
     testProfileUpgrading(require('../fixtures/upgrades/gecko-2.json'));
   });
+
+  it('handles a counter with no collected data', function () {
+    // The version 18 upgrader turns a counter whose sample_groups object has no
+    // samples into one with an empty sample_groups array. The version 29
+    // upgrader must not crash when unwrapping that empty array.
+    const profile: any = {
+      meta: { version: 17 },
+      processes: [],
+      threads: [],
+      counters: [
+        {
+          name: 'power',
+          category: 'power',
+          description: 'Power counter',
+          sample_groups: { id: 0 },
+        },
+      ],
+    };
+    upgradeGeckoProfileToCurrentVersion(profile);
+    expect(profile.meta.version).toEqual(GECKO_PROFILE_VERSION);
+    const [counter] = profile.counters;
+    expect(counter.sample_groups).toBe(undefined);
+    expect(counter.samples.data).toEqual([]);
+  });
 });
 
 describe('upgrading processed profiles', function () {


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6160--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

The version 29 gecko upgrader unwraps `counter.sample_groups[0].samples` into `counter.samples`, guarding only against a missing `sample_groups`:

```js
if (!counter.sample_groups) {
  continue;
}
counter.samples = counter.sample_groups[0].samples;
```

But the version 18 upgrader deliberately produces an *empty array* for a counter that collected no data:

```js
// It's possible to have an empty sample_groups object due to gecko bug.
// Remove it if that's the case.
if ('samples' in counter.sample_groups) {
  counter.sample_groups = [counter.sample_groups];
} else {
  counter.sample_groups = [];
}
```

`[]` is truthy, so the `!counter.sample_groups` guard doesn't skip it, and `[][0].samples` throws `TypeError: Cannot read properties of undefined (reading 'samples')`, aborting the whole profile load. No upgrader between 19 and 28 touches counters, so the empty array reaches version 29 unchanged. Any gecko profile from version 17–28 that contains a data-less counter (e.g. an external power counter that recorded nothing) hits this.

Fix: when there's no group to unwrap, fall back to an empty samples table. Downstream `_processCounters` already drops counters whose `samples.data` is empty, so the counter is handled gracefully.

Added a regression test that upgrades a version 17 profile with an empty `sample_groups` object to the current version; it fails on the current code with the TypeError above and passes with the fix.