### PR TITLE
Add marker handles to `profiler-cli thread network`

### DIFF
--- a/profiler-cli/schemas.txt
+++ b/profiler-cli/schemas.txt
@@ -157,7 +157,7 @@ profiler-cli thread network --json
       phaseTotals: { dns?, tcp?, tls?, ttfb?, download?, mainThread? }
     },
     requests: [{
-      url, httpStatus?, httpVersion?, cacheStatus?,
+      markerHandle, url, httpStatus?, httpVersion?, cacheStatus?,
       transferSizeKB?, startTime, duration,
       phases: { dns?, tcp?, tls?, ttfb?, download?, mainThread? }
     }],

--- a/profiler-cli/src/formatters.ts
+++ b/profiler-cli/src/formatters.ts
@@ -1322,7 +1322,7 @@ export function formatThreadNetworkResult(
         ? `  size=${req.transferSizeKB.toFixed(1)}KB`
         : '';
 
-    lines.push(`  ${url}`);
+    lines.push(`  ${req.markerHandle}  ${url}`);
     lines.push(
       `    ${status}${version}${cache}${size}  duration=${formatDuration(req.duration)}`
     );

--- a/profiler-cli/src/test/unit/network-formatting.test.ts
+++ b/profiler-cli/src/test/unit/network-formatting.test.ts
@@ -24,6 +24,7 @@ function makeRequest(
   overrides: Partial<NetworkRequestEntry> = {}
 ): NetworkRequestEntry {
   return {
+    markerHandle: 'm-1',
     url: 'https://example.com/resource',
     startTime: 0,
     duration: 100,
@@ -253,5 +254,14 @@ describe('formatThreadNetworkResult', function () {
     const output = formatThreadNetworkResult(result);
 
     expect(output).toContain('No network requests');
+  });
+
+  it('shows a marker handle for each request', function () {
+    const result = makeResult();
+    result.requests = [makeRequest({ markerHandle: 'm-42' })];
+
+    const output = formatThreadNetworkResult(result);
+
+    expect(output).toContain('m-42');
   });
 });

--- a/src/profile-query/formatters/marker-info.ts
+++ b/src/profile-query/formatters/marker-info.ts
@@ -1136,6 +1136,7 @@ function buildNetworkPhases(data: NetworkPayload): NetworkPhaseTimings {
 export function collectThreadNetwork(
   store: Store,
   threadMap: ThreadMap,
+  markerMap: MarkerMap,
   threadHandle?: string,
   filterOptions: {
     searchString?: string;
@@ -1253,6 +1254,7 @@ export function collectThreadNetwork(
     const duration = data.endTime - data.startTime;
 
     return {
+      markerHandle: markerMap.handleForMarker(threadIndexes, i),
       url: data.URI,
       httpStatus: data.responseStatus,
       httpVersion: data.httpVersion,

--- a/src/profile-query/index.ts
+++ b/src/profile-query/index.ts
@@ -1053,6 +1053,7 @@ export class ProfileQuerier {
     const result = collectThreadNetwork(
       this._store,
       this._threadMap,
+      this._markerMap,
       threadHandle,
       filterOptions
     );

--- a/src/profile-query/types.ts
+++ b/src/profile-query/types.ts
@@ -428,6 +428,7 @@ export type NetworkPhaseTimings = {
 };
 
 export type NetworkRequestEntry = {
+  markerHandle: string;
   url: string;
   httpStatus?: number;
   httpVersion?: string;

--- a/src/test/unit/profile-query/marker-utils.test.ts
+++ b/src/test/unit/profile-query/marker-utils.test.ts
@@ -731,11 +731,12 @@ describe('collectThreadNetwork', function () {
     const store = storeWithProfile(profile);
     const threadMap = new ThreadMap();
     threadMap.handleForThreadIndex(0);
-    return { store, threadMap };
+    const markerMap = new MarkerMap();
+    return { store, threadMap, markerMap };
   }
 
   it('counts only STATUS_STOP markers, ignoring STATUS_START', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         uri: 'https://example.com/a',
@@ -752,14 +753,14 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
 
     expect(result.totalRequestCount).toBe(2);
     expect(result.requests).toHaveLength(2);
   });
 
   it('filters by searchString case-insensitively', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         uri: 'https://api.example.com/data',
@@ -783,9 +784,15 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap, undefined, {
-      searchString: 'API',
-    });
+    const result = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        searchString: 'API',
+      }
+    );
 
     expect(result.totalRequestCount).toBe(3);
     expect(result.filteredRequestCount).toBe(2);
@@ -793,7 +800,7 @@ describe('collectThreadNetwork', function () {
   });
 
   it('filters by minDuration', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         uri: 'https://example.com/fast',
@@ -810,16 +817,22 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap, undefined, {
-      minDuration: 5,
-    });
+    const result = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        minDuration: 5,
+      }
+    );
 
     expect(result.filteredRequestCount).toBe(1);
     expect(result.requests[0].url).toContain('slow');
   });
 
   it('filters by maxDuration', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         uri: 'https://example.com/fast',
@@ -836,16 +849,22 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap, undefined, {
-      maxDuration: 5,
-    });
+    const result = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        maxDuration: 5,
+      }
+    );
 
     expect(result.filteredRequestCount).toBe(1);
     expect(result.requests[0].url).toContain('fast');
   });
 
   it('limit restricts the requests list but summary stats cover all filtered results', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         uri: 'https://example.com/a',
@@ -869,9 +888,15 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap, undefined, {
-      limit: 2,
-    });
+    const result = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        limit: 2,
+      }
+    );
 
     expect(result.filteredRequestCount).toBe(3);
     expect(result.requests).toHaveLength(2);
