### PR TITLE
Fix dark mode contrast of the warning icons in the publish panel

### DIFF
--- a/src/components/app/MenuButtons/Publish.css
+++ b/src/components/app/MenuButtons/Publish.css
@@ -57,6 +57,7 @@
   --internal-upload-percentage-foreground-color: var(--blue-60);
   --internal-upload-bar-background-color: var(--grey-40);
   --internal-upload-bar-inner-background-color: var(--blue-50);
+  --internal-warning-indicator-icon: url(../../../../res/img/svg/warning.svg);
 }
 
 :root.dark-mode {
@@ -80,6 +81,7 @@
     --internal-upload-percentage-foreground-color: var(--blue-60);
     --internal-upload-bar-background-color: var(--grey-40);
     --internal-upload-bar-inner-background-color: var(--blue-50);
+    --internal-warning-indicator-icon: url(../../../../res/img/svg/warning-light.svg);
   }
 }
 
@@ -115,7 +117,11 @@
 }
 
 .publishPanelDataChoicesIndicator {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
   margin-left: 8px;
+  background: var(--internal-warning-indicator-icon) center no-repeat;
   vertical-align: middle;
 }
 

--- a/src/components/app/MenuButtons/Publish.tsx
+++ b/src/components/app/MenuButtons/Publish.tsx
@@ -36,8 +36,6 @@ import explicitConnect, {
   type ConnectedProps,
 } from 'firefox-profiler/utils/connect';
 
-import WarningImage from 'firefox-profiler-res/img/svg/warning.svg';
-
 import type {
   Profile,
   CheckedSharingOptions,
@@ -231,9 +229,8 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
                     id="MenuButtons--publish--renderCheckbox-label-private-browsing-warning-image"
                     attrs={{ title: true }}
                   >
-                    <img
+                    <span
                       className="publishPanelDataChoicesIndicator"
-                      src={WarningImage}
                       title="This profile contains private browsing data"
                     />
                   </Localized>
@@ -247,9 +244,8 @@ class PublishPanelImpl extends React.PureComponent<PublishProps, {}> {
                     id="MenuButtons--publish--renderCheckbox-label-argument-values-warning-image"
                     attrs={{ title: true }}
                   >
-                    <img
+                    <span
                       className="publishPanelDataChoicesIndicator"
-                      src={WarningImage}
                       title="This profile contains function argument values recorded from the page, which may include personal data"
                     />
                   </Localized>


### PR DESCRIPTION
<!-- profiler-preview-links:start -->
[Main](https://main--perf-html.netlify.app/) | [Deploy preview](https://deploy-preview-6280--perf-html.netlify.app/)
<!-- profiler-preview-links:end -->

Fixes #6279.

The warning indicators next to the publish panel checkboxes were img elements using warning.svg, which has a hardcoded black fill and stayed black on dark backgrounds. 

This commit renders them as spans with a background image instead, so they can switch to the light variant (warning-light.svg, already used by the photon message bars) in dark mode.

See the issue for the before image. This is the picture after:
<img width="530" height="380" alt="Screenshot 2026-08-24 at 10 35 06" src="https://github.com/user-attachments/assets/b7368224-66d8-4a24-9106-9bb03a921e1f" />


STR:
- Open a private window
- Capture a profile
- Open the sharing popup to see the icon.