### PR TITLE
profiler-cli: report one time base for text and JSON output

### DIFF
--- a/profiler-cli/src/formatters.ts
+++ b/profiler-cli/src/formatters.ts
@@ -317,8 +317,7 @@ Stack trace for marker ${result.markerHandle}: ${result.markerName}\n`;
   }
 
   if (result.stack.capturedAt !== undefined) {
-    const rootStart = result.context.rootRange.start;
-    output += `\nCaptured at: ${formatDuration(result.stack.capturedAt - rootStart)}\n`;
+    output += `\nCaptured at: ${formatDuration(result.stack.capturedAt)}\n`;
   }
 
   for (let i = 0; i < result.stack.frames.length; i++) {
@@ -352,11 +351,9 @@ Marker ${result.markerHandle}: ${result.name}`;
   output += `Type: ${result.markerType ?? 'None'}\n`;
   output += `Category: ${result.category.name}\n`;
 
-  // Time and duration (relative to profile root start)
-  const rootStart = result.context.rootRange.start;
-  const startStr = formatDuration(result.start - rootStart);
+  const startStr = formatDuration(result.start);
   if (result.end !== null) {
-    const endStr = formatDuration(result.end - rootStart);
+    const endStr = formatDuration(result.end);
     const durationStr = formatDuration(result.duration!);
     output += `Time: ${startStr} - ${endStr} (${durationStr})\n`;
   } else {
@@ -383,7 +380,7 @@ Marker ${result.markerHandle}: ${result.name}`;
   if (result.stack && result.stack.frames.length > 0) {
     output += '\nStack trace:\n';
     if (result.stack.capturedAt !== undefined) {
-      output += `  Captured at: ${formatDuration(result.stack.capturedAt - rootStart)}\n`;
+      output += `  Captured at: ${formatDuration(result.stack.capturedAt)}\n`;
     }
 
     for (let i = 0; i < result.stack.frames.length; i++) {
@@ -770,9 +767,8 @@ export function formatCounterInfoResult(
     `  Samples: ${result.sampleCount} total, ${result.rangeSampleCount} in current range`
   );
   if (result.rangeStart !== null && result.rangeEnd !== null) {
-    const zeroAt = result.context.rootRange.start;
     lines.push(
-      `  Time span: ${formatDuration(result.rangeStart - zeroAt)} → ${formatDuration(result.rangeEnd - zeroAt)}`
+      `  Time span: ${formatDuration(result.rangeStart)} → ${formatDuration(result.rangeEnd)}`
     );
   }
   if (result.stats.length > 0) {
@@ -1151,10 +1147,9 @@ export function formatThreadMarkersResult(
 
   // Flat list mode: one row per marker in chronological order
   if (result.flatMarkers) {
-    const rootStart = result.context.rootRange.start;
     for (const m of result.flatMarkers) {
       const stackIndicator = m.hasStack ? '✓' : '✗';
-      const startStr = `t=${formatDuration(m.start - rootStart)}`;
+      const startStr = `t=${formatDuration(m.start)}`;
       const durationStr =
         m.duration !== undefined ? formatDuration(m.duration) : 'instant';
       const labelSuffix = m.label !== m.name ? `  ${m.label}` : '';

--- a/profiler-cli/src/test/unit/counter-formatting.test.ts
+++ b/profiler-cli/src/test/unit/counter-formatting.test.ts
@@ -168,7 +168,7 @@ describe('formatCounterListResult', function () {
 
 describe('formatCounterInfoResult', function () {
   function makeInfo(
-    overrides: Partial<CounterInfoResult> = {}
+    overrides: Partial<WithContext<CounterInfoResult>> = {}
   ): WithContext<CounterInfoResult> {
     return {
       context: createContext(),
@@ -194,6 +194,19 @@ describe('formatCounterInfoResult', function () {
     expect(output).toContain('Main thread: t-0 (GeckoMain)');
     expect(output).toContain('Description: Amount of allocated memory');
     expect(output).toContain('memory range in graph: 27B');
+  });
+
+  // As above: already profile-start-relative, so "Time span" prints verbatim.
+  it('renders the time span verbatim, without re-subtracting rootRange.start', function () {
+    const output = formatCounterInfoResult(
+      makeInfo({
+        context: { ...createContext(), rootRange: { start: 9.2, end: 3000 } },
+        rangeStart: 91.81,
+        rangeEnd: 200,
+      })
+    );
+    expect(output).toContain('Time span: 91.810ms');
+    expect(output).not.toContain('82.610ms'); // 91.81 - 9.2, if subtracted twice
   });
 
   it('shows a CO2e estimate next to a stat when present', function () {

--- a/profiler-cli/src/test/unit/marker-formatting.test.ts
+++ b/profiler-cli/src/test/unit/marker-formatting.test.ts
@@ -20,7 +20,7 @@ function createContext(): SessionContext {
 }
 
 function makeResult(
-  overrides: Partial<ThreadMarkersResult> = {}
+  overrides: Partial<WithContext<ThreadMarkersResult>> = {}
 ): WithContext<ThreadMarkersResult> {
   return {
     context: createContext(),
@@ -146,6 +146,22 @@ describe('formatThreadMarkersResult flat list mode', function () {
     const output = formatThreadMarkersResult(result);
     expect(output).not.toContain('By Name');
     expect(output).not.toContain('By Category');
+  });
+
+  // `start` is already profile-start-relative, so `t=` must print it verbatim.
+  // Needs a non-zero `rootRange.start`: at the 0 used elsewhere in this file, a
+  // second subtraction would be invisible.
+  it('renders the flat marker start verbatim, without re-subtracting rootRange.start', function () {
+    const result = makeResult({
+      context: { ...createContext(), rootRange: { start: 9.2, end: 3000 } },
+      filteredMarkerCount: 1,
+      flatMarkers: [makeFlat({ handle: 'm-1', start: 549.34 })],
+    });
+
+    const output = formatThreadMarkersResult(result);
+    const line = output.split('\n').find((l) => l.includes('m-1'))!;
+    expect(line).toContain('t=549.34ms');
+    expect(line).not.toContain('540.14ms'); // 549.34 - 9.2, if subtracted twice
   });
 });
 

--- a/src/profile-query/formatters/counter-info.ts
+++ b/src/profile-query/formatters/counter-info.ts
@@ -9,6 +9,7 @@ import {
   getCommittedRange,
   getProfileInterval,
   getMeta,
+  getZeroAt,
 } from 'firefox-profiler/selectors/profile';
 import {
   formatBytes,
@@ -538,11 +539,15 @@ export function collectCounterInfo(
     counterIndex
   );
 
-  // Sample times are already in absolute profile-time space (the same space as
-  // the committed range), so they need no zeroAt offset here.
+  // The indexes above are raw profile time; only what we report is rebased.
+  const zeroAt = getZeroAt(state);
   const hasRange = rangeEndIndex > rangeStartIndex;
-  const rangeStart = hasRange ? counter.samples.time[rangeStartIndex] : null;
-  const rangeEnd = hasRange ? counter.samples.time[rangeEndIndex - 1] : null;
+  const rangeStart = hasRange
+    ? counter.samples.time[rangeStartIndex] - zeroAt
+    : null;
+  const rangeEnd = hasRange
+    ? counter.samples.time[rangeEndIndex - 1] - zeroAt
+    : null;
 
   return {
     ...summary,

--- a/src/profile-query/formatters/marker-info.ts
+++ b/src/profile-query/formatters/marker-info.ts
@@ -13,6 +13,7 @@ import {
   getMarkerSchemaByName,
   getStringTable,
   getCommittedRange,
+  getZeroAt,
 } from 'firefox-profiler/selectors/profile';
 import {
   intervalUnionMs,
@@ -707,6 +708,9 @@ export function collectThreadMarkers(
     const categories = getCategories(state);
     const markerSchemaByName = getMarkerSchemaByName(state);
     const stringTable = getStringTable(state);
+    // Usually non-zero (earliest sample or marker across all threads), so
+    // reporting a raw marker time leaks that offset.
+    const zeroAt = getZeroAt(state);
 
     // Get marker indexes scoped to the committed (zoom) range. When a search is
     // active we use the search-filtered set, which is itself built on top of the
@@ -774,7 +778,7 @@ export function collectThreadMarkers(
       );
 
       // Add markerIndex to topMarkers in groups
-      customGroups = addMarkerIndexToGroups(groups);
+      customGroups = addMarkerIndexToGroups(groups, zeroAt);
     }
 
     // Aggregate by type (with optional auto-grouping)
@@ -801,12 +805,12 @@ export function collectThreadMarkers(
       topMarkers: stats.topMarkers.map((m) => ({
         handle: m.handle,
         label: m.label,
-        start: m.start,
+        start: m.start - zeroAt,
         duration: m.duration,
         hasStack: m.hasStack,
       })),
       subGroups: stats.subGroups
-        ? addMarkerIndexToGroups(stats.subGroups)
+        ? addMarkerIndexToGroups(stats.subGroups, zeroAt)
         : undefined,
       subGroupKey: stats.subGroupKey,
     }));
@@ -864,7 +868,7 @@ export function collectThreadMarkers(
           handle,
           name: marker.name,
           label: label || marker.name,
-          start: marker.start,
+          start: marker.start - zeroAt,
           duration,
           hasStack,
           category: categoryName,
@@ -896,7 +900,10 @@ export function collectThreadMarkers(
 /**
  * Helper to add markerIndex to topMarkers in MarkerGroup arrays.
  */
-function addMarkerIndexToGroups(groups: MarkerGroup[]): MarkerGroupData[] {
+function addMarkerIndexToGroups(
+  groups: MarkerGroup[],
+  zeroAt: number
+): MarkerGroupData[] {
   return groups.map((group) => ({
     groupName: group.groupName,
     count: group.count,
@@ -906,12 +913,12 @@ function addMarkerIndexToGroups(groups: MarkerGroup[]): MarkerGroupData[] {
     topMarkers: group.topMarkers.map((m) => ({
       handle: m.handle,
       label: m.label,
-      start: m.start,
+      start: m.start - zeroAt,
       duration: m.duration,
       hasStack: m.hasStack,
     })),
     subGroups: group.subGroups
-      ? addMarkerIndexToGroups(group.subGroups)
+      ? addMarkerIndexToGroups(group.subGroups, zeroAt)
       : undefined,
   }));
 }
@@ -996,7 +1003,13 @@ export function collectMarkerStack(
   let stack: StackTraceData | null = null;
   if (marker.data && 'cause' in marker.data && marker.data.cause) {
     const cause = marker.data.cause;
-    stack = collectStackTrace(cause.stack, thread, libs, cause.time);
+    const zeroAt = getZeroAt(state);
+    stack = collectStackTrace(
+      cause.stack,
+      thread,
+      libs,
+      cause.time !== undefined ? cause.time - zeroAt : undefined
+    );
   }
 
   return {
@@ -1036,6 +1049,7 @@ export function collectMarkerInfo(
   const markerSchemaByName = getMarkerSchemaByName(state);
   const stringTable = getStringTable(state);
   const threadHandleDisplay = threadMap.handleForThreadIndexes(threadIndexes);
+  const zeroAt = getZeroAt(state);
 
   // Get tooltip label
   const getTooltipLabel = getLabelGetter(
@@ -1093,7 +1107,12 @@ export function collectMarkerInfo(
     const thread = threadSelectors.getFilteredThread(state);
     const libs = profile.libs;
 
-    const fullStack = collectStackTrace(cause.stack, thread, libs, cause.time);
+    const fullStack = collectStackTrace(
+      cause.stack,
+      thread,
+      libs,
+      cause.time !== undefined ? cause.time - zeroAt : undefined
+    );
     if (fullStack && fullStack.frames.length > 0) {
       // Truncate to 20 frames
       const truncated = fullStack.frames.length > 20;
@@ -1118,8 +1137,8 @@ export function collectMarkerInfo(
       index: marker.category,
       name: categories[marker.category]?.name ?? 'Unknown',
     },
-    start: marker.start,
-    end: marker.end,
+    start: marker.start - zeroAt,
+    end: marker.end !== null ? marker.end - zeroAt : null,
     duration: marker.end !== null ? marker.end - marker.start : undefined,
     fields,
     schema: schemaInfo,

--- a/src/profile-query/types.ts
+++ b/src/profile-query/types.ts
@@ -20,7 +20,7 @@ import type {
 export type TopMarker = {
   handle: string;
   label: string;
-  start: number;
+  start: number; // Milliseconds since the profile start (`rootRange.start`)
   duration?: number;
   hasStack?: boolean;
 };
@@ -50,7 +50,7 @@ export type FlatMarkerItem = {
   handle: string;
   name: string;
   label: string; // Schema-derived table label (may equal name if no schema)
-  start: number; // Absolute milliseconds
+  start: number; // Milliseconds since the profile start (`rootRange.start`)
   duration?: number; // Milliseconds if interval marker
   hasStack: boolean;
   category: string;
@@ -122,6 +122,7 @@ export type SessionContext = {
     end: number;
     endName: string;
   } | null; // null if viewing full profile
+  // Deliberately NOT rebased: this is the origin the other times subtract.
   rootRange: {
     start: number;
     end: number;
@@ -681,7 +682,7 @@ export type MarkerInfoResult = {
     index: number;
     name: string;
   };
-  start: number;
+  start: number; // Ms since the profile start, as in `FlatMarkerItem`
   end: number | null;
   duration?: number;
   fields?: Array<{
@@ -707,7 +708,7 @@ export type MarkerStackResult = {
 };
 
 export type StackTraceData = {
-  capturedAt?: number;
+  capturedAt?: number; // Milliseconds since the profile start (`rootRange.start`)
   frames: FunctionDisplayInfo[];
   truncated: boolean;
 };
@@ -851,8 +852,9 @@ export type CounterInfoResult = CounterSummary & {
   type: 'counter-info';
   description: string;
   sampleCount: number; // total samples in the counter (whole profile)
-  rangeStart: number | null; // absolute time of first in-range sample
-  rangeEnd: number | null; // absolute time of last in-range sample
+  // First/last in-range sample, ms since the profile start.
+  rangeStart: number | null;
+  rangeEnd: number | null;
   overTime: CounterTimeBucket[]; // per-bucket values across the current view
 };
 

--- a/src/test/unit/profile-query/marker-utils.test.ts
+++ b/src/test/unit/profile-query/marker-utils.test.ts
@@ -461,8 +461,9 @@ describe('collectMarkerInfo', function () {
     expect(result.type).toBe('marker-info');
     expect(result.name).toBe('DOMEvent');
     expect(result.markerType).toBe('DOMEvent');
-    expect(result.start).toBe(10);
-    expect(result.end).toBe(30);
+    // `zeroAt` is the first marker at 10ms, so this one starts at 0.
+    expect(result.start).toBe(0);
+    expect(result.end).toBe(20);
     expect(result.duration).toBe(20);
     expect(result.fields).toBeDefined();
     const eventTypeField = result.fields!.find((f) => f.key === 'eventType');
@@ -598,7 +599,8 @@ describe('collectThreadMarkers list option', function () {
     const m = result.flatMarkers![0];
     expect(m.handle).toMatch(/^m-/);
     expect(m.name).toBe('DOMEvent');
-    expect(m.start).toBe(5);
+    // Relative to the profile start, which is the only marker's start (5ms).
+    expect(m.start).toBe(0);
     expect(m.duration).toBe(10);
     expect(m.hasStack).toBe(false);
     expect(m.category).toBeDefined();
@@ -726,6 +728,149 @@ describe('collectMarkerStack', function () {
     expect(result.stack!.frames.length).toBeGreaterThan(0);
     // Leaf frame first
     expect(result.stack!.frames[0].name).toBe('leafFunc');
+  });
+});
+
+// Marker times are ms since the profile start (`zeroAt`), never raw timestamps.
+describe('marker time base', function () {
+  // The earliest marker sits here, so `zeroAt` is 1000: reported times are
+  // 1000ms below the raw ones.
+  const ZERO_AT = 1000;
+
+  function setup() {
+    return setupWithMarkers([
+      ['Anchor', ZERO_AT, null, { type: 'Text', name: 'Anchor' }],
+      [
+        'DOMEvent',
+        ZERO_AT + 500,
+        ZERO_AT + 520,
+        { type: 'DOMEvent', eventType: 'keydown', latency: 1 },
+      ],
+    ]);
+  }
+
+  it('reports flatMarkers start relative to the profile start', function () {
+    const { store, threadMap, markerMap } = setup();
+
+    const result = collectThreadMarkers(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      { list: true }
+    );
+
+    const starts = result.flatMarkers!.map((m) => m.start);
+    expect(starts).toEqual([0, 500]);
+  });
+
+  it('reports topMarkers start relative to the profile start', function () {
+    const { store, threadMap, markerMap } = setup();
+
+    const result = collectThreadMarkers(store, threadMap, markerMap);
+
+    const domEvent = result.byType.find((s) => s.markerName === 'DOMEvent');
+    expect(domEvent!.topMarkers[0].start).toBe(500);
+  });
+
+  it('reports grouped topMarkers start relative to the profile start', function () {
+    const { store, threadMap, markerMap } = setup();
+
+    const result = collectThreadMarkers(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      { groupBy: 'name' }
+    );
+
+    const domEvent = result.customGroups!.find(
+      (g) => g.groupName === 'DOMEvent'
+    );
+    expect(domEvent!.topMarkers[0].start).toBe(500);
+  });
+
+  it('reports markerInfo start and end relative to the profile start', function () {
+    const { store, threadMap, markerMap, registerMarker } = setup();
+    const handle = registerMarker(1);
+
+    const result = collectMarkerInfo(store, markerMap, threadMap, handle);
+
+    expect(result.start).toBe(500);
+    expect(result.end).toBe(520);
+    // The duration is a difference, so the time base cancels out.
+    expect(result.duration).toBe(20);
+  });
+
+  it('reports the flat list and markerInfo on the same time base', function () {
+    const { store, threadMap, markerMap, registerMarker } = setup();
+    const handle = registerMarker(1);
+
+    const listResult = collectThreadMarkers(
+      store,
+      threadMap,
+      markerMap,
+      undefined,
+      { list: true }
+    );
+    const infoResult = collectMarkerInfo(store, markerMap, threadMap, handle);
+
+    const listed = listResult.flatMarkers!.find((m) => m.handle === handle);
+    expect(listed!.start).toBe(infoResult.start);
+    // Both paths read the same `zeroAt`, so agreement alone would pass even
+    // unrebased. Pin the value too.
+    expect(listed!.start).toBe(500);
+  });
+
+  it('reports the stack capturedAt relative to the profile start', function () {
+    const { profile } = getProfileFromTextSamples(`
+      rootFunc
+      leafFunc
+    `);
+    const thread = profile.threads[0];
+    const stackIndex = thread.samples.stack[0];
+
+    if (stackIndex === null || stackIndex === undefined) {
+      throw new Error('Expected a non-null stack index from text samples');
+    }
+
+    // Without this the profile starts at 0 and the two bases coincide.
+    const { time } = thread.samples;
+    if (time === undefined) {
+      throw new Error('Expected the text-sample thread to have sample times');
+    }
+    thread.samples.time = time.map((t) => t + ZERO_AT);
+
+    const stringTable = StringTable.withBackingArray(
+      profile.shared.stringArray
+    );
+    const markerNameIdx = stringTable.indexForString('TestMarker');
+    const markers = getRawMarkerTableBuilderFromExisting(thread.markers);
+    thread.markers = markers;
+    markers.name.push(markerNameIdx);
+    markers.startTime.push(ZERO_AT + 30);
+    markers.endTime.push(ZERO_AT + 50);
+    markers.phase.push(INTERVAL);
+    markers.category.push(0);
+    markers.data.push({
+      type: 'Text',
+      name: 'TestMarker',
+      cause: { stack: stackIndex, time: ZERO_AT + 30 },
+    });
+    markers.length++;
+
+    const store = storeWithProfile(profile);
+    const threadMap = new ThreadMap();
+    const markerMap = new MarkerMap();
+    threadMap.handleForThreadIndex(0);
+    const handle = markerMap.handleForMarker(new Set([0]), 0);
+
+    const stackResult = collectMarkerStack(store, markerMap, threadMap, handle);
+    const infoResult = collectMarkerInfo(store, markerMap, threadMap, handle);
+
+    expect(stackResult.stack!.capturedAt).toBe(30);
+    expect(infoResult.start).toBe(30);
+    expect(infoResult.stack!.capturedAt).toBe(30);
   });
 });
 

--- a/src/test/unit/profile-query/profile-querier.test.ts
+++ b/src/test/unit/profile-query/profile-querier.test.ts
@@ -573,7 +573,9 @@ describe('ProfileQuerier', function () {
       const info = await querierFor(profile).counterInfo('c-0');
 
       expect(info.rangeStart).not.toBeNull();
-      expect(info.rangeStart! - info.context.rootRange.start).toBe(0);
+      // The first sample sits at the profile start, so this is 0, not 1000.
+      expect(info.rangeStart).toBe(0);
+      expect(info.context.rootRange.start).toBe(1000);
     });
 
     it('excludes the padded boundary samples when zoomed', async function () {


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6266--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

Marker times in --list text and --json disagreed by a constant rootRange.start (9.2ms on a CI profile), because the text path subtracted the profile start and the raw JSON path did not. Both now report milliseconds since profile start, matching what profiler.firefox.com displays.

Also applies the same fix to counter info, which had the identical text-vs-JSON contradiction.