### PR TITLE
profiler-cli: record a session owner and refuse to stop others' sessions

### DIFF
--- a/profiler-cli/guide.txt
+++ b/profiler-cli/guide.txt
@@ -408,7 +408,9 @@ SCRIPTING
 
   When using profiler-cli in scripts or pipelines:
 
-  Always use a named session for isolation:
+  Always use a named session for isolation, and set PROFILER_CLI_SESSION_OWNER
+  so "stop" refuses sessions that are not yours:
+    export PROFILER_CLI_SESSION_OWNER=my-script
     profiler-cli load profile.json.gz --session my-analysis
     profiler-cli profile info --session my-analysis
     profiler-cli thread select t-0 --session my-analysis
@@ -442,11 +444,19 @@ SESSION MANAGEMENT
     profiler-cli session use <id>                           Switch the current session
     profiler-cli stop                                       Stop the current session
     profiler-cli stop <id>                                  Stop a specific session
-    profiler-cli stop --all                                 Stop all sessions
+    profiler-cli stop --all                                 Stop all sessions you own
+    profiler-cli stop <id> --force                          Stop a session owned by someone else
     profiler-cli load profile.json.gz --session my-session   Named session
     profiler-cli load profile.json.gz --symbol-server <url>  Override symbol server (else ?symbolServer= URL param or Mozilla default)
     profiler-cli thread info --session my-session            Query a specific session
 
+  Sessions in one directory are shared by every profiler-cli process, so each
+  records its creator and "stop" refuses sessions that are not yours (exit 1,
+  naming the owner); --force overrides. Set PROFILER_CLI_SESSION_OWNER to name
+  yourself, otherwise the owner is the parent process id -- so a "stop" from a
+  different live shell is refused. A pid owner is released once that process
+  exits, since detached daemons outlive the shell that started them; a named
+  owner is never released. See "profiler-cli stop --help".
 
 ERROR HANDLING
 

