### PR TITLE
profiler-cli: name the process in the thread banner, and follow the queried thread

### DIFF
--- a/profiler-cli/schemas.txt
+++ b/profiler-cli/schemas.txt
@@ -6,7 +6,9 @@ document the exact fields returned by each command.
 SessionContext (present on all command results):
   {
     selectedThreadHandle,
-    selectedThreads: [{ threadIndex, name }],
+    selectedThreads: [{ threadIndex, name, processName }],
+    resultThreadHandle: threadHandle | null,
+    resultThreads: [{ threadIndex, name, processName }],
     currentViewRange: { start, startName, end, endName } | null,
     rootRange: { start, end },
     callTreeSummaryStrategy: CallTreeSummaryStrategy
@@ -277,7 +279,7 @@ profiler-cli status --json
   {
     type: "status",
     selectedThreadHandle,
-    selectedThreads: [{ threadIndex, name }],
+    selectedThreads: [{ threadIndex, name, processName }],
     viewRanges: [{ start, startName, end, endName }],
     rootRange: { start, end },
     filterStacks: [{ threadHandle, filters: FilterEntry[] }],

--- a/profiler-cli/src/formatters.ts
+++ b/profiler-cli/src/formatters.ts
@@ -175,6 +175,28 @@ function weightHeadingNoun(weightType: WeightType): string {
 }
 
 /**
+ * `GeckoMain, WebExtensions` — thread name then process, the process dropped
+ * when it merely repeats the thread name.
+ */
+function formatThreadAndProcess(thread: {
+  name: string;
+  processName?: string;
+}): string {
+  if (!thread.processName || thread.processName === thread.name) {
+    return thread.name;
+  }
+  return `${thread.name}, ${thread.processName}`;
+}
+
+/** `t-0,t-1 (GeckoMain, Parent Process; Renderer)` */
+function formatThreadList(
+  handle: string,
+  threads: Array<{ name: string; processName?: string }>
+): string {
+  return `${handle} (${threads.map(formatThreadAndProcess).join('; ')})`;
+}
+
+/**
  * Format a SessionContext as a compact header line.
  * Shows current thread selection, zoom range, and full profile duration.
  */
@@ -183,18 +205,25 @@ export function formatContextHeader(
   activeFilters?: FilterEntry[],
   ephemeralFilters?: SampleFilterSpec[]
 ): string {
-  // Thread info
+  // Thread info. The header leads with the thread this result is about, and
+  // only names the sticky selection separately when the two have diverged, so
+  // that a `--thread` query does not read as having changed the selection.
   let threadInfo = 'No thread selected';
-  if (context.selectedThreadHandle && context.selectedThreads.length > 0) {
-    if (context.selectedThreads.length === 1) {
-      const thread = context.selectedThreads[0];
-      threadInfo = `${context.selectedThreadHandle} (${thread.name})`;
-    } else {
-      const names = context.selectedThreads
-        .map((t: { name: string }) => t.name)
-        .join(', ');
-      threadInfo = `${context.selectedThreadHandle} (${names})`;
-    }
+  let selectedInfo = '';
+  if (context.resultThreadHandle && context.resultThreads.length > 0) {
+    threadInfo = formatThreadList(
+      context.resultThreadHandle,
+      context.resultThreads
+    );
+    selectedInfo = ` | Selected: ${context.selectedThreadHandle ?? 'none'}`;
+  } else if (
+    context.selectedThreadHandle &&
+    context.selectedThreads.length > 0
+  ) {
+    threadInfo = formatThreadList(
+      context.selectedThreadHandle,
+      context.selectedThreads
+    );
   }
 
   // View range info
@@ -213,7 +242,7 @@ export function formatContextHeader(
     (activeFilters?.length ?? 0) + (ephemeralFilters?.length ?? 0);
   const filterInfo =
     totalFilterCount > 0 ? ` | Filters: ${totalFilterCount}` : '';
-  return `[Thread: ${threadInfo} | View: ${viewInfo} | Full: ${fullInfo}${filterInfo}]`;
+  return `[Thread: ${threadInfo}${selectedInfo} | View: ${viewInfo} | Full: ${fullInfo}${filterInfo}]`;
 }
 
 /**
@@ -222,13 +251,10 @@ export function formatContextHeader(
 export function formatStatusResult(result: StatusResult): string {
   let threadInfo = 'No thread selected';
   if (result.selectedThreadHandle && result.selectedThreads.length > 0) {
-    if (result.selectedThreads.length === 1) {
-      const thread = result.selectedThreads[0];
-      threadInfo = `${result.selectedThreadHandle} (${thread.name})`;
-    } else {
-      const names = result.selectedThreads.map((t) => t.name).join(', ');
-      threadInfo = `${result.selectedThreadHandle} (${names})`;
-    }
+    threadInfo = formatThreadList(
+      result.selectedThreadHandle,
+      result.selectedThreads
+    );
   }
 
   let rangesInfo = 'Full profile';
@@ -2261,7 +2287,11 @@ export function formatThreadSelectResult(
   result: WithContext<ThreadSelectResult>
 ): string {
   const count = result.threadNames.length;
-  const names = result.threadNames.join(', ');
+  // Only the context carries process names, so fall back if it disagrees.
+  const names =
+    result.context.selectedThreads.length === count
+      ? result.context.selectedThreads.map(formatThreadAndProcess).join('; ')
+      : result.threadNames.join(', ');
   if (count === 1) {
     return `Selected thread: ${result.threadHandle} (${names})`;
   }

--- a/profiler-cli/src/formatters.ts
+++ b/profiler-cli/src/formatters.ts
@@ -583,8 +583,7 @@ Name: ${result.name}\n`;
       }
     }
 
-    const etld1Suffix = process.etld1 ? ` [${process.etld1}]` : '';
-    output += `  p-${process.processIndex}: ${process.name}${etld1Suffix} [pid ${process.pid}]${timingInfo} - ${process.cpuMs.toFixed(3)}ms\n`;
+    output += `  p-${process.processIndex}: ${process.name} [pid ${process.pid}]${timingInfo} - ${process.cpuMs.toFixed(3)}ms\n`;
 
     for (const thread of process.threads) {
       output += `    ${thread.threadHandle}: ${thread.name} [tid ${thread.tid}] - ${thread.cpuMs.toFixed(3)}ms\n`;
@@ -804,13 +803,12 @@ function formatCounterStats(counter: CounterSummary): string {
   return `${stats} [${counter.rangeSampleCount} samples]`;
 }
 
-/** `p-N Process Name (etld+1)` identifying the owning process. */
+/** `p-N Process Name` identifying the owning process. */
 function formatCounterProcessName(counter: CounterSummary): string {
-  const etld1 = counter.etld1 ? ` (${counter.etld1})` : '';
-  return `p-${counter.processIndex} ${counter.processName}${etld1}`;
+  return `p-${counter.processIndex} ${counter.processName}`;
 }
 
-/** The ` [p-N Process Name (etld+1), pid X]` segment identifying the owning process. */
+/** The ` [p-N Process Name, pid X]` segment identifying the owning process. */
 function formatCounterProcess(counter: CounterSummary): string {
   return ` [${formatCounterProcessName(counter)}, pid ${counter.pid}]`;
 }

--- a/profiler-cli/src/test/unit/__snapshots__/allocation-formatting.test.ts.snap
+++ b/profiler-cli/src/test/unit/__snapshots__/allocation-formatting.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`functions formatting with an allocation strategy reports bytes rather than sample counts 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Parent Process) | View: Full profile | Full: 1s]
 
 Functions in thread t-0 (Empty) — 9 functions
 
@@ -22,7 +22,7 @@ Use --search <term>, --min-self <percent>, or --limit <N> (0 = no limit) to filt
 `;
 
 exports[`samples formatting with an allocation strategy reports bytes rather than sample counts 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Parent Process) | View: Full profile | Full: 1s]
 
 Thread: Empty
 

--- a/profiler-cli/src/test/unit/__snapshots__/call-tree-formatting.test.ts.snap
+++ b/profiler-cli/src/test/unit/__snapshots__/call-tree-formatting.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`call tree formatting bottom-up view complex nested trees formats a deep call chain inverted 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -21,7 +21,7 @@ f-5. Phys [total: 25.0%, self: 25.0%]
 `;
 
 exports[`call tree formatting bottom-up view complex nested trees shows which functions call a leaf function 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -34,7 +34,7 @@ f-2. E [total: 100.0%, self: 100.0%]
 `;
 
 exports[`call tree formatting bottom-up view different scoring strategies exponential-0.9 strategy for bottom-up 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -51,7 +51,7 @@ f-6. C [total: 20.0%, self: 20.0%]"
 `;
 
 exports[`call tree formatting bottom-up view elision bugs each parent node should have at most one elision marker 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -63,7 +63,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting bottom-up view elision bugs elided children percentages should be relative to parent, not full profile 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -75,7 +75,7 @@ f-7. D [total: 50.0%, self: 50.0%]
 `;
 
 exports[`call tree formatting bottom-up view elision bugs node whose children were never expanded must still show elision marker 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -90,7 +90,7 @@ f-0. Root [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting bottom-up view elision bugs sibling nodes with elided children should each show their own elision marker 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -104,7 +104,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting bottom-up view simple trees formats a branching tree inverted 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -118,7 +118,7 @@ f-4. C [total: 14.3%, self: 14.3%]"
 `;
 
 exports[`call tree formatting bottom-up view simple trees formats a simple linear tree inverted 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -130,7 +130,7 @@ f-3. D [total: 100.0%, self: 100.0%]
 `;
 
 exports[`call tree formatting bottom-up view trees with truncation shows elided callers at multiple levels 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -146,7 +146,7 @@ f-7. D [total: 25.0%, self: 25.0%]
 `;
 
 exports[`call tree formatting bottom-up view trees with truncation shows elided callers with correct percentages 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -160,7 +160,7 @@ f-3. D [total: 10.0%, self: 10.0%]
 `;
 
 exports[`call tree formatting top-down view complex nested trees formats a complex tree with mixed branching patterns 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -181,7 +181,7 @@ f-0. Main [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting top-down view complex nested trees formats a deep nested path with branching 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -198,7 +198,7 @@ f-8. B [total: 20.0%, self: 20.0%]"
 `;
 
 exports[`call tree formatting top-down view different scoring strategies exponential-0.9 strategy output 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -213,7 +213,7 @@ f-6. C [total: 20.0%, self: 20.0%]"
 `;
 
 exports[`call tree formatting top-down view different scoring strategies percentage-only strategy output 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -228,7 +228,7 @@ f-6. C [total: 20.0%, self: 20.0%]"
 `;
 
 exports[`call tree formatting top-down view ordering and percentages correctly calculates percentages for nested nodes 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -242,7 +242,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting top-down view ordering and percentages maintains correct ordering by sample count 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -254,7 +254,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting top-down view simple trees formats a branching tree 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -267,7 +267,7 @@ f-4. C [total: 14.3%, self: 14.3%]"
 `;
 
 exports[`call tree formatting top-down view simple trees formats a simple linear tree 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -279,7 +279,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting top-down view trees with truncation shows elided children at multiple levels 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -293,7 +293,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting top-down view trees with truncation shows elided children with correct percentages 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -304,7 +304,7 @@ f-0. A [total: 100.0%, self: 0.0%]
 `;
 
 exports[`call tree formatting top-down view trees with truncation shows truncation with wide trees (many siblings) 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Test Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 

--- a/profiler-cli/src/test/unit/__snapshots__/category-formatting.test.ts.snap
+++ b/profiler-cli/src/test/unit/__snapshots__/category-formatting.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`category breakdown formatting renders categories with their subcategories in thread samples 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Parent Process) | View: Full profile | Full: 1s]
 
 Thread: Test Thread
 
@@ -27,7 +27,7 @@ Heaviest stack (0.0 samples, 0 frames):
 `;
 
 exports[`category breakdown formatting renders the running and self breakdowns in function info 1`] = `
-"[Thread: t-0 (Test Thread) | View: Full profile | Full: 1s]
+"[Thread: t-0 (Test Thread, Parent Process) | View: Full profile | Full: 1s]
 
 Function f-12:
   Full name: libxul.so!nsBlockFrame::Reflow

--- a/profiler-cli/src/test/unit/__snapshots__/meta-formatting.test.ts.snap
+++ b/profiler-cli/src/test/unit/__snapshots__/meta-formatting.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`formatProfileMetaResult renders a full Firefox recording grouped into sections 1`] = `
-"[Thread: t-0 (GeckoMain) | View: Full profile | Full: 3s]
+"[Thread: t-0 (GeckoMain, Parent Process) | View: Full profile | Full: 3s]
 
 Recording:
   Started: 2024-09-02T14:35:00.000Z
@@ -28,7 +28,7 @@ Platform:
 `;
 
 exports[`formatProfileMetaResult renders a sparse imported profile, skipping absent sections 1`] = `
-"[Thread: t-0 (GeckoMain) | View: Full profile | Full: 3s]
+"[Thread: t-0 (GeckoMain, Parent Process) | View: Full profile | Full: 3s]
 
 Recording:
   Sampling interval: 1ms
@@ -43,7 +43,7 @@ Import:
 `;
 
 exports[`formatProfileMetaResult renders extra importer sections as their own heading blocks 1`] = `
-"[Thread: t-0 (GeckoMain) | View: Full profile | Full: 3s]
+"[Thread: t-0 (GeckoMain, Parent Process) | View: Full profile | Full: 3s]
 
 Recording:
   Sampling interval: 1ms

--- a/profiler-cli/src/test/unit/allocation-formatting.test.ts
+++ b/profiler-cli/src/test/unit/allocation-formatting.test.ts
@@ -55,7 +55,11 @@ function threadMap(): ThreadMap {
 function mockContext(strategy: CallTreeSummaryStrategy): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'Test Thread' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'Test Thread', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 1000 },
     callTreeSummaryStrategy: strategy,

--- a/profiler-cli/src/test/unit/call-tree-formatting.test.ts
+++ b/profiler-cli/src/test/unit/call-tree-formatting.test.ts
@@ -34,7 +34,11 @@ import {
 function createMockContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'Test Thread' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'Test Thread', processName: 'Test Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 1000 },
     callTreeSummaryStrategy: 'timing',

--- a/profiler-cli/src/test/unit/category-formatting.test.ts
+++ b/profiler-cli/src/test/unit/category-formatting.test.ts
@@ -17,7 +17,11 @@ import {
 function createMockContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'Test Thread' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'Test Thread', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 1000 },
     callTreeSummaryStrategy: 'timing',

--- a/profiler-cli/src/test/unit/context-header-formatting.test.ts
+++ b/profiler-cli/src/test/unit/context-header-formatting.test.ts
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the thread identity shown in the `[Thread: ...]` banner and the
+ * other places that name the selected thread. A profile has many threads called
+ * "GeckoMain", so the thread name on its own does not say which one you are
+ * looking at; the process name is what disambiguates it. The banner also has to
+ * keep the sticky selection distinct from the thread a single command queried.
+ */
+
+import {
+  formatContextHeader,
+  formatStatusResult,
+  formatThreadSelectResult,
+} from '../../formatters';
+import type {
+  SessionContext,
+  StatusResult,
+  ThreadSelectResult,
+  WithContext,
+} from '../../protocol';
+
+function createContext(
+  overrides: Partial<SessionContext> = {}
+): SessionContext {
+  return {
+    selectedThreadHandle: 't-94',
+    selectedThreads: [
+      { threadIndex: 94, name: 'GeckoMain', processName: 'WebExtensions' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
+    currentViewRange: null,
+    rootRange: { start: 0, end: 3000 },
+    callTreeSummaryStrategy: 'timing',
+    ...overrides,
+  };
+}
+
+describe('formatContextHeader', function () {
+  it('names the process the thread belongs to', function () {
+    expect(formatContextHeader(createContext())).toBe(
+      '[Thread: t-94 (GeckoMain, WebExtensions) | View: Full profile | Full: 3s]'
+    );
+  });
+
+  it('omits the process name when it repeats the thread name', function () {
+    const context = createContext({
+      selectedThreadHandle: 't-5',
+      selectedThreads: [
+        { threadIndex: 5, name: 'Renderer', processName: 'Renderer' },
+      ],
+    });
+    expect(formatContextHeader(context)).toBe(
+      '[Thread: t-5 (Renderer) | View: Full profile | Full: 3s]'
+    );
+  });
+
+  it('separates several threads so each name/process pair stays readable', function () {
+    const context = createContext({
+      selectedThreadHandle: 't-0,t-90',
+      selectedThreads: [
+        { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+        { threadIndex: 90, name: 'GeckoMain', processName: 'GPU Process' },
+      ],
+    });
+    expect(formatContextHeader(context)).toBe(
+      '[Thread: t-0,t-90 (GeckoMain, Parent Process; GeckoMain, GPU Process) | ' +
+        'View: Full profile | Full: 3s]'
+    );
+  });
+
+  it('names both threads when the command queried a different one', function () {
+    const context = createContext({
+      resultThreadHandle: 't-2',
+      resultThreads: [
+        { threadIndex: 2, name: 'GeckoMain', processName: 'GPU Process' },
+      ],
+    });
+    expect(formatContextHeader(context)).toBe(
+      '[Thread: t-2 (GeckoMain, GPU Process) | Selected: t-94 | ' +
+        'View: Full profile | Full: 3s]'
+    );
+  });
+
+  it('leaves out the selection when the queried thread is the selected one', function () {
+    // The querier only fills the result-scoped fields on a divergence, so this
+    // is what an explicit `--thread t-94` on the selected thread looks like.
+    expect(formatContextHeader(createContext())).not.toContain('Selected:');
+  });
+
+  it('still reports when no thread is selected', function () {
+    const context = createContext({
+      selectedThreadHandle: null,
+      selectedThreads: [],
+    });
+    expect(formatContextHeader(context)).toContain(
+      '[Thread: No thread selected'
+    );
+  });
+});
+
+describe('formatStatusResult', function () {
+  it('names the process of the selected thread', function () {
+    const result: StatusResult = {
+      type: 'status',
+      selectedThreadHandle: 't-94',
+      selectedThreads: [
+        { threadIndex: 94, name: 'GeckoMain', processName: 'WebExtensions' },
+      ],
+      viewRanges: [],
+      rootRange: { start: 0, end: 3000 },
+      filterStacks: [],
+      callTreeSummaryStrategy: 'timing',
+    };
+    expect(formatStatusResult(result)).toContain(
+      'Selected thread: t-94 (GeckoMain, WebExtensions)'
+    );
+  });
+});
+
+describe('formatThreadSelectResult', function () {
+  it('names the process of the newly selected thread', function () {
+    const result: WithContext<ThreadSelectResult> = {
+      type: 'thread-select',
+      threadHandle: 't-94',
+      threadNames: ['GeckoMain'],
+      context: createContext(),
+    };
+    expect(formatThreadSelectResult(result)).toBe(
+      'Selected thread: t-94 (GeckoMain, WebExtensions)'
+    );
+  });
+});

--- a/profiler-cli/src/test/unit/counter-formatting.test.ts
+++ b/profiler-cli/src/test/unit/counter-formatting.test.ts
@@ -17,7 +17,11 @@ import type {
 function createContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 3000 },
     callTreeSummaryStrategy: 'timing',

--- a/profiler-cli/src/test/unit/counter-formatting.test.ts
+++ b/profiler-cli/src/test/unit/counter-formatting.test.ts
@@ -72,7 +72,7 @@ describe('formatCounterListResult', function () {
           category: 'Bandwidth',
           graphType: 'line-rate',
           processIndex: 3,
-          processName: 'Isolated Web Content',
+          processName: 'example.com',
           etld1: 'example.com',
           pid: '456',
           stats: [
@@ -95,7 +95,7 @@ describe('formatCounterListResult', function () {
     expect(output).toContain('memory range in graph: 27B');
     expect(output).toContain('[7 samples]');
     expect(output).toContain(
-      'c-1: Bandwidth (Bandwidth) [p-3 Isolated Web Content (example.com), pid 456]'
+      'c-1: Bandwidth (Bandwidth) [p-3 example.com, pid 456]'
     );
     expect(output).toContain('Data transferred in the visible range: 2KB');
   });

--- a/profiler-cli/src/test/unit/marker-formatting.test.ts
+++ b/profiler-cli/src/test/unit/marker-formatting.test.ts
@@ -13,7 +13,11 @@ import type {
 function createContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 3000 },
     callTreeSummaryStrategy: 'timing',

--- a/profiler-cli/src/test/unit/meta-formatting.test.ts
+++ b/profiler-cli/src/test/unit/meta-formatting.test.ts
@@ -12,7 +12,11 @@ import type {
 function createContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 3000 },
     callTreeSummaryStrategy: 'timing',

--- a/profiler-cli/src/test/unit/network-formatting.test.ts
+++ b/profiler-cli/src/test/unit/network-formatting.test.ts
@@ -23,7 +23,11 @@ import type {
 function createContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 1000 },
     callTreeSummaryStrategy: 'timing',

--- a/profiler-cli/src/test/unit/sourcemap-formatting.test.ts
+++ b/profiler-cli/src/test/unit/sourcemap-formatting.test.ts
@@ -17,7 +17,11 @@ import type {
 function createContext(): SessionContext {
   return {
     selectedThreadHandle: 't-0',
-    selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+    selectedThreads: [
+      { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+    ],
+    resultThreadHandle: null,
+    resultThreads: [],
     currentViewRange: null,
     rootRange: { start: 0, end: 3000 },
     callTreeSummaryStrategy: 'timing',

--- a/src/profile-logic/profile-data.ts
+++ b/src/profile-logic/profile-data.ts
@@ -3439,6 +3439,31 @@ export function getSampleIndexClosestToCenteredTime(
   return distanceToPrevious <= maxTimeDistance ? index - 1 : null;
 }
 
+/**
+ * The friendly label for a bare process type, for processes whose back end did
+ * not supply a `processName`. Returns null for a type we have no name for.
+ */
+export function getProcessTypeLabel(
+  processType: string | undefined
+): string | null {
+  switch (processType) {
+    case 'default':
+      return 'Parent Process';
+    case 'gpu':
+      return 'GPU Process';
+    case 'rdd':
+      return 'Remote Data Decoder';
+    case 'tab':
+      return 'Content Process';
+    case 'plugin':
+      return 'Plugin Process';
+    case 'socket':
+      return 'Socket Process';
+    default:
+      return null;
+  }
+}
+
 export function getFriendlyThreadName(
   threads: RawThread[],
   thread: RawThread
@@ -3463,33 +3488,12 @@ export function getFriendlyThreadName(
           return thread.name === 'GeckoMain' && thread.processName === label;
         });
       } else {
-        switch (thread.processType) {
-          case 'default':
-            label = 'Parent Process';
-            break;
-          case 'gpu':
-            label = 'GPU Process';
-            break;
-          case 'rdd':
-            label = 'Remote Data Decoder';
-            break;
-          case 'tab': {
-            label = 'Content Process';
-            homonymThreads = threads.filter((thread) => {
-              return (
-                thread.name === 'GeckoMain' && thread.processType === 'tab'
-              );
-            });
-            break;
-          }
-          case 'plugin':
-            label = 'Plugin Process';
-            break;
-          case 'socket':
-            label = 'Socket Process';
-            break;
-          default:
-          // should we throw here ?
+        // should we throw here if the process type is unknown?
+        label = getProcessTypeLabel(thread.processType) ?? undefined;
+        if (thread.processType === 'tab') {
+          homonymThreads = threads.filter((thread) => {
+            return thread.name === 'GeckoMain' && thread.processType === 'tab';
+          });
         }
       }
       break;

--- a/src/profile-query/formatters/counter-info.ts
+++ b/src/profile-query/formatters/counter-info.ts
@@ -27,7 +27,7 @@ import {
 import { getSampleIndexRangeForSelection } from 'firefox-profiler/profile-logic/profile-data';
 import { ensureExists } from 'firefox-profiler/utils/types';
 import { getCounterHandle, parseCounterHandle } from '../counter-map';
-import { getProcessName } from '../process-thread-list';
+import { getFriendlyProcessName } from '../process-thread-list';
 import type {
   CounterIndex,
   CounterDisplayConfig,
@@ -221,7 +221,7 @@ export function collectCounterSummary(
     color: display.color,
     pid: counter.pid,
     processIndex,
-    processName: getProcessName(mainThread),
+    processName: getFriendlyProcessName(profile.threads, mainThread),
     etld1: mainThread['eTLD+1'],
     mainThreadIndex: counter.mainThreadIndex,
     mainThreadHandle: threadMap.handleForThreadIndex(counter.mainThreadIndex),

--- a/src/profile-query/formatters/profile-info.ts
+++ b/src/profile-query/formatters/profile-info.ts
@@ -8,7 +8,10 @@ import {
   getRangeFilteredCombinedThreadActivitySlices,
 } from 'firefox-profiler/selectors/profile';
 import { getProfileNameWithDefault } from 'firefox-profiler/selectors/url-state';
-import { buildProcessThreadList, getProcessName } from '../process-thread-list';
+import {
+  buildProcessThreadList,
+  getFriendlyProcessName,
+} from '../process-thread-list';
 import { collectSliceTree } from '../cpu-activity';
 import { collectCounterSummary, getSortedCounterIndexes } from './counter-info';
 import { computeProfileNetworkSummary } from '../network-summary';
@@ -95,7 +98,10 @@ export function collectProfileInfo(
       (t) => t.pid === processItem.pid
     );
     if (threadFromProcess) {
-      processItem.name = getProcessName(threadFromProcess);
+      processItem.name = getFriendlyProcessName(
+        profile.threads,
+        threadFromProcess
+      );
       processItem.etld1 = threadFromProcess['eTLD+1'];
       processItem.startTime = threadFromProcess.processStartupTime;
       processItem.endTime = threadFromProcess.processShutdownTime;

--- a/src/profile-query/index.ts
+++ b/src/profile-query/index.ts
@@ -48,6 +48,7 @@ import {
 import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
 import { TimestampManager } from './timestamps';
 import { ThreadMap } from './thread-map';
+import { getFriendlyProcessName } from './process-thread-list';
 import { parseFunctionHandle } from './function-map';
 import { getSourceHandle, parseSourceHandle } from './source-handle';
 import {
@@ -101,6 +102,7 @@ import type {
 import type {
   StatusResult,
   SessionContext,
+  ContextThreadInfo,
   WithContext,
   FunctionExpandResult,
   FunctionInfoResult,
@@ -296,7 +298,10 @@ export class ProfileQuerier {
       this._markerMap,
       threadHandle
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(threadHandle),
+    };
   }
 
   async threadSamples(
@@ -980,7 +985,7 @@ export class ProfileQuerier {
       activeFilters: activeFilters.length > 0 ? activeFilters : undefined,
       ephemeralFilters:
         sampleFilters && sampleFilters.length > 0 ? sampleFilters : undefined,
-      context: this._getContext(strategy),
+      context: this._getContext(strategy, threadIndexes),
     };
   }
 
@@ -1076,23 +1081,32 @@ export class ProfileQuerier {
     }
   }
 
-  private _buildBaseStatus(state: ReturnType<Store['getState']>) {
+  /** Describe a set of threads for a context header: handle plus per-thread names. */
+  private _describeThreads(
+    state: ReturnType<Store['getState']>,
+    threadIndexes: Set<ThreadIndex>
+  ): { handle: string | null; threads: ContextThreadInfo[] } {
     const profile = getProfile(state);
+    const handle =
+      threadIndexes.size > 0
+        ? this._threadMap.handleForThreadIndexes(threadIndexes)
+        : null;
+    const threads = Array.from(threadIndexes).map((threadIndex) => ({
+      threadIndex,
+      name: profile.threads[threadIndex].name,
+      processName: getFriendlyProcessName(
+        profile.threads,
+        profile.threads[threadIndex]
+      ),
+    }));
+    return { handle, threads };
+  }
+
+  private _buildBaseStatus(state: ReturnType<Store['getState']>) {
     const rootRange = getProfileRootRange(state);
     const committedRanges = getAllCommittedRanges(state);
-    const selectedThreadIndexes = getSelectedThreadIndexes(state);
-
-    const selectedThreadHandle =
-      selectedThreadIndexes.size > 0
-        ? this._threadMap.handleForThreadIndexes(selectedThreadIndexes)
-        : null;
-
-    const selectedThreads = Array.from(selectedThreadIndexes).map(
-      (threadIndex) => ({
-        threadIndex,
-        name: profile.threads[threadIndex].name,
-      })
-    );
+    const { handle: selectedThreadHandle, threads: selectedThreads } =
+      this._describeThreads(state, getSelectedThreadIndexes(state));
 
     const zeroAt = rootRange.start;
     const viewRanges = committedRanges.map((range) => {
@@ -1123,16 +1137,32 @@ export class ProfileQuerier {
    * store has already been restored to the session value by then.
    */
   private _getContext(
-    effectiveStrategy?: CallTreeSummaryStrategy
+    effectiveStrategy?: CallTreeSummaryStrategy,
+    resultThreadIndexes?: Set<ThreadIndex>
   ): SessionContext {
     const state = this._store.getState();
     const { selectedThreadHandle, selectedThreads, viewRanges, rootRange } =
       this._buildBaseStatus(state);
     const currentViewRange =
       viewRanges.length > 0 ? viewRanges[viewRanges.length - 1] : null;
+
+    // The result-scoped fields only exist to record a divergence, so leave them
+    // empty when the command ran against the selection after all.
+    let resultThreadHandle: string | null = null;
+    let resultThreads: ContextThreadInfo[] = [];
+    if (resultThreadIndexes !== undefined) {
+      const described = this._describeThreads(state, resultThreadIndexes);
+      if (described.handle !== selectedThreadHandle) {
+        resultThreadHandle = described.handle;
+        resultThreads = described.threads;
+      }
+    }
+
     return {
       selectedThreadHandle,
       selectedThreads,
+      resultThreadHandle,
+      resultThreads,
       currentViewRange,
       rootRange,
       callTreeSummaryStrategy:
@@ -1148,6 +1178,17 @@ export class ProfileQuerier {
       return getLastSelectedCallTreeSummaryStrategy(state);
     }
     return getThreadSelectors(threadIndexes).getCallTreeSummaryStrategy(state);
+  }
+
+  private _getContextForThreadHandle(
+    threadHandle: string | undefined
+  ): SessionContext {
+    return this._getContext(
+      undefined,
+      threadHandle !== undefined
+        ? this._threadMap.threadIndexesForHandle(threadHandle)
+        : undefined
+    );
   }
 
   /**
@@ -1293,7 +1334,10 @@ export class ProfileQuerier {
       threadHandle,
       filterOptions
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(threadHandle),
+    };
   }
 
   /**
@@ -1316,7 +1360,10 @@ export class ProfileQuerier {
       threadHandle,
       filterOptions
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(threadHandle),
+    };
   }
 
   /**
@@ -1334,7 +1381,10 @@ export class ProfileQuerier {
       threadHandle,
       options
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(threadHandle),
+    };
   }
 
   /**
@@ -1355,7 +1405,10 @@ export class ProfileQuerier {
       this._threadMap,
       filterOptions
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(filterOptions.thread),
+    };
   }
 
   /**
@@ -1403,7 +1456,7 @@ export class ProfileQuerier {
       activeFilters: activeFilters.length > 0 ? activeFilters : undefined,
       ephemeralFilters:
         sampleFilters && sampleFilters.length > 0 ? sampleFilters : undefined,
-      context: this._getContext(strategy),
+      context: this._getContext(strategy, threadIndexes),
     };
   }
 
@@ -1419,7 +1472,10 @@ export class ProfileQuerier {
       this._threadMap,
       markerHandle
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(result.threadHandle),
+    };
   }
 
   async markerStack(
@@ -1431,7 +1487,10 @@ export class ProfileQuerier {
       this._threadMap,
       markerHandle
     );
-    return { ...result, context: this._getContext() };
+    return {
+      ...result,
+      context: this._getContextForThreadHandle(result.threadHandle),
+    };
   }
 
   /**

--- a/src/profile-query/process-thread-list.ts
+++ b/src/profile-query/process-thread-list.ts
@@ -3,10 +3,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { RawThread } from 'firefox-profiler/types';
+import { getFriendlyThreadName } from 'firefox-profiler/profile-logic/profile-data';
 
 /** The display name of the process a thread belongs to. */
 export function getProcessName(thread: RawThread): string {
   return thread.processName || thread.processType || 'unknown';
+}
+
+/**
+ * The front end's label for a thread's process ("Parent Process", "GPU
+ * Process", an eTLD+1). Only a process' GeckoMain thread carries that label, so
+ * we ask that thread; processes without one fall back to `getProcessName`.
+ */
+export function getFriendlyProcessName(
+  threads: RawThread[],
+  thread: RawThread
+): string {
+  const mainThread = threads.find(
+    (candidate) =>
+      candidate.pid === thread.pid && candidate.name === 'GeckoMain'
+  );
+  if (mainThread === undefined) {
+    return getProcessName(thread);
+  }
+  return getFriendlyThreadName(threads, mainThread);
 }
 
 export type ThreadInfo = {

--- a/src/profile-query/process-thread-list.ts
+++ b/src/profile-query/process-thread-list.ts
@@ -3,11 +3,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { RawThread } from 'firefox-profiler/types';
-import { getFriendlyThreadName } from 'firefox-profiler/profile-logic/profile-data';
+import {
+  getFriendlyThreadName,
+  getProcessTypeLabel,
+} from 'firefox-profiler/profile-logic/profile-data';
 
-/** The display name of the process a thread belongs to. */
+/**
+ * The name a process reports for itself, for a process with no GeckoMain thread
+ * to carry a friendly label. An isolated content process is named after the
+ * site it hosts; otherwise this falls back to the label for the bare process
+ * type, so a process reads as "GPU Process" rather than the raw "gpu".
+ *
+ * Prefer `getFriendlyProcessName`, which is what every output uses.
+ */
 export function getProcessName(thread: RawThread): string {
-  return thread.processName || thread.processType || 'unknown';
+  return (
+    thread['eTLD+1'] ||
+    thread.processName ||
+    getProcessTypeLabel(thread.processType) ||
+    thread.processType ||
+    'unknown'
+  );
 }
 
 /**

--- a/src/profile-query/types.ts
+++ b/src/profile-query/types.ts
@@ -114,12 +114,28 @@ export type FilterStackResult = {
 // ===== Session Context =====
 // Context information included in all command results for persistent display
 
+/** A thread as named in the context header: its own name and its process'. */
+export type ContextThreadInfo = {
+  threadIndex: number;
+  name: string;
+  /** Name of the process owning the thread, e.g. "WebExtensions". */
+  processName: string;
+};
+
 export type SessionContext = {
-  selectedThreadHandle: string | null; // Combined handle like "t-0" or "t-0,t-1,t-2"
-  selectedThreads: Array<{
-    threadIndex: number;
-    name: string;
-  }>;
+  /**
+   * The sticky session selection, as set by `thread select`. Combined handle
+   * like "t-0" or "t-0,t-1,t-2". Unaffected by a command's `--thread`.
+   */
+  selectedThreadHandle: string | null;
+  selectedThreads: ContextThreadInfo[];
+  /**
+   * The thread this particular result is about, when it is not the selected
+   * one: a `--thread`-scoped command, or a marker looked up in another thread.
+   * Null when the result is about the selection.
+   */
+  resultThreadHandle: string | null;
+  resultThreads: ContextThreadInfo[];
   currentViewRange: {
     start: number;
     startName: string;
@@ -144,10 +160,7 @@ export type WithContext<T> = T & { context: SessionContext };
 export type StatusResult = {
   type: 'status';
   selectedThreadHandle: string | null; // Combined handle like "t-0" or "t-0,t-1,t-2"
-  selectedThreads: Array<{
-    threadIndex: number;
-    name: string;
-  }>;
+  selectedThreads: ContextThreadInfo[];
   viewRanges: Array<{
     start: number;
     startName: string;

--- a/src/test/unit/profile-query/process-thread-list.test.ts
+++ b/src/test/unit/profile-query/process-thread-list.test.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { buildProcessThreadList } from 'firefox-profiler/profile-query/process-thread-list';
+import {
+  buildProcessThreadList,
+  getFriendlyProcessName,
+  getProcessName,
+} from 'firefox-profiler/profile-query/process-thread-list';
+import { getEmptyThread } from 'firefox-profiler/profile-logic/data-structures';
 
 import type { ThreadInfo } from 'firefox-profiler/profile-query/process-thread-list';
 
@@ -432,5 +437,123 @@ describe('buildProcessThreadList', function () {
       combinedCpuMs: 150, // 50 + 40 + 30 + 20 + 10
       maxCpuMs: 50,
     });
+  });
+});
+
+/**
+ * The fallback `getFriendlyProcessName` uses for a process with no GeckoMain
+ * thread to carry a label. The back end omits `processName` for some process
+ * types, so those fall back to a label for the bare `processType`.
+ */
+describe('getProcessName', function () {
+  it('names a process that the back end did not name', function () {
+    expect(
+      getProcessName(getEmptyThread({ name: 'GeckoMain', processType: 'gpu' }))
+    ).toBe('GPU Process');
+    expect(
+      getProcessName(getEmptyThread({ name: 'GeckoMain', processType: 'rdd' }))
+    ).toBe('Remote Data Decoder');
+  });
+
+  it('names an isolated content process after the site it hosts', function () {
+    expect(
+      getProcessName(
+        getEmptyThread({
+          name: 'GeckoMain',
+          processType: 'tab',
+          processName: 'Web Content',
+          'eTLD+1': 'example.com',
+        })
+      )
+    ).toBe('example.com');
+  });
+
+  it('prefers the name the back end supplied over the process type', function () {
+    // A supplied processName is already friendly, and most processes have one.
+    expect(
+      getProcessName(
+        getEmptyThread({
+          name: 'GeckoMain',
+          processType: 'gpu',
+          processName: 'WebExtensions',
+        })
+      )
+    ).toBe('WebExtensions');
+  });
+
+  it('falls back to the raw type, then to "unknown"', function () {
+    expect(
+      getProcessName(
+        getEmptyThread({ name: 'GeckoMain', processType: 'nonesuch' })
+      )
+    ).toBe('nonesuch');
+    expect(
+      getProcessName(getEmptyThread({ name: 'GeckoMain', processType: '' }))
+    ).toBe('unknown');
+  });
+});
+
+/**
+ * `profile info` and the thread banner both name processes with this, so the
+ * two outputs cannot disagree. A content process is the interesting case: its
+ * label comes from the eTLD+1 rather than from `processName`, and gets an
+ * "(n/m)" suffix when several processes share a domain.
+ */
+describe('getFriendlyProcessName', function () {
+  function geckoMain(pid: string, extra: object = {}) {
+    return getEmptyThread({
+      name: 'GeckoMain',
+      processType: 'tab',
+      pid,
+      ...extra,
+    });
+  }
+
+  it('prefers the eTLD+1 over a generic processName', function () {
+    const thread = geckoMain('1', {
+      processName: 'Web Content',
+      'eTLD+1': 'example.com',
+    });
+    expect(getFriendlyProcessName([thread], thread)).toBe('example.com');
+  });
+
+  it('numbers processes that share a domain', function () {
+    const a = geckoMain('1', { 'eTLD+1': 'example.com' });
+    const b = geckoMain('2', { 'eTLD+1': 'example.com' });
+    const threads = [a, b];
+    expect(getFriendlyProcessName(threads, a)).toBe('example.com (1/2)');
+    expect(getFriendlyProcessName(threads, b)).toBe('example.com (2/2)');
+  });
+
+  it('takes the label from the process\u2019 GeckoMain thread', function () {
+    // A non-main thread carries neither the eTLD+1 nor the process name, so the
+    // label has to come from its process' GeckoMain thread.
+    const main = geckoMain('1', { 'eTLD+1': 'example.com' });
+    const worker = getEmptyThread({
+      name: 'StyleThread',
+      processType: 'tab',
+      pid: '1',
+    });
+    expect(getFriendlyProcessName([main, worker], worker)).toBe('example.com');
+  });
+
+  it('falls back to the process name when the process has no GeckoMain thread', function () {
+    const orphan = getEmptyThread({
+      name: 'StyleThread',
+      processType: 'gpu',
+      pid: '9',
+    });
+    expect(getFriendlyProcessName([orphan], orphan)).toBe('GPU Process');
+
+    // The fallback names such a process after its site too, so a content
+    // process reads the same whether or not its GeckoMain thread is present.
+    const orphanTab = getEmptyThread({
+      name: 'StyleThread',
+      processType: 'tab',
+      processName: 'Web Content',
+      'eTLD+1': 'example.com',
+      pid: '10',
+    });
+    expect(getFriendlyProcessName([orphanTab], orphanTab)).toBe('example.com');
   });
 });

--- a/src/test/unit/profile-query/profile-querier.test.ts
+++ b/src/test/unit/profile-query/profile-querier.test.ts
@@ -755,4 +755,122 @@ describe('ProfileQuerier', function () {
       expect(listedNames).toEqual(['Beta']);
     });
   });
+
+  describe('session context', function () {
+    /**
+     * Two GeckoMain threads in two processes: t-0 in the parent process and t-1
+     * in the GPU process. Both threads are named "GeckoMain", so the process is
+     * the only thing that tells them apart.
+     */
+    function querierWithTwoProcesses() {
+      const profile = getProfileWithMarkers(
+        [['Parent marker', 10, null, { type: 'tracing', category: 'Test' }]],
+        [['GPU marker', 20, null, { type: 'tracing', category: 'Test' }]]
+      );
+      profile.threads[0].name = 'GeckoMain';
+      profile.threads[0].pid = '111';
+      profile.threads[0].processType = 'default';
+      profile.threads[1].name = 'GeckoMain';
+      profile.threads[1].pid = '222';
+      profile.threads[1].processType = 'gpu';
+      const store = storeWithProfile(profile);
+      const rootRange = getProfileRootRange(store.getState());
+      return new ProfileQuerier(store, rootRange);
+    }
+
+    it('names the process of each thread in the context', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-0');
+
+      const { context } = await querier.profileInfo();
+      expect(context.selectedThreadHandle).toBe('t-0');
+      // The thread name alone ("GeckoMain") does not say which process this is.
+      expect(context.selectedThreads).toEqual([
+        { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+      ]);
+    });
+
+    it('reports --thread alongside the untouched selection', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-0');
+
+      const result = await querier.threadMarkers('t-1');
+      // The body reports t-1, so the result-scoped fields must too, while the
+      // selection stays on t-0 because `--thread` does not select anything.
+      expect(result.threadHandle).toBe('t-1');
+      expect(result.context.resultThreadHandle).toBe('t-1');
+      expect(result.context.resultThreads).toEqual([
+        { threadIndex: 1, name: 'GeckoMain', processName: 'GPU Process' },
+      ]);
+      expect(result.context.selectedThreadHandle).toBe('t-0');
+      expect(result.context.selectedThreads).toEqual([
+        { threadIndex: 0, name: 'GeckoMain', processName: 'Parent Process' },
+      ]);
+    });
+
+    it('reports the queried marker thread alongside the selection', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-0');
+
+      // Find the handle of the marker living in the GPU process thread.
+      const markers = await querier.threadMarkers('t-1', { list: true });
+      const gpuMarker = markers.flatMarkers!.find(
+        (m) => m.name === 'GPU marker'
+      );
+      expect(gpuMarker).toBeDefined();
+
+      const info = await querier.markerInfo(gpuMarker!.handle);
+      expect(info.threadHandle).toBe('t-1');
+      expect(info.context.resultThreadHandle).toBe('t-1');
+      expect(info.context.resultThreads).toEqual([
+        { threadIndex: 1, name: 'GeckoMain', processName: 'GPU Process' },
+      ]);
+      expect(info.context.selectedThreadHandle).toBe('t-0');
+    });
+
+    it('leaves the result-scoped fields empty without --thread', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-1');
+
+      const { context } = await querier.threadMarkers();
+      expect(context.selectedThreadHandle).toBe('t-1');
+      expect(context.resultThreadHandle).toBeNull();
+      expect(context.resultThreads).toEqual([]);
+    });
+
+    it('leaves the result-scoped fields empty when --thread names the selected thread', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-1');
+
+      // Passing the thread that is already selected is not a divergence, so the
+      // header must not grow a redundant "Selected:" segment.
+      const { context } = await querier.threadMarkers('t-1');
+      expect(context.selectedThreadHandle).toBe('t-1');
+      expect(context.resultThreadHandle).toBeNull();
+      expect(context.resultThreads).toEqual([]);
+    });
+
+    it('reports "profile logs --thread" alongside the selection', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-0');
+
+      const { context } = await querier.profileLogs({ thread: 't-1' });
+      expect(context.resultThreadHandle).toBe('t-1');
+      expect(context.resultThreads).toEqual([
+        { threadIndex: 1, name: 'GeckoMain', processName: 'GPU Process' },
+      ]);
+      expect(context.selectedThreadHandle).toBe('t-0');
+    });
+
+    it('reports the selected thread for "profile logs" across all threads', async function () {
+      const querier = querierWithTwoProcesses();
+      await querier.threadSelect('t-0');
+
+      // Without --thread, "profile logs" spans every thread, so the selected
+      // thread stays the right thing to report.
+      const { context } = await querier.profileLogs();
+      expect(context.selectedThreadHandle).toBe('t-0');
+      expect(context.resultThreadHandle).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6269--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

The [Thread: ...] banner named the thread but not its process, so "t-94 (GeckoMain)" read as the parent process when it was a child, and an empty result looked like missing data rather than the wrong thread. It also kept showing the selected thread when a command queried a different one via --thread.

The banner now reads "t-94 (GeckoMain, WebExtensions)" and follows --thread. Process labels use the front end's naming, so it says "GPU Process" where profile info prints the raw "gpu".