### PR TITLE
Profiler cli screenshots pr

### DIFF
--- a/profiler-cli/README.md
+++ b/profiler-cli/README.md
@@ -44,6 +44,8 @@ profiler-cli thread network                # Show network requests with timing p
 profiler-cli thread page-load              # Show page load summary (navigation timing, resources, CPU, jank)
 profiler-cli marker info <handle>          # Show detailed marker information (e.g., m-1234)
 profiler-cli marker stack <handle>         # Show full stack trace for a marker
+profiler-cli marker screenshot <handle>    # Write a CompositorScreenshot marker's image to a file [-o path]
+profiler-cli screenshots                   # Write one image per window [--at 11.287 | --range 11.2,11.4] [-o dir/]
 profiler-cli function expand <handle>      # Show full untruncated function name (e.g., f-123)
 profiler-cli function info <handle>        # Show detailed function information
 profiler-cli function annotate <handle>    # Show annotated source/assembly with timing data [--mode src|asm|all] [--context 2|file|N] [--symbol-server <url>]

--- a/profiler-cli/guide.txt
+++ b/profiler-cli/guide.txt
@@ -99,6 +99,9 @@ CORE WORKFLOW
   Step 6: Drill into specifics
     profiler-cli marker info m-1234          Full details for a marker (from handles in marker list)
     profiler-cli marker stack m-1234         Full stack trace at the time of a marker
+    profiler-cli screenshots --at 24.835 -o shots/    Each window on screen at t=24.835s
+    profiler-cli screenshots --range 11.2,11.4 -o shots/  All windows' frames in a range
+    profiler-cli marker screenshot m-1234 -o shot.jpg  Image from one CompositorScreenshot marker
     profiler-cli function info f-12          Function details (source location, library)
     profiler-cli function expand f-12        Show full untruncated function name
     profiler-cli function annotate f-12      Annotated source with per-line self/total timing

--- a/profiler-cli/src/commands/marker.ts
+++ b/profiler-cli/src/commands/marker.ts
@@ -8,6 +8,11 @@
 
 import type { Command } from 'commander';
 import { addGlobalOptions, runCommand } from './shared';
+import { writeScreenshotFile } from '../utils/screenshot-file';
+import { elideScreenshotData } from '../../../src/profile-query/screenshot';
+import type { MarkerScreenshotJson, WithContext } from '../protocol';
+import { sendCommand } from '../client';
+import { formatOutput, formatJson } from '../output';
 
 export function registerMarkerCommand(
   program: Command,
@@ -26,6 +31,64 @@ export function registerMarkerCommand(
       sessionDir,
       { command: 'marker', subcommand: 'info', marker: markerHandle },
       opts
+    );
+  });
+
+  addGlobalOptions(
+    marker
+      .command('screenshot [handle]')
+      .description(
+        "Extract one window's image from a CompositorScreenshot marker"
+      )
+      .option('--marker <handle>', 'Marker handle')
+      .option(
+        '-o, --output <path>',
+        'File to write the image to, or a directory to write it into'
+      )
+  ).action(async (handleArg: string | undefined, opts) => {
+    const markerHandle = handleArg ?? opts.marker;
+    // Require an explicit destination rather than dropping a binary into
+    // whatever the current working directory happens to be. `--json` does not
+    // waive this: the image bytes are never inlined in the JSON either.
+    if (opts.output === undefined) {
+      console.error(
+        'Error: -o/--output is required (a file path, or a directory to write into).'
+      );
+      process.exit(1);
+    }
+    const result = await sendCommand(
+      sessionDir,
+      { command: 'marker', subcommand: 'screenshot', marker: markerHandle },
+      opts.session
+    );
+
+    if (typeof result === 'string' || result.type !== 'marker-screenshot') {
+      // Unexpected shape: let the normal formatter report it.
+      console.log(formatOutput(result, opts.json));
+      return;
+    }
+
+    // `-o` applies whether or not `--json` was passed.
+    const written = writeScreenshotFile(
+      result.screenshot,
+      opts.output,
+      result.markerHandle
+    );
+
+    if (opts.json) {
+      const payload: WithContext<MarkerScreenshotJson> = {
+        ...result,
+        screenshot: elideScreenshotData(result.screenshot),
+        path: written.path,
+        byteLength: written.byteLength,
+      };
+      console.log(formatJson(payload));
+      return;
+    }
+
+    console.log(formatOutput(result, false));
+    console.log(
+      `\nWrote ${written.path} (${written.byteLength.toLocaleString('en-US')} bytes)`
     );
   });
 

--- a/profiler-cli/src/commands/screenshots.ts
+++ b/profiler-cli/src/commands/screenshots.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * `profiler-cli screenshots` command.
+ */
+
+import type { Command } from 'commander';
+import { addGlobalOptions } from './shared';
+import { sendCommand } from '../client';
+import { formatOutput, formatJson } from '../output';
+import { writeScreenshots } from '../utils/screenshot-file';
+import { elideScreenshotData } from '../../../src/profile-query/screenshot';
+import type { ScreenshotsJson, WithContext } from '../protocol';
+
+export function registerScreenshotsCommand(
+  program: Command,
+  sessionDir: string
+): void {
+  addGlobalOptions(
+    program
+      .command('screenshots')
+      .description(
+        'Write one CompositorScreenshot image per window, at a time or over a range'
+      )
+      .option(
+        '--at <time>',
+        'Instant, e.g. 11.287, 11287ms, 10% or a ts- handle'
+      )
+      .option('--range <start,end>', 'Range to look up, e.g. 11.2,11.4')
+      .option('-o, --output <dir>', 'Directory to write the images into')
+  ).action(async (opts) => {
+    const result = await sendCommand(
+      sessionDir,
+      { command: 'screenshots', at: opts.at, range: opts.range },
+      opts.session
+    );
+
+    if (typeof result === 'string' || result.type !== 'screenshots') {
+      // Unexpected shape: let the normal formatter report it.
+      console.log(formatOutput(result, opts.json));
+      return;
+    }
+
+    // `-o` applies whether or not `--json` was passed: a flag that is accepted
+    // and silently ignored is worse than one that errors.
+    const written = writeScreenshots(result, opts.output);
+
+    if (opts.json) {
+      // Never inline the image bytes. With `-o` they are on disk and `path`
+      // points at them; without it, `marker screenshot <handle> -o` fetches any
+      // single frame.
+      const payload: WithContext<ScreenshotsJson> = {
+        ...result,
+        screenshots: result.screenshots.map((entry, index) => ({
+          ...entry,
+          screenshot: elideScreenshotData(entry.screenshot),
+          path: written[index]?.path,
+          byteLength: written[index]?.byteLength,
+        })),
+        written: written.map((file) => file.path),
+      };
+      console.log(formatJson(payload));
+      return;
+    }
+
+    console.log(formatOutput(result, false));
+
+    if (written.length === 0) {
+      return;
+    }
+    console.log(`\nWrote ${written.length} image(s):`);
+    console.log(
+      written
+        .map(
+          (file) =>
+            `  ${file.path} (${file.byteLength.toLocaleString('en-US')} bytes)`
+        )
+        .join('\n')
+    );
+  });
+}

--- a/profiler-cli/src/daemon.ts
+++ b/profiler-cli/src/daemon.ts
@@ -474,11 +474,21 @@ export class Daemon {
               throw new Error('marker handle required for marker stack');
             }
             return this.querier.markerStack(command.marker);
+          case 'screenshot':
+            if (!command.marker) {
+              throw new Error('marker handle required for marker screenshot');
+            }
+            return this.querier.markerScreenshot(command.marker);
           case 'select':
             throw new Error('unimplemented');
           default:
             throw assertExhaustiveCheck(command);
         }