@@ -880,21 +905,27 @@ describe('collectThreadNetwork', function () {
   });
 
   it('limit 0 means no limit — all requests are returned', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       { id: 1, startTime: 0, fetchStart: 0, endTime: 5 },
       { id: 2, startTime: 6, fetchStart: 6, endTime: 11 },
       { id: 3, startTime: 12, fetchStart: 12, endTime: 17 },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap, undefined, {
-      limit: 0,
-    });
+    const result = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        limit: 0,
+      }
+    );
 
     expect(result.requests).toHaveLength(3);
   });
 
   it('accumulates cache stats correctly', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         startTime: 0,
@@ -933,7 +964,7 @@ describe('collectThreadNetwork', function () {
       { id: 6, startTime: 10, fetchStart: 10, endTime: 11 },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
 
     expect(result.summary.cacheHit).toBe(3);
     expect(result.summary.cacheMiss).toBe(2);
@@ -941,7 +972,7 @@ describe('collectThreadNetwork', function () {
   });
 
   it('extracts phase timings per request', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         startTime: 0,
@@ -959,7 +990,7 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
     const phases = result.requests[0].phases;
 
     expect(phases.dns).toBe(5);
@@ -971,7 +1002,7 @@ describe('collectThreadNetwork', function () {
   });
 
   it('extracts TLS phase only when secureConnectionStart > 0', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         startTime: 0,
@@ -986,13 +1017,13 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
 
     expect(result.requests[0].phases.tls).toBe(8);
   });
 
   it('skips TLS phase when secureConnectionStart is 0', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         startTime: 0,
@@ -1005,13 +1036,13 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
 
     expect(result.requests[0].phases.tls).toBeUndefined();
   });
 
   it('accumulates phase totals in summary across all filtered requests', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         startTime: 0,
@@ -1028,20 +1059,26 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
 
     expect(result.summary.phaseTotals.ttfb).toBe(20);
   });
 
   it('sets filters field only when at least one filter is applied', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       { id: 1, startTime: 0, fetchStart: 0, endTime: 5 },
     ]);
 
-    const noFilters = collectThreadNetwork(store, threadMap);
-    const withFilter = collectThreadNetwork(store, threadMap, undefined, {
-      searchString: 'example',
-    });
+    const noFilters = collectThreadNetwork(store, threadMap, markerMap);
+    const withFilter = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        searchString: 'example',
+      }
+    );
 
     expect(noFilters.filters).toBeUndefined();
     expect(withFilter.filters).toBeDefined();
