### PR TITLE
WIP upload as JSLB

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -745,6 +745,8 @@ MenuButtons--publish--cancel-upload = Cancel Upload
 MenuButtons--publish--message-something-went-wrong = Uh oh, something went wrong when uploading the profile.
 MenuButtons--publish--message-try-again = Try again
 MenuButtons--publish--download = Download
+MenuButtons--publish--download-json = Download as JSON
+MenuButtons--publish--download-json-error = Error preparing JSON download
 MenuButtons--publish--compressing = Compressing…
 MenuButtons--publish--error-while-compressing = Error while compressing, try unchecking some checkboxes to reduce the profile size.
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -775,6 +775,8 @@ MenuButtons--publish--cancel-upload = Cancel Upload
 MenuButtons--publish--message-something-went-wrong = Uh oh, something went wrong when uploading the profile.
 MenuButtons--publish--message-try-again = Try again
 MenuButtons--publish--download = Download
+MenuButtons--publish--download-json = Download as JSON
+MenuButtons--publish--download-json-error = Error preparing JSON download
 MenuButtons--publish--compressing = Compressing…
 MenuButtons--publish--error-while-compressing = Error while compressing, try unchecking some checkboxes to reduce the profile size.
 

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -60,7 +60,10 @@ import type {
   ProfileIndexTranslationMaps,
 } from 'firefox-profiler/types';
 import { compress } from 'firefox-profiler/utils/gz';