+      case 'screenshots':
+        return this.querier.screenshots({
+          at: command.at,
+          range: command.range,
+        });
       case 'counter':
         switch (command.subcommand) {
           case 'list':

--- a/profiler-cli/src/formatters.ts
+++ b/profiler-cli/src/formatters.ts
@@ -19,6 +19,9 @@ import type {
   ThreadInfoResult,
   MarkerStackResult,
   MarkerInfoResult,
+  MarkerScreenshotResult,
+  ScreenshotsResult,
+  ScreenshotEntry,
   ProfileInfoResult,
   ProfileMetaResult,
   ThreadSamplesResult,
@@ -50,6 +53,7 @@ import type {
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/types';
 import { truncateFunctionName } from '../../src/profile-query/function-list';
 import { describeSpec } from '../../src/profile-query/filter-stack';
+import { screenshotFileExtension } from '../../src/profile-query/screenshot';
 import {
   formatTimestamp as formatDuration,
   formatBytes,
@@ -333,6 +337,19 @@ Stack trace for marker ${result.markerHandle}: ${result.markerName}\n`;
 }
 
 /**
+ * The decoded byte length of a base64 string, without decoding it.
+ */
+export function decodedBase64ByteLength(base64: string): number {
+  let padding = 0;
+  if (base64.endsWith('==')) {
+    padding = 2;
+  } else if (base64.endsWith('=')) {
+    padding = 1;
+  }
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+/**
  * Format a MarkerInfoResult as plain text.
  */
 export function formatMarkerInfoResult(
@@ -370,6 +387,36 @@ Marker ${result.markerHandle}: ${result.name}`;
     }
   }
 
+  // Raw payload keys, for marker types whose schema does not model every key
+  // (or that have no schema at all, e.g. CompositorScreenshot).
+  if (result.rawFields && result.rawFields.length > 0) {
+    const heading =
+      result.fields && result.fields.length > 0
+        ? '\nOther payload fields (no schema):\n'
+        : '\nFields (raw payload, no schema):\n';
+    output += heading;
+    for (const field of result.rawFields) {
+      const ellipsis = field.truncated ? '…' : '';
+      output += `  ${field.key}: ${field.value}${ellipsis}\n`;
+    }
+  }
+
+  // Screenshot image, if this marker carries one.
+  if (result.screenshot) {
+    const { windowWidth, windowHeight, mimeType, base64 } = result.screenshot;
+    output += '\nScreenshot:\n';
+    if (windowWidth !== undefined && windowHeight !== undefined) {
+      output += `  Window size: ${windowWidth}px × ${windowHeight}px\n`;
+    }
+    if (mimeType) {
+      output += `  Image type: ${mimeType}\n`;
+    }
+    if (base64) {
+      output += `  Image data: ${formatBytes(decodedBase64ByteLength(base64))} (full data URL in --json output)\n`;
+    }
+    output += `  Extract it with: profiler-cli marker screenshot ${result.markerHandle} -o shot.${screenshotFileExtension(result.screenshot)}\n`;
+  }
+
   // Schema description
   if (result.schema?.description) {
     output += '\nDescription:\n';
@@ -394,6 +441,119 @@ Marker ${result.markerHandle}: ${result.name}`;
   }
 
   return output;
+}
+
+/**
+ * Describe one screenshot on a single line, e.g.
+ * "m-11  t=1,421s  win 2  1280px × 1024px  18,4kB  image/jpeg".
+ *
+ * `--at` returns one row per window, so the window ID is what tells the rows
+ * apart; without it "which of these is the browser window?" is unanswerable.
+ */
+function formatScreenshotLine(
+  entry: ScreenshotEntry | MarkerScreenshotResult,
+  rootStart: number
+): string {
+  const { screenshot } = entry;
+  const parts = [
+    entry.markerHandle.padEnd(8),
+    `t=${formatDuration(entry.start - rootStart)}`.padEnd(14),
+  ];
+  if (screenshot.windowID !== undefined) {
+    parts.push(`win ${screenshot.windowID}`.padEnd(8));
+  }
+  if (
+    screenshot.windowWidth !== undefined &&
+    screenshot.windowHeight !== undefined
+  ) {
+    parts.push(
+      `${screenshot.windowWidth}px × ${screenshot.windowHeight}px`.padEnd(16)
+    );
+  }
+  if (screenshot.base64) {
+    parts.push(formatBytes(decodedBase64ByteLength(screenshot.base64)));
+  }
+  if (screenshot.mimeType) {
+    parts.push(screenshot.mimeType);
+  }
+  if ('isFallback' in entry && entry.isFallback) {
+    const staleBy = entry.staleByMs;
+    parts.push(
+      staleBy !== undefined
+        ? `(stale: ended ${formatDuration(staleBy)} earlier)`
+        : '(stale)'
+    );
+  }
+  return `  ${parts.join('  ')}`;
+}
+
+/**
+ * Format a MarkerScreenshotResult as plain text. The image itself is written to
+ * disk by the command, which appends its own "Wrote ..." line.
+ */
+export function formatMarkerScreenshotResult(
+  result: WithContext<MarkerScreenshotResult>
+): string {
+  const rootStart = result.context.rootRange.start;
+  const lines = [
+    formatContextHeader(result.context),
+    '',
+    `Screenshot from marker ${result.markerHandle} in thread ${result.threadHandle} (${result.friendlyThreadName}):`,
+    formatScreenshotLine(result, rootStart),
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Format a ScreenshotsResult as plain text.
+ */
+export function formatScreenshotsResult(
+  result: WithContext<ScreenshotsResult>
+): string {
+  const rootStart = result.context.rootRange.start;
+  const lines = [formatContextHeader(result.context), ''];
+
+  let query: string;
+  if (result.at !== undefined) {
+    query = `at t=${formatDuration(result.at - rootStart)}`;
+  } else if (result.range) {
+    query = `in range ${formatDuration(result.range.start - rootStart)} - ${formatDuration(result.range.end - rootStart)}`;
+  } else {
+    query = '';
+  }
+
+  if (result.screenshots.length === 0) {
+    lines.push(
+      `No screenshots ${query}. The profile has ${result.totalScreenshotCount} screenshot marker(s).`
+    );
+    if (result.totalScreenshotCount === 0) {
+      lines.push(
+        '',
+        'This profile was captured without the "screenshots" feature.'
+      );
+    }
+    return lines.join('\n');
+  }
+
+  lines.push(
+    `${result.screenshots.length} screenshot(s) ${query} (of ${result.totalScreenshotCount} in the profile)`,
+    ''
+  );
+  for (const entry of result.screenshots) {
+    lines.push(formatScreenshotLine(entry, rootStart));
+  }
+
+  const fallbackCount = result.screenshots.filter(
+    (entry) => entry.isFallback
+  ).length;
+  if (fallbackCount > 0) {
+    lines.push(
+      '',
+      `Note: ${fallbackCount} frame(s) marked stale did not span the requested time — they are`,
+      'the last frame each window painted before it, not what was on screen at that instant.'
+    );
+  }
+  return lines.join('\n');
 }
 
 /**

--- a/profiler-cli/src/index.ts
+++ b/profiler-cli/src/index.ts
@@ -36,6 +36,7 @@ import { VERSION } from './constants';
 import { registerProfileCommand } from './commands/profile';
 import { registerThreadCommand } from './commands/thread';
 import { registerMarkerCommand } from './commands/marker';
+import { registerScreenshotsCommand } from './commands/screenshots';
 import { registerFunctionCommand } from './commands/function';
 import { registerCounterCommand } from './commands/counter';
 import { registerZoomCommand } from './commands/zoom';
@@ -192,6 +193,7 @@ Examples:
   registerProfileCommand(program, SESSION_DIR);
   registerThreadCommand(program, SESSION_DIR);
   registerMarkerCommand(program, SESSION_DIR);
+  registerScreenshotsCommand(program, SESSION_DIR);
   registerFunctionCommand(program, SESSION_DIR);
   registerCounterCommand(program, SESSION_DIR);
   registerZoomCommand(program, SESSION_DIR);

--- a/profiler-cli/src/output.ts
+++ b/profiler-cli/src/output.ts
@@ -18,6 +18,8 @@ import {
   formatThreadInfoResult,
   formatMarkerStackResult,
   formatMarkerInfoResult,
+  formatMarkerScreenshotResult,
+  formatScreenshotsResult,
   formatProfileInfoResult,
   formatProfileMetaResult,
   formatThreadSamplesResult,
@@ -34,6 +36,18 @@ import {
   formatSourceMapSourcesResult,
   formatApplySourceMapResult,
 } from './formatters';
+
+/**
+ * Serialize a JSON payload that is not a `CommandResult`.
+ *
+ * The screenshot commands reshape their result before printing `--json`: the
+ * image bytes are elided and the written file paths added. That shape is
+ * deliberately not a `CommandResult`, so it cannot go through `formatOutput`,
+ * whose switch must stay exhaustive over the text formatters.
+ */
+export function formatJson(payload: unknown): string {
+  return JSON.stringify(payload, null, 2);
+}
 
 /**
  * Format a command result for output.
@@ -73,6 +87,10 @@ export function formatOutput(
       return formatMarkerStackResult(result);
     case 'marker-info':
       return formatMarkerInfoResult(result);
+    case 'marker-screenshot':
+      return formatMarkerScreenshotResult(result);
+    case 'screenshots':
+      return formatScreenshotsResult(result);
     case 'profile-info':
       return formatProfileInfoResult(result);
     case 'profile-meta':

--- a/profiler-cli/src/protocol.ts
+++ b/profiler-cli/src/protocol.ts
@@ -51,6 +51,12 @@ export type {
   MarkerGroupData,
   MarkerInfoResult,
   MarkerStackResult,
+  MarkerScreenshotResult,
+  ScreenshotsResult,
+  ScreenshotEntry,
+  ScreenshotData,
+  ScreenshotsJson,
+  MarkerScreenshotJson,
   StackTraceData,
   ProfileInfoResult,
   ProfileMetaResult,
@@ -81,6 +87,8 @@ import type {
   ThreadInfoResult,
   MarkerStackResult,
   MarkerInfoResult,
+  MarkerScreenshotResult,
+  ScreenshotsResult,
   ProfileInfoResult,
   ProfileMetaResult,
   ThreadSamplesResult,
@@ -162,8 +170,15 @@ export type ClientCommand =
     }
   | {
       command: 'marker';
-      subcommand: 'info' | 'select' | 'stack';
+      subcommand: 'info' | 'select' | 'stack' | 'screenshot';
       marker?: string;
+    }
+  | {
+      command: 'screenshots';
+      /** Instant to look up, e.g. "11.287", "11287ms", "10%" or "ts-6". */
+      at?: string;
+      /** Range to look up, e.g. "11.2,11.4". */
+      range?: string;
     }
   | {
       command: 'counter';
@@ -222,6 +237,8 @@ export type CommandResult =
   | WithContext<ThreadInfoResult>
   | WithContext<MarkerStackResult>
   | WithContext<MarkerInfoResult>
+  | WithContext<MarkerScreenshotResult>
+  | WithContext<ScreenshotsResult>
   | WithContext<ProfileInfoResult>
   | WithContext<ProfileMetaResult>
   | WithContext<ThreadSamplesResult>

--- a/profiler-cli/src/test/unit/screenshot-output.test.ts
+++ b/profiler-cli/src/test/unit/screenshot-output.test.ts
@@ -1,0 +1,305 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the CLI side of screenshot extraction: decoding a data URL to a
+ * file, and rendering the screenshot listings.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  writeScreenshotFile,
+  writeScreenshots,
+} from '../../utils/screenshot-file';
+import { formatScreenshotsResult } from '../../formatters';
+import { elideScreenshotData } from 'firefox-profiler/profile-query/screenshot';
+import type {
+  ScreenshotData,
+  ScreenshotsResult,
+  SessionContext,
+  WithContext,
+} from 'firefox-profiler/profile-query/types';
+
+// A 1x1 JPEG. Small, but real bytes with the FFD8FF magic number.
+const JPEG_BASE64 =
+  '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwcJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPDIzNP/AABEIAAEAAQMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAABAgMEBQYHCAkKC//EAKHAAAEC/9oADAMBAAIRAxEAPwD3+iiigD//2Q==';
+
+function makeScreenshot(
+  overrides: Partial<ScreenshotData> = {}
+): ScreenshotData {
+  return {
+    url: `data:image/jpeg;base64,${JPEG_BASE64}`,
+    mimeType: 'image/jpeg',
+    base64: JPEG_BASE64,
+    windowWidth: 1280,
+    windowHeight: 951,
+    windowID: '0x1',
+    ...overrides,
+  };
+}
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pcli-screenshot-test-'));
+}
+
+describe('writeScreenshotFile', function () {
+  let tempDir: string;
+
+  beforeEach(function () {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(function () {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('decodes the base64 payload to real image bytes', function () {
+    const target = path.join(tempDir, 'shot.jpg');
+    const result = writeScreenshotFile(makeScreenshot(), target, 'm-11');
+
+    expect(result.path).toBe(target);
+    const bytes = fs.readFileSync(target);
+    expect(result.byteLength).toBe(bytes.length);
+    // JPEG magic number, so the file really is an image and not base64 text.
+    expect([bytes[0], bytes[1], bytes[2]]).toEqual([0xff, 0xd8, 0xff]);
+  });
+
+  it('creates missing parent directories', function () {
+    const target = path.join(tempDir, 'nested', 'deeper', 'shot.jpg');
+    writeScreenshotFile(makeScreenshot(), target, 'm-11');
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  it('writes inside an existing directory, naming the file after the marker', function () {
+    const result = writeScreenshotFile(makeScreenshot(), tempDir, 'm-11');
+    expect(result.path).toBe(path.join(tempDir, 'screenshot-m-11.jpg'));
+  });
+
+  it('treats a trailing separator as a directory even if it does not exist yet', function () {
+    const dir = path.join(tempDir, 'shots');
+    const result = writeScreenshotFile(
+      makeScreenshot(),
+      dir + path.sep,
+      'm-12'
+    );
+    expect(result.path).toBe(path.join(dir, 'screenshot-m-12.jpg'));
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it('derives the extension from the MIME type', function () {
+    const result = writeScreenshotFile(
+      makeScreenshot({ mimeType: 'image/png' }),
+      tempDir,
+      'm-13'
+    );
+    expect(result.path.endsWith('screenshot-m-13.png')).toBe(true);
+  });
+
+  it('throws rather than writing a bogus file when there is no base64 payload', function () {
+    expect(() =>
+      writeScreenshotFile(
+        makeScreenshot({ base64: undefined }),
+        path.join(tempDir, 'shot.jpg'),
+        'm-14'
+      )
+    ).toThrow(/cannot be written/);
+  });
+});
+
+describe('formatScreenshotsResult', function () {
+  function makeContext(): SessionContext {
+    return {
+      selectedThreadHandle: 't-0',
+      selectedThreads: [{ threadIndex: 0, name: 'GeckoMain' }],
+      currentViewRange: null,
+      rootRange: { start: 0, end: 3000 },
+    };
+  }
+
+  function makeResult(
+    screenshots: ScreenshotsResult['screenshots'],
+    at = 1000
+  ): WithContext<ScreenshotsResult> {
+    return {
+      type: 'screenshots',
+      at,
+      totalScreenshotCount: 10,
+      screenshots,
+      context: makeContext(),
+    };
+  }
+
+  const baseEntry = {
+    markerHandle: 'm-1',
+    threadHandle: 't-90',
+    friendlyThreadName: 'GPU Process',
+    start: 900,
+    end: 1100,
+    screenshot: makeScreenshot(),
+  };
+
+  it('marks stale frames and explains why', function () {
+    const output = formatScreenshotsResult(
+      makeResult([{ ...baseEntry, end: 500, isFallback: true, staleByMs: 500 }])
+    );
+
+    expect(output).toContain('stale');
+    // The staleness must be quantified, not just asserted.
+    expect(output).toMatch(/ended .* earlier/);
+    expect(output).toContain('not what was on screen at that instant');
+  });
+
+  it('does not mention staleness when every frame spans the instant', function () {
+    const output = formatScreenshotsResult(makeResult([baseEntry]));
+    expect(output).not.toContain('stale');
+  });
+
+  it('identifies the window on each row, since --at returns one per window', function () {
+    const output = formatScreenshotsResult(
+      makeResult([
+        baseEntry,
+        {
+          ...baseEntry,
+          markerHandle: 'm-2',
+          screenshot: makeScreenshot({ windowID: '0x2' }),
+        },
+      ])
+    );
+    // Two rows for the same instant are only tellable apart by their window.
+    expect(output).toContain('win 0x1');
+    expect(output).toContain('win 0x2');
+  });
+
+  it('explains an empty result when the profile has no screenshots at all', function () {
+    const output = formatScreenshotsResult({
+      ...makeResult([]),
+      totalScreenshotCount: 0,
+    });
+    expect(output).toContain('No screenshots');
+    expect(output).toContain('"screenshots" feature');
+  });
+});
+
+describe('elideScreenshotData', function () {
+  it('replaces the image bytes with a stand-in, keeping the metadata', function () {
+    const elided = elideScreenshotData(makeScreenshot());
+
+    // The point of the elision: --json must never carry the blob itself.
+    expect(elided.url).toEqual({
+      elided: true,
+      length: `data:image/jpeg;base64,${JPEG_BASE64}`.length,
+      preview: `data:image/jpeg;base64,${JPEG_BASE64}`.slice(0, 64),
+    });
+    expect(elided.base64).toEqual({
+      elided: true,
+      length: JPEG_BASE64.length,
+      preview: JPEG_BASE64.slice(0, 64),
+    });
+    // Everything a consumer might filter on survives.
+    expect(elided.mimeType).toBe('image/jpeg');
+    expect(elided.windowWidth).toBe(1280);
+    expect(elided.windowID).toBe('0x1');
+  });
+
+  it('serializes to a payload far smaller than the raw image', function () {
+    const screenshot = makeScreenshot();
+    const raw = JSON.stringify(screenshot).length;
+    const elided = JSON.stringify(elideScreenshotData(screenshot)).length;
+    expect(elided).toBeLessThan(raw);
+    // No base64 run survives anywhere in the serialized form.
+    expect(JSON.stringify(elideScreenshotData(screenshot))).not.toContain(
+      JPEG_BASE64
+    );
+  });
+
+  it('leaves base64 absent when the payload had none', function () {
+    const elided = elideScreenshotData(makeScreenshot({ base64: undefined }));
+    expect(elided.base64).toBeUndefined();
+  });
+});
+
+describe('screenshots --json with -o', function () {
+  let tempDir: string;
+
+  beforeEach(function () {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(function () {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeResult(): ScreenshotsResult {
+    return {
+      type: 'screenshots',
+      at: 1000,
+      totalScreenshotCount: 10,
+      screenshots: [
+        {
+          markerHandle: 'm-1',
+          threadHandle: 't-90',
+          friendlyThreadName: 'GPU Process',
+          start: 900,
+          end: 1100,
+          screenshot: makeScreenshot({ windowID: '0x1' }),
+        },
+        {
+          markerHandle: 'm-2',
+          threadHandle: 't-90',
+          friendlyThreadName: 'GPU Process',
+          start: 950,
+          end: 1100,
+          screenshot: makeScreenshot({ windowID: '0x2' }),
+        },
+      ],
+    };
+  }
+
+  // The bug that shipped: --json returned before the writing loop, so -o was
+  // silently ignored and the base64 went to stdout instead.
+  it('writes one file per window, so -o is not ignored', function () {
+    const written = writeScreenshots(makeResult(), tempDir);
+
+    expect(written).toHaveLength(2);
+    expect(fs.readdirSync(tempDir).sort()).toEqual([
+      'screenshot-m-1.jpg',
+      'screenshot-m-2.jpg',
+    ]);
+    for (const file of written) {
+      expect(fs.existsSync(file.path)).toBe(true);
+      expect(file.byteLength).toBeGreaterThan(0);
+    }
+  });
+
+  it('reports the written paths in result order, so they zip onto the entries', function () {
+    const result = makeResult();
+    const written = writeScreenshots(result, tempDir);
+
+    expect(written.map((file) => path.basename(file.path))).toEqual([
+      'screenshot-m-1.jpg',
+      'screenshot-m-2.jpg',
+    ]);
+    // Machine-readable pairing is the whole point of --json.
+    const payload = result.screenshots.map((entry, index) => ({
+      markerHandle: entry.markerHandle,
+      path: written[index].path,
+    }));
+    expect(payload[0].markerHandle).toBe('m-1');
+    expect(payload[0].path).toBe(written[0].path);
+  });
+
+  it('accepts a directory without a trailing separator', function () {
+    const dir = path.join(tempDir, 'shots');
+    const written = writeScreenshots(makeResult(), dir);
+    expect(written).toHaveLength(2);
+    expect(fs.existsSync(path.join(dir, 'screenshot-m-1.jpg'))).toBe(true);
+  });
+
+  it('writes nothing when no -o was given', function () {
+    expect(writeScreenshots(makeResult(), undefined)).toEqual([]);
+    expect(fs.readdirSync(tempDir)).toEqual([]);
+  });
+});

--- a/profiler-cli/src/utils/screenshot-file.ts
+++ b/profiler-cli/src/utils/screenshot-file.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Writing extracted screenshot images to disk.
+ *
+ * Kept free of any daemon/client imports so it can be unit-tested without the
+ * build-time constants those modules need.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { screenshotFileExtension } from '../../../src/profile-query/screenshot';
+import type {
+  ScreenshotData,
+  ScreenshotsResult,
+} from '../../../src/profile-query/types';
+
+/**
+ * Decode a screenshot's base64 data URL and write it to `outputPath`.
+ *
+ * When `outputPath` names an existing directory, or ends with a path separator,
+ * the file is written inside it using a name derived from the marker handle.
+ * Parent directories are created as needed. Returns the resolved path and the
+ * number of bytes written.
+ */
+export function writeScreenshotFile(
+  screenshot: ScreenshotData,
+  outputPath: string | undefined,
+  markerHandle: string
+): { path: string; byteLength: number } {
+  if (!screenshot.base64) {
+    throw new Error(
+      `Screenshot for ${markerHandle} is not a base64 data URL, so it cannot be written to a file.`
+    );
+  }
+
+  const extension = screenshotFileExtension(screenshot);
+  const defaultName = `screenshot-${markerHandle}.${extension}`;
+
+  let resolved: string;
+  if (outputPath === undefined) {
+    resolved = path.resolve(defaultName);
+  } else {
+    const isDirectory =
+      outputPath.endsWith(path.sep) ||
+      outputPath.endsWith('/') ||
+      (fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory());
+    resolved = isDirectory
+      ? path.resolve(outputPath, defaultName)
+      : path.resolve(outputPath);
+  }
+
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  const buffer = Buffer.from(screenshot.base64, 'base64');
+  fs.writeFileSync(resolved, buffer);
+  return { path: resolved, byteLength: buffer.byteLength };
+}
+
+/**
+ * Write every screenshot of a `screenshots` result into the `-o` directory, in
+ * result order so callers can zip the returned files back onto the entries.
+ * Returns an empty array when no `-o` was given.
+ *
+ * This runs for `--json` too: `-o` is honoured whichever output mode is in use,
+ * since a flag that is accepted and silently ignored is worse than one that
+ * errors.
+ */
+export function writeScreenshots(
+  result: ScreenshotsResult,
+  outputDir: string | undefined
+): Array<{ path: string; byteLength: number }> {
+  if (outputDir === undefined || result.screenshots.length === 0) {
+    return [];
+  }
+  // Always treat -o as a directory for this command, which emits one image per
+  // window.
+  const directory = outputDir.endsWith(path.sep)
+    ? outputDir
+    : outputDir + path.sep;
+  return result.screenshots.map((entry) =>
+    writeScreenshotFile(entry.screenshot, directory, entry.markerHandle)
+  );
+}

--- a/src/profile-query/formatters/marker-info.ts
+++ b/src/profile-query/formatters/marker-info.ts
@@ -67,6 +67,7 @@ import {
   resolveLogMarkerMessage,
 } from 'firefox-profiler/profile-logic/marker-data';
 import { formatFunctionNameWithLibrary } from '../function-list';
+import { getScreenshotData } from '../screenshot';
 import type {
   NetworkPayload,
   LogMarkerPayload,
@@ -1033,6 +1034,89 @@ export function collectMarkerStack(
 /**
  * Collect detailed marker information in structured format.
  */
+/**
+ * Maximum length of a stringified raw payload value before it is truncated.
+ * Screenshot data URLs run to tens of kilobytes, which would otherwise flood
+ * the terminal; the full value stays available via the dedicated
+ * `screenshot` field and the `marker screenshot` command.
+ */
+export const RAW_FIELD_MAX_LENGTH = 200;
+
+/**
+ * Stringify a raw payload value for display. Objects are JSON-encoded, and
+ * string-table indexes are resolved by the caller before we get here.
+ */
+function stringifyRawValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  ) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    // Cyclic or otherwise unserializable payloads.
+    return String(value);
+  }
+}
+
+/**
+ * Collect the raw keys of a marker payload, so payloads that no schema models
+ * are still visible in `marker info`.
+ *
+ * Keys already reported through `schemaFields` are skipped, as are structural
+ * keys (`type`, `cause`) that are surfaced elsewhere. String-table indexes are
+ * resolved to their strings, and long values are truncated.
+ */
+function collectRawPayloadFields(
+  data: Record<string, unknown>,
+  schemaFields: MarkerInfoResult['fields'],
+  stringTable: StringTable,
+  stringIndexMarkerFieldsByDataType: Map<string, string[]>
+): MarkerInfoResult['rawFields'] {
+  const reportedKeys = new Set((schemaFields ?? []).map((field) => field.key));
+  // `type` is shown as "Type:" and `cause` is rendered as a stack trace.
+  const skippedKeys = new Set(['type', 'cause']);
+
+  const stringIndexFields =
+    stringIndexMarkerFieldsByDataType.get(String(data.type)) ?? [];
+
+  const rawFields: NonNullable<MarkerInfoResult['rawFields']> = [];
+  for (const key of Object.keys(data)) {
+    if (reportedKeys.has(key) || skippedKeys.has(key)) {
+      continue;
+    }
+    const value = data[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    // Resolve string-table indexes (e.g. CompositorScreenshot's `url`).
+    const resolved =
+      stringIndexFields.includes(key) && typeof value === 'number'
+        ? stringTable.getString(value)
+        : value;
+
+    const stringified = stringifyRawValue(resolved);
+    if (stringified.length > RAW_FIELD_MAX_LENGTH) {
+      rawFields.push({
+        key,
+        value: stringified.slice(0, RAW_FIELD_MAX_LENGTH),
+        truncated: true,
+      });
+    } else {
+      rawFields.push({ key, value: stringified });
+    }
+  }
+
+  return rawFields.length > 0 ? rawFields : undefined;
+}
+
 export function collectMarkerInfo(
   store: Store,
   markerMap: MarkerMap,
@@ -1071,6 +1155,7 @@ export function collectMarkerInfo(
 
   // Collect marker fields
   let fields: MarkerInfoResult['fields'];
+  let rawFields: MarkerInfoResult['rawFields'];
   let schemaInfo: MarkerInfoResult['schema'];
 
   if (marker.data) {
@@ -1100,11 +1185,26 @@ export function collectMarkerInfo(
       }
     }
 
+    // Always surface the raw payload keys. For marker types the schema does not
+    // model (such as CompositorScreenshot, which has no schema at all — #5303),
+    // this is the only way the payload is visible; without it `marker info`
+    // prints no fields and reads as "this marker has no payload".
+    rawFields = collectRawPayloadFields(
+      marker.data,
+      fields,
+      stringTable,
+      computeStringIndexMarkerFieldsByDataType(getMarkerSchema(state))
+    );
+
     // Include schema description if available
     if (schema?.description) {
       schemaInfo = { description: schema.description };
     }
   }
+
+  // Decode CompositorScreenshot images so the data URL is reachable from
+  // `marker info --json` without a schema.
+  const screenshot = getScreenshotData(marker, stringTable) ?? undefined;
 
   // Collect stack trace if available (truncated to 20 frames)
   let stack: StackTraceData | undefined;
@@ -1148,6 +1248,8 @@ export function collectMarkerInfo(
     end: marker.end !== null ? marker.end - zeroAt : null,
     duration: marker.end !== null ? marker.end - marker.start : undefined,
     fields,
+    rawFields,
+    screenshot,
     schema: schemaInfo,
     stack,
   };

--- a/src/profile-query/index.ts
+++ b/src/profile-query/index.ts
@@ -85,6 +85,7 @@ import {
   collectCounterList,
   collectCounterInfo,
 } from './formatters/counter-info';
+import { collectMarkerScreenshot, collectScreenshots } from './screenshot';
 import { parseTimeValue } from './time-range-parser';
 import { describeTransformGroup, pushSpecTransforms } from './filter-stack';
 import { functionAnnotate as computeFunctionAnnotate } from './function-annotate';
@@ -107,6 +108,8 @@ import type {
   ThreadInfoResult,
   MarkerStackResult,
   MarkerInfoResult,
+  MarkerScreenshotResult,
+  ScreenshotsResult,
   ProfileInfoResult,
   ProfileMetaResult,
   ThreadSamplesResult,
@@ -1318,6 +1321,85 @@ export class ProfileQuerier {
       markerHandle
     );
     return { ...result, context: this._getContext() };
+  }
+
+  /**
+   * Extract the screenshot image carried by a `CompositorScreenshot` marker.
+   */
+  async markerScreenshot(
+    markerHandle: string
+  ): Promise<WithContext<MarkerScreenshotResult>> {
+    const result = collectMarkerScreenshot(
+      this._store,
+      this._markerMap,
+      this._threadMap,
+      markerHandle
+    );
+    return { ...result, context: this._getContext() };
+  }
+
+  /**
+   * Find screenshots at an instant (`at`) or over a range, across all threads.
+   * Times are parsed like `zoom push` ranges: seconds ("2.7"), milliseconds
+   * ("2700ms"), percentages ("10%") or timestamp names ("ts-6").
+   */
+  async screenshots(options: {
+    at?: string;
+    range?: string;
+  }): Promise<WithContext<ScreenshotsResult>> {
+    const { at, range } = options;
+    if (at !== undefined && range !== undefined) {
+      throw new Error('Pass only one of --at and --range.');
+    }
+    if (at === undefined && range === undefined) {
+      throw new Error(
+        'Pass --at <time> or --range <start>,<end> (e.g. --at 11.287 or --range 11.2,11.4).'
+      );
+    }
+
+    let resolved: { at?: number; range?: { start: number; end: number } };
+    if (at !== undefined) {
+      resolved = { at: this._resolveTime(at) };
+    } else {
+      const parts = (range as string).split(',');
+      if (parts.length !== 2) {
+        throw new Error(
+          `Invalid range "${range}". Expected "<start>,<end>", e.g. "11.2,11.4".`
+        );
+      }
+      const start = this._resolveTime(parts[0].trim());
+      const end = this._resolveTime(parts[1].trim());
+      if (end < start) {
+        throw new Error(`Invalid range "${range}": end is before start.`);
+      }
+      resolved = { range: { start, end } };
+    }
+
+    const result = collectScreenshots(
+      this._store,
+      this._markerMap,
+      this._threadMap,
+      resolved
+    );
+    return { ...result, context: this._getContext() };
+  }
+
+  /**
+   * Resolve a time argument to an absolute timestamp in ms, accepting either a
+   * timestamp name ("ts-6") or a time value ("2.7", "2700ms", "10%").
+   */
+  _resolveTime(value: string): number {
+    const rootRange = getProfileRootRange(this._store.getState());
+    const parsed = parseTimeValue(value, rootRange);
+    if (parsed !== null) {
+      return parsed;
+    }
+    // parseTimeValue returns null for timestamp names ("ts-N").
+    const ts = this._timestampManager.timestampForName(value);
+    if (ts === null) {
+      throw new Error(`Unknown timestamp name: "${value}"`);
+    }
+    return ts;
   }
 
   async markerStack(

--- a/src/profile-query/screenshot.ts
+++ b/src/profile-query/screenshot.ts
@@ -1,0 +1,384 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Extraction of `CompositorScreenshot` marker payloads.
+ *
+ * Screenshot markers store their image as a `data:` URL in the profile's string
+ * table, so `payload.url` is an *index*, not a string (see `ScreenshotPayload`
+ * in `src/types/markers.ts`). These helpers resolve that index and split the
+ * data URL so callers can write the image to disk.
+ */
+
+import { getProfile, getStringTable } from 'firefox-profiler/selectors/profile';
+import { getThreadSelectors } from 'firefox-profiler/selectors/per-thread';
+import type { Marker, ThreadIndex } from 'firefox-profiler/types';
+import type { StringTable } from 'firefox-profiler/utils/string-table';
+import type { Store } from '../types/store';
+import type { ThreadMap } from './thread-map';
+import type { MarkerMap } from './marker-map';
+import type {
+  ScreenshotData,
+  ScreenshotEntry,
+  ScreenshotsResult,
+  MarkerScreenshotResult,
+  ElidedString,
+  ElidedScreenshotData,
+} from './types';
+
+export const SCREENSHOT_MARKER_TYPE = 'CompositorScreenshot';
+
+/**
+ * Resolve a screenshot marker payload into a `ScreenshotData`.
+ *
+ * Returns null when the marker is not a screenshot, or is a
+ * `CompositorScreenshotWindowDestroyed` marker — those share the
+ * `CompositorScreenshot` payload type but carry no image (`url` is undefined).
+ */
+export function getScreenshotData(
+  marker: Marker,
+  stringTable: StringTable
+): ScreenshotData | null {
+  const data = marker.data;
+  if (!data || data.type !== SCREENSHOT_MARKER_TYPE) {
+    return null;
+  }
+
+  // Window-destroyed markers have `url: void`.
+  const urlIndex = (data as any).url;
+  if (urlIndex === undefined || urlIndex === null) {
+    return null;
+  }
+
+  // `url` is an index into the string table, not a string. Be tolerant of an
+  // already-resolved string in case an importer inlines it.
+  const url =
+    typeof urlIndex === 'number' ? stringTable.getString(urlIndex) : urlIndex;
+  if (typeof url !== 'string' || url === '') {
+    return null;
+  }
+
+  const screenshot: ScreenshotData = { url };
+
+  // Parse "data:image/jpeg;base64,<payload>".
+  const base64Marker = ';base64,';
+  const base64Index = url.indexOf(base64Marker);
+  if (url.startsWith('data:') && base64Index !== -1) {
+    screenshot.mimeType = url.slice('data:'.length, base64Index);
+    screenshot.base64 = url.slice(base64Index + base64Marker.length);
+  }
+
+  const { windowWidth, windowHeight, windowID } = data as any;
+  if (typeof windowWidth === 'number') {
+    screenshot.windowWidth = windowWidth;
+  }
+  if (typeof windowHeight === 'number') {
+    screenshot.windowHeight = windowHeight;
+  }
+  if (windowID !== undefined) {
+    screenshot.windowID = String(windowID);
+  }
+
+  return screenshot;
+}
+
+/**
+ * A file extension for a screenshot, derived from its MIME type.
+ * Defaults to `jpg` since Gecko captures screenshots as JPEG.
+ */
+export function screenshotFileExtension(screenshot: ScreenshotData): string {
+  const mimeType = screenshot.mimeType;
+  if (!mimeType) {
+    return 'jpg';
+  }
+  switch (mimeType) {
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/webp':
+      return 'webp';
+    default: {
+      // "image/avif" -> "avif"
+      const slash = mimeType.indexOf('/');
+      const subtype = slash === -1 ? mimeType : mimeType.slice(slash + 1);
+      return /^[a-z0-9]+$/.test(subtype) ? subtype : 'jpg';
+    }
+  }
+}
+
+/**
+ * Replace a long string with a `{ elided, length, preview }` stand-in.
+ *
+ * Same shape as the elision `thread markers --list --json` applies to
+ * `CompositorScreenshot.url`, so every command that can return a screenshot
+ * agrees on how the blob is represented.
+ */
+export function elideString(value: string): ElidedString {
+  return { elided: true, length: value.length, preview: value.slice(0, 64) };
+}
+
+/**
+ * A `ScreenshotData` with its image bytes replaced by elision stand-ins.
+ *
+ * `--json` exists to be piped into `jq`; one frame is tens of kilobytes of
+ * base64 and `screenshots` returns one per window, so the bytes are never
+ * inlined. They are reachable as files via `-o`. Elision is keyed by field
+ * identity rather than size, matching `--list --json`.
+ */
+export function elideScreenshotData(
+  screenshot: ScreenshotData
+): ElidedScreenshotData {
+  const { base64, ...rest } = screenshot;
+  return {
+    ...rest,
+    url: elideString(screenshot.url),
+    base64: base64 === undefined ? undefined : elideString(base64),
+  };
+}
+
+/**
+ * Extract the screenshot image for a single marker handle.
+ */
+export function collectMarkerScreenshot(
+  store: Store,
+  markerMap: MarkerMap,
+  threadMap: ThreadMap,
+  markerHandle: string
+): MarkerScreenshotResult {
+  const state = store.getState();
+  const { threadIndexes, markerIndex } =
+    markerMap.markerForHandle(markerHandle);
+
+  const threadSelectors = getThreadSelectors(threadIndexes);
+  const fullMarkerList = threadSelectors.getFullMarkerList(state);
+  const marker = fullMarkerList[markerIndex];
+  if (!marker) {
+    throw new Error(`Marker ${markerHandle} not found`);
+  }
+
+  const markerType = marker.data?.type;
+  if (markerType !== SCREENSHOT_MARKER_TYPE) {
+    throw new Error(
+      `Marker ${markerHandle} is a "${markerType ?? 'payload-less'}" marker, not a ${SCREENSHOT_MARKER_TYPE} marker. ` +
+        `Find screenshot markers with: thread markers --search ${SCREENSHOT_MARKER_TYPE} --list`
+    );
+  }
+
+  const stringTable = getStringTable(state);
+  const screenshot = getScreenshotData(marker, stringTable);
+  if (!screenshot) {
+    throw new Error(
+      `Marker ${markerHandle} is a ${SCREENSHOT_MARKER_TYPE} marker but carries no image ` +
+        `(window-destroyed markers only record a window ID).`
+    );
+  }
+
+  return {
+    type: 'marker-screenshot',
+    markerHandle,
+    threadHandle: threadMap.handleForThreadIndexes(threadIndexes),
+    friendlyThreadName: threadSelectors.getFriendlyThreadName(state),
+    start: marker.start,
+    end: marker.end,
+    screenshot,
+  };
+}
+
+/**
+ * Every thread index in the profile that could hold screenshot markers.
+ */
+function getAllThreadIndexes(store: Store): ThreadIndex[] {
+  const profile = getProfile(store.getState());
+  return profile.threads.map((_thread, threadIndex) => threadIndex);
+}
+
+/**
+ * The time at which each window was destroyed, keyed the same way as
+ * `windowKey`. `CompositorScreenshotWindowDestroyed` markers carry a `windowID`
+ * but no image, so they are the only record that a window went away.
+ */
+function collectWindowDestroyTimes(
+  store: Store,
+  threadMap: ThreadMap
+): Map<string, number> {
+  const state = store.getState();
+  const destroyTimes = new Map<string, number>();
+
+  for (const threadIndex of getAllThreadIndexes(store)) {
+    const threadIndexes = new Set([threadIndex]);
+    const fullMarkerList =
+      getThreadSelectors(threadIndexes).getFullMarkerList(state);
+    let threadHandle: string | null = null;
+
+    for (const marker of fullMarkerList) {
+      const data = marker.data;
+      if (
+        data?.type !== SCREENSHOT_MARKER_TYPE ||
+        marker.name !== 'CompositorScreenshotWindowDestroyed'
+      ) {
+        continue;
+      }
+      const windowID = (data as any).windowID;
+      if (windowID === undefined) {
+        continue;
+      }
+      if (threadHandle === null) {
+        threadHandle = threadMap.handleForThreadIndexes(threadIndexes);
+      }
+      const key = windowKey(threadHandle, String(windowID));
+      // Keep the earliest destroy time for a window ID, in case an ID is reused.
+      const previous = destroyTimes.get(key);
+      if (previous === undefined || marker.start < previous) {
+        destroyTimes.set(key, marker.start);
+      }
+    }
+  }
+
+  return destroyTimes;
+}
+
+/** Key identifying one window within one thread. */
+function windowKey(threadHandle: string, windowID: string | undefined): string {
+  return `${threadHandle}:${windowID ?? ''}`;
+}
+
+/**
+ * Find screenshots at an instant or over a range, across all threads.
+ *
+ * For `at`, resolves each window independently: if one of that window's frames
+ * spans the instant, that is the frame that was on screen. Screenshot markers
+ * are intervals running from one composite to the next, so a spanning frame is
+ * an exact answer.
+ *
+ * A window with no spanning frame falls back to its latest preceding frame,
+ * which is the last thing that window painted — useful, but not literally the
+ * frame at that instant, so it is flagged `isFallback` with `staleByMs`. Windows
+ * destroyed before the instant are dropped entirely: their last frame is not
+ * "what was on screen", it is a window that no longer existed.
+ */
+export function collectScreenshots(
+  store: Store,
+  markerMap: MarkerMap,
+  threadMap: ThreadMap,
+  options: { at?: number; range?: { start: number; end: number } }
+): ScreenshotsResult {
+  const state = store.getState();
+  const stringTable = getStringTable(state);
+
+  let totalScreenshotCount = 0;
+  const candidates: ScreenshotEntry[] = [];
+
+  for (const threadIndex of getAllThreadIndexes(store)) {
+    const threadIndexes = new Set([threadIndex]);
+    const threadSelectors = getThreadSelectors(threadIndexes);
+    const fullMarkerList = threadSelectors.getFullMarkerList(state);
+
+    let threadHandle: string | null = null;
+    let friendlyThreadName: string | null = null;
+
+    for (
+      let markerIndex = 0;
+      markerIndex < fullMarkerList.length;
+      markerIndex++
+    ) {
+      const marker = fullMarkerList[markerIndex];
+      if (marker.data?.type !== SCREENSHOT_MARKER_TYPE) {
+        continue;
+      }
+      const screenshot = getScreenshotData(marker, stringTable);
+      if (!screenshot) {
+        // Window-destroyed marker: no image.
+        continue;
+      }
+      totalScreenshotCount++;
+
+      // Screenshot markers are intervals; treat a missing end as an instant.
+      const start = marker.start;
+      const end = marker.end ?? marker.start;
+
+      if (options.range) {
+        // Any overlap with the requested range.
+        if (start > options.range.end || end < options.range.start) {
+          continue;
+        }
+      } else if (options.at !== undefined) {
+        // Keep every frame starting at or before the instant: the covering
+        // frame, plus earlier ones used as a fallback when none covers it.
+        if (start > options.at) {
+          continue;
+        }
+      }
+
+      if (threadHandle === null) {
+        threadHandle = threadMap.handleForThreadIndexes(threadIndexes);
+        friendlyThreadName = threadSelectors.getFriendlyThreadName(state);
+      }
+
+      candidates.push({
+        markerHandle: markerMap.handleForMarker(threadIndexes, markerIndex),
+        threadHandle,
+        friendlyThreadName: friendlyThreadName as string,
+        start,
+        end: marker.end,
+        screenshot,
+      });
+    }
+  }
+
+  let screenshots: ScreenshotEntry[];
+  if (options.at !== undefined) {
+    const at = options.at;
+    const destroyTimes = collectWindowDestroyTimes(store, threadMap);
+
+    // Resolve each window on its own: a frame spanning the instant if the window
+    // has one, otherwise that window's latest preceding frame.
+    const bestByWindow = new Map<string, ScreenshotEntry>();
+    for (const entry of candidates) {
+      const key = windowKey(entry.threadHandle, entry.screenshot.windowID);
+
+      // Drop windows that were already destroyed at the requested instant.
+      const destroyedAt = destroyTimes.get(key);
+      if (destroyedAt !== undefined && destroyedAt <= at) {
+        continue;
+      }
+
+      const covers = entry.start <= at && (entry.end ?? entry.start) >= at;
+      const previous = bestByWindow.get(key);
+      if (previous === undefined) {
+        bestByWindow.set(key, entry);
+        continue;
+      }
+      const previousCovers =
+        previous.start <= at && (previous.end ?? previous.start) >= at;
+      // A spanning frame always beats a preceding one; between two of the same
+      // kind, the later one is closer to the instant.
+      if ((covers && !previousCovers) || entry.start > previous.start) {
+        bestByWindow.set(key, entry);
+      }
+    }
+
+    screenshots = [...bestByWindow.values()].map((entry) => {
+      const end = entry.end ?? entry.start;
+      if (entry.start <= at && end >= at) {
+        return entry;
+      }
+      // Preceding frame, not a spanning one: say so, and by how much.
+      return { ...entry, isFallback: true, staleByMs: at - end };
+    });
+  } else {
+    screenshots = candidates;
+  }
+
+  screenshots.sort((a, b) => a.start - b.start);
+
+  return {
+    type: 'screenshots',
+    at: options.at,
+    range: options.range,
+    totalScreenshotCount,
+    screenshots,
+  };
+}

--- a/src/profile-query/types.ts
+++ b/src/profile-query/types.ts
@@ -696,10 +696,149 @@ export type MarkerInfoResult = {
     value: any;
     formattedValue: string;
   }>;
+  /**
+   * Raw payload keys for marker types with no schema (or whose schema does not
+   * model every key). Without this, `marker info` prints no "Fields:" section at
+   * all for such markers, which reads as "this marker has no payload".
+   * String-table indexes are resolved to their strings, and long values (such as
+   * screenshot data URLs) are truncated — see `screenshot` for the full data.
+   */
+  rawFields?: Array<{
+    key: string;
+    /** Stringified value, truncated to `RAW_FIELD_MAX_LENGTH` characters. */
+    value: string;
+    /** True when `value` was truncated from a longer original. */
+    truncated?: boolean;
+  }>;
+  /**
+   * Present for `CompositorScreenshot` markers that carry an image. Gives the
+   * full `data:` URL so consumers can extract the image, e.g.
+   * `marker info m-N --json | jq -r .screenshot.url | sed 's/^.*base64,//' | base64 -d`.
+   */
+  screenshot?: ScreenshotData;
   schema?: {
     description?: string;
   };
   stack?: StackTraceData;
+};
+
+/**
+ * A long string replaced by a short stand-in, so a `--json` payload never
+ * carries a megabyte of base64. Same shape as the elision applied to
+ * `CompositorScreenshot.url` in `thread markers --list --json`.
+ */
+export type ElidedString = {
+  elided: true;
+  /** Length in characters of the original string. */
+  length: number;
+  /** First 64 characters of the original string. */
+  preview: string;
+};
+
+/**
+ * A decoded `CompositorScreenshot` payload. `url` is the full `data:` URL, with
+ * the string-table index already resolved.
+ *
+ * This is the in-process shape, carrying the real bytes. On the way out to
+ * `--json` the CLI converts it to `ElidedScreenshotData`.
+ */
+export type ScreenshotData = {
+  /** Full data URL, e.g. "data:image/jpeg;base64,..." */
+  url: string;
+  /** MIME type parsed out of the data URL, e.g. "image/jpeg". */
+  mimeType?: string;
+  /** Base64 payload of the data URL, i.e. everything after "base64,". */
+  base64?: string;
+  /** Original window dimensions in device pixels (the image is scaled down). */
+  windowWidth?: number;
+  windowHeight?: number;
+  /** Opaque identifier of the captured window. */
+  windowID?: string;
+};
+
+/**
+ * A `ScreenshotData` as it appears in `--json`: same keys, but the image bytes
+ * replaced by stand-ins. `--json` is meant to be piped into `jq`, and a single
+ * frame is tens of kilobytes of base64, so the bytes are never inlined. Get
+ * them as files with `-o`.
+ */
+export type ElidedScreenshotData = Omit<ScreenshotData, 'url' | 'base64'> & {
+  url: ElidedString;
+  base64?: ElidedString;
+};
+
+/** Result of `marker screenshot m-N`, used to write an image file. */
+export type MarkerScreenshotResult = {
+  type: 'marker-screenshot';
+  markerHandle: string;
+  threadHandle: string;
+  friendlyThreadName: string;
+  /** Marker start, absolute ms (same timebase as `MarkerInfoResult.start`). */
+  start: number;
+  end: number | null;
+  screenshot: ScreenshotData;
+};
+
+/** One screenshot in a `screenshots` query result. */
+export type ScreenshotEntry = {
+  markerHandle: string;
+  threadHandle: string;
+  friendlyThreadName: string;
+  /** Marker start, absolute ms. */
+  start: number;
+  end: number | null;
+  screenshot: ScreenshotData;
+  /**
+   * Set for `--at` when this frame does not span the requested instant: it is
+   * the window's latest *preceding* frame, i.e. the last thing that window
+   * painted, not literally what was on screen at that instant.
+   */
+  isFallback?: boolean;
+  /** For a fallback frame, how long before the instant its interval ended. */
+  staleByMs?: number;
+};
+
+/** Result of `screenshots --at T` / `screenshots --range A,B`. */
+export type ScreenshotsResult = {
+  type: 'screenshots';
+  /** The requested instant, absolute ms — set when `--at` was used. */
+  at?: number;
+  /** The requested range, absolute ms — set when `--range` was used. */
+  range?: { start: number; end: number };
+  /** Total screenshot markers considered across all threads. */
+  totalScreenshotCount: number;
+  screenshots: ScreenshotEntry[];
+};
+
+/**
+ * `marker screenshot --json` output: the result, with the image elided and the
+ * written file reported so the payload is machine-readable end to end.
+ */
+export type MarkerScreenshotJson = Omit<
+  MarkerScreenshotResult,
+  'screenshot'
+> & {
+  screenshot: ElidedScreenshotData;
+  /** Absolute path of the image written by `-o`. */
+  path: string;
+  /** Size on disk in bytes of the decoded image. */
+  byteLength: number;
+};
+
+/** One entry of `screenshots --json`, with the image elided. */
+export type ScreenshotEntryJson = Omit<ScreenshotEntry, 'screenshot'> & {
+  screenshot: ElidedScreenshotData;
+  /** Absolute path of the image written by `-o`; absent without `-o`. */
+  path?: string;
+  /** Size on disk in bytes of the decoded image; absent without `-o`. */
+  byteLength?: number;
+};
+
+/** `screenshots --json` output. */
+export type ScreenshotsJson = Omit<ScreenshotsResult, 'screenshots'> & {
+  screenshots: ScreenshotEntryJson[];
+  /** Absolute paths of every image written by `-o`, in result order. */
+  written: string[];
 };
 
 export type MarkerStackResult = {

--- a/src/test/unit/profile-query/screenshot.test.ts
+++ b/src/test/unit/profile-query/screenshot.test.ts
@@ -1,0 +1,316 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for extracting `CompositorScreenshot` payloads.
+ *
+ * Screenshot markers have no marker schema (#5303), so before these behaviours
+ * existed `marker info` reported no fields at all for them and the image data
+ * URL — stored as a string table index — was unreachable from the CLI.
+ */
+
+import { ProfileQuerier } from 'firefox-profiler/profile-query';
+import { getProfileWithMarkers } from '../../fixtures/profiles/processed-profile';
+import { getProfileRootRange } from 'firefox-profiler/selectors/profile';
+import { storeWithProfile } from '../../fixtures/stores';
+import {
+  screenshotFileExtension,
+  SCREENSHOT_MARKER_TYPE,
+} from 'firefox-profiler/profile-query/screenshot';
+import type { Profile } from 'firefox-profiler/types';
+
+// A 1x1 JPEG, base64-encoded. Small but genuinely decodable.
+const JPEG_BASE64 =
+  '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwcJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPDIzNP/AABEIAAEAAQMBIgACEQEDEQH/xAAfAAABBQEBAQEBAQAAAAAAAAABAgMEBQYHCAkKC//EAKHAAAEC/9oADAMBAAIRAxEAPwD3+iiigD//2Q==';
+const DATA_URL = `data:image/jpeg;base64,${JPEG_BASE64}`;
+
+/**
+ * Build a profile with screenshot markers whose `url` really points into the
+ * string table, mirroring how Gecko stores them.
+ */
+function getProfileWithScreenshots(): Profile {
+  const profile = getProfileWithMarkers([
+    [
+      'CompositorScreenshot',
+      10,
+      20,
+      {
+        type: 'CompositorScreenshot',
+        // Resolved to DATA_URL through the string table below.
+        url: 0,
+        windowID: '0x1',
+        windowWidth: 1280,
+        windowHeight: 951,
+      } as any,
+    ],
+    [
+      'CompositorScreenshot',
+      20,
+      30,
+      {
+        type: 'CompositorScreenshot',
+        url: 0,
+        windowID: '0x1',
+        windowWidth: 1280,
+        windowHeight: 951,
+      } as any,
+    ],
+    // A second, concurrently-captured window.
+    [
+      'CompositorScreenshot',
+      5,
+      40,
+      {
+        type: 'CompositorScreenshot',
+        url: 0,
+        windowID: '0x2',
+        windowWidth: 800,
+        windowHeight: 600,
+      } as any,
+    ],
+    // Window-destroyed markers share the payload type but carry no image.
+    [
+      'CompositorScreenshotWindowDestroyed',
+      40,
+      null,
+      {
+        type: 'CompositorScreenshot',
+        windowID: '0x2',
+        url: undefined,
+      } as any,
+    ],
+  ]);
+
+  // Point string index 0 at the data URL the markers reference.
+  profile.shared.stringArray[0] = DATA_URL;
+  return profile;
+}
+
+function makeQuerier(profile: Profile): ProfileQuerier {
+  const store = storeWithProfile(profile);
+  const rootRange = getProfileRootRange(store.getState());
+  return new ProfileQuerier(store, rootRange);
+}
+
+/**
+ * The marker handles matching `searchString`, in chronological order.
+ */
+async function getMarkerHandles(
+  querier: ProfileQuerier,
+  searchString: string
+): Promise<string[]> {
+  const result = await querier.threadMarkers(undefined, {
+    searchString,
+    list: true,
+  });
+  const flatMarkers = result.flatMarkers ?? [];
+  expect(flatMarkers.length).toBeGreaterThan(0);
+  return flatMarkers.map((marker) => marker.handle);
+}
+
+/**
+ * The handle of the screenshot marker starting at `startTime` (ms, relative to
+ * the profile start). Picking by time rather than by list position keeps these
+ * assertions readable, since the flat list is chronological across windows.
+ */
+async function getScreenshotHandleAt(
+  querier: ProfileQuerier,
+  startTime: number
+): Promise<string> {
+  const result = await querier.threadMarkers(undefined, {
+    searchString: SCREENSHOT_MARKER_TYPE,
+    list: true,
+  });
+  const rootStart = getProfileRootRange(querier._store.getState()).start;
+  const match = (result.flatMarkers ?? []).find(
+    (marker) => Math.abs(marker.start - rootStart - startTime) < 0.001
+  );
+  if (!match) {
+    throw new Error(`No screenshot marker starting at ${startTime}ms`);
+  }
+  return match.handle;
+}
+
+describe('CompositorScreenshot extraction', function () {
+  describe('markerInfo', function () {
+    it('exposes the data URL and window size for a screenshot marker', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      // The first frame of window 0x1, captured at 1280x951. Times are relative
+      // to the profile root range, which starts at the earliest marker -- so
+      // window 0x2's frame sits at -5 and this one lands at 0.
+      const handle = await getScreenshotHandleAt(querier, 0);
+
+      const info = await querier.markerInfo(handle);
+
+      // The payload data must be reachable, so `--json | base64 -d` works.
+      expect(info.screenshot).toBeDefined();
+      expect(info.screenshot?.url).toBe(DATA_URL);
+      expect(info.screenshot?.mimeType).toBe('image/jpeg');
+      expect(info.screenshot?.base64).toBe(JPEG_BASE64);
+      expect(info.screenshot?.windowWidth).toBe(1280);
+      expect(info.screenshot?.windowHeight).toBe(951);
+
+      // The base64 payload really decodes to a JPEG (FF D8 FF magic bytes).
+      const bytes = Buffer.from(info.screenshot?.base64 ?? '', 'base64');
+      expect(bytes.length).toBeGreaterThan(0);
+      expect([bytes[0], bytes[1], bytes[2]]).toEqual([0xff, 0xd8, 0xff]);
+    });
+
+    it('reports raw payload keys for markers with no schema', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const [handle] = await getMarkerHandles(querier, SCREENSHOT_MARKER_TYPE);
+      const info = await querier.markerInfo(handle);
+
+      // Screenshot markers have no schema, so `fields` stays empty; without
+      // `rawFields` the payload would look absent entirely.
+      const rawKeys = (info.rawFields ?? []).map((field) => field.key);
+      expect(rawKeys).toEqual(
+        expect.arrayContaining([
+          'url',
+          'windowID',
+          'windowWidth',
+          'windowHeight',
+        ])
+      );
+
+      // The string-table index is resolved, not printed as a number...
+      const urlField = info.rawFields?.find((field) => field.key === 'url');
+      expect(urlField?.value.startsWith('data:image/jpeg;base64,')).toBe(true);
+      // ...and truncated so it does not flood the terminal.
+      expect(urlField?.truncated).toBe(true);
+      expect(urlField?.value.length).toBeLessThan(DATA_URL.length);
+    });
+  });
+
+  describe('markerScreenshot', function () {
+    it('extracts the image for a screenshot marker', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const [handle] = await getMarkerHandles(querier, SCREENSHOT_MARKER_TYPE);
+
+      const result = await querier.markerScreenshot(handle);
+      expect(result.type).toBe('marker-screenshot');
+      expect(result.screenshot.base64).toBe(JPEG_BASE64);
+      expect(screenshotFileExtension(result.screenshot)).toBe('jpg');
+    });
+
+    it('rejects a window-destroyed marker, which carries no image', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const [handle] = await getMarkerHandles(
+        querier,
+        'CompositorScreenshotWindowDestroyed'
+      );
+
+      await expect(querier.markerScreenshot(handle)).rejects.toThrow(
+        /carries no image/
+      );
+    });
+  });
+
+  describe('screenshots', function () {
+    it('returns the frame covering an instant, one per window', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const rootRange = getProfileRootRange(querier._store.getState());
+
+      // t=25ms is covered by the 20-30ms frame of window 0x1 and by the
+      // 5-40ms frame of window 0x2.
+      const result = await querier.screenshots({ at: '25ms' });
+
+      expect(result.screenshots).toHaveLength(2);
+      const windowIDs = result.screenshots
+        .map((entry) => entry.screenshot.windowID)
+        .sort();
+      expect(windowIDs).toEqual(['0x1', '0x2']);
+
+      // Every returned frame really spans the requested instant.
+      const at = rootRange.start + 25;
+      for (const entry of result.screenshots) {
+        expect(entry.start).toBeLessThanOrEqual(at);
+        expect(entry.end ?? entry.start).toBeGreaterThanOrEqual(at);
+      }
+
+      // The window-destroyed marker must not be counted as a screenshot.
+      expect(result.totalScreenshotCount).toBe(3);
+    });
+
+    it('returns every frame overlapping a range', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const result = await querier.screenshots({ range: '0ms,45ms' });
+
+      // All three image-carrying frames overlap the full range.
+      expect(result.screenshots).toHaveLength(3);
+      // Results are ordered by time.
+      const starts = result.screenshots.map((entry) => entry.start);
+      expect(starts).toEqual([...starts].sort((a, b) => a - b));
+    });
+
+    it('flags a preceding frame as stale rather than passing it off as the frame at the instant', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const rootStart = getProfileRootRange(querier._store.getState()).start;
+
+      // Window 0x1's last frame ends at 36ms and it is never destroyed, so at
+      // t=50ms it is the last thing that window painted — useful, but not the
+      // frame at that instant, so it must say so.
+      const result = await querier.screenshots({ at: '50ms' });
+
+      expect(result.screenshots.length).toBeGreaterThan(0);
+      for (const entry of result.screenshots) {
+        expect(entry.isFallback).toBe(true);
+        // Reported staleness matches the gap between the frame's end and the
+        // requested instant.
+        const end = entry.end ?? entry.start;
+        expect(entry.staleByMs).toBeCloseTo(rootStart + 50 - end, 3);
+        expect(entry.staleByMs).toBeGreaterThan(0);
+      }
+    });
+
+    it('drops windows destroyed before the instant', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+
+      // Window 0x2 is destroyed at 35ms (fixture time 40ms). Its last frame is
+      // not "what was on screen" at 50ms — that window no longer existed.
+      const result = await querier.screenshots({ at: '50ms' });
+
+      const windowIDs = result.screenshots.map(
+        (entry) => entry.screenshot.windowID
+      );
+      expect(windowIDs).not.toContain('0x2');
+      expect(windowIDs).toEqual(['0x1']);
+    });
+
+    it('resolves each window independently, mixing covering and stale frames', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      const rootStart = getProfileRootRange(querier._store.getState()).start;
+
+      // At t=20ms window 0x2's 0-35ms frame spans the instant, while window
+      // 0x1's frames (5-15ms, 15-36ms) — pick a time where only one window
+      // covers, to prove the choice is per window and not all-or-nothing.
+      const result = await querier.screenshots({ at: '20ms' });
+      const at = rootStart + 20;
+
+      // Every window is represented at most once, and each entry's isFallback
+      // reflects that window's own frame, not a global decision.
+      const byWindow = new Map(
+        result.screenshots.map((entry) => [entry.screenshot.windowID, entry])
+      );
+      expect(byWindow.size).toBe(result.screenshots.length);
+      for (const entry of result.screenshots) {
+        const covers = entry.start <= at && (entry.end ?? entry.start) >= at;
+        expect(entry.isFallback ?? false).toBe(!covers);
+      }
+    });
+
+    it('requires exactly one of --at and --range', async function () {
+      const querier = makeQuerier(getProfileWithScreenshots());
+      await expect(querier.screenshots({})).rejects.toThrow(
+        /Pass --at .* or --range/
+      );
+      await expect(
+        querier.screenshots({ at: '1ms', range: '0ms,2ms' })
+      ).rejects.toThrow(/only one/);
+      await expect(querier.screenshots({ range: '5ms,1ms' })).rejects.toThrow(
+        /end is before start/
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6278--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

Makes `CompositorScreenshot` images reachable from the CLI. They're in the profile,
but nothing could get at them, so sessions resorted to ~30 lines of Python over the
gzipped JSON.

Two commits:

1. **query layer** — these markers have no schema (#5303), so the image, a data URL
   stored as a string table index, was unreachable. Adds lookup by instant or range.
2. **`marker screenshot` and `screenshots`** — write one image, or one per window at
   a time / over a range. Both require `-o`; `--json` honours it and elides the
   base64 like `thread markers --list --json`.

A profile normally has several windows (harness + browser at minimum), so an instant
resolves each window separately and `--at` returns one image per window, with a
`win N` column to tell them apart:

```
  m-19  t=3,485s  win 2  800px × 600px   3 685B  image/jpeg
  m-39  t=3,995s  win 1  1280px × 951px  5 367B  image/jpeg
```

A window whose frames all precede the instant is labelled stale rather than passed
off as current.

`src/profile-query/` is shared with profiler.firefox.com; the additions there are new
exports, no existing path changes behaviour.