### PR TITLE
Fix horizontal overflow when the transform navigator is long

### DIFF
--- a/src/components/app/Details.css
+++ b/src/components/app/Details.css
@@ -5,8 +5,12 @@
   display: flex;
 
   /* If .Details is squished to a very small size between the sidebar and/or bottom bar,
-     don't spill out our contents over those other elements. */
+     don't spill out our contents over those other elements. overflow: clip isn't a
+     scroll container though, so it doesn't zero out the flex automatic minimum size:
+     without min-width: 0, a wide child forces .Details past its container width and
+     overflows the whole viewport. */
   overflow: clip;
+  min-width: 0;
   flex: 1;
   flex-direction: column;
 }


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/public/s0vwpjkw5ydc6k8mav97by9hkv58peqnv9w1jfr/flame-graph/?globalTrackOrder=0&range=2965m1958&thread=0&transforms=df-210~df-1474~df-22~df-996~df-1805~df-422~df-415~df-360~df-387&v=17) | [Deploy preview](https://deploy-preview-6199--perf-html.netlify.app/public/s0vwpjkw5ydc6k8mav97by9hkv58peqnv9w1jfr/flame-graph/?globalTrackOrder=0&range=2965m1958&thread=0&transforms=df-210~df-1474~df-22~df-996~df-1805~df-422~df-415~df-360~df-387&v=17)
<!-- profiler-preview-links:end -->

Fixes #6198 

.Details relied on `overflow: clip` to avoid spilling its contents over neighboring panels. But `overflow: clip` is not a scroll container, so it doesn't zero out the flex automatic minimum size the way a scroll container would. As a flex item of .DetailsContainer, .Details kept its content-based min-width and refused to shrink below the min-content width of its widest child. A long transform navigator then could push .Details past its container, overflowed the `contain: size` DetailsContainer (which doesn't clip), and gave the whole viewport a horizontal scrollbar.

This regressed in #4606, which replaced react-splitter-layout (whose absolutely-positioned panes gave .Details a definite width) with flexbox. That PR added `min-width: 0` to the sidebar wrapper but not to .Details.