### PR TITLE
Deactivate a menu button as soon as its panel is dismissed

### DIFF
--- a/src/components/shared/ButtonWithPanel/index.tsx
+++ b/src/components/shared/ButtonWithPanel/index.tsx
@@ -88,8 +88,6 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
   };
 
   _onPanelClose = () => {
-    this.setState({ open: false });
-
     // Let's focus the delete button after dismissing the dialog, but _only_ if
     // the focus was part of the dialog before.
     // Note this branch isn't tested because jsdom doesn't support the
@@ -116,6 +114,8 @@ export class ButtonWithPanel extends React.PureComponent<Props, State> {
 
   closePanel() {
     if (this._panel && this.state.open) {
+      // Close immediately so the button doesn't stay active while the panel animates out.
+      this.setState({ open: false });
       this._panel.close();
     }
   }

--- a/src/test/components/ButtonWithPanel.test.tsx
+++ b/src/test/components/ButtonWithPanel.test.tsx
@@ -175,4 +175,20 @@ describe('shared/ButtonWithPanel', () => {
     });
     expect(container.querySelector('.arrowPanel.open')).toBe(null);
   });
+
+  it('marks the button as no longer open as soon as the panel starts closing', () => {
+    const { container } = setup();
+
+    fireFullClick(screen.getByText('My Button'));
+    act(() => {
+      jest.runAllTimers();
+    });
+    ensureExists(container.querySelector('.buttonWithPanel.open'));
+
+    fireFullClick(screen.getByText('My Button'));
+
+    // Timers are deliberately not run: the panel is still animating out.
+    expect(container.querySelector('.buttonWithPanel.open')).toBe(null);
+    ensureExists(container.querySelector('.arrowPanel'));
+  });
 });


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/public/3en80jjyhgptn0h87ezdd8bg283taz3frzcr3yr/calltree/?globalTrackOrder=0c978ab5w16&hiddenGlobalTracks=124w689c&hiddenLocalTracksByPid=1173-1~1216-0~1435-0~1439-0&thread=9&v=17) | [Deploy preview](https://deploy-preview-6251--perf-html.netlify.app/public/3en80jjyhgptn0h87ezdd8bg283taz3frzcr3yr/calltree/?globalTrackOrder=0c978ab5w16&hiddenGlobalTracks=124w689c&hiddenLocalTracksByPid=1173-1~1216-0~1435-0~1439-0&thread=9&v=17)
<!-- profiler-preview-links:end -->

The dismissed button kept its active background until ArrowPanel's 400ms closing timeout had run, so two buttons looked active at once. closePanel now clears the open state when the close starts, leaving the animation to ArrowPanel.

Closes #6243

[Profile](https://share.firefox.dev/3S5kGdU)