### PR TITLE
Fixed botched merge which broke 'yarn ts'

### DIFF
--- a/src/profile-logic/data-structures.ts
+++ b/src/profile-logic/data-structures.ts
@@ -174,9 +174,6 @@ export function getRawSamplesTableBuilderFromExisting(
   if (existing.threadCPUDelta !== undefined) {
     builder.threadCPUDelta = existing.threadCPUDelta.slice();
   }
-  if (existing.threadId !== undefined) {
-    builder.threadId = existing.threadId.slice();
-  }
   return builder;
 }
 


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6174--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

The auto-rebase of #6151 over #6168 caused a typecheck failure and auto-merge merged anyway. I've now added the "typecheck (ubuntu-latest)" task to the required passing tasks in the branch protection rules so this shouldn't happen again.