### PR TITLE
Bump the Gecko profile version to make sure that the Text and Log marker changes are picked up in the frontends

### DIFF
--- a/docs-developer/CHANGELOG-formats.md
+++ b/docs-developer/CHANGELOG-formats.md
@@ -211,6 +211,12 @@ Older versions are not documented in this changelog but can be found in [process
 
 ## Gecko profile format
 
+### Version 36
+
+The `Text` marker's `name` field and the `Log` marker's `message` field are now unique strings, so their payloads hold a string table index instead of the text itself. Both marker schemas declare this with the `unique-string` field format.
+
+No profile format upgrade is needed, as the frontend reads the field format from the marker schema. But older frontends read these two fields directly instead of looking at their schema, so they throw an error while sanitizing the profile for upload and while extracting the MOZ_LOG output. This version bump makes sure that these older frontend versions get updated.
+
 ### Version 35
 
 A new `hexadecimal` marker schema field format type has been added, which displays an integer value in hexadecimal with a `0x` prefix.

--- a/src/app-logic/constants.ts
+++ b/src/app-logic/constants.ts
@@ -7,7 +7,7 @@ import type { MarkerPhase } from 'firefox-profiler/types';
 // The current version of the Gecko profile format.
 // Please don't forget to update the gecko profile format changelog in
 // `docs-developer/CHANGELOG-formats.md`.
-export const GECKO_PROFILE_VERSION = 35;
+export const GECKO_PROFILE_VERSION = 36;
 
 // The current version of the "processed" profile format.
 // Please don't forget to update the processed profile format changelog in

--- a/src/profile-logic/gecko-profile-versioning.ts
+++ b/src/profile-logic/gecko-profile-versioning.ts
@@ -1570,6 +1570,14 @@ const _upgraders: {
     // marker data with hexadecimal typed data, and no modification is needed in the
     // frontend to display older formats.
   },
+  [36]: (_: any) => {
+    // The Text marker's "name" field and the Log marker's "message" field are
+    // now unique strings, so their payloads hold a string table index instead
+    // of the text itself.
+    // No upgrade is needed, as the frontend reads the field format from the
+    // marker schema. This bump is only here so that older frontends, which read
+    // these two fields directly, get updated.
+  },
 
   // If you add a new upgrader here, please document the change in
   // `docs-developer/CHANGELOG-formats.md`.

--- a/src/test/store/__snapshots__/profile-view.test.ts.snap
+++ b/src/test/store/__snapshots__/profile-view.test.ts.snap
@@ -436,7 +436,7 @@ Object {
     "startTime": 0,
     "symbolicated": true,
     "toolkit": "",
-    "version": 35,
+    "version": 36,
   },
   "pages": Array [
     Object {

--- a/src/test/unit/__snapshots__/profile-conversion.test.ts.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.ts.snap
@@ -45,7 +45,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "ART Trace (Android)",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 2686,
@@ -1025,7 +1025,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "ART Trace (Android)",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 5412,
@@ -2308,7 +2308,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 26,
@@ -2700,7 +2700,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 26,
@@ -3089,7 +3089,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 47,
@@ -3190,7 +3190,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 0,
@@ -3543,7 +3543,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 164,
@@ -3608,7 +3608,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 231,
@@ -3762,7 +3762,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Chrome Trace",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 47,
@@ -3820,7 +3820,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Firefox",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 202,
@@ -4210,7 +4210,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Firefox",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 610,
@@ -4268,7 +4268,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Firefox",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 229,
@@ -4326,7 +4326,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Firefox",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 802,
@@ -5322,7 +5322,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "target/debug/examples/work_log (dhat)",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 430,
@@ -5455,7 +5455,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Flamegraph",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 154,
@@ -5513,7 +5513,7 @@ Object {
       "preprocessedProfileVersion": 69,
       "product": "Flamegraph",
       "symbolicated": true,
-      "version": 35,
+      "version": 36,
     },
     "sharedCounts": Object {
       "frames": 5,

--- a/src/test/unit/__snapshots__/profile-upgrading.test.ts.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.ts.snap
@@ -53,7 +53,7 @@ Object {
     "symbolicated": true,
     "toolkit": undefined,
     "updateChannel": undefined,
-    "version": 35,
+    "version": 36,
     "visualMetrics": undefined,
   },
   "pages": Array [],
@@ -4610,7 +4610,7 @@ Object {
     "stackwalk": 1,
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
-    "version": 35,
+    "version": 36,
   },
   "pausedRanges": Array [],
   "processes": Array [
@@ -6086,7 +6086,7 @@ Object {
     "stackwalk": 1,
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
-    "version": 35,
+    "version": 36,
   },
   "pages": Array [
     Object {


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6252--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

The Text marker's `name` and the Log marker's `message` are unique strings now, so their payloads hold a string table index instead of the text.

But we realized that the frontend had some hardcoded assumptions about these marker types, and they weren't looking at the schema at all. That's fixed in #6247.

There is nothing to upgrade because the frontend reads the field format from the marker schema. But since older frontends read these two fields directly, this bump makes sure that they get updated.

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=2054010