### PR TITLE
Add `profile meta` command to profiler-cli

### DIFF
--- a/profiler-cli/README.md
+++ b/profiler-cli/README.md
@@ -31,6 +31,7 @@ Run `profiler-cli --help` for the full options reference.
 ```bash
 profiler-cli load <PATH>                   # Start daemon and load profile (file or http/https URL)
 profiler-cli profile info                  # Print profile summary [--all] [--search <term>]
+profiler-cli profile meta                  # Print profile metadata (application, platform, recording settings)
 profiler-cli profile logs                  # Print Log markers in MOZ_LOG format [--thread] [--module] [--level] [--search] [--limit]
 profiler-cli thread info                   # Print detailed thread information
 profiler-cli thread select <handle>        # Select a thread (e.g., t-0, t-1)

--- a/profiler-cli/guide.txt
+++ b/profiler-cli/guide.txt
@@ -29,6 +29,7 @@ CORE WORKFLOW
     profiler-cli profile info          Overview: processes, threads, time range, CPU activity
     profiler-cli profile info --all    Show all processes and threads (not just top 5)
     profiler-cli profile info --search GeckoMain   Filter by process/thread name, pid, or tid
+    profiler-cli profile meta          Metadata: application, platform, and recording settings
     profiler-cli profile logs          Print all Log markers in MOZ_LOG format (across all threads)
 
     See the "Network activity" section in "profile info": if requests are in

--- a/profiler-cli/schemas.txt
+++ b/profiler-cli/schemas.txt
@@ -44,6 +44,25 @@ ProfileNetworkSummary:
     byThread: [{ threadHandle, threadName, requestCount, inFlightMs }]
   }
 
+profiler-cli profile meta --json
+  All fields except type, interval, and product are optional and omitted when
+  absent. Times are in milliseconds since the epoch; *Formatted fields are ISO
+  strings of the same value.
+  {
+    type: "profile-meta",
+    startTime?, startTimeFormatted?, durationMs?,
+    endTime?, endTimeFormatted?, interval, symbolicated?,
+    bufferCapacityBytes?, bufferDuration?, features?: [string], threadsFilter?: [string],
+    product, productAndVersion?, uptimeMs?,
+    appBuildID?, sourceURL?, updateChannel?, debug?, arguments?,
+    extensions?: [{ name, id, baseURL? }],
+    platform?, oscpu?, abi?, device?, cpuName?, physicalCPUs?, logicalCPUs?, mainMemoryBytes?,
+    importedFrom?, fileName?, fileSize?, version?, preprocessedProfileVersion?,
+    sampleUnits?: { time, eventDelay, threadCPUDelta },
+    extra?: [{ label, entries: [{ label, value, formatted }] }],
+    context: SessionContext
+  }
+
 CounterSummary:
   {
     counterHandle, counterIndex, name, label, category,

--- a/profiler-cli/src/commands/profile.ts
+++ b/profiler-cli/src/commands/profile.ts
@@ -39,6 +39,23 @@ export function registerProfileCommand(
     );
   });
 
+  addGlobalOptions(
+    profile
+      .command('meta')
+      .description(
+        'Print profile metadata (application, platform, recording settings)'
+      )
+  ).action(async (opts) => {
+    await runCommand(
+      sessionDir,
+      {
+        command: 'profile',
+        subcommand: 'meta',
+      },
+      opts
+    );
+  });
+
   const VALID_LOG_LEVELS = ['error', 'warn', 'info', 'debug', 'verbose'];
 
   addGlobalOptions(

--- a/profiler-cli/src/daemon.ts
+++ b/profiler-cli/src/daemon.ts
@@ -303,6 +303,8 @@ export class Daemon {
         switch (command.subcommand) {
           case 'info':
             return this.querier.profileInfo(command.all, command.search);
+          case 'meta':
+            return this.querier.profileMeta();
           case 'threads':
             throw new Error('unimplemented');
           case 'logs':

--- a/profiler-cli/src/formatters.ts
+++ b/profiler-cli/src/formatters.ts
@@ -20,6 +20,7 @@ import type {
   MarkerStackResult,
   MarkerInfoResult,
   ProfileInfoResult,
+  ProfileMetaResult,
   ThreadSamplesResult,
   ThreadSamplesTopDownResult,
   ThreadSamplesBottomUpResult,
@@ -44,7 +45,10 @@ import type {
 } from './protocol';
 import { truncateFunctionName } from '../../src/profile-query/function-list';
 import { describeSpec } from '../../src/profile-query/filter-stack';
-import { formatTimestamp as formatDuration } from 'firefox-profiler/utils/format-numbers';
+import {
+  formatTimestamp as formatDuration,
+  formatBytes,
+} from 'firefox-profiler/utils/format-numbers';
 
 // Maximum display width for function names in call-tree and sample views.
 const FUNC_NAME_WIDTH = 120;
@@ -471,6 +475,165 @@ Name: ${result.name}\n`;
   }
 
   return output;
