### PR TITLE
Copy column contents in getRawSamplesTableBuilderFromExisting for consistency

### DIFF
--- a/src/profile-logic/data-structures.ts
+++ b/src/profile-logic/data-structures.ts
@@ -147,37 +147,37 @@ export function getRawStackTableBuilder(): RawStackTableBuilder {
   };
 }
 
-/**
- * Return a `RawSamplesTableBuilder` view of an existing samples table. If the
- * table's time / timeDeltas columns are already plain arrays, they are aliased
- * through so that in-place mutations on the builder are visible via the
- * returned reference. If they are typed arrays (only produced by the JSLB
- * loader), they are copied into plain arrays.
- *
- * The returned builder shares object identity with `existing` in the common
- * (plain-array) case, so callers do not need to reassign it back onto the
- * thread. In the typed-array case a new object is returned; callers should
- * reassign it (`thread.samples = builder`) to preserve mutations.
- */
 export function getRawSamplesTableBuilderFromExisting(
   existing: RawSamplesTable
 ): RawSamplesTableBuilder {
-  const time = existing.time;
-  const timeDeltas = existing.timeDeltas;
-  if (
-    (time === undefined || Array.isArray(time)) &&
-    (timeDeltas === undefined || Array.isArray(timeDeltas))
-  ) {
-    return existing as RawSamplesTableBuilder;
-  }
-  return {
-    ...existing,
-    time: time === undefined || Array.isArray(time) ? time : Array.from(time),
-    timeDeltas:
-      timeDeltas === undefined || Array.isArray(timeDeltas)
-        ? timeDeltas
-        : Array.from(timeDeltas),
+  const builder: RawSamplesTableBuilder = {
+    stack: existing.stack.slice(),
+    weight: existing.weight === null ? null : existing.weight.slice(),
+    weightType: existing.weightType,
+    length: existing.length,
   };
+  if (existing.responsiveness !== undefined) {
+    builder.responsiveness = existing.responsiveness.slice();
+  }
+  if (existing.eventDelay !== undefined) {
+    builder.eventDelay = existing.eventDelay.slice();
+  }
+  if (existing.time !== undefined) {
+    builder.time = Array.from(existing.time);
+  }
+  if (existing.timeDeltas !== undefined) {
+    builder.timeDeltas = Array.from(existing.timeDeltas);
+  }
+  if (existing.argumentValues !== undefined) {
+    builder.argumentValues = existing.argumentValues.slice();
+  }
+  if (existing.threadCPUDelta !== undefined) {
+    builder.threadCPUDelta = existing.threadCPUDelta.slice();
+  }
+  if (existing.threadId !== undefined) {
+    builder.threadId = existing.threadId.slice();
+  }
+  return builder;
 }
 
 export function finishRawSamplesTableBuilder(


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6168--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

The other getRawXYZBuilderWithExistingContents functions do the same; the samples version is only called in places where we then overwrite the original table so it didn't really make a difference, but let's be consistent with the other tables and actually make it so that if you push to the builder columns, the original table is unaffected.