### PR TITLE
Allow specifying the stage reliost symbol server

### DIFF
--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -378,6 +378,7 @@ function _shouldAllowSymbolServerUrl(symbolServerUrl: string) {
     const otherAllowedHostnames = [
       'symbols.mozilla.org',
       'symbolication.services.mozilla.com',
+      'stage.reliost.nonprod.webservices.mozgcp.net',
     ];
     if (!otherAllowedHostnames.includes(url.hostname)) {
       console.error(

--- a/src/selectors/url-state.ts
+++ b/src/selectors/url-state.ts
@@ -379,6 +379,7 @@ function _shouldAllowSymbolServerUrl(symbolServerUrl: string) {
       'symbols.mozilla.org',
       'symbolication.services.mozilla.com',
       'stage.reliost.nonprod.webservices.mozgcp.net',
+      'mozilla.symbols.samplyprofiler.com',
     ];
     if (!otherAllowedHostnames.includes(url.hostname)) {
       console.error(


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6228--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

Add `stage.reliost.nonprod.webservices.mozgcp.net` to the list of hosts that are accepted in the `?symbolServer=` arg