@@ -1049,7 +1086,7 @@ describe('collectThreadNetwork', function () {
   });
 
   it('returns zero requests when no markers match filters', function () {
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       {
         id: 1,
         uri: 'https://example.com/',
@@ -1059,9 +1096,15 @@ describe('collectThreadNetwork', function () {
       },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap, undefined, {
-      searchString: 'no-match-here',
-    });
+    const result = collectThreadNetwork(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      {
+        searchString: 'no-match-here',
+      }
+    );
 
     expect(result.totalRequestCount).toBe(1);
     expect(result.filteredRequestCount).toBe(0);
@@ -1071,12 +1114,22 @@ describe('collectThreadNetwork', function () {
   it('returns correct duration on each request entry', function () {
     // The merged marker sets data.startTime to the START marker's table time
     // (0), so total duration = endTime - startTime = 25 - 0 = 25.
-    const { store, threadMap } = setupWithNetworkMarkers([
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
       { id: 1, startTime: 0, fetchStart: 5, endTime: 25 },
     ]);
 
-    const result = collectThreadNetwork(store, threadMap);
+    const result = collectThreadNetwork(store, threadMap, markerMap);
 
     expect(result.requests[0].duration).toBe(25);
+  });
+
+  it('assigns a marker handle to each request entry', function () {
+    const { store, threadMap, markerMap } = setupWithNetworkMarkers([
+      { id: 1, startTime: 0, fetchStart: 0, endTime: 5 },
+    ]);
+
+    const result = collectThreadNetwork(store, threadMap, markerMap);
+
+    expect(result.requests[0].markerHandle).toBe('m-1');
   });
 });


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/public/xqqdjsmyp4czgkns0zx7ch767n6cfn6bjgh3kcr/flame-graph/?globalTrackOrder=0&implementation=js&thread=0&v=16) | [Deploy preview](https://deploy-preview-6172--perf-html.netlify.app/public/xqqdjsmyp4czgkns0zx7ch767n6cfn6bjgh3kcr/flame-graph/?globalTrackOrder=0&implementation=js&thread=0&v=16)
<!-- profiler-preview-links:end -->

~~Note that this depends on #6171 since it touches the schemas.txt. That PR needs to be reviewed first. Please ignore the first commit in this PR (as that belongs to that PR) and only review the second one.~~
The previous PR has landed.

Every request entry in `thread network` now has a marker handle, so a slow request can be fed straight to `zoom push m-N` or `marker info m-N` without re-finding it via `thread markers`. Other commands in the cli usually have marker handles if they show any markers, we didn't include that before, but it's always good to include it.

Example profile: https://share.firefox.dev/4aGPacn

`pq thread network` before:

```
[Thread: t-0 (GeckoMain) | View: Full profile | Full: 6.639s]

Network requests in thread t-0 (https://firefox.com) — 11 requests

Summary:
  Cache: 0 hit, 0 miss, 11 unknown
  Phase totals:
    TTFB:             3.635s
    Download:         626.10ms
    Main thread wait: 1.551s

  https://symbolication.services.mozilla.com/symbolicate/v5
    200  h2  size=221.1KB  duration=708.27ms
    Phases: TTFB=414.43ms  DL=22.913ms  wait=32.476ms

  https://symbolication.services.mozilla.com/symbolicate/v5
    200  h2  size=1705.9KB  duration=1.345s
    Phases: TTFB=700.41ms  DL=178.28ms  wait=205.48ms

  https://symbolication.services.mozilla.com/symbolicate/v5
    200  h2  size=116.1KB  duration=705.23ms
    Phases: TTFB=298.93ms  DL=39.541ms  wait=113.42ms
```

After:

```
[Thread: t-0 (GeckoMain) | View: Full profile | Full: 6.639s]

Network requests in thread t-0 (https://firefox.com) — 11 requests

Summary:
  Cache: 0 hit, 0 miss, 11 unknown
  Phase totals:
    TTFB:             3.635s
    Download:         626.10ms
    Main thread wait: 1.551s

  m-1  https://symbolication.services.mozilla.com/symbolicate/v5
    200  h2  size=221.1KB  duration=708.27ms
    Phases: TTFB=414.43ms  DL=22.913ms  wait=32.476ms

  m-2  https://symbolication.services.mozilla.com/symbolicate/v5
    200  h2  size=1705.9KB  duration=1.345s
    Phases: TTFB=700.41ms  DL=178.28ms  wait=205.48ms

  m-3  https://symbolication.services.mozilla.com/symbolicate/v5
    200  h2  size=116.1KB  duration=705.23ms
    Phases: TTFB=298.93ms  DL=39.541ms  wait=113.42ms
```