### PR TITLE
Skip preview links for non-main PRs

### DIFF
--- a/.github/workflows/add-preview-links.yml
+++ b/.github/workflows/add-preview-links.yml
@@ -2,6 +2,8 @@ name: Add preview links
 
 on:
   pull_request_target:
+    branches:
+      - main
     types:
       - opened
       - edited


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/public/1g98hh2q406ng1dx7517j22qn7tn5nc7wtbkx4g/flame-graph/?globalTrackOrder=0&thread=0&v=16) | [Deploy preview](https://deploy-preview-6161--perf-html.netlify.app/public/1g98hh2q406ng1dx7517j22qn7tn5nc7wtbkx4g/flame-graph/?globalTrackOrder=0&thread=0&v=16)
<!-- profiler-preview-links:end -->

## Summary

- Limit the preview-link workflow to pull requests that target the main branch.
- Skip deployment PRs that target production by not running the workflow for them.

## Example

For a deployment PR like #6156 that targets production, the add-preview-links workflow no longer runs, so it will not re-add preview links after they are removed.

Addresses #6157.

## Testing

- `node --test .github/scripts/add-preview-links.test.mjs`
- `node --check .github/scripts/add-preview-links.mjs`
- `node --check .github/scripts/add-preview-links.test.mjs`
- `git diff --check`
- `oxfmt --check .github/scripts/add-preview-links.mjs .github/scripts/add-preview-links.test.mjs`