### PR TITLE
Import frame line numbers from Chrome profiles

### DIFF
--- a/src/profile-logic/import/chrome.ts
+++ b/src/profile-logic/import/chrome.ts
@@ -6,6 +6,7 @@ import type {
   Profile,
   RawThread,
   IndexIntoStackTable,
+  IndexIntoFuncTable,
   MixedObject,
 } from 'firefox-profiler/types';
 
@@ -18,6 +19,7 @@ import {
   type RawMarkerTableBuilder,
   type RawSamplesTableBuilder,
   type RawStackTableBuilder,
+  type RawFrameTableBuilder,
 } from '../data-structures';
 import type { StringTable } from '../../utils/string-table';
 import { ensureExists, coerce } from '../../utils/types';
@@ -107,6 +109,10 @@ type ProfileChunkEvent = TracingEvent<{
         }>;
         samples: number[]; // Index into cpuProfile nodes
       };
+      // Per-sample executed source positions, parallel to cpuProfile.samples.
+      // This is what the DevTools trace format uses instead of positionTicks.
+      lines?: number[];
+      columns?: number[];
       timeDeltas: number[];
     };
   };
@@ -317,6 +323,18 @@ type SampleStackChooser = {
   emitted: number;
 };
 
+// Everything needed to lazily materialize an executed-position frame for a node
+// during resampling. Used by the trace ProfileChunk format, which records a
+// per-sample position rather than the per-node positionTicks of the .cpuprofile
+// format.
+type NodeFrameInfo = {
+  prefixStackIndex: IndexIntoStackTable | null;
+  baseStackIndex: IndexIntoStackTable;
+  funcId: IndexIntoFuncTable;
+  category: number;
+  hasSource: boolean;
+};
+
 type ThreadInfo = {
   thread: RawThread;
   samples: RawSamplesTableBuilder;
@@ -324,6 +342,12 @@ type ThreadInfo = {
   nodeIdToStackId: Map<number | void, IndexIntoStackTable | null>;
   // Populated for nodes with valid positionTicks.
   nodeIdToSampleChooser: Map<number, SampleStackChooser>;
+  // Per-node data used to lazily create executed-position frames.
+  nodeIdToFrameInfo: Map<number, NodeFrameInfo>;
+  // Cache of executed-position stacks, keyed by base stack index, line, and
+  // column. Keyed by base stack rather than node id because node ids restart
+  // when a new Profile session begins on the same thread.
+  positionStackCache: Map<string, IndexIntoStackTable>;
   lastSeenTime: number;
   lastSampledTime: number;
   pid: number;
@@ -350,6 +374,52 @@ function pickSampleStack(chooser: SampleStackChooser): IndexIntoStackTable {
   }
   assigned[bestIndex]++;
   return stacks[bestIndex];
+}
+
+// Look up or create a stack for a leaf sample recorded at an exact source
+// position from a trace ProfileChunk.
+// Falls back to the base stack when the node has no source to attribute the
+// position to.
+function getOrCreatePositionStack(
+  threadInfo: ThreadInfo,
+  nodeIndex: number,
+  line: number,
+  column: number | null,
+  frameTable: RawFrameTableBuilder,
+  stackTable: RawStackTableBuilder
+): IndexIntoStackTable {
+  const info = threadInfo.nodeIdToFrameInfo.get(nodeIndex);
+  if (!info || !info.hasSource) {
+    return info
+      ? info.baseStackIndex
+      : ensureExists(
+          threadInfo.nodeIdToStackId.get(nodeIndex),
+          'Could not find the stack information for a sample when decoding a Chrome profile.'
+        );
+  }
+
+  const key = `${info.baseStackIndex}:${line}:${column ?? ''}`;
+  let stackIndex = threadInfo.positionStackCache.get(key);
+  if (stackIndex === undefined) {
+    const frameIndex = frameTable.length++;
+    frameTable.address[frameIndex] = -1;
+    frameTable.category[frameIndex] = info.category;
+    frameTable.subcategory[frameIndex] = 0;
+    frameTable.func[frameIndex] = info.funcId;
+    frameTable.nativeSymbol[frameIndex] = null;
+    frameTable.innerWindowID[frameIndex] = 0;
+    // Positive values in data.lines and data.columns are 1-based, which
+    // matches the Firefox profiler convention.
+    frameTable.line[frameIndex] = line;
+    frameTable.column[frameIndex] = column;
+    frameTable.originalLocation[frameIndex] = null;
+
+    stackTable.frame.push(frameIndex);
+    stackTable.prefix.push(info.prefixStackIndex);
+    stackIndex = stackTable.length++;
+    threadInfo.positionStackCache.set(key, stackIndex);
+  }
+  return stackIndex;
 }
 
 function findEvent<T extends TracingEventUnion>(
@@ -482,6 +552,8 @@ function getThreadInfo(
     markers,
     nodeIdToStackId,
     nodeIdToSampleChooser: new Map(),
+    nodeIdToFrameInfo: new Map(),
+    positionStackCache: new Map(),
     lastSeenTime: chunk.ts / 1000,
     lastSampledTime: 0,
     pid: chunk.pid,
@@ -660,6 +732,21 @@ async function processTracingEvents(
         continue;
       }
 
+      // The trace ProfileChunk format records the exact executed source
+      // position of each sample in arrays parallel to `samples`. This is what
+      // the DevTools trace format uses instead of the per-node positionTicks of
+      // the .cpuprofile format, so when it's present it takes precedence.
+      const lines: number[] | undefined = Array.isArray(
+        profileChunk.args.data.lines
+      )
+        ? profileChunk.args.data.lines
+        : undefined;
+      const columns: number[] | undefined = Array.isArray(
+        profileChunk.args.data.columns
+      )
+        ? profileChunk.args.data.columns
+        : undefined;
+
       if (nodes) {
         const parentMap = new Map<number, number>();
         for (const node of nodes) {
@@ -766,9 +853,11 @@ async function processTracingEvents(
           // V8's positionTicks give the self-time breakdown per executed source
           // line. We only trust them for JS frames that resolve to a source. For
           // native frames the line has nothing to map to. Aggregate ticks per
-          // line (1-based already) so we can create an executed-line frame.
+          // line (1-based already) so we can create an executed-line frame. This
+          // is skipped when the chunk carries per-sample lines, which are more
+          // precise and take precedence.
           let executedLines: Array<[number, number]> | null = null;
-          if (source !== null && node.positionTicks) {
+          if (source !== null && node.positionTicks && lines === undefined) {
             const ticksByLine = new Map<number, number>();
             for (const { line, ticks } of node.positionTicks) {
               if (line > 0 && ticks > 0) {
@@ -788,6 +877,16 @@ async function processTracingEvents(
           // positionTicks describe only this node's self samples.
           const baseStackIndex = pushFrameAndStack(null, null);
           nodeIdToStackId.set(nodeIndex, baseStackIndex);
+
+          // Remember what's needed to build executed-position frames lazily for
+          // this node when the trace carries per-sample positions.
+          threadInfo.nodeIdToFrameInfo.set(nodeIndex, {
+            prefixStackIndex,
+            baseStackIndex,
+            funcId,
+            category,
+            hasSource: source !== null,
+          });
 
           // Add sibling stacks for every executed line and spread only this
           // node's leaf samples across them.
@@ -815,7 +914,6 @@ async function processTracingEvents(
       // is most likely slightly higher. Chrome profiles have been observed sampling
       // between 100us to 300us. Reconstruct the profile at 500us, which is a somewhat
       // reasonable interval.
-
       for (let i = 0; i < samples.length; i++) {
         const nodeIndex = samples[i];
         // Convert to milliseconds:
@@ -825,15 +923,39 @@ async function processTracingEvents(
           profile.meta.interval
         ) {
           threadInfo.lastSampledTime = threadInfo.lastSeenTime;
-          // For nodes whose self time spans several executed lines, route this
-          // sample to one of the per-line stacks; otherwise use the base stack.
+
+          // Route the sample to a leaf frame carrying the executed position:
+          //  1. a per-sample line and optional column, when provided;
+          //  2. otherwise a positionTicks per-line stack (.cpuprofile format);
+          //  3. otherwise the node's base stack.
+          // Chrome uses 0 for unavailable positions. Our frame tables use null.
+          const lineValue = lines?.[i];
+          const line =
+            typeof lineValue === 'number' && lineValue > 0 ? lineValue : null;
+          const columnValue = columns?.[i];
+          const column =
+            typeof columnValue === 'number' && columnValue > 0
+              ? columnValue
+              : null;
           const chooser = threadInfo.nodeIdToSampleChooser.get(nodeIndex);
-          const stackIndex = chooser
-            ? pickSampleStack(chooser)
-            : ensureExists(
-                nodeIdToStackId.get(nodeIndex),
-                'Could not find the stack information for a sample when decoding a Chrome profile.'
-              );
+          let stackIndex: IndexIntoStackTable;
+          if (line !== null) {
+            stackIndex = getOrCreatePositionStack(
+              threadInfo,
+              nodeIndex,
+              line,
+              column,
+              frameTable,
+              stackTable
+            );
+          } else if (chooser) {
+            stackIndex = pickSampleStack(chooser);
+          } else {
+            stackIndex = ensureExists(
+              nodeIdToStackId.get(nodeIndex),
+              'Could not find the stack information for a sample when decoding a Chrome profile.'
+            );
+          }
           ensureExists(
             samplesTable.eventDelay,
             'Could not find the eventDelay in samplesTable inside the newly created Chrome profile thread.'

--- a/src/profile-logic/import/chrome.ts
+++ b/src/profile-logic/import/chrome.ts
@@ -687,14 +687,17 @@ async function processTracingEvents(
             columnNumber === undefined ? null : columnNumber
           );
 
-          // Node indexes start at 1, while frame indexes start at 0.
-          const frameIndex = nodeIndex - 1;
           const prefixStackIndex = nodeIdToStackId.get(parent);
           if (prefixStackIndex === undefined) {
             throw new Error(
               'Unable to find the prefix stack index from a node index.'
             );
           }
+
+          // Allocate a fresh frame index from the shared frame table. Node ids
+          // restart at 1 for each thread, so deriving the frame index from the
+          // node id would make different threads collide in this global table.
+          const frameIndex = frameTable.length++;
           frameTable.address[frameIndex] = -1;
           frameTable.category[frameIndex] = category;
           frameTable.subcategory[frameIndex] = 0;
@@ -706,7 +709,6 @@ async function processTracingEvents(
           frameTable.column[frameIndex] =
             columnNumber === undefined ? null : columnNumber;
           frameTable.originalLocation[frameIndex] = null;
-          frameTable.length = Math.max(frameTable.length, frameIndex + 1);
 
           stackTable.frame.push(frameIndex);
           stackTable.prefix.push(prefixStackIndex);

--- a/src/profile-logic/import/chrome.ts
+++ b/src/profile-logic/import/chrome.ts
@@ -101,6 +101,9 @@ type ProfileChunkEvent = TracingEvent<{
           };
           id: number;
           parent?: number;
+          // Per-source-line breakdown of the node's self time. Line numbers are
+          // 1-based here, unlike the 0-based callFrame.lineNumber.
+          positionTicks?: Array<{ line: number; ticks: number }>;
         }>;
         samples: number[]; // Index into cpuProfile nodes
       };
@@ -141,6 +144,9 @@ type CpuProfileData = {
     };
     id: number;
     children?: number[];
+    // Per-source-line breakdown of the node's self time. Line numbers are
+    // 1-based here, unlike the 0-based callFrame.lineNumber.
+    positionTicks?: Array<{ line: number; ticks: number }>;
   }>;
   samples: number[]; // Index into cpuProfile nodes
   timeDeltas: number[];
@@ -295,11 +301,29 @@ export function attemptToConvertChromeProfile(
   return processTracingEvents(eventsByName, profileUrl);
 }
 
+// When V8's positionTicks provide executed source lines for a node, we create
+// one stack per line and distribute the node's leaf samples across them in
+// proportion to their tick counts.
+type SampleStackChooser = {
+  // The candidate stacks, one per distinct executed line.
+  stacks: IndexIntoStackTable[];
+  // Tick weight for each stack, parallel to `stacks`.
+  weights: number[];
+  // Sum of `weights`.
+  totalWeight: number;
+  // Error-diffusion state: how many samples we've assigned to each stack.
+  assigned: number[];
+  // Total samples emitted for this node so far.
+  emitted: number;
+};
+
 type ThreadInfo = {
   thread: RawThread;
   samples: RawSamplesTableBuilder;
   markers: RawMarkerTableBuilder;
   nodeIdToStackId: Map<number | void, IndexIntoStackTable | null>;
+  // Populated for nodes with valid positionTicks.
+  nodeIdToSampleChooser: Map<number, SampleStackChooser>;
   lastSeenTime: number;
   lastSampledTime: number;
   pid: number;
@@ -307,6 +331,26 @@ type ThreadInfo = {
   threadSortIndex: number;
   tieBreakerIndex: number;
 };
+
+// Pick the stack for the next leaf sample of a node with positionTicks, keeping
+// the per-line distribution proportional to the tick weights. Uses deterministic
+// largest-deficit rounding so results are reproducible.
+function pickSampleStack(chooser: SampleStackChooser): IndexIntoStackTable {
+  const { stacks, weights, totalWeight, assigned } = chooser;
+  chooser.emitted++;
+  let bestIndex = 0;
+  let bestDeficit = -Infinity;
+  for (let i = 0; i < stacks.length; i++) {
+    const target = (weights[i] / totalWeight) * chooser.emitted;
+    const deficit = target - assigned[i];
+    if (deficit > bestDeficit) {
+      bestDeficit = deficit;
+      bestIndex = i;
+    }
+  }
+  assigned[bestIndex]++;
+  return stacks[bestIndex];
+}
 
 function findEvent<T extends TracingEventUnion>(
   eventsByName: Map<string, TracingEventUnion[]>,
@@ -437,6 +481,7 @@ function getThreadInfo(
     samples,
     markers,
     nodeIdToStackId,
+    nodeIdToSampleChooser: new Map(),
     lastSeenTime: chunk.ts / 1000,
     lastSampledTime: 0,
     pid: chunk.pid,
@@ -694,25 +739,73 @@ async function processTracingEvents(
             );
           }
 
-          // Allocate a fresh frame index from the shared frame table. Node ids
-          // restart at 1 for each thread, so deriving the frame index from the
-          // node id would make different threads collide in this global table.
-          const frameIndex = frameTable.length++;
-          frameTable.address[frameIndex] = -1;
-          frameTable.category[frameIndex] = category;
-          frameTable.subcategory[frameIndex] = 0;
-          frameTable.func[frameIndex] = funcId;
-          frameTable.nativeSymbol[frameIndex] = null;
-          frameTable.innerWindowID[frameIndex] = 0;
-          frameTable.line[frameIndex] =
-            lineNumber === undefined ? null : lineNumber;
-          frameTable.column[frameIndex] =
-            columnNumber === undefined ? null : columnNumber;
-          frameTable.originalLocation[frameIndex] = null;
+          // Create a frame with the given line and a stack for it, hanging off
+          // the node's prefix. Node ids restart at 1 for each thread, so a fresh
+          // frame index is allocated from the shared frame table instead of
+          // being derived from the node id (which would collide across threads).
+          const pushFrameAndStack = (
+            line: number | null,
+            column: number | null
+          ): IndexIntoStackTable => {
+            const frameIndex = frameTable.length++;
+            frameTable.address[frameIndex] = -1;
+            frameTable.category[frameIndex] = category;
+            frameTable.subcategory[frameIndex] = 0;
+            frameTable.func[frameIndex] = funcId;
+            frameTable.nativeSymbol[frameIndex] = null;
+            frameTable.innerWindowID[frameIndex] = 0;
+            frameTable.line[frameIndex] = line;
+            frameTable.column[frameIndex] = column;
+            frameTable.originalLocation[frameIndex] = null;
 
-          stackTable.frame.push(frameIndex);
-          stackTable.prefix.push(prefixStackIndex);
-          nodeIdToStackId.set(nodeIndex, stackTable.length++);
+            stackTable.frame.push(frameIndex);
+            stackTable.prefix.push(prefixStackIndex);
+            return stackTable.length++;
+          };
+
+          // V8's positionTicks give the self-time breakdown per executed source
+          // line. We only trust them for JS frames that resolve to a source. For
+          // native frames the line has nothing to map to. Aggregate ticks per
+          // line (1-based already) so we can create an executed-line frame.
+          let executedLines: Array<[number, number]> | null = null;
+          if (source !== null && node.positionTicks) {
+            const ticksByLine = new Map<number, number>();
+            for (const { line, ticks } of node.positionTicks) {
+              if (line > 0 && ticks > 0) {
+                ticksByLine.set(line, (ticksByLine.get(line) ?? 0) + ticks);
+              }
+            }
+            if (ticksByLine.size > 0) {
+              // Sort by descending ticks, then ascending line for a stable order.
+              executedLines = [...ticksByLine.entries()].sort(
+                (a, b) => b[1] - a[1] || a[0] - b[0]
+              );
+            }
+          }
+
+          // Keep a neutral frame as the structural stack that children hang
+          // off of. The definition location lives in the func table, while
+          // positionTicks describe only this node's self samples.
+          const baseStackIndex = pushFrameAndStack(null, null);
+          nodeIdToStackId.set(nodeIndex, baseStackIndex);
+
+          // Add sibling stacks for every executed line and spread only this
+          // node's leaf samples across them.
+          if (executedLines) {
+            const stacks: IndexIntoStackTable[] = [];
+            const weights: number[] = [];
+            for (const [line, ticks] of executedLines) {
+              stacks.push(pushFrameAndStack(line, null));
+              weights.push(ticks);
+            }
+            threadInfo.nodeIdToSampleChooser.set(nodeIndex, {
+              stacks,
+              weights,
+              totalWeight: weights.reduce((sum, w) => sum + w, 0),
+              assigned: new Array(stacks.length).fill(0),
+              emitted: 0,
+            });
+          }
         }
       }
 
@@ -732,10 +825,15 @@ async function processTracingEvents(
           profile.meta.interval
         ) {
           threadInfo.lastSampledTime = threadInfo.lastSeenTime;
-          const stackIndex = ensureExists(
-            nodeIdToStackId.get(nodeIndex),
-            'Could not find the stack information for a sample when decoding a Chrome profile.'
-          );
+          // For nodes whose self time spans several executed lines, route this
+          // sample to one of the per-line stacks; otherwise use the base stack.
+          const chooser = threadInfo.nodeIdToSampleChooser.get(nodeIndex);
+          const stackIndex = chooser
+            ? pickSampleStack(chooser)
+            : ensureExists(
+                nodeIdToStackId.get(nodeIndex),
+                'Could not find the stack information for a sample when decoding a Chrome profile.'
+              );
           ensureExists(
             samplesTable.eventDelay,
             'Could not find the eventDelay in samplesTable inside the newly created Chrome profile thread.'

--- a/src/test/unit/__snapshots__/profile-conversion.test.ts.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.ts.snap
@@ -3092,12 +3092,12 @@ Object {
       "version": 34,
     },
     "sharedCounts": Object {
-      "frames": 47,
+      "frames": 252,
       "funcs": 41,
       "libs": 0,
       "nativeSymbols": 0,
       "resources": 1,
-      "stacks": 47,
+      "stacks": 252,
       "strings": 47,
     },
     "threads": Array [
@@ -3150,10 +3150,10 @@ Object {
     Object {
       "stacks": Array [
         "2 (2x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value -> tick -> forEach -> (anonymous) -> Object.create.setAttribute.value -> value -> value -> NewComponent -> module.exports.Component -> updateProperties -> module.exports.Object.create.emit.value -> dispatchEvent",
-        "2 (2x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value",
         "2 (2x) (root) -> (program)",
         "2 (2x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value -> tick -> Object.create.setAttribute.value -> value -> updateProperties -> (anonymous) -> emitChange -> module.exports.Object.create.emit.value -> dispatchEvent",
         "1 (1x) (root) -> hookedCallback -> onAnimationFrame -> window.requestAnimationFrame.callback -> requestAnimationFrame",
+        "1 (1x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value",
       ],
       "thread": "CrRendererMain",
       "tid": "19485:19517",
@@ -3546,12 +3546,12 @@ Object {
       "version": 34,
     },
     "sharedCounts": Object {
-      "frames": 164,
+      "frames": 270,
       "funcs": 117,
       "libs": 0,
       "nativeSymbols": 0,
       "resources": 45,
-      "stacks": 164,
+      "stacks": 270,
       "strings": 139,
     },
     "threads": Array [
@@ -3576,9 +3576,9 @@ Object {
       "stacks": Array [
         "11 (11x) (root) -> (anonymous) -> prepareMainThreadExecution -> initializeCJSLoader -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader",
         "5 (5x) (root) -> (anonymous) -> prepareMainThreadExecution -> initializeCJSLoader -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader -> (anonymous) -> nativeModuleRequire -> compileForInternalLoader",
-        "5 (5x) (root) -> (anonymous) -> executeUserEntryPoint -> resolveMainPath -> Module._findPath -> toRealPath -> realpathSync",
-        "4 (4x) (root) -> (anonymous) -> prepareMainThreadExecution -> patchProcessObject",
-        "4 (4x) (root) -> (anonymous) -> prepareMainThreadExecution",
+        "3 (3x) (root) -> (program)",
+        "3 (3x) (root) -> (anonymous) -> prepareMainThreadExecution -> initializeReport -> nativeModuleRequire -> compileForInternalLoader",
+        "3 (3x) (root) -> (anonymous) -> executeUserEntryPoint -> Module._load -> Module.load -> Module._extensions..js -> Module._compile -> (anonymous) -> consoleCall -> log -> value -> get -> getStdout -> createWritableStdioStream",
       ],
       "thread": "Chrome Thread",
       "tid": "0:0",
@@ -3611,12 +3611,12 @@ Object {
       "version": 34,
     },
     "sharedCounts": Object {
-      "frames": 231,
+      "frames": 247,
       "funcs": 142,
       "libs": 0,
       "nativeSymbols": 0,
       "resources": 23,
-      "stacks": 231,
+      "stacks": 247,
       "strings": 164,
     },
     "threads": Array [
@@ -3765,12 +3765,12 @@ Object {
       "version": 34,
     },
     "sharedCounts": Object {
-      "frames": 47,
+      "frames": 252,
       "funcs": 41,
       "libs": 0,
       "nativeSymbols": 0,
       "resources": 1,
-      "stacks": 47,
+      "stacks": 252,
       "strings": 37,
     },
     "threads": Array [
@@ -3794,10 +3794,10 @@ Object {
     Object {
       "stacks": Array [
         "2 (2x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value -> tick -> forEach -> (anonymous) -> Object.create.setAttribute.value -> value -> value -> NewComponent -> module.exports.Component -> updateProperties -> module.exports.Object.create.emit.value -> dispatchEvent",
-        "2 (2x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value",
         "2 (2x) (root) -> (program)",
         "2 (2x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value -> tick -> Object.create.setAttribute.value -> value -> updateProperties -> (anonymous) -> emitChange -> module.exports.Object.create.emit.value -> dispatchEvent",
         "1 (1x) (root) -> hookedCallback -> onAnimationFrame -> window.requestAnimationFrame.callback -> requestAnimationFrame",
+        "1 (1x) (root) -> hookedCallback -> onAnimationFrame -> onAnimationFrame -> bound -> value -> value",
       ],
       "thread": "Chrome Thread",
       "tid": "0:0",

--- a/src/test/unit/profile-conversion.test.ts
+++ b/src/test/unit/profile-conversion.test.ts
@@ -420,6 +420,186 @@ describe('converting Google Chrome profile', function () {
     });
   });
 
+  describe('per-sample positions (trace ProfileChunk format)', function () {
+    // A minimal traceEvents profile (Profile + ProfileChunk) where the chunk
+    // carries per-sample `lines` and `columns` arrays. Node 2 "doWork" is a JS
+    // frame whose four samples were taken at two columns on line 11. Node 3
+    // "nativeThing" has no source, so its position is ignored.
+    function makeTraceText(includeColumns = true): string {
+      const events = [
+        {
+          name: 'Profile',
+          ph: 'P',
+          id: '0x1',
+          cat: 'disabled-by-default-v8.cpu_profiler',
+          pid: 1,
+          tid: 1,
+          ts: 0,
+          args: { data: { startTime: 0 } },
+        },
+        {
+          name: 'ProfileChunk',
+          ph: 'P',
+          id: '0x1',
+          cat: 'disabled-by-default-v8.cpu_profiler',
+          pid: 1,
+          tid: 1,
+          ts: 0,
+          args: {
+            data: {
+              cpuProfile: {
+                nodes: [
+                  {
+                    id: 1,
+                    callFrame: {
+                      functionName: '(root)',
+                      scriptId: 0,
+                      url: '',
+                      lineNumber: -1,
+                      columnNumber: -1,
+                    },
+                    children: [2, 3],
+                  },
+                  {
+                    id: 2,
+                    callFrame: {
+                      functionName: 'doWork',
+                      scriptId: 1,
+                      url: 'file:///app.js',
+                      lineNumber: 9,
+                      columnNumber: 2,
+                    },
+                  },
+                  {
+                    id: 3,
+                    callFrame: {
+                      functionName: 'nativeThing',
+                      scriptId: 0,
+                      url: '',
+                      lineNumber: -1,
+                      columnNumber: -1,
+                    },
+                  },
+                ],
+                samples: [2, 2, 2, 2, 3],
+              },
+              lines: [11, 11, 11, 11, 42],
+              columns: includeColumns ? [10, 10, 20, 20, 7] : undefined,
+              timeDeltas: [1000, 1000, 1000, 1000, 1000],
+            },
+          },
+        },
+      ];
+      return JSON.stringify(events);
+    }
+
+    function findFuncByName(profile: Profile, name: string): number {
+      const { funcTable, stringArray } = profile.shared;
+      for (let i = 0; i < funcTable.length; i++) {
+        if (stringArray[funcTable.name[i]] === name) {
+          return i;
+        }
+      }
+      throw new Error(`Could not find a func named "${name}".`);
+    }
+
+    it('creates executed-position frames and routes samples to them', async function () {
+      const profile =
+        await unserializeProfileOfArbitraryFormat(makeTraceText());
+      if (profile === undefined) {
+        throw new Error('Unable to parse the profile.');
+      }
+      assertProfileIntegrity(profile);
+
+      const { frameTable, funcTable, stackTable } = profile.shared;
+      const doWork = findFuncByName(profile, 'doWork');
+
+      // The definition location lives on the func, while the frames contain
+      // the actual sampled positions plus the neutral structural frame.
+      expect(funcTable.columnNumber[doWork]).toBe(3);
+      const doWorkFrames = [];
+      for (let f = 0; f < frameTable.length; f++) {
+        if (frameTable.func[f] === doWork) {
+          doWorkFrames.push(f);
+        }
+      }
+      const locations = doWorkFrames
+        .map((f) => ({
+          line: frameTable.line[f],
+          column: frameTable.column[f],
+        }))
+        .sort((a, b) => (a.column ?? 0) - (b.column ?? 0));
+      expect(locations).toEqual([
+        { line: null, column: null },
+        { line: 11, column: 10 },
+        { line: 11, column: 20 },
+      ]);
+
+      // Samples split 2/2 across the two columns.
+      const thread = profile.threads[0];
+      const hitsByColumn = new Map();
+      for (let i = 0; i < thread.samples.length; i++) {
+        const s = thread.samples.stack[i];
+        if (s === null) {
+          continue;
+        }
+        const frame = stackTable.frame[s];
+        if (frameTable.func[frame] === doWork) {
+          const column = frameTable.column[frame];
+          hitsByColumn.set(column, (hitsByColumn.get(column) ?? 0) + 1);
+        }
+      }
+      expect(hitsByColumn.get(10)).toBe(2);
+      expect(hitsByColumn.get(20)).toBe(2);
+    });
+
+    it('keeps columns null when a trace only provides lines', async function () {
+      const profile = await unserializeProfileOfArbitraryFormat(
+        makeTraceText(false)
+      );
+      if (profile === undefined) {
+        throw new Error('Unable to parse the profile.');
+      }
+      assertProfileIntegrity(profile);
+
+      const { frameTable } = profile.shared;
+      const doWork = findFuncByName(profile, 'doWork');
+      const locations = [];
+      for (let f = 0; f < frameTable.length; f++) {
+        if (frameTable.func[f] === doWork) {
+          locations.push({
+            line: frameTable.line[f],
+            column: frameTable.column[f],
+          });
+        }
+      }
+      expect(locations).toEqual([
+        { line: null, column: null },
+        { line: 11, column: null },
+      ]);
+    });
+
+    it('ignores per-sample positions on native frames without a source', async function () {
+      const profile =
+        await unserializeProfileOfArbitraryFormat(makeTraceText());
+      if (profile === undefined) {
+        throw new Error('Unable to parse the profile.');
+      }
+
+      const { frameTable } = profile.shared;
+      const nativeThing = findFuncByName(profile, 'nativeThing');
+      const frames = [];
+      for (let f = 0; f < frameTable.length; f++) {
+        if (frameTable.func[f] === nativeThing) {
+          frames.push(f);
+        }
+      }
+      // The sampled line 42 is dropped; only the base frame exists.
+      expect(frames).toHaveLength(1);
+      expect(frameTable.line[frames[0]]).toBe(null);
+    });
+  });
+
   it('successfully imports a profile with DevTools timestamp in filename', async function () {
     const fs = require('fs');
     const profileFilename =

--- a/src/test/unit/profile-conversion.test.ts
+++ b/src/test/unit/profile-conversion.test.ts
@@ -209,6 +209,217 @@ describe('converting Google Chrome profile', function () {
     expect(profileImportSnapshot(profile)).toMatchSnapshot();
   });
 
+  describe('positionTicks (executed line numbers)', function () {
+    // A minimal node-style single-CpuProfile with:
+    //  - node 2 "doWork": a JS frame whose self time spans two executed lines
+    //    (12 with 3 ticks, 15 with 1 tick).
+    //  - node 3 "leaf": a JS frame with a single executed line (22).
+    //  - node 4 "nativeThing": a native frame (no url) that still carries
+    //    positionTicks, which must be ignored.
+    // Line/column in callFrame are 0-based; positionTicks lines are 1-based.
+    function makeProfileText(): string {
+      const cpuProfile = {
+        startTime: 0,
+        endTime: 10000,
+        nodes: [
+          {
+            id: 1,
+            callFrame: {
+              functionName: '(root)',
+              scriptId: 0,
+              url: '',
+              lineNumber: -1,
+              columnNumber: -1,
+            },
+            hitCount: 0,
+            children: [2, 4],
+          },
+          {
+            id: 2,
+            callFrame: {
+              functionName: 'doWork',
+              scriptId: 1,
+              url: 'file:///app.js',
+              lineNumber: 9,
+              columnNumber: 2,
+            },
+            hitCount: 4,
+            children: [3],
+            positionTicks: [
+              { line: 12, ticks: 3 },
+              { line: 15, ticks: 1 },
+            ],
+          },
+          {
+            id: 3,
+            callFrame: {
+              functionName: 'leaf',
+              scriptId: 1,
+              url: 'file:///app.js',
+              lineNumber: 19,
+              columnNumber: 4,
+            },
+            hitCount: 2,
+            positionTicks: [{ line: 22, ticks: 2 }],
+          },
+          {
+            id: 4,
+            callFrame: {
+              functionName: 'nativeThing',
+              scriptId: 0,
+              url: '',
+              lineNumber: -1,
+              columnNumber: -1,
+            },
+            hitCount: 1,
+            positionTicks: [{ line: 99, ticks: 1 }],
+          },
+        ],
+        // One µs delta per sample: with a 500µs target interval every sample is
+        // emitted, so counts below are deterministic.
+        samples: [2, 2, 2, 2, 3, 3, 4],
+        timeDeltas: [1000, 1000, 1000, 1000, 1000, 1000, 1000],
+      };
+      return JSON.stringify(cpuProfile);
+    }
+
+    function findFuncByName(profile: Profile, name: string): number {
+      const { funcTable, stringArray } = profile.shared;
+      for (let i = 0; i < funcTable.length; i++) {
+        if (stringArray[funcTable.name[i]] === name) {
+          return i;
+        }
+      }
+      throw new Error(`Could not find a func named "${name}".`);
+    }
+
+    function framesForFunc(profile: Profile, funcIndex: number): number[] {
+      const { frameTable } = profile.shared;
+      const frames = [];
+      for (let i = 0; i < frameTable.length; i++) {
+        if (frameTable.func[i] === funcIndex) {
+          frames.push(i);
+        }
+      }
+      return frames;
+    }
+
+    it('splits a multi-line node into per-line frames and distributes its samples', async function () {
+      const profile =
+        await unserializeProfileOfArbitraryFormat(makeProfileText());
+      if (profile === undefined) {
+        throw new Error('Unable to parse the profile.');
+      }
+      assertProfileIntegrity(profile);
+
+      const { frameTable, funcTable, stackTable } = profile.shared;
+      const doWork = findFuncByName(profile, 'doWork');
+
+      // The func keeps its 1-based definition line, and there's exactly one
+      // func even though it now has multiple frames.
+      expect(funcTable.lineNumber[doWork]).toBe(10);
+
+      // The neutral structural frame is separate from the executed-line frames.
+      const frames = framesForFunc(profile, doWork);
+      const locations = frames
+        .map((frame) => ({
+          line: frameTable.line[frame],
+          column: frameTable.column[frame],
+        }))
+        .sort((a, b) => (a.line ?? 0) - (b.line ?? 0));
+      expect(locations).toEqual([
+        { line: null, column: null },
+        { line: 12, column: null },
+        { line: 15, column: null },
+      ]);
+
+      // Leaf samples are distributed proportionally to the tick counts (3:1).
+      const thread = profile.threads[0];
+      const hitsByLine = new Map();
+      for (let i = 0; i < thread.samples.length; i++) {
+        const stackIndex = thread.samples.stack[i];
+        if (stackIndex === null) {
+          continue;
+        }
+        const frame = stackTable.frame[stackIndex];
+        if (frameTable.func[frame] === doWork) {
+          const line = frameTable.line[frame];
+          hitsByLine.set(line, (hitsByLine.get(line) ?? 0) + 1);
+        }
+      }
+      expect(hitsByLine.get(12)).toBe(3);
+      expect(hitsByLine.get(15)).toBe(1);
+      expect(hitsByLine.has(null)).toBe(false);
+    });
+
+    it('uses the single executed line for a node with one positionTick line', async function () {
+      const profile =
+        await unserializeProfileOfArbitraryFormat(makeProfileText());
+      if (profile === undefined) {
+        throw new Error('Unable to parse the profile.');
+      }
+
+      const { frameTable, funcTable, stackTable } = profile.shared;
+      const doWork = findFuncByName(profile, 'doWork');
+      const leaf = findFuncByName(profile, 'leaf');
+
+      // A single executed line still has a neutral structural frame.
+      const frames = framesForFunc(profile, leaf);
+      const locations = frames
+        .map((frame) => ({
+          line: frameTable.line[frame],
+          column: frameTable.column[frame],
+        }))
+        .sort((a, b) => (a.line ?? 0) - (b.line ?? 0));
+      expect(locations).toEqual([
+        { line: null, column: null },
+        { line: 22, column: null },
+      ]);
+      expect(funcTable.lineNumber[leaf]).toBe(20);
+
+      const thread = profile.threads[0];
+      const leafSampleStacks = thread.samples.stack.filter((stackIndex) => {
+        if (stackIndex === null) {
+          return false;
+        }
+        return frameTable.func[stackTable.frame[stackIndex]] === leaf;
+      });
+      expect(leafSampleStacks).toHaveLength(2);
+      for (const stackIndex of leafSampleStacks) {
+        if (stackIndex === null) {
+          throw new Error('Expected a stack for the leaf sample.');
+        }
+        const leafFrame = stackTable.frame[stackIndex];
+        expect(frameTable.line[leafFrame]).toBe(22);
+
+        const prefixOffset = stackTable.prefixOffset[stackIndex];
+        if (prefixOffset === 0) {
+          throw new Error('Expected the leaf stack to have a prefix.');
+        }
+        const prefixStack = stackIndex - prefixOffset;
+        const prefixFrame = stackTable.frame[prefixStack];
+        expect(frameTable.func[prefixFrame]).toBe(doWork);
+        expect(frameTable.line[prefixFrame]).toBe(null);
+        expect(funcTable.lineNumber[doWork]).toBe(10);
+      }
+    });
+
+    it('ignores positionTicks on native frames that have no source', async function () {
+      const profile =
+        await unserializeProfileOfArbitraryFormat(makeProfileText());
+      if (profile === undefined) {
+        throw new Error('Unable to parse the profile.');
+      }
+
+      const { frameTable } = profile.shared;
+      const nativeThing = findFuncByName(profile, 'nativeThing');
+      const frames = framesForFunc(profile, nativeThing);
+      expect(frames).toHaveLength(1);
+      // positionTicks line 99 must be ignored; there's no source to map it to.
+      expect(frameTable.line[frames[0]]).toBe(null);
+    });
+  });
+
   it('successfully imports a profile with DevTools timestamp in filename', async function () {
     const fs = require('fs');
     const profileFilename =


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/public/0k792qyryr6nc23qdnc5sksnzkaxs4fb4crz9y0/flame-graph/?globalTrackOrder=0&range=8639m24210&sourceViewIndex=4&thread=0&transforms=df-375&v=17) | [Deploy preview](https://deploy-preview-6192--perf-html.netlify.app/public/0k792qyryr6nc23qdnc5sksnzkaxs4fb4crz9y0/flame-graph/?globalTrackOrder=0&range=8639m24210&sourceViewIndex=4&thread=0&transforms=df-375&v=17)
<!-- profiler-preview-links:end -->

Fixes #6182


It isn't super easy to see what this does without having the source code in the source view. But you can check the frame table to see that we have line and column numbers now.

For example, you can use this chrome trace: [Trace-20260715T220108.json.gz](https://github.com/user-attachments/files/30081191/Trace-20260715T220108.json.gz)

Check the frameTable in the before and after profiles with:

```js
// line numbers
profile.shared.frameTable.line.filter(l => !!l)

// and column
profile.shared.frameTable.column.filter(c => !!c)
```
It'll look like now we have less information in the frame table, but no. Previously, we were always adding the line and column of the function definition, which wasn't correct. Now these numbers are in the funcTable. And we only have line and column number if the frame truly has line/column. Otherwise we omit that information.