-import { serializeProfileToJsonString } from 'firefox-profiler/profile-logic/process-profile';
+import {
+  optimizeProfileForStorage,
+  serializeProfileToJsonSlabsFile,
+} from 'firefox-profiler/profile-logic/process-profile';
 
 export function updateSharingOption(
   slug: keyof CheckedSharingOptions,
@@ -322,9 +325,10 @@ export function encodeSanitizedProfile(
     const encodingPromise: Promise<ProfileEncodingResult> = (async function () {
       try {
         dispatch(sanitizedProfileEncodingStarted(sanitizedProfile));
-        const gzipData = await compress(
-          serializeProfileToJsonString(sanitizedProfile)
+        const jslbData = serializeProfileToJsonSlabsFile(
+          optimizeProfileForStorage(sanitizedProfile)
         );
+        const gzipData = await compress(jslbData);
         const blob = new Blob([gzipData], { type: 'application/octet-binary' });
         dispatch(sanitizedProfileEncodingCompleted(sanitizedProfile, blob));
         return { type: 'SUCCESS', profileData: blob };

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -58,11 +58,13 @@ import type {
   Pid,
   TrackIndex,
   ProfileIndexTranslationMaps,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 import { compress } from 'firefox-profiler/utils/gz';
 import {
   optimizeProfileForStorage,
   serializeProfileToJsonSlabsFile,
+  serializeProfileToJsonString,
 } from 'firefox-profiler/profile-logic/process-profile';
 
 export function updateSharingOption(
@@ -77,31 +79,37 @@ export function updateSharingOption(
 }
 
 export function sanitizedProfileEncodingStarted(
+  format: PublishProfileFormat,
   sanitizedProfile: Profile
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_STARTED',
+    format,
     sanitizedProfile,
   };
 }
 
 export function sanitizedProfileEncodingCompleted(
+  format: PublishProfileFormat,
   sanitizedProfile: Profile,
   profileData: Blob
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_COMPLETED',
+    format,
     sanitizedProfile,
     profileData,
   };
 }
 
 export function sanitizedProfileEncodingFailed(
+  format: PublishProfileFormat,
   sanitizedProfile: Profile,
   error: Error
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_FAILED',
+    format,
     sanitizedProfile,
     error,
   };
@@ -271,9 +279,26 @@ function unwrapEncodedProfile(encodingResult: ProfileEncodingResult): Blob {
 }
 
 export type InflightProfileEncoding = {
+  format: PublishProfileFormat;
   sanitizedProfile: Profile;
   encodingPromise: Promise<ProfileEncodingResult>;
 };
+
+function serializeSanitizedProfile(
+  format: PublishProfileFormat,
+  sanitizedProfile: Profile
+): string | Uint8Array<ArrayBuffer> {
+  switch (format) {
+    case 'jslb':
+      return serializeProfileToJsonSlabsFile(
+        optimizeProfileForStorage(sanitizedProfile)
+      );
+    case 'json':
+      return serializeProfileToJsonString(sanitizedProfile);
+    default:
+      throw new Error(`Unknown publish format: ${format as string}`);
+  }
+}
 
 /**
  * Kick off "encoding" of the sanitized profile. Specifically this means:
@@ -292,26 +317,31 @@ export type InflightProfileEncoding = {
  * This thunk action is synchronous.
  */
 export function encodeSanitizedProfile(
+  format: PublishProfileFormat,
   previousInflightEncoding?: InflightProfileEncoding
 ): ThunkAction<InflightProfileEncoding> {
   return (dispatch, getState): InflightProfileEncoding => {
     const state = getState();
     const sanitizedProfile = getSanitizedProfile(state).profile;
 
-    if (previousInflightEncoding?.sanitizedProfile === sanitizedProfile) {
+    if (
+      previousInflightEncoding?.format === format &&
+      previousInflightEncoding.sanitizedProfile === sanitizedProfile
+    ) {
       // No need to kick of another compression. The current encoding may still
       // be in-flight, and returning the original promise allows the caller to
       // await it.
       return previousInflightEncoding;
     }
 
-    const encodingState = getSanitizedProfileEncodingState(state);
+    const encodingState = getSanitizedProfileEncodingState(state, format);
     if (
       encodingState.phase === 'DONE' &&
       encodingState.sanitizedProfile === sanitizedProfile
     ) {
       // We already have an encoded version of this profile in our state! Use it.
       return {
+        format,
         sanitizedProfile,
         encodingPromise: Promise.resolve({
           type: 'SUCCESS',
@@ -324,22 +354,24 @@ export function encodeSanitizedProfile(
     // just return it as part of the InflightProfileEncoding.
     const encodingPromise: Promise<ProfileEncodingResult> = (async function () {
       try {
-        dispatch(sanitizedProfileEncodingStarted(sanitizedProfile));
-        const jslbData = serializeProfileToJsonSlabsFile(
-          optimizeProfileForStorage(sanitizedProfile)
-        );
-        const gzipData = await compress(jslbData);
+        dispatch(sanitizedProfileEncodingStarted(format, sanitizedProfile));
+        const serialized = serializeSanitizedProfile(format, sanitizedProfile);
+        const gzipData = await compress(serialized);
         const blob = new Blob([gzipData], { type: 'application/octet-binary' });
-        dispatch(sanitizedProfileEncodingCompleted(sanitizedProfile, blob));
+        dispatch(
+          sanitizedProfileEncodingCompleted(format, sanitizedProfile, blob)
+        );
         return { type: 'SUCCESS', profileData: blob };
       } catch (error) {
-        dispatch(sanitizedProfileEncodingFailed(sanitizedProfile, error));
+        dispatch(
+          sanitizedProfileEncodingFailed(format, sanitizedProfile, error)
+        );
         console.error('Error while compressing the profile data', error);
         return { type: 'ERROR', error };
       }
     })();
 
-    return { sanitizedProfile, encodingPromise };
+    return { format, sanitizedProfile, encodingPromise };
   };
 }
 
@@ -392,7 +424,7 @@ export function attemptToPublish(
 
       const sanitizedInformation = getSanitizedProfile(prePublishedState);
       const profileEncoding = dispatch(
-        encodeSanitizedProfile(previousInflightEncoding)
+        encodeSanitizedProfile('jslb', previousInflightEncoding)
       );
       const encodingResult = await profileEncoding.encodingPromise;
 

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -62,7 +62,10 @@ import type {
   SharingMode,
 } from 'firefox-profiler/types';
 import { compress } from 'firefox-profiler/utils/gz';
-import { serializeProfileToJsonString } from 'firefox-profiler/profile-logic/process-profile';
+import {
+  optimizeProfileForStorage,
+  serializeProfileToJsonSlabsFile,
+} from 'firefox-profiler/profile-logic/process-profile';
 
 export function updateSharingOption(
   mode: SharingMode,
@@ -322,9 +325,10 @@ export function encodeSanitizedProfile(
       // synchronous failure here could dispatch FAILED, which the reducer drops.
       await Promise.resolve();
       try {
-        const gzipData = await compress(
-          serializeProfileToJsonString(sanitizedProfile)
+        const jslbData = serializeProfileToJsonSlabsFile(
+          optimizeProfileForStorage(sanitizedProfile)
         );
+        const gzipData = await compress(jslbData);
         const blob = new Blob([gzipData], { type: 'application/octet-binary' });
         dispatch(
           sanitizedProfileEncodingCompleted(mode, sanitizedProfile, blob)

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -274,11 +274,6 @@ function unwrapEncodedProfile(encodingResult: ProfileEncodingResult): Blob {
   return encodingResult.profileData;
 }
 
-export type InflightProfileEncoding = {
-  sanitizedProfile: Profile;
-  encodingPromise: Promise<ProfileEncodingResult>;
-};
-
 /**
  * Kick off "encoding" of the sanitized profile. Specifically this means:
  * - Compute the sanitized profile
@@ -287,7 +282,7 @@ export type InflightProfileEncoding = {
  *
  * The asynchronous compression can take a few seconds, so we kick it off
  * immediately when the download or share panel is opened. The in-flight
- * compression is tracked in the redux state, so opening the other panel or
+ * compression is tracked in the redux state, so reopening the panel or
  * pressing Upload reuses it (for the same sanitized profile) instead of
  * compressing again. The returned promise lets the caller wait on the
  * compressed result.
@@ -296,8 +291,8 @@ export type InflightProfileEncoding = {
  */
 export function encodeSanitizedProfile(
   mode: SharingMode
-): ThunkAction<InflightProfileEncoding> {
-  return (dispatch, getState): InflightProfileEncoding => {
+): ThunkAction<Promise<ProfileEncodingResult>> {
+  return (dispatch, getState): Promise<ProfileEncodingResult> => {
     const state = getState();
     const sanitizedProfile = getSanitizedProfile(state, mode).profile;
 
@@ -307,27 +302,21 @@ export function encodeSanitizedProfile(
       encodingState.sanitizedProfile === sanitizedProfile
     ) {
       // A compression for this profile is already in-flight; reuse it.
-      return {
-        sanitizedProfile,
-        encodingPromise: encodingState.encodingPromise,
-      };
+      return encodingState.encodingPromise;
     }
     if (
       encodingState.phase === 'DONE' &&
       encodingState.sanitizedProfile === sanitizedProfile
     ) {
       // We already have an encoded version of this profile in our state! Use it.
-      return {
-        sanitizedProfile,
-        encodingPromise: Promise.resolve({
-          type: 'SUCCESS',
-          profileData: encodingState.profileData,
-        }),
-      };
+      return Promise.resolve({
+        type: 'SUCCESS',
+        profileData: encodingState.profileData,
+      });
     }
 
     // Kick off a new encoding for this profile. Don't await the promise,
-    // just return it as part of the InflightProfileEncoding.
+    // just hand it back to the caller.
     const encodingPromise: Promise<ProfileEncodingResult> = (async function () {
       // Yield so the ENCODING phase (dispatched below) is in the store before a
       // synchronous failure here could dispatch FAILED, which the reducer drops.
@@ -351,7 +340,7 @@ export function encodeSanitizedProfile(
     dispatch(
       sanitizedProfileEncodingStarted(mode, sanitizedProfile, encodingPromise)
     );
-    return { sanitizedProfile, encodingPromise };
+    return encodingPromise;
   };
 }
 
@@ -402,8 +391,7 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
         prePublishedState,
         'upload'
       );
-      const profileEncoding = dispatch(encodeSanitizedProfile('upload'));
-      const encodingResult = await profileEncoding.encodingPromise;
+      const encodingResult = await dispatch(encodeSanitizedProfile('upload'));
 
       // The previous line was async, check to make sure that this request is still valid.
       // The upload could have been aborted while we were compressing the data.

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -78,33 +78,39 @@ export function updateSharingOption(
 }
 
 export function sanitizedProfileEncodingStarted(
+  mode: SharingMode,
   sanitizedProfile: Profile,
   encodingPromise: Promise<ProfileEncodingResult>
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_STARTED',
+    mode,
     sanitizedProfile,
     encodingPromise,
   };
 }
 
 export function sanitizedProfileEncodingCompleted(
+  mode: SharingMode,
   sanitizedProfile: Profile,
   profileData: Blob
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_COMPLETED',
+    mode,
     sanitizedProfile,
     profileData,
   };
 }
 
 export function sanitizedProfileEncodingFailed(
+  mode: SharingMode,
   sanitizedProfile: Profile,
   error: Error
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_FAILED',
+    mode,
     sanitizedProfile,
     error,
   };
@@ -295,7 +301,7 @@ export function encodeSanitizedProfile(
     const state = getState();
     const sanitizedProfile = getSanitizedProfile(state, mode).profile;
 
-    const encodingState = getSanitizedProfileEncodingState(state);
+    const encodingState = getSanitizedProfileEncodingState(state, mode);
     if (
       encodingState.phase === 'ENCODING' &&
       encodingState.sanitizedProfile === sanitizedProfile
@@ -331,17 +337,19 @@ export function encodeSanitizedProfile(
           serializeProfileToJsonString(sanitizedProfile)
         );
         const blob = new Blob([gzipData], { type: 'application/octet-binary' });
-        dispatch(sanitizedProfileEncodingCompleted(sanitizedProfile, blob));
+        dispatch(
+          sanitizedProfileEncodingCompleted(mode, sanitizedProfile, blob)
+        );
         return { type: 'SUCCESS', profileData: blob };
       } catch (error) {
-        dispatch(sanitizedProfileEncodingFailed(sanitizedProfile, error));
+        dispatch(sanitizedProfileEncodingFailed(mode, sanitizedProfile, error));
         console.error('Error while compressing the profile data', error);
         return { type: 'ERROR', error };
       }
     })();
 
     dispatch(
-      sanitizedProfileEncodingStarted(sanitizedProfile, encodingPromise)
+      sanitizedProfileEncodingStarted(mode, sanitizedProfile, encodingPromise)
     );
     return { sanitizedProfile, encodingPromise };
   };

--- a/src/actions/publish.ts
+++ b/src/actions/publish.ts
@@ -60,11 +60,13 @@ import type {
   ProfileIndexTranslationMaps,
   ProfileEncodingResult,
   SharingMode,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 import { compress } from 'firefox-profiler/utils/gz';
 import {
   optimizeProfileForStorage,
   serializeProfileToJsonSlabsFile,
+  serializeProfileToJsonString,
 } from 'firefox-profiler/profile-logic/process-profile';
 
 export function updateSharingOption(
@@ -82,12 +84,14 @@ export function updateSharingOption(
 
 export function sanitizedProfileEncodingStarted(
   mode: SharingMode,
+  format: PublishProfileFormat,
   sanitizedProfile: Profile,
   encodingPromise: Promise<ProfileEncodingResult>
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_STARTED',
     mode,
+    format,
     sanitizedProfile,
     encodingPromise,
   };
@@ -95,12 +99,14 @@ export function sanitizedProfileEncodingStarted(
 
 export function sanitizedProfileEncodingCompleted(
   mode: SharingMode,
+  format: PublishProfileFormat,
   sanitizedProfile: Profile,
   profileData: Blob
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_COMPLETED',
     mode,
+    format,
     sanitizedProfile,
     profileData,
   };
@@ -108,12 +114,14 @@ export function sanitizedProfileEncodingCompleted(
 
 export function sanitizedProfileEncodingFailed(
   mode: SharingMode,
+  format: PublishProfileFormat,
   sanitizedProfile: Profile,
   error: Error
 ): Action {
   return {
     type: 'SANITIZED_PROFILE_ENCODING_FAILED',
     mode,
+    format,
     sanitizedProfile,
     error,
   };
@@ -277,6 +285,22 @@ function unwrapEncodedProfile(encodingResult: ProfileEncodingResult): Blob {
   return encodingResult.profileData;
 }
 
+function serializeSanitizedProfile(
+  format: PublishProfileFormat,
+  sanitizedProfile: Profile
+): string | Uint8Array<ArrayBuffer> {
+  switch (format) {
+    case 'jslb':
+      return serializeProfileToJsonSlabsFile(
+        optimizeProfileForStorage(sanitizedProfile)
+      );
+    case 'json':
+      return serializeProfileToJsonString(sanitizedProfile);
+    default:
+      throw new Error(`Unknown publish format: ${format as string}`);
+  }
+}
+
 /**
  * Kick off "encoding" of the sanitized profile. Specifically this means:
  * - Compute the sanitized profile
@@ -293,13 +317,14 @@ function unwrapEncodedProfile(encodingResult: ProfileEncodingResult): Blob {
  * This thunk action is synchronous.
  */
 export function encodeSanitizedProfile(
-  mode: SharingMode
+  mode: SharingMode,
+  format: PublishProfileFormat
 ): ThunkAction<Promise<ProfileEncodingResult>> {
   return (dispatch, getState): Promise<ProfileEncodingResult> => {
     const state = getState();
     const sanitizedProfile = getSanitizedProfile(state, mode).profile;
 
-    const encodingState = getSanitizedProfileEncodingState(state, mode);
+    const encodingState = getSanitizedProfileEncodingState(state, mode, format);
     if (
       encodingState.phase === 'ENCODING' &&
       encodingState.sanitizedProfile === sanitizedProfile
@@ -325,24 +350,34 @@ export function encodeSanitizedProfile(
       // synchronous failure here could dispatch FAILED, which the reducer drops.
       await Promise.resolve();
       try {
-        const jslbData = serializeProfileToJsonSlabsFile(
-          optimizeProfileForStorage(sanitizedProfile)
-        );
-        const gzipData = await compress(jslbData);
+        const serialized = serializeSanitizedProfile(format, sanitizedProfile);
+        const gzipData = await compress(serialized);
         const blob = new Blob([gzipData], { type: 'application/octet-binary' });
         dispatch(
-          sanitizedProfileEncodingCompleted(mode, sanitizedProfile, blob)
+          sanitizedProfileEncodingCompleted(
+            mode,
+            format,
+            sanitizedProfile,
+            blob
+          )
         );
         return { type: 'SUCCESS', profileData: blob };
       } catch (error) {
-        dispatch(sanitizedProfileEncodingFailed(mode, sanitizedProfile, error));
+        dispatch(
+          sanitizedProfileEncodingFailed(mode, format, sanitizedProfile, error)
+        );
         console.error('Error while compressing the profile data', error);
         return { type: 'ERROR', error };
       }
     })();
 
     dispatch(
-      sanitizedProfileEncodingStarted(mode, sanitizedProfile, encodingPromise)
+      sanitizedProfileEncodingStarted(
+        mode,
+        format,
+        sanitizedProfile,
+        encodingPromise
+      )
     );
     return encodingPromise;
   };
@@ -395,7 +430,9 @@ export function attemptToPublish(): ThunkAction<Promise<boolean>> {
         prePublishedState,
         'upload'
       );
-      const encodingResult = await dispatch(encodeSanitizedProfile('upload'));
+      const encodingResult = await dispatch(
+        encodeSanitizedProfile('upload', 'jslb')
+      );
 
       // The previous line was async, check to make sure that this request is still valid.
       // The upload could have been aborted while we were compressing the data.

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -154,6 +154,63 @@
   background: var(--internal-download-icon) center center no-repeat;
 }
 
+/* Split-button styling: primary "Download" button on the left, dropdown
+ * toggle on the right, visually joined. */
+.publishPanelSplitButton {
+  display: inline-flex;
+  margin: 0 8px;
+}
+
+.publishPanelSplitButtonMain {
+  margin: 0;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.publishPanelSplitButtonToggle {
+  /* Override the flex-column from .buttonWithPanel — we want the button
+   * baseline to line up with the primary button, not stack. */
+  flex-flow: row nowrap;
+}
+
+.publishPanelSplitButtonToggleButton {
+  width: 24px;
+  min-width: 0;
+  height: 32px;
+  padding: 0;
+  border-left: 1px solid var(--grey-30-a60, rgb(12 12 13 / 0.2));
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  cursor: default;
+}
+
+.publishPanelSplitButtonToggleButton::after {
+  content: '▾';
+  font-size: 10px;
+  line-height: 1;
+}
+
+.publishPanelSplitButtonPanel {
+  --width: 220px;
+}
+
+.publishPanelSplitButtonMenuItem {
+  display: inline-block;
+  color: var(--clickable-foreground-color);
+  cursor: default;
+  text-decoration: none;
+}
+
+.publishPanelSplitButtonMenuItem:not(
+    .publishPanelSplitButtonMenuItemDisabled
+  ):hover {
+  text-decoration: underline;
+}
+
+.publishPanelSplitButtonMenuItemDisabled {
+  opacity: 0.6;
+}
+
 .menuButtonsDownloadSize {
   display: inline-block;
   margin: 0 4px;

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -195,6 +195,13 @@
   transform: translate(-50%, -25%);
 }
 
+/* Pin the download-format menu to a fixed width. The JS side subtracts this
+ * width from the toggle button's right edge to right-anchor the menu; the
+ * two must stay in sync. */
+.publishPanelDownloadFormatContextMenu {
+  width: 220px;
+}
+
 .menuButtonsDownloadSize {
   display: inline-block;
   margin: 0 4px;

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -167,13 +167,8 @@
   border-top-right-radius: 0;
 }
 
-.publishPanelSplitButtonToggle {
-  /* Override the flex-column from .buttonWithPanel — we want the button
-   * baseline to line up with the primary button, not stack. */
-  flex-flow: row nowrap;
-}
-
 .publishPanelSplitButtonToggleButton {
+  position: relative;
   width: 24px;
   min-width: 0;
   height: 32px;
@@ -184,31 +179,20 @@
   cursor: default;
 }
 
+/* Down-caret drawn with borders, matching the marker-chart filter/copy
+ * buttons' style. */
 .publishPanelSplitButtonToggleButton::after {
-  content: '▾';
-  font-size: 10px;
-  line-height: 1;
-}
-
-.publishPanelSplitButtonPanel {
-  --width: 220px;
-}
-
-.publishPanelSplitButtonMenuItem {
-  display: inline-block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-top: 5px solid;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
   color: var(--clickable-foreground-color);
-  cursor: default;
-  text-decoration: none;
-}
-
-.publishPanelSplitButtonMenuItem:not(
-    .publishPanelSplitButtonMenuItemDisabled
-  ):hover {
-  text-decoration: underline;
-}
-
-.publishPanelSplitButtonMenuItemDisabled {
-  opacity: 0.6;
+  content: '';
+  transform: translate(-50%, -25%);
 }
 
 .menuButtonsDownloadSize {

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -170,6 +170,63 @@
   background-image: url(../../../../res/img/svg/download-light.svg);
 }
 
+/* Split-button styling: primary "Download" button on the left, dropdown
+ * toggle on the right, visually joined. */
+.publishPanelSplitButton {
+  display: inline-flex;
+  margin: 0 8px;
+}
+
+.publishPanelSplitButtonMain {
+  margin: 0;
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.publishPanelSplitButtonToggle {
+  /* Override the flex-column from .buttonWithPanel — we want the button
+   * baseline to line up with the primary button, not stack. */
+  flex-flow: row nowrap;
+}
+
+.publishPanelSplitButtonToggleButton {
+  width: 24px;
+  min-width: 0;
+  height: 32px;
+  padding: 0;
+  border-left: 1px solid var(--grey-30-a60, rgb(12 12 13 / 0.2));
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  cursor: default;
+}
+
+.publishPanelSplitButtonToggleButton::after {
+  content: '▾';
+  font-size: 10px;
+  line-height: 1;
+}
+
+.publishPanelSplitButtonPanel {
+  --width: 220px;
+}
+
+.publishPanelSplitButtonMenuItem {
+  display: inline-block;
+  color: var(--clickable-foreground-color);
+  cursor: default;
+  text-decoration: none;
+}
+
+.publishPanelSplitButtonMenuItem:not(
+  .publishPanelSplitButtonMenuItemDisabled
+):hover {
+  text-decoration: underline;
+}
+
+.publishPanelSplitButtonMenuItemDisabled {
+  opacity: 0.6;
+}
+
 .menuButtonsDownloadSize {
   display: inline-block;
   margin: 0 4px;

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -183,13 +183,8 @@
   border-top-right-radius: 0;
 }
 
-.publishPanelSplitButtonToggle {
-  /* Override the flex-column from .buttonWithPanel — we want the button
-   * baseline to line up with the primary button, not stack. */
-  flex-flow: row nowrap;
-}
-
 .publishPanelSplitButtonToggleButton {
+  position: relative;
   width: 24px;
   min-width: 0;
   height: 32px;
@@ -200,31 +195,20 @@
   cursor: default;
 }
 
+/* Down-caret drawn with borders, matching the marker-chart filter/copy
+ * buttons' style. */
 .publishPanelSplitButtonToggleButton::after {
-  content: '▾';
-  font-size: 10px;
-  line-height: 1;
-}
-
-.publishPanelSplitButtonPanel {
-  --width: 220px;
-}
-
-.publishPanelSplitButtonMenuItem {
-  display: inline-block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-top: 5px solid;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
   color: var(--clickable-foreground-color);
-  cursor: default;
-  text-decoration: none;
-}
-
-.publishPanelSplitButtonMenuItem:not(
-  .publishPanelSplitButtonMenuItemDisabled
-):hover {
-  text-decoration: underline;
-}
-
-.publishPanelSplitButtonMenuItemDisabled {
-  opacity: 0.6;
+  content: '';
+  transform: translate(-50%, -25%);
 }
 
 .menuButtonsDownloadSize {

--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -211,6 +211,13 @@
   transform: translate(-50%, -25%);
 }
 
+/* Pin the download-format menu to a fixed width. The JS side subtracts this
+ * width from the toggle button's right edge to right-anchor the menu; the
+ * two must stay in sync. */
+.publishPanelDownloadFormatContextMenu {
+  width: 220px;
+}
+
 .menuButtonsDownloadSize {
   display: inline-block;
   margin: 0 4px;

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -29,7 +29,8 @@ import {
   getSanitizedProfileEncodingStates,
 } from 'firefox-profiler/selectors/publish';
 import { BlobUrlLink } from 'firefox-profiler/components/shared/BlobUrlLink';
-import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
+import { ContextMenu } from 'firefox-profiler/components/shared/ContextMenu';
+import { MenuItem, showMenu } from '@firefox-devtools/react-contextmenu';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import prettyBytes from 'firefox-profiler/utils/pretty-bytes';
 
@@ -408,6 +409,8 @@ export const PublishPanel = explicitConnect<
   component: PublishPanelImpl,
 });
 
+const DOWNLOAD_FORMAT_MENU_ID = 'PublishDownloadFormatContextMenu';
+
 type DownloadSplitButtonProps = {
   readonly jslbEncodingState: SanitizedProfileEncodingState;
   readonly jsonEncodingState: SanitizedProfileEncodingState;
@@ -416,19 +419,71 @@ type DownloadSplitButtonProps = {
   readonly onJsonDropdownOpen: () => void;
 };
 
+type DownloadSplitButtonState = {
+  readonly isMenuVisible: boolean;
+  // react-contextmenu hides the menu on mousedown even if it's already
+  // visible. We track visibility at mousedown time so that clicking the
+  // toggle button while the menu is open results in a net "close" rather
+  // than a hide-then-reshow.
+  readonly wasMenuVisibleOnMouseDown: boolean;
+};
+
 /**
  * Split button: the main body downloads the profile as JSLB, and the arrow
  * on the right opens a dropdown menu with alternate download formats.
+ * The dropdown uses the same react-contextmenu-based menu style as the
+ * marker chart's filter/copy buttons.
  */
-class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> {
+class DownloadSplitButton extends React.PureComponent<
+  DownloadSplitButtonProps,
+  DownloadSplitButtonState
+> {
+  override state: DownloadSplitButtonState = {
+    isMenuVisible: false,
+    wasMenuVisibleOnMouseDown: false,
+  };
+
+  _onToggleClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (this.state.wasMenuVisibleOnMouseDown) {
+      // The menu was already open on mousedown, so react-contextmenu has
+      // already hidden it. Don't reopen it.
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    // The menu is right-aligned to the toggle button since it sits near the
+    // right edge of the publish panel.
+    showMenu({
+      data: null,
+      id: DOWNLOAD_FORMAT_MENU_ID,
+      position: { x: rect.right, y: rect.bottom },
+      target: event.target,
+    });
+  };
+
+  _onToggleMouseDown = () => {
+    this.setState((state) => ({
+      wasMenuVisibleOnMouseDown: state.isMenuVisible,
+    }));
+  };
+
+  _onMenuShow = () => {
+    this.setState({ isMenuVisible: true });
+    this.props.onJsonDropdownOpen();
+  };
+
+  _onMenuHide = () => {
+    this.setState({ isMenuVisible: false });
+  };
+
   override render() {
     const {
       jslbEncodingState,
       jsonEncodingState,
       jslbDownloadFileName,
       jsonDownloadFileName,
-      onJsonDropdownOpen,
     } = this.props;
+    const { isMenuVisible } = this.state;
 
     return (
       <div className="publishPanelSplitButton">
@@ -436,19 +491,27 @@ class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> 
           encodingState={jslbEncodingState}
           downloadFileName={jslbDownloadFileName}
         />
-        <ButtonWithPanel
-          className="publishPanelSplitButtonToggle"
-          buttonClassName="photon-button publishPanelSplitButtonToggleButton"
-          panelClassName="publishPanelSplitButtonPanel"
-          label=""
-          title="Show other download formats"
-          onPanelOpen={onJsonDropdownOpen}
-          panelContent={
-            <DownloadFormatMenu
-              jsonEncodingState={jsonEncodingState}
-              jsonDownloadFileName={jsonDownloadFileName}
-            />
-          }
+        <button
+          type="button"
+          className={classNames(
+            'photon-button',
+            'publishPanelSplitButtonToggleButton',
+            {
+              'publishPanelSplitButtonToggleButton--open': isMenuVisible,
+            }
+          )}
+          title="Other download formats"
+          aria-haspopup="menu"
+          aria-expanded={isMenuVisible}
+          onClick={this._onToggleClick}
+          onMouseDown={this._onToggleMouseDown}
+        />
+        <DownloadFormatContextMenu
+          menuId={DOWNLOAD_FORMAT_MENU_ID}
+          onShow={this._onMenuShow}
+          onHide={this._onMenuHide}
+          jsonEncodingState={jsonEncodingState}
+          jsonDownloadFileName={jsonDownloadFileName}
         />
       </div>
     );
@@ -512,68 +575,98 @@ class DownloadPrimary extends React.PureComponent<DownloadPrimaryProps> {
   }
 }
 
-type DownloadFormatMenuProps = {
+type DownloadFormatContextMenuProps = {
+  readonly menuId: string;
+  readonly onShow: () => void;
+  readonly onHide: () => void;
   readonly jsonEncodingState: SanitizedProfileEncodingState;
   readonly jsonDownloadFileName: string;
 };
 
 /**
- * Content of the dropdown panel: alternative download formats.
+ * Trigger a file download for a Blob without needing a persistent
+ * BlobUrlLink anchor. Used from a react-contextmenu MenuItem's onClick,
+ * where we can't wrap the item in an <a download>.
  */
-class DownloadFormatMenu extends React.PureComponent<DownloadFormatMenuProps> {
-  override render() {
-    const { jsonEncodingState, jsonDownloadFileName } = this.props;
-    const itemClassName = 'publishPanelSplitButtonMenuItem';
+function _triggerBlobDownload(blob: Blob, downloadFileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = downloadFileName;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  // Revoke asynchronously so Safari has a chance to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
 
+/**
+ * The dropdown menu for alternative download formats, rendered as a
+ * react-contextmenu (the same menu style used next to the marker chart
+ * search field).
+ */
+class DownloadFormatContextMenu extends React.PureComponent<DownloadFormatContextMenuProps> {
+  _onDownloadJson = () => {
+    const { jsonEncodingState, jsonDownloadFileName } = this.props;
+    if (jsonEncodingState.phase !== 'DONE') {
+      return;
+    }
+    _triggerBlobDownload(
+      jsonEncodingState.profileData,
+      `${jsonDownloadFileName}.gz`
+    );
+  };
+
+  _renderJsonMenuItemLabel() {
+    const { jsonEncodingState } = this.props;
     switch (jsonEncodingState.phase) {
-      case 'DONE': {
-        const { profileData } = jsonEncodingState;
+      case 'DONE':
         return (
-          <BlobUrlLink
-            blob={profileData}
-            download={`${jsonDownloadFileName}.gz`}
-            className={itemClassName}
-          >
+          <>
             <Localized id="MenuButtons--publish--download-json">
               Download as JSON
-            </Localized>{' '}
-            <span className="menuButtonsDownloadSize">
-              ({prettyBytes(profileData.size)})
-            </span>
-          </BlobUrlLink>
-        );
-      }
-      case 'ERROR': {
-        return (
-          <span
-            className={classNames(
-              itemClassName,
-              'publishPanelSplitButtonMenuItemDisabled'
-            )}
-          >
-            <Localized id="MenuButtons--publish--download-json-error">
-              Error preparing JSON download
             </Localized>
-          </span>
+            {` (${prettyBytes(jsonEncodingState.profileData.size)})`}
+          </>
         );
-      }
+      case 'ERROR':
+        return (
+          <Localized id="MenuButtons--publish--download-json-error">
+            Error preparing JSON download
+          </Localized>
+        );
       case 'INITIAL':
-      case 'ENCODING': {
+      case 'ENCODING':
         return (
-          <span
-            className={classNames(
-              itemClassName,
-              'publishPanelSplitButtonMenuItemDisabled'
-            )}
-          >
-            <Localized id="MenuButtons--publish--compressing">
-              Compressing…
-            </Localized>
-          </span>
+          <Localized id="MenuButtons--publish--compressing">
+            Compressing…
+          </Localized>
         );
-      }
       default:
         throw assertExhaustiveCheck(jsonEncodingState);
     }
+  }
+
+  override render() {
+    const { menuId, onShow, onHide, jsonEncodingState } = this.props;
+    const jsonReady = jsonEncodingState.phase === 'DONE';
+
+    return (
+      <ContextMenu
+        id={menuId}
+        className="publishPanelDownloadFormatContextMenu"
+        onShow={onShow}
+        onHide={onHide}
+      >
+        <MenuItem
+          onClick={this._onDownloadJson}
+          disabled={!jsonReady}
+          preventClose={!jsonReady}
+        >
+          {this._renderJsonMenuItemLabel()}
+        </MenuItem>
+      </ContextMenu>
+    );
   }
 }

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -476,7 +476,10 @@ class DownloadSplitButton extends React.PureComponent<
 
   _onMenuShow = () => {
     this.setState({ isMenuVisible: true });
-    this.props.onJsonDropdownOpen();
+    // Defer the JSON encoding so the menu can paint first. The serializer
+    // is synchronous and can take a while on large profiles; running it on
+    // the current task would delay the menu's first paint.
+    setTimeout(this.props.onJsonDropdownOpen, 0);
   };
 
   _onMenuHide = () => {

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -410,6 +410,10 @@ export const PublishPanel = explicitConnect<
 });
 
 const DOWNLOAD_FORMAT_MENU_ID = 'PublishDownloadFormatContextMenu';
+// react-contextmenu positions the menu with its top-left at `position`. To
+// right-anchor to the toggle button we subtract an estimated menu width; the
+// actual width is pinned to this value via CSS.
+const DOWNLOAD_FORMAT_MENU_WIDTH_PX = 220;
 
 type DownloadSplitButtonProps = {
   readonly jslbEncodingState: SanitizedProfileEncodingState;
@@ -451,12 +455,15 @@ class DownloadSplitButton extends React.PureComponent<
     }
 
     const rect = event.currentTarget.getBoundingClientRect();
-    // The menu is right-aligned to the toggle button since it sits near the
-    // right edge of the publish panel.
+    // Right-anchor the menu: its top-right sits at the toggle button's
+    // bottom-right, so it grows leftwards into the panel.
     showMenu({
       data: null,
       id: DOWNLOAD_FORMAT_MENU_ID,
-      position: { x: rect.right, y: rect.bottom },
+      position: {
+        x: rect.right - DOWNLOAD_FORMAT_MENU_WIDTH_PX,
+        y: rect.bottom,
+      },
       target: event.target,
     });
   };

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -20,15 +20,16 @@ import {
 import {
   getAbortFunction,
   getCheckedSharingOptions,
-  getFilenameString,
+  getDownloadFilename,
   getUploadPhase,
   getUploadProgress,
   getUploadProgressString,
   getUploadError,
   getShouldSanitizeByDefault,
-  getSanitizedProfileEncodingState,
+  getSanitizedProfileEncodingStates,
 } from 'firefox-profiler/selectors/publish';
 import { BlobUrlLink } from 'firefox-profiler/components/shared/BlobUrlLink';
+import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import prettyBytes from 'firefox-profiler/utils/pretty-bytes';
 
@@ -44,6 +45,7 @@ import type {
   StartEndRange,
   UploadPhase,
   SanitizedProfileEncodingState,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 
 import './Publish.css';
@@ -59,8 +61,12 @@ type StateProps = {
   readonly shouldShowPreferenceOption: boolean;
   readonly profileContainsPrivateBrowsingInformation: boolean;
   readonly checkedSharingOptions: CheckedSharingOptions;
-  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
-  readonly downloadFileName: string;
+  readonly sanitizedProfileEncodingStates: Record<
+    PublishProfileFormat,
+    SanitizedProfileEncodingState
+  >;
+  readonly jslbDownloadFileName: string;
+  readonly jsonDownloadFileName: string;
   readonly uploadPhase: UploadPhase;
   readonly uploadProgress: number;
   readonly uploadProgressString: string;
@@ -79,19 +85,40 @@ type DispatchProps = {
 type PublishProps = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
-  _inflightEncoding: InflightProfileEncoding | undefined;
+  _inflightEncodings: Record<
+    PublishProfileFormat,
+    InflightProfileEncoding | undefined
+  > = { jslb: undefined, json: undefined };
 
   override componentDidMount(): void {
-    this._inflightEncoding = this.props.encodeSanitizedProfile();
+    this._inflightEncodings.jslb = this.props.encodeSanitizedProfile('jslb');
   }
+
+  _refreshEncoding = (format: PublishProfileFormat) => {
+    this._inflightEncodings[format] = this.props.encodeSanitizedProfile(
+      format,
+      this._inflightEncodings[format]
+    );
+  };
 
   _onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const sharingOption = e.target.name as keyof CheckedSharingOptions;
     this.props.updateSharingOption(sharingOption, e.target.checked);
 
-    this._inflightEncoding = this.props.encodeSanitizedProfile(
-      this._inflightEncoding
-    );
+    this._refreshEncoding('jslb');
+    // Only keep the JSON encoding fresh if it has already been requested at
+    // least once (i.e. the user has opened the download dropdown).
+    if (this.props.sanitizedProfileEncodingStates.json.phase !== 'INITIAL') {
+      this._refreshEncoding('json');
+    }
+  };
+
+  _onJsonDropdownOpen = () => {
+    this._refreshEncoding('json');
+  };
+
+  _onSubmit = () => {
+    this.props.attemptToPublish(this._inflightEncodings.jslb);
   };
 
   _renderCheckbox(
@@ -115,16 +142,28 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
     );
   }
 
-  _onSubmit = () => {
-    this.props.attemptToPublish(this._inflightEncoding);
-  };
+  _renderDownloadButton() {
+    const {
+      sanitizedProfileEncodingStates,
+      jslbDownloadFileName,
+      jsonDownloadFileName,
+    } = this.props;
+    return (
+      <DownloadSplitButton
+        jslbEncodingState={sanitizedProfileEncodingStates.jslb}
+        jsonEncodingState={sanitizedProfileEncodingStates.json}
+        jslbDownloadFileName={jslbDownloadFileName}
+        jsonDownloadFileName={jsonDownloadFileName}
+        onJsonDropdownOpen={this._onJsonDropdownOpen}
+      />
+    );
+  }
 
   _renderPublishPanel() {
     const {
       shouldShowPreferenceOption,
       profileContainsPrivateBrowsingInformation,
-      sanitizedProfileEncodingState,
-      downloadFileName,
+      sanitizedProfileEncodingStates,
       shouldSanitizeByDefault,
       isRepublish,
     } = this.props;
@@ -211,7 +250,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
                 )
               : null}
           </div>
-          {sanitizedProfileEncodingState.phase === 'ERROR' ? (
+          {sanitizedProfileEncodingStates.jslb.phase === 'ERROR' ? (
             <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">
               <div className="photon-message-bar-inner-text">
                 <Localized id="MenuButtons--publish--error-while-compressing">
@@ -222,14 +261,11 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
             </div>
           ) : null}
           <div className="publishPanelButtons">
-            <DownloadButton
-              downloadFileName={downloadFileName}
-              sanitizedProfileEncodingState={sanitizedProfileEncodingState}
-            />
+            {this._renderDownloadButton()}
             <button
               type="submit"
               className="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
-              disabled={sanitizedProfileEncodingState.phase === 'ERROR'}
+              disabled={sanitizedProfileEncodingStates.jslb.phase === 'ERROR'}
             >
               <span className="publishPanelButtonsSvg publishPanelButtonsSvgUpload" />
               <Localized id="MenuButtons--publish--button-upload">
@@ -243,13 +279,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
   }
 
   _renderUploadPanel() {
-    const {
-      uploadProgress,
-      uploadProgressString,
-      abortFunction,
-      downloadFileName,
-      sanitizedProfileEncodingState,
-    } = this.props;
+    const { uploadProgress, uploadProgressString, abortFunction } = this.props;
 
     return (
       <div
@@ -273,10 +303,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
           </div>
         </div>
         <div className="publishPanelButtons">
-          <DownloadButton
-            downloadFileName={downloadFileName}
-            sanitizedProfileEncodingState={sanitizedProfileEncodingState}
-          />
+          {this._renderDownloadButton()}
           <button
             type="button"
             className="photon-button photon-button-default publishPanelButton publishPanelButtonsCancelUpload"
@@ -362,8 +389,9 @@ export const PublishPanel = explicitConnect<
     profileContainsPrivateBrowsingInformation:
       getContainsPrivateBrowsingInformation(state),
     checkedSharingOptions: getCheckedSharingOptions(state),
-    downloadFileName: getFilenameString(state),
-    sanitizedProfileEncodingState: getSanitizedProfileEncodingState(state),
+    jslbDownloadFileName: getDownloadFilename(state, 'jslb'),
+    jsonDownloadFileName: getDownloadFilename(state, 'json'),
+    sanitizedProfileEncodingStates: getSanitizedProfileEncodingStates(state),
     uploadPhase: getUploadPhase(state),
     uploadProgress: getUploadProgress(state),
     uploadProgressString: getUploadProgressString(state),
@@ -380,23 +408,70 @@ export const PublishPanel = explicitConnect<
   component: PublishPanelImpl,
 });
 
-type DownloadButtonProps = {
-  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
+type DownloadSplitButtonProps = {
+  readonly jslbEncodingState: SanitizedProfileEncodingState;
+  readonly jsonEncodingState: SanitizedProfileEncodingState;
+  readonly jslbDownloadFileName: string;
+  readonly jsonDownloadFileName: string;
+  readonly onJsonDropdownOpen: () => void;
+};
+
+/**
+ * Split button: the main body downloads the profile as JSLB, and the arrow
+ * on the right opens a dropdown menu with alternate download formats.
+ */
+class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> {
+  override render() {
+    const {
+      jslbEncodingState,
+      jsonEncodingState,
+      jslbDownloadFileName,
+      jsonDownloadFileName,
+      onJsonDropdownOpen,
+    } = this.props;
+
+    return (
+      <div className="publishPanelSplitButton">
+        <DownloadPrimary
+          encodingState={jslbEncodingState}
+          downloadFileName={jslbDownloadFileName}
+        />
+        <ButtonWithPanel
+          className="publishPanelSplitButtonToggle"
+          buttonClassName="photon-button publishPanelSplitButtonToggleButton"
+          panelClassName="publishPanelSplitButtonPanel"
+          label=""
+          title="Show other download formats"
+          onPanelOpen={onJsonDropdownOpen}
+          panelContent={
+            <DownloadFormatMenu
+              jsonEncodingState={jsonEncodingState}
+              jsonDownloadFileName={jsonDownloadFileName}
+            />
+          }
+        />
+      </div>
+    );
+  }
+}
+
+type DownloadPrimaryProps = {
+  readonly encodingState: SanitizedProfileEncodingState;
   readonly downloadFileName: string;
 };
 
 /**
- * The DownloadButton handles unpacking the compressed profile promise.
+ * The primary (left) part of the split button. Downloads the profile as JSLB.
  */
-class DownloadButton extends React.PureComponent<DownloadButtonProps, {}> {
+class DownloadPrimary extends React.PureComponent<DownloadPrimaryProps> {
   override render() {
-    const { sanitizedProfileEncodingState, downloadFileName } = this.props;
+    const { encodingState, downloadFileName } = this.props;
     const className =
-      'photon-button publishPanelButton publishPanelButtonsDownload';
+      'photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload';
 
-    switch (sanitizedProfileEncodingState.phase) {
+    switch (encodingState.phase) {
       case 'DONE': {
-        const { profileData } = sanitizedProfileEncodingState;
+        const { profileData } = encodingState;
         return (
           <BlobUrlLink
             blob={profileData}
@@ -432,7 +507,73 @@ class DownloadButton extends React.PureComponent<DownloadButtonProps, {}> {
         );
       }
       default:
-        throw assertExhaustiveCheck(sanitizedProfileEncodingState);
+        throw assertExhaustiveCheck(encodingState);
+    }
+  }
+}
+
+type DownloadFormatMenuProps = {
+  readonly jsonEncodingState: SanitizedProfileEncodingState;
+  readonly jsonDownloadFileName: string;
+};
+
+/**
+ * Content of the dropdown panel: alternative download formats.
+ */
+class DownloadFormatMenu extends React.PureComponent<DownloadFormatMenuProps> {
+  override render() {
+    const { jsonEncodingState, jsonDownloadFileName } = this.props;
+    const itemClassName = 'publishPanelSplitButtonMenuItem';
+
+    switch (jsonEncodingState.phase) {
+      case 'DONE': {
+        const { profileData } = jsonEncodingState;
+        return (
+          <BlobUrlLink
+            blob={profileData}
+            download={`${jsonDownloadFileName}.gz`}
+            className={itemClassName}
+          >
+            <Localized id="MenuButtons--publish--download-json">
+              Download as JSON
+            </Localized>{' '}
+            <span className="menuButtonsDownloadSize">
+              ({prettyBytes(profileData.size)})
+            </span>
+          </BlobUrlLink>
+        );
+      }
+      case 'ERROR': {
+        return (
+          <span
+            className={classNames(
+              itemClassName,
+              'publishPanelSplitButtonMenuItemDisabled'
+            )}
+          >
+            <Localized id="MenuButtons--publish--download-json-error">
+              Error preparing JSON download
+            </Localized>
+          </span>
+        );
+      }
+      case 'INITIAL':
+      case 'ENCODING': {
+        return (
+          <span
+            className={classNames(
+              itemClassName,
+              'publishPanelSplitButtonMenuItemDisabled'
+            )}
+          >
+            <Localized id="MenuButtons--publish--compressing">
+              Compressing…
+            </Localized>
+          </span>
+        );
+      }
+      default:
+        throw assertExhaustiveCheck(jsonEncodingState);
     }
   }
 }

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -425,7 +425,10 @@ export const PublishPanel = explicitConnect<
     profileHasJSTracingArgumentValues: getHasJSTracingArgumentValues(state),
     checkedSharingOptions: getCheckedSharingOptions(state, ownProps.mode),
     downloadFileName: getFilenameString(state),
-    sanitizedProfileEncodingState: getSanitizedProfileEncodingState(state),
+    sanitizedProfileEncodingState: getSanitizedProfileEncodingState(
+      state,
+      ownProps.mode
+    ),
     uploadPhase: getUploadPhase(state),
     uploadProgress: getUploadProgress(state),
     uploadProgressString: getUploadProgressString(state),

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -484,6 +484,10 @@ export const PublishPanel = explicitConnect<
 });
 
 const DOWNLOAD_FORMAT_MENU_ID = 'PublishDownloadFormatContextMenu';
+// react-contextmenu positions the menu with its top-left at `position`. To
+// right-anchor to the toggle button we subtract an estimated menu width; the
+// actual width is pinned to this value via CSS.
+const DOWNLOAD_FORMAT_MENU_WIDTH_PX = 220;
 
 type DownloadSplitButtonProps = {
   readonly primary: boolean;
@@ -526,12 +530,15 @@ class DownloadSplitButton extends React.PureComponent<
     }
 
     const rect = event.currentTarget.getBoundingClientRect();
-    // The menu is right-aligned to the toggle button since it sits near the
-    // right edge of the publish panel.
+    // Right-anchor the menu: its top-right sits at the toggle button's
+    // bottom-right, so it grows leftwards into the panel.
     showMenu({
       data: null,
       id: DOWNLOAD_FORMAT_MENU_ID,
-      position: { x: rect.right, y: rect.bottom },
+      position: {
+        x: rect.right - DOWNLOAD_FORMAT_MENU_WIDTH_PX,
+        y: rect.bottom,
+      },
       target: event.target,
     });
   };

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -551,7 +551,10 @@ class DownloadSplitButton extends React.PureComponent<
 
   _onMenuShow = () => {
     this.setState({ isMenuVisible: true });
-    this.props.onJsonDropdownOpen();
+    // Defer the JSON encoding so the menu can paint first. The serializer
+    // is synchronous and can take a while on large profiles; running it on
+    // the current task would delay the menu's first paint.
+    setTimeout(this.props.onJsonDropdownOpen, 0);
   };
 
   _onMenuHide = () => {

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -20,15 +20,16 @@ import {
 import {
   getAbortFunction,
   getCheckedSharingOptions,
-  getFilenameString,
+  getDownloadFilename,
   getUploadPhase,
   getUploadProgress,
   getUploadProgressString,
   getUploadError,
   getShouldSanitizeByDefault,
-  getSanitizedProfileEncodingState,
+  getSanitizedProfileEncodingStates,
 } from 'firefox-profiler/selectors/publish';
 import { BlobUrlLink } from 'firefox-profiler/components/shared/BlobUrlLink';
+import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import prettyBytes from 'firefox-profiler/utils/pretty-bytes';
 
@@ -45,6 +46,7 @@ import type {
   StartEndRange,
   UploadPhase,
   SanitizedProfileEncodingState,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 
 import './Publish.css';
@@ -62,8 +64,12 @@ type StateProps = {
   readonly profileContainsPrivateBrowsingInformation: boolean;
   readonly profileHasJSTracingArgumentValues: boolean;
   readonly checkedSharingOptions: CheckedSharingOptions;
-  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
-  readonly downloadFileName: string;
+  readonly sanitizedProfileEncodingStates: Record<
+    PublishProfileFormat,
+    SanitizedProfileEncodingState
+  >;
+  readonly jslbDownloadFileName: string;
+  readonly jsonDownloadFileName: string;
   readonly uploadPhase: UploadPhase;
   readonly uploadProgress: number;
   readonly uploadProgressString: string;
@@ -83,8 +89,12 @@ type PublishProps = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
   override componentDidMount(): void {
-    this.props.encodeSanitizedProfile(this.props.mode);
+    this._refreshEncoding('jslb');
   }
+
+  _refreshEncoding = (format: PublishProfileFormat) => {
+    this.props.encodeSanitizedProfile(this.props.mode, format);
+  };
 
   _onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const sharingOption = e.target.name as keyof CheckedSharingOptions;
@@ -94,7 +104,16 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
       e.target.checked
     );
 
-    this.props.encodeSanitizedProfile(this.props.mode);
+    this._refreshEncoding('jslb');
+    // Only keep the JSON encoding fresh if it has already been requested at
+    // least once (i.e. the user has opened the download dropdown).
+    if (this.props.sanitizedProfileEncodingStates.json.phase !== 'INITIAL') {
+      this._refreshEncoding('json');
+    }
+  };
+
+  _onJsonDropdownOpen = () => {
+    this._refreshEncoding('json');
   };
 
   _renderCheckbox(
@@ -140,13 +159,30 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
     this.props.attemptToPublish();
   };
 
+  _renderDownloadButton(primary: boolean) {
+    const {
+      sanitizedProfileEncodingStates,
+      jslbDownloadFileName,
+      jsonDownloadFileName,
+    } = this.props;
+    return (
+      <DownloadSplitButton
+        primary={primary}
+        jslbEncodingState={sanitizedProfileEncodingStates.jslb}
+        jsonEncodingState={sanitizedProfileEncodingStates.json}
+        jslbDownloadFileName={jslbDownloadFileName}
+        jsonDownloadFileName={jsonDownloadFileName}
+        onJsonDropdownOpen={this._onJsonDropdownOpen}
+      />
+    );
+  }
+
   _renderPublishPanel() {
     const {
       shouldShowPreferenceOption,
       profileContainsPrivateBrowsingInformation,
       profileHasJSTracingArgumentValues,
-      sanitizedProfileEncodingState,
-      downloadFileName,
+      sanitizedProfileEncodingStates,
       shouldSanitizeByDefault,
       isRepublish,
       mode,
@@ -269,7 +305,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
                 )
               : null}
           </div>
-          {sanitizedProfileEncodingState.phase === 'ERROR' ? (
+          {sanitizedProfileEncodingStates.jslb.phase === 'ERROR' ? (
             <div className="photon-message-bar photon-message-bar-error photon-message-bar-inner-content">
               <div className="photon-message-bar-inner-text">
                 <Localized id="MenuButtons--publish--error-while-compressing">
@@ -281,26 +317,22 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
           ) : null}
           <div className="publishPanelButtons">
             {isDownload ? (
-              <DownloadButton
-                primary
-                downloadFileName={downloadFileName}
-                sanitizedProfileEncodingState={sanitizedProfileEncodingState}
-              />
+              this._renderDownloadButton(true)
             ) : (
               <button
                 type="submit"
                 className="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
-                disabled={sanitizedProfileEncodingState.phase === 'ERROR'}
+                disabled={sanitizedProfileEncodingStates.jslb.phase === 'ERROR'}
               >
                 <span className="publishPanelButtonsSvg publishPanelButtonsSvgUpload" />
                 <Localized id="MenuButtons--publish--button-upload">
                   Upload
                 </Localized>{' '}
-                {sanitizedProfileEncodingState.phase === 'DONE' ? (
+                {sanitizedProfileEncodingStates.jslb.phase === 'DONE' ? (
                   <span className="menuButtonsDownloadSize">
                     (
                     {prettyBytes(
-                      sanitizedProfileEncodingState.profileData.size
+                      sanitizedProfileEncodingStates.jslb.profileData.size
                     )}
                     )
                   </span>
@@ -314,13 +346,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
   }
 
   _renderUploadPanel() {
-    const {
-      uploadProgress,
-      uploadProgressString,
-      abortFunction,
-      downloadFileName,
-      sanitizedProfileEncodingState,
-    } = this.props;
+    const { uploadProgress, uploadProgressString, abortFunction } = this.props;
 
     return (
       <div
@@ -344,10 +370,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
           </div>
         </div>
         <div className="publishPanelButtons">
-          <DownloadButton
-            downloadFileName={downloadFileName}
-            sanitizedProfileEncodingState={sanitizedProfileEncodingState}
-          />
+          {this._renderDownloadButton(false)}
           <button
             type="button"
             className="photon-button photon-button-default publishPanelButton publishPanelButtonsCancelUpload"
@@ -437,8 +460,9 @@ export const PublishPanel = explicitConnect<
       getContainsPrivateBrowsingInformation(state),
     profileHasJSTracingArgumentValues: getHasJSTracingArgumentValues(state),
     checkedSharingOptions: getCheckedSharingOptions(state, ownProps.mode),
-    downloadFileName: getFilenameString(state),
-    sanitizedProfileEncodingState: getSanitizedProfileEncodingState(
+    jslbDownloadFileName: getDownloadFilename(state, 'jslb'),
+    jsonDownloadFileName: getDownloadFilename(state, 'json'),
+    sanitizedProfileEncodingStates: getSanitizedProfileEncodingStates(
       state,
       ownProps.mode
     ),
@@ -458,27 +482,76 @@ export const PublishPanel = explicitConnect<
   component: PublishPanelImpl,
 });
 
-type DownloadButtonProps = {
-  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
+type DownloadSplitButtonProps = {
+  readonly primary: boolean;
+  readonly jslbEncodingState: SanitizedProfileEncodingState;
+  readonly jsonEncodingState: SanitizedProfileEncodingState;
+  readonly jslbDownloadFileName: string;
+  readonly jsonDownloadFileName: string;
+  readonly onJsonDropdownOpen: () => void;
+};
+
+/**
+ * Split button: the main body downloads the profile as JSLB, and the arrow
+ * on the right opens a dropdown menu with alternate download formats.
+ */
+class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> {
+  override render() {
+    const {
+      primary,
+      jslbEncodingState,
+      jsonEncodingState,
+      jslbDownloadFileName,
+      jsonDownloadFileName,
+      onJsonDropdownOpen,
+    } = this.props;
+
+    return (
+      <div className="publishPanelSplitButton">
+        <DownloadPrimary
+          primary={primary}
+          encodingState={jslbEncodingState}
+          downloadFileName={jslbDownloadFileName}
+        />
+        <ButtonWithPanel
+          className="publishPanelSplitButtonToggle"
+          buttonClassName="photon-button publishPanelSplitButtonToggleButton"
+          panelClassName="publishPanelSplitButtonPanel"
+          label=""
+          title="Show other download formats"
+          onPanelOpen={onJsonDropdownOpen}
+          panelContent={
+            <DownloadFormatMenu
+              jsonEncodingState={jsonEncodingState}
+              jsonDownloadFileName={jsonDownloadFileName}
+            />
+          }
+        />
+      </div>
+    );
+  }
+}
+
+type DownloadPrimaryProps = {
+  readonly encodingState: SanitizedProfileEncodingState;
   readonly downloadFileName: string;
   readonly primary?: boolean;
 };
 
 /**
- * The DownloadButton handles unpacking the compressed profile promise.
+ * The primary (left) part of the split button. Downloads the profile as JSLB.
  */
-class DownloadButton extends React.PureComponent<DownloadButtonProps, {}> {
+class DownloadPrimary extends React.PureComponent<DownloadPrimaryProps> {
   override render() {
-    const { sanitizedProfileEncodingState, downloadFileName, primary } =
-      this.props;
+    const { encodingState, downloadFileName, primary } = this.props;
     const className = classNames(
-      'photon-button publishPanelButton publishPanelButtonsDownload',
+      'photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload',
       { 'photon-button-primary publishPanelButtonsDownloadPrimary': primary }
     );
 
-    switch (sanitizedProfileEncodingState.phase) {
+    switch (encodingState.phase) {
       case 'DONE': {
-        const { profileData } = sanitizedProfileEncodingState;
+        const { profileData } = encodingState;
         return (
           <BlobUrlLink
             blob={profileData}
@@ -514,7 +587,73 @@ class DownloadButton extends React.PureComponent<DownloadButtonProps, {}> {
         );
       }
       default:
-        throw assertExhaustiveCheck(sanitizedProfileEncodingState);
+        throw assertExhaustiveCheck(encodingState);
+    }
+  }
+}
+
+type DownloadFormatMenuProps = {
+  readonly jsonEncodingState: SanitizedProfileEncodingState;
+  readonly jsonDownloadFileName: string;
+};
+
+/**
+ * Content of the dropdown panel: alternative download formats.
+ */
+class DownloadFormatMenu extends React.PureComponent<DownloadFormatMenuProps> {
+  override render() {
+    const { jsonEncodingState, jsonDownloadFileName } = this.props;
+    const itemClassName = 'publishPanelSplitButtonMenuItem';
+
+    switch (jsonEncodingState.phase) {
+      case 'DONE': {
+        const { profileData } = jsonEncodingState;
+        return (
+          <BlobUrlLink
+            blob={profileData}
+            download={`${jsonDownloadFileName}.gz`}
+            className={itemClassName}
+          >
+            <Localized id="MenuButtons--publish--download-json">
+              Download as JSON
+            </Localized>{' '}
+            <span className="menuButtonsDownloadSize">
+              ({prettyBytes(profileData.size)})
+            </span>
+          </BlobUrlLink>
+        );
+      }
+      case 'ERROR': {
+        return (
+          <span
+            className={classNames(
+              itemClassName,
+              'publishPanelSplitButtonMenuItemDisabled'
+            )}
+          >
+            <Localized id="MenuButtons--publish--download-json-error">
+              Error preparing JSON download
+            </Localized>
+          </span>
+        );
+      }
+      case 'INITIAL':
+      case 'ENCODING': {
+        return (
+          <span
+            className={classNames(
+              itemClassName,
+              'publishPanelSplitButtonMenuItemDisabled'
+            )}
+          >
+            <Localized id="MenuButtons--publish--compressing">
+              Compressing…
+            </Localized>
+          </span>
+        );
+      }
+      default:
+        throw assertExhaustiveCheck(jsonEncodingState);
     }
   }
 }

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -102,9 +102,13 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
     labelL10nId: string,
     additionalContent?: React.ReactNode
   ) {
-    const { checkedSharingOptions, uploadPhase } = this.props;
+    const { checkedSharingOptions, uploadPhase, mode } = this.props;
+    // Only the panel whose upload is in flight needs to freeze its options.
+    // The two modes have independent options, so an upload started from Share
+    // is no reason to stop someone adjusting what they save to disk.
     const isUploading =
-      uploadPhase === 'uploading' || uploadPhase === 'compressing';
+      mode === 'upload' &&
+      (uploadPhase === 'uploading' || uploadPhase === 'compressing');
     return (
       <label className="photon-label publishPanelDataChoicesLabel">
         <input

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -123,7 +123,16 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
     );
   }
 
-  _onSubmit = () => {
+  _onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    // Without this, submitting the form navigates to the current URL and
+    // reloads the whole app. Today that is masked by attemptToPublish
+    // dispatching synchronously, which unmounts the form before the browser
+    // gets to the default action -- don't rely on that.
+    event.preventDefault();
+    if (this.props.mode === 'download') {
+      // The download panel has no submit button; there is nothing to publish.
+      return;
+    }
     this.props.attemptToPublish();
   };
 
@@ -166,7 +175,7 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
       <div data-testid="PublishPanel-container">
         <form
           className="publishPanelContent photon-body-10"
-          onSubmit={isDownload ? undefined : this._onSubmit}
+          onSubmit={this._onSubmit}
         >
           <h1 className="publishPanelTitle photon-title-30">{title}</h1>
           <p className="publishPanelInfoDescription">

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -29,7 +29,8 @@ import {
   getSanitizedProfileEncodingStates,
 } from 'firefox-profiler/selectors/publish';
 import { BlobUrlLink } from 'firefox-profiler/components/shared/BlobUrlLink';
-import { ButtonWithPanel } from 'firefox-profiler/components/shared/ButtonWithPanel';
+import { ContextMenu } from 'firefox-profiler/components/shared/ContextMenu';
+import { MenuItem, showMenu } from '@firefox-devtools/react-contextmenu';
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import prettyBytes from 'firefox-profiler/utils/pretty-bytes';
 
@@ -482,6 +483,8 @@ export const PublishPanel = explicitConnect<
   component: PublishPanelImpl,
 });
 
+const DOWNLOAD_FORMAT_MENU_ID = 'PublishDownloadFormatContextMenu';
+
 type DownloadSplitButtonProps = {
   readonly primary: boolean;
   readonly jslbEncodingState: SanitizedProfileEncodingState;
@@ -491,11 +494,63 @@ type DownloadSplitButtonProps = {
   readonly onJsonDropdownOpen: () => void;
 };
 
+type DownloadSplitButtonState = {
+  readonly isMenuVisible: boolean;
+  // react-contextmenu hides the menu on mousedown even if it's already
+  // visible. We track visibility at mousedown time so that clicking the
+  // toggle button while the menu is open results in a net "close" rather
+  // than a hide-then-reshow.
+  readonly wasMenuVisibleOnMouseDown: boolean;
+};
+
 /**
  * Split button: the main body downloads the profile as JSLB, and the arrow
  * on the right opens a dropdown menu with alternate download formats.
+ * The dropdown uses the same react-contextmenu-based menu style as the
+ * marker chart's filter/copy buttons.
  */
-class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> {
+class DownloadSplitButton extends React.PureComponent<
+  DownloadSplitButtonProps,
+  DownloadSplitButtonState
+> {
+  override state: DownloadSplitButtonState = {
+    isMenuVisible: false,
+    wasMenuVisibleOnMouseDown: false,
+  };
+
+  _onToggleClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (this.state.wasMenuVisibleOnMouseDown) {
+      // The menu was already open on mousedown, so react-contextmenu has
+      // already hidden it. Don't reopen it.
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    // The menu is right-aligned to the toggle button since it sits near the
+    // right edge of the publish panel.
+    showMenu({
+      data: null,
+      id: DOWNLOAD_FORMAT_MENU_ID,
+      position: { x: rect.right, y: rect.bottom },
+      target: event.target,
+    });
+  };
+
+  _onToggleMouseDown = () => {
+    this.setState((state) => ({
+      wasMenuVisibleOnMouseDown: state.isMenuVisible,
+    }));
+  };
+
+  _onMenuShow = () => {
+    this.setState({ isMenuVisible: true });
+    this.props.onJsonDropdownOpen();
+  };
+
+  _onMenuHide = () => {
+    this.setState({ isMenuVisible: false });
+  };
+
   override render() {
     const {
       primary,
@@ -503,8 +558,8 @@ class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> 
       jsonEncodingState,
       jslbDownloadFileName,
       jsonDownloadFileName,
-      onJsonDropdownOpen,
     } = this.props;
+    const { isMenuVisible } = this.state;
 
     return (
       <div className="publishPanelSplitButton">
@@ -513,19 +568,27 @@ class DownloadSplitButton extends React.PureComponent<DownloadSplitButtonProps> 
           encodingState={jslbEncodingState}
           downloadFileName={jslbDownloadFileName}
         />
-        <ButtonWithPanel
-          className="publishPanelSplitButtonToggle"
-          buttonClassName="photon-button publishPanelSplitButtonToggleButton"
-          panelClassName="publishPanelSplitButtonPanel"
-          label=""
-          title="Show other download formats"
-          onPanelOpen={onJsonDropdownOpen}
-          panelContent={
-            <DownloadFormatMenu
-              jsonEncodingState={jsonEncodingState}
-              jsonDownloadFileName={jsonDownloadFileName}
-            />
-          }
+        <button
+          type="button"
+          className={classNames(
+            'photon-button',
+            'publishPanelSplitButtonToggleButton',
+            {
+              'publishPanelSplitButtonToggleButton--open': isMenuVisible,
+            }
+          )}
+          title="Other download formats"
+          aria-haspopup="menu"
+          aria-expanded={isMenuVisible}
+          onClick={this._onToggleClick}
+          onMouseDown={this._onToggleMouseDown}
+        />
+        <DownloadFormatContextMenu
+          menuId={DOWNLOAD_FORMAT_MENU_ID}
+          onShow={this._onMenuShow}
+          onHide={this._onMenuHide}
+          jsonEncodingState={jsonEncodingState}
+          jsonDownloadFileName={jsonDownloadFileName}
         />
       </div>
     );
@@ -592,68 +655,98 @@ class DownloadPrimary extends React.PureComponent<DownloadPrimaryProps> {
   }
 }
 
-type DownloadFormatMenuProps = {
+type DownloadFormatContextMenuProps = {
+  readonly menuId: string;
+  readonly onShow: () => void;
+  readonly onHide: () => void;
   readonly jsonEncodingState: SanitizedProfileEncodingState;
   readonly jsonDownloadFileName: string;
 };
 
 /**
- * Content of the dropdown panel: alternative download formats.
+ * Trigger a file download for a Blob without needing a persistent
+ * BlobUrlLink anchor. Used from a react-contextmenu MenuItem's onClick,
+ * where we can't wrap the item in an <a download>.
  */
-class DownloadFormatMenu extends React.PureComponent<DownloadFormatMenuProps> {
-  override render() {
-    const { jsonEncodingState, jsonDownloadFileName } = this.props;
-    const itemClassName = 'publishPanelSplitButtonMenuItem';
+function _triggerBlobDownload(blob: Blob, downloadFileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = downloadFileName;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  // Revoke asynchronously so Safari has a chance to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
 
+/**
+ * The dropdown menu for alternative download formats, rendered as a
+ * react-contextmenu (the same menu style used next to the marker chart
+ * search field).
+ */
+class DownloadFormatContextMenu extends React.PureComponent<DownloadFormatContextMenuProps> {
+  _onDownloadJson = () => {
+    const { jsonEncodingState, jsonDownloadFileName } = this.props;
+    if (jsonEncodingState.phase !== 'DONE') {
+      return;
+    }
+    _triggerBlobDownload(
+      jsonEncodingState.profileData,
+      `${jsonDownloadFileName}.gz`
+    );
+  };
+
+  _renderJsonMenuItemLabel() {
+    const { jsonEncodingState } = this.props;
     switch (jsonEncodingState.phase) {
-      case 'DONE': {
-        const { profileData } = jsonEncodingState;
+      case 'DONE':
         return (
-          <BlobUrlLink
-            blob={profileData}
-            download={`${jsonDownloadFileName}.gz`}
-            className={itemClassName}
-          >
+          <>
             <Localized id="MenuButtons--publish--download-json">
               Download as JSON
-            </Localized>{' '}
-            <span className="menuButtonsDownloadSize">
-              ({prettyBytes(profileData.size)})
-            </span>
-          </BlobUrlLink>
-        );
-      }
-      case 'ERROR': {
-        return (
-          <span
-            className={classNames(
-              itemClassName,
-              'publishPanelSplitButtonMenuItemDisabled'
-            )}
-          >
-            <Localized id="MenuButtons--publish--download-json-error">
-              Error preparing JSON download
             </Localized>
-          </span>
+            {` (${prettyBytes(jsonEncodingState.profileData.size)})`}
+          </>
         );
-      }
+      case 'ERROR':
+        return (
+          <Localized id="MenuButtons--publish--download-json-error">
+            Error preparing JSON download
+          </Localized>
+        );
       case 'INITIAL':
-      case 'ENCODING': {
+      case 'ENCODING':
         return (
-          <span
-            className={classNames(
-              itemClassName,
-              'publishPanelSplitButtonMenuItemDisabled'
-            )}
-          >
-            <Localized id="MenuButtons--publish--compressing">
-              Compressing…
-            </Localized>
-          </span>
+          <Localized id="MenuButtons--publish--compressing">
+            Compressing…
+          </Localized>
         );
-      }
       default:
         throw assertExhaustiveCheck(jsonEncodingState);
     }
+  }
+
+  override render() {
+    const { menuId, onShow, onHide, jsonEncodingState } = this.props;
+    const jsonReady = jsonEncodingState.phase === 'DONE';
+
+    return (
+      <ContextMenu
+        id={menuId}
+        className="publishPanelDownloadFormatContextMenu"
+        onShow={onShow}
+        onHide={onHide}
+      >
+        <MenuItem
+          onClick={this._onDownloadJson}
+          disabled={!jsonReady}
+          preventClose={!jsonReady}
+        >
+          {this._renderJsonMenuItemLabel()}
+        </MenuItem>
+      </ContextMenu>
+    );
   }
 }

--- a/src/reducers/publish.ts
+++ b/src/reducers/publish.ts
@@ -13,6 +13,7 @@ import type {
   Reducer,
   State,
   SanitizedProfileEncodingState,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 
 function _getSanitizingSharingOptions(): CheckedSharingOptions {
@@ -213,32 +214,53 @@ const hasSanitizedProfile: Reducer<boolean> = (state = false, action) => {
   }
 };
 
-const sanitizedProfileEncodingState: Reducer<SanitizedProfileEncodingState> = (
-  state = { phase: 'INITIAL' },
+type EncodingStates = Record<
+  PublishProfileFormat,
+  SanitizedProfileEncodingState
+>;
+
+const INITIAL_ENCODING_STATES: EncodingStates = {
+  jslb: { phase: 'INITIAL' },
+  json: { phase: 'INITIAL' },
+};
+
+const sanitizedProfileEncodingStates: Reducer<EncodingStates> = (
+  state = INITIAL_ENCODING_STATES,
   action
-): SanitizedProfileEncodingState => {
+): EncodingStates => {
   switch (action.type) {
     case 'SANITIZED_PROFILE_ENCODING_STARTED': {
-      const { sanitizedProfile } = action;
-      return { phase: 'ENCODING', sanitizedProfile };
+      const { format, sanitizedProfile } = action;
+      return {
+        ...state,
+        [format]: { phase: 'ENCODING', sanitizedProfile },
+      };
     }
     case 'SANITIZED_PROFILE_ENCODING_COMPLETED': {
-      const { sanitizedProfile, profileData } = action;
+      const { format, sanitizedProfile, profileData } = action;
+      const current = state[format];
       if (
-        state.phase === 'ENCODING' &&
-        state.sanitizedProfile === sanitizedProfile
+        current.phase === 'ENCODING' &&
+        current.sanitizedProfile === sanitizedProfile
       ) {
-        return { phase: 'DONE', sanitizedProfile, profileData };
+        return {
+          ...state,
+          [format]: { phase: 'DONE', sanitizedProfile, profileData },
+        };
       }
       return state; // Ignore updates from earlier encodings.
     }
     case 'SANITIZED_PROFILE_ENCODING_FAILED': {
-      const { sanitizedProfile, error } = action;
+      const { format, sanitizedProfile, error } = action;
+      const current = state[format];
       if (
-        state.phase === 'ENCODING' &&
-        state.sanitizedProfile === sanitizedProfile
+        current.phase === 'ENCODING' &&
+        current.sanitizedProfile === sanitizedProfile
       ) {
-        return { phase: 'ERROR', sanitizedProfile, error };
+        return {
+          ...state,
+          [format]: { phase: 'ERROR', sanitizedProfile, error },
+        };
       }
       return state; // Ignore updates from earlier encodings.
     }
@@ -249,7 +271,7 @@ const sanitizedProfileEncodingState: Reducer<SanitizedProfileEncodingState> = (
 
 const publishReducer: Reducer<PublishState> = combineReducers({
   checkedSharingOptions,
-  sanitizedProfileEncodingState,
+  sanitizedProfileEncodingStates,
   upload,
   isHidingStaleProfile,
   hasSanitizedProfile,

--- a/src/reducers/publish.ts
+++ b/src/reducers/publish.ts
@@ -46,8 +46,10 @@ function _getMostlyNonSanitizingSharingOptions(): CheckedSharingOptions {
   };
 }
 
-// Both modes reference the same object until one is edited, so an untouched
-// profile is only encoded once.
+// Both modes start out referencing the same options object. Note that this
+// does not make them share an encoding: the sanitized profile is memoized per
+// mode, and sanitizePII always returns a fresh object, so each mode encodes
+// its own copy. See sanitizedProfileEncodingStates below.
 function _sharingOptionsForBothModes(
   options: CheckedSharingOptions
 ): Record<SharingMode, CheckedSharingOptions> {
@@ -230,32 +232,53 @@ const hasSanitizedProfile: Reducer<boolean> = (state = false, action) => {
   }
 };
 
-const sanitizedProfileEncodingState: Reducer<SanitizedProfileEncodingState> = (
-  state = { phase: 'INITIAL' },
+type EncodingStates = Record<SharingMode, SanitizedProfileEncodingState>;
+
+const INITIAL_ENCODING_STATES: EncodingStates = {
+  download: { phase: 'INITIAL' },
+  upload: { phase: 'INITIAL' },
+};
+
+// One slot per sharing mode. Keying by mode keeps each panel's encoding
+// stable across reopens, and guarantees a panel can never be handed a blob
+// that was encoded for the other mode's sharing options.
+const sanitizedProfileEncodingStates: Reducer<EncodingStates> = (
+  state = INITIAL_ENCODING_STATES,
   action
-): SanitizedProfileEncodingState => {
+): EncodingStates => {
   switch (action.type) {
     case 'SANITIZED_PROFILE_ENCODING_STARTED': {
-      const { sanitizedProfile, encodingPromise } = action;
-      return { phase: 'ENCODING', sanitizedProfile, encodingPromise };
+      const { mode, sanitizedProfile, encodingPromise } = action;
+      return {
+        ...state,
+        [mode]: { phase: 'ENCODING', sanitizedProfile, encodingPromise },
+      };
     }
     case 'SANITIZED_PROFILE_ENCODING_COMPLETED': {
-      const { sanitizedProfile, profileData } = action;
+      const { mode, sanitizedProfile, profileData } = action;
+      const current = state[mode];
       if (
-        state.phase === 'ENCODING' &&
-        state.sanitizedProfile === sanitizedProfile
+        current.phase === 'ENCODING' &&
+        current.sanitizedProfile === sanitizedProfile
       ) {
-        return { phase: 'DONE', sanitizedProfile, profileData };
+        return {
+          ...state,
+          [mode]: { phase: 'DONE', sanitizedProfile, profileData },
+        };
       }
       return state; // Ignore updates from earlier encodings.
     }
     case 'SANITIZED_PROFILE_ENCODING_FAILED': {
-      const { sanitizedProfile, error } = action;
+      const { mode, sanitizedProfile, error } = action;
+      const current = state[mode];
       if (
-        state.phase === 'ENCODING' &&
-        state.sanitizedProfile === sanitizedProfile
+        current.phase === 'ENCODING' &&
+        current.sanitizedProfile === sanitizedProfile
       ) {
-        return { phase: 'ERROR', sanitizedProfile, error };
+        return {
+          ...state,
+          [mode]: { phase: 'ERROR', sanitizedProfile, error },
+        };
       }
       return state; // Ignore updates from earlier encodings.
     }
@@ -266,7 +289,7 @@ const sanitizedProfileEncodingState: Reducer<SanitizedProfileEncodingState> = (
 
 const publishReducer: Reducer<PublishState> = combineReducers({
   checkedSharingOptions,
-  sanitizedProfileEncodingState,
+  sanitizedProfileEncodingStates,
   upload,
   isHidingStaleProfile,
   hasSanitizedProfile,

--- a/src/reducers/publish.ts
+++ b/src/reducers/publish.ts
@@ -14,6 +14,7 @@ import type {
   Reducer,
   State,
   SanitizedProfileEncodingState,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 
 function _getSanitizingSharingOptions(): CheckedSharingOptions {
@@ -232,53 +233,77 @@ const hasSanitizedProfile: Reducer<boolean> = (state = false, action) => {
   }
 };
 
-type EncodingStates = Record<SharingMode, SanitizedProfileEncodingState>;
+type FormatEncodingStates = Record<
+  PublishProfileFormat,
+  SanitizedProfileEncodingState
+>;
+type EncodingStates = Record<SharingMode, FormatEncodingStates>;
 
-const INITIAL_ENCODING_STATES: EncodingStates = {
-  download: { phase: 'INITIAL' },
-  upload: { phase: 'INITIAL' },
+const INITIAL_FORMAT_ENCODING_STATES: FormatEncodingStates = {
+  jslb: { phase: 'INITIAL' },
+  json: { phase: 'INITIAL' },
 };
 
-// One slot per sharing mode. Keying by mode keeps each panel's encoding
-// stable across reopens, and guarantees a panel can never be handed a blob
-// that was encoded for the other mode's sharing options.
+const INITIAL_ENCODING_STATES: EncodingStates = {
+  download: INITIAL_FORMAT_ENCODING_STATES,
+  upload: INITIAL_FORMAT_ENCODING_STATES,
+};
+
+function _withEncodingState(
+  state: EncodingStates,
+  mode: SharingMode,
+  format: PublishProfileFormat,
+  encodingState: SanitizedProfileEncodingState
+): EncodingStates {
+  return {
+    ...state,
+    [mode]: { ...state[mode], [format]: encodingState },
+  };
+}
+
+// One slot per (sharing mode, format) pair. Keying by mode keeps each panel's
+// encoding stable across reopens, and guarantees a panel can never be handed a
+// blob that was encoded for the other mode's sharing options.
 const sanitizedProfileEncodingStates: Reducer<EncodingStates> = (
   state = INITIAL_ENCODING_STATES,
   action
 ): EncodingStates => {
   switch (action.type) {
     case 'SANITIZED_PROFILE_ENCODING_STARTED': {
-      const { mode, sanitizedProfile, encodingPromise } = action;
-      return {
-        ...state,
-        [mode]: { phase: 'ENCODING', sanitizedProfile, encodingPromise },
-      };
+      const { mode, format, sanitizedProfile, encodingPromise } = action;
+      return _withEncodingState(state, mode, format, {
+        phase: 'ENCODING',
+        sanitizedProfile,
+        encodingPromise,
+      });
     }
     case 'SANITIZED_PROFILE_ENCODING_COMPLETED': {
-      const { mode, sanitizedProfile, profileData } = action;
-      const current = state[mode];
+      const { mode, format, sanitizedProfile, profileData } = action;
+      const current = state[mode][format];
       if (
         current.phase === 'ENCODING' &&
         current.sanitizedProfile === sanitizedProfile
       ) {
-        return {
-          ...state,
-          [mode]: { phase: 'DONE', sanitizedProfile, profileData },
-        };
+        return _withEncodingState(state, mode, format, {
+          phase: 'DONE',
+          sanitizedProfile,
+          profileData,
+        });
       }
       return state; // Ignore updates from earlier encodings.
     }
     case 'SANITIZED_PROFILE_ENCODING_FAILED': {
-      const { mode, sanitizedProfile, error } = action;
-      const current = state[mode];
+      const { mode, format, sanitizedProfile, error } = action;
+      const current = state[mode][format];
       if (
         current.phase === 'ENCODING' &&
         current.sanitizedProfile === sanitizedProfile
       ) {
-        return {
-          ...state,
-          [mode]: { phase: 'ERROR', sanitizedProfile, error },
-        };
+        return _withEncodingState(state, mode, format, {
+          phase: 'ERROR',
+          sanitizedProfile,
+          error,
+        });
       }
       return state; // Ignore updates from earlier encodings.
     }

--- a/src/selectors/publish.ts
+++ b/src/selectors/publish.ts
@@ -65,7 +65,7 @@ export const getFilenameString: Selector<string> = createSelector(
     const dateString = `${year}-${month}-${day} ${hour}.${min}`;
 
     // Return the final file name
-    return `${product} ${dateString} profile.json`;
+    return `${product} ${dateString} profile.jslb`;
   }
 );
 

--- a/src/selectors/publish.ts
+++ b/src/selectors/publish.ts
@@ -37,6 +37,7 @@ import type {
   ThreadIndex,
   CounterIndex,
   SanitizedProfileEncodingState,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 import { getThreadSelectors } from './per-thread';
 
@@ -46,7 +47,7 @@ export const getCheckedSharingOptions: Selector<CheckedSharingOptions> = (
   state
 ) => getPublishState(state).checkedSharingOptions;
 
-export const getFilenameString: Selector<string> = createSelector(
+const getFilenameStem: Selector<string> = createSelector(
   getProfile,
   getProfileRootRange,
   (profile, rootRange) => {
@@ -64,10 +65,16 @@ export const getFilenameString: Selector<string> = createSelector(
     const min = pad(date.getMinutes());
     const dateString = `${year}-${month}-${day} ${hour}.${min}`;
 
-    // Return the final file name
-    return `${product} ${dateString} profile.jslb`;
+    return `${product} ${dateString} profile`;
   }
 );
+
+export function getDownloadFilename(
+  state: State,
+  format: PublishProfileFormat
+): string {
+  return `${getFilenameStem(state)}.${format}`;
+}
 
 export const getRemoveProfileInformation: Selector<RemoveProfileInformation | null> =
   createSelector(
@@ -216,9 +223,16 @@ export const getSanitizedProfile: Selector<SanitizeProfileResult> =
     sanitizePII
   );
 
-export const getSanitizedProfileEncodingState: Selector<
-  SanitizedProfileEncodingState
-> = (state) => getPublishState(state).sanitizedProfileEncodingState;
+export const getSanitizedProfileEncodingStates: Selector<
+  Record<PublishProfileFormat, SanitizedProfileEncodingState>
+> = (state) => getPublishState(state).sanitizedProfileEncodingStates;
+
+export function getSanitizedProfileEncodingState(
+  state: State,
+  format: PublishProfileFormat
+): SanitizedProfileEncodingState {
+  return getSanitizedProfileEncodingStates(state)[format];
+}
 
 export const getUploadState: Selector<UploadState> = (state) =>
   getPublishState(state).upload;

--- a/src/selectors/publish.ts
+++ b/src/selectors/publish.ts
@@ -275,9 +275,14 @@ export const getSanitizedProfile: DangerousSelectorWithArguments<
   SharingMode
 > = (state, mode) => _sanitizedProfileSelectors[mode](state);
 
-export const getSanitizedProfileEncodingState: Selector<
-  SanitizedProfileEncodingState
-> = (state) => getPublishState(state).sanitizedProfileEncodingState;
+export const getSanitizedProfileEncodingStates: Selector<
+  Record<SharingMode, SanitizedProfileEncodingState>
+> = (state) => getPublishState(state).sanitizedProfileEncodingStates;
+
+export const getSanitizedProfileEncodingState: DangerousSelectorWithArguments<
+  SanitizedProfileEncodingState,
+  SharingMode
+> = (state, mode) => getSanitizedProfileEncodingStates(state)[mode];
 
 export const getUploadState: Selector<UploadState> = (state) =>
   getPublishState(state).upload;

--- a/src/selectors/publish.ts
+++ b/src/selectors/publish.ts
@@ -40,6 +40,7 @@ import type {
   ThreadIndex,
   CounterIndex,
   SanitizedProfileEncodingState,
+  PublishProfileFormat,
 } from 'firefox-profiler/types';
 import { getThreadSelectors } from './per-thread';
 
@@ -50,7 +51,7 @@ export const getCheckedSharingOptions: DangerousSelectorWithArguments<
   SharingMode
 > = (state, mode) => getPublishState(state).checkedSharingOptions[mode];
 
-export const getFilenameString: Selector<string> = createSelector(
+const getFilenameStem: Selector<string> = createSelector(
   getProfile,
   getProfileRootRange,
   (profile, rootRange) => {
@@ -68,10 +69,16 @@ export const getFilenameString: Selector<string> = createSelector(
     const min = pad(date.getMinutes());
     const dateString = `${year}-${month}-${day} ${hour}.${min}`;
 
-    // Return the final file name
-    return `${product} ${dateString} profile.jslb`;
+    return `${product} ${dateString} profile`;
   }
 );
+
+export function getDownloadFilename(
+  state: State,
+  format: PublishProfileFormat
+): string {
+  return `${getFilenameStem(state)}.${format}`;
+}
 
 const _makeGetRemoveProfileInformation = (mode: SharingMode) =>
   createSelector(
@@ -275,14 +282,19 @@ export const getSanitizedProfile: DangerousSelectorWithArguments<
   SharingMode
 > = (state, mode) => _sanitizedProfileSelectors[mode](state);
 
-export const getSanitizedProfileEncodingStates: Selector<
-  Record<SharingMode, SanitizedProfileEncodingState>
-> = (state) => getPublishState(state).sanitizedProfileEncodingStates;
-
-export const getSanitizedProfileEncodingState: DangerousSelectorWithArguments<
-  SanitizedProfileEncodingState,
+export const getSanitizedProfileEncodingStates: DangerousSelectorWithArguments<
+  Record<PublishProfileFormat, SanitizedProfileEncodingState>,
   SharingMode
-> = (state, mode) => getSanitizedProfileEncodingStates(state)[mode];
+> = (state, mode) =>
+  getPublishState(state).sanitizedProfileEncodingStates[mode];
+
+export function getSanitizedProfileEncodingState(
+  state: State,
+  mode: SharingMode,
+  format: PublishProfileFormat
+): SanitizedProfileEncodingState {
+  return getSanitizedProfileEncodingStates(state, mode)[format];
+}
 
 export const getUploadState: Selector<UploadState> = (state) =>
   getPublishState(state).upload;

--- a/src/selectors/publish.ts
+++ b/src/selectors/publish.ts
@@ -69,7 +69,7 @@ export const getFilenameString: Selector<string> = createSelector(
     const dateString = `${year}-${month}-${day} ${hour}.${min}`;
 
     // Return the final file name
-    return `${product} ${dateString} profile.json`;
+    return `${product} ${dateString} profile.jslb`;
   }
 );
 

--- a/src/test/components/MenuButtons.test.tsx
+++ b/src/test/components/MenuButtons.test.tsx
@@ -519,17 +519,18 @@ describe('app/MenuButtons', function () {
       expect(getPanel()).toMatchSnapshot();
     });
 
-    it('keeps Download available but locks the options while uploading', async () => {
+    it('keeps Download available and editable while uploading', async () => {
       const { openPublishPanel, getPanelForm, openDownloadPanel } =
         setupForPublish();
       await openPublishPanel();
       fireEvent.submit(getPanelForm());
 
-      // The Download button stays in the toolbar while the upload is running.
+      // The Download button stays in the toolbar while the upload is running,
+      // and its options stay editable: they are independent of the upload's.
       await openDownloadPanel();
       expect(
         screen.getByRole('checkbox', { name: /Include hidden threads/ })
-      ).toBeDisabled();
+      ).toBeEnabled();
     });
   });
 

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -1954,13 +1954,27 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
     <div
       class="publishPanelButtons"
     >
-      <button
-        class="photon-button publishPanelButton publishPanelButtonsDownload"
-        disabled=""
-        type="button"
+      <div
+        class="publishPanelSplitButton"
       >
-        Download
-      </button>
+        <button
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload"
+          disabled=""
+          type="button"
+        >
+          Download
+        </button>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
       <button
         class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         disabled=""
@@ -2170,24 +2184,38 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
     <div
       class="publishPanelButtons"
     >
-      <a
-        class="photon-button publishPanelButton publishPanelButtonsDownload"
-        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
-        href="mockCreateObjectUrl"
+      <div
+        class="publishPanelSplitButton"
       >
-        <span
-          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
-        />
-        Download
-         
-        <span
-          class="menuButtonsDownloadSize"
+        <a
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload"
+          download="Firefox 1970-01-01 00.00 profile.jslb.gz"
+          href="mockCreateObjectUrl"
         >
-          (
-          1.58 kB
-          )
-        </span>
-      </a>
+          <span
+            class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
+          />
+          Download
+           
+          <span
+            class="menuButtonsDownloadSize"
+          >
+            (
+            1.58 kB
+            )
+          </span>
+        </a>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
       <button
         class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         type="submit"
@@ -2288,24 +2316,38 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     <div
       class="publishPanelButtons"
     >
-      <a
-        class="photon-button publishPanelButton publishPanelButtonsDownload"
-        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
-        href="mockCreateObjectUrl"
+      <div
+        class="publishPanelSplitButton"
       >
-        <span
-          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
-        />
-        Download
-         
-        <span
-          class="menuButtonsDownloadSize"
+        <a
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload"
+          download="Firefox 1970-01-01 00.00 profile.jslb.gz"
+          href="mockCreateObjectUrl"
         >
-          (
-          1.58 kB
-          )
-        </span>
-      </a>
+          <span
+            class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
+          />
+          Download
+           
+          <span
+            class="menuButtonsDownloadSize"
+          >
+            (
+            1.58 kB
+            )
+          </span>
+        </a>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
       <button
         class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         type="submit"
@@ -2401,24 +2443,38 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     <div
       class="publishPanelButtons"
     >
-      <a
-        class="photon-button publishPanelButton publishPanelButtonsDownload"
-        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
-        href="mockCreateObjectUrl"
+      <div
+        class="publishPanelSplitButton"
       >
-        <span
-          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
-        />
-        Download
-         
-        <span
-          class="menuButtonsDownloadSize"
+        <a
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload"
+          download="Firefox 1970-01-01 00.00 profile.jslb.gz"
+          href="mockCreateObjectUrl"
         >
-          (
-          1.58 kB
-          )
-        </span>
-      </a>
+          <span
+            class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
+          />
+          Download
+           
+          <span
+            class="menuButtonsDownloadSize"
+          >
+            (
+            1.58 kB
+            )
+          </span>
+        </a>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
       <button
         class="photon-button photon-button-primary publishPanelButton publishPanelButtonsUpload"
         type="submit"

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -1964,15 +1964,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for a compression error 
         >
           Download
         </button>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
       <button
@@ -2205,15 +2219,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
             )
           </span>
         </a>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
       <button
@@ -2337,15 +2365,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
             )
           </span>
         </a>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
       <button
@@ -2464,15 +2506,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
             )
           </span>
         </a>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
       <button

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -2172,7 +2172,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
     >
       <a
         class="photon-button publishPanelButton publishPanelButtonsDownload"
-        download="Firefox 1970-01-01 00.00 profile.json.gz"
+        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
         href="mockCreateObjectUrl"
       >
         <span
@@ -2290,7 +2290,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     >
       <a
         class="photon-button publishPanelButton publishPanelButtonsDownload"
-        download="Firefox 1970-01-01 00.00 profile.json.gz"
+        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
         href="mockCreateObjectUrl"
       >
         <span
@@ -2403,7 +2403,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     >
       <a
         class="photon-button publishPanelButton publishPanelButtonsDownload"
-        download="Firefox 1970-01-01 00.00 profile.json.gz"
+        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
         href="mockCreateObjectUrl"
       >
         <span

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -2238,15 +2238,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
             )
           </span>
         </a>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
     </div>
@@ -2371,15 +2385,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
             )
           </span>
         </a>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
     </div>
@@ -2499,15 +2527,29 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
             )
           </span>
         </a>
-        <div
-          class="buttonWithPanel publishPanelSplitButtonToggle"
-        >
-          <button
-            aria-expanded="false"
-            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
-            title="Show other download formats"
-            type="button"
-          />
+        <button
+          aria-expanded="false"
+          aria-haspopup="menu"
+          class="photon-button publishPanelSplitButtonToggleButton"
+          title="Other download formats"
+          type="button"
+        />
+        <div>
+          <nav
+            class="react-contextmenu publishPanelDownloadFormatContextMenu"
+            role="menu"
+            style="position: fixed; opacity: 0; pointer-events: none;"
+            tabindex="-1"
+          >
+            <div
+              aria-disabled="true"
+              class="react-contextmenu-item react-contextmenu-item--disabled"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Compressing…
+            </div>
+          </nav>
         </div>
       </div>
     </div>

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -2219,7 +2219,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
     >
       <a
         class="photon-button publishPanelButton publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
-        download="Firefox 1970-01-01 00.00 profile.json.gz"
+        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
         href="mockCreateObjectUrl"
       >
         <span
@@ -2338,7 +2338,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     >
       <a
         class="photon-button publishPanelButton publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
-        download="Firefox 1970-01-01 00.00 profile.json.gz"
+        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
         href="mockCreateObjectUrl"
       >
         <span
@@ -2452,7 +2452,7 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     >
       <a
         class="photon-button publishPanelButton publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
-        download="Firefox 1970-01-01 00.00 profile.json.gz"
+        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
         href="mockCreateObjectUrl"
       >
         <span

--- a/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.tsx.snap
@@ -2217,24 +2217,38 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the menu buttons and
     <div
       class="publishPanelButtons"
     >
-      <a
-        class="photon-button publishPanelButton publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
-        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
-        href="mockCreateObjectUrl"
+      <div
+        class="publishPanelSplitButton"
       >
-        <span
-          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
-        />
-        Download
-         
-        <span
-          class="menuButtonsDownloadSize"
+        <a
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
+          download="Firefox 1970-01-01 00.00 profile.jslb.gz"
+          href="mockCreateObjectUrl"
         >
-          (
-          1.58 kB
-          )
-        </span>
-      </a>
+          <span
+            class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
+          />
+          Download
+           
+          <span
+            class="menuButtonsDownloadSize"
+          >
+            (
+            1.58 kB
+            )
+          </span>
+        </a>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
     </div>
   </form>
 </div>
@@ -2336,24 +2350,38 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     <div
       class="publishPanelButtons"
     >
-      <a
-        class="photon-button publishPanelButton publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
-        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
-        href="mockCreateObjectUrl"
+      <div
+        class="publishPanelSplitButton"
       >
-        <span
-          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
-        />
-        Download
-         
-        <span
-          class="menuButtonsDownloadSize"
+        <a
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
+          download="Firefox 1970-01-01 00.00 profile.jslb.gz"
+          href="mockCreateObjectUrl"
         >
-          (
-          1.58 kB
-          )
-        </span>
-      </a>
+          <span
+            class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
+          />
+          Download
+           
+          <span
+            class="menuButtonsDownloadSize"
+          >
+            (
+            1.58 kB
+            )
+          </span>
+        </a>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
     </div>
   </form>
 </div>
@@ -2450,24 +2478,38 @@ exports[`app/MenuButtons <Publish> matches the snapshot for the opened panel for
     <div
       class="publishPanelButtons"
     >
-      <a
-        class="photon-button publishPanelButton publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
-        download="Firefox 1970-01-01 00.00 profile.jslb.gz"
-        href="mockCreateObjectUrl"
+      <div
+        class="publishPanelSplitButton"
       >
-        <span
-          class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
-        />
-        Download
-         
-        <span
-          class="menuButtonsDownloadSize"
+        <a
+          class="photon-button publishPanelButton publishPanelSplitButtonMain publishPanelButtonsDownload photon-button-primary publishPanelButtonsDownloadPrimary"
+          download="Firefox 1970-01-01 00.00 profile.jslb.gz"
+          href="mockCreateObjectUrl"
         >
-          (
-          1.58 kB
-          )
-        </span>
-      </a>
+          <span
+            class="publishPanelButtonsSvg publishPanelButtonsSvgDownload"
+          />
+          Download
+           
+          <span
+            class="menuButtonsDownloadSize"
+          >
+            (
+            1.58 kB
+            )
+          </span>
+        </a>
+        <div
+          class="buttonWithPanel publishPanelSplitButtonToggle"
+        >
+          <button
+            aria-expanded="false"
+            class="buttonWithPanelButton photon-button publishPanelSplitButtonToggleButton"
+            title="Show other download formats"
+            type="button"
+          />
+        </div>
+      </div>
     </div>
   </form>
 </div>

--- a/src/test/store/publish.test.ts
+++ b/src/test/store/publish.test.ts
@@ -190,8 +190,8 @@ describe('encodeSanitizedProfile', function () {
     const first = dispatch(encodeSanitizedProfile('upload'));
     const second = dispatch(encodeSanitizedProfile('upload'));
 
-    expect(second.encodingPromise).toBe(first.encodingPromise);
-    await first.encodingPromise;
+    expect(second).toBe(first);
+    await first;
   });
 
   it('keeps a separate encoding per mode, so alternating panel opens each reuse their own', async function () {
@@ -202,17 +202,13 @@ describe('encodeSanitizedProfile', function () {
     // encoding...
     const download = dispatch(encodeSanitizedProfile('download'));
     const upload = dispatch(encodeSanitizedProfile('upload'));
-    expect(upload.encodingPromise).not.toBe(download.encodingPromise);
+    expect(upload).not.toBe(download);
 
     // ...but reopening a panel must not start a third and fourth encoding.
-    expect(dispatch(encodeSanitizedProfile('download')).encodingPromise).toBe(
-      download.encodingPromise
-    );
-    expect(dispatch(encodeSanitizedProfile('upload')).encodingPromise).toBe(
-      upload.encodingPromise
-    );
+    expect(dispatch(encodeSanitizedProfile('download'))).toBe(download);
+    expect(dispatch(encodeSanitizedProfile('upload'))).toBe(upload);
 
-    await Promise.all([download.encodingPromise, upload.encodingPromise]);
+    await Promise.all([download, upload]);
   });
 
   it('never exposes a mode the blob that was encoded for the other mode', async function () {
@@ -229,7 +225,7 @@ describe('encodeSanitizedProfile', function () {
 
     // Opt into URLs for uploading only, and let that encoding finish.
     dispatch(updateSharingOption('upload', 'includeUrls', true));
-    await dispatch(encodeSanitizedProfile('upload')).encodingPromise;
+    await dispatch(encodeSanitizedProfile('upload'));
     expect(getSanitizedProfileEncodingState(getState(), 'upload').phase).toBe(
       'DONE'
     );
@@ -242,7 +238,7 @@ describe('encodeSanitizedProfile', function () {
     expect(forDownload.phase).toBe('INITIAL');
 
     // And once download has encoded too, each mode keeps its own blob.
-    await dispatch(encodeSanitizedProfile('download')).encodingPromise;
+    await dispatch(encodeSanitizedProfile('download'));
     const encodedBlob = (mode: SharingMode) => {
       const encodingState = getSanitizedProfileEncodingState(getState(), mode);
       if (encodingState.phase !== 'DONE') {

--- a/src/test/store/publish.test.ts
+++ b/src/test/store/publish.test.ts
@@ -23,6 +23,7 @@ import {
   getUploadProgress,
   getUploadProgressString,
   getUploadGeneration,
+  getSanitizedProfileEncodingState,
 } from '../../selectors/publish';
 import {
   getUrlState,
@@ -68,7 +69,7 @@ import {
   listAllUploadedProfileInformationFromDb,
 } from 'firefox-profiler/app-logic/uploaded-profiles-db';
 
-import type { Store, UploadPhase } from 'firefox-profiler/types';
+import type { Store, UploadPhase, SharingMode } from 'firefox-profiler/types';
 
 import { autoMockIndexedDB } from 'firefox-profiler/test/fixtures/mocks/indexeddb';
 autoMockIndexedDB();
@@ -191,6 +192,67 @@ describe('encodeSanitizedProfile', function () {
 
     expect(second.encodingPromise).toBe(first.encodingPromise);
     await first.encodingPromise;
+  });
+
+  it('keeps a separate encoding per mode, so alternating panel opens each reuse their own', async function () {
+    const { profile } = getProfileFromTextSamples('A');
+    const { dispatch } = storeWithProfile(profile);
+
+    // The two modes sanitize to different profiles, so they each need their own
+    // encoding...
+    const download = dispatch(encodeSanitizedProfile('download'));
+    const upload = dispatch(encodeSanitizedProfile('upload'));
+    expect(upload.encodingPromise).not.toBe(download.encodingPromise);
+
+    // ...but reopening a panel must not start a third and fourth encoding.
+    expect(dispatch(encodeSanitizedProfile('download')).encodingPromise).toBe(
+      download.encodingPromise
+    );
+    expect(dispatch(encodeSanitizedProfile('upload')).encodingPromise).toBe(
+      upload.encodingPromise
+    );
+
+    await Promise.all([download.encodingPromise, upload.encodingPromise]);
+  });
+
+  it('never exposes a mode the blob that was encoded for the other mode', async function () {
+    const { profile } = getProfileFromTextSamples('A');
+    profile.pages = [
+      {
+        tabID: 1,
+        innerWindowID: 1,
+        url: 'https://example.com/private-page',
+        embedderInnerWindowID: 0,
+      },
+    ];
+    const { dispatch, getState } = storeWithProfile(profile);
+
+    // Opt into URLs for uploading only, and let that encoding finish.
+    dispatch(updateSharingOption('upload', 'includeUrls', true));
+    await dispatch(encodeSanitizedProfile('upload')).encodingPromise;
+    expect(getSanitizedProfileEncodingState(getState(), 'upload').phase).toBe(
+      'DONE'
+    );
+
+    // The download panel, whose options still strip URLs, must not see it.
+    const forDownload = getSanitizedProfileEncodingState(
+      getState(),
+      'download'
+    );
+    expect(forDownload.phase).toBe('INITIAL');
+
+    // And once download has encoded too, each mode keeps its own blob.
+    await dispatch(encodeSanitizedProfile('download')).encodingPromise;
+    const encodedBlob = (mode: SharingMode) => {
+      const encodingState = getSanitizedProfileEncodingState(getState(), mode);
+      if (encodingState.phase !== 'DONE') {
+        throw new Error(
+          `Expected the ${mode} encoding to be DONE, but it is ${encodingState.phase}.`
+        );
+      }
+      return encodingState.profileData;
+    };
+    expect(encodedBlob('download')).not.toBe(encodedBlob('upload'));
   });
 });
 

--- a/src/test/store/publish.test.ts
+++ b/src/test/store/publish.test.ts
@@ -187,8 +187,8 @@ describe('encodeSanitizedProfile', function () {
     const { profile } = getProfileFromTextSamples('A');
     const { dispatch } = storeWithProfile(profile);
 
-    const first = dispatch(encodeSanitizedProfile('upload'));
-    const second = dispatch(encodeSanitizedProfile('upload'));
+    const first = dispatch(encodeSanitizedProfile('upload', 'jslb'));
+    const second = dispatch(encodeSanitizedProfile('upload', 'jslb'));
 
     expect(second).toBe(first);
     await first;
@@ -200,13 +200,13 @@ describe('encodeSanitizedProfile', function () {
 
     // The two modes sanitize to different profiles, so they each need their own
     // encoding...
-    const download = dispatch(encodeSanitizedProfile('download'));
-    const upload = dispatch(encodeSanitizedProfile('upload'));
+    const download = dispatch(encodeSanitizedProfile('download', 'jslb'));
+    const upload = dispatch(encodeSanitizedProfile('upload', 'jslb'));
     expect(upload).not.toBe(download);
 
     // ...but reopening a panel must not start a third and fourth encoding.
-    expect(dispatch(encodeSanitizedProfile('download'))).toBe(download);
-    expect(dispatch(encodeSanitizedProfile('upload'))).toBe(upload);
+    expect(dispatch(encodeSanitizedProfile('download', 'jslb'))).toBe(download);
+    expect(dispatch(encodeSanitizedProfile('upload', 'jslb'))).toBe(upload);
 
     await Promise.all([download, upload]);
   });
@@ -225,22 +225,27 @@ describe('encodeSanitizedProfile', function () {
 
     // Opt into URLs for uploading only, and let that encoding finish.
     dispatch(updateSharingOption('upload', 'includeUrls', true));
-    await dispatch(encodeSanitizedProfile('upload'));
-    expect(getSanitizedProfileEncodingState(getState(), 'upload').phase).toBe(
-      'DONE'
-    );
+    await dispatch(encodeSanitizedProfile('upload', 'jslb'));
+    expect(
+      getSanitizedProfileEncodingState(getState(), 'upload', 'jslb').phase
+    ).toBe('DONE');
 
     // The download panel, whose options still strip URLs, must not see it.
     const forDownload = getSanitizedProfileEncodingState(
       getState(),
-      'download'
+      'download',
+      'jslb'
     );
     expect(forDownload.phase).toBe('INITIAL');
 
     // And once download has encoded too, each mode keeps its own blob.
-    await dispatch(encodeSanitizedProfile('download'));
+    await dispatch(encodeSanitizedProfile('download', 'jslb'));
     const encodedBlob = (mode: SharingMode) => {
-      const encodingState = getSanitizedProfileEncodingState(getState(), mode);
+      const encodingState = getSanitizedProfileEncodingState(
+        getState(),
+        mode,
+        'jslb'
+      );
       if (encodingState.phase !== 'DONE') {
         throw new Error(
           `Expected the ${mode} encoding to be DONE, but it is ${encodingState.phase}.`

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -46,6 +46,7 @@ import type {
   ApiQueryError,
   TableViewOptions,
   DecodedInstruction,
+  PublishProfileFormat,
 } from './state';
 import type { CssPixels, StartEndRange, Milliseconds } from './units';
 import type { BrowserConnectionStatus } from '../app-logic/browser-connection';
@@ -653,15 +654,18 @@ type PublishAction =
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_STARTED';
+      readonly format: PublishProfileFormat;
       readonly sanitizedProfile: Profile;
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_COMPLETED';
+      readonly format: PublishProfileFormat;
       readonly sanitizedProfile: Profile;
       readonly profileData: Blob;
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_FAILED';
+      readonly format: PublishProfileFormat;
       readonly sanitizedProfile: Profile;
       readonly error: Error;
     }

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -656,16 +656,19 @@ type PublishAction =
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_STARTED';
+      readonly mode: SharingMode;
       readonly sanitizedProfile: Profile;
       readonly encodingPromise: Promise<ProfileEncodingResult>;
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_COMPLETED';
+      readonly mode: SharingMode;
       readonly sanitizedProfile: Profile;
       readonly profileData: Blob;
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_FAILED';
+      readonly mode: SharingMode;
       readonly sanitizedProfile: Profile;
       readonly error: Error;
     }

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -46,6 +46,7 @@ import type {
   TableViewOptions,
   DecodedInstruction,
   ProfileEncodingResult,
+  PublishProfileFormat,
 } from './state';
 import type { CssPixels, StartEndRange, Milliseconds } from './units';
 import type { BrowserConnectionStatus } from '../app-logic/browser-connection';
@@ -657,18 +658,21 @@ type PublishAction =
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_STARTED';
       readonly mode: SharingMode;
+      readonly format: PublishProfileFormat;
       readonly sanitizedProfile: Profile;
       readonly encodingPromise: Promise<ProfileEncodingResult>;
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_COMPLETED';
       readonly mode: SharingMode;
+      readonly format: PublishProfileFormat;
       readonly sanitizedProfile: Profile;
       readonly profileData: Blob;
     }
   | {
       readonly type: 'SANITIZED_PROFILE_ENCODING_FAILED';
       readonly mode: SharingMode;
+      readonly format: PublishProfileFormat;
       readonly sanitizedProfile: Profile;
       readonly error: Error;
     }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -229,9 +229,16 @@ export type SanitizedProfileEncodingState =
     }
   | { phase: 'ERROR'; sanitizedProfile: Profile; error: Error };
 
+// The upload path always uses 'jslb'; 'json' is only used for the "Download
+// as JSON" option in the publish panel's split download button.
+export type PublishProfileFormat = 'jslb' | 'json';
+
 export type PublishState = {
   readonly checkedSharingOptions: CheckedSharingOptions;
-  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
+  readonly sanitizedProfileEncodingStates: Record<
+    PublishProfileFormat,
+    SanitizedProfileEncodingState
+  >;
   readonly upload: UploadState;
   readonly isHidingStaleProfile: boolean;
   readonly hasSanitizedProfile: boolean;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -237,15 +237,21 @@ export type SanitizedProfileEncodingState =
     }
   | { phase: 'ERROR'; sanitizedProfile: Profile; error: Error };
 
+// The upload path always uses 'jslb'; 'json' is only used for the "Download
+// as JSON" option in the publish panel's split download button.
+export type PublishProfileFormat = 'jslb' | 'json';
+
 export type PublishState = {
   readonly checkedSharingOptions: Record<SharingMode, CheckedSharingOptions>;
-  // One encoding slot per sharing mode. The two modes have independent
-  // sharing options, so they sanitize to different profiles and must not
-  // share a slot: otherwise each mode's encoding clobbers the other's, and a
-  // panel could offer a blob that was encoded for the *other* mode's options.
+  // One encoding slot per (sharing mode, format) pair. The two modes have
+  // independent sharing options, so they sanitize to different profiles and
+  // must not share a slot: otherwise each mode's encoding clobbers the
+  // other's, and a panel could offer a blob that was encoded for the *other*
+  // mode's options. The formats are independent for the same reason: each is
+  // a separate serialization, offered by a different control.
   readonly sanitizedProfileEncodingStates: Record<
     SharingMode,
-    SanitizedProfileEncodingState
+    Record<PublishProfileFormat, SanitizedProfileEncodingState>
   >;
   readonly upload: UploadState;
   readonly isHidingStaleProfile: boolean;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -239,7 +239,14 @@ export type SanitizedProfileEncodingState =
 
 export type PublishState = {
   readonly checkedSharingOptions: Record<SharingMode, CheckedSharingOptions>;
-  readonly sanitizedProfileEncodingState: SanitizedProfileEncodingState;
+  // One encoding slot per sharing mode. The two modes have independent
+  // sharing options, so they sanitize to different profiles and must not
+  // share a slot: otherwise each mode's encoding clobbers the other's, and a
+  // panel could offer a blob that was encoded for the *other* mode's options.
+  readonly sanitizedProfileEncodingStates: Record<
+    SharingMode,
+    SanitizedProfileEncodingState
+  >;
   readonly upload: UploadState;
   readonly isHidingStaleProfile: boolean;
   readonly hasSanitizedProfile: boolean;


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/from-url/https%3A%2F%2Fstorage.googleapis.com%2Fprofiler-get-symbols-fixtures%2FCVdpkviXTEyAJH37VBMTGQ_compact.jslb.gz/calltree/?globalTrackOrder=0&thread=0&v=17) | [Deploy preview](https://deploy-preview-6193--perf-html.netlify.app/from-url/https%3A%2F%2Fstorage.googleapis.com%2Fprofiler-get-symbols-fixtures%2FCVdpkviXTEyAJH37VBMTGQ_compact.jslb.gz/calltree/?globalTrackOrder=0&thread=0&v=17)
<!-- profiler-preview-links:end -->

This is currently blocked until we deploy https://github.com/firefox-devtools/profiler-server/pull/696 on the server side.

I'm also considering waiting a bit more before landing this because the perf difference from encoding to jslb will be more pronounced once we've converted more columns to typed arrays.