+}
+
+function formatCpuCores(result: ProfileMetaResult): string | null {
+  const { physicalCPUs, logicalCPUs } = result;
+  if (physicalCPUs !== undefined && logicalCPUs !== undefined) {
+    return `${physicalCPUs} physical, ${logicalCPUs} logical cores`;
+  }
+  if (physicalCPUs !== undefined) {
+    return `${physicalCPUs} physical cores`;
+  }
+  if (logicalCPUs !== undefined) {
+    return `${logicalCPUs} logical cores`;
+  }
+  return null;
+}
+
+/**
+ * Format the sampling interval. Size profiles measure the "interval" in bytes,
+ * everything else in time.
+ */
+function formatInterval(result: ProfileMetaResult): string {
+  if (result.sampleUnits?.time === 'bytes') {
+    return formatBytes(result.interval);
+  }
+  return formatDuration(result.interval, 4, 1);
+}
+
+/**
+ * Format a ProfileMetaResult as plain text, grouped into the same sections the
+ * web UI's "Profile Info" panel uses. Absent fields (and empty sections) are
+ * skipped.
+ */
+export function formatProfileMetaResult(
+  result: WithContext<ProfileMetaResult>
+): string {
+  const blocks: string[] = [];
+  const pushSection = (heading: string, rows: string[]) => {
+    if (rows.length) {
+      blocks.push(`${heading}:\n` + rows.map((row) => `  ${row}`).join('\n'));
+    }
+  };
+
+  // ===== Recording =====
+  const recording: string[] = [];
+  if (result.startTimeFormatted) {
+    recording.push(`Started: ${result.startTimeFormatted}`);
+  }
+  if (result.durationMs !== undefined) {
+    recording.push(`Duration: ${formatDuration(result.durationMs)}`);
+  }
+  if (result.endTimeFormatted) {
+    recording.push(`Main process ended: ${result.endTimeFormatted}`);
+  }
+  recording.push(`Sampling interval: ${formatInterval(result)}`);
+  if (result.bufferCapacityBytes !== undefined) {
+    recording.push(
+      `Buffer capacity: ${formatBytes(result.bufferCapacityBytes, 0)}`
+    );
+  }
+  if (result.bufferDuration !== undefined) {
+    recording.push(`Buffer duration: ${result.bufferDuration}s`);
+  }
+  if (result.symbolicated !== undefined) {
+    recording.push(`Symbolicated: ${result.symbolicated ? 'yes' : 'no'}`);
+  }
+  if (result.features && result.features.length) {
+    recording.push(`Features: ${result.features.join(', ')}`);
+  }
+  if (result.threadsFilter && result.threadsFilter.length) {
+    recording.push(`Threads filter: ${result.threadsFilter.join(', ')}`);
+  }
+  pushSection('Recording', recording);
+
+  // ===== Application =====
+  const application: string[] = [];
+  if (result.productAndVersion) {
+    let name = result.productAndVersion;
+    if (result.appBuildID) {
+      name += ` (build ${result.appBuildID})`;
+    }
+    application.push(`Name: ${name}`);
+  } else if (result.appBuildID) {
+    application.push(`Build ID: ${result.appBuildID}`);
+  }
+  if (result.uptimeMs !== undefined) {
+    application.push(`Uptime: ${formatDuration(result.uptimeMs)}`);
+  }
+  if (result.updateChannel) {
+    application.push(`Update channel: ${result.updateChannel}`);
+  }
+  if (result.debug !== undefined) {
+    application.push(`Build type: ${result.debug ? 'debug' : 'opt'}`);
+  }
+  if (result.sourceURL) {
+    application.push(`Source URL: ${result.sourceURL}`);
+  }
+  if (result.arguments) {
+    application.push(`Arguments: ${result.arguments}`);
+  }
+  if (result.extensions && result.extensions.length) {
+    const names = result.extensions.map((ext) => ext.name).join(', ');
+    application.push(`Extensions (${result.extensions.length}): ${names}`);
+  }
+  pushSection('Application', application);
+
+  // ===== Platform =====
+  const platform: string[] = [];
+  if (result.device) {
+    platform.push(`Device: ${result.device}`);
+  }
+  if (result.platform) {
+    let os = result.platform;
+    if (result.abi) {
+      os += ` (${result.abi})`;
+    }
+    platform.push(`OS: ${os}`);
+  } else if (result.abi) {
+    platform.push(`ABI: ${result.abi}`);
+  }
+  const cpuCores = formatCpuCores(result);
+  if (result.cpuName) {
+    let cpu = result.cpuName;
+    if (cpuCores) {
+      cpu += ` (${cpuCores})`;
+    }
+    platform.push(`CPU: ${cpu}`);
+  } else if (cpuCores) {
+    platform.push(`CPU cores: ${cpuCores}`);
+  }
+  if (result.mainMemoryBytes !== undefined) {
+    platform.push(`Memory: ${formatBytes(result.mainMemoryBytes)}`);
+  }
+  pushSection('Platform', platform);
+
+  // ===== Import =====
+  const importInfo: string[] = [];
+  if (result.importedFrom) {
+    importInfo.push(`Imported from: ${result.importedFrom}`);
+  }
+  if (result.fileName) {
+    importInfo.push(`File name: ${result.fileName}`);
+  }
+  if (result.fileSize !== undefined) {
+    importInfo.push(`File size: ${formatBytes(result.fileSize)}`);
+  }
+  pushSection('Import', importInfo);
+
+  // ===== Extra =====
+  if (result.extra) {
+    for (const section of result.extra) {
+      const rows = section.entries.map(
+        (entry) => `${entry.label}: ${entry.formatted}`
+      );
+      pushSection(section.label, rows);
+    }
+  }
+
+  const contextHeader = formatContextHeader(result.context);
+  return `${contextHeader}\n\n${blocks.join('\n\n')}`;
 }
 
 function formatCounterStatInline(

--- a/profiler-cli/src/output.ts
+++ b/profiler-cli/src/output.ts
@@ -19,6 +19,7 @@ import {
   formatMarkerStackResult,
   formatMarkerInfoResult,
   formatProfileInfoResult,
+  formatProfileMetaResult,
   formatThreadSamplesResult,
   formatThreadSamplesTopDownResult,
   formatThreadSamplesBottomUpResult,
@@ -72,6 +73,8 @@ export function formatOutput(
       return formatMarkerInfoResult(result);
     case 'profile-info':
       return formatProfileInfoResult(result);
+    case 'profile-meta':
+      return formatProfileMetaResult(result);
     case 'thread-samples':
       return formatThreadSamplesResult(result);
     case 'thread-samples-top-down':

--- a/profiler-cli/src/protocol.ts
+++ b/profiler-cli/src/protocol.ts
@@ -53,6 +53,7 @@ export type {
   MarkerStackResult,
   StackTraceData,
   ProfileInfoResult,
+  ProfileMetaResult,
   ProfileLogsResult,
   ThreadSelectResult,
   CounterSummary,
@@ -77,6 +78,7 @@ import type {
   MarkerStackResult,
   MarkerInfoResult,
   ProfileInfoResult,
+  ProfileMetaResult,
   ThreadSamplesResult,
   ThreadSamplesTopDownResult,
   ThreadSamplesBottomUpResult,
@@ -104,6 +106,10 @@ export type ClientCommand =
       subcommand: 'info' | 'threads';
       all?: boolean;
       search?: string;
+    }
+  | {
+      command: 'profile';
+      subcommand: 'meta';
     }
   | {
       command: 'profile';
@@ -203,6 +209,7 @@ export type CommandResult =
   | WithContext<MarkerStackResult>
   | WithContext<MarkerInfoResult>
   | WithContext<ProfileInfoResult>
+  | WithContext<ProfileMetaResult>
   | WithContext<ThreadSamplesResult>
   | WithContext<ThreadSamplesTopDownResult>
   | WithContext<ThreadSamplesBottomUpResult>

--- a/profiler-cli/src/test/integration/basic.test.ts
+++ b/profiler-cli/src/test/integration/basic.test.ts
@@ -18,6 +18,7 @@ import {
 
 import type {
   FilterStackResult,
+  ProfileMetaResult,
   SessionMetadata,
   StatusResult,
   ThreadSamplesResult,
@@ -69,6 +70,28 @@ describe('profiler-cli basic functionality', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('This profile contains');
+  });
+
+  it('profile meta works after load', async () => {
+    await cli(ctx, ['load', 'src/test/fixtures/upgrades/processed-1.json']);
+
+    const result = await cli(ctx, ['profile', 'meta']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Recording:');
+    expect(result.stdout).toContain('Sampling interval:');
+  });
+
+  it('profile meta --json returns typed structured output', async () => {
+    await cli(ctx, ['load', 'src/test/fixtures/upgrades/processed-1.json']);
+
+    const result = await cli(ctx, ['profile', 'meta', '--json']);
+
+    expect(result.exitCode).toBe(0);
+    const meta = JSON.parse(result.stdout) as WithContext<ProfileMetaResult>;
+    expect(meta.type).toBe('profile-meta');
+    expect(typeof meta.product).toBe('string');
+    expect(typeof meta.interval).toBe('number');
   });
 
   it('thread select works immediately after load', async () => {

--- a/profiler-cli/src/test/unit/__snapshots__/meta-formatting.test.ts.snap
+++ b/profiler-cli/src/test/unit/__snapshots__/meta-formatting.test.ts.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`formatProfileMetaResult renders a full Firefox recording grouped into sections 1`] = `
+"[Thread: t-0 (GeckoMain) | View: Full profile | Full: 3s]
+
+Recording:
+  Started: 2024-09-02T14:35:00.000Z
+  Duration: 5.200s
+  Main process ended: 2024-09-02T14:35:10.000Z
+  Sampling interval: 1ms
+  Buffer capacity: 8MB
+  Buffer duration: 20s
+  Symbolicated: yes
+  Features: js, stackwalk
+  Threads filter: GeckoMain
+
+Application:
+  Name: Firefox 130 (build 20240902143034)
+  Uptime: 34s
+  Update channel: nightly
+  Build type: opt
+  Extensions (2): uBlock Origin, 1Password
+
+Platform:
+  OS: macOS 14.6 (aarch64-gcc3)
+  CPU: Apple M1 Max (10 physical, 10 logical cores)
+  Memory: 34.4GB"
+`;
+
+exports[`formatProfileMetaResult renders a sparse imported profile, skipping absent sections 1`] = `
+"[Thread: t-0 (GeckoMain) | View: Full profile | Full: 3s]
+
+Recording:
+  Sampling interval: 1ms
+
+Application:
+  Name: Google Chrome
+
+Import:
+  Imported from: Chrome Trace
+  File name: trace.json
+  File size: 2.50MB"
+`;
+
+exports[`formatProfileMetaResult renders extra importer sections as their own heading blocks 1`] = `
+"[Thread: t-0 (GeckoMain) | View: Full profile | Full: 3s]
+
+Recording:
+  Sampling interval: 1ms
+
+System:
+  Kernel: 6.1.0
+  CPUs: 16"
+`;

--- a/profiler-cli/src/test/unit/meta-formatting.test.ts
+++ b/profiler-cli/src/test/unit/meta-formatting.test.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { formatProfileMetaResult } from '../../formatters';
+import type {
+  ProfileMetaResult,
+  SessionContext,
+  WithContext,
+} from 'firefox-profiler/profile-query/types';
+
+function createContext(): SessionContext {
+  return {
+    selectedThreadHandle: 't-0',
+    selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+    currentViewRange: null,
+    rootRange: { start: 0, end: 3000 },
+  };
+}
+
+function withContext(meta: ProfileMetaResult): WithContext<ProfileMetaResult> {
+  return { ...meta, context: createContext() };
+}
+
+describe('formatProfileMetaResult', function () {
+  it('renders a full Firefox recording grouped into sections', function () {
+    const result = withContext({
+      type: 'profile-meta',
+      startTime: 1_725_287_700_000,
+      startTimeFormatted: '2024-09-02T14:35:00.000Z',
+      durationMs: 5200,
+      endTime: 1_725_287_710_000,
+      endTimeFormatted: '2024-09-02T14:35:10.000Z',
+      interval: 1,
+      symbolicated: true,
+      bufferCapacityBytes: 8_000_000,
+      bufferDuration: 20,
+      features: ['js', 'stackwalk'],
+      threadsFilter: ['GeckoMain'],
+      product: 'Firefox',
+      productAndVersion: 'Firefox 130',
+      uptimeMs: 34_000,
+      appBuildID: '20240902143034',
+      updateChannel: 'nightly',
+      debug: false,
+      extensions: [
+        { name: 'uBlock Origin', id: 'uBlock0@raymondhill.net' },
+        { name: '1Password', id: '1password@agilebits.com' },
+      ],
+      platform: 'macOS 14.6',
+      abi: 'aarch64-gcc3',
+      cpuName: 'Apple M1 Max',
+      physicalCPUs: 10,
+      logicalCPUs: 10,
+      mainMemoryBytes: 34_359_738_368,
+    });
+
+    const output = formatProfileMetaResult(result);
+
+    expect(output).toContain('Recording:');
+    expect(output).toContain('Started: 2024-09-02T14:35:00.000Z');
+    expect(output).toContain('Main process ended: 2024-09-02T14:35:10.000Z');
+    expect(output).toContain('Sampling interval: 1ms');
+    expect(output).toContain('Buffer capacity: 8MB');
+    expect(output).toContain('Symbolicated: yes');
+    expect(output).toContain('Features: js, stackwalk');
+
+    expect(output).toContain('Application:');
+    expect(output).toContain('Name: Firefox 130 (build 20240902143034)');
+    expect(output).toContain('Update channel: nightly');
+    expect(output).toContain('Build type: opt');
+    expect(output).toContain('Extensions (2): uBlock Origin, 1Password');
+
+    expect(output).toContain('Platform:');
+    expect(output).toContain('OS: macOS 14.6 (aarch64-gcc3)');
+    expect(output).toContain(
+      'CPU: Apple M1 Max (10 physical, 10 logical cores)'
+    );
+    expect(output).toContain('Memory: 34.4GB');
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('renders a sparse imported profile, skipping absent sections', function () {
+    const result = withContext({
+      type: 'profile-meta',
+      interval: 1,
+      product: 'Google Chrome',
+      productAndVersion: 'Google Chrome',
+      importedFrom: 'Chrome Trace',
+      fileName: 'trace.json',
+      fileSize: 2_500_000,
+    });
+
+    const output = formatProfileMetaResult(result);
+
+    expect(output).toContain('Recording:');
+    expect(output).toContain('Sampling interval: 1ms');
+    expect(output).toContain('Application:');
+    expect(output).toContain('Name: Google Chrome');
+    expect(output).toContain('Import:');
+    expect(output).toContain('Imported from: Chrome Trace');
+    expect(output).toContain('File name: trace.json');
+    expect(output).toContain('File size: 2.50MB');
+
+    // No platform data, so the Platform section is omitted.
+    expect(output).not.toContain('Platform:');
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it('formats the interval in bytes for size profiles', function () {
+    const result = withContext({
+      type: 'profile-meta',
+      interval: 65536,
+      product: 'Firefox',
+      sampleUnits: {
+        time: 'bytes',
+        eventDelay: 'ms',
+        threadCPUDelta: 'variable CPU cycles',
+      },
+    });
+
+    const output = formatProfileMetaResult(result);
+    expect(output).toContain('Sampling interval: 65.5KB');
+  });
+
+  it('renders extra importer sections as their own heading blocks', function () {
+    const result = withContext({
+      type: 'profile-meta',
+      interval: 1,
+      product: 'perf',
+      extra: [
+        {
+          label: 'System',
+          entries: [
+            { label: 'Kernel', value: '6.1.0', formatted: '6.1.0' },
+            { label: 'CPUs', value: 16, formatted: '16' },
+          ],
+        },
+      ],
+    });
+
+    const output = formatProfileMetaResult(result);
+    expect(output).toContain('System:');
+    expect(output).toContain('Kernel: 6.1.0');
+    expect(output).toContain('CPUs: 16');
+
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/src/profile-query/formatters/profile-meta.ts
+++ b/src/profile-query/formatters/profile-meta.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getProfile } from 'firefox-profiler/selectors/profile';
+import {
+  formatProductAndVersion,
+  formatPlatform,
+} from 'firefox-profiler/profile-logic/profile-metainfo';
+import { formatFromMarkerSchema } from 'firefox-profiler/profile-logic/marker-schema';
+import { StringTable } from 'firefox-profiler/utils/string-table';
+import type { Store } from '../../types/store';
+import type { ProfileMetaResult } from '../types';
+
+/**
+ * Collect the profile's `meta` field into a structured, grouped result. This
+ * mirrors what the "Profile Info" panel renders in the web UI, reusing the same
+ * formatting helpers so the CLI and the UI stay consistent.
+ */
+export function collectProfileMeta(store: Store): ProfileMetaResult {
+  const { meta } = getProfile(store.getState());
+
+  const result: ProfileMetaResult = {
+    type: 'profile-meta',
+    interval: meta.interval,
+    product: meta.product,
+  };
+
+  // ===== Recording =====
+  // When profilingStartTime is present, startTime + profilingStartTime is the
+  // moment recording actually began. Otherwise fall back to the raw startTime.
+  const startTime =
+    meta.profilingStartTime !== undefined
+      ? meta.startTime + meta.profilingStartTime
+      : meta.startTime;
+  if (startTime !== undefined) {
+    result.startTime = startTime;
+    result.startTimeFormatted = new Date(startTime).toISOString();
+  }
+
+  let durationMs;
+  if (
+    meta.profilingStartTime !== undefined &&
+    meta.profilingEndTime !== undefined
+  ) {
+    durationMs = meta.profilingEndTime - meta.profilingStartTime;
+  } else if (meta.endTime !== undefined) {
+    durationMs = meta.endTime - (meta.profilingStartTime ?? 0);
+  }
+  if (durationMs !== undefined) {
+    result.durationMs = durationMs;
+  }
+
+  if (meta.endTime !== undefined) {
+    result.endTime = meta.endTime;
+    result.endTimeFormatted = new Date(meta.endTime).toISOString();
+  }
+
+  if (meta.symbolicated !== undefined) {
+    result.symbolicated = meta.symbolicated;
+  }
+
+  const { configuration } = meta;
+  if (configuration) {
+    // Capacity is stored in entries of 8 bytes each.
+    result.bufferCapacityBytes = configuration.capacity * 8;
+    if (configuration.duration !== undefined) {
+      result.bufferDuration = configuration.duration;
+    }
+    if (configuration.features.length) {
+      result.features = configuration.features;
+    }
+    if (configuration.threads.length) {
+      result.threadsFilter = configuration.threads;
+    }
+  }
+
+  // ===== Application =====
+  const productAndVersion = formatProductAndVersion(meta);
+  if (productAndVersion) {
+    result.productAndVersion = productAndVersion;
+  }
+  if (meta.profilingStartTime !== undefined) {
+    result.uptimeMs = meta.profilingStartTime;
+  }
+  if (meta.appBuildID !== undefined) {
+    result.appBuildID = meta.appBuildID;
+  }
+  if (meta.sourceURL !== undefined) {
+    result.sourceURL = meta.sourceURL;
+  }
+  if (meta.updateChannel !== undefined) {
+    result.updateChannel = meta.updateChannel;
+  }
+  if (meta.debug !== undefined) {
+    result.debug = meta.debug;
+  }
+  if (meta.arguments !== undefined) {
+    result.arguments = meta.arguments;
+  }
+  if (meta.extensions && meta.extensions.length) {
+    const { extensions } = meta;
+    const list = [];
+    for (let i = 0; i < extensions.length; i++) {
+      const entry: { name: string; id: string; baseURL?: string } = {
+        name: extensions.name[i],
+        id: extensions.id[i],
+      };
+      if (extensions.baseURL[i] !== undefined) {
+        entry.baseURL = extensions.baseURL[i];
+      }
+      list.push(entry);
+    }
+    list.sort((a, b) => a.name.localeCompare(b.name));
+    result.extensions = list;
+  }
+
+  // ===== Platform =====
+  const platform = formatPlatform(meta);
+  if (platform) {
+    result.platform = platform;
+  }
+  if (meta.oscpu !== undefined) {
+    result.oscpu = meta.oscpu;
+  }
+  if (meta.abi !== undefined) {
+    result.abi = meta.abi;
+  }
+  if (meta.device !== undefined) {
+    result.device = meta.device;
+  }
+  if (meta.CPUName !== undefined) {
+    result.cpuName = meta.CPUName;
+  }
+  if (meta.physicalCPUs !== undefined) {
+    result.physicalCPUs = meta.physicalCPUs;
+  }
+  if (meta.logicalCPUs !== undefined) {
+    result.logicalCPUs = meta.logicalCPUs;
+  }
+  if (meta.mainMemory !== undefined) {
+    result.mainMemoryBytes = meta.mainMemory;
+  }
+
+  // ===== Import / misc =====
+  if (meta.importedFrom !== undefined) {
+    result.importedFrom = meta.importedFrom;
+  }
+  if (meta.fileName !== undefined) {
+    result.fileName = meta.fileName;
+  }
+  if (meta.fileSize !== undefined) {
+    result.fileSize = meta.fileSize;
+  }
+  if (meta.version !== undefined) {
+    result.version = meta.version;
+  }
+  if (meta.preprocessedProfileVersion !== undefined) {
+    result.preprocessedProfileVersion = meta.preprocessedProfileVersion;
+  }
+  if (meta.sampleUnits !== undefined) {
+    result.sampleUnits = meta.sampleUnits;
+  }
+
+  // ===== Extra =====
+  if (meta.extra && meta.extra.length) {
+    const stringTable = StringTable.withBackingArray([]);
+    result.extra = meta.extra.map((section) => ({
+      label: section.label,
+      entries: section.entries.map((entry) => ({
+        label: entry.label,
+        value: entry.value,
+        formatted: formatFromMarkerSchema(
+          'moreInfo',
+          entry.format,
+          entry.value,
+          stringTable
+        ),
+      })),
+    }));
+  }
+
+  return result;
+}

--- a/src/profile-query/index.ts
+++ b/src/profile-query/index.ts
@@ -47,6 +47,7 @@ import { getLibForFunc } from './function-list';
 import { MarkerMap } from './marker-map';
 import { loadProfileFromFileOrUrl, type LoadOptions } from './loader';
 import { collectProfileInfo } from './formatters/profile-info';
+import { collectProfileMeta } from './formatters/profile-meta';
 import {
   collectThreadInfo,
   collectThreadSamples,
@@ -88,6 +89,7 @@ import type {
   MarkerStackResult,
   MarkerInfoResult,
   ProfileInfoResult,
+  ProfileMetaResult,
   ThreadSamplesResult,
   ThreadSamplesTopDownResult,
   ThreadSamplesBottomUpResult,
@@ -219,6 +221,10 @@ export class ProfileQuerier {
       search
     );
     return { ...result, context: this._getContext() };
+  }
+
+  async profileMeta(): Promise<WithContext<ProfileMetaResult>> {
+    return { ...collectProfileMeta(this._store), context: this._getContext() };
   }
 
   async counterList(): Promise<WithContext<CounterListResult>> {

--- a/src/profile-query/types.ts
+++ b/src/profile-query/types.ts
@@ -12,6 +12,7 @@ import type {
   CounterGraphType,
   CounterTooltipDataSource,
   NetworkStatus,
+  SampleUnits,
 } from 'firefox-profiler/types';
 
 // ===== Utility types =====
@@ -904,4 +905,72 @@ export type ProfileInfoResult = {
     depthLevel: number;
   }> | null;
   networkActivity: ProfileNetworkSummary | null;
+};
+
+/**
+ * Structured view of the profile's `meta` field, mirroring the "Profile Info"
+ * panel in the web UI (`src/components/app/MenuButtons/MetaInfo.tsx`). Fields
+ * are grouped by the panel's sections and are all optional except `interval`
+ * and `product`. Absent fields are omitted entirely rather than set to
+ * `undefined`, so the text formatter and `--json` output stay compact.
+ */
+export type ProfileMetaResult = {
+  type: 'profile-meta';
+
+  // ===== Recording =====
+  // Wall-clock start of the recording (ms since epoch). When
+  // `meta.profilingStartTime` is defined this is `startTime + profilingStartTime`
+  // (the actual moment recording began), otherwise the raw `meta.startTime`.
+  startTime?: number;
+  startTimeFormatted?: string; // ISO string of `startTime`
+  // Length of the recording in milliseconds, when derivable.
+  durationMs?: number;
+  endTime?: number; // raw `meta.endTime` (main process ended, ms since epoch)
+  endTimeFormatted?: string; // ISO string of `endTime`
+  interval: number; // sampling interval, in ms (or bytes for size profiles)
+  symbolicated?: boolean;
+  // Recording buffer, from `meta.configuration`. Capacity is converted from
+  // entries (8 bytes each) to bytes here.
+  bufferCapacityBytes?: number;
+  bufferDuration?: number; // buffer duration in seconds
+  features?: string[]; // enabled profiler features
+  threadsFilter?: string[]; // thread name filters
+
+  // ===== Application =====
+  product: string;
+  productAndVersion?: string; // e.g. "Firefox 130"
+  uptimeMs?: number; // time from process start to recording start
+  appBuildID?: string;
+  sourceURL?: string;
+  updateChannel?: string;
+  debug?: boolean;
+  arguments?: string;
+  extensions?: Array<{ name: string; id: string; baseURL?: string }>;
+
+  // ===== Platform =====
+  platform?: string; // formatted via `formatPlatform`
+  oscpu?: string; // raw `meta.oscpu`
+  abi?: string;
+  device?: string;
+  cpuName?: string;
+  physicalCPUs?: number;
+  logicalCPUs?: number;
+  mainMemoryBytes?: number;
+
+  // ===== Import / misc =====
+  importedFrom?: string;
+  fileName?: string;
+  fileSize?: number;
+  version?: number; // Gecko profile format version
+  preprocessedProfileVersion?: number;
+  sampleUnits?: SampleUnits;
+
+  // ===== Extra =====
+  // Free-form importer sections (`meta.extra`). `value` is passed through raw so
+  // `--json` stays machine-usable; `formatted` is the human-readable string
+  // produced with the entry's marker-schema format.
+  extra?: Array<{
+    label: string;
+    entries: Array<{ label: string; value: any; formatted: string }>;
+  }>;
 };

--- a/src/test/unit/profile-query/profile-meta.test.ts
+++ b/src/test/unit/profile-query/profile-meta.test.ts
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { collectProfileMeta } from 'firefox-profiler/profile-query/formatters/profile-meta';
+import {
+  formatProductAndVersion,
+  formatPlatform,
+} from 'firefox-profiler/profile-logic/profile-metainfo';
+import { getProfile } from 'firefox-profiler/selectors/profile';
+import { getProfileFromTextSamples } from '../../fixtures/profiles/processed-profile';
+import { storeWithProfile } from '../../fixtures/stores';
+import type { Profile } from 'firefox-profiler/types';
+
+// Build a store from a profile whose `meta` has been enriched in-place.
+function storeFromMeta(mutate: (profile: Profile) => void) {
+  const { profile } = getProfileFromTextSamples(`
+    A  A  A
+    B  B  B
+  `);
+  mutate(profile);
+  return storeWithProfile(profile);
+}
+
+describe('collectProfileMeta', function () {
+  it('collects a full Firefox recording meta', function () {
+    const store = storeFromMeta((profile) => {
+      Object.assign(profile.meta, {
+        interval: 1,
+        startTime: 1_000_000,
+        endTime: 1_000_000 + 5000,
+        profilingStartTime: 34_000,
+        profilingEndTime: 39_200,
+        processType: 0,
+        product: 'Firefox',
+        misc: 'rv:130.0',
+        oscpu: 'Intel Mac OS X 14.6',
+        toolkit: 'cocoa',
+        platform: 'Macintosh',
+        abi: 'aarch64-gcc3',
+        CPUName: 'Apple M1 Max',
+        physicalCPUs: 10,
+        logicalCPUs: 10,
+        mainMemory: 34_359_738_368,
+        symbolicated: true,
+        updateChannel: 'nightly',
+        appBuildID: '20240902143034',
+        sourceURL: 'https://hg.mozilla.org/mozilla-central/rev/abc',
+        debug: false,
+        extensions: {
+          length: 2,
+          baseURL: [
+            'moz-extension://uuid-ublock/',
+            'moz-extension://uuid-1password/',
+          ],
+          id: ['uBlock0@raymondhill.net', '1password@agilebits.com'],
+          name: ['uBlock Origin', '1Password'],
+        },
+        configuration: {
+          threads: ['GeckoMain', 'Compositor'],
+          features: ['js', 'stackwalk'],
+          capacity: 1_000_000,
+          duration: 20,
+        },
+        extra: [
+          {
+            label: 'Environment',
+            entries: [
+              { label: 'Hostname', format: 'string', value: 'my-host' },
+              { label: 'CPU count', format: 'integer', value: 8 },
+            ],
+          },
+        ],
+      });
+    });
+
+    const result = collectProfileMeta(store);
+
+    expect(result.type).toBe('profile-meta');
+
+    // Recording.
+    expect(result.interval).toBe(1);
+    // startTime is adjusted by profilingStartTime.
+    expect(result.startTime).toBe(1_000_000 + 34_000);
+    expect(result.startTimeFormatted).toBe(
+      new Date(1_000_000 + 34_000).toISOString()
+    );
+    expect(result.endTime).toBe(1_005_000);
+    expect(result.endTimeFormatted).toBe(new Date(1_005_000).toISOString());
+    // durationMs = profilingEndTime - profilingStartTime.
+    expect(result.durationMs).toBe(5200);
+    expect(result.symbolicated).toBe(true);
+    // capacity is in entries of 8 bytes each.
+    expect(result.bufferCapacityBytes).toBe(8_000_000);
+    expect(result.bufferDuration).toBe(20);
+    expect(result.features).toEqual(['js', 'stackwalk']);
+    expect(result.threadsFilter).toEqual(['GeckoMain', 'Compositor']);
+
+    // Application.
+    expect(result.product).toBe('Firefox');
+    expect(result.productAndVersion).toBe(
+      formatProductAndVersion(getProfile(store.getState()).meta)
+    );
+    expect(result.productAndVersion).toBe('Firefox 130');
+    expect(result.uptimeMs).toBe(34_000);
+    expect(result.appBuildID).toBe('20240902143034');
+    expect(result.sourceURL).toBe(
+      'https://hg.mozilla.org/mozilla-central/rev/abc'
+    );
+    expect(result.updateChannel).toBe('nightly');
+    expect(result.debug).toBe(false);
+    // Extensions come out sorted by name as {name, id, baseURL}.
+    expect(result.extensions).toEqual([
+      {
+        name: '1Password',
+        id: '1password@agilebits.com',
+        baseURL: 'moz-extension://uuid-1password/',
+      },
+      {
+        name: 'uBlock Origin',
+        id: 'uBlock0@raymondhill.net',
+        baseURL: 'moz-extension://uuid-ublock/',
+      },
+    ]);
+
+    // Platform.
+    expect(result.platform).toBe(
+      formatPlatform(getProfile(store.getState()).meta)
+    );
+    expect(result.platform).toBe('macOS 14.6');
+    expect(result.oscpu).toBe('Intel Mac OS X 14.6');
+    expect(result.abi).toBe('aarch64-gcc3');
+    expect(result.cpuName).toBe('Apple M1 Max');
+    expect(result.physicalCPUs).toBe(10);
+    expect(result.logicalCPUs).toBe(10);
+    expect(result.mainMemoryBytes).toBe(34_359_738_368);
+
+    // Extra sections carry raw value and formatted string.
+    expect(result.extra).toEqual([
+      {
+        label: 'Environment',
+        entries: [
+          { label: 'Hostname', value: 'my-host', formatted: 'my-host' },
+          { label: 'CPU count', value: 8, formatted: '8' },
+        ],
+      },
+    ]);
+  });
+
+  it('omits absent fields for a sparse (imported) profile', function () {
+    const store = storeFromMeta((profile) => {
+      const { meta } = profile;
+      // Simulate an imported-profile shape.
+      delete meta.extensions;
+      delete meta.configuration;
+      delete meta.oscpu;
+      delete meta.profilingStartTime;
+      delete meta.profilingEndTime;
+      delete meta.extra;
+      delete meta.endTime;
+      delete meta.symbolicated;
+      Object.assign(meta, {
+        interval: 1,
+        startTime: 1_700_000_000_000,
+        product: 'Google Chrome',
+        importedFrom: 'Chrome Trace',
+      });
+    });
+
+    const result = collectProfileMeta(store);
+
+    expect(result.product).toBe('Google Chrome');
+    expect(result.importedFrom).toBe('Chrome Trace');
+    // Raw startTime is used when profilingStartTime is absent.
+    expect(result.startTime).toBe(1_700_000_000_000);
+
+    // Absent fields are omitted entirely (not undefined/NaN).
+    expect('durationMs' in result).toBe(false);
+    expect('endTime' in result).toBe(false);
+    expect('bufferCapacityBytes' in result).toBe(false);
+    expect('features' in result).toBe(false);
+    expect('threadsFilter' in result).toBe(false);
+    expect('extensions' in result).toBe(false);
+    expect('uptimeMs' in result).toBe(false);
+    expect('oscpu' in result).toBe(false);
+    expect('symbolicated' in result).toBe(false);
+    expect('extra' in result).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6177--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

Fixes #6165.
 
Expose the profile's metadata via a new `profiler-cli profile meta` command. It mostly mirrors the web UI's "Profile Info" panel. Groups into Recording, Application, Platform, Import, and free-form Extra sections.

Example output:

```
$ pq profile meta
[Thread: t-0 (GeckoMain) | View: Full profile | Full: 6.639s]

Recording:
  Started: 2026-06-17T16:21:26.825Z
  Duration: 6.639s
  Sampling interval: 1ms
  Buffer capacity: 1GB
  Symbolicated: yes
  Features: js, screenshots, stackwalk, cpu, processcpu, memory, jssources
  Threads filter: GeckoMain, Compositor, Renderer, SwComposite, DOM Worker, onnx_worker, llama.cpp

Application:
  Name: Firefox 154 (build 20260617101013)
  Uptime: 2h13m
  Update channel: nightly
  Build type: opt
  Source URL: https://hg.mozilla.org/mozilla-central/rev/41bab63bf46ac59a75d77e8dd277c8278072417d

Platform:
  OS: macOS 26.4.1 (aarch64-gcc3)
  CPU: Apple M5 Max (18 physical, 18 logical cores)
```