### PR TITLE
Avoid stack overflow on large marker threads

### DIFF
--- a/src/profile-query/formatters/marker-info.ts
+++ b/src/profile-query/formatters/marker-info.ts
@@ -161,10 +161,25 @@ export function computeRateStats(markers: Marker[]): RateStats {
   }
 
   const sorted = [...markers].sort((a, b) => a.start - b.start);
-  const gaps: number[] = [];
 
+  // Accumulate the gap statistics in a single pass. Do not build an array of
+  // gaps and spread it into Math.min/Math.max: a spread passes one argument per
+  // element, which blows the stack ("Maximum call stack size exceeded") once a
+  // marker name has more than ~100k markers in it, as happens on the parent
+  // process main thread of a long profile.
+  let minGap = Infinity;
+  let maxGap = -Infinity;
+  let gapSum = 0;
+  const gapCount = sorted.length - 1;
   for (let i = 1; i < sorted.length; i++) {
-    gaps.push(sorted[i].start - sorted[i - 1].start);
+    const gap = sorted[i].start - sorted[i - 1].start;
+    if (gap < minGap) {
+      minGap = gap;
+    }
+    if (gap > maxGap) {
+      maxGap = gap;
+    }
+    gapSum += gap;
   }
 
   const timeRange = sorted[sorted.length - 1].start - sorted[0].start;
@@ -174,9 +189,9 @@ export function computeRateStats(markers: Marker[]): RateStats {
 
   return {
     markersPerSecond,
-    minGap: Math.min(...gaps),
-    avgGap: gaps.reduce((a, b) => a + b, 0) / gaps.length,
-    maxGap: Math.max(...gaps),
+    minGap,
+    avgGap: gapSum / gapCount,
+    maxGap,
   };
 }
 

--- a/src/test/unit/profile-query/marker-utils.test.ts
+++ b/src/test/unit/profile-query/marker-utils.test.ts
@@ -220,6 +220,28 @@ describe('marker-info utility functions', function () {
       expect(stats.avgGap).toBe(50);
       expect(stats.maxGap).toBe(100);
     });
+
+    it('handles more markers than fit in a spread call', function () {
+      // The gap statistics used to be computed with Math.min(...gaps) /
+      // Math.max(...gaps), which throws "Maximum call stack size exceeded"
+      // above roughly 100k elements. The parent process main thread of a long
+      // profile easily has that many markers with the same name.
+      const count = 300000;
+      const markers = Array.from({ length: count }, (_, i) =>
+        makeMarker(i * 2, null)
+      );
+      // Make one gap smaller and one larger than the uniform 2ms gap.
+      markers[1] = makeMarker(1, null);
+      markers[count - 1] = makeMarker((count - 2) * 2 + 10, null);
+
+      const stats = computeRateStats(markers);
+      expect(stats.minGap).toBe(1);
+      expect(stats.maxGap).toBe(10);
+      expect(stats.avgGap).toBeCloseTo(
+        ((count - 2) * 2 + 10) / (count - 1),
+        10
+      );
+    });
   });
 
   describe('collectThreadMarkers', function () {
@@ -272,6 +294,41 @@ describe('marker-info utility functions', function () {
           count: 1,
         }),
       ]);
+    });
+
+    it('aggregates a thread with more markers than fit in a spread call', function () {
+      // Regression test: `thread markers` on the parent process main thread of
+      // a long profile used to fail with "Maximum call stack size exceeded"
+      // because the per-name gap statistics were computed by spreading the gap
+      // array into Math.min/Math.max.
+      const count = 150000;
+      const markers: TestDefinedMarker[] = Array.from(
+        { length: count },
+        (_, i) => ['NotifyObservers', i * 2, i * 2 + 1] as TestDefinedMarker
+      );
+      const profile = getProfileWithMarkers(markers);
+      const store = storeWithProfile(profile);
+      const threadMap = new ThreadMap();
+      const markerMap = new MarkerMap();
+
+      const result = collectThreadMarkers(store, threadMap, markerMap);
+      expect(result.totalMarkerCount).toBe(count);
+      expect(result.byType).toHaveLength(1);
+      expect(result.byType[0].markerName).toBe('NotifyObservers');
+      expect(result.byType[0].count).toBe(count);
+      expect(result.byType[0].rateStats?.minGap).toBe(2);
+      expect(result.byType[0].rateStats?.maxGap).toBe(2);
+    });
+
+    it('reports an unknown thread handle as-is', function () {
+      const profile = getProfileWithMarkers([['A', 0, 1]]);
+      const store = storeWithProfile(profile);
+      const threadMap = new ThreadMap();
+      const markerMap = new MarkerMap();
+
+      expect(() =>
+        collectThreadMarkers(store, threadMap, markerMap, 't-999')
+      ).toThrow(/^Unknown thread t-999$/);
     });
 
     it('reports the raw categoryIndex in byCategory (not recovered by name)', function () {


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6264--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

thread markers on a thread with over ~1M markers failed with "Maximum call stack size exceeded". The cause was computeRateStats spreading its per-name gap array into Math.min/Math.max: an argument spread pushes one argument per element and V8 overflows around 100k. aggregateMarkersByName calls it once per marker name, so the trigger is the largest name group, not the thread size.

Reduce the gaps to min/avg/max in a single pass with no intermediate array, and wrap the whole-thread aggregation so that any remaining failure points at --search / --min-duration / --category, which narrow the same query.