--- a/profiler-cli/src/client.ts
+++ b/profiler-cli/src/client.ts
@@ -15,6 +15,7 @@ import type {
   ClientMessage,
   ServerResponse,
   CommandResult,
+  SessionMetadata,
 } from './protocol';
 import {
   cleanupIfDaemonGone,
@@ -22,9 +23,14 @@ import {
   generateSessionId,
   getCurrentSessionId,
   getCurrentSocketPath,
+  describeSessionOwner,
   getLogPath,
   getLogSize,
+  getSessionAge,
+  getSessionOwner,
   getSocketPath,
+  ownsSession,
+  SESSION_OWNER_ENV_VAR,
   getStartupErrorPath,
   isDaemonReachable,
   loadSessionMetadata,
@@ -508,7 +514,13 @@ export async function startNewDaemon(
     {
       detached: true,
       stdio: 'ignore', // Don't pipe stdin/stdout/stderr
-      env: { ...process.env, PROFILER_CLI_SESSION_DIR: sessionDir }, // Pass sessionDir via env
+      env: {
+        ...process.env,
+        PROFILER_CLI_SESSION_DIR: sessionDir, // Pass sessionDir via env
+        // Resolved here, not in the daemon: the fallback is the parent pid, and
+        // the daemon's parent is this process, which is about to exit.
+        [SESSION_OWNER_ENV_VAR]: getSessionOwner(),
+      },
     }
   );
 
@@ -678,16 +690,53 @@ export async function startNewDaemon(
   );
 }
 
+/** One line describing a session about to be stopped: which, whose, how old. */
+export function describeSessionForStop(metadata: SessionMetadata): string {
+  const age = getSessionAge(metadata);
+  return [
+    `${metadata.id}`,
+    `owner ${describeSessionOwner(metadata)}`,
+    `daemon pid ${metadata.pid}`,
+    ...(age === null ? [] : [`age ${age}`]),
+  ].join(', ');
+}
+
+/** Thrown when `stop` is asked to stop somebody else's session. */
+export class SessionNotOwnedError extends Error {
+  readonly metadata: SessionMetadata;
+
+  constructor(metadata: SessionMetadata, owner: string) {
+    const recorded = describeSessionOwner(metadata);
+    // A refused pid owner is still running, so pointing at it beats telling the
+    // caller to adopt a live process's identity by guessing its number.
+    const advice = recorded.startsWith('pid:')
+      ? `The owning process (${recorded.slice('pid:'.length)}) still appears to be running. Pass --force to stop the session anyway.`
+      : `Pass --force to stop it anyway, or set ${SESSION_OWNER_ENV_VAR}=${recorded} if these sessions are yours.`;
+    super(
+      [
+        `Session ${metadata.id} belongs to ${recorded}, not to you (${owner}), so it was not stopped.`,
+        `  ${describeSessionForStop(metadata)}`,
+        advice,
+      ].join('\n')
+    );
+    this.name = 'SessionNotOwnedError';
+    this.metadata = metadata;
+  }
+}
+
 /**
  * Stop a running daemon.
  *
  * Only reports success once the daemon is known to be gone. One that merely
  * cannot be reached may still be running, and saying it stopped would leave
  * the user with a process no command can find.
+ *
+ * Refuses sessions created by a different owner unless `force` is set.
  */
 export async function stopDaemon(
   sessionDir: string,
-  sessionId?: string
+  sessionId?: string,
+  options: { force?: boolean; announce?: boolean } = {}
 ): Promise<void> {
   const resolvedSessionId = sessionId || getCurrentSessionId(sessionDir);
 
@@ -700,6 +749,15 @@ export async function stopDaemon(
     cleanupSession(sessionDir, resolvedSessionId);
     console.log(`Session ${resolvedSessionId} was not running.`);
     return;
+  }
+
+  const owner = getSessionOwner();
+  if (!options.force && !ownsSession(metadata, owner)) {
+    throw new SessionNotOwnedError(metadata, owner);
+  }
+
+  if (options.announce) {
+    console.log(`Stopping session ${describeSessionForStop(metadata)}`);
   }
 
   try {

--- a/profiler-cli/src/commands/session.ts
+++ b/profiler-cli/src/commands/session.ts
@@ -12,9 +12,13 @@ import { wasExplicit } from './shared';
 import {
   cleanupIfDaemonGone,
   cleanupSession,
+  describeSessionOwner,
   getCurrentSessionId,
+  getSessionAge,
+  getSessionOwner,
   listSessions,
   loadSessionMetadata,
+  ownsSession,
   setCurrentSession,
   validateSession,
 } from '../session';
@@ -35,7 +39,7 @@ export function registerSessionCommand(
 
   session
     .command('list', { isDefault: true })
-    .description('List all running daemon sessions')
+    .description('List all running daemon sessions, with their owner and age')
     .action(async () => {
       const sessionIds = listSessions(sessionDir);
       let numCleaned = 0;
@@ -90,12 +94,15 @@ export function registerSessionCommand(
       );
 
       const currentSessionId = getCurrentSessionId(sessionDir);
+      const owner = getSessionOwner();
       console.log(`Found ${runningSessionMetadata.length} running sessions:`);
       for (const metadata of runningSessionMetadata) {
         const isCurrent = metadata.id === currentSessionId;
         const marker = isCurrent ? '* ' : '  ';
+        const age = getSessionAge(metadata);
+        const mine = ownsSession(metadata, owner) ? ' (yours)' : '';
         console.log(
-          `${marker}${metadata.id}, created at ${metadata.createdAt} [daemon pid: ${metadata.pid}]`
+          `${marker}${metadata.id}, created at ${metadata.createdAt}${age === null ? '' : ` (${age} ago)`} [owner: ${describeSessionOwner(metadata)}${mine}, daemon pid: ${metadata.pid}]`
         );
       }
 
@@ -106,7 +113,7 @@ export function registerSessionCommand(
         );
         for (const { metadata, error } of unreachableSessions) {
           console.log(
-            `  ${metadata.id} [daemon pid: ${metadata.pid}]: ${toErrorMessage(error)}`
+            `  ${metadata.id} [owner: ${describeSessionOwner(metadata)}, daemon pid: ${metadata.pid}]: ${toErrorMessage(error)}`
           );
         }
         if (unreachableSessions.some(({ error }) => isPermissionErrno(error))) {
@@ -124,7 +131,9 @@ export function registerSessionCommand(
 
   session
     .command('use <id>')
-    .description('Switch the current session')
+    .description(
+      'Switch the current session (shared with every caller of this session directory)'
+    )
     .action(async (sessionId: string) => {
       const metadata = await validateSession(sessionDir, sessionId);
       if (metadata === null) {
@@ -135,5 +144,16 @@ export function registerSessionCommand(
       }
       setCurrentSession(sessionDir, sessionId);
       console.log(`Switched to session ${sessionId}`);
+      // Switching this pointer also redirects other callers' unqualified
+      // commands, so warn rather than doing it silently.
+      const owner = getSessionOwner();
+      if (!ownsSession(metadata, owner)) {
+        console.log(
+          `Note: session ${sessionId} is owned by ${describeSessionOwner(metadata)}, not you (${owner}).`
+        );
+      }
+      console.log(
+        'Note: the current session is shared state for this session directory. Pass --session <id> instead to avoid affecting other callers.'
+      );
     });
 }

--- a/profiler-cli/src/daemon.ts
+++ b/profiler-cli/src/daemon.ts
@@ -21,6 +21,7 @@ import type {
 } from './protocol';
 import {
   generateSessionId,
+  getSessionOwner,
   getSocketPath,
   getLogPath,
   saveSessionMetadata,
@@ -78,17 +79,22 @@ export class Daemon {
   private profileLoadError: string | null = null;
   private isListening: boolean = false;
   private hasPublishedMetadata: boolean = false;
+  private owner: string;
 
   constructor(
     sessionDir: string,
     profilePath: string,
     sessionId?: string,
-    symbolServerUrl?: string
+    symbolServerUrl?: string,
+    owner?: string
   ) {
     this.sessionDir = sessionDir;
     this.profilePath = profilePath;
     this.sessionId = sessionId || generateSessionId();
     this.symbolServerUrl = symbolServerUrl;
+    // The client passes the owner in the spawn environment; the fallback is
+    // only for a daemon started by hand with --daemon.
+    this.owner = owner ?? getSessionOwner();
     this.socketPath = getSocketPath(sessionDir, this.sessionId);
     this.logPath = getLogPath(sessionDir, this.sessionId);
 
@@ -226,6 +232,7 @@ export class Daemon {
         profilePath: this.profilePath,
         createdAt: new Date().toISOString(),
         buildHash: BUILD_HASH,
+        owner: this.owner,
       };
       try {
         saveSessionMetadata(this.sessionDir, metadata);
@@ -601,13 +608,15 @@ export async function startDaemon(
   sessionDir: string,
   profilePath: string,
   sessionId?: string,
-  symbolServerUrl?: string
+  symbolServerUrl?: string,
+  owner?: string
 ): Promise<void> {
   const daemon = new Daemon(
     sessionDir,
     profilePath,
     sessionId,
-    symbolServerUrl
+    symbolServerUrl,
+    owner
   );
   await daemon.start();
 }

--- a/profiler-cli/src/index.ts
+++ b/profiler-cli/src/index.ts
@@ -10,7 +10,7 @@
  *   profiler-cli profile info [--session <id>]         Print profile summary
  *   profiler-cli thread info [--thread <handle>]       Print thread information
  *   profiler-cli thread samples [--thread <handle>]    Show thread call tree and top functions
- *   profiler-cli stop [<id>] [--all]                   Stop the daemon
+ *   profiler-cli stop [<id>] [--all] [--force]         Stop the daemon
  *   profiler-cli session list                          List all running sessions
  *   profiler-cli session use <id>                      Switch the current session
  *
@@ -28,8 +28,18 @@ import { Command } from 'commander';
 import guideText from '../guide.txt';
 import schemasText from '../schemas.txt';
 import { startDaemon } from './daemon';
-import { startNewDaemon, stopDaemon, sendCommand } from './client';
-import { listSessions } from './session';
+import {
+  describeSessionForStop,
+  startNewDaemon,
+  stopDaemon,
+  sendCommand,
+} from './client';
+import {
+  getSessionOwner,
+  listSessions,
+  loadSessionMetadata,
+  ownsSession,
+} from './session';
 import { formatOutput } from './output';
 import { addGlobalOptions, runCommand } from './commands/shared';
 import { VERSION } from './constants';
@@ -148,13 +158,81 @@ Examples:
       .description(
         'Stop the current session, a specific session, or all with --all'
       )
-      .option('--all', 'Stop all running sessions')
+      .option('--all', 'Stop all running sessions you own')
+      .option(
+        '--force',
+        'Stop sessions owned by someone else (see PROFILER_CLI_SESSION_OWNER)'
+      )
+      .addHelpText(
+        'after',
+        `
+Session ownership:
+  "stop" refuses a session created by a different owner, naming the owner and
+  exiting 1; --force overrides.
+
+  Set PROFILER_CLI_SESSION_OWNER to a value unique to your shell, script, or
+  agent. Without it the owner is the parent process id, so a "stop" from a
+  different shell is refused -- set the variable in CI jobs that load and stop
+  in separate steps.
+
+  A pid owner is released once that process exits, since daemons outlive the
+  shell that started them. A named owner is never released. Sessions from
+  before owner tracking are stoppable by anyone.`
+      )
   ).action(async (idArg: string | undefined, opts) => {
+    const force = opts.force ?? false;
+
     if (opts.all) {
       const sessionIds = listSessions(SESSION_DIR);
+      const owner = getSessionOwner();
+
+      // Metadata is read once and kept, so what is announced below cannot
+      // drift from what is stopped.
+      const targets: Array<{ id: string; description: string }> = [];
+      const skipped: Array<{ id: string; description: string }> = [];
+      for (const id of sessionIds) {
+        const metadata = loadSessionMetadata(SESSION_DIR, id);
+        // Vanished metadata leaves no owner to check.
+        const entry = {
+          id,
+          description:
+            metadata === null ? id : describeSessionForStop(metadata),
+        };
+        if (metadata === null || force || ownsSession(metadata, owner)) {
+          targets.push(entry);
+        } else {
+          skipped.push(entry);
+        }
+      }
+
+      if (targets.length !== 0) {
+        console.log(`Stopping ${targets.length} session(s):`);
+        for (const { description } of targets) {
+          console.log(`  ${description}`);
+        }
+      }
+
+      if (skipped.length !== 0) {
+        console.log(
+          `Skipping ${skipped.length} session(s) owned by someone else (you are ${owner}); pass --force to stop them too:`
+        );
+        for (const { description } of skipped) {
+          console.log(`  ${description}`);
+        }
+      }
+
+      // Say which reason, so exit 0 cannot imply a clean machine.
+      if (targets.length === 0) {
+        console.log(
+          skipped.length === 0
+            ? 'No running sessions to stop.'
+            : `Stopped 0 sessions: all ${skipped.length} running session(s) are owned by someone else. Nothing was stopped; pass --force to stop them.`
+        );
+      }
+
       // Settled, so one session that refuses to stop does not hide the others.
       const results = await Promise.allSettled(
-        sessionIds.map((id: string) => stopDaemon(SESSION_DIR, id))
+        targets.map(({ id }) => stopDaemon(SESSION_DIR, id, { force }))
       );
       const failures = results.filter((r) => r.status === 'rejected');
       for (const failure of failures) {
@@ -164,12 +242,17 @@ Examples:
       }
       if (failures.length !== 0) {
         throw new Error(
-          `Could not stop ${failures.length} of ${sessionIds.length} sessions.`
+          `Could not stop ${failures.length} of ${targets.length} sessions.`
         );
       }
     } else {
       const sessionId = idArg ?? opts.session;
-      await stopDaemon(SESSION_DIR, sessionId);
+      await stopDaemon(SESSION_DIR, sessionId, {
+        force,
+        // Only a stop with no id picks its target from shared state, so only
+        // that one needs to say what it picked.
+        announce: sessionId === undefined,
+      });
     }
   });
 

--- a/profiler-cli/src/protocol.ts
+++ b/profiler-cli/src/protocol.ts
@@ -247,4 +247,9 @@ export interface SessionMetadata {
   profilePath: string;
   createdAt: string;
   buildHash: string;
+  /**
+   * Who created this session, so `stop` can refuse someone else's. Optional:
+   * sessions from older builds have none and are stoppable by anyone.
+   */
+  owner?: string;
 }

--- a/profiler-cli/src/session.ts
+++ b/profiler-cli/src/session.ts
@@ -34,6 +34,139 @@ export function generateSessionId(): string {
   return Math.random().toString(36).substring(2, 15);
 }
 
+/** Names the owner of the sessions a process creates, and the ones it may stop. */
+export const SESSION_OWNER_ENV_VAR = 'PROFILER_CLI_SESSION_OWNER';
+
+/**
+ * Identify the caller for session ownership purposes.
+ *
+ * The parent pid is the fallback because separate `profiler-cli` invocations
+ * from one shell share a parent, giving them a common identity without any
+ * setup.
+ */
+export function getSessionOwner(
+  env: NodeJS.ProcessEnv = process.env,
+  parentPid: number = process.ppid
+): string {
+  const configured = env[SESSION_OWNER_ENV_VAR];
+  if (configured !== undefined && configured.trim() !== '') {
+    return configured.trim();
+  }
+  return `pid:${parentPid}`;
+}
+
+/**
+ * The owner recorded in a metadata file, or null when there is not a usable one.
+ *
+ * JSON has no `undefined`, so a `null` owner is a value these files really
+ * hold; comparing it by equality against a string would match nobody and lock
+ * the session away from every caller.
+ */
+export function readSessionOwner(
+  metadata: Pick<SessionMetadata, 'owner'>
+): string | null {
+  const recorded = metadata.owner;
+  if (typeof recorded !== 'string' || recorded.trim() === '') {
+    return null;
+  }
+  return recorded.trim();
+}
+
+/** The pid a `pid:<n>` owner refers to, or null for any other owner form. */
+function getOwnerPid(owner: string): number | null {
+  const match = /^pid:(\d+)$/.exec(owner);
+  if (match === null) {
+    return null;
+  }
+  const pid = Number(match[1]);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
+/**
+ * Whether a `pid:<n>` owner's process is *provably* gone.
+ *
+ * Only ESRCH proves it. EPERM means a process is there that we may not signal,
+ * which a sandbox also returns for processes we do own, and success means
+ * alive. Releasing a session on anything but ESRCH would hand it to other
+ * callers whenever the answer was merely unavailable.
+ */
+function isOwnerProcessGone(owner: string): boolean {
+  const pid = getOwnerPid(owner);
+  if (pid === null) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    return getErrnoCode(error) === 'ESRCH';
+  }
+}
+
+/**
+ * Whether `owner` may stop a session recorded with this metadata.
+ *
+ * A session with no usable owner is stoppable by anyone, as sessions written
+ * before owner tracking are. So is one owned by a `pid:` that has exited: the
+ * daemon is detached and outlives the shell that started it, so nobody could
+ * ever present that pid again. Only `pid:` owners are released this way, so a
+ * name from PROFILER_CLI_SESSION_OWNER keeps the guard for the session's life.
+ */
+export function ownsSession(
+  metadata: Pick<SessionMetadata, 'owner'>,
+  owner: string
+): boolean {
+  const recorded = readSessionOwner(metadata);
+  if (recorded === null || recorded === owner) {
+    return true;
+  }
+  return isOwnerProcessGone(recorded);
+}
+
+/**
+ * Human-readable owner of a session, for listings and refusals.
+ *
+ * Says "unknown" for exactly the values ownsSession() treats as unowned, so a
+ * session is never described as someone's while being stoppable by anyone.
+ */
+export function describeSessionOwner(
+  metadata: Pick<SessionMetadata, 'owner'>
+): string {
+  return readSessionOwner(metadata) ?? 'unknown';
+}
+
+/** Format an elapsed duration compactly, for session ages in `session list`. */
+export function formatSessionAge(ageMs: number): string {
+  if (!Number.isFinite(ageMs) || ageMs < 0) {
+    return 'unknown';
+  }
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+/** Age of a session as of `now`, or null when its creation time is unusable. */
+export function getSessionAge(
+  metadata: Pick<SessionMetadata, 'createdAt'>,
+  now: number = Date.now()
+): string | null {
+  const createdAt = new Date(metadata.createdAt).getTime();
+  if (Number.isNaN(createdAt)) {
+    return null;
+  }
+  return formatSessionAge(now - createdAt);
+}
+
 /**
  * Get a stable namespace for a session directory.
  */

--- a/profiler-cli/src/test/integration/daemon-failures.test.ts
+++ b/profiler-cli/src/test/integration/daemon-failures.test.ts
@@ -282,7 +282,9 @@ describe('session denied by policy', () => {
 
     const text = output(result);
     expect(text).toContain('Could not reach the following sessions');
-    expect(text).toContain(`${sessionId} [daemon pid: ${daemonPid}]`);
+    expect(text).toMatch(
+      new RegExp(`${sessionId} \\[owner: [^,]+, daemon pid: ${daemonPid}\\]`)
+    );
     expect(text).toContain('sandbox');
     // An unreachable daemon cannot be stopped through its own socket, so the
     // pid has to be enough to act on.

--- a/profiler-cli/src/test/integration/sessions.test.ts
+++ b/profiler-cli/src/test/integration/sessions.test.ts
@@ -200,6 +200,286 @@ describe('profiler-cli multiple concurrent sessions', () => {
     expect(result.stdout).toContain('This profile contains');
   });
 
+  describe('session ownership', () => {
+    // Session directories are shared by every process on the machine, so a
+    // `stop` that reaches beyond the caller's own sessions destroys other
+    // people's work. Two distinct owners in one directory is exactly the
+    // situation those tests need to cover.
+    const mine = { PROFILER_CLI_SESSION_OWNER: 'owner-mine' };
+    const theirs = { PROFILER_CLI_SESSION_OWNER: 'owner-theirs' };
+
+    async function loadOwned(
+      env: Record<string, string>,
+      sessionId: string,
+      fixture = 'src/test/fixtures/upgrades/processed-1.json'
+    ) {
+      await cli(ctx, ['load', fixture, '--session', sessionId], { env });
+    }
+
+    it('records the owner and shows it with the age in session list', async () => {
+      await loadOwned(mine, 'owned-by-me');
+
+      const result = await cli(ctx, ['session', 'list'], { env: mine });
+
+      expect(result.stdout).toContain('owner: owner-mine (yours)');
+      expect(result.stdout).toMatch(/\(\d+s ago\)/);
+
+      // The same session seen by a different owner is not marked as theirs.
+      const asOther = await cli(ctx, ['session', 'list'], { env: theirs });
+      expect(asOther.stdout).toContain('owner: owner-mine');
+      expect(asOther.stdout).not.toContain('(yours)');
+
+      await cli(ctx, ['stop', 'owned-by-me'], { env: mine });
+    });
+
+    it('refuses to stop a session owned by someone else', async () => {
+      await loadOwned(theirs, 'not-mine');
+
+      const result = await cliFail(ctx, ['stop', 'not-mine'], { env: mine });
+
+      expect(result.exitCode).not.toBe(0);
+      const output = String(result.stdout || '') + String(result.stderr || '');
+      expect(output).toContain('belongs to owner-theirs');
+      expect(output).toContain('not to you (owner-mine)');
+      expect(output).toContain('--force');
+
+      // The refusal has to leave the session alive, or it is no protection.
+      const stillThere = await cli(ctx, [
+        'profile',
+        'info',
+        '--session',
+        'not-mine',
+      ]);
+      expect(stillThere.exitCode).toBe(0);
+
+      await cli(ctx, ['stop', 'not-mine'], { env: theirs });
+    });
+
+    it('stops another owner’s session with --force', async () => {
+      await loadOwned(theirs, 'not-mine');
+
+      const result = await cli(ctx, ['stop', 'not-mine', '--force'], {
+        env: mine,
+      });
+      expect(result.stdout).toContain('Session not-mine stopped');
+
+      await cliFail(ctx, ['profile', 'info', '--session', 'not-mine']);
+    });
+
+    it('stops sessions with no recorded owner, as older builds left them', async () => {
+      // A session written before owner tracking existed. Refusing these would
+      // break every script that already relies on stopping them.
+      const sessionId = 'legacy-session';
+      const metadataPath = join(ctx.sessionDir, `${sessionId}.json`);
+      const socketPath = join(ctx.sessionDir, `${sessionId}.sock`);
+      await writeFile(
+        metadataPath,
+        JSON.stringify({
+          id: sessionId,
+          socketPath,
+          logPath: join(ctx.sessionDir, `${sessionId}.log`),
+          pid: 999999,
+          profilePath: '/tmp/does-not-exist.json',
+          createdAt: '2026-04-11T00:00:00.000Z',
+          buildHash: 'legacy-build',
+        }),
+        'utf-8'
+      );
+
+      const result = await cli(ctx, ['stop', sessionId], { env: mine });
+      expect(result.stdout).toContain(`Session ${sessionId}`);
+      expect(result.stdout).not.toContain('belongs to');
+      await expect(access(metadataPath)).rejects.toThrow();
+    });
+
+    it('stops a session whose recorded owner is unusable', async () => {
+      // JSON cannot hold undefined, so null is what a truncated or hand-edited
+      // metadata file really contains. Such a session must not end up refused
+      // to everyone, with a message naming an owner nobody can present.
+      const sessionId = 'null-owner';
+      const metadataPath = join(ctx.sessionDir, `${sessionId}.json`);
+      await writeFile(
+        metadataPath,
+        JSON.stringify({
+          id: sessionId,
+          socketPath: join(ctx.sessionDir, `${sessionId}.sock`),
+          logPath: join(ctx.sessionDir, `${sessionId}.log`),
+          pid: 999999,
+          profilePath: '/tmp/does-not-exist.json',
+          createdAt: '2026-04-11T00:00:00.000Z',
+          buildHash: 'weird-build',
+          owner: null,
+        }),
+        'utf-8'
+      );
+
+      const result = await cli(ctx, ['stop', sessionId], { env: mine });
+      expect(result.stdout).not.toContain('belongs to');
+      await expect(access(metadataPath)).rejects.toThrow();
+    });
+
+    it('lets anyone stop a session whose owning process has exited', async () => {
+      // A pid owner outlives its process: the daemon is detached on purpose, so
+      // the shell that ran `load` is usually gone well before the session is.
+      // pid 999999 stands in for that exited shell.
+      const sessionId = 'dead-owner';
+      const metadataPath = join(ctx.sessionDir, `${sessionId}.json`);
+      await writeFile(
+        metadataPath,
+        JSON.stringify({
+          id: sessionId,
+          socketPath: join(ctx.sessionDir, `${sessionId}.sock`),
+          logPath: join(ctx.sessionDir, `${sessionId}.log`),
+          pid: 999998,
+          profilePath: '/tmp/does-not-exist.json',
+          createdAt: '2026-04-11T00:00:00.000Z',
+          buildHash: 'orphan-build',
+          owner: 'pid:999999',
+        }),
+        'utf-8'
+      );
+
+      const result = await cli(ctx, ['stop', sessionId], { env: mine });
+      expect(result.stdout).not.toContain('belongs to');
+      await expect(access(metadataPath)).rejects.toThrow();
+    });
+
+    it('stop --all says so when every session belongs to someone else', async () => {
+      await loadOwned(theirs, 'only-theirs');
+
+      const result = await cli(ctx, ['stop', '--all'], { env: mine });
+
+      // Exit 0 with nothing stopped is the one way this command can report a
+      // clean machine while daemons are still running, so it has to say it.
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Stopped 0 sessions');
+      expect(result.stdout).toContain('owned by someone else');
+      expect(result.stdout).not.toContain('Stopping 1 session(s)');
+
+      const survivor = await cli(ctx, [
+        'profile',
+        'info',
+        '--session',
+        'only-theirs',
+      ]);
+      expect(survivor.exitCode).toBe(0);
+
+      await cli(ctx, ['stop', 'only-theirs'], { env: theirs });
+    });
+
+    it('stop --all says so when there is nothing running at all', async () => {
+      const result = await cli(ctx, ['stop', '--all'], { env: mine });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No running sessions to stop.');
+    });
+
+    it('bare stop names the session it picked and who owns it', async () => {
+      await loadOwned(mine, 'current-one');
+
+      const result = await cli(ctx, ['stop'], { env: mine });
+
+      // A stop with no id reads its target out of shared state, so it has to
+      // say what that turned out to be before acting on it.
+      expect(result.stdout).toContain(
+        'Stopping session current-one, owner owner-mine'
+      );
+      expect(result.stdout).toMatch(/daemon pid \d+/);
+      expect(result.stdout).toContain('Session current-one stopped');
+    });
+
+    it('bare stop refuses when the current session is someone else’s', async () => {
+      // The hazard in one test: another owner's `load` moved the shared current
+      // session pointer, so a bare `stop` now aims at their session.
+      await loadOwned(theirs, 'theirs-current');
+
+      const result = await cliFail(ctx, ['stop'], { env: mine });
+
+      expect(result.exitCode).not.toBe(0);
+      const output = String(result.stdout || '') + String(result.stderr || '');
+      expect(output).toContain('belongs to owner-theirs');
+
+      const stillThere = await cli(ctx, [
+        'profile',
+        'info',
+        '--session',
+        'theirs-current',
+      ]);
+      expect(stillThere.exitCode).toBe(0);
+
+      await cli(ctx, ['stop', 'theirs-current'], { env: theirs });
+    });
+
+    it('stop --all lists what it stops and skips other owners', async () => {
+      await loadOwned(mine, 'all-mine');
+      await loadOwned(
+        theirs,
+        'all-theirs',
+        'src/test/fixtures/upgrades/processed-2.json'
+      );
+
+      const result = await cli(ctx, ['stop', '--all'], { env: mine });
+
+      expect(result.stdout).toContain('Stopping 1 session(s):');
+      expect(result.stdout).toContain('all-mine, owner owner-mine');
+      expect(result.stdout).toContain(
+        'Skipping 1 session(s) owned by someone else (you are owner-mine)'
+      );
+      expect(result.stdout).toContain('all-theirs, owner owner-theirs');
+      expect(result.stdout).toContain('Session all-mine stopped');
+
+      // The other owner's session survives a stop --all that was not theirs.
+      const survivor = await cli(ctx, [
+        'profile',
+        'info',
+        '--session',
+        'all-theirs',
+      ]);
+      expect(survivor.exitCode).toBe(0);
+
+      await cli(ctx, ['stop', 'all-theirs'], { env: theirs });
+    });
+
+    it('stop --all --force stops every owner’s sessions', async () => {
+      await loadOwned(mine, 'force-mine');
+      await loadOwned(
+        theirs,
+        'force-theirs',
+        'src/test/fixtures/upgrades/processed-2.json'
+      );
+
+      const result = await cli(ctx, ['stop', '--all', '--force'], {
+        env: mine,
+      });
+
+      expect(result.stdout).toContain('Stopping 2 session(s):');
+      expect(result.stdout).not.toContain('Skipping');
+
+      const listed = await cli(ctx, ['session', 'list']);
+      expect(listed.stdout).toContain('Found 0 running sessions');
+    });
+
+    it('session use warns when it redirects to another owner’s session', async () => {
+      await loadOwned(mine, 'use-mine');
+      await loadOwned(
+        theirs,
+        'use-theirs',
+        'src/test/fixtures/upgrades/processed-2.json'
+      );
+
+      const result = await cli(ctx, ['session', 'use', 'use-theirs'], {
+        env: mine,
+      });
+
+      expect(result.stdout).toContain('Switched to session use-theirs');
+      expect(result.stdout).toContain('owned by owner-theirs, not you');
+      expect(result.stdout).toContain('shared state');
+
+      await cli(ctx, ['stop', 'use-mine'], { env: mine });
+      await cli(ctx, ['stop', 'use-theirs'], { env: theirs });
+    });
+  });
+
   it('session list cleans up stale session metadata files', async () => {
     const staleSessionId = 'stale-session';
     const metadataPath = join(ctx.sessionDir, `${staleSessionId}.json`);

--- a/profiler-cli/src/test/integration/utils.ts
+++ b/profiler-cli/src/test/integration/utils.ts
@@ -152,10 +152,12 @@ export async function cli(
   args: string[],
   options?: {
     timeout?: number;
+    /** Extra environment for this invocation, e.g. a session owner. */
+    env?: Record<string, string>;
   }
 ): Promise<CommandResult> {
   const result = await exec(process.execPath, [CLI_BIN, ...args], {
-    env: ctx.env,
+    env: { ...ctx.env, ...options?.env },
     timeout: options?.timeout ?? 30000,
   });
 
@@ -173,10 +175,14 @@ export async function cli(
  */
 export async function cliFail(
   ctx: CliTestContext,
-  args: string[]
+  args: string[],
+  options?: {
+    timeout?: number;
+    env?: Record<string, string>;
+  }
 ): Promise<CommandResult> {
   try {
-    await cli(ctx, args);
+    await cli(ctx, args, options);
     throw new Error('Expected command to fail but it succeeded');
   } catch (error) {
     if (error instanceof Error && error.message.includes('Expected command')) {

--- a/profiler-cli/src/test/unit/session.test.ts
+++ b/profiler-cli/src/test/unit/session.test.ts
@@ -36,6 +36,13 @@ import {
   readLogTail,
   writeStartupError,
   takeStartupError,
+  describeSessionOwner,
+  formatSessionAge,
+  getSessionAge,
+  getSessionOwner,
+  ownsSession,
+  readSessionOwner,
+  SESSION_OWNER_ENV_VAR,
 } from '../../session';
 import type { SessionMetadata } from '../../protocol';
 
@@ -411,6 +418,130 @@ describe('profiler-cli session management', function () {
     it('does not make startup errors look like sessions', function () {
       writeStartupError(testSessionDir, 'failed', 'could not bind');
       expect(listSessions(testSessionDir)).toEqual([]);
+    });
+  });
+
+  describe('session ownership', function () {
+    it('prefers the configured owner over the parent pid', function () {
+      expect(
+        getSessionOwner({ [SESSION_OWNER_ENV_VAR]: 'agent-L' }, 4242)
+      ).toBe('agent-L');
+      // Surrounding whitespace from a shell export must not make two callers
+      // that meant the same owner look like different ones.
+      expect(
+        getSessionOwner({ [SESSION_OWNER_ENV_VAR]: '  agent-L\n' }, 4242)
+      ).toBe('agent-L');
+    });
+
+    it('falls back to the parent pid when no owner is configured', function () {
+      expect(getSessionOwner({}, 4242)).toBe('pid:4242');
+      // An empty value is a variable that was exported but never set, not a
+      // request to be owned by "".
+      expect(getSessionOwner({ [SESSION_OWNER_ENV_VAR]: '' }, 4242)).toBe(
+        'pid:4242'
+      );
+    });
+
+    it('recognises only the recorded owner', function () {
+      expect(ownsSession({ owner: 'agent-L' }, 'agent-L')).toBe(true);
+      expect(ownsSession({ owner: 'agent-L' }, 'agent-M')).toBe(false);
+    });
+
+    it('treats a session with no recorded owner as anyone’s', function () {
+      // Sessions written by builds that predate owner tracking, which existing
+      // scripts must still be able to stop.
+      expect(ownsSession({}, 'agent-L')).toBe(true);
+      expect(describeSessionOwner({})).toBe('unknown');
+      expect(describeSessionOwner({ owner: 'agent-L' })).toBe('agent-L');
+    });
+
+    it('treats an unusable recorded owner as no owner at all', function () {
+      // JSON has no undefined, so a null owner is a value a metadata file can
+      // really hold. Comparing it by strict equality against a string would
+      // match nobody and lock the session away from every caller, which is the
+      // failure this ownership check exists to prevent, inverted.
+      for (const owner of [null, '', '   ', 1234, {}, []] as any[]) {
+        expect(readSessionOwner({ owner })).toBeNull();
+        expect(ownsSession({ owner }, 'agent-L')).toBe(true);
+        // Whatever is displayed must agree with what is enforced: a session
+        // that anyone may stop must not claim to belong to someone.
+        expect(describeSessionOwner({ owner })).toBe('unknown');
+      }
+    });
+
+    it('normalises the recorded owner the way the environment one is', function () {
+      expect(readSessionOwner({ owner: '  agent-L\n' })).toBe('agent-L');
+      // Both sides of the comparison get trimmed, so a stray newline in a
+      // metadata file cannot separate an owner from its own sessions.
+      expect(ownsSession({ owner: '  agent-L\n' }, 'agent-L')).toBe(true);
+    });
+
+    it('releases a pid owner whose process is provably gone', function () {
+      // The daemon is detached and outlives the shell that started it, so a
+      // pid: owner refers to a dead process for most of a long session's life.
+      // Refusing those forever would leave sessions nobody can ever reclaim.
+      expect(ownsSession({ owner: 'pid:999999' }, 'pid:4242')).toBe(true);
+      // Still refused to a different caller while that process is alive.
+      expect(ownsSession({ owner: `pid:${process.pid}` }, 'pid:4242')).toBe(
+        false
+      );
+    });
+
+    it('never releases a named owner, however its processes fare', function () {
+      // A name chosen via PROFILER_CLI_SESSION_OWNER is not tied to any
+      // process, so there is no death that could release it. Callers following
+      // the multi-agent convention keep the guard for their sessions' lifetime.
+      expect(ownsSession({ owner: 'agent-theirs' }, 'agent-L')).toBe(false);
+      // Owners that merely look pid-ish are names too, not pids to probe.
+      expect(ownsSession({ owner: 'pid:notanumber' }, 'agent-L')).toBe(false);
+      expect(ownsSession({ owner: 'pid:999999x' }, 'agent-L')).toBe(false);
+      expect(ownsSession({ owner: 'pid:0' }, 'agent-L')).toBe(false);
+      expect(ownsSession({ owner: 'pid:-1' }, 'agent-L')).toBe(false);
+    });
+
+    it('round-trips the owner through the metadata file', function () {
+      const metadata: SessionMetadata = {
+        id: 'owned',
+        socketPath: getSocketPath(testSessionDir, 'owned'),
+        logPath: getLogPath(testSessionDir, 'owned'),
+        pid: 12345,
+        profilePath: '/path/to/profile.json',
+        createdAt: '2026-08-17T10:00:00.000Z',
+        buildHash: TEST_BUILD_HASH,
+        owner: 'agent-L',
+      };
+
+      saveSessionMetadata(testSessionDir, metadata);
+
+      expect(loadSessionMetadata(testSessionDir, 'owned')?.owner).toBe(
+        'agent-L'
+      );
+    });
+  });
+
+  describe('session age', function () {
+    it('formats ages by the largest useful unit', function () {
+      expect(formatSessionAge(0)).toBe('0s');
+      expect(formatSessionAge(45_000)).toBe('45s');
+      expect(formatSessionAge(90_000)).toBe('1m 30s');
+      expect(formatSessionAge(3_900_000)).toBe('1h 5m');
+      expect(formatSessionAge(100_000_000)).toBe('1d 3h');
+    });
+
+    it('reports an unusable duration as unknown rather than guessing', function () {
+      expect(formatSessionAge(-1)).toBe('unknown');
+      expect(formatSessionAge(NaN)).toBe('unknown');
+    });
+
+    it('measures the age from createdAt', function () {
+      const now = Date.parse('2026-08-17T10:02:00.000Z');
+      expect(
+        getSessionAge({ createdAt: '2026-08-17T10:00:00.000Z' }, now)
+      ).toBe('2m 0s');
+    });
+
+    it('returns null for an unparseable createdAt', function () {
+      expect(getSessionAge({ createdAt: 'not a date' })).toBeNull();
     });
   });
 


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6268--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

One session directory is shared by every profiler-cli process on the machine, and "the current session" is a single file in it that any caller's "load" can move, so a mis-aimed "stop" destroys a profile someone else is using. Each session now records its creator -- PROFILER_CLI_SESSION_OWNER, else the parent pid -- and "stop" refuses one owned by another, naming the owner and exiting 1. "session list" shows owner and age.

BEHAVIOUR CHANGE: "stop <id>" exits 1 where it exited 0 for a session created by a different owner, and "stop --all" reaches only your own sessions. --force restores the old behaviour.

Sessions with no owner recorded, with unreadable owner metadata, or owned by a pid that has provably exited stay stoppable by anyone, so nothing is stranded. Only ESRCH releases a pid owner: EPERM means a live process we may